### PR TITLE
fix(ai-reporting): add empty-state placeholder and avoid default "AI Reporting" title

### DIFF
--- a/components/reports/AiReportingView.tsx
+++ b/components/reports/AiReportingView.tsx
@@ -18,7 +18,7 @@ export interface AiReportingViewProps {
 }
 
 const toOptionLabel = (session: ReportChatSessionSummary) => {
-  const title = session.title?.trim() ? session.title.trim() : 'AI Reporting';
+  const title = session.title?.trim() ? session.title.trim() : '';
   return title;
 };
 
@@ -171,7 +171,7 @@ const AiReportingView: React.FC<AiReportingViewProps> = ({
       const res = await api.reports.createSession();
       const session: ReportChatSessionSummary = {
         id: res.id,
-        title: 'AI Reporting',
+        title: '',
         createdAt: now,
         updatedAt: now,
       };
@@ -332,9 +332,13 @@ const AiReportingView: React.FC<AiReportingViewProps> = ({
 
   const activeTitle = isNewChat
     ? t('aiReporting.newChat', { defaultValue: 'New Chat' })
-    : sessions.find((s) => s.id === activeSessionId)?.title || 'AI Reporting';
+    : sessions.find((s) => s.id === activeSessionId)?.title ||
+      t('aiReporting.newChat', { defaultValue: 'New Chat' });
   const activeSession = sessions.find((s) => s.id === activeSessionId) || null;
-  const sessionOptions = sessions.map((s) => ({ id: s.id, name: toOptionLabel(s) }));
+  const sessionOptions = sessions.map((s) => ({
+    id: s.id,
+    name: toOptionLabel(s) || t('aiReporting.newChat', { defaultValue: 'New Chat' }),
+  }));
   const canDeleteActive =
     Boolean(activeSession) && canArchive && !isDeletingSession && !isLoadingSessions;
   const isEmptySession = Boolean(activeSessionId) && !isLoadingMessages && messages.length === 0;
@@ -469,7 +473,21 @@ const AiReportingView: React.FC<AiReportingViewProps> = ({
               )}
 
               {!isLoadingMessages && messages.length === 0 && (
-                <div className="text-sm text-slate-500">{t('aiReporting.noSessions')}</div>
+                <div className="min-h-[45vh] flex items-center justify-center px-4">
+                  <div className="max-w-xl text-center">
+                    <div className="text-3xl md:text-4xl font-black text-slate-900 tracking-tight">
+                      {t('aiReporting.emptyPlaceholderTitle', {
+                        defaultValue: 'What should we build together now?',
+                      })}
+                    </div>
+                    <div className="mt-3 text-sm md:text-base text-slate-500 leading-relaxed">
+                      {t('aiReporting.emptyPlaceholderBody', {
+                        defaultValue:
+                          'Start with a question about your business data. I will use your reports to help you.',
+                      })}
+                    </div>
+                  </div>
+                </div>
               )}
 
               <div className="space-y-5">
@@ -728,7 +746,10 @@ const AiReportingView: React.FC<AiReportingViewProps> = ({
               </h3>
               <p className="text-sm text-slate-500 mt-2 leading-relaxed">
                 {t('aiReporting.deleteChatConfirm', {
-                  name: sessionToDelete ? toOptionLabel(sessionToDelete) : '',
+                  name: sessionToDelete
+                    ? toOptionLabel(sessionToDelete) ||
+                      t('aiReporting.newChat', { defaultValue: 'New Chat' })
+                    : '',
                   defaultValue: 'This will remove "{{name}}" from your chat history.',
                 })}
               </p>

--- a/locales/en/reports.json
+++ b/locales/en/reports.json
@@ -7,6 +7,8 @@
     "placeholder": "Ask a question about your business data...",
     "thinking": "Thinking...",
     "noSessions": "No chats yet.",
+    "emptyPlaceholderTitle": "What should we analyze next?",
+    "emptyPlaceholderBody": "Start with a question about your business data and I will help you with a useful answer.",
     "noPermissionToSend": "You do not have permission to use AI Reporting.",
     "disabledByAdmin": "AI Reporting is disabled by administration.",
     "disabledTitle": "AI Reporting disabled",

--- a/locales/it/reports.json
+++ b/locales/it/reports.json
@@ -7,6 +7,8 @@
     "placeholder": "Fai una domanda sui tuoi dati aziendali...",
     "thinking": "Sto pensando...",
     "noSessions": "Nessuna chat.",
+    "emptyPlaceholderTitle": "Quale analisi dovremmo fare adesso?",
+    "emptyPlaceholderBody": "Inizia con una domanda sui tuoi dati aziendali e ti aiuterò con una risposta utile.",
     "noPermissionToSend": "Non hai i permessi per usare AI Reporting.",
     "disabledByAdmin": "AI Reporting e' disabilitato dall'amministrazione.",
     "disabledTitle": "AI Reporting disabilitato",


### PR DESCRIPTION
### Motivation
- Replace the terse “No chats” line with an inviting, centered placeholder while a conversation is empty to improve the UX. 
- Stop persisting the literal `AI Reporting` string as the default session title so new/untitled chats present as `New Chat` and can receive an AI-generated title after the first message.

### Description
- Frontend: updated `components/reports/AiReportingView.tsx` to render a centered empty-state placeholder when there are no messages, to treat session titles as empty instead of the hardcoded `AI Reporting`, and to fallback to `New Chat` in UI labels and dropdowns. 
- Backend: changed `server/routes/reports.ts` so session creation persists an empty title by default and the chat auto-title update treats both empty titles and legacy `AI Reporting` titles as candidates for replacement with a generated/cleaned title. 
- i18n: added `emptyPlaceholderTitle` and `emptyPlaceholderBody` translation strings to `locales/en/reports.json` and `locales/it/reports.json` for the new placeholder copy. 

### Testing
- Ran `bun run lint` (Biome) which completed with no issues. 
- Built the frontend with `bun run build` which succeeded. 
- Attempted server build with `cd server && bun run build` which failed due to an existing type issue unrelated to these changes (`TS7016` for `nodemailer`), so server typecheck/build did not complete here. 
- Launched the dev frontend and captured a headless screenshot of the updated UI as an automated visual validation step which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cd05640288325bdfd9a44dff43e66)