### PR TITLE
fix(reports): center AI reporting footer hint text

### DIFF
--- a/components/reports/AiReportingView.tsx
+++ b/components/reports/AiReportingView.tsx
@@ -1238,7 +1238,7 @@ const AiReportingView: React.FC<AiReportingViewProps> = ({
                     </div>
                   </div>
                 </div>
-                <div className="mx-auto w-full max-w-[760px] mt-2 px-2">
+                <div className="mx-auto w-full max-w-[760px] mt-2 px-2 text-center">
                   <div className="text-[11px] text-slate-400">
                     {footerHintWithPeriod ? `${footerHintWithPeriod} ${aiWarning}` : aiWarning}
                   </div>


### PR DESCRIPTION
### Motivation
- The informational helper/warning text under the AI Reporting chat composer was left-aligned and visually inconsistent with the centered composer, so it needed to be centered.

### Description
- Added `text-center` to the footer wrapper in `components/reports/AiReportingView.tsx` by changing the wrapper div class from `mx-auto w-full max-w-[760px] mt-2 px-2` to include `text-center`.

### Testing
- Ran `bun run lint` (Biome) and it completed successfully.
- Ran `bun run build` (Vite) and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d16f638e08325b40a11f58f6e2aeb)