### PR TITLE
feat(administration): migrate Logs view to StandardTable and add refresh action

### DIFF
--- a/components/administration/LogsView.tsx
+++ b/components/administration/LogsView.tsx
@@ -1,33 +1,44 @@
 import type React from 'react';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { logsApi } from '../../services/api';
 import type { AuditLogEntry } from '../../types';
+import StandardTable, { type Column } from '../shared/StandardTable';
 
 const LogsView: React.FC = () => {
-  const { t, i18n } = useTranslation('administration');
+  const { t, i18n } = useTranslation(['administration', 'common']);
   const [activeTab, setActiveTab] = useState<'audit'>('audit');
   const [rows, setRows] = useState<AuditLogEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const loadAuditLogs = useCallback(async () => {
+    setError('');
+    try {
+      const data = await logsApi.listAudit();
+      setRows(data);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : t('logs.errors.loadFailed');
+      setError(message || t('logs.errors.loadFailed'));
+    }
+  }, [t]);
 
   useEffect(() => {
     const load = async () => {
       setLoading(true);
-      setError('');
-      try {
-        const data = await logsApi.listAudit();
-        setRows(data);
-      } catch (err) {
-        const message = err instanceof Error ? err.message : t('logs.errors.loadFailed');
-        setError(message || t('logs.errors.loadFailed'));
-      } finally {
-        setLoading(false);
-      }
+      await loadAuditLogs();
+      setLoading(false);
     };
 
     void load();
-  }, [t]);
+  }, [loadAuditLogs]);
+
+  const handleRefreshLogs = async () => {
+    setIsRefreshing(true);
+    await loadAuditLogs();
+    setIsRefreshing(false);
+  };
 
   const dateTimeFormatter = useMemo(
     () =>
@@ -38,6 +49,43 @@ const LogsView: React.FC = () => {
     [i18n.language],
   );
 
+  const columns = useMemo<Column<AuditLogEntry>[]>(
+    () => [
+      {
+        header: t('logs.columns.user'),
+        accessorKey: 'userName',
+        disableFiltering: true,
+      },
+      {
+        header: t('logs.columns.username'),
+        accessorKey: 'username',
+      },
+      {
+        header: t('logs.columns.ip'),
+        accessorKey: 'ipAddress',
+        className: 'font-mono text-xs',
+      },
+      {
+        header: t('logs.columns.timestamp'),
+        id: 'createdAt',
+        accessorFn: (row) => dateTimeFormatter.format(new Date(row.createdAt)),
+      },
+    ],
+    [dateTimeFormatter, t],
+  );
+
+  const refreshButton = (
+    <button
+      type="button"
+      onClick={handleRefreshLogs}
+      disabled={loading || isRefreshing}
+      className="h-10 px-4 inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white text-slate-600 text-sm font-semibold hover:bg-slate-50 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+    >
+      <i className={`fa-solid ${isRefreshing ? 'fa-circle-notch fa-spin' : 'fa-rotate-right'}`} />
+      {t('buttons.refresh', { ns: 'common' })}
+    </button>
+  );
+
   return (
     <div className="space-y-6 animate-in fade-in duration-300">
       <div>
@@ -45,68 +93,43 @@ const LogsView: React.FC = () => {
         <p className="text-slate-500 mt-1">{t('logs.subtitle')}</p>
       </div>
 
-      <div className="inline-flex rounded-xl border border-slate-200 bg-white p-1 shadow-sm">
+      <div className="flex border-b border-slate-200 gap-8">
         <button
           type="button"
           onClick={() => setActiveTab('audit')}
-          className={`px-4 py-2 rounded-lg text-sm font-semibold transition-colors ${
-            activeTab === 'audit'
-              ? 'bg-praetor text-white shadow-sm'
-              : 'text-slate-600 hover:text-slate-800 hover:bg-slate-100'
-          }`}
+          className={`pb-4 text-sm font-bold transition-all relative ${activeTab === 'audit' ? 'text-praetor' : 'text-slate-400 hover:text-slate-600'}`}
         >
+          <i className="fa-solid fa-shield-halved mr-2"></i>
           {t('logs.tabs.audit')}
+          {activeTab === 'audit' && (
+            <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-praetor rounded-full"></div>
+          )}
         </button>
       </div>
 
       {activeTab === 'audit' && (
-        <div className="bg-white rounded-2xl shadow-sm border border-slate-100 overflow-hidden">
+        <>
+          {error && <div className="text-sm font-medium text-red-600">{error}</div>}
+
           {loading ? (
-            <div className="p-8 text-center text-slate-500">
+            <div className="bg-white rounded-2xl border border-slate-200 shadow-sm p-8 text-center text-slate-500">
               <i className="fa-solid fa-circle-notch fa-spin mr-2" />
               {t('logs.loading')}
             </div>
-          ) : error ? (
-            <div className="p-8 text-center text-red-600">{error}</div>
-          ) : rows.length === 0 ? (
-            <div className="p-8 text-center text-slate-500">{t('logs.empty')}</div>
           ) : (
-            <div className="overflow-x-auto">
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="bg-slate-50 border-b border-slate-100">
-                    <th className="text-left px-4 py-3 font-semibold text-slate-700">
-                      {t('logs.columns.user')}
-                    </th>
-                    <th className="text-left px-4 py-3 font-semibold text-slate-700">
-                      {t('logs.columns.username')}
-                    </th>
-                    <th className="text-left px-4 py-3 font-semibold text-slate-700">
-                      {t('logs.columns.ip')}
-                    </th>
-                    <th className="text-left px-4 py-3 font-semibold text-slate-700">
-                      {t('logs.columns.timestamp')}
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {rows.map((entry) => (
-                    <tr key={entry.id} className="border-b border-slate-100 hover:bg-slate-50/70">
-                      <td className="px-4 py-3 text-slate-800">{entry.userName}</td>
-                      <td className="px-4 py-3 text-slate-600">{entry.username}</td>
-                      <td className="px-4 py-3 text-slate-600 font-mono text-xs">
-                        {entry.ipAddress}
-                      </td>
-                      <td className="px-4 py-3 text-slate-600">
-                        {dateTimeFormatter.format(new Date(entry.createdAt))}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
+            <StandardTable<AuditLogEntry>
+              title={t('logs.tabs.audit')}
+              data={rows}
+              columns={columns}
+              headerAction={refreshButton}
+              emptyState={
+                <div className="p-8 text-center text-slate-500 text-sm font-medium">
+                  {t('logs.empty')}
+                </div>
+              }
+            />
           )}
-        </div>
+        </>
       )}
     </div>
   );

--- a/components/administration/LogsView.tsx
+++ b/components/administration/LogsView.tsx
@@ -68,7 +68,9 @@ const LogsView: React.FC = () => {
       {
         header: t('logs.columns.timestamp'),
         id: 'createdAt',
-        accessorFn: (row) => dateTimeFormatter.format(new Date(row.createdAt)),
+        accessorFn: (row) => new Date(row.createdAt).getTime(),
+        cell: ({ row }) => dateTimeFormatter.format(new Date(row.createdAt)),
+        filterFormat: (value) => dateTimeFormatter.format(new Date(Number(value))),
       },
     ],
     [dateTimeFormatter, t],


### PR DESCRIPTION
### Motivation
- Reuse the shared `StandardTable` to standardize table behavior (sorting/filtering/pagination) across the app and reduce duplicated UI code.
- Provide operators a quick way to reload audit logs without leaving the page via a visible refresh control.
- Align the Logs tab visual style with the underline tab pattern used in `GeneralSettings` for consistent Administration UX.

### Description
- Replaced the custom HTML table in `components/administration/LogsView.tsx` with the shared `StandardTable` and defined typed `columns` for `AuditLogEntry` including a formatted timestamp column using `dateTimeFormatter`.
- Extracted log loading into a reusable `loadAuditLogs` function and added `handleRefreshLogs` plus an inline `refreshButton` (spinner and disabled states) wired to `StandardTable` via `headerAction`.
- Updated translations usage to include the `common` namespace for the `Refresh` label and updated the Logs tab markup to use the underline tab style consistent with `GeneralSettings`.

### Testing
- Ran `bun run lint` after formatting and the lint check passed successfully.
- Ran `bun run build` (frontend) and the build completed successfully.
- Ran `cd server && bun run build` which failed due to an existing TypeScript declaration issue (`TS7016` for `nodemailer`) unrelated to these frontend changes.
- Captured a headless browser snapshot of the Logs page to validate the layout (automated Playwright script produced an artifact).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cea3d82888325918542916c0e72ef)