### PR TITLE
fix(security): resolve remaining CodeQL alerts

### DIFF
--- a/components/administration/AuthSettings.tsx
+++ b/components/administration/AuthSettings.tsx
@@ -23,6 +23,18 @@ const DEFAULT_CONFIG: LdapConfig = {
   roleMappings: [],
 };
 
+const isExampleLdapServerUrl = (serverUrl: string) => {
+  try {
+    const parsed = new URL(serverUrl);
+    return (
+      (parsed.protocol === 'ldap:' || parsed.protocol === 'ldaps:') &&
+      parsed.hostname === 'ldap.example.com'
+    );
+  } catch {
+    return false;
+  }
+};
+
 const AuthSettings: React.FC<AuthSettingsProps> = ({ config, onSave, roles }) => {
   const { t } = useTranslation('auth');
   const [formData, setFormData] = useState<LdapConfig>(config || DEFAULT_CONFIG);
@@ -132,7 +144,7 @@ const AuthSettings: React.FC<AuthSettingsProps> = ({ config, onSave, roles }) =>
 
     // Mock Validation Logic
     if (
-      formData.serverUrl.includes('example.com') &&
+      isExampleLdapServerUrl(formData.serverUrl) &&
       testUser === 'admin' &&
       testPass === 'password'
     ) {

--- a/components/reports/AiReportingView.tsx
+++ b/components/reports/AiReportingView.tsx
@@ -76,6 +76,7 @@ const normalizeTableCellText = (value: string) =>
     .map((line) => line.trim())
     .filter(Boolean)
     .join(' <br> ')
+    .replace(/\\/g, '\\\\')
     .replace(/\|/g, '\\|');
 
 const toMarkdownTableRow = (cells: string[]) => `| ${cells.join(' | ')} |`;

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -161,6 +161,78 @@
                 }
               }
             }
+          },
+          "403": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
           }
         }
       }
@@ -820,6 +892,24 @@
             }
           },
           "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
             "description": "Default Response",
             "content": {
               "application/json": {
@@ -2150,6 +2240,24 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
           }
         }
       },
@@ -3076,6 +3184,24 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
           }
         }
       },
@@ -3693,6 +3819,24 @@
             }
           },
           "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
             "description": "Default Response",
             "content": {
               "application/json": {
@@ -4695,6 +4839,24 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
           }
         }
       },
@@ -5054,6 +5216,24 @@
             }
           },
           "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
             "description": "Default Response",
             "content": {
               "application/json": {
@@ -5517,6 +5697,24 @@
             }
           },
           "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
             "description": "Default Response",
             "content": {
               "application/json": {
@@ -6887,6 +7085,24 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
           }
         }
       },
@@ -7739,6 +7955,24 @@
             }
           },
           "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
             "description": "Default Response",
             "content": {
               "application/json": {
@@ -8802,6 +9036,24 @@
             }
           },
           "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
             "description": "Default Response",
             "content": {
               "application/json": {
@@ -10795,6 +11047,24 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
           }
         }
       },
@@ -11809,6 +12079,24 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
           }
         }
       },
@@ -12708,6 +12996,24 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
           }
         }
       },
@@ -13369,6 +13675,24 @@
             }
           },
           "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
             "description": "Default Response",
             "content": {
               "application/json": {
@@ -14085,6 +14409,24 @@
             }
           },
           "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
             "description": "Default Response",
             "content": {
               "application/json": {
@@ -17745,6 +18087,24 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
           }
         }
       },
@@ -19611,6 +19971,24 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
           }
         }
       },
@@ -20286,6 +20664,24 @@
             }
           },
           "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
             "description": "Default Response",
             "content": {
               "application/json": {
@@ -22025,6 +22421,24 @@
             }
           },
           "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
             "description": "Default Response",
             "content": {
               "application/json": {

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -14895,6 +14895,24 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
           }
         }
       },
@@ -15833,6 +15851,24 @@
                 }
               }
             }
+          },
+          "429": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
           }
         }
       },
@@ -16755,6 +16791,24 @@
             }
           },
           "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
             "description": "Default Response",
             "content": {
               "application/json": {
@@ -18648,6 +18702,24 @@
             }
           },
           "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
             "description": "Default Response",
             "content": {
               "application/json": {

--- a/server/app.ts
+++ b/server/app.ts
@@ -33,6 +33,7 @@ import tasksRoutes from './routes/tasks.ts';
 import usersRoutes from './routes/users.ts';
 import workUnitsRoutes from './routes/work-units.ts';
 import { loggerOptions, serializeError } from './utils/logger.ts';
+import { GLOBAL_RATE_LIMIT } from './utils/rate-limit.ts';
 
 dotenv.config();
 
@@ -45,8 +46,9 @@ export const buildApp = async () => {
   });
 
   await fastify.register(rateLimit, {
-    global: false,
+    global: true,
     hook: 'onRequest',
+    ...GLOBAL_RATE_LIMIT,
     errorResponseBuilder: () => ({
       error: 'Too many requests',
     }),
@@ -106,6 +108,9 @@ export const buildApp = async () => {
   fastify.get(
     '/api/health',
     {
+      config: {
+        rateLimit: false,
+      },
       schema: {
         tags: ['health'],
         summary: 'Health check',

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,4 +1,5 @@
 import cors from '@fastify/cors';
+import rateLimit from '@fastify/rate-limit';
 import swagger from '@fastify/swagger';
 import dotenv from 'dotenv';
 import Fastify from 'fastify';
@@ -41,6 +42,14 @@ export const buildApp = async () => {
   await fastify.register(cors, {
     origin: process.env.FRONTEND_URL || 'http://localhost:5173',
     credentials: true,
+  });
+
+  await fastify.register(rateLimit, {
+    global: false,
+    hook: 'onRequest',
+    errorResponseBuilder: () => ({
+      error: 'Too many requests',
+    }),
   });
 
   await fastify.register(swagger, {

--- a/server/bun.lock
+++ b/server/bun.lock
@@ -6,6 +6,7 @@
       "name": "praetor-server",
       "dependencies": {
         "@fastify/cors": "^10.0.1",
+        "@fastify/rate-limit": "^10.3.0",
         "@fastify/swagger": "^9.3.0",
         "bcryptjs": "^2.4.3",
         "dotenv": "^16.4.5",
@@ -45,6 +46,8 @@
 
     "@fastify/proxy-addr": ["@fastify/proxy-addr@5.1.0", "", { "dependencies": { "@fastify/forwarded": "^3.0.0", "ipaddr.js": "^2.1.0" } }, "sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw=="],
 
+    "@fastify/rate-limit": ["@fastify/rate-limit@10.3.0", "", { "dependencies": { "@lukeed/ms": "^2.0.2", "fastify-plugin": "^5.0.0", "toad-cache": "^3.7.0" } }, "sha512-eIGkG9XKQs0nyynatApA3EVrojHOuq4l6fhB4eeCk4PIOeadvOJz9/4w3vGI44Go17uaXOWEcPkaD8kuKm7g6Q=="],
+
     "@fastify/swagger": ["@fastify/swagger@9.6.1", "", { "dependencies": { "fastify-plugin": "^5.0.0", "json-schema-resolver": "^3.0.0", "openapi-types": "^12.1.3", "rfdc": "^1.3.1", "yaml": "^2.4.2" } }, "sha512-fKlpJqFMWoi4H3EdUkDaMteEYRCfQMEkK0HJJ0eaf4aRlKd8cbq0pVkOfXDXmtvMTXYcnx3E+l023eFDBsA1HA=="],
 
     "@ldapjs/asn1": ["@ldapjs/asn1@2.0.0", "", {}, "sha512-G9+DkEOirNgdPmD0I8nu57ygQJKOOgFEMKknEuQvIHbGLwP3ny1mY+OTUYLCbCaGJP4sox5eYgBJRuSUpnAddA=="],
@@ -62,6 +65,8 @@
     "@ldapjs/messages": ["@ldapjs/messages@1.3.0", "", { "dependencies": { "@ldapjs/asn1": "^2.0.0", "@ldapjs/attribute": "^1.0.0", "@ldapjs/change": "^1.0.0", "@ldapjs/controls": "^2.1.0", "@ldapjs/dn": "^1.1.0", "@ldapjs/filter": "^2.1.1", "@ldapjs/protocol": "^1.2.1", "process-warning": "^2.2.0" } }, "sha512-K7xZpXJ21bj92jS35wtRbdcNrwmxAtPwy4myeh9duy/eR3xQKvikVycbdWVzkYEAVE5Ce520VXNOwCHjomjCZw=="],
 
     "@ldapjs/protocol": ["@ldapjs/protocol@1.2.1", "", {}, "sha512-O89xFDLW2gBoZWNXuXpBSM32/KealKCTb3JGtJdtUQc7RjAk8XzrRgyz02cPAwGKwKPxy0ivuC7UP9bmN87egQ=="],
+
+    "@lukeed/ms": ["@lukeed/ms@2.0.2", "", {}, "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA=="],
 
     "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
 

--- a/server/package.json
+++ b/server/package.json
@@ -10,20 +10,21 @@
     "dev": "bun --watch index.ts"
   },
   "dependencies": {
-    "bcryptjs": "^2.4.3",
     "@fastify/cors": "^10.0.1",
+    "@fastify/rate-limit": "^10.3.0",
     "@fastify/swagger": "^9.3.0",
+    "bcryptjs": "^2.4.3",
     "dotenv": "^16.4.5",
     "fastify": "^5.2.0",
     "jsonwebtoken": "^9.0.2",
     "ldapjs": "^3.0.7",
+    "nodemailer": "^8.0.1",
+    "pg": "^8.13.0",
     "pino": "^10.3.0",
     "pino-pretty": "^13.1.2",
-    "pg": "^8.13.0",
     "redis": "^4.7.0",
-    "uuid": "^11.0.0",
     "selfsigned": "^2.4.1",
-    "nodemailer": "^8.0.1"
+    "uuid": "^11.0.0"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.2",

--- a/server/routes/ai.ts
+++ b/server/routes/ai.ts
@@ -3,6 +3,7 @@ import { query } from '../db/index.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
 import { standardErrorResponses } from '../schemas/common.ts';
 import { cacheGetSetJson } from '../services/cache.ts';
+import { normalizeGeminiModelPath } from '../utils/ai-models.ts';
 import { badRequest, optionalNonEmptyString, validateEnum } from '../utils/validation.ts';
 
 type AiProvider = 'gemini' | 'openrouter';
@@ -31,15 +32,9 @@ const getGeneralAiConfig = async (): Promise<GeneralAiConfig> => {
   };
 };
 
-const normalizeGeminiModelPath = (modelId: string) => {
-  const trimmed = modelId.trim();
-  if (trimmed.startsWith('models/') || trimmed.startsWith('tunedModels/')) return trimmed;
-  return `models/${trimmed}`;
-};
-
-const googleModelExists = async (apiKey: string, modelId: string): Promise<boolean> => {
-  const path = normalizeGeminiModelPath(modelId);
-  const url = `https://generativelanguage.googleapis.com/v1beta/${path}?key=${encodeURIComponent(apiKey)}`;
+const googleModelExists = async (apiKey: string, modelPath: string): Promise<boolean> => {
+  const url = new URL(`/v1beta/${modelPath}`, 'https://generativelanguage.googleapis.com');
+  url.searchParams.set('key', apiKey);
   const res = await fetch(url, { method: 'GET' });
   if (res.status === 404) return false;
   return res.ok;
@@ -147,8 +142,12 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
 
       try {
         if (providerResult.value === 'gemini') {
-          const normalizedModelId = normalizeGeminiModelPath(resolvedModelId);
-          const exists = await googleModelExists(keyToUse, resolvedModelId);
+          const normalizedModelIdResult = normalizeGeminiModelPath(resolvedModelId);
+          if (!normalizedModelIdResult.ok) {
+            return badRequest(reply, normalizedModelIdResult.message);
+          }
+          const normalizedModelId = normalizedModelIdResult.value;
+          const exists = await googleModelExists(keyToUse, normalizedModelId);
           return reply.send(
             exists
               ? { ok: true, normalizedModelId }

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -3,8 +3,9 @@ import { randomUUID } from 'crypto';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { query } from '../db/index.ts';
 import { authenticateToken, generateToken } from '../middleware/auth.ts';
-import { errorResponseSchema, standardErrorResponses } from '../schemas/common.ts';
+import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
 import { getRolePermissions } from '../utils/permissions.ts';
+import { LOGIN_RATE_LIMIT } from '../utils/rate-limit.ts';
 import { badRequest, requireNonEmptyString } from '../utils/validation.ts';
 
 const authUserSchema = {
@@ -99,6 +100,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.post(
     '/login',
     {
+      config: {
+        rateLimit: LOGIN_RATE_LIMIT,
+      },
       schema: {
         tags: ['auth'],
         summary: 'Login',
@@ -106,8 +110,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         security: [],
         response: {
           200: loginResponseSchema,
-          400: errorResponseSchema,
-          401: errorResponseSchema,
+          ...standardRateLimitedErrorResponses,
         },
       },
     },

--- a/server/routes/client-offers.ts
+++ b/server/routes/client-offers.ts
@@ -1,7 +1,8 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { query } from '../db/index.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
-import { standardErrorResponses } from '../schemas/common.ts';
+import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
+import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
   optionalDateString,
@@ -223,13 +224,16 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
+      config: {
+        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
+      },
       onRequest: [requirePermission('sales.client_offers.view')],
       schema: {
         tags: ['client-offers'],
         summary: 'List client offers',
         response: {
           200: { type: 'array', items: offerSchema },
-          ...standardErrorResponses,
+          ...standardRateLimitedErrorResponses,
         },
       },
     },

--- a/server/routes/client-quotes.ts
+++ b/server/routes/client-quotes.ts
@@ -1,7 +1,8 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { query } from '../db/index.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
-import { standardErrorResponses } from '../schemas/common.ts';
+import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
+import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
   optionalDateString,
@@ -382,13 +383,16 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
+      config: {
+        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
+      },
       onRequest: [requirePermission('sales.client_quotes.view')],
       schema: {
         tags: ['client-quotes'],
         summary: 'List client quotes',
         response: {
           200: { type: 'array', items: quoteSchema },
-          ...standardErrorResponses,
+          ...standardRateLimitedErrorResponses,
         },
       },
     },

--- a/server/routes/clients-orders.ts
+++ b/server/routes/clients-orders.ts
@@ -1,7 +1,8 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { query } from '../db/index.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
-import { standardErrorResponses } from '../schemas/common.ts';
+import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
+import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
   optionalLocalizedNonNegativeNumber,
@@ -158,13 +159,16 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
+      config: {
+        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
+      },
       onRequest: [requirePermission('accounting.clients_orders.view')],
       schema: {
         tags: ['clients-orders'],
         summary: 'List client orders',
         response: {
           200: { type: 'array', items: clientOrderSchema },
-          ...standardErrorResponses,
+          ...standardRateLimitedErrorResponses,
         },
       },
     },

--- a/server/routes/clients.ts
+++ b/server/routes/clients.ts
@@ -1,7 +1,11 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { query } from '../db/index.ts';
 import { authenticateToken, requireAnyPermission, requirePermission } from '../middleware/auth.ts';
-import { messageResponseSchema, standardErrorResponses } from '../schemas/common.ts';
+import {
+  messageResponseSchema,
+  standardErrorResponses,
+  standardRateLimitedErrorResponses,
+} from '../schemas/common.ts';
 import {
   bumpNamespaceVersion,
   cacheGetSetJson,
@@ -10,6 +14,7 @@ import {
   TTL_LIST_SECONDS,
 } from '../services/cache.ts';
 import { assertAuthenticated } from '../utils/auth-assert.ts';
+import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
   optionalEmail,
@@ -224,6 +229,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
+      config: {
+        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
+      },
       onRequest: [
         authenticateToken,
         requireAnyPermission(
@@ -252,7 +260,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         summary: 'List clients',
         response: {
           200: { type: 'array', items: clientSchema },
-          ...standardErrorResponses,
+          ...standardRateLimitedErrorResponses,
         },
       },
     },

--- a/server/routes/entries.ts
+++ b/server/routes/entries.ts
@@ -1,7 +1,11 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { query } from '../db/index.ts';
 import { authenticateToken, requireAnyPermission, requirePermission } from '../middleware/auth.ts';
-import { messageResponseSchema, standardErrorResponses } from '../schemas/common.ts';
+import {
+  messageResponseSchema,
+  standardErrorResponses,
+  standardRateLimitedErrorResponses,
+} from '../schemas/common.ts';
 import {
   bumpNamespaceVersion,
   cacheGetSetJson,
@@ -10,6 +14,7 @@ import {
   TTL_ENTRIES_SECONDS,
 } from '../services/cache.ts';
 import { assertAuthenticated } from '../utils/auth-assert.ts';
+import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
   isWeekendDate,
@@ -119,6 +124,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
+      config: {
+        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
+      },
       onRequest: [authenticateToken, requirePermission('timesheets.tracker.view')],
       schema: {
         tags: ['entries'],
@@ -126,7 +134,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         querystring: entriesListQuerySchema,
         response: {
           200: { type: 'array', items: entrySchema },
-          ...standardErrorResponses,
+          ...standardRateLimitedErrorResponses,
         },
       },
     },
@@ -548,6 +556,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.delete(
     '/',
     {
+      config: {
+        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
+      },
       onRequest: [
         authenticateToken,
         requireAnyPermission('timesheets.tracker.delete', 'timesheets.recurring.delete'),
@@ -558,7 +569,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         querystring: entriesBulkDeleteQuerySchema,
         response: {
           200: messageResponseSchema,
-          ...standardErrorResponses,
+          ...standardRateLimitedErrorResponses,
         },
       },
     },

--- a/server/routes/expenses.ts
+++ b/server/routes/expenses.ts
@@ -1,7 +1,8 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { query } from '../db/index.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
-import { standardErrorResponses } from '../schemas/common.ts';
+import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
+import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
   optionalDateString,
@@ -73,13 +74,16 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
+      config: {
+        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
+      },
       onRequest: [requirePermission('finances.expenses.view')],
       schema: {
         tags: ['expenses'],
         summary: 'List expenses',
         response: {
           200: { type: 'array', items: expenseSchema },
-          ...standardErrorResponses,
+          ...standardRateLimitedErrorResponses,
         },
       },
     },

--- a/server/routes/invoices.ts
+++ b/server/routes/invoices.ts
@@ -1,7 +1,8 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { query } from '../db/index.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
-import { standardErrorResponses } from '../schemas/common.ts';
+import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
+import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
   optionalDateString,
@@ -139,13 +140,16 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
+      config: {
+        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
+      },
       onRequest: [requirePermission('accounting.clients_invoices.view')],
       schema: {
         tags: ['invoices'],
         summary: 'List invoices',
         response: {
           200: { type: 'array', items: invoiceSchema },
-          ...standardErrorResponses,
+          ...standardRateLimitedErrorResponses,
         },
       },
     },

--- a/server/routes/notifications.ts
+++ b/server/routes/notifications.ts
@@ -1,7 +1,12 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { query } from '../db/index.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
-import { standardErrorResponses, successResponseSchema } from '../schemas/common.ts';
+import {
+  standardErrorResponses,
+  standardRateLimitedErrorResponses,
+  successResponseSchema,
+} from '../schemas/common.ts';
+import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import { badRequest, requireNonEmptyString } from '../utils/validation.ts';
 
 const idParamSchema = {
@@ -44,13 +49,16 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
+      config: {
+        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
+      },
       onRequest: [requirePermission('notifications.view')],
       schema: {
         tags: ['notifications'],
         summary: 'Fetch notifications',
         response: {
           200: notificationsResponseSchema,
-          ...standardErrorResponses,
+          ...standardRateLimitedErrorResponses,
         },
       },
     },

--- a/server/routes/payments.ts
+++ b/server/routes/payments.ts
@@ -1,7 +1,8 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { query } from '../db/index.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
-import { standardErrorResponses } from '../schemas/common.ts';
+import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
+import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
   optionalDateString,
@@ -69,13 +70,16 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
+      config: {
+        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
+      },
       onRequest: [requirePermission('finances.payments.view')],
       schema: {
         tags: ['payments'],
         summary: 'List payments',
         response: {
           200: { type: 'array', items: paymentSchema },
-          ...standardErrorResponses,
+          ...standardRateLimitedErrorResponses,
         },
       },
     },

--- a/server/routes/products.ts
+++ b/server/routes/products.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { query } from '../db/index.ts';
 import { authenticateToken, requireAnyPermission } from '../middleware/auth.ts';
-import { standardErrorResponses } from '../schemas/common.ts';
+import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
 import {
   bumpNamespaceVersion,
   cacheGetSetJson,
@@ -9,6 +9,7 @@ import {
   shouldBypassCache,
   TTL_LIST_SECONDS,
 } from '../services/cache.ts';
+import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
   parseBoolean,
@@ -90,6 +91,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
+      config: {
+        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
+      },
       onRequest: [
         requireAnyPermission(
           'catalog.internal_listing.view',
@@ -107,7 +111,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         summary: 'List products',
         response: {
           200: { type: 'array', items: productSchema },
-          ...standardErrorResponses,
+          ...standardRateLimitedErrorResponses,
         },
       },
     },

--- a/server/routes/projects.ts
+++ b/server/routes/projects.ts
@@ -1,7 +1,11 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { query } from '../db/index.ts';
 import { authenticateToken, requireAnyPermission, requirePermission } from '../middleware/auth.ts';
-import { messageResponseSchema, standardErrorResponses } from '../schemas/common.ts';
+import {
+  messageResponseSchema,
+  standardErrorResponses,
+  standardRateLimitedErrorResponses,
+} from '../schemas/common.ts';
 import {
   bumpNamespaceVersion,
   cacheGetSetJson,
@@ -10,6 +14,7 @@ import {
   TTL_LIST_SECONDS,
 } from '../services/cache.ts';
 import { assertAuthenticated } from '../utils/auth-assert.ts';
+import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import { badRequest, requireNonEmptyString, validateHexColor } from '../utils/validation.ts';
 
 const idParamSchema = {
@@ -69,6 +74,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
+      config: {
+        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
+      },
       onRequest: [
         authenticateToken,
         requireAnyPermission(
@@ -83,7 +91,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         summary: 'List projects',
         response: {
           200: { type: 'array', items: projectSchema },
-          ...standardErrorResponses,
+          ...standardRateLimitedErrorResponses,
         },
       },
     },

--- a/server/routes/reports.ts
+++ b/server/routes/reports.ts
@@ -3,7 +3,7 @@ import { createHash, randomUUID } from 'crypto';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { query as dbQuery } from '../db/index.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
-import { standardErrorResponses } from '../schemas/common.ts';
+import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
 import {
   bumpNamespaceVersion,
   cacheGetSetJson,
@@ -12,6 +12,8 @@ import {
   TTL_ENTRIES_SECONDS,
   TTL_LIST_SECONDS,
 } from '../services/cache.ts';
+import { normalizeGeminiModelPath } from '../utils/ai-models.ts';
+import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import { badRequest, optionalNonEmptyString, requireNonEmptyString } from '../utils/validation.ts';
 
 type AiProvider = 'gemini' | 'openrouter';
@@ -71,12 +73,6 @@ const resolveProviderKeyModel = (cfg: GeneralAiConfig) => {
     };
   }
   return { provider: 'gemini' as const, apiKey: cfg.geminiApiKey, modelId: cfg.geminiModelId };
-};
-
-const normalizeGeminiModelPath = (modelId: string) => {
-  const trimmed = modelId.trim();
-  if (trimmed.startsWith('models/') || trimmed.startsWith('tunedModels/')) return trimmed;
-  return `models/${trimmed}`;
 };
 
 type AiTextResult = { text: string; thoughtContent?: string };
@@ -254,8 +250,15 @@ const buildSessionTitlePrompt = (firstUserMessage: string, language: UiLanguage)
 };
 
 const geminiGenerateText = async (apiKey: string, modelId: string, prompt: string) => {
-  const path = normalizeGeminiModelPath(modelId);
-  const url = `https://generativelanguage.googleapis.com/v1beta/${path}:generateContent?key=${encodeURIComponent(apiKey)}`;
+  const modelPathResult = normalizeGeminiModelPath(modelId);
+  if (!modelPathResult.ok) {
+    throw new Error(modelPathResult.message);
+  }
+  const url = new URL(
+    `/v1beta/${modelPathResult.value}:generateContent`,
+    'https://generativelanguage.googleapis.com',
+  );
+  url.searchParams.set('key', apiKey);
   const res = await fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -298,8 +301,16 @@ const geminiGenerateTextStream = async (
   callbacks: AiStreamCallbacks = {},
   signal?: AbortSignal,
 ) => {
-  const path = normalizeGeminiModelPath(modelId);
-  const url = `https://generativelanguage.googleapis.com/v1beta/${path}:streamGenerateContent?alt=sse&key=${encodeURIComponent(apiKey)}`;
+  const modelPathResult = normalizeGeminiModelPath(modelId);
+  if (!modelPathResult.ok) {
+    throw new Error(modelPathResult.message);
+  }
+  const url = new URL(
+    `/v1beta/${modelPathResult.value}:streamGenerateContent`,
+    'https://generativelanguage.googleapis.com',
+  );
+  url.searchParams.set('alt', 'sse');
+  url.searchParams.set('key', apiKey);
   const res = await fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -2920,13 +2931,16 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/ai-reporting/sessions',
     {
+      config: {
+        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
+      },
       onRequest: [requirePermission('reports.ai_reporting.view')],
       schema: {
         tags: ['reports'],
         summary: 'List AI Reporting chat sessions for the current user',
         response: {
           200: { type: 'array', items: sessionSummarySchema },
-          ...standardErrorResponses,
+          ...standardRateLimitedErrorResponses,
         },
       },
     },

--- a/server/routes/settings.ts
+++ b/server/routes/settings.ts
@@ -2,7 +2,11 @@ import bcrypt from 'bcryptjs';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { query } from '../db/index.ts';
 import { authenticateToken } from '../middleware/auth.ts';
-import { messageResponseSchema, standardErrorResponses } from '../schemas/common.ts';
+import {
+  messageResponseSchema,
+  standardErrorResponses,
+  standardRateLimitedErrorResponses,
+} from '../schemas/common.ts';
 import {
   bumpNamespaceVersion,
   cacheGetSetJson,
@@ -11,6 +15,7 @@ import {
   TTL_USER_SETTINGS_SECONDS,
 } from '../services/cache.ts';
 import { assertAuthenticated } from '../utils/auth-assert.ts';
+import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
   optionalEmail,
@@ -51,13 +56,16 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
+      config: {
+        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
+      },
       onRequest: [authenticateToken],
       schema: {
         tags: ['settings'],
         summary: 'Get current user settings',
         response: {
           200: settingsSchema,
-          ...standardErrorResponses,
+          ...standardRateLimitedErrorResponses,
         },
       },
     },

--- a/server/routes/special-bids.ts
+++ b/server/routes/special-bids.ts
@@ -1,7 +1,8 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { query } from '../db/index.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
-import { standardErrorResponses } from '../schemas/common.ts';
+import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
+import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
   optionalDateString,
@@ -92,13 +93,16 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
+      config: {
+        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
+      },
       onRequest: [requirePermission('catalog.special_bids.view')],
       schema: {
         tags: ['special-bids'],
         summary: 'List special bids',
         response: {
           200: { type: 'array', items: specialBidSchema },
-          ...standardErrorResponses,
+          ...standardRateLimitedErrorResponses,
         },
       },
     },

--- a/server/routes/supplier-invoices.ts
+++ b/server/routes/supplier-invoices.ts
@@ -1,7 +1,8 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { query } from '../db/index.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
-import { standardErrorResponses } from '../schemas/common.ts';
+import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
+import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
   optionalDateString,
@@ -326,13 +327,16 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
+      config: {
+        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
+      },
       onRequest: [requirePermission('accounting.supplier_invoices.view')],
       schema: {
         tags: ['supplier-invoices'],
         summary: 'List supplier invoices',
         response: {
           200: { type: 'array', items: invoiceSchema },
-          ...standardErrorResponses,
+          ...standardRateLimitedErrorResponses,
         },
       },
     },

--- a/server/routes/supplier-offers.ts
+++ b/server/routes/supplier-offers.ts
@@ -1,7 +1,8 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { query } from '../db/index.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
-import { rateLimitErrorResponseSchema, standardErrorResponses } from '../schemas/common.ts';
+import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
+import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
   optionalDateString,
@@ -191,10 +192,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
     '/',
     {
       config: {
-        rateLimit: {
-          max: 120,
-          timeWindow: '1 minute',
-        },
+        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
       },
       onRequest: [requirePermission('sales.supplier_offers.view')],
       schema: {
@@ -202,8 +200,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         summary: 'List supplier offers',
         response: {
           200: { type: 'array', items: offerSchema },
-          429: rateLimitErrorResponseSchema,
-          ...standardErrorResponses,
+          ...standardRateLimitedErrorResponses,
         },
       },
     },

--- a/server/routes/supplier-offers.ts
+++ b/server/routes/supplier-offers.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { query } from '../db/index.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
-import { standardErrorResponses } from '../schemas/common.ts';
+import { rateLimitErrorResponseSchema, standardErrorResponses } from '../schemas/common.ts';
 import {
   badRequest,
   optionalDateString,
@@ -190,12 +190,19 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
+      config: {
+        rateLimit: {
+          max: 120,
+          timeWindow: '1 minute',
+        },
+      },
       onRequest: [requirePermission('sales.supplier_offers.view')],
       schema: {
         tags: ['supplier-offers'],
         summary: 'List supplier offers',
         response: {
           200: { type: 'array', items: offerSchema },
+          429: rateLimitErrorResponseSchema,
           ...standardErrorResponses,
         },
       },

--- a/server/routes/supplier-orders.ts
+++ b/server/routes/supplier-orders.ts
@@ -1,7 +1,8 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { query } from '../db/index.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
-import { rateLimitErrorResponseSchema, standardErrorResponses } from '../schemas/common.ts';
+import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
+import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
   optionalLocalizedNonNegativeNumber,
@@ -181,10 +182,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
     '/',
     {
       config: {
-        rateLimit: {
-          max: 120,
-          timeWindow: '1 minute',
-        },
+        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
       },
       onRequest: [requirePermission('accounting.supplier_orders.view')],
       schema: {
@@ -192,8 +190,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         summary: 'List supplier sale orders',
         response: {
           200: { type: 'array', items: orderSchema },
-          429: rateLimitErrorResponseSchema,
-          ...standardErrorResponses,
+          ...standardRateLimitedErrorResponses,
         },
       },
     },

--- a/server/routes/supplier-orders.ts
+++ b/server/routes/supplier-orders.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { query } from '../db/index.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
-import { standardErrorResponses } from '../schemas/common.ts';
+import { rateLimitErrorResponseSchema, standardErrorResponses } from '../schemas/common.ts';
 import {
   badRequest,
   optionalLocalizedNonNegativeNumber,
@@ -180,12 +180,19 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
+      config: {
+        rateLimit: {
+          max: 120,
+          timeWindow: '1 minute',
+        },
+      },
       onRequest: [requirePermission('accounting.supplier_orders.view')],
       schema: {
         tags: ['supplier-orders'],
         summary: 'List supplier sale orders',
         response: {
           200: { type: 'array', items: orderSchema },
+          429: rateLimitErrorResponseSchema,
           ...standardErrorResponses,
         },
       },

--- a/server/routes/supplier-quotes.ts
+++ b/server/routes/supplier-quotes.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { query } from '../db/index.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
-import { standardErrorResponses } from '../schemas/common.ts';
+import { rateLimitErrorResponseSchema, standardErrorResponses } from '../schemas/common.ts';
 import {
   badRequest,
   optionalDateString,
@@ -127,12 +127,19 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
+      config: {
+        rateLimit: {
+          max: 120,
+          timeWindow: '1 minute',
+        },
+      },
       onRequest: [requirePermission('sales.supplier_quotes.view')],
       schema: {
         tags: ['supplier-quotes'],
         summary: 'List supplier quotes',
         response: {
           200: { type: 'array', items: supplierQuoteSchema },
+          429: rateLimitErrorResponseSchema,
           ...standardErrorResponses,
         },
       },

--- a/server/routes/supplier-quotes.ts
+++ b/server/routes/supplier-quotes.ts
@@ -1,7 +1,8 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { query } from '../db/index.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
-import { rateLimitErrorResponseSchema, standardErrorResponses } from '../schemas/common.ts';
+import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
+import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
   optionalDateString,
@@ -128,10 +129,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
     '/',
     {
       config: {
-        rateLimit: {
-          max: 120,
-          timeWindow: '1 minute',
-        },
+        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
       },
       onRequest: [requirePermission('sales.supplier_quotes.view')],
       schema: {
@@ -139,8 +137,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         summary: 'List supplier quotes',
         response: {
           200: { type: 'array', items: supplierQuoteSchema },
-          429: rateLimitErrorResponseSchema,
-          ...standardErrorResponses,
+          ...standardRateLimitedErrorResponses,
         },
       },
     },

--- a/server/routes/suppliers.ts
+++ b/server/routes/suppliers.ts
@@ -1,7 +1,8 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { query } from '../db/index.ts';
 import { authenticateToken, requireAnyPermission, requirePermission } from '../middleware/auth.ts';
-import { standardErrorResponses } from '../schemas/common.ts';
+import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
+import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
   optionalEmail,
@@ -77,6 +78,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
+      config: {
+        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
+      },
       onRequest: [
         requireAnyPermission(
           'crm.suppliers.view',
@@ -93,7 +97,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         summary: 'List suppliers',
         response: {
           200: { type: 'array', items: supplierSchema },
-          ...standardErrorResponses,
+          ...standardRateLimitedErrorResponses,
         },
       },
     },

--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -1,7 +1,11 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { query } from '../db/index.ts';
 import { authenticateToken, requireAnyPermission, requirePermission } from '../middleware/auth.ts';
-import { messageResponseSchema, standardErrorResponses } from '../schemas/common.ts';
+import {
+  messageResponseSchema,
+  standardErrorResponses,
+  standardRateLimitedErrorResponses,
+} from '../schemas/common.ts';
 import {
   bumpNamespaceVersion,
   cacheGetSetJson,
@@ -10,6 +14,7 @@ import {
   TTL_LIST_SECONDS,
 } from '../services/cache.ts';
 import { assertAuthenticated } from '../utils/auth-assert.ts';
+import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
   optionalDateString,
@@ -95,6 +100,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
+      config: {
+        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
+      },
       onRequest: [
         authenticateToken,
         requireAnyPermission(
@@ -109,7 +117,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         summary: 'List tasks',
         response: {
           200: { type: 'array', items: taskSchema },
-          ...standardErrorResponses,
+          ...standardRateLimitedErrorResponses,
         },
       },
     },

--- a/server/routes/users.ts
+++ b/server/routes/users.ts
@@ -3,7 +3,11 @@ import { randomUUID } from 'crypto';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { query } from '../db/index.ts';
 import { authenticateToken, requireAnyPermission, requirePermission } from '../middleware/auth.ts';
-import { messageResponseSchema, standardErrorResponses } from '../schemas/common.ts';
+import {
+  messageResponseSchema,
+  standardErrorResponses,
+  standardRateLimitedErrorResponses,
+} from '../schemas/common.ts';
 import {
   bumpNamespaceVersion,
   cacheGetSetJson,
@@ -12,6 +16,7 @@ import {
   TTL_LIST_SECONDS,
 } from '../services/cache.ts';
 import { assertAuthenticated } from '../utils/auth-assert.ts';
+import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
   ensureArrayOfStrings,
@@ -128,6 +133,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
+      config: {
+        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
+      },
       onRequest: [
         authenticateToken,
         requireAnyPermission(
@@ -146,7 +154,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         summary: 'List users',
         response: {
           200: { type: 'array', items: userSchema },
-          ...standardErrorResponses,
+          ...standardRateLimitedErrorResponses,
         },
       },
     },

--- a/server/schemas/common.ts
+++ b/server/schemas/common.ts
@@ -31,3 +31,8 @@ export const standardErrorResponses = {
   404: errorResponseSchema,
   409: errorResponseSchema,
 } as const;
+
+export const standardRateLimitedErrorResponses = {
+  429: rateLimitErrorResponseSchema,
+  ...standardErrorResponses,
+} as const;

--- a/server/schemas/common.ts
+++ b/server/schemas/common.ts
@@ -22,6 +22,8 @@ export const successResponseSchema = {
   required: ['success'],
 } as const;
 
+export const rateLimitErrorResponseSchema = errorResponseSchema;
+
 export const standardErrorResponses = {
   400: errorResponseSchema,
   401: errorResponseSchema,

--- a/server/services/email.ts
+++ b/server/services/email.ts
@@ -157,7 +157,7 @@ class EmailService {
         to,
         subject,
         html,
-        text: text || html.replace(/<[^>]*>/g, ''), // Strip HTML for text version
+        text: text || 'This email contains HTML content. Open it in an HTML-capable email client.',
       });
 
       return {
@@ -182,6 +182,14 @@ class EmailService {
     messageId?: string;
   }> {
     const subject = 'Praetor Email Configuration Test';
+    const text = [
+      'Praetor Email Configuration Test',
+      '',
+      'This is a test email from your Praetor installation.',
+      "If you're receiving this email, your SMTP configuration is working correctly.",
+      '',
+      `Sent from Praetor at ${new Date().toISOString()}`,
+    ].join('\n');
     const html = `
       <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
         <h2 style="color: #334155;">Email Configuration Test</h2>
@@ -194,7 +202,7 @@ class EmailService {
       </div>
     `;
 
-    return this.sendEmail(recipientEmail, subject, html);
+    return this.sendEmail(recipientEmail, subject, html, text);
   }
 }
 

--- a/server/services/ldap.ts
+++ b/server/services/ldap.ts
@@ -29,7 +29,7 @@ interface LdapClient {
   unbind: (callback: (err?: Error) => void) => void;
   search: (
     base: string,
-    options: { scope: string; filter: string; attributes?: string[] },
+    options: { scope: string; filter: unknown; attributes?: string[] },
     callback: (err: Error | null, res: LdapSearchResult) => void,
   ) => void;
 }
@@ -48,6 +48,15 @@ interface LdapSearchEntry {
   objectName: string;
   object: Record<string, unknown>;
 }
+
+const escapeLdapFilterValue = (value: string) =>
+  value
+    .replace(/\\/g, '\\5c')
+    .replace(/\*/g, '\\2a')
+    .replace(/\(/g, '\\28')
+    .replace(/\)/g, '\\29')
+    .split('\0')
+    .join('\\00');
 
 class LDAPService {
   config: LdapConfig | null;
@@ -156,10 +165,12 @@ class LDAPService {
     if (!config) {
       return null;
     }
-    const filter = config.user_filter.replace('{0}', username);
+    const filter = ldap.parseFilter(
+      config.user_filter.replace('{0}', escapeLdapFilterValue(username)),
+    );
     const searchOptions = {
       scope: 'sub',
-      filter: filter,
+      filter,
     };
 
     return new Promise((resolve, reject) => {

--- a/server/utils/ai-models.ts
+++ b/server/utils/ai-models.ts
@@ -1,0 +1,39 @@
+const GEMINI_ALLOWED_PREFIXES = new Set(['models', 'tunedModels']);
+const GEMINI_MODEL_SEGMENT_PATTERN = /^[A-Za-z0-9._-]+$/;
+
+const invalidModelId = (message: string) => ({ ok: false as const, message });
+
+export const normalizeGeminiModelPath = (modelId: string) => {
+  const trimmed = modelId.trim();
+  if (!trimmed) return invalidModelId('modelId is required');
+  if (/\s/.test(trimmed)) {
+    return invalidModelId('modelId must not contain whitespace');
+  }
+  if (
+    trimmed.includes('..') ||
+    trimmed.includes('?') ||
+    trimmed.includes('#') ||
+    trimmed.includes('%') ||
+    trimmed.includes(':')
+  ) {
+    return invalidModelId('modelId contains invalid characters');
+  }
+
+  const parts = trimmed.split('/');
+  if (parts.length === 1) {
+    if (!GEMINI_MODEL_SEGMENT_PATTERN.test(parts[0])) {
+      return invalidModelId('modelId contains invalid characters');
+    }
+    return { ok: true as const, value: `models/${parts[0]}` };
+  }
+
+  if (
+    parts.length === 2 &&
+    GEMINI_ALLOWED_PREFIXES.has(parts[0]) &&
+    GEMINI_MODEL_SEGMENT_PATTERN.test(parts[1])
+  ) {
+    return { ok: true as const, value: `${parts[0]}/${parts[1]}` };
+  }
+
+  return invalidModelId('modelId must use a supported Gemini model path');
+};

--- a/server/utils/rate-limit.ts
+++ b/server/utils/rate-limit.ts
@@ -1,0 +1,14 @@
+export const GLOBAL_RATE_LIMIT = {
+  max: 1000,
+  timeWindow: '1 minute',
+} as const;
+
+export const STANDARD_ROUTE_RATE_LIMIT = {
+  max: 120,
+  timeWindow: '1 minute',
+} as const;
+
+export const LOGIN_RATE_LIMIT = {
+  max: 10,
+  timeWindow: '15 minutes',
+} as const;

--- a/server/utils/validation.ts
+++ b/server/utils/validation.ts
@@ -433,8 +433,24 @@ export function badRequest(reply: FastifyReply, message: string): FastifyReply {
  * Validate email format (basic regex)
  */
 export function isValidEmail(value: string): boolean {
-  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-  return emailRegex.test(value);
+  if (value !== value.trim()) return false;
+  if (!value || /\s/.test(value)) return false;
+
+  const atIndex = value.indexOf('@');
+  if (atIndex <= 0 || atIndex !== value.lastIndexOf('@')) return false;
+
+  const localPart = value.slice(0, atIndex);
+  const domainPart = value.slice(atIndex + 1);
+  if (!localPart || !domainPart) return false;
+  if (localPart.startsWith('.') || localPart.endsWith('.')) return false;
+  if (localPart.includes('..') || domainPart.includes('..')) return false;
+  if (!domainPart.includes('.')) return false;
+
+  const domainLabels = domainPart.split('.');
+  if (domainLabels.some((label) => !label)) return false;
+  if (domainLabels.some((label) => label.startsWith('-') || label.endsWith('-'))) return false;
+
+  return true;
 }
 
 export function validateEmail(


### PR DESCRIPTION
## Summary
- add app-wide and route-specific rate limiting for all remaining CodeQL-hit routes
- harden Gemini model path handling, LDAP filter construction, email/text fallback, and frontend sanitization helpers
- regenerate the OpenAPI spec for the new 429 responses

## Validation
- cd server && bun run build
- bun run build
- bun run lint
- bun run docs:api