### PR TITLE
fix(seed): improve demo seeding reliability

### DIFF
--- a/server/db/seed.sql
+++ b/server/db/seed.sql
@@ -43,7 +43,8 @@ ON CONFLICT (user_id) DO NOTHING;
 -- Refreshable demo dataset.
 -- Demo records intentionally use dm_* ids and DM-* business codes so reseeding restores the
 -- curated showcase rows in place without deleting non-demo records that reference demo entities.
-BEGIN;
+-- NOTE: No explicit transaction wrapper — the app layer executes each statement independently
+-- so that a single table failure does not roll back the entire seed.
 
 INSERT INTO clients (
     id,
@@ -1321,5 +1322,3 @@ ON CONFLICT (id) DO UPDATE SET
     data = EXCLUDED.data,
     is_read = EXCLUDED.is_read,
     created_at = EXCLUDED.created_at;
-
-COMMIT;

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,7 +1,7 @@
 import bcrypt from 'bcryptjs';
 import { randomUUID } from 'crypto';
 import buildApp from './app.ts';
-import { query } from './db/index.ts';
+import pool, { query } from './db/index.ts';
 import { closeRedis } from './services/redis.ts';
 import { createChildLogger, serializeError } from './utils/logger.ts';
 
@@ -167,8 +167,37 @@ try {
     const isDemoSeedingEnabled = parseBooleanEnv(process.env.DEMO_SEEDING);
     if (isDemoSeedingEnabled && fs.existsSync(seedPath)) {
       const seedSql = fs.readFileSync(seedPath, 'utf8');
-      await query(seedSql);
-      logger.info('Demo seed data applied');
+      const statements = seedSql
+        .split(/;\s*\n/)
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0 && !s.startsWith('--'));
+
+      let succeeded = 0;
+      let failed = 0;
+      const failedTables: string[] = [];
+      const client = await pool.connect();
+      try {
+        for (const stmt of statements) {
+          try {
+            await client.query(stmt);
+            succeeded++;
+          } catch (err) {
+            failed++;
+            const tableMatch = stmt.match(/INSERT\s+INTO\s+(\S+)/i);
+            const table = tableMatch ? tableMatch[1] : 'unknown';
+            failedTables.push(table);
+            logger.warn({ err: serializeError(err), table }, 'Seed statement failed');
+          }
+        }
+      } finally {
+        client.release();
+      }
+
+      if (failed === 0) {
+        logger.info({ statements: succeeded }, 'Demo seed data applied successfully');
+      } else {
+        logger.warn({ succeeded, failed, failedTables }, 'Demo seed data applied with errors');
+      }
     } else if (isDemoSeedingEnabled) {
       logger.warn({ seedPath }, 'Demo seeding requested but seed file not found');
     } else {


### PR DESCRIPTION
## Summary

- **Expanded demo seed data** with comprehensive business entities (clients, suppliers, products, quotes, offers, orders, invoices, expenses, projects, notifications) using `DM-*` prefixed codes for non-destructive reseeding
- **Fixed silent seed rollback** — the seed SQL was wrapped in `BEGIN/COMMIT`, causing the entire seed to silently roll back if any single INSERT failed. Now each statement is executed independently with per-table error logging
- **Made reseeding idempotent** — uses `ON CONFLICT DO UPDATE` so restarting the backend restores curated demo rows without duplicates or deleting user-created data
- **Security hardening** — added rate limiting across all routes, LDAP filter sanitization, proxy trust configuration, and CodeQL-aligned imports
- **UI fixes** — renamed sales component folder, aligned supplier views with client order styles, restored supplier table controls, and completed i18n translations

## Test plan

- [ ] `docker compose up -d --build` with `DEMO_SEEDING=true`
- [ ] Check backend logs for "Demo seed data applied successfully" (or per-table warnings if any fail)
- [ ] Navigate to Clients, Suppliers, Products, Quotes, Offers, Orders, Invoices — verify `DM-*` prefixed demo records appear
- [ ] Restart backend (`docker compose restart backend`) — verify reseeding is idempotent (no errors, no duplicates)
- [ ] Verify rate limiting is active on API routes
- [ ] Verify LDAP authentication still works with special characters in usernames

🤖 Generated with [Claude Code](https://claude.com/claude-code)