### PR TITLE
fix(ai-reporting): make retry action icon-only

### DIFF
--- a/components/reports/AiReportingView.tsx
+++ b/components/reports/AiReportingView.tsx
@@ -1123,15 +1123,14 @@ const AiReportingView: React.FC<AiReportingViewProps> = ({
                                   type="button"
                                   onClick={() => void handleRetryMessage(m.id)}
                                   disabled={!canRetryAssistantMessage}
-                                  className={`inline-flex items-center gap-1 rounded-lg px-2 py-1 text-xs font-semibold transition-colors ${
+                                  className={`rounded-lg p-1.5 transition-colors ${
                                     canRetryAssistantMessage
-                                      ? 'text-slate-500 hover:text-slate-700 hover:bg-slate-100'
+                                      ? 'text-slate-400 hover:text-slate-600 hover:bg-slate-100'
                                       : 'text-slate-300 cursor-not-allowed'
                                   }`}
                                   aria-label={t('aiReporting.retry', { defaultValue: 'Retry' })}
                                 >
-                                  <i className="fa-solid fa-rotate-right text-[11px]" />
-                                  {t('aiReporting.retry', { defaultValue: 'Retry' })}
+                                  <i className="fa-solid fa-rotate-right" />
                                 </button>
                               )}
                             </Tooltip>


### PR DESCRIPTION
### Motivation
- Reduce visual clutter and align the retry action with the copy icon button in the AI Reporting assistant message actions by making the retry control icon-only.

### Description
- Updated `components/reports/AiReportingView.tsx` to remove the retry text label, change the retry button `className` from the previous inline-text styling to `rounded-lg p-1.5 transition-colors` and adjusted the color/hover classes and icon sizing so the retry control matches the copy icon button footprint.

### Testing
- Ran `bun run lint` which completed successfully, and launched the dev server and executed a Playwright script to capture a screenshot of the updated UI which completed and produced an artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d16e338b08325b99351017b632f79)