### PR TITLE
fix(demo): make demo seed refresh-safe

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,9 @@ LOG_LEVEL=info
 # Pretty logs are enabled by default outside production; set explicitly if needed.
 # LOG_PRETTY=true
 
-# Optional demo data seeding on backend startup
+# Optional demo refresh on backend startup.
+# When true, the backend provisions the demo manager/user credentials plus the canonical
+# demo business dataset. Intended for demo/test Docker stacks and reused volumes.
 DEMO_SEEDING=false
 
 # Default password for bootstrap admin user (username: admin)

--- a/App.tsx
+++ b/App.tsx
@@ -94,6 +94,13 @@ const getCurrencySymbol = (currency: string) => {
   }
 };
 
+type ModuleLoadErrors = Partial<Record<string, string[]>>;
+
+const getErrorMessage = (error: unknown) => {
+  if (error instanceof Error && error.message) return error.message;
+  return 'Unknown error';
+};
+
 const getModuleFromView = (view: View | '404'): string | null => {
   if (view === '404') return null;
   if (view.startsWith('timesheets/')) return 'timesheets';
@@ -600,6 +607,7 @@ const App: React.FC = () => {
     language: 'auto',
   });
   const [loadedModules, setLoadedModules] = useState<Set<string>>(new Set());
+  const [moduleLoadErrors, setModuleLoadErrors] = useState<ModuleLoadErrors>({});
   const [hasLoadedGeneralSettings, setHasLoadedGeneralSettings] = useState(false);
   const [hasLoadedLdapConfig, setHasLoadedLdapConfig] = useState(false);
   const [hasLoadedEmailConfig, setHasLoadedEmailConfig] = useState(false);
@@ -948,7 +956,58 @@ const App: React.FC = () => {
       setHasLoadedRoles(true);
     };
 
+    const loadDatasets = async (
+      moduleName: string,
+      requests: Array<{
+        dataset: string;
+        enabled: boolean;
+        load: () => Promise<unknown>;
+        apply: (data: unknown) => void;
+      }>,
+    ) => {
+      const activeRequests = requests.filter((request) => request.enabled);
+      if (activeRequests.length === 0) return [] as string[];
+
+      const results = await Promise.allSettled(activeRequests.map((request) => request.load()));
+      const failures: string[] = [];
+
+      results.forEach((result, index) => {
+        const request = activeRequests[index];
+        if (result.status === 'fulfilled') {
+          request.apply(result.value);
+          return;
+        }
+
+        failures.push(request.dataset);
+        console.error(
+          `Failed to load ${moduleName} dataset "${request.dataset}": ${getErrorMessage(result.reason)}`,
+          result.reason,
+        );
+      });
+
+      return failures;
+    };
+
+    const loadOptionalDataset = async (
+      moduleName: string,
+      dataset: string,
+      load: () => Promise<void>,
+      failures: string[],
+    ) => {
+      try {
+        await load();
+      } catch (err) {
+        failures.push(dataset);
+        console.error(
+          `Failed to load ${moduleName} dataset "${dataset}": ${getErrorMessage(err)}`,
+          err,
+        );
+      }
+    };
+
     const loadModuleData = async () => {
+      let failedDatasets: string[] = [];
+
       try {
         const permissions = currentUser.permissions || [];
         const canViewTimesheets = hasAnyPermission(permissions, [
@@ -1163,29 +1222,62 @@ const App: React.FC = () => {
         switch (module) {
           case 'timesheets': {
             if (!canViewTimesheets) return;
-            const [entriesData, clientsData, projectsData, tasksData, usersData] =
-              await Promise.all([
-                api.entries.list(),
-                canListClients ? api.clients.list() : Promise.resolve([]),
-                canListProjects ? api.projects.list() : Promise.resolve([]),
-                canListTasks ? api.tasks.list() : Promise.resolve([]),
-                canListUsers ? api.users.list() : Promise.resolve([]),
-              ]);
-            setEntries(entriesData);
-            setClients(clientsData);
-            setProjects(projectsData);
-            setProjectTasks(tasksData);
-            setUsers(usersData);
-            await loadGeneralSettings();
+            failedDatasets = await loadDatasets(module, [
+              {
+                dataset: 'entries',
+                enabled: true,
+                load: () => api.entries.list(),
+                apply: (data) => setEntries(data as TimeEntry[]),
+              },
+              {
+                dataset: 'clients',
+                enabled: canListClients,
+                load: () => api.clients.list(),
+                apply: (data) => setClients(data as Client[]),
+              },
+              {
+                dataset: 'projects',
+                enabled: canListProjects,
+                load: () => api.projects.list(),
+                apply: (data) => setProjects(data as Project[]),
+              },
+              {
+                dataset: 'tasks',
+                enabled: canListTasks,
+                load: () => api.tasks.list(),
+                apply: (data) => setProjectTasks(data as ProjectTask[]),
+              },
+              {
+                dataset: 'users',
+                enabled: canListUsers,
+                load: () => api.users.list(),
+                apply: (data) => setUsers(data as User[]),
+              },
+            ]);
+            await loadOptionalDataset(
+              module,
+              'general settings',
+              loadGeneralSettings,
+              failedDatasets,
+            );
             break;
           }
           case 'hr': {
             if (!canViewHr) return;
-            const [usersData] = await Promise.all([
-              canListUsers ? api.users.list() : Promise.resolve([]),
+            failedDatasets = await loadDatasets(module, [
+              {
+                dataset: 'users',
+                enabled: canListUsers,
+                load: () => api.users.list(),
+                apply: (data) => setUsers(data as User[]),
+              },
             ]);
-            setUsers(usersData);
-            await loadGeneralSettings();
+            await loadOptionalDataset(
+              module,
+              'general settings',
+              loadGeneralSettings,
+              failedDatasets,
+            );
             break;
           }
           case 'administration': {
@@ -1195,189 +1287,367 @@ const App: React.FC = () => {
             const shouldLoadWorkUnits = canViewWorkUnits;
             const shouldLoadRoles = canViewRoles || canViewAuthentication || canViewUserManagement;
 
-            const [usersData, clientsData, projectsData, tasksData, workUnitsData] =
-              await Promise.all([
-                shouldLoadUsers && canListUsers ? api.users.list() : Promise.resolve([]),
-                shouldLoadAssignments && canListClients ? api.clients.list() : Promise.resolve([]),
-                shouldLoadAssignments && canListProjects
-                  ? api.projects.list()
-                  : Promise.resolve([]),
-                shouldLoadAssignments && canListTasks ? api.tasks.list() : Promise.resolve([]),
-                shouldLoadWorkUnits && canListWorkUnits
-                  ? api.workUnits.list()
-                  : Promise.resolve([]),
-              ]);
+            failedDatasets = await loadDatasets(module, [
+              {
+                dataset: 'users',
+                enabled: shouldLoadUsers && canListUsers,
+                load: () => api.users.list(),
+                apply: (data) => setUsers(data as User[]),
+              },
+              {
+                dataset: 'clients',
+                enabled: shouldLoadAssignments && canListClients,
+                load: () => api.clients.list(),
+                apply: (data) => setClients(data as Client[]),
+              },
+              {
+                dataset: 'projects',
+                enabled: shouldLoadAssignments && canListProjects,
+                load: () => api.projects.list(),
+                apply: (data) => setProjects(data as Project[]),
+              },
+              {
+                dataset: 'tasks',
+                enabled: shouldLoadAssignments && canListTasks,
+                load: () => api.tasks.list(),
+                apply: (data) => setProjectTasks(data as ProjectTask[]),
+              },
+              {
+                dataset: 'work units',
+                enabled: shouldLoadWorkUnits && canListWorkUnits,
+                load: () => api.workUnits.list(),
+                apply: (data) => setWorkUnits(data as WorkUnit[]),
+              },
+            ]);
 
-            if (shouldLoadUsers) setUsers(usersData);
-            if (shouldLoadAssignments) {
-              setClients(clientsData);
-              setProjects(projectsData);
-              setProjectTasks(tasksData);
+            await loadOptionalDataset(
+              module,
+              'general settings',
+              loadGeneralSettings,
+              failedDatasets,
+            );
+            if (shouldLoadRoles) {
+              await loadOptionalDataset(module, 'roles', loadRoles, failedDatasets);
             }
-            if (shouldLoadWorkUnits) setWorkUnits(workUnitsData);
-
-            await loadGeneralSettings();
-            if (shouldLoadRoles) await loadRoles();
-            if (canViewAuthentication) await loadLdapConfig();
-            if (canViewEmail) await loadEmailConfig();
+            if (canViewAuthentication) {
+              await loadOptionalDataset(module, 'authentication', loadLdapConfig, failedDatasets);
+            }
+            if (canViewEmail) {
+              await loadOptionalDataset(module, 'email settings', loadEmailConfig, failedDatasets);
+            }
             break;
           }
           case 'crm': {
             if (!canViewCrm) return;
-            const [clientsData, suppliersData] = await Promise.all([
-              canViewCrmClients && canListClients ? api.clients.list() : Promise.resolve([]),
-              canViewCrmSuppliers && canListSuppliers ? api.suppliers.list() : Promise.resolve([]),
+            failedDatasets = await loadDatasets(module, [
+              {
+                dataset: 'clients',
+                enabled: canViewCrmClients && canListClients,
+                load: () => api.clients.list(),
+                apply: (data) => setClients(data as Client[]),
+              },
+              {
+                dataset: 'suppliers',
+                enabled: canViewCrmSuppliers && canListSuppliers,
+                load: () => api.suppliers.list(),
+                apply: (data) => setSuppliers(data as Supplier[]),
+              },
             ]);
-            if (canViewCrmClients) setClients(clientsData);
-            if (canViewCrmSuppliers) setSuppliers(suppliersData);
-            await loadGeneralSettings();
+            await loadOptionalDataset(
+              module,
+              'general settings',
+              loadGeneralSettings,
+              failedDatasets,
+            );
             break;
           }
           case 'sales': {
             if (!canViewSales) return;
-            const [
-              quotesData,
-              clientOffersData,
-              supplierQuotesData,
-              supplierOffersData,
-              clientsData,
-              suppliersData,
-              productsData,
-              specialBidsData,
-            ] = await Promise.all([
-              canListQuotes ? api.quotes.list() : Promise.resolve([]),
-              canListClientOffers ? api.clientOffers.list() : Promise.resolve([]),
-              canListSupplierQuotes ? api.supplierQuotes.list() : Promise.resolve([]),
-              canListSupplierOffers ? api.supplierOffers.list() : Promise.resolve([]),
-              canListClients ? api.clients.list() : Promise.resolve([]),
-              canListSuppliers ? api.suppliers.list() : Promise.resolve([]),
-              canListProducts ? api.products.list() : Promise.resolve([]),
-              canListSpecialBids ? api.specialBids.list() : Promise.resolve([]),
+            failedDatasets = await loadDatasets(module, [
+              {
+                dataset: 'quotes',
+                enabled: canListQuotes,
+                load: () => api.quotes.list(),
+                apply: (data) => setQuotes(data as Quote[]),
+              },
+              {
+                dataset: 'client offers',
+                enabled: canListClientOffers,
+                load: () => api.clientOffers.list(),
+                apply: (data) => setClientOffers(data as ClientOffer[]),
+              },
+              {
+                dataset: 'supplier quotes',
+                enabled: canListSupplierQuotes,
+                load: () => api.supplierQuotes.list(),
+                apply: (data) => setSupplierQuotes(data as SupplierQuote[]),
+              },
+              {
+                dataset: 'supplier offers',
+                enabled: canListSupplierOffers,
+                load: () => api.supplierOffers.list(),
+                apply: (data) => setSupplierOffers(data as SupplierOffer[]),
+              },
+              {
+                dataset: 'clients',
+                enabled: canListClients,
+                load: () => api.clients.list(),
+                apply: (data) => setClients(data as Client[]),
+              },
+              {
+                dataset: 'suppliers',
+                enabled: canListSuppliers,
+                load: () => api.suppliers.list(),
+                apply: (data) => setSuppliers(data as Supplier[]),
+              },
+              {
+                dataset: 'products',
+                enabled: canListProducts,
+                load: () => api.products.list(),
+                apply: (data) => setProducts(data as Product[]),
+              },
+              {
+                dataset: 'special bids',
+                enabled: canListSpecialBids,
+                load: () => api.specialBids.list(),
+                apply: (data) => setSpecialBids(data as SpecialBid[]),
+              },
             ]);
-            if (canListQuotes) setQuotes(quotesData);
-            if (canListClientOffers) setClientOffers(clientOffersData);
-            if (canListSupplierQuotes) setSupplierQuotes(supplierQuotesData);
-            if (canListSupplierOffers) setSupplierOffers(supplierOffersData);
-            if (canListClients) setClients(clientsData);
-            if (canListSuppliers) setSuppliers(suppliersData);
-            if (canListProducts) setProducts(productsData);
-            if (canListSpecialBids) setSpecialBids(specialBidsData);
-            await loadGeneralSettings();
+            await loadOptionalDataset(
+              module,
+              'general settings',
+              loadGeneralSettings,
+              failedDatasets,
+            );
             break;
           }
           case 'accounting': {
             if (!canViewAccounting) return;
-            const [
-              ordersData,
-              invoicesData,
-              supplierOrdersData,
-              supplierInvoicesData,
-              clientsData,
-              suppliersData,
-              productsData,
-              specialBidsData,
-            ] = await Promise.all([
-              canListOrders ? api.clientsOrders.list() : Promise.resolve([]),
-              canListInvoices ? api.invoices.list() : Promise.resolve([]),
-              canListSupplierOrders ? api.supplierOrders.list() : Promise.resolve([]),
-              canListSupplierInvoices ? api.supplierInvoices.list() : Promise.resolve([]),
-              canListClients ? api.clients.list() : Promise.resolve([]),
-              canListSuppliers ? api.suppliers.list() : Promise.resolve([]),
-              canListProducts ? api.products.list() : Promise.resolve([]),
-              canListSpecialBids ? api.specialBids.list() : Promise.resolve([]),
+            failedDatasets = await loadDatasets(module, [
+              {
+                dataset: 'client orders',
+                enabled: canListOrders,
+                load: () => api.clientsOrders.list(),
+                apply: (data) => setClientsOrders(data as ClientsOrder[]),
+              },
+              {
+                dataset: 'invoices',
+                enabled: canListInvoices,
+                load: () => api.invoices.list(),
+                apply: (data) => setInvoices(data as Invoice[]),
+              },
+              {
+                dataset: 'supplier orders',
+                enabled: canListSupplierOrders,
+                load: () => api.supplierOrders.list(),
+                apply: (data) => setSupplierOrders(data as SupplierSaleOrder[]),
+              },
+              {
+                dataset: 'supplier invoices',
+                enabled: canListSupplierInvoices,
+                load: () => api.supplierInvoices.list(),
+                apply: (data) => setSupplierInvoices(data as SupplierInvoice[]),
+              },
+              {
+                dataset: 'clients',
+                enabled: canListClients,
+                load: () => api.clients.list(),
+                apply: (data) => setClients(data as Client[]),
+              },
+              {
+                dataset: 'suppliers',
+                enabled: canListSuppliers,
+                load: () => api.suppliers.list(),
+                apply: (data) => setSuppliers(data as Supplier[]),
+              },
+              {
+                dataset: 'products',
+                enabled: canListProducts,
+                load: () => api.products.list(),
+                apply: (data) => setProducts(data as Product[]),
+              },
+              {
+                dataset: 'special bids',
+                enabled: canListSpecialBids,
+                load: () => api.specialBids.list(),
+                apply: (data) => setSpecialBids(data as SpecialBid[]),
+              },
             ]);
-            if (canListOrders) setClientsOrders(ordersData);
-            if (canListInvoices) setInvoices(invoicesData);
-            if (canListSupplierOrders) setSupplierOrders(supplierOrdersData);
-            if (canListSupplierInvoices) setSupplierInvoices(supplierInvoicesData);
-            if (canListClients) setClients(clientsData);
-            if (canListSuppliers) setSuppliers(suppliersData);
-            if (canListProducts) setProducts(productsData);
-            if (canListSpecialBids) setSpecialBids(specialBidsData);
-            await loadGeneralSettings();
+            await loadOptionalDataset(
+              module,
+              'general settings',
+              loadGeneralSettings,
+              failedDatasets,
+            );
             break;
           }
           case 'catalog': {
             if (!canViewCatalog) return;
-            const [productsData, specialBidsData, clientsData, suppliersData] = await Promise.all([
-              canListProducts ? api.products.list() : Promise.resolve([]),
-              canListSpecialBids ? api.specialBids.list() : Promise.resolve([]),
-              canViewCatalogSpecialBids && canListClients
-                ? api.clients.list()
-                : Promise.resolve([]),
-              canViewCatalogExternal && canListSuppliers
-                ? api.suppliers.list()
-                : Promise.resolve([]),
+            failedDatasets = await loadDatasets(module, [
+              {
+                dataset: 'products',
+                enabled:
+                  canListProducts &&
+                  (canViewCatalogInternal || canViewCatalogExternal || canViewCatalogSpecialBids),
+                load: () => api.products.list(),
+                apply: (data) => setProducts(data as Product[]),
+              },
+              {
+                dataset: 'special bids',
+                enabled: canListSpecialBids && canViewCatalogSpecialBids,
+                load: () => api.specialBids.list(),
+                apply: (data) => setSpecialBids(data as SpecialBid[]),
+              },
+              {
+                dataset: 'clients',
+                enabled: canViewCatalogSpecialBids && canListClients,
+                load: () => api.clients.list(),
+                apply: (data) => setClients(data as Client[]),
+              },
+              {
+                dataset: 'suppliers',
+                enabled: canViewCatalogExternal && canListSuppliers,
+                load: () => api.suppliers.list(),
+                apply: (data) => setSuppliers(data as Supplier[]),
+              },
             ]);
-            if (
-              canListProducts &&
-              (canViewCatalogInternal || canViewCatalogExternal || canViewCatalogSpecialBids)
-            )
-              setProducts(productsData);
-            if (canListSpecialBids && canViewCatalogSpecialBids) setSpecialBids(specialBidsData);
-            if (canViewCatalogSpecialBids && canListClients) setClients(clientsData);
-            if (canViewCatalogExternal && canListSuppliers) setSuppliers(suppliersData);
-            await loadGeneralSettings();
+            await loadOptionalDataset(
+              module,
+              'general settings',
+              loadGeneralSettings,
+              failedDatasets,
+            );
             break;
           }
           case 'finances': {
             if (!canViewFinances) return;
-            const [paymentsData, expensesData, clientsData] = await Promise.all([
-              canListPayments ? api.payments.list() : Promise.resolve([]),
-              canListExpenses ? api.expenses.list() : Promise.resolve([]),
-              canListClients ? api.clients.list() : Promise.resolve([]),
+            failedDatasets = await loadDatasets(module, [
+              {
+                dataset: 'payments',
+                enabled: canListPayments,
+                load: () => api.payments.list(),
+                apply: (data) => setPayments(data as Payment[]),
+              },
+              {
+                dataset: 'expenses',
+                enabled: canListExpenses,
+                load: () => api.expenses.list(),
+                apply: (data) => setExpenses(data as Expense[]),
+              },
+              {
+                dataset: 'clients',
+                enabled: canListClients,
+                load: () => api.clients.list(),
+                apply: (data) => setClients(data as Client[]),
+              },
             ]);
-            if (canListPayments) setPayments(paymentsData);
-            if (canListExpenses) setExpenses(expensesData);
-            if (canListClients) setClients(clientsData);
-            await loadGeneralSettings();
+            await loadOptionalDataset(
+              module,
+              'general settings',
+              loadGeneralSettings,
+              failedDatasets,
+            );
             break;
           }
           case 'projects': {
             if (!canViewProjects) return;
-            const [projectsData, tasksData, clientsData, usersData, workUnitsData] =
-              await Promise.all([
-                canListProjects ? api.projects.list() : Promise.resolve([]),
-                canListTasks ? api.tasks.list() : Promise.resolve([]),
-                canListClients ? api.clients.list() : Promise.resolve([]),
-                canListUsers ? api.users.list() : Promise.resolve([]),
-                canListWorkUnits ? api.workUnits.list() : Promise.resolve([]),
-              ]);
-            if (canListProjects) setProjects(projectsData);
-            if (canListTasks) setProjectTasks(tasksData);
-            if (canListClients) setClients(clientsData);
-            if (canListUsers) setUsers(usersData);
-            if (canListWorkUnits) setWorkUnits(workUnitsData);
+            failedDatasets = await loadDatasets(module, [
+              {
+                dataset: 'projects',
+                enabled: canListProjects,
+                load: () => api.projects.list(),
+                apply: (data) => setProjects(data as Project[]),
+              },
+              {
+                dataset: 'tasks',
+                enabled: canListTasks,
+                load: () => api.tasks.list(),
+                apply: (data) => setProjectTasks(data as ProjectTask[]),
+              },
+              {
+                dataset: 'clients',
+                enabled: canListClients,
+                load: () => api.clients.list(),
+                apply: (data) => setClients(data as Client[]),
+              },
+              {
+                dataset: 'users',
+                enabled: canListUsers,
+                load: () => api.users.list(),
+                apply: (data) => setUsers(data as User[]),
+              },
+              {
+                dataset: 'work units',
+                enabled: canListWorkUnits,
+                load: () => api.workUnits.list(),
+                apply: (data) => setWorkUnits(data as WorkUnit[]),
+              },
+            ]);
             break;
           }
           case 'suppliers': {
             if (!canViewSuppliersModule) return;
-            const [suppliersData, supplierQuotesData, productsData] = await Promise.all([
-              canListSuppliers ? api.suppliers.list() : Promise.resolve([]),
-              canListSupplierQuotes ? api.supplierQuotes.list() : Promise.resolve([]),
-              canListProducts ? api.products.list() : Promise.resolve([]),
+            failedDatasets = await loadDatasets(module, [
+              {
+                dataset: 'suppliers',
+                enabled: canListSuppliers,
+                load: () => api.suppliers.list(),
+                apply: (data) => setSuppliers(data as Supplier[]),
+              },
+              {
+                dataset: 'supplier quotes',
+                enabled: canListSupplierQuotes,
+                load: () => api.supplierQuotes.list(),
+                apply: (data) => setSupplierQuotes(data as SupplierQuote[]),
+              },
+              {
+                dataset: 'products',
+                enabled: canListProducts,
+                load: () => api.products.list(),
+                apply: (data) => setProducts(data as Product[]),
+              },
             ]);
-            if (canListSuppliers) setSuppliers(suppliersData);
-            if (canListSupplierQuotes) setSupplierQuotes(supplierQuotesData);
-            if (canListProducts) setProducts(productsData);
-            await loadGeneralSettings();
+            await loadOptionalDataset(
+              module,
+              'general settings',
+              loadGeneralSettings,
+              failedDatasets,
+            );
             break;
           }
           case 'reports': {
             // Reports pages fetch their own data as needed, but they still depend on global settings
             // (e.g. AI Reporting enablement).
-            await loadGeneralSettings();
+            await loadOptionalDataset(
+              module,
+              'general settings',
+              loadGeneralSettings,
+              failedDatasets,
+            );
             break;
           }
         }
+      } catch (err) {
+        console.error('Failed to load module data:', err);
+        failedDatasets.push('module data');
+      } finally {
+        const uniqueFailures = Array.from(new Set(failedDatasets));
+
+        setModuleLoadErrors((prev) => {
+          const next = { ...prev };
+          if (uniqueFailures.length > 0) {
+            next[module] = uniqueFailures;
+          } else {
+            delete next[module];
+          }
+          return next;
+        });
 
         setLoadedModules((prev) => {
           const next = new Set(prev);
           next.add(module);
           return next;
         });
-      } catch (err) {
-        console.error('Failed to load module data:', err);
       }
     };
 
@@ -2575,6 +2845,7 @@ const App: React.FC = () => {
       setAuthToken(token);
     }
     setLoadedModules(new Set());
+    setModuleLoadErrors({});
     setHasLoadedGeneralSettings(false);
     setHasLoadedLdapConfig(false);
     setHasLoadedEmailConfig(false);
@@ -2618,6 +2889,7 @@ const App: React.FC = () => {
     setCurrentUser(null);
     setViewingUserId('');
     setLoadedModules(new Set());
+    setModuleLoadErrors({});
     setHasLoadedGeneralSettings(false);
     setHasLoadedLdapConfig(false);
     setHasLoadedEmailConfig(false);
@@ -2649,6 +2921,7 @@ const App: React.FC = () => {
     try {
       // Clear potentially-privileged data to avoid stale UI after dropping permissions.
       setLoadedModules(new Set());
+      setModuleLoadErrors({});
       setHasLoadedGeneralSettings(false);
       setHasLoadedLdapConfig(false);
       setHasLoadedEmailConfig(false);
@@ -2819,6 +3092,13 @@ const App: React.FC = () => {
     }
   };
 
+  const activeModule = activeView === '404' ? null : getModuleFromView(activeView);
+  const activeModuleLoadFailures = activeModule ? (moduleLoadErrors[activeModule] ?? []) : [];
+  const reportsSettingsFailed =
+    activeView === 'reports/ai-reporting' &&
+    !hasLoadedGeneralSettings &&
+    activeModuleLoadFailures.includes('general settings');
+
   if (isLoading) {
     return (
       <div className="min-h-screen bg-slate-100 flex items-center justify-center">
@@ -2879,6 +3159,16 @@ const App: React.FC = () => {
           <NotFound onReturn={() => setActiveView('timesheets/tracker')} />
         ) : (
           <>
+            {activeModuleLoadFailures.length > 0 && (
+              <div className="mb-6 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900 shadow-sm">
+                <div className="flex items-start gap-3">
+                  <i className="fa-solid fa-triangle-exclamation mt-0.5 text-amber-500" />
+                  <p className="font-medium">
+                    Failed to load: {activeModuleLoadFailures.join(', ')}.
+                  </p>
+                </div>
+              </div>
+            )}
             {activeView === 'timesheets/tracker' && (
               <TrackerView
                 entries={entries.filter((e) => e.userId === viewingUserId)}
@@ -3277,12 +3567,23 @@ const App: React.FC = () => {
             )}
             {activeView === 'reports/ai-reporting' &&
               (!hasLoadedGeneralSettings ? (
-                <div className="flex h-[calc(100vh-180px)] min-h-[560px] items-center justify-center">
-                  <div className="text-center">
-                    <i className="fa-solid fa-circle-notch fa-spin text-3xl text-praetor mb-3" />
-                    <p className="text-slate-600 font-medium">Loading...</p>
+                reportsSettingsFailed ? (
+                  <div className="flex h-[calc(100vh-180px)] min-h-[560px] items-center justify-center">
+                    <div className="text-center">
+                      <i className="fa-solid fa-triangle-exclamation text-3xl text-amber-500 mb-3" />
+                      <p className="text-slate-700 font-medium">
+                        AI reporting settings failed to load.
+                      </p>
+                    </div>
                   </div>
-                </div>
+                ) : (
+                  <div className="flex h-[calc(100vh-180px)] min-h-[560px] items-center justify-center">
+                    <div className="text-center">
+                      <i className="fa-solid fa-circle-notch fa-spin text-3xl text-praetor mb-3" />
+                      <p className="text-slate-600 font-medium">Loading...</p>
+                    </div>
+                  </div>
+                )
               ) : (
                 <AiReportingView
                   currentUserId={currentUser.id}

--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ docker compose up -d --build
 ```
 
 The compose setup defaults backend `TRUST_PROXY=1` for the bundled Caddy -> API hop.
+Set `DEMO_SEEDING=true` in `.env` when you want the stack to provision the canonical demo users and demo business data.
+That refresh flow is intended for demo and test stacks, owns the canonical demo namespace, and supports reused Docker volumes.
+
+To rerun the same refresh manually against an existing backend database:
+
+```bash
+cd server
+bun run seed:demo
+```
 
 ### Customer Compose (pulls prebuilt images)
 
@@ -90,9 +99,9 @@ The workflow runs on `v*` git tags and can also be run manually.
 ## Usage Guide
 
 - **Login**:
-  - Default Admin: `admin` / `password`
-  - Default Manager: `manager` / `password`
-  - Default User: `user` / `password`
+  - Bootstrap Admin: `admin` / `password`
+  - Demo Manager: `manager` / `password` when `DEMO_SEEDING=true`
+  - Demo User: `user` / `password` when `DEMO_SEEDING=true`
   
 - **Tracking Time**: Navigate to the "Time Tracker" view and log time entries.
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -27,8 +27,9 @@ DB_PASSWORD=tempo
 # JWT Secret (change this in production!)
 JWT_SECRET=tempo-secret-key-change-in-production
 
-# Optional demo data seeding on startup
-# Set to true only for local/testing environments where demo entities are desired.
+# Optional demo refresh on startup.
+# When true, the backend provisions the demo manager/user credentials plus the canonical
+# demo business dataset. Intended for demo/test environments and reused demo volumes.
 DEMO_SEEDING=false
 
 # Default password for bootstrap admin user (username: admin)

--- a/server/db/bootstrapAdmin.ts
+++ b/server/db/bootstrapAdmin.ts
@@ -1,0 +1,52 @@
+import bcrypt from 'bcryptjs';
+import { randomUUID } from 'crypto';
+import { createChildLogger } from '../utils/logger.ts';
+import { query } from './index.ts';
+
+export const ADMIN_USERNAME = 'admin';
+export const DEFAULT_ADMIN_USER_ID = 'u1';
+export const DEFAULT_ADMIN_PASSWORD = 'password';
+
+const logger = createChildLogger({ module: 'db:bootstrap-admin' });
+
+export const ensureBootstrapAdmin = async () => {
+  const existingAdmin = await query('SELECT id FROM users WHERE username = $1 LIMIT 1', [
+    ADMIN_USERNAME,
+  ]);
+
+  let adminId: string;
+  if (existingAdmin.rows.length > 0) {
+    adminId = existingAdmin.rows[0].id as string;
+    logger.info('Bootstrap admin already exists. Skipping admin creation');
+  } else {
+    const defaultIdCheck = await query('SELECT 1 FROM users WHERE id = $1 LIMIT 1', [
+      DEFAULT_ADMIN_USER_ID,
+    ]);
+    adminId = defaultIdCheck.rows.length === 0 ? DEFAULT_ADMIN_USER_ID : randomUUID();
+
+    const rawPassword = process.env.ADMIN_DEFAULT_PASSWORD?.trim();
+    const adminPassword =
+      rawPassword && rawPassword.length > 0 ? rawPassword : DEFAULT_ADMIN_PASSWORD;
+    const passwordHash = await bcrypt.hash(adminPassword, 12);
+
+    await query(
+      `INSERT INTO users (id, name, username, password_hash, role, avatar_initials)
+       VALUES ($1, $2, $3, $4, $5, $6)`,
+      [adminId, 'Admin User', ADMIN_USERNAME, passwordHash, 'admin', 'AD'],
+    );
+    logger.info(
+      {
+        passwordSource:
+          rawPassword && rawPassword.length > 0 ? 'ADMIN_DEFAULT_PASSWORD' : 'fallback',
+      },
+      'Bootstrap admin created',
+    );
+  }
+
+  await query('INSERT INTO user_roles (user_id, role_id) VALUES ($1, $2) ON CONFLICT DO NOTHING', [
+    adminId,
+    'admin',
+  ]);
+
+  return adminId;
+};

--- a/server/db/demoSeed.ts
+++ b/server/db/demoSeed.ts
@@ -1,0 +1,874 @@
+import { readFileSync } from 'fs';
+import type { PoolClient } from 'pg';
+import { bumpNamespaceVersion } from '../services/cache.ts';
+import { createChildLogger, serializeError } from '../utils/logger.ts';
+import { migrate as assignItemsToManagers } from './assign_items_to_managers.ts';
+import { ensureBootstrapAdmin } from './bootstrapAdmin.ts';
+import {
+  DEMO_CACHE_NAMESPACES,
+  DEMO_CLIENTS,
+  DEMO_CUSTOMER_OFFERS,
+  DEMO_EXPECTED_COUNTS,
+  DEMO_EXPENSES,
+  DEMO_IDS,
+  DEMO_INVOICES,
+  DEMO_ITEM_IDS,
+  DEMO_NOTIFICATIONS,
+  DEMO_PASSWORD_HASH,
+  DEMO_PAYMENTS,
+  DEMO_PRODUCTS,
+  DEMO_PROJECTS,
+  DEMO_QUOTES,
+  DEMO_SALES,
+  DEMO_SETTINGS_CACHE_NAMESPACES,
+  DEMO_SUPPLIER_INVOICES,
+  DEMO_SUPPLIER_OFFERS,
+  DEMO_SUPPLIER_QUOTES,
+  DEMO_SUPPLIER_SALES,
+  DEMO_SUPPLIERS,
+  DEMO_USER_IDS,
+  DEMO_USERS,
+} from './demoSeedManifest.ts';
+import pool, { query } from './index.ts';
+
+const logger = createChildLogger({ module: 'db:demo-seed' });
+
+const DEMO_SEED_MARKER = '-- Refreshable demo dataset.';
+const seedPath = new URL('./seed.sql', import.meta.url);
+
+type DemoSeedSource = 'startup' | 'manual';
+
+type FailedStatement = {
+  table: string;
+  keys: string[];
+  statementIndex: number;
+  error: Record<string, unknown>;
+};
+
+export type DemoSeedResult = {
+  demoSeedingEnabled: true;
+  source: DemoSeedSource;
+  cleanupCountsByTable: Record<string, number>;
+  insertCountsByTable: Record<string, number>;
+  verificationCountsByTable: Record<string, number>;
+};
+
+type PredicateValues = Array<string | null>;
+
+type PredicateBuilder = {
+  params: PredicateValues[];
+  parts: string[];
+};
+
+type VerificationStep = {
+  table: string;
+  countColumn?: string;
+  ids: readonly string[];
+  expected: number;
+};
+
+const nonEmpty = <T>(values: readonly (T | null | undefined)[]) =>
+  values.filter((value): value is T => value !== null && value !== undefined);
+
+const incrementCount = (counts: Record<string, number>, table: string, delta: number) => {
+  if (delta <= 0) return;
+  counts[table] = (counts[table] ?? 0) + delta;
+};
+
+const splitSqlStatements = (sql: string) =>
+  sql
+    .split(/;\s*\n/)
+    .map((statement) => statement.trim())
+    .filter((statement) => statement.length > 0 && /\S/m.test(statement.replace(/--.*$/gm, '')));
+
+const extractInsertTable = (statement: string) => {
+  const match = statement.match(/INSERT\s+INTO\s+([a-z_]+)/i);
+  return match ? match[1] : 'unknown';
+};
+
+const extractStatementKeys = (statement: string) =>
+  Array.from(statement.matchAll(/'(dm_[^']+|DM-[A-Z0-9-]+|OBS-RENEW-2026)'/g))
+    .map((match) => match[1])
+    .slice(0, 6);
+
+const buildDeleteQuery = (table: string, build: (builder: PredicateBuilder) => void) => {
+  const builder: PredicateBuilder = { params: [], parts: [] };
+  build(builder);
+  if (builder.parts.length === 0) return null;
+
+  return {
+    sql: `DELETE FROM ${table} WHERE ${builder.parts.join(' OR ')}`,
+    params: builder.params,
+  };
+};
+
+const pushTextArrayPredicate = (
+  builder: PredicateBuilder,
+  expression: string,
+  values: readonly string[],
+) => {
+  if (values.length === 0) return;
+  builder.params.push([...values]);
+  builder.parts.push(`${expression} = ANY($${builder.params.length}::text[])`);
+};
+
+const pushLowerTextArrayPredicate = (
+  builder: PredicateBuilder,
+  column: string,
+  values: readonly string[],
+) => {
+  const lowered = values.map((value) => value.toLowerCase());
+  pushTextArrayPredicate(builder, `LOWER(${column})`, lowered);
+};
+
+const executeDelete = async (
+  client: PoolClient,
+  table: string,
+  build: (builder: PredicateBuilder) => void,
+) => {
+  const deleteQuery = buildDeleteQuery(table, build);
+  if (!deleteQuery) return 0;
+  const result = await client.query(deleteQuery.sql, deleteQuery.params);
+  return result.rowCount ?? 0;
+};
+
+const executeStatement = async (client: PoolClient, sql: string, params?: unknown[]) =>
+  client.query(sql, params);
+
+const loadDemoStatements = () => {
+  const seedSql = readFileSync(seedPath, 'utf8');
+  const markerIndex = seedSql.indexOf(DEMO_SEED_MARKER);
+  if (markerIndex === -1) {
+    throw new Error(`Demo seed marker not found in ${seedPath.pathname}`);
+  }
+  return splitSqlStatements(seedSql.slice(markerIndex));
+};
+
+const insertCompatibilityDefaults = async (client: PoolClient, counts: Record<string, number>) => {
+  const clientsResult = await executeStatement(
+    client,
+    `INSERT INTO clients (id, name, created_at) VALUES
+        ('c1', 'Acme Corp', '2024-01-15 09:30:00'),
+        ('c2', 'Global Tech', '2024-03-05 14:15:00')
+     ON CONFLICT (id) DO NOTHING`,
+  );
+  incrementCount(counts, 'clients', clientsResult.rowCount ?? 0);
+
+  const projectsResult = await executeStatement(
+    client,
+    `INSERT INTO projects (id, name, client_id, color, description) VALUES
+        ('p1', 'Website Redesign', 'c1', '#3b82f6', 'Complete overhaul of the main marketing site.'),
+        ('p2', 'Mobile App', 'c1', '#10b981', 'Native iOS and Android application development.'),
+        ('p3', 'Internal Research', 'c2', '#8b5cf6', 'Ongoing research into new market trends.')
+     ON CONFLICT (id) DO NOTHING`,
+  );
+  incrementCount(counts, 'projects', projectsResult.rowCount ?? 0);
+
+  const tasksResult = await executeStatement(
+    client,
+    `INSERT INTO tasks (id, name, project_id, description) VALUES
+        ('t1', 'Initial Design', 'p1', 'Lo-fi wireframes and moodboards.'),
+        ('t2', 'Frontend Dev', 'p1', 'React component implementation.'),
+        ('t3', 'API Integration', 'p2', 'Connecting the app to the backend services.'),
+        ('t4', 'General Support', 'p3', 'Misc administrative tasks and support.')
+     ON CONFLICT (id) DO NOTHING`,
+  );
+  incrementCount(counts, 'tasks', tasksResult.rowCount ?? 0);
+};
+
+const insertDemoUsersAndSettings = async (client: PoolClient, counts: Record<string, number>) => {
+  const userValues: unknown[] = [];
+  const userTuples = DEMO_USERS.map((user) => {
+    userValues.push(
+      user.id,
+      user.name,
+      user.username,
+      DEMO_PASSWORD_HASH,
+      user.role,
+      user.avatarInitials,
+    );
+    const index = userValues.length - 5;
+    return `($${index}, $${index + 1}, $${index + 2}, $${index + 3}, $${index + 4}, $${index + 5})`;
+  });
+  const usersResult = await executeStatement(
+    client,
+    `INSERT INTO users (id, name, username, password_hash, role, avatar_initials)
+     VALUES ${userTuples.join(', ')}
+     ON CONFLICT (id) DO UPDATE SET
+       name = EXCLUDED.name,
+       username = EXCLUDED.username,
+       password_hash = EXCLUDED.password_hash,
+       role = EXCLUDED.role,
+       avatar_initials = EXCLUDED.avatar_initials,
+       is_disabled = FALSE`,
+    userValues,
+  );
+  incrementCount(counts, 'users', usersResult.rowCount ?? 0);
+
+  const userRolesResult = await executeStatement(
+    client,
+    `INSERT INTO user_roles (user_id, role_id)
+     SELECT user_id, role_id
+     FROM (
+       VALUES ('u2', 'manager'), ('u3', 'user')
+     ) AS v(user_id, role_id)
+     ON CONFLICT DO NOTHING`,
+  );
+  incrementCount(counts, 'user_roles', userRolesResult.rowCount ?? 0);
+
+  const settingsValues: unknown[] = [];
+  const settingsTuples = DEMO_USERS.map((user) => {
+    settingsValues.push(user.id, user.fullName, user.email);
+    const index = settingsValues.length - 2;
+    return `($${index}, $${index + 1}, $${index + 2})`;
+  });
+  const settingsResult = await executeStatement(
+    client,
+    `INSERT INTO settings (user_id, full_name, email)
+     VALUES ${settingsTuples.join(', ')}
+     ON CONFLICT (user_id) DO UPDATE SET
+       full_name = EXCLUDED.full_name,
+       email = EXCLUDED.email,
+       updated_at = CURRENT_TIMESTAMP`,
+    settingsValues,
+  );
+  incrementCount(counts, 'settings', settingsResult.rowCount ?? 0);
+};
+
+const cleanupDemoNamespace = async (client: PoolClient, demoUserIdsToDelete: string[]) => {
+  const cleanupCountsByTable: Record<string, number> = {};
+
+  incrementCount(
+    cleanupCountsByTable,
+    'notifications',
+    await executeDelete(client, 'notifications', (builder) => {
+      pushTextArrayPredicate(builder, 'id', DEMO_NOTIFICATIONS);
+    }),
+  );
+
+  incrementCount(
+    cleanupCountsByTable,
+    'expenses',
+    await executeDelete(client, 'expenses', (builder) => {
+      pushTextArrayPredicate(builder, 'id', DEMO_IDS.expenses);
+      pushTextArrayPredicate(builder, 'supplier_invoice_id', DEMO_IDS.supplierInvoices);
+      pushTextArrayPredicate(
+        builder,
+        'receipt_reference',
+        nonEmpty(DEMO_EXPENSES.map((expense) => expense.receiptReference)),
+      );
+    }),
+  );
+
+  incrementCount(
+    cleanupCountsByTable,
+    'supplier_invoice_items',
+    await executeDelete(client, 'supplier_invoice_items', (builder) => {
+      pushTextArrayPredicate(builder, 'id', DEMO_ITEM_IDS.supplierInvoiceItems);
+      pushTextArrayPredicate(builder, 'invoice_id', DEMO_IDS.supplierInvoices);
+      pushTextArrayPredicate(builder, 'product_id', DEMO_IDS.products);
+    }),
+  );
+
+  incrementCount(
+    cleanupCountsByTable,
+    'supplier_invoices',
+    await executeDelete(client, 'supplier_invoices', (builder) => {
+      pushTextArrayPredicate(builder, 'id', DEMO_IDS.supplierInvoices);
+      pushTextArrayPredicate(builder, 'supplier_id', DEMO_IDS.suppliers);
+      pushTextArrayPredicate(
+        builder,
+        'invoice_number',
+        DEMO_SUPPLIER_INVOICES.map((invoice) => invoice.invoiceNumber),
+      );
+      pushTextArrayPredicate(
+        builder,
+        'linked_sale_id',
+        nonEmpty(DEMO_SUPPLIER_INVOICES.map((invoice) => invoice.linkedSaleId)),
+      );
+    }),
+  );
+
+  incrementCount(
+    cleanupCountsByTable,
+    'supplier_sale_items',
+    await executeDelete(client, 'supplier_sale_items', (builder) => {
+      pushTextArrayPredicate(builder, 'id', DEMO_ITEM_IDS.supplierSaleItems);
+      pushTextArrayPredicate(builder, 'sale_id', DEMO_IDS.supplierSales);
+      pushTextArrayPredicate(builder, 'product_id', DEMO_IDS.products);
+    }),
+  );
+
+  incrementCount(
+    cleanupCountsByTable,
+    'supplier_sales',
+    await executeDelete(client, 'supplier_sales', (builder) => {
+      pushTextArrayPredicate(builder, 'id', DEMO_IDS.supplierSales);
+      pushTextArrayPredicate(builder, 'supplier_id', DEMO_IDS.suppliers);
+      pushTextArrayPredicate(
+        builder,
+        'linked_offer_id',
+        nonEmpty(DEMO_SUPPLIER_SALES.map((sale) => sale.linkedOfferId)),
+      );
+    }),
+  );
+
+  incrementCount(
+    cleanupCountsByTable,
+    'supplier_offer_items',
+    await executeDelete(client, 'supplier_offer_items', (builder) => {
+      pushTextArrayPredicate(builder, 'id', DEMO_ITEM_IDS.supplierOfferItems);
+      pushTextArrayPredicate(builder, 'offer_id', DEMO_IDS.supplierOffers);
+      pushTextArrayPredicate(builder, 'product_id', DEMO_IDS.products);
+    }),
+  );
+
+  incrementCount(
+    cleanupCountsByTable,
+    'supplier_offers',
+    await executeDelete(client, 'supplier_offers', (builder) => {
+      pushTextArrayPredicate(builder, 'id', DEMO_IDS.supplierOffers);
+      pushTextArrayPredicate(builder, 'supplier_id', DEMO_IDS.suppliers);
+      pushTextArrayPredicate(
+        builder,
+        'offer_code',
+        DEMO_SUPPLIER_OFFERS.map((offer) => offer.offerCode),
+      );
+      pushTextArrayPredicate(
+        builder,
+        'linked_quote_id',
+        DEMO_SUPPLIER_OFFERS.map((offer) => offer.linkedQuoteId),
+      );
+    }),
+  );
+
+  incrementCount(
+    cleanupCountsByTable,
+    'supplier_quote_items',
+    await executeDelete(client, 'supplier_quote_items', (builder) => {
+      pushTextArrayPredicate(builder, 'id', DEMO_ITEM_IDS.supplierQuoteItems);
+      pushTextArrayPredicate(builder, 'quote_id', DEMO_IDS.supplierQuotes);
+      pushTextArrayPredicate(builder, 'product_id', DEMO_IDS.products);
+    }),
+  );
+
+  incrementCount(
+    cleanupCountsByTable,
+    'supplier_quotes',
+    await executeDelete(client, 'supplier_quotes', (builder) => {
+      pushTextArrayPredicate(builder, 'id', DEMO_IDS.supplierQuotes);
+      pushTextArrayPredicate(builder, 'supplier_id', DEMO_IDS.suppliers);
+      pushTextArrayPredicate(
+        builder,
+        'quote_code',
+        DEMO_SUPPLIER_QUOTES.map((quote) => quote.quoteCode),
+      );
+      pushTextArrayPredicate(
+        builder,
+        'purchase_order_number',
+        DEMO_SUPPLIER_QUOTES.map((quote) => quote.purchaseOrderNumber),
+      );
+    }),
+  );
+
+  incrementCount(
+    cleanupCountsByTable,
+    'payments',
+    await executeDelete(client, 'payments', (builder) => {
+      pushTextArrayPredicate(builder, 'id', DEMO_IDS.payments);
+      pushTextArrayPredicate(builder, 'invoice_id', DEMO_IDS.invoices);
+      pushTextArrayPredicate(builder, 'client_id', DEMO_IDS.clients);
+      pushTextArrayPredicate(
+        builder,
+        'reference',
+        DEMO_PAYMENTS.map((payment) => payment.reference),
+      );
+    }),
+  );
+
+  incrementCount(
+    cleanupCountsByTable,
+    'invoice_items',
+    await executeDelete(client, 'invoice_items', (builder) => {
+      pushTextArrayPredicate(builder, 'id', DEMO_ITEM_IDS.invoiceItems);
+      pushTextArrayPredicate(builder, 'invoice_id', DEMO_IDS.invoices);
+      pushTextArrayPredicate(builder, 'product_id', DEMO_IDS.products);
+    }),
+  );
+
+  incrementCount(
+    cleanupCountsByTable,
+    'invoices',
+    await executeDelete(client, 'invoices', (builder) => {
+      pushTextArrayPredicate(builder, 'id', DEMO_IDS.invoices);
+      pushTextArrayPredicate(builder, 'client_id', DEMO_IDS.clients);
+      pushTextArrayPredicate(
+        builder,
+        'invoice_number',
+        DEMO_INVOICES.map((invoice) => invoice.invoiceNumber),
+      );
+      pushTextArrayPredicate(
+        builder,
+        'linked_sale_id',
+        nonEmpty(DEMO_INVOICES.map((invoice) => invoice.linkedSaleId)),
+      );
+    }),
+  );
+
+  incrementCount(
+    cleanupCountsByTable,
+    'sale_items',
+    await executeDelete(client, 'sale_items', (builder) => {
+      pushTextArrayPredicate(builder, 'id', DEMO_ITEM_IDS.saleItems);
+      pushTextArrayPredicate(builder, 'sale_id', DEMO_IDS.sales);
+      pushTextArrayPredicate(builder, 'product_id', DEMO_IDS.products);
+      pushTextArrayPredicate(builder, 'special_bid_id', DEMO_IDS.specialBids);
+    }),
+  );
+
+  incrementCount(
+    cleanupCountsByTable,
+    'sales',
+    await executeDelete(client, 'sales', (builder) => {
+      pushTextArrayPredicate(builder, 'id', DEMO_IDS.sales);
+      pushTextArrayPredicate(builder, 'client_id', DEMO_IDS.clients);
+      pushTextArrayPredicate(
+        builder,
+        'linked_offer_id',
+        nonEmpty(DEMO_SALES.map((sale) => sale.linkedOfferId)),
+      );
+    }),
+  );
+
+  incrementCount(
+    cleanupCountsByTable,
+    'customer_offer_items',
+    await executeDelete(client, 'customer_offer_items', (builder) => {
+      pushTextArrayPredicate(builder, 'id', DEMO_ITEM_IDS.customerOfferItems);
+      pushTextArrayPredicate(builder, 'offer_id', DEMO_IDS.customerOffers);
+      pushTextArrayPredicate(builder, 'product_id', DEMO_IDS.products);
+      pushTextArrayPredicate(builder, 'special_bid_id', DEMO_IDS.specialBids);
+    }),
+  );
+
+  incrementCount(
+    cleanupCountsByTable,
+    'customer_offers',
+    await executeDelete(client, 'customer_offers', (builder) => {
+      pushTextArrayPredicate(builder, 'id', DEMO_IDS.customerOffers);
+      pushTextArrayPredicate(builder, 'client_id', DEMO_IDS.clients);
+      pushTextArrayPredicate(
+        builder,
+        'offer_code',
+        DEMO_CUSTOMER_OFFERS.map((offer) => offer.offerCode),
+      );
+      pushTextArrayPredicate(
+        builder,
+        'linked_quote_id',
+        DEMO_CUSTOMER_OFFERS.map((offer) => offer.linkedQuoteId),
+      );
+    }),
+  );
+
+  incrementCount(
+    cleanupCountsByTable,
+    'quote_items',
+    await executeDelete(client, 'quote_items', (builder) => {
+      pushTextArrayPredicate(builder, 'id', DEMO_ITEM_IDS.quoteItems);
+      pushTextArrayPredicate(builder, 'quote_id', DEMO_IDS.quotes);
+      pushTextArrayPredicate(builder, 'product_id', DEMO_IDS.products);
+      pushTextArrayPredicate(builder, 'special_bid_id', DEMO_IDS.specialBids);
+    }),
+  );
+
+  incrementCount(
+    cleanupCountsByTable,
+    'quotes',
+    await executeDelete(client, 'quotes', (builder) => {
+      pushTextArrayPredicate(builder, 'id', DEMO_IDS.quotes);
+      pushTextArrayPredicate(builder, 'client_id', DEMO_IDS.clients);
+      pushTextArrayPredicate(
+        builder,
+        'quote_code',
+        DEMO_QUOTES.map((quote) => quote.quoteCode),
+      );
+    }),
+  );
+
+  incrementCount(
+    cleanupCountsByTable,
+    'special_bids',
+    await executeDelete(client, 'special_bids', (builder) => {
+      pushTextArrayPredicate(builder, 'id', DEMO_IDS.specialBids);
+      pushTextArrayPredicate(builder, 'client_id', DEMO_IDS.clients);
+      pushTextArrayPredicate(builder, 'product_id', DEMO_IDS.products);
+    }),
+  );
+
+  incrementCount(
+    cleanupCountsByTable,
+    'products',
+    await executeDelete(client, 'products', (builder) => {
+      pushTextArrayPredicate(builder, 'id', DEMO_IDS.products);
+      pushTextArrayPredicate(
+        builder,
+        'product_code',
+        DEMO_PRODUCTS.map((product) => product.productCode),
+      );
+      pushTextArrayPredicate(
+        builder,
+        'name',
+        DEMO_PRODUCTS.map((product) => product.name),
+      );
+      pushTextArrayPredicate(builder, 'supplier_id', DEMO_IDS.suppliers);
+    }),
+  );
+
+  incrementCount(
+    cleanupCountsByTable,
+    'projects',
+    await executeDelete(client, 'projects', (builder) => {
+      pushTextArrayPredicate(builder, 'id', DEMO_IDS.projects);
+      pushTextArrayPredicate(
+        builder,
+        'name',
+        DEMO_PROJECTS.map((project) => project.name),
+      );
+      pushTextArrayPredicate(builder, 'client_id', DEMO_IDS.clients);
+    }),
+  );
+
+  incrementCount(
+    cleanupCountsByTable,
+    'tasks',
+    await executeDelete(client, 'tasks', (builder) => {
+      pushTextArrayPredicate(builder, 'project_id', DEMO_IDS.projects);
+    }),
+  );
+
+  incrementCount(
+    cleanupCountsByTable,
+    'suppliers',
+    await executeDelete(client, 'suppliers', (builder) => {
+      pushTextArrayPredicate(builder, 'id', DEMO_IDS.suppliers);
+      pushTextArrayPredicate(
+        builder,
+        'supplier_code',
+        DEMO_SUPPLIERS.map((supplier) => supplier.supplierCode),
+      );
+    }),
+  );
+
+  incrementCount(
+    cleanupCountsByTable,
+    'clients',
+    await executeDelete(client, 'clients', (builder) => {
+      pushTextArrayPredicate(builder, 'id', DEMO_IDS.clients);
+      pushTextArrayPredicate(
+        builder,
+        'client_code',
+        DEMO_CLIENTS.map((clientItem) => clientItem.clientCode),
+      );
+      pushLowerTextArrayPredicate(
+        builder,
+        'fiscal_code',
+        DEMO_CLIENTS.map((clientItem) => clientItem.fiscalCode),
+      );
+    }),
+  );
+
+  incrementCount(
+    cleanupCountsByTable,
+    'settings',
+    await executeDelete(client, 'settings', (builder) => {
+      pushTextArrayPredicate(builder, 'user_id', demoUserIdsToDelete);
+    }),
+  );
+
+  incrementCount(
+    cleanupCountsByTable,
+    'user_roles',
+    await executeDelete(client, 'user_roles', (builder) => {
+      pushTextArrayPredicate(builder, 'user_id', demoUserIdsToDelete);
+    }),
+  );
+
+  incrementCount(
+    cleanupCountsByTable,
+    'users',
+    await executeDelete(client, 'users', (builder) => {
+      pushTextArrayPredicate(builder, 'id', demoUserIdsToDelete);
+    }),
+  );
+
+  return cleanupCountsByTable;
+};
+
+const executeDemoStatements = async (client: PoolClient, counts: Record<string, number>) => {
+  const statements = loadDemoStatements();
+  const failedStatements: FailedStatement[] = [];
+
+  for (const [index, statement] of statements.entries()) {
+    const savepoint = `demo_seed_stmt_${index + 1}`;
+    await client.query(`SAVEPOINT ${savepoint}`);
+
+    try {
+      const result = await client.query(statement);
+      incrementCount(counts, extractInsertTable(statement), result.rowCount ?? 0);
+      await client.query(`RELEASE SAVEPOINT ${savepoint}`);
+    } catch (err) {
+      await client.query(`ROLLBACK TO SAVEPOINT ${savepoint}`);
+      await client.query(`RELEASE SAVEPOINT ${savepoint}`);
+
+      failedStatements.push({
+        table: extractInsertTable(statement),
+        keys: extractStatementKeys(statement),
+        statementIndex: index + 1,
+        error: serializeError(err),
+      });
+    }
+  }
+
+  return failedStatements;
+};
+
+const verificationSteps: VerificationStep[] = [
+  { table: 'users', countColumn: 'id', ids: DEMO_USER_IDS, expected: DEMO_EXPECTED_COUNTS.users },
+  {
+    table: 'settings',
+    countColumn: 'user_id',
+    ids: DEMO_IDS.settingsUserIds,
+    expected: DEMO_EXPECTED_COUNTS.settings,
+  },
+  { table: 'clients', ids: DEMO_IDS.clients, expected: DEMO_EXPECTED_COUNTS.clients },
+  { table: 'suppliers', ids: DEMO_IDS.suppliers, expected: DEMO_EXPECTED_COUNTS.suppliers },
+  { table: 'products', ids: DEMO_IDS.products, expected: DEMO_EXPECTED_COUNTS.products },
+  {
+    table: 'special_bids',
+    ids: DEMO_IDS.specialBids,
+    expected: DEMO_EXPECTED_COUNTS.special_bids,
+  },
+  { table: 'quotes', ids: DEMO_IDS.quotes, expected: DEMO_EXPECTED_COUNTS.quotes },
+  {
+    table: 'quote_items',
+    ids: DEMO_ITEM_IDS.quoteItems,
+    expected: DEMO_EXPECTED_COUNTS.quote_items,
+  },
+  {
+    table: 'customer_offers',
+    ids: DEMO_IDS.customerOffers,
+    expected: DEMO_EXPECTED_COUNTS.customer_offers,
+  },
+  {
+    table: 'customer_offer_items',
+    ids: DEMO_ITEM_IDS.customerOfferItems,
+    expected: DEMO_EXPECTED_COUNTS.customer_offer_items,
+  },
+  { table: 'sales', ids: DEMO_IDS.sales, expected: DEMO_EXPECTED_COUNTS.sales },
+  {
+    table: 'sale_items',
+    ids: DEMO_ITEM_IDS.saleItems,
+    expected: DEMO_EXPECTED_COUNTS.sale_items,
+  },
+  { table: 'invoices', ids: DEMO_IDS.invoices, expected: DEMO_EXPECTED_COUNTS.invoices },
+  {
+    table: 'invoice_items',
+    ids: DEMO_ITEM_IDS.invoiceItems,
+    expected: DEMO_EXPECTED_COUNTS.invoice_items,
+  },
+  { table: 'payments', ids: DEMO_IDS.payments, expected: DEMO_EXPECTED_COUNTS.payments },
+  {
+    table: 'supplier_quotes',
+    ids: DEMO_IDS.supplierQuotes,
+    expected: DEMO_EXPECTED_COUNTS.supplier_quotes,
+  },
+  {
+    table: 'supplier_quote_items',
+    ids: DEMO_ITEM_IDS.supplierQuoteItems,
+    expected: DEMO_EXPECTED_COUNTS.supplier_quote_items,
+  },
+  {
+    table: 'supplier_offers',
+    ids: DEMO_IDS.supplierOffers,
+    expected: DEMO_EXPECTED_COUNTS.supplier_offers,
+  },
+  {
+    table: 'supplier_offer_items',
+    ids: DEMO_ITEM_IDS.supplierOfferItems,
+    expected: DEMO_EXPECTED_COUNTS.supplier_offer_items,
+  },
+  {
+    table: 'supplier_sales',
+    ids: DEMO_IDS.supplierSales,
+    expected: DEMO_EXPECTED_COUNTS.supplier_sales,
+  },
+  {
+    table: 'supplier_sale_items',
+    ids: DEMO_ITEM_IDS.supplierSaleItems,
+    expected: DEMO_EXPECTED_COUNTS.supplier_sale_items,
+  },
+  {
+    table: 'supplier_invoices',
+    ids: DEMO_IDS.supplierInvoices,
+    expected: DEMO_EXPECTED_COUNTS.supplier_invoices,
+  },
+  {
+    table: 'supplier_invoice_items',
+    ids: DEMO_ITEM_IDS.supplierInvoiceItems,
+    expected: DEMO_EXPECTED_COUNTS.supplier_invoice_items,
+  },
+  { table: 'expenses', ids: DEMO_IDS.expenses, expected: DEMO_EXPECTED_COUNTS.expenses },
+  { table: 'projects', ids: DEMO_IDS.projects, expected: DEMO_EXPECTED_COUNTS.projects },
+  {
+    table: 'notifications',
+    ids: DEMO_IDS.notifications,
+    expected: DEMO_EXPECTED_COUNTS.notifications,
+  },
+];
+
+const verifyDemoDataset = async () => {
+  const verificationCountsByTable: Record<string, number> = {};
+  const mismatches: Array<{ table: string; expected: number; actual: number }> = [];
+
+  for (const step of verificationSteps) {
+    const countColumn = step.countColumn ?? 'id';
+    const result = await query(
+      `SELECT COUNT(*)::int AS count FROM ${step.table} WHERE ${countColumn} = ANY($1::text[])`,
+      [step.ids],
+    );
+    const actual = Number(result.rows[0]?.count ?? 0);
+    verificationCountsByTable[step.table] = actual;
+    if (actual !== step.expected) {
+      mismatches.push({ table: step.table, expected: step.expected, actual });
+    }
+  }
+
+  return { verificationCountsByTable, mismatches };
+};
+
+const invalidateDemoCaches = async () => {
+  for (const namespace of DEMO_CACHE_NAMESPACES) {
+    await bumpNamespaceVersion(namespace);
+  }
+
+  for (const namespace of DEMO_SETTINGS_CACHE_NAMESPACES) {
+    await bumpNamespaceVersion(namespace);
+  }
+};
+
+const collectDemoUserIdsToDelete = async (client: PoolClient) => {
+  const result = await client.query<{ id: string }>(
+    `SELECT id
+     FROM users
+     WHERE id = ANY($1::text[]) OR username = ANY($2::text[])
+     ORDER BY id`,
+    [DEMO_IDS.users, DEMO_USERS.map((user) => user.username)],
+  );
+  return result.rows.map((row) => row.id);
+};
+
+export const runDemoSeedRefresh = async ({
+  source,
+}: {
+  source: DemoSeedSource;
+}): Promise<DemoSeedResult> => {
+  const insertCountsByTable: Record<string, number> = {};
+  let cleanupCountsByTable: Record<string, number> = {};
+  let verificationCountsByTable: Record<string, number> = {};
+  let failedStatements: FailedStatement[] = [];
+
+  await ensureBootstrapAdmin();
+
+  const client = await pool.connect();
+  let inTransaction = false;
+
+  try {
+    const demoUserIdsToDelete = await collectDemoUserIdsToDelete(client);
+
+    await client.query('BEGIN');
+    inTransaction = true;
+
+    cleanupCountsByTable = await cleanupDemoNamespace(client, demoUserIdsToDelete);
+    await insertCompatibilityDefaults(client, insertCountsByTable);
+    await insertDemoUsersAndSettings(client, insertCountsByTable);
+
+    failedStatements = await executeDemoStatements(client, insertCountsByTable);
+
+    if (failedStatements.length > 0) {
+      throw new Error('Demo seed insert phase failed');
+    }
+
+    await client.query('COMMIT');
+    inTransaction = false;
+  } catch (err) {
+    if (inTransaction) {
+      await client.query('ROLLBACK');
+    }
+
+    logger.error(
+      {
+        demoSeedingEnabled: true,
+        source,
+        cleanupCountsByTable,
+        insertCountsByTable,
+        failedStatements,
+        err: serializeError(err),
+      },
+      'Demo seed refresh failed during cleanup or insert phase',
+    );
+    throw err;
+  } finally {
+    client.release();
+  }
+
+  try {
+    await assignItemsToManagers();
+    const verification = await verifyDemoDataset();
+    verificationCountsByTable = verification.verificationCountsByTable;
+
+    if (verification.mismatches.length > 0) {
+      logger.error(
+        {
+          demoSeedingEnabled: true,
+          source,
+          cleanupCountsByTable,
+          insertCountsByTable,
+          verificationCountsByTable,
+          verificationMismatches: verification.mismatches,
+        },
+        'Demo seed verification failed',
+      );
+      throw new Error(
+        `Demo seed verification failed for ${verification.mismatches
+          .map((item) => `${item.table} expected ${item.expected} got ${item.actual}`)
+          .join(', ')}`,
+      );
+    }
+
+    await invalidateDemoCaches();
+
+    const result: DemoSeedResult = {
+      demoSeedingEnabled: true,
+      source,
+      cleanupCountsByTable,
+      insertCountsByTable,
+      verificationCountsByTable,
+    };
+
+    logger.info(result, 'Demo seed refresh completed');
+    return result;
+  } catch (err) {
+    logger.error(
+      {
+        demoSeedingEnabled: true,
+        source,
+        cleanupCountsByTable,
+        insertCountsByTable,
+        verificationCountsByTable,
+        err: serializeError(err),
+      },
+      'Demo seed refresh failed after insert phase',
+    );
+    throw err;
+  }
+};

--- a/server/db/demoSeedManifest.ts
+++ b/server/db/demoSeedManifest.ts
@@ -1,0 +1,267 @@
+const rangeIds = (prefix: string, count: number, pad = 2) =>
+  Array.from({ length: count }, (_, index) => `${prefix}${String(index + 1).padStart(pad, '0')}`);
+
+const currentYear = new Date().getFullYear();
+
+export const DEMO_PASSWORD_HASH = '$2a$12$z5H7VrzTpLImYWSH3xufKufCiGB0n9CSlNMOrRBRIxq.6mvuVS7uy';
+
+export const DEMO_CACHE_NAMESPACES = ['clients', 'products', 'projects', 'tasks', 'users'] as const;
+export const DEMO_SETTINGS_CACHE_NAMESPACES = ['settings:user:u2', 'settings:user:u3'] as const;
+
+export const DEMO_USERS = [
+  {
+    id: 'u2',
+    name: 'Manager User',
+    username: 'manager',
+    role: 'manager',
+    avatarInitials: 'MG',
+    fullName: 'Manager User',
+    email: 'manager@example.com',
+  },
+  {
+    id: 'u3',
+    name: 'Standard User',
+    username: 'user',
+    role: 'user',
+    avatarInitials: 'US',
+    fullName: 'Standard User',
+    email: 'user@example.com',
+  },
+] as const;
+
+export const DEMO_USER_IDS = DEMO_USERS.map((user) => user.id);
+export const DEMO_USERNAMES = DEMO_USERS.map((user) => user.username);
+
+export const COMPATIBILITY_DEFAULTS = {
+  clients: ['c1', 'c2'],
+  projects: ['p1', 'p2', 'p3'],
+  tasks: ['t1', 't2', 't3', 't4'],
+} as const;
+
+export const DEMO_CLIENTS = [
+  { id: 'dm_cli_01', clientCode: 'DM-CLI-001', fiscalCode: 'IT10000000001' },
+  { id: 'dm_cli_02', clientCode: 'DM-CLI-002', fiscalCode: 'IT10000000002' },
+  { id: 'dm_cli_03', clientCode: 'DM-CLI-003', fiscalCode: 'IT10000000003' },
+  { id: 'dm_cli_04', clientCode: 'DM-CLI-004', fiscalCode: 'FRRGLI90A41A944K' },
+  { id: 'dm_cli_05', clientCode: 'DM-CLI-005', fiscalCode: 'IT10000000005' },
+] as const;
+
+export const DEMO_SUPPLIERS = [
+  { id: 'dm_sup_01', supplierCode: 'DM-SUP-001' },
+  { id: 'dm_sup_02', supplierCode: 'DM-SUP-002' },
+  { id: 'dm_sup_03', supplierCode: 'DM-SUP-003' },
+  { id: 'dm_sup_04', supplierCode: 'DM-SUP-004' },
+  { id: 'dm_sup_05', supplierCode: 'DM-SUP-005' },
+] as const;
+
+export const DEMO_PRODUCTS = [
+  { id: 'dm_prd_01', productCode: 'DM-SVC-AUDIT', name: 'Strategy Assessment' },
+  { id: 'dm_prd_02', productCode: 'DM-SVC-DEPLOY', name: 'Deployment Sprint' },
+  { id: 'dm_prd_03', productCode: 'DM-SVC-SUPPORT', name: 'Managed Support Retainer' },
+  { id: 'dm_prd_04', productCode: 'DM-CNS-TRAIN', name: 'Workshop Training Day' },
+  { id: 'dm_prd_05', productCode: 'DM-SUP-LAPTOP', name: 'Business Laptop Bundle' },
+  { id: 'dm_prd_06', productCode: 'DM-SUP-M365', name: 'Microsoft 365 Annual Seat' },
+  { id: 'dm_prd_07', productCode: 'DM-SUP-FW', name: 'Managed Firewall Appliance' },
+  { id: 'dm_prd_08', productCode: 'DM-SUP-PRINT', name: 'Branded Print Kit' },
+  { id: 'dm_prd_09', productCode: 'DM-DISABLED-001', name: 'Legacy Token Pack' },
+] as const;
+
+export const DEMO_SPECIAL_BIDS = [
+  { id: 'dm_bid_01', clientId: 'dm_cli_01', productId: 'dm_prd_06' },
+  { id: 'dm_bid_02', clientId: 'dm_cli_02', productId: 'dm_prd_05' },
+  { id: 'dm_bid_03', clientId: 'dm_cli_03', productId: 'dm_prd_08' },
+] as const;
+
+export const DEMO_QUOTES = [
+  { id: 'dm_cq_01', quoteCode: 'DM-Q-2601' },
+  { id: 'dm_cq_02', quoteCode: 'DM-Q-2602' },
+  { id: 'dm_cq_03', quoteCode: 'DM-Q-2603' },
+  { id: 'dm_cq_04', quoteCode: 'DM-Q-2604' },
+  { id: 'dm_cq_05', quoteCode: 'DM-Q-2605' },
+  { id: 'dm_cq_06', quoteCode: 'DM-Q-2606' },
+  { id: 'dm_cq_07', quoteCode: 'DM-Q-2607' },
+  { id: 'dm_cq_08', quoteCode: 'DM-Q-2608' },
+  { id: 'dm_cq_09', quoteCode: 'DM-Q-2609' },
+  { id: 'dm_cq_10', quoteCode: 'DM-Q-2610' },
+] as const;
+
+export const DEMO_CUSTOMER_OFFERS = [
+  { id: 'dm_co_01', offerCode: 'DM-OFF-2601', linkedQuoteId: 'dm_cq_04' },
+  { id: 'dm_co_02', offerCode: 'DM-OFF-2602', linkedQuoteId: 'dm_cq_05' },
+  { id: 'dm_co_03', offerCode: 'DM-OFF-2603', linkedQuoteId: 'dm_cq_06' },
+  { id: 'dm_co_04', offerCode: 'DM-OFF-2604', linkedQuoteId: 'dm_cq_07' },
+  { id: 'dm_co_05', offerCode: 'DM-OFF-2605', linkedQuoteId: 'dm_cq_08' },
+] as const;
+
+export const DEMO_SALES = [
+  { id: 'dm_so_01', linkedOfferId: null },
+  { id: 'dm_so_02', linkedOfferId: 'dm_co_04' },
+  { id: 'dm_so_03', linkedOfferId: null },
+  { id: 'dm_so_04', linkedOfferId: null },
+  { id: 'dm_so_05', linkedOfferId: null },
+] as const;
+
+export const DEMO_INVOICES = [
+  { id: 'dm_inv_01', invoiceNumber: 'DM-INV-2601', linkedSaleId: null },
+  { id: 'dm_inv_02', invoiceNumber: 'DM-INV-2602', linkedSaleId: null },
+  { id: 'dm_inv_03', invoiceNumber: 'DM-INV-2603', linkedSaleId: 'dm_so_04' },
+  { id: 'dm_inv_04', invoiceNumber: 'DM-INV-2604', linkedSaleId: null },
+  { id: 'dm_inv_05', invoiceNumber: 'DM-INV-2605', linkedSaleId: null },
+] as const;
+
+export const DEMO_PAYMENTS = [
+  { id: 'dm_pay_01', reference: 'DM-PAY-2601' },
+  { id: 'dm_pay_02', reference: 'DM-PAY-2602' },
+  { id: 'dm_pay_03', reference: 'DM-PAY-2603' },
+] as const;
+
+export const DEMO_SUPPLIER_QUOTES = [
+  { id: 'dm_sq_01', quoteCode: 'DM-SQ-2601', purchaseOrderNumber: 'DM-SQ-2601' },
+  { id: 'dm_sq_02', quoteCode: 'DM-SQ-2602', purchaseOrderNumber: 'DM-SQ-2602' },
+  { id: 'dm_sq_03', quoteCode: 'DM-SQ-2603', purchaseOrderNumber: 'DM-SQ-2603' },
+  { id: 'dm_sq_04', quoteCode: 'DM-SQ-2604', purchaseOrderNumber: 'DM-SQ-2604' },
+  { id: 'dm_sq_05', quoteCode: 'DM-SQ-2605', purchaseOrderNumber: 'DM-SQ-2605' },
+  { id: 'dm_sq_06', quoteCode: 'DM-SQ-2606', purchaseOrderNumber: 'DM-SQ-2606' },
+  { id: 'dm_sq_07', quoteCode: 'DM-SQ-2607', purchaseOrderNumber: 'DM-SQ-2607' },
+  { id: 'dm_sq_08', quoteCode: 'DM-SQ-2608', purchaseOrderNumber: 'DM-SQ-2608' },
+  { id: 'dm_sq_09', quoteCode: 'DM-SQ-2609', purchaseOrderNumber: 'DM-SQ-2609' },
+  { id: 'dm_sq_10', quoteCode: 'DM-SQ-2610', purchaseOrderNumber: 'DM-SQ-2610' },
+  { id: 'dm_sq_11', quoteCode: 'DM-SQ-2611', purchaseOrderNumber: 'DM-SQ-2611' },
+  { id: 'dm_sq_12', quoteCode: 'DM-SQ-2612', purchaseOrderNumber: 'DM-SQ-2612' },
+  { id: 'dm_sq_13', quoteCode: 'DM-SQ-2613', purchaseOrderNumber: 'DM-SQ-2613' },
+  { id: 'dm_sq_14', quoteCode: 'DM-SQ-2614', purchaseOrderNumber: 'DM-SQ-2614' },
+] as const;
+
+export const DEMO_SUPPLIER_OFFERS = [
+  { id: 'dm_sfo_01', offerCode: 'DM-SOF-2601', linkedQuoteId: 'dm_sq_04' },
+  { id: 'dm_sfo_02', offerCode: 'DM-SOF-2602', linkedQuoteId: 'dm_sq_05' },
+  { id: 'dm_sfo_03', offerCode: 'DM-SOF-2603', linkedQuoteId: 'dm_sq_06' },
+  { id: 'dm_sfo_04', offerCode: 'DM-SOF-2604', linkedQuoteId: 'dm_sq_07' },
+  { id: 'dm_sfo_05', offerCode: 'DM-SOF-2605', linkedQuoteId: 'dm_sq_08' },
+  { id: 'dm_sfo_06', offerCode: 'DM-SOF-2606', linkedQuoteId: 'dm_sq_11' },
+  { id: 'dm_sfo_07', offerCode: 'DM-SOF-2607', linkedQuoteId: 'dm_sq_12' },
+  { id: 'dm_sfo_08', offerCode: 'DM-SOF-2608', linkedQuoteId: 'dm_sq_13' },
+  { id: 'dm_sfo_09', offerCode: 'DM-SOF-2609', linkedQuoteId: 'dm_sq_14' },
+] as const;
+
+export const DEMO_SUPPLIER_SALES = [
+  { id: 'dm_ss_01', linkedOfferId: 'dm_sfo_06' },
+  { id: 'dm_ss_02', linkedOfferId: 'dm_sfo_04' },
+  { id: 'dm_ss_03', linkedOfferId: 'dm_sfo_07' },
+  { id: 'dm_ss_04', linkedOfferId: 'dm_sfo_08' },
+  { id: 'dm_ss_05', linkedOfferId: 'dm_sfo_09' },
+] as const;
+
+export const DEMO_SUPPLIER_INVOICES = [
+  { id: 'dm_sinv_01', invoiceNumber: 'DM-SINV-2601', linkedSaleId: null },
+  { id: 'dm_sinv_02', invoiceNumber: 'DM-SINV-2602', linkedSaleId: null },
+  { id: 'dm_sinv_03', invoiceNumber: 'DM-SINV-2603', linkedSaleId: 'dm_ss_04' },
+  { id: 'dm_sinv_04', invoiceNumber: 'DM-SINV-2604', linkedSaleId: null },
+  { id: 'dm_sinv_05', invoiceNumber: 'DM-SINV-2605', linkedSaleId: null },
+] as const;
+
+export const DEMO_EXPENSES = [
+  {
+    id: 'dm_exp_si_01',
+    supplierInvoiceId: 'dm_sinv_01',
+    receiptReference: 'DM-SINV-2601',
+  },
+  {
+    id: 'dm_exp_si_02',
+    supplierInvoiceId: 'dm_sinv_02',
+    receiptReference: 'DM-SINV-2602',
+  },
+  {
+    id: 'dm_exp_si_03',
+    supplierInvoiceId: 'dm_sinv_03',
+    receiptReference: 'DM-SINV-2603',
+  },
+  {
+    id: 'dm_exp_si_04',
+    supplierInvoiceId: 'dm_sinv_04',
+    receiptReference: 'DM-SINV-2604',
+  },
+  {
+    id: 'dm_exp_si_05',
+    supplierInvoiceId: 'dm_sinv_05',
+    receiptReference: 'DM-SINV-2605',
+  },
+  {
+    id: 'dm_exp_m_01',
+    supplierInvoiceId: null,
+    receiptReference: null,
+  },
+  {
+    id: 'dm_exp_m_02',
+    supplierInvoiceId: null,
+    receiptReference: 'OBS-RENEW-2026',
+  },
+] as const;
+
+export const DEMO_PROJECTS = [
+  { id: 'dm_proj_01', name: `DM-CLI-001_DM-SVC-AUDIT_${currentYear}` },
+  { id: 'dm_proj_02', name: `DM-CLI-001_DM-SVC-DEPLOY_${currentYear}` },
+] as const;
+
+export const DEMO_NOTIFICATIONS = ['dm_notif_01', 'dm_notif_02'] as const;
+
+export const DEMO_ITEM_IDS = {
+  quoteItems: rangeIds('dm_cqi_', 14),
+  customerOfferItems: rangeIds('dm_coi_', 7),
+  saleItems: rangeIds('dm_soi_', 8),
+  invoiceItems: rangeIds('dm_inv_item_', 6),
+  supplierQuoteItems: rangeIds('dm_sqi_', 15),
+  supplierOfferItems: rangeIds('dm_sfoi_', 10),
+  supplierSaleItems: rangeIds('dm_ssi_', 6),
+  supplierInvoiceItems: rangeIds('dm_sinv_item_', 6),
+} as const;
+
+export const DEMO_IDS = {
+  clients: DEMO_CLIENTS.map((item) => item.id),
+  suppliers: DEMO_SUPPLIERS.map((item) => item.id),
+  products: DEMO_PRODUCTS.map((item) => item.id),
+  specialBids: DEMO_SPECIAL_BIDS.map((item) => item.id),
+  quotes: DEMO_QUOTES.map((item) => item.id),
+  customerOffers: DEMO_CUSTOMER_OFFERS.map((item) => item.id),
+  sales: DEMO_SALES.map((item) => item.id),
+  invoices: DEMO_INVOICES.map((item) => item.id),
+  payments: DEMO_PAYMENTS.map((item) => item.id),
+  supplierQuotes: DEMO_SUPPLIER_QUOTES.map((item) => item.id),
+  supplierOffers: DEMO_SUPPLIER_OFFERS.map((item) => item.id),
+  supplierSales: DEMO_SUPPLIER_SALES.map((item) => item.id),
+  supplierInvoices: DEMO_SUPPLIER_INVOICES.map((item) => item.id),
+  expenses: DEMO_EXPENSES.map((item) => item.id),
+  projects: DEMO_PROJECTS.map((item) => item.id),
+  notifications: [...DEMO_NOTIFICATIONS],
+  users: [...DEMO_USER_IDS],
+  settingsUserIds: [...DEMO_USER_IDS],
+} as const;
+
+export const DEMO_EXPECTED_COUNTS = {
+  users: DEMO_USERS.length,
+  settings: DEMO_USERS.length,
+  clients: DEMO_CLIENTS.length,
+  suppliers: DEMO_SUPPLIERS.length,
+  products: DEMO_PRODUCTS.length,
+  special_bids: DEMO_SPECIAL_BIDS.length,
+  quotes: DEMO_QUOTES.length,
+  quote_items: DEMO_ITEM_IDS.quoteItems.length,
+  customer_offers: DEMO_CUSTOMER_OFFERS.length,
+  customer_offer_items: DEMO_ITEM_IDS.customerOfferItems.length,
+  sales: DEMO_SALES.length,
+  sale_items: DEMO_ITEM_IDS.saleItems.length,
+  invoices: DEMO_INVOICES.length,
+  invoice_items: DEMO_ITEM_IDS.invoiceItems.length,
+  payments: DEMO_PAYMENTS.length,
+  supplier_quotes: DEMO_SUPPLIER_QUOTES.length,
+  supplier_quote_items: DEMO_ITEM_IDS.supplierQuoteItems.length,
+  supplier_offers: DEMO_SUPPLIER_OFFERS.length,
+  supplier_offer_items: DEMO_ITEM_IDS.supplierOfferItems.length,
+  supplier_sales: DEMO_SUPPLIER_SALES.length,
+  supplier_sale_items: DEMO_ITEM_IDS.supplierSaleItems.length,
+  supplier_invoices: DEMO_SUPPLIER_INVOICES.length,
+  supplier_invoice_items: DEMO_ITEM_IDS.supplierInvoiceItems.length,
+  expenses: DEMO_EXPENSES.length,
+  projects: DEMO_PROJECTS.length,
+  notifications: DEMO_NOTIFICATIONS.length,
+} as const;

--- a/server/db/seed.sql
+++ b/server/db/seed.sql
@@ -1,4 +1,8 @@
--- Seed data for Praetor
+-- Seed data for Praetor demo mode.
+-- The canonical demo refresh is orchestrated by server/db/demoSeed.ts.
+-- DEMO_SEEDING=true provisions the demo users and demo business data by first cleaning the
+-- canonical demo namespace and any demo business-key collisions, then reapplying this file.
+-- This flow is intended for demo/test environments and supports reused Docker volumes.
 
 -- Default users (password is 'password' for all, hashed with bcrypt cost 10)
 -- To generate: require('bcrypt').hashSync('password', 10)
@@ -43,8 +47,8 @@ ON CONFLICT (user_id) DO NOTHING;
 -- Refreshable demo dataset.
 -- Demo records intentionally use dm_* ids and DM-* business codes so reseeding restores the
 -- curated showcase rows in place without deleting non-demo records that reference demo entities.
--- NOTE: No explicit transaction wrapper — the app layer executes each statement independently
--- so that a single table failure does not roll back the entire seed.
+-- The app-layer orchestrator executes these statements in a controlled refresh workflow after
+-- cleanup, verification, manager assignment, and cache invalidation steps are prepared.
 
 INSERT INTO clients (
     id,

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,14 +1,11 @@
-import bcrypt from 'bcryptjs';
-import { randomUUID } from 'crypto';
 import buildApp from './app.ts';
-import pool, { query } from './db/index.ts';
+import { DEFAULT_ADMIN_PASSWORD, ensureBootstrapAdmin } from './db/bootstrapAdmin.ts';
+import { runDemoSeedRefresh } from './db/demoSeed.ts';
+import { query } from './db/index.ts';
 import { closeRedis } from './services/redis.ts';
 import { createChildLogger, serializeError } from './utils/logger.ts';
 
 const PORT = Number(process.env.PORT ?? 3001);
-const ADMIN_USERNAME = 'admin';
-const DEFAULT_ADMIN_USER_ID = 'u1';
-const DEFAULT_ADMIN_PASSWORD = 'password';
 const DEFAULT_JWT_SECRET = 'praetor-secret-key-change-in-production';
 const DEFAULT_ENCRYPTION_KEY = 'praetor-encryption-key-change-in-production';
 const logger = createChildLogger({ module: 'startup' });
@@ -40,46 +37,6 @@ const warnInsecureRuntimeDefaults = () => {
   for (const warning of warnings) {
     logger.warn({ warning }, 'Security warning');
   }
-};
-
-const ensureBootstrapAdmin = async () => {
-  const existingAdmin = await query('SELECT id FROM users WHERE username = $1 LIMIT 1', [
-    ADMIN_USERNAME,
-  ]);
-
-  let adminId: string;
-  if (existingAdmin.rows.length > 0) {
-    adminId = existingAdmin.rows[0].id as string;
-    logger.info('Bootstrap admin already exists. Skipping admin creation');
-  } else {
-    const defaultIdCheck = await query('SELECT 1 FROM users WHERE id = $1 LIMIT 1', [
-      DEFAULT_ADMIN_USER_ID,
-    ]);
-    adminId = defaultIdCheck.rows.length === 0 ? DEFAULT_ADMIN_USER_ID : randomUUID();
-
-    const rawPassword = process.env.ADMIN_DEFAULT_PASSWORD?.trim();
-    const adminPassword =
-      rawPassword && rawPassword.length > 0 ? rawPassword : DEFAULT_ADMIN_PASSWORD;
-    const passwordHash = await bcrypt.hash(adminPassword, 12);
-
-    await query(
-      `INSERT INTO users (id, name, username, password_hash, role, avatar_initials)
-       VALUES ($1, $2, $3, $4, $5, $6)`,
-      [adminId, 'Admin User', ADMIN_USERNAME, passwordHash, 'admin', 'AD'],
-    );
-    logger.info(
-      {
-        passwordSource:
-          rawPassword && rawPassword.length > 0 ? 'ADMIN_DEFAULT_PASSWORD' : 'fallback',
-      },
-      'Bootstrap admin created',
-    );
-  }
-
-  await query('INSERT INTO user_roles (user_id, role_id) VALUES ($1, $2) ON CONFLICT DO NOTHING', [
-    adminId,
-    'admin',
-  ]);
 };
 
 const shutdown = async (signal: string) => {
@@ -163,43 +120,9 @@ try {
     await ensureBootstrapAdmin();
 
     // Run demo seed.sql only when explicitly enabled.
-    const seedPath = path.join(__dirname, 'db', 'seed.sql');
     const isDemoSeedingEnabled = parseBooleanEnv(process.env.DEMO_SEEDING);
-    if (isDemoSeedingEnabled && fs.existsSync(seedPath)) {
-      const seedSql = fs.readFileSync(seedPath, 'utf8');
-      const statements = seedSql
-        .split(/;\s*\n/)
-        .map((s) => s.trim())
-        .filter((s) => s.length > 0 && /\S/m.test(s.replace(/--.*$/gm, '')));
-
-      let succeeded = 0;
-      let failed = 0;
-      const failedTables: string[] = [];
-      const client = await pool.connect();
-      try {
-        for (const stmt of statements) {
-          try {
-            await client.query(stmt);
-            succeeded++;
-          } catch (err) {
-            failed++;
-            const tableMatch = stmt.match(/INSERT\s+INTO\s+(\S+)/i);
-            const table = tableMatch ? tableMatch[1] : 'unknown';
-            failedTables.push(table);
-            logger.warn({ err: serializeError(err), table }, 'Seed statement failed');
-          }
-        }
-      } finally {
-        client.release();
-      }
-
-      if (failed === 0) {
-        logger.info({ statements: succeeded }, 'Demo seed data applied successfully');
-      } else {
-        logger.warn({ succeeded, failed, failedTables }, 'Demo seed data applied with errors');
-      }
-    } else if (isDemoSeedingEnabled) {
-      logger.warn({ seedPath }, 'Demo seeding requested but seed file not found');
+    if (isDemoSeedingEnabled) {
+      await runDemoSeedRefresh({ source: 'startup' });
     } else {
       logger.info('Demo seeding disabled (set DEMO_SEEDING=true to enable)');
     }
@@ -278,14 +201,16 @@ try {
     }
 
     // Run migration to assign all items to manager users
-    try {
-      const { migrate: assignItemsToManagers } = await import('./db/assign_items_to_managers.ts');
-      await assignItemsToManagers();
-    } catch (err) {
-      logger.error(
-        { err: serializeError(err), migration: 'assign_items_to_managers' },
-        'Migration failed',
-      );
+    if (!isDemoSeedingEnabled) {
+      try {
+        const { migrate: assignItemsToManagers } = await import('./db/assign_items_to_managers.ts');
+        await assignItemsToManagers();
+      } catch (err) {
+        logger.error(
+          { err: serializeError(err), migration: 'assign_items_to_managers' },
+          'Migration failed',
+        );
+      }
     }
 
     // Run migration to update currency precision

--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "start": "bun run dist/index.js",
-    "dev": "bun --watch index.ts"
+    "dev": "bun --watch index.ts",
+    "seed:demo": "bun run scripts/seed-demo.ts"
   },
   "dependencies": {
     "@fastify/cors": "^10.0.1",

--- a/server/scripts/seed-demo.ts
+++ b/server/scripts/seed-demo.ts
@@ -1,0 +1,19 @@
+import { runDemoSeedRefresh } from '../db/demoSeed.ts';
+import pool from '../db/index.ts';
+import { closeRedis } from '../services/redis.ts';
+import { createChildLogger, serializeError } from '../utils/logger.ts';
+
+const logger = createChildLogger({ module: 'scripts:seed-demo' });
+
+try {
+  await runDemoSeedRefresh({ source: 'manual' });
+  logger.info('Demo seed refresh finished successfully');
+  await closeRedis();
+  await pool.end();
+  process.exit(0);
+} catch (err) {
+  logger.error({ err: serializeError(err) }, 'Demo seed refresh failed');
+  await closeRedis();
+  await pool.end();
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add a deterministic demo reseed orchestrator with explicit manifest-driven cleanup, verification, manager reassignment, and cache invalidation
- route both startup demo seeding and a new manual `bun run seed:demo` command through the same backend implementation path
- harden App.tsx module loading so datasets apply independently and partial backend failures surface as a compact in-page banner instead of silent empty states
- document `DEMO_SEEDING=true` as the switch that provisions demo users and demo business data for demo/test stacks with reused volumes

## Testing
- bun run build
- cd server && bun run build
- bun run lint
