### PR TITLE
fix(reports): stream thought process before final response

### DIFF
--- a/components/reports/AiReportingView.tsx
+++ b/components/reports/AiReportingView.tsx
@@ -104,19 +104,13 @@ const AiReportingView: React.FC<AiReportingViewProps> = ({
       opts: { sessionId?: string } = {},
     ) => {
       const speedMs = 8;
-      const answerChunks = 2;
       const thoughtChunks = 3;
+      const answerChunks = 2;
       const finalThought = String(thoughtContent || '');
-      let nextAnswer = '';
       let nextThought = '';
-      let answerIndex = 0;
       let thoughtIndex = 0;
 
-      while (answerIndex < finalContent.length || thoughtIndex < finalThought.length) {
-        if (answerIndex < finalContent.length) {
-          nextAnswer += finalContent.slice(answerIndex, answerIndex + answerChunks);
-          answerIndex += answerChunks;
-        }
+      while (thoughtIndex < finalThought.length) {
         if (thoughtIndex < finalThought.length) {
           nextThought += finalThought.slice(thoughtIndex, thoughtIndex + thoughtChunks);
           thoughtIndex += thoughtChunks;
@@ -127,8 +121,37 @@ const AiReportingView: React.FC<AiReportingViewProps> = ({
             m.id === messageId
               ? {
                   ...m,
-                  content: nextAnswer,
+                  content: '',
                   thoughtContent: nextThought || undefined,
+                  sessionId: opts.sessionId || m.sessionId,
+                }
+              : m,
+          ),
+        );
+        if (isAtBottomRef.current) {
+          requestAnimationFrame(scrollToBottom);
+        } else {
+          setHasNewText(true);
+        }
+        await new Promise((resolve) => setTimeout(resolve, speedMs));
+      }
+
+      let nextAnswer = '';
+      let answerIndex = 0;
+
+      while (answerIndex < finalContent.length) {
+        if (answerIndex < finalContent.length) {
+          nextAnswer += finalContent.slice(answerIndex, answerIndex + answerChunks);
+          answerIndex += answerChunks;
+        }
+
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === messageId
+              ? {
+                  ...m,
+                  content: nextAnswer,
+                  thoughtContent: finalThought || undefined,
                   sessionId: opts.sessionId || m.sessionId,
                 }
               : m,


### PR DESCRIPTION
### Motivation
- Users observed the AI "thought process" appearing together with the final answer instead of while the model is still elaborating, so the UI should show the thought stream first and then the final response.

### Description
- Split the assistant typing flow in `typeAssistantMessage` to two sequential phases: first stream `thoughtContent` while `content` remains empty, then stream `content` once the thought stream completes.
- Kept existing scrolling and new-text behavior by reusing `scrollToBottom` / `isAtBottomRef` in both phases so auto-scroll and the "new text" badge are preserved.
- Updated chunking loops and message updates to reflect the two-phase streaming approach in `components/reports/AiReportingView.tsx`.
- Commit: `fix(reports): stream thought process before final response`.

### Testing
- Ran frontend production build with `bun run build` and it completed successfully. ✅
- Ran lint with `bun run lint` and it passed. ✅
- Attempted server build with `cd server && bun run build`, which failed in this environment due to missing type declarations for `nodemailer` (`@types/nodemailer`), so server build is blocked by environment typings, not by the change. ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ce98503dc832597bdfbc2a974f74f)