### PR TITLE
fix(security): finalize remaining CodeQL follow-ups

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -33,7 +33,6 @@ import tasksRoutes from './routes/tasks.ts';
 import usersRoutes from './routes/users.ts';
 import workUnitsRoutes from './routes/work-units.ts';
 import { loggerOptions, serializeError } from './utils/logger.ts';
-import { GLOBAL_RATE_LIMIT } from './utils/rate-limit.ts';
 
 dotenv.config();
 
@@ -46,9 +45,8 @@ export const buildApp = async () => {
   });
 
   await fastify.register(rateLimit, {
-    global: true,
+    global: false,
     hook: 'onRequest',
-    ...GLOBAL_RATE_LIMIT,
     errorResponseBuilder: () => ({
       error: 'Too many requests',
     }),
@@ -108,9 +106,6 @@ export const buildApp = async () => {
   fastify.get(
     '/api/health',
     {
-      config: {
-        rateLimit: false,
-      },
       schema: {
         tags: ['health'],
         summary: 'Health check',

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -100,9 +100,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.post(
     '/login',
     {
-      config: {
-        rateLimit: LOGIN_RATE_LIMIT,
-      },
+      onRequest: fastify.rateLimit(LOGIN_RATE_LIMIT),
       schema: {
         tags: ['auth'],
         summary: 'Login',

--- a/server/routes/client-offers.ts
+++ b/server/routes/client-offers.ts
@@ -224,10 +224,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
-      config: {
-        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
-      },
-      onRequest: [requirePermission('sales.client_offers.view')],
+      onRequest: [
+        fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
+        requirePermission('sales.client_offers.view'),
+      ],
       schema: {
         tags: ['client-offers'],
         summary: 'List client offers',

--- a/server/routes/client-quotes.ts
+++ b/server/routes/client-quotes.ts
@@ -383,10 +383,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
-      config: {
-        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
-      },
-      onRequest: [requirePermission('sales.client_quotes.view')],
+      onRequest: [
+        fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
+        requirePermission('sales.client_quotes.view'),
+      ],
       schema: {
         tags: ['client-quotes'],
         summary: 'List client quotes',

--- a/server/routes/clients-orders.ts
+++ b/server/routes/clients-orders.ts
@@ -159,10 +159,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
-      config: {
-        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
-      },
-      onRequest: [requirePermission('accounting.clients_orders.view')],
+      onRequest: [
+        fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
+        requirePermission('accounting.clients_orders.view'),
+      ],
       schema: {
         tags: ['clients-orders'],
         summary: 'List client orders',

--- a/server/routes/clients.ts
+++ b/server/routes/clients.ts
@@ -229,10 +229,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
-      config: {
-        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
-      },
       onRequest: [
+        fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
         authenticateToken,
         requireAnyPermission(
           'crm.clients.view',

--- a/server/routes/entries.ts
+++ b/server/routes/entries.ts
@@ -124,10 +124,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
-      config: {
-        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
-      },
-      onRequest: [authenticateToken, requirePermission('timesheets.tracker.view')],
+      onRequest: [
+        fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
+        authenticateToken,
+        requirePermission('timesheets.tracker.view'),
+      ],
       schema: {
         tags: ['entries'],
         summary: 'List time entries',
@@ -556,10 +557,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.delete(
     '/',
     {
-      config: {
-        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
-      },
       onRequest: [
+        fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
         authenticateToken,
         requireAnyPermission('timesheets.tracker.delete', 'timesheets.recurring.delete'),
       ],

--- a/server/routes/expenses.ts
+++ b/server/routes/expenses.ts
@@ -74,10 +74,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
-      config: {
-        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
-      },
-      onRequest: [requirePermission('finances.expenses.view')],
+      onRequest: [
+        fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
+        requirePermission('finances.expenses.view'),
+      ],
       schema: {
         tags: ['expenses'],
         summary: 'List expenses',

--- a/server/routes/invoices.ts
+++ b/server/routes/invoices.ts
@@ -140,10 +140,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
-      config: {
-        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
-      },
-      onRequest: [requirePermission('accounting.clients_invoices.view')],
+      onRequest: [
+        fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
+        requirePermission('accounting.clients_invoices.view'),
+      ],
       schema: {
         tags: ['invoices'],
         summary: 'List invoices',

--- a/server/routes/notifications.ts
+++ b/server/routes/notifications.ts
@@ -49,10 +49,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
-      config: {
-        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
-      },
-      onRequest: [requirePermission('notifications.view')],
+      onRequest: [
+        fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
+        requirePermission('notifications.view'),
+      ],
       schema: {
         tags: ['notifications'],
         summary: 'Fetch notifications',

--- a/server/routes/payments.ts
+++ b/server/routes/payments.ts
@@ -70,10 +70,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
-      config: {
-        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
-      },
-      onRequest: [requirePermission('finances.payments.view')],
+      onRequest: [
+        fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
+        requirePermission('finances.payments.view'),
+      ],
       schema: {
         tags: ['payments'],
         summary: 'List payments',

--- a/server/routes/products.ts
+++ b/server/routes/products.ts
@@ -91,10 +91,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
-      config: {
-        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
-      },
       onRequest: [
+        fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
         requireAnyPermission(
           'catalog.internal_listing.view',
           'catalog.external_listing.view',

--- a/server/routes/projects.ts
+++ b/server/routes/projects.ts
@@ -74,10 +74,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
-      config: {
-        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
-      },
       onRequest: [
+        fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
         authenticateToken,
         requireAnyPermission(
           'projects.manage.view',

--- a/server/routes/reports.ts
+++ b/server/routes/reports.ts
@@ -2931,10 +2931,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/ai-reporting/sessions',
     {
-      config: {
-        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
-      },
-      onRequest: [requirePermission('reports.ai_reporting.view')],
+      onRequest: [
+        fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
+        requirePermission('reports.ai_reporting.view'),
+      ],
       schema: {
         tags: ['reports'],
         summary: 'List AI Reporting chat sessions for the current user',

--- a/server/routes/settings.ts
+++ b/server/routes/settings.ts
@@ -56,10 +56,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
-      config: {
-        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
-      },
-      onRequest: [authenticateToken],
+      onRequest: [fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT), authenticateToken],
       schema: {
         tags: ['settings'],
         summary: 'Get current user settings',

--- a/server/routes/special-bids.ts
+++ b/server/routes/special-bids.ts
@@ -93,10 +93,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
-      config: {
-        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
-      },
-      onRequest: [requirePermission('catalog.special_bids.view')],
+      onRequest: [
+        fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
+        requirePermission('catalog.special_bids.view'),
+      ],
       schema: {
         tags: ['special-bids'],
         summary: 'List special bids',

--- a/server/routes/supplier-invoices.ts
+++ b/server/routes/supplier-invoices.ts
@@ -327,10 +327,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
-      config: {
-        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
-      },
-      onRequest: [requirePermission('accounting.supplier_invoices.view')],
+      onRequest: [
+        fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
+        requirePermission('accounting.supplier_invoices.view'),
+      ],
       schema: {
         tags: ['supplier-invoices'],
         summary: 'List supplier invoices',

--- a/server/routes/supplier-offers.ts
+++ b/server/routes/supplier-offers.ts
@@ -191,10 +191,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
-      config: {
-        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
-      },
-      onRequest: [requirePermission('sales.supplier_offers.view')],
+      onRequest: [
+        fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
+        requirePermission('sales.supplier_offers.view'),
+      ],
       schema: {
         tags: ['supplier-offers'],
         summary: 'List supplier offers',

--- a/server/routes/supplier-orders.ts
+++ b/server/routes/supplier-orders.ts
@@ -181,10 +181,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
-      config: {
-        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
-      },
-      onRequest: [requirePermission('accounting.supplier_orders.view')],
+      onRequest: [
+        fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
+        requirePermission('accounting.supplier_orders.view'),
+      ],
       schema: {
         tags: ['supplier-orders'],
         summary: 'List supplier sale orders',

--- a/server/routes/supplier-quotes.ts
+++ b/server/routes/supplier-quotes.ts
@@ -128,10 +128,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
-      config: {
-        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
-      },
-      onRequest: [requirePermission('sales.supplier_quotes.view')],
+      onRequest: [
+        fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
+        requirePermission('sales.supplier_quotes.view'),
+      ],
       schema: {
         tags: ['supplier-quotes'],
         summary: 'List supplier quotes',

--- a/server/routes/suppliers.ts
+++ b/server/routes/suppliers.ts
@@ -78,10 +78,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
-      config: {
-        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
-      },
       onRequest: [
+        fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
         requireAnyPermission(
           'crm.suppliers.view',
           'crm.suppliers_all.view',

--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -100,10 +100,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
-      config: {
-        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
-      },
       onRequest: [
+        fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
         authenticateToken,
         requireAnyPermission(
           'projects.tasks.view',

--- a/server/routes/users.ts
+++ b/server/routes/users.ts
@@ -133,10 +133,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
-      config: {
-        rateLimit: STANDARD_ROUTE_RATE_LIMIT,
-      },
       onRequest: [
+        fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
         authenticateToken,
         requireAnyPermission(
           'administration.user_management.view',

--- a/server/services/ldap.ts
+++ b/server/services/ldap.ts
@@ -49,14 +49,10 @@ interface LdapSearchEntry {
   object: Record<string, unknown>;
 }
 
-const escapeLdapFilterValue = (value: string) =>
-  value
-    .replace(/\\/g, '\\5c')
-    .replace(/\*/g, '\\2a')
-    .replace(/\(/g, '\\28')
-    .replace(/\)/g, '\\29')
-    .split('\0')
-    .join('\\00');
+const getUserFilterAttribute = (userFilter: string) => {
+  const match = /^\(\s*([A-Za-z][A-Za-z0-9-]*)\s*=\s*\{0\}\s*\)$/.exec(userFilter.trim());
+  return match?.[1] || null;
+};
 
 class LDAPService {
   config: LdapConfig | null;
@@ -165,12 +161,16 @@ class LDAPService {
     if (!config) {
       return null;
     }
-    const filter = ldap.parseFilter(
-      config.user_filter.replace('{0}', escapeLdapFilterValue(username)),
-    );
+    const attribute = getUserFilterAttribute(config.user_filter);
+    if (!attribute) {
+      throw new Error('LDAP user_filter must use a simple equality template such as (uid={0})');
+    }
     const searchOptions = {
       scope: 'sub',
-      filter,
+      filter: new ldap.EqualityFilter({
+        attribute,
+        value: username,
+      }),
     };
 
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary
- move the remaining flagged routes to explicit route-level Fastify rate limiting hooks
- remove the global/config-only rate limit pattern that CodeQL still reported on main
- tighten LDAP user lookup to a structured equality filter

## Validation
- cd server && bun run build
- bun run build
- bun run lint
- bun run docs:api