### PR TITLE
fix(seed): stop comment filter from dropping SQL statements

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -170,7 +170,7 @@ try {
       const statements = seedSql
         .split(/;\s*\n/)
         .map((s) => s.trim())
-        .filter((s) => s.length > 0 && !s.startsWith('--'));
+        .filter((s) => s.length > 0 && /\S/m.test(s.replace(/--.*$/gm, '')));
 
       let succeeded = 0;
       let failed = 0;


### PR DESCRIPTION
## Summary

- Fixes a bug introduced in #27 where the statement-splitting filter (`!s.startsWith('--')`) silently discarded any SQL chunk that began with comment lines
- This dropped the `INSERT INTO users`, `INSERT INTO user_roles`, `INSERT INTO clients` (both lightweight and demo) statements, causing all downstream FK-dependent inserts (quotes, offers, orders, invoices) to also fail
- The filter now strips `-- ...` comments before checking if the chunk contains actual SQL content

## Test plan

- [ ] `docker compose up -d --build` with `DEMO_SEEDING=true`
- [ ] Backend logs show `Demo seed data applied successfully` with no failed tables
- [ ] Verify demo users exist (admin/manager/user can all log in)
- [ ] Verify demo clients appear in Clients view (DM-CLI-001 through DM-CLI-005)
- [ ] Verify demo quotes, offers, orders, and invoices are populated in their respective views

🤖 Generated with [Claude Code](https://claude.com/claude-code)