### PR TITLE
fix(ai-reporting): prevent duplicate empty chat creation

### DIFF
--- a/components/reports/AiReportingView.tsx
+++ b/components/reports/AiReportingView.tsx
@@ -294,10 +294,14 @@ const AiReportingView: React.FC<AiReportingViewProps> = ({
   useEffect(() => {
     if (!activeSessionId || !pendingEmptySessionId) return;
     if (activeSessionId !== pendingEmptySessionId) return;
-    if (messages.length > 0) {
+    if (isLoadingMessages) return;
+    const hasPendingMessages = messages.some(
+      (message) => message.sessionId === pendingEmptySessionId,
+    );
+    if (hasPendingMessages) {
       setPendingEmptySessionId('');
     }
-  }, [activeSessionId, messages, pendingEmptySessionId]);
+  }, [activeSessionId, isLoadingMessages, messages, pendingEmptySessionId]);
 
   const confirmDeleteSession = useCallback((session: ReportChatSessionSummary) => {
     setSessionToDelete(session);

--- a/locales/en/reports.json
+++ b/locales/en/reports.json
@@ -1,6 +1,6 @@
 {
   "aiReporting": {
-    "newChat": "New chat",
+    "newChat": "New Chat",
     "session": "Session",
     "selectSession": "Select chat",
     "loadingSessions": "Loading...",

--- a/locales/it/reports.json
+++ b/locales/it/reports.json
@@ -1,6 +1,6 @@
 {
   "aiReporting": {
-    "newChat": "Nuova chat",
+    "newChat": "Nuova Chat",
     "session": "Sessione",
     "selectSession": "Seleziona chat",
     "loadingSessions": "Caricamento...",


### PR DESCRIPTION
### Motivation

- Prevent users from spamming the backend with multiple empty AI Reporting sessions by repeatedly pressing **New Chat** from old conversations. 
- Match ChatGPT-style behavior where subsequent New Chat clicks reuse the already-created empty session and keep the UI label localized/capitalized as `New Chat`.

### Description

- Added `pendingEmptySessionId` state to track an in-progress empty session created by the New Chat button. 
- In `handleNewChat` the UI now navigates to an existing `pendingEmptySessionId` instead of creating another session when one already exists. 
- Mark a session as pending when optimistically created and clear `pendingEmptySessionId` when the pending session receives its first message, is deleted, or the user/context resets. 
- Updated localized labels for the new-chat placeholder capitalization in `locales/en/reports.json` and `locales/it/reports.json`, and aligned component fallbacks to `New Chat`.

### Testing

- Ran frontend production build with `bun run build` which completed successfully. 
- Ran linter with `bun run lint` which passed. 
- Attempted server build (`cd server && bun run build`) which failed due to a pre-existing TypeScript typing issue for `nodemailer` (missing declaration file). 
- Started the dev frontend and executed an automated Playwright script to capture the updated UI state (screenshot produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c84ba8b0483258bb925583415b508)