### PR TITLE
fix: normalize date-only values across server and ui

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -71,7 +71,12 @@ import type {
   View,
   WorkUnit,
 } from './types';
-import { getLocalDateString } from './utils/date';
+import {
+  addDaysToDateOnly,
+  dateOnlyStringToLocalDate,
+  formatDateOnlyForLocale,
+  getLocalDateString,
+} from './utils/date';
 import { isItalianHoliday } from './utils/holidays';
 import {
   buildPermission,
@@ -317,7 +322,7 @@ const TrackerView: React.FC<{
                   <h3 className="text-sm font-bold uppercase tracking-wider text-slate-400">
                     {selectedDate
                       ? t('tracker.activityFor', {
-                          date: new Date(selectedDate).toLocaleDateString(undefined, {
+                          date: formatDateOnlyForLocale(selectedDate, undefined, {
                             month: 'long',
                             day: 'numeric',
                           }),
@@ -1786,9 +1791,11 @@ const App: React.FC = () => {
       const client = project ? clients.find((c) => c.id === project.clientId) : null;
       if (!project || !client) continue;
 
-      const startDate = task.recurrenceStart ? new Date(task.recurrenceStart) : new Date();
+      const startDate = task.recurrenceStart
+        ? dateOnlyStringToLocalDate(task.recurrenceStart)
+        : new Date();
       // Use recurrence end date if specified, otherwise use default 14-day limit
-      const taskEndDate = task.recurrenceEnd ? new Date(task.recurrenceEnd) : null;
+      const taskEndDate = task.recurrenceEnd ? dateOnlyStringToLocalDate(task.recurrenceEnd) : null;
       const futureLimit =
         taskEndDate && taskEndDate > defaultFutureLimit ? taskEndDate : defaultFutureLimit;
 
@@ -2604,9 +2611,9 @@ const App: React.FC = () => {
 
   const handleCreateSupplierInvoiceFromOrder = async (order: SupplierSaleOrder) => {
     try {
-      const now = new Date();
       const paymentDays = Number.parseInt(order.paymentTerms?.replace(/\D/g, '') || '30', 10) || 30;
-      const dueDate = new Date(now.getTime() + paymentDays * 24 * 60 * 60 * 1000);
+      const issueDate = getLocalDateString();
+      const dueDate = addDaysToDateOnly(issueDate, paymentDays);
       const items = order.items.map((item) => ({
         id: `tmp-${Math.random().toString(36).slice(2, 9)}`,
         invoiceId: '',
@@ -2632,8 +2639,8 @@ const App: React.FC = () => {
         linkedSaleId: order.id,
         supplierId: order.supplierId,
         supplierName: order.supplierName,
-        issueDate: now.toISOString().split('T')[0],
-        dueDate: dueDate.toISOString().split('T')[0],
+        issueDate,
+        dueDate,
         status: 'draft',
         subtotal: totals.subtotal,
         taxAmount: totals.taxAmount,

--- a/components/ExpensesView.tsx
+++ b/components/ExpensesView.tsx
@@ -2,6 +2,7 @@ import type React from 'react';
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Expense } from '../types';
+import { formatDateOnlyForLocale, getLocalDateString } from '../utils/date';
 import CustomSelect from './shared/CustomSelect';
 import Modal from './shared/Modal';
 import StandardTable from './shared/StandardTable';
@@ -74,7 +75,7 @@ const ExpensesView: React.FC<ExpensesViewProps> = ({
   const [formData, setFormData] = useState<Partial<Expense>>({
     description: '',
     amount: 0,
-    expenseDate: new Date().toISOString().split('T')[0],
+    expenseDate: getLocalDateString(),
     category: 'other',
     vendor: '',
     receiptReference: '',
@@ -87,7 +88,7 @@ const ExpensesView: React.FC<ExpensesViewProps> = ({
     setFormData({
       description: '',
       amount: 0,
-      expenseDate: new Date().toISOString().split('T')[0],
+      expenseDate: getLocalDateString(),
       category: 'other',
       vendor: '',
       receiptReference: '',
@@ -461,7 +462,7 @@ const ExpensesView: React.FC<ExpensesViewProps> = ({
                 className="hover:bg-slate-50/50 cursor-pointer transition-colors"
               >
                 <td className="px-6 py-4 text-sm text-slate-600">
-                  {new Date(expense.expenseDate).toLocaleDateString()}
+                  {formatDateOnlyForLocale(expense.expenseDate)}
                 </td>
                 <td className="px-6 py-4 font-bold text-slate-800">
                   <div>{expense.description}</div>

--- a/components/PaymentsView.tsx
+++ b/components/PaymentsView.tsx
@@ -2,6 +2,7 @@ import type React from 'react';
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Client, Invoice, Payment } from '../types';
+import { formatDateOnlyForLocale, getLocalDateString } from '../utils/date';
 import CustomSelect from './shared/CustomSelect';
 import Modal from './shared/Modal';
 import StandardTable from './shared/StandardTable';
@@ -82,7 +83,7 @@ const PaymentsView: React.FC<PaymentsViewProps> = ({
     clientId: '',
     invoiceId: '',
     amount: 0,
-    paymentDate: new Date().toISOString().split('T')[0],
+    paymentDate: getLocalDateString(),
     paymentMethod: 'bank_transfer',
     reference: '',
     notes: '',
@@ -94,7 +95,7 @@ const PaymentsView: React.FC<PaymentsViewProps> = ({
       clientId: '',
       invoiceId: '',
       amount: 0,
-      paymentDate: new Date().toISOString().split('T')[0],
+      paymentDate: getLocalDateString(),
       paymentMethod: 'bank_transfer',
       reference: '',
       notes: '',
@@ -492,7 +493,7 @@ const PaymentsView: React.FC<PaymentsViewProps> = ({
                   className="hover:bg-slate-50/50 cursor-pointer transition-colors"
                 >
                   <td className="px-6 py-4 text-sm text-slate-600">
-                    {new Date(payment.paymentDate).toLocaleDateString()}
+                    {formatDateOnlyForLocale(payment.paymentDate)}
                   </td>
                   <td className="px-6 py-4 font-bold text-slate-800">
                     {client?.name || t('payments.unknownClient')}

--- a/components/RecurringManager.tsx
+++ b/components/RecurringManager.tsx
@@ -2,6 +2,7 @@ import type React from 'react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Client, Project, ProjectTask } from '../types';
+import { formatDateOnlyForLocale } from '../utils/date';
 import Modal from './shared/Modal';
 import Tooltip from './shared/Tooltip';
 
@@ -107,7 +108,7 @@ const RecurringManager: React.FC<RecurringManagerProps> = ({
                     <td className="px-6 py-4">
                       {task.recurrenceEnd ? (
                         <span className="text-xs font-medium text-slate-600 bg-slate-100 px-2 py-1 rounded">
-                          {new Date(task.recurrenceEnd).toLocaleDateString()}
+                          {formatDateOnlyForLocale(task.recurrenceEnd)}
                         </span>
                       ) : (
                         <span className="text-xs text-slate-400 italic">

--- a/components/accounting/ClientsInvoicesView.tsx
+++ b/components/accounting/ClientsInvoicesView.tsx
@@ -2,6 +2,7 @@ import type React from 'react';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Client, ClientsOrder, Invoice, InvoiceItem, Product } from '../../types';
+import { addDaysToDateOnly, formatDateOnlyForLocale, getLocalDateString } from '../../utils/date';
 import { roundToTwoDecimals } from '../../utils/numbers';
 import CustomSelect from '../shared/CustomSelect';
 import Modal from '../shared/Modal';
@@ -55,15 +56,14 @@ const ClientsInvoicesView: React.FC<ClientsInvoicesViewProps> = ({
 
   // Form State
   const defaultInvoice = useMemo(() => {
-    const now = new Date();
-    const dueDate = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000);
+    const issueDate = getLocalDateString();
     return {
       clientId: '',
       clientName: '',
       invoiceNumber: '',
       items: [],
-      issueDate: now.toISOString().split('T')[0],
-      dueDate: dueDate.toISOString().split('T')[0],
+      issueDate,
+      dueDate: addDaysToDateOnly(issueDate, 30),
       status: 'draft' as const,
       notes: '',
       amountPaid: 0,
@@ -88,8 +88,8 @@ const ClientsInvoicesView: React.FC<ClientsInvoicesViewProps> = ({
       clientName: '',
       invoiceNumber: generateInvoiceNumber(),
       items: [],
-      issueDate: new Date().toISOString().split('T')[0],
-      dueDate: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0],
+      issueDate: getLocalDateString(),
+      dueDate: addDaysToDateOnly(getLocalDateString(), 30),
       status: 'draft',
       notes: '',
       amountPaid: 0,
@@ -281,20 +281,16 @@ const ClientsInvoicesView: React.FC<ClientsInvoicesViewProps> = ({
       },
       {
         header: t('common:labels.date'),
-        accessorFn: (row: Invoice) => new Date(row.issueDate).toLocaleDateString(),
+        accessorFn: (row: Invoice) => formatDateOnlyForLocale(row.issueDate),
         cell: ({ row }: { row: Invoice }) => (
-          <span className="text-sm text-slate-600">
-            {new Date(row.issueDate).toLocaleDateString()}
-          </span>
+          <span className="text-sm text-slate-600">{formatDateOnlyForLocale(row.issueDate)}</span>
         ),
       },
       {
         header: t('accounting:clientsInvoices.dueDate'),
-        accessorFn: (row: Invoice) => new Date(row.dueDate).toLocaleDateString(),
+        accessorFn: (row: Invoice) => formatDateOnlyForLocale(row.dueDate),
         cell: ({ row }: { row: Invoice }) => (
-          <span className="text-sm text-slate-600">
-            {new Date(row.dueDate).toLocaleDateString()}
-          </span>
+          <span className="text-sm text-slate-600">{formatDateOnlyForLocale(row.dueDate)}</span>
         ),
       },
       {

--- a/components/accounting/ClientsOrdersView.tsx
+++ b/components/accounting/ClientsOrdersView.tsx
@@ -2,6 +2,7 @@ import type React from 'react';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Client, ClientsOrder, ClientsOrderItem, Product, SpecialBid } from '../../types';
+import { getLocalDateString, isDateOnlyWithinInclusiveRange } from '../../utils/date';
 import { parseNumberInputValue, roundToTwoDecimals } from '../../utils/numbers';
 import CustomSelect from '../shared/CustomSelect';
 import Modal from '../shared/Modal';
@@ -370,12 +371,9 @@ const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
 
   const activeClients = clients.filter((c) => !c.isDisabled);
   const activeProducts = products.filter((p) => !p.isDisabled);
+  const today = getLocalDateString();
   const activeSpecialBids = specialBids.filter((b) => {
-    const now = new Date();
-    const startDate = b.startDate ? new Date(b.startDate) : null;
-    const endDate = b.endDate ? new Date(b.endDate) : null;
-    if (!startDate || !endDate) return true;
-    return now >= startDate && now <= endDate;
+    return isDateOnlyWithinInclusiveRange(today, b.startDate, b.endDate);
   });
   const clientSpecialBids = formData.clientId
     ? activeSpecialBids.filter((b) => b.clientId === formData.clientId)

--- a/components/accounting/SupplierInvoicesView.tsx
+++ b/components/accounting/SupplierInvoicesView.tsx
@@ -2,6 +2,7 @@ import type React from 'react';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Product, Supplier, SupplierInvoice, SupplierInvoiceItem } from '../../types';
+import { addDaysToDateOnly, getLocalDateString, normalizeDateOnlyString } from '../../utils/date';
 import { roundToTwoDecimals } from '../../utils/numbers';
 import CustomSelect from '../shared/CustomSelect';
 import Modal from '../shared/Modal';
@@ -81,8 +82,8 @@ const SupplierInvoicesView: React.FC<SupplierInvoicesViewProps> = ({
     supplierId: '',
     supplierName: '',
     invoiceNumber: '',
-    issueDate: new Date().toISOString().split('T')[0],
-    dueDate: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0],
+    issueDate: getLocalDateString(),
+    dueDate: addDaysToDateOnly(getLocalDateString(), 30),
     status: 'draft',
     subtotal: 0,
     taxAmount: 0,
@@ -96,8 +97,8 @@ const SupplierInvoicesView: React.FC<SupplierInvoicesViewProps> = ({
     setEditingInvoice(invoice);
     setFormData({
       ...invoice,
-      issueDate: invoice.issueDate?.split('T')[0] || '',
-      dueDate: invoice.dueDate?.split('T')[0] || '',
+      issueDate: invoice.issueDate ? normalizeDateOnlyString(invoice.issueDate) : '',
+      dueDate: invoice.dueDate ? normalizeDateOnlyString(invoice.dueDate) : '',
       items: invoice.items.map((item) => ({ ...item })),
     });
     setIsModalOpen(true);

--- a/components/catalog/SpecialBidsView.tsx
+++ b/components/catalog/SpecialBidsView.tsx
@@ -2,6 +2,13 @@ import type React from 'react';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Client, Product, SpecialBid } from '../../types';
+import {
+  formatDateOnlyForLocale,
+  getLocalDateString,
+  isDateOnlyAfterToday,
+  isDateOnlyBeforeToday,
+  normalizeDateOnlyString,
+} from '../../utils/date';
 import { parseNumberInputValue, roundToTwoDecimals } from '../../utils/numbers';
 import Calendar from '../shared/Calendar';
 import CustomSelect from '../shared/CustomSelect';
@@ -11,8 +18,8 @@ import StatusBadge from '../shared/StatusBadge';
 import Tooltip from '../shared/Tooltip';
 import ValidatedNumberInput from '../shared/ValidatedNumberInput';
 
-const isExpired = (endDate: string) => new Date(endDate) < new Date();
-const isNotStarted = (startDate: string) => new Date(startDate) > new Date();
+const isExpired = (endDate: string) => isDateOnlyBeforeToday(endDate);
+const isNotStarted = (startDate: string) => isDateOnlyAfterToday(startDate);
 
 export interface SpecialBidsViewProps {
   bids: SpecialBid[];
@@ -55,8 +62,8 @@ const SpecialBidsView: React.FC<SpecialBidsViewProps> = ({
     productName: '',
     unitPrice: 0,
     molPercentage: undefined,
-    startDate: new Date().toISOString().split('T')[0],
-    endDate: new Date().toISOString().split('T')[0],
+    startDate: getLocalDateString(),
+    endDate: getLocalDateString(),
   });
 
   const activeClients = clients.filter((c) => !c.isDisabled);
@@ -78,8 +85,8 @@ const SpecialBidsView: React.FC<SpecialBidsViewProps> = ({
       productName: '',
       unitPrice: 0,
       molPercentage: undefined,
-      startDate: new Date().toISOString().split('T')[0],
-      endDate: new Date().toISOString().split('T')[0],
+      startDate: getLocalDateString(),
+      endDate: getLocalDateString(),
     });
     setErrors({});
     setIsModalOpen(true);
@@ -87,10 +94,8 @@ const SpecialBidsView: React.FC<SpecialBidsViewProps> = ({
 
   const openEditModal = (bid: SpecialBid) => {
     setEditingBid(bid);
-    const formattedStartDate = bid.startDate
-      ? new Date(bid.startDate).toISOString().split('T')[0]
-      : '';
-    const formattedEndDate = bid.endDate ? new Date(bid.endDate).toISOString().split('T')[0] : '';
+    const formattedStartDate = bid.startDate ? normalizeDateOnlyString(bid.startDate) : '';
+    const formattedEndDate = bid.endDate ? normalizeDateOnlyString(bid.endDate) : '';
     setFormData({
       clientId: bid.clientId,
       clientName: bid.clientName,
@@ -323,8 +328,8 @@ const SpecialBidsView: React.FC<SpecialBidsViewProps> = ({
       {
         header: t('externalListing.validityPeriod'),
         accessorFn: (row: SpecialBid) => {
-          const start = new Date(row.startDate).toLocaleDateString();
-          const end = new Date(row.endDate).toLocaleDateString();
+          const start = formatDateOnlyForLocale(row.startDate);
+          const end = formatDateOnlyForLocale(row.endDate);
           return `${start} - ${end}`;
         },
         cell: ({ row }: { row: SpecialBid }) => {
@@ -334,8 +339,7 @@ const SpecialBidsView: React.FC<SpecialBidsViewProps> = ({
             <div
               className={`text-sm ${expired ? 'text-red-600 font-bold' : notStarted ? 'text-amber-600 font-bold' : 'text-slate-600'}`}
             >
-              {new Date(row.startDate).toLocaleDateString()} -{' '}
-              {new Date(row.endDate).toLocaleDateString()}
+              {formatDateOnlyForLocale(row.startDate)} - {formatDateOnlyForLocale(row.endDate)}
             </div>
           );
         },
@@ -588,13 +592,13 @@ const SpecialBidsView: React.FC<SpecialBidsViewProps> = ({
               <div className="flex items-center gap-4 text-sm text-slate-600 mb-2">
                 <span className="font-bold">
                   {formData.startDate
-                    ? new Date(formData.startDate).toLocaleDateString()
+                    ? formatDateOnlyForLocale(formData.startDate)
                     : t('externalListing.selectStart')}
                 </span>
                 <i className="fa-solid fa-arrow-right text-slate-400"></i>
                 <span className="font-bold">
                   {formData.endDate
-                    ? new Date(formData.endDate).toLocaleDateString()
+                    ? formatDateOnlyForLocale(formData.endDate)
                     : t('externalListing.selectEnd')}
                 </span>
               </div>

--- a/components/sales/ClientOffersView.tsx
+++ b/components/sales/ClientOffersView.tsx
@@ -2,6 +2,11 @@ import type React from 'react';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Client, ClientOffer, ClientOfferItem, Product, SpecialBid } from '../../types';
+import {
+  getLocalDateString,
+  isDateOnlyWithinInclusiveRange,
+  normalizeDateOnlyString,
+} from '../../utils/date';
 import { roundToTwoDecimals } from '../../utils/numbers';
 import CustomSelect from '../shared/CustomSelect';
 import Modal from '../shared/Modal';
@@ -118,14 +123,12 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
     () => products.filter((product) => !product.isDisabled),
     [products],
   );
+  const today = getLocalDateString();
   const activeSpecialBids = useMemo(() => {
-    const now = new Date();
     return specialBids.filter((bid) => {
-      const start = new Date(bid.startDate);
-      const end = new Date(bid.endDate);
-      return start <= now && end >= now;
+      return isDateOnlyWithinInclusiveRange(today, bid.startDate, bid.endDate);
     });
-  }, [specialBids]);
+  }, [specialBids, today]);
 
   const [editingOffer, setEditingOffer] = useState<ClientOffer | null>(null);
   const [offerToDelete, setOfferToDelete] = useState<ClientOffer | null>(null);
@@ -143,7 +146,7 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
     paymentTerms: 'immediate',
     discount: 0,
     status: 'draft',
-    expirationDate: new Date().toISOString().split('T')[0],
+    expirationDate: getLocalDateString(),
     notes: '',
   });
 
@@ -164,7 +167,7 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
     setEditingOffer(offer);
     setFormData({
       ...offer,
-      expirationDate: offer.expirationDate?.split('T')[0] || '',
+      expirationDate: offer.expirationDate ? normalizeDateOnlyString(offer.expirationDate) : '',
     });
     setErrors({});
     setIsModalOpen(true);
@@ -367,7 +370,7 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
       paymentTerms: 'immediate',
       discount: 0,
       status: 'draft',
-      expirationDate: new Date().toISOString().split('T')[0],
+      expirationDate: getLocalDateString(),
       notes: '',
     });
     setErrors({});

--- a/components/sales/ClientQuotesView.tsx
+++ b/components/sales/ClientQuotesView.tsx
@@ -2,6 +2,13 @@ import type React from 'react';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Client, ClientOffer, Product, Quote, QuoteItem, SpecialBid } from '../../types';
+import {
+  formatDateOnlyForLocale,
+  getLocalDateString,
+  isDateOnlyBeforeToday,
+  isDateOnlyWithinInclusiveRange,
+  normalizeDateOnlyString,
+} from '../../utils/date';
 import { parseNumberInputValue, roundToTwoDecimals } from '../../utils/numbers';
 import CustomSelect from '../shared/CustomSelect';
 import Modal from '../shared/Modal';
@@ -94,14 +101,10 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
   );
 
   // Helper: Check if quote is expired
-  const isExpired = useCallback((expirationDate: string) => {
-    const normalizedDate = expirationDate.includes('T')
-      ? expirationDate
-      : `${expirationDate}T00:00:00`;
-    const expiry = new Date(normalizedDate);
-    expiry.setDate(expiry.getDate() + 1);
-    return new Date() >= expiry;
-  }, []);
+  const isExpired = useCallback(
+    (expirationDate: string) => isDateOnlyBeforeToday(expirationDate),
+    [],
+  );
 
   const isQuoteExpired = useCallback(
     (quote: Quote) => {
@@ -186,7 +189,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
     paymentTerms: 'immediate',
     discount: 0,
     status: 'draft',
-    expirationDate: new Date().toISOString().split('T')[0],
+    expirationDate: getLocalDateString(),
     notes: '',
   });
   const isReadOnly = Boolean(
@@ -208,7 +211,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
       paymentTerms: 'immediate',
       discount: 0,
       status: 'draft',
-      expirationDate: new Date().toISOString().split('T')[0],
+      expirationDate: getLocalDateString(),
       notes: '',
     });
     setErrors({});
@@ -219,9 +222,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
     setEditingQuote(quote);
     setPendingClientChange(null);
     // Ensure expirationDate is in YYYY-MM-DD format for the date input
-    const formattedDate = quote.expirationDate
-      ? new Date(quote.expirationDate).toISOString().split('T')[0]
-      : '';
+    const formattedDate = quote.expirationDate ? normalizeDateOnlyString(quote.expirationDate) : '';
     setFormData({
       quoteCode: quote.quoteCode,
       clientId: quote.clientId,
@@ -596,12 +597,9 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
 
   const activeClients = clients.filter((c) => !c.isDisabled);
   const activeProducts = products.filter((p) => !p.isDisabled);
+  const today = getLocalDateString();
   const activeSpecialBids = specialBids.filter((b) => {
-    const now = new Date();
-    const startDate = b.startDate ? new Date(b.startDate) : null;
-    const endDate = b.endDate ? new Date(b.endDate) : null;
-    if (!startDate || !endDate) return true;
-    return now >= startDate && now <= endDate;
+    return isDateOnlyWithinInclusiveRange(today, b.startDate, b.endDate);
   });
   const clientSpecialBids = formData.clientId
     ? activeSpecialBids.filter((b) => b.clientId === formData.clientId)
@@ -681,7 +679,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                 history ? 'text-slate-400' : expired ? 'text-red-600 font-bold' : 'text-slate-600'
               }`}
             >
-              {new Date(row.expirationDate).toLocaleDateString()}
+              {formatDateOnlyForLocale(row.expirationDate)}
               {expired && !history && (
                 <span className="ml-2 text-[10px] font-black">
                   {t('sales:clientQuotes.expiredLabel')}

--- a/components/sales/SupplierOffersView.tsx
+++ b/components/sales/SupplierOffersView.tsx
@@ -2,6 +2,7 @@ import type React from 'react';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Product, Supplier, SupplierOffer, SupplierOfferItem } from '../../types';
+import { getLocalDateString, normalizeDateOnlyString } from '../../utils/date';
 import { roundToTwoDecimals } from '../../utils/numbers';
 import CustomSelect from '../shared/CustomSelect';
 import Modal from '../shared/Modal';
@@ -101,7 +102,7 @@ const SupplierOffersView: React.FC<SupplierOffersViewProps> = ({
     paymentTerms: 'immediate',
     discount: 0,
     status: 'draft',
-    expirationDate: new Date().toISOString().split('T')[0],
+    expirationDate: getLocalDateString(),
     notes: '',
   });
 
@@ -121,7 +122,7 @@ const SupplierOffersView: React.FC<SupplierOffersViewProps> = ({
     setEditingOffer(offer);
     setFormData({
       ...offer,
-      expirationDate: offer.expirationDate?.split('T')[0] || '',
+      expirationDate: offer.expirationDate ? normalizeDateOnlyString(offer.expirationDate) : '',
     });
     setErrors({});
     setIsModalOpen(true);

--- a/components/sales/SupplierQuotesView.tsx
+++ b/components/sales/SupplierQuotesView.tsx
@@ -2,6 +2,11 @@ import type React from 'react';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Product, Supplier, SupplierQuote, SupplierQuoteItem } from '../../types';
+import {
+  formatDateOnlyForLocale,
+  getLocalDateString,
+  normalizeDateOnlyString,
+} from '../../utils/date';
 import { roundToTwoDecimals } from '../../utils/numbers';
 import CustomSelect from '../shared/CustomSelect';
 import Modal from '../shared/Modal';
@@ -101,7 +106,7 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
     paymentTerms: 'immediate',
     discount: 0,
     status: 'draft',
-    expirationDate: new Date().toISOString().split('T')[0],
+    expirationDate: getLocalDateString(),
     notes: '',
   });
 
@@ -131,7 +136,7 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
       paymentTerms: 'immediate',
       discount: 0,
       status: 'draft',
-      expirationDate: new Date().toISOString().split('T')[0],
+      expirationDate: getLocalDateString(),
       notes: '',
     });
     setErrors({});
@@ -144,7 +149,7 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
       ...quote,
       quoteCode: quote.quoteCode || quote.purchaseOrderNumber || '',
       purchaseOrderNumber: quote.quoteCode || quote.purchaseOrderNumber || '',
-      expirationDate: quote.expirationDate?.split('T')[0] || '',
+      expirationDate: quote.expirationDate ? normalizeDateOnlyString(quote.expirationDate) : '',
     });
     setErrors({});
     setIsModalOpen(true);
@@ -224,7 +229,7 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
                     defaultValue: 'Linked to offer',
                   })} ${row.linkedOfferId}`
                 : row.expirationDate
-                  ? new Date(row.expirationDate).toLocaleDateString()
+                  ? formatDateOnlyForLocale(row.expirationDate)
                   : ''}
             </div>
           </div>

--- a/components/shared/Calendar.tsx
+++ b/components/shared/Calendar.tsx
@@ -2,7 +2,7 @@ import type React from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { TimeEntry } from '../../types';
-import { getLocalDateString } from '../../utils/date';
+import { dateOnlyStringToLocalDate, getLocalDateString } from '../../utils/date';
 import { isItalianHoliday } from '../../utils/holidays';
 import Tooltip from './Tooltip';
 
@@ -39,7 +39,11 @@ const Calendar: React.FC<CalendarProps> = ({
   allowWeekendSelection = false,
 }) => {
   const { t } = useTranslation('timesheets');
-  const [viewDate, setViewDate] = useState(new Date(selectedDate || startDate || new Date()));
+  const [viewDate, setViewDate] = useState(() => {
+    if (selectedDate) return dateOnlyStringToLocalDate(selectedDate);
+    if (startDate) return dateOnlyStringToLocalDate(startDate);
+    return new Date();
+  });
   const [isMonthPickerOpen, setIsMonthPickerOpen] = useState(false);
   const [isYearPickerOpen, setIsYearPickerOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -114,7 +118,7 @@ const Calendar: React.FC<CalendarProps> = ({
       } else {
         // Complete the range
         // Ensure start is before end
-        if (new Date(dateStr) < new Date(startDate)) {
+        if (dateStr < startDate) {
           onRangeSelect(dateStr, startDate);
         } else {
           onRangeSelect(startDate, dateStr);

--- a/server/routes/client-offers.ts
+++ b/server/routes/client-offers.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { query } from '../db/index.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
 import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
+import { normalizeNullableDateOnly } from '../utils/date.ts';
 import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
@@ -236,15 +237,6 @@ const toNullableString = (value: unknown) => {
   return String(value);
 };
 
-const toDateOnlyString = (value: Date) => value.toISOString().slice(0, 10);
-
-const toNullableDateOnlyString = (value: unknown, fieldName: string) => {
-  if (value === undefined || value === null) return null;
-  if (value instanceof Date) return toDateOnlyString(value);
-  if (typeof value === 'string') return value;
-  throw new TypeError(`Invalid date value for ${fieldName}`);
-};
-
 const normalizeOfferItemRow = (row: Record<string, unknown>) => ({
   id: String(row.id),
   offerId: String(row.offerId),
@@ -280,7 +272,7 @@ const normalizeOfferRow = (row: Record<string, unknown>) => ({
   paymentTerms: toNullableString(row.paymentTerms),
   discount: toFiniteNumber(row.discount, 'offer.discount'),
   status: String(row.status),
-  expirationDate: toNullableDateOnlyString(row.expirationDate, 'offer.expirationDate'),
+  expirationDate: normalizeNullableDateOnly(row.expirationDate, 'offer.expirationDate'),
   notes: toNullableString(row.notes),
   createdAt: toFiniteNumber(row.createdAt, 'offer.createdAt'),
   updatedAt: toFiniteNumber(row.updatedAt, 'offer.updatedAt'),

--- a/server/routes/client-offers.ts
+++ b/server/routes/client-offers.ts
@@ -218,6 +218,74 @@ const normalizeItems = (items: OfferItemInput[], reply: FastifyReply) => {
   return normalizedItems;
 };
 
+const toFiniteNumber = (value: unknown, fieldName: string) => {
+  const parsedValue = Number(value);
+  if (!Number.isFinite(parsedValue)) {
+    throw new TypeError(`Invalid numeric value for ${fieldName}`);
+  }
+  return parsedValue;
+};
+
+const toNullableFiniteNumber = (value: unknown, fieldName: string) => {
+  if (value === undefined || value === null) return null;
+  return toFiniteNumber(value, fieldName);
+};
+
+const toNullableString = (value: unknown) => {
+  if (value === undefined || value === null) return null;
+  return String(value);
+};
+
+const toDateOnlyString = (value: Date) => value.toISOString().slice(0, 10);
+
+const toNullableDateOnlyString = (value: unknown, fieldName: string) => {
+  if (value === undefined || value === null) return null;
+  if (value instanceof Date) return toDateOnlyString(value);
+  if (typeof value === 'string') return value;
+  throw new TypeError(`Invalid date value for ${fieldName}`);
+};
+
+const normalizeOfferItemRow = (row: Record<string, unknown>) => ({
+  id: String(row.id),
+  offerId: String(row.offerId),
+  productId: toNullableString(row.productId),
+  productName: String(row.productName),
+  specialBidId: toNullableString(row.specialBidId),
+  quantity: toFiniteNumber(row.quantity, 'offerItem.quantity'),
+  unitPrice: toFiniteNumber(row.unitPrice, 'offerItem.unitPrice'),
+  productCost: toFiniteNumber(row.productCost, 'offerItem.productCost'),
+  productTaxRate: toFiniteNumber(row.productTaxRate, 'offerItem.productTaxRate'),
+  productMolPercentage: toNullableFiniteNumber(
+    row.productMolPercentage,
+    'offerItem.productMolPercentage',
+  ),
+  specialBidUnitPrice: toNullableFiniteNumber(
+    row.specialBidUnitPrice,
+    'offerItem.specialBidUnitPrice',
+  ),
+  specialBidMolPercentage: toNullableFiniteNumber(
+    row.specialBidMolPercentage,
+    'offerItem.specialBidMolPercentage',
+  ),
+  note: toNullableString(row.note),
+  discount: toFiniteNumber(row.discount, 'offerItem.discount'),
+});
+
+const normalizeOfferRow = (row: Record<string, unknown>) => ({
+  id: String(row.id),
+  offerCode: String(row.offerCode),
+  linkedQuoteId: String(row.linkedQuoteId),
+  clientId: String(row.clientId),
+  clientName: String(row.clientName),
+  paymentTerms: toNullableString(row.paymentTerms),
+  discount: toFiniteNumber(row.discount, 'offer.discount'),
+  status: String(row.status),
+  expirationDate: toNullableDateOnlyString(row.expirationDate, 'offer.expirationDate'),
+  notes: toNullableString(row.notes),
+  createdAt: toFiniteNumber(row.createdAt, 'offer.createdAt'),
+  updatedAt: toFiniteNumber(row.updatedAt, 'offer.updatedAt'),
+});
+
 export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.addHook('onRequest', authenticateToken);
 
@@ -276,15 +344,22 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
          ORDER BY created_at ASC`,
       );
 
-      const itemsByOffer: Record<string, unknown[]> = {};
-      itemsResult.rows.forEach((item: { offerId: string }) => {
+      const normalizedOfferItems = itemsResult.rows.map((item) =>
+        normalizeOfferItemRow(item as Record<string, unknown>),
+      );
+      const normalizedOffers = offersResult.rows.map((offer) =>
+        normalizeOfferRow(offer as Record<string, unknown>),
+      );
+
+      const itemsByOffer: Record<string, ReturnType<typeof normalizeOfferItemRow>[]> = {};
+      normalizedOfferItems.forEach((item) => {
         if (!itemsByOffer[item.offerId]) {
           itemsByOffer[item.offerId] = [];
         }
         itemsByOffer[item.offerId].push(item);
       });
 
-      return offersResult.rows.map((offer: { id: string }) => ({
+      return normalizedOffers.map((offer) => ({
         ...offer,
         items: itemsByOffer[offer.id] || [],
       }));
@@ -409,7 +484,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         throw err;
       }
 
-      const createdItems: unknown[] = [];
+      const createdItems: ReturnType<typeof normalizeOfferItemRow>[] = [];
       for (const item of normalizedItems) {
         const itemId = 'coi-' + Date.now() + '-' + Math.random().toString(36).slice(2, 9);
         const itemResult = await query(
@@ -448,11 +523,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
             item.note,
           ],
         );
-        createdItems.push(itemResult.rows[0]);
+        createdItems.push(normalizeOfferItemRow(itemResult.rows[0] as Record<string, unknown>));
       }
 
       return reply.code(201).send({
-        ...createdOfferResult.rows[0],
+        ...normalizeOfferRow(createdOfferResult.rows[0] as Record<string, unknown>),
         items: createdItems,
       });
     },
@@ -644,7 +719,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         return reply.code(404).send({ error: 'Offer not found' });
       }
 
-      let updatedItems: unknown[] = [];
+      let updatedItems: ReturnType<typeof normalizeOfferItemRow>[] = [];
       if (items !== undefined) {
         if (!Array.isArray(items) || items.length === 0) {
           return badRequest(reply, 'Items must be a non-empty array');
@@ -690,7 +765,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
               item.note,
             ],
           );
-          updatedItems.push(itemResult.rows[0]);
+          updatedItems.push(normalizeOfferItemRow(itemResult.rows[0] as Record<string, unknown>));
         }
       } else {
         const itemsResult = await query(
@@ -713,11 +788,13 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
            WHERE offer_id = $1`,
           [idResult.value],
         );
-        updatedItems = itemsResult.rows;
+        updatedItems = itemsResult.rows.map((item) =>
+          normalizeOfferItemRow(item as Record<string, unknown>),
+        );
       }
 
       return {
-        ...updatedOfferResult.rows[0],
+        ...normalizeOfferRow(updatedOfferResult.rows[0] as Record<string, unknown>),
         items: updatedItems,
       };
     },

--- a/server/routes/client-quotes.ts
+++ b/server/routes/client-quotes.ts
@@ -356,6 +356,74 @@ const quoteUpdateBodySchema = {
   },
 } as const;
 
+const toFiniteNumber = (value: unknown, fieldName: string) => {
+  const parsedValue = Number(value);
+  if (!Number.isFinite(parsedValue)) {
+    throw new TypeError(`Invalid numeric value for ${fieldName}`);
+  }
+  return parsedValue;
+};
+
+const toNullableFiniteNumber = (value: unknown, fieldName: string) => {
+  if (value === undefined || value === null) return null;
+  return toFiniteNumber(value, fieldName);
+};
+
+const toNullableString = (value: unknown) => {
+  if (value === undefined || value === null) return null;
+  return String(value);
+};
+
+const toDateOnlyString = (value: Date) => value.toISOString().slice(0, 10);
+
+const toNullableDateOnlyString = (value: unknown, fieldName: string) => {
+  if (value === undefined || value === null) return null;
+  if (value instanceof Date) return toDateOnlyString(value);
+  if (typeof value === 'string') return value;
+  throw new TypeError(`Invalid date value for ${fieldName}`);
+};
+
+const normalizeQuoteItemRow = (row: Record<string, unknown>) => ({
+  id: String(row.id),
+  quoteId: String(row.quoteId),
+  productId: String(row.productId),
+  productName: String(row.productName),
+  specialBidId: toNullableString(row.specialBidId),
+  quantity: toFiniteNumber(row.quantity, 'quoteItem.quantity'),
+  unitPrice: toFiniteNumber(row.unitPrice, 'quoteItem.unitPrice'),
+  productCost: toFiniteNumber(row.productCost, 'quoteItem.productCost'),
+  productTaxRate: toFiniteNumber(row.productTaxRate, 'quoteItem.productTaxRate'),
+  productMolPercentage: toNullableFiniteNumber(
+    row.productMolPercentage,
+    'quoteItem.productMolPercentage',
+  ),
+  specialBidUnitPrice: toNullableFiniteNumber(
+    row.specialBidUnitPrice,
+    'quoteItem.specialBidUnitPrice',
+  ),
+  specialBidMolPercentage: toNullableFiniteNumber(
+    row.specialBidMolPercentage,
+    'quoteItem.specialBidMolPercentage',
+  ),
+  discount: toFiniteNumber(row.discount, 'quoteItem.discount'),
+  note: toNullableString(row.note),
+});
+
+const normalizeQuoteRow = (row: Record<string, unknown>) => ({
+  id: String(row.id),
+  quoteCode: String(row.quoteCode),
+  linkedOfferId: toNullableString(row.linkedOfferId),
+  clientId: String(row.clientId),
+  clientName: String(row.clientName),
+  paymentTerms: toNullableString(row.paymentTerms),
+  discount: toFiniteNumber(row.discount, 'quote.discount'),
+  status: String(row.status),
+  expirationDate: toNullableDateOnlyString(row.expirationDate, 'quote.expirationDate'),
+  notes: toNullableString(row.notes),
+  createdAt: toFiniteNumber(row.createdAt, 'quote.createdAt'),
+  updatedAt: toFiniteNumber(row.updatedAt, 'quote.updatedAt'),
+});
+
 export default async function (fastify: FastifyInstance, _opts: unknown) {
   // All quote routes require authentication
   fastify.addHook('onRequest', authenticateToken);
@@ -444,9 +512,16 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         [],
       );
 
+      const normalizedQuoteItems = itemsResult.rows.map((item) =>
+        normalizeQuoteItemRow(item as Record<string, unknown>),
+      );
+      const normalizedQuotes = quotesResult.rows.map((quote) =>
+        normalizeQuoteRow(quote as Record<string, unknown>),
+      );
+
       // Group items by quote
-      const itemsByQuote: Record<string, unknown[]> = {};
-      itemsResult.rows.forEach((item: { quoteId: string }) => {
+      const itemsByQuote: Record<string, ReturnType<typeof normalizeQuoteItemRow>[]> = {};
+      normalizedQuoteItems.forEach((item) => {
         if (!itemsByQuote[item.quoteId]) {
           itemsByQuote[item.quoteId] = [];
         }
@@ -454,17 +529,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       });
 
       // Attach items to quotes
-      const quotes = quotesResult.rows.map(
-        (quote: {
-          id: string;
-          status: string;
-          expirationDate: string | Date | null | undefined;
-        }) => ({
-          ...quote,
-          items: itemsByQuote[quote.id] || [],
-          isExpired: isQuoteExpired(quote.status, quote.expirationDate),
-        }),
-      );
+      const quotes = normalizedQuotes.map((quote) => ({
+        ...quote,
+        items: itemsByQuote[quote.id] || [],
+        isExpired: isQuoteExpired(quote.status, quote.expirationDate),
+      }));
 
       return quotes;
     },
@@ -614,7 +683,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         );
 
         // Insert quote items
-        const createdItems: unknown[] = [];
+        const createdItems: ReturnType<typeof normalizeQuoteItemRow>[] = [];
         for (const item of resolvedItems) {
           const itemId = 'qi-' + Date.now() + '-' + Math.random().toString(36).substr(2, 9);
           const itemResult = await query(
@@ -652,13 +721,15 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
               item.note || null,
             ],
           );
-          createdItems.push(itemResult.rows[0]);
+          createdItems.push(normalizeQuoteItemRow(itemResult.rows[0] as Record<string, unknown>));
         }
 
+        const normalizedQuote = normalizeQuoteRow(quoteResult.rows[0] as Record<string, unknown>);
+
         return reply.code(201).send({
-          ...quoteResult.rows[0],
+          ...normalizedQuote,
           items: createdItems,
-          isExpired: isQuoteExpired(quoteResult.rows[0].status, quoteResult.rows[0].expirationDate),
+          isExpired: isQuoteExpired(normalizedQuote.status, normalizedQuote.expirationDate),
         });
       } catch (err) {
         console.error('CRITICAL ERROR creating quote:', err);
@@ -975,7 +1046,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       }
 
       // If items are provided, update them
-      let updatedItems: unknown[] = [];
+      let updatedItems: ReturnType<typeof normalizeQuoteItemRow>[] = [];
       if (normalizedItems) {
         // Delete existing items
         await query('DELETE FROM quote_items WHERE quote_id = $1', [idResult.value]);
@@ -1018,7 +1089,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
               item.note || null,
             ],
           );
-          updatedItems.push(itemResult.rows[0]);
+          updatedItems.push(normalizeQuoteItemRow(itemResult.rows[0] as Record<string, unknown>));
         }
       } else {
         // Fetch existing items
@@ -1042,16 +1113,20 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
                 WHERE quote_id = $1`,
           [idResult.value],
         );
-        updatedItems = itemsResult.rows;
+        updatedItems = itemsResult.rows.map((item) =>
+          normalizeQuoteItemRow(item as Record<string, unknown>),
+        );
       }
 
+      const normalizedQuote = normalizeQuoteRow(quoteResult.rows[0] as Record<string, unknown>);
+
       return {
-        ...quoteResult.rows[0],
+        ...normalizedQuote,
         items: updatedItems,
         isExpired:
           typeof isExpiredOverride === 'boolean'
             ? isExpiredOverride
-            : isQuoteExpired(quoteResult.rows[0].status, quoteResult.rows[0].expirationDate),
+            : isQuoteExpired(normalizedQuote.status, normalizedQuote.expirationDate),
       };
     },
   );

--- a/server/routes/client-quotes.ts
+++ b/server/routes/client-quotes.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { query } from '../db/index.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
 import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
+import { isPastLocalDate, normalizeNullableDateOnly } from '../utils/date.ts';
 import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
@@ -374,15 +375,6 @@ const toNullableString = (value: unknown) => {
   return String(value);
 };
 
-const toDateOnlyString = (value: Date) => value.toISOString().slice(0, 10);
-
-const toNullableDateOnlyString = (value: unknown, fieldName: string) => {
-  if (value === undefined || value === null) return null;
-  if (value instanceof Date) return toDateOnlyString(value);
-  if (typeof value === 'string') return value;
-  throw new TypeError(`Invalid date value for ${fieldName}`);
-};
-
 const normalizeQuoteItemRow = (row: Record<string, unknown>) => ({
   id: String(row.id),
   quoteId: String(row.quoteId),
@@ -418,7 +410,7 @@ const normalizeQuoteRow = (row: Record<string, unknown>) => ({
   paymentTerms: toNullableString(row.paymentTerms),
   discount: toFiniteNumber(row.discount, 'quote.discount'),
   status: String(row.status),
-  expirationDate: toNullableDateOnlyString(row.expirationDate, 'quote.expirationDate'),
+  expirationDate: normalizeNullableDateOnly(row.expirationDate, 'quote.expirationDate'),
   notes: toNullableString(row.notes),
   createdAt: toFiniteNumber(row.createdAt, 'quote.createdAt'),
   updatedAt: toFiniteNumber(row.updatedAt, 'quote.updatedAt'),
@@ -428,23 +420,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   // All quote routes require authentication
   fastify.addHook('onRequest', authenticateToken);
 
-  const isQuoteExpired = (status: string, expirationDate: string | Date | null | undefined) => {
+  const isQuoteExpired = (status: string, expirationDate: string | null | undefined) => {
     if (status === 'confirmed') return false;
     if (!expirationDate) return false;
-
-    let normalizedDate: string;
-    if (expirationDate instanceof Date) {
-      normalizedDate = expirationDate.toISOString().split('T')[0];
-    } else {
-      normalizedDate = expirationDate.toString().includes('T')
-        ? expirationDate.toString().split('T')[0]
-        : expirationDate.toString();
-    }
-
-    const expiry = new Date(normalizedDate);
-    // Set time to end of day to avoid premature expiration
-    expiry.setHours(23, 59, 59, 999);
-    return new Date() > expiry;
+    return isPastLocalDate(expirationDate);
   };
 
   // GET / - List all quotes with their items

--- a/server/routes/clients-orders.ts
+++ b/server/routes/clients-orders.ts
@@ -150,6 +150,64 @@ const clientOrderUpdateBodySchema = {
   },
 } as const;
 
+const toFiniteNumber = (value: unknown, fieldName: string) => {
+  const parsedValue = Number(value);
+  if (!Number.isFinite(parsedValue)) {
+    throw new TypeError(`Invalid numeric value for ${fieldName}`);
+  }
+  return parsedValue;
+};
+
+const toNullableFiniteNumber = (value: unknown, fieldName: string) => {
+  if (value === undefined || value === null) return null;
+  return toFiniteNumber(value, fieldName);
+};
+
+const toNullableString = (value: unknown) => {
+  if (value === undefined || value === null) return null;
+  return String(value);
+};
+
+const normalizeClientOrderItemRow = (row: Record<string, unknown>) => ({
+  id: String(row.id),
+  orderId: String(row.orderId),
+  productId: toNullableString(row.productId),
+  productName: String(row.productName),
+  specialBidId: toNullableString(row.specialBidId),
+  quantity: toFiniteNumber(row.quantity, 'clientOrderItem.quantity'),
+  unitPrice: toFiniteNumber(row.unitPrice, 'clientOrderItem.unitPrice'),
+  productCost: toFiniteNumber(row.productCost, 'clientOrderItem.productCost'),
+  productTaxRate: toFiniteNumber(row.productTaxRate, 'clientOrderItem.productTaxRate'),
+  productMolPercentage: toNullableFiniteNumber(
+    row.productMolPercentage,
+    'clientOrderItem.productMolPercentage',
+  ),
+  specialBidUnitPrice: toNullableFiniteNumber(
+    row.specialBidUnitPrice,
+    'clientOrderItem.specialBidUnitPrice',
+  ),
+  specialBidMolPercentage: toNullableFiniteNumber(
+    row.specialBidMolPercentage,
+    'clientOrderItem.specialBidMolPercentage',
+  ),
+  note: toNullableString(row.note),
+  discount: toFiniteNumber(row.discount, 'clientOrderItem.discount'),
+});
+
+const normalizeClientOrderRow = (row: Record<string, unknown>) => ({
+  id: String(row.id),
+  linkedQuoteId: toNullableString(row.linkedQuoteId),
+  linkedOfferId: toNullableString(row.linkedOfferId),
+  clientId: String(row.clientId),
+  clientName: String(row.clientName),
+  paymentTerms: toNullableString(row.paymentTerms),
+  discount: toFiniteNumber(row.discount, 'clientOrder.discount'),
+  status: String(row.status),
+  notes: toNullableString(row.notes),
+  createdAt: toFiniteNumber(row.createdAt, 'clientOrder.createdAt'),
+  updatedAt: toFiniteNumber(row.updatedAt, 'clientOrder.updatedAt'),
+});
+
 export default async function (fastify: FastifyInstance, _opts: unknown) {
   // All clients_orders routes require authentication
   fastify.addHook('onRequest', authenticateToken);
@@ -212,9 +270,16 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
             ORDER BY created_at ASC`,
       );
 
+      const normalizedOrders = clients_ordersResult.rows.map((order) =>
+        normalizeClientOrderRow(order as Record<string, unknown>),
+      );
+      const normalizedItems = itemsResult.rows.map((item) =>
+        normalizeClientOrderItemRow(item as Record<string, unknown>),
+      );
+
       // Group items by order
-      const itemsByOrder: Record<string, unknown[]> = {};
-      itemsResult.rows.forEach((item: { orderId: string }) => {
+      const itemsByOrder: Record<string, ReturnType<typeof normalizeClientOrderItemRow>[]> = {};
+      normalizedItems.forEach((item) => {
         if (!itemsByOrder[item.orderId]) {
           itemsByOrder[item.orderId] = [];
         }
@@ -222,7 +287,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       });
 
       // Attach items to clients_orders
-      const clients_orders = clients_ordersResult.rows.map((order: { id: string }) => ({
+      const clients_orders = normalizedOrders.map((order) => ({
         ...order,
         items: itemsByOrder[order.id] || [],
       }));
@@ -407,7 +472,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       }
 
       // Insert order items
-      const createdItems = [];
+      const createdItems: ReturnType<typeof normalizeClientOrderItemRow>[] = [];
       for (const item of normalizedItems) {
         const itemId = 'si-' + Date.now() + '-' + Math.random().toString(36).substr(2, 9);
         const itemResult = await query(
@@ -445,11 +510,13 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
             item.note || null,
           ],
         );
-        createdItems.push(itemResult.rows[0]);
+        createdItems.push(
+          normalizeClientOrderItemRow(itemResult.rows[0] as Record<string, unknown>),
+        );
       }
 
       return reply.code(201).send({
-        ...orderResult.rows[0],
+        ...normalizeClientOrderRow(orderResult.rows[0] as Record<string, unknown>),
         items: createdItems,
       });
     },
@@ -862,10 +929,12 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       }
 
       // If items are provided, update them
-      let updatedItems = [];
+      let updatedItems: ReturnType<typeof normalizeClientOrderItemRow>[] = [];
       if (isSourceLinkedOrder) {
         if (existingItems) {
-          updatedItems = existingItems;
+          updatedItems = existingItems.map((item) =>
+            normalizeClientOrderItemRow(item as Record<string, unknown>),
+          );
         } else {
           const itemsResult = await query(
             `SELECT
@@ -887,7 +956,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
                     WHERE sale_id = $1`,
             [idResult.value],
           );
-          updatedItems = itemsResult.rows;
+          updatedItems = itemsResult.rows.map((item) =>
+            normalizeClientOrderItemRow(item as Record<string, unknown>),
+          );
         }
       } else if (items !== undefined) {
         if (!normalizedItems) return;
@@ -932,7 +1003,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
               item.note || null,
             ],
           );
-          updatedItems.push(itemResult.rows[0]);
+          updatedItems.push(
+            normalizeClientOrderItemRow(itemResult.rows[0] as Record<string, unknown>),
+          );
         }
       } else {
         // Fetch existing items
@@ -956,7 +1029,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
                 WHERE sale_id = $1`,
           [idResult.value],
         );
-        updatedItems = itemsResult.rows;
+        updatedItems = itemsResult.rows.map((item) =>
+          normalizeClientOrderItemRow(item as Record<string, unknown>),
+        );
       }
 
       // Auto-create projects when order is confirmed for the first time
@@ -1048,7 +1123,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       }
 
       return {
-        ...orderResult.rows[0],
+        ...normalizeClientOrderRow(orderResult.rows[0] as Record<string, unknown>),
         items: updatedItems,
       };
     },

--- a/server/routes/entries.ts
+++ b/server/routes/entries.ts
@@ -14,6 +14,7 @@ import {
   TTL_ENTRIES_SECONDS,
 } from '../services/cache.ts';
 import { assertAuthenticated } from '../utils/auth-assert.ts';
+import { normalizeNullableDateOnly, todayLocalDateOnly } from '../utils/date.ts';
 import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
@@ -119,6 +120,14 @@ const entriesBulkDeleteQuerySchema = {
 const hasPermission = (request: FastifyRequest, permission: string) =>
   request.user?.permissions?.includes(permission) ?? false;
 
+const toRequiredDateOnly = (value: unknown, fieldName: string) => {
+  const normalizedDate = normalizeNullableDateOnly(value, fieldName);
+  if (!normalizedDate) {
+    throw new TypeError(`Invalid date value for ${fieldName}`);
+  }
+  return normalizedDate;
+};
+
 export default async function (fastify: FastifyInstance, _opts: unknown) {
   // GET / - List time entries
   fastify.get(
@@ -220,7 +229,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           return result.rows.map((e) => ({
             id: e.id,
             userId: e.user_id,
-            date: e.date.toISOString().split('T')[0],
+            date: toRequiredDateOnly(e.date, 'entry.date'),
             clientId: e.client_id,
             clientName: e.client_name,
             projectId: e.project_id,
@@ -482,7 +491,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       return {
         id: e.id,
         userId: e.user_id,
-        date: e.date.toISOString().split('T')[0],
+        date: toRequiredDateOnly(e.date, 'entry.date'),
         clientId: e.client_id,
         clientName: e.client_name,
         projectId: e.project_id,
@@ -609,7 +618,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
 
       if (futureOnlyValue === true) {
         sql += ` AND date >= $${paramIndex++}`;
-        params.push(new Date().toISOString().split('T')[0]);
+        params.push(todayLocalDateOnly());
       }
 
       if (placeholderOnlyValue === true) {

--- a/server/routes/expenses.ts
+++ b/server/routes/expenses.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { query } from '../db/index.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
 import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
+import { normalizeNullableDateOnly } from '../utils/date.ts';
 import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
@@ -66,6 +67,20 @@ const expenseUpdateBodySchema = {
   },
 } as const;
 
+const toRequiredDateOnly = (value: unknown, fieldName: string) => {
+  const normalizedDate = normalizeNullableDateOnly(value, fieldName);
+  if (!normalizedDate) {
+    throw new TypeError(`Invalid date value for ${fieldName}`);
+  }
+  return normalizedDate;
+};
+
+const formatExpenseResponse = (expense: Record<string, unknown>) => ({
+  ...expense,
+  amount: parseFloat(String(expense.amount ?? 0)),
+  expenseDate: toRequiredDateOnly(expense.expenseDate, 'expense.expenseDate'),
+});
+
 export default async function (fastify: FastifyInstance, _opts: unknown) {
   // All expenses routes require authentication
   fastify.addHook('onRequest', authenticateToken);
@@ -105,11 +120,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
             ORDER BY expense_date DESC`,
       );
 
-      const expenses = result.rows.map((expense) => ({
-        ...expense,
-        amount: parseFloat(expense.amount),
-        expenseDate: expense.expenseDate.toISOString().split('T')[0],
-      }));
+      const expenses = result.rows.map((expense) =>
+        formatExpenseResponse(expense as Record<string, unknown>),
+      );
 
       return expenses;
     },
@@ -195,11 +208,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       );
 
       const expense = result.rows[0];
-      return reply.code(201).send({
-        ...expense,
-        amount: parseFloat(expense.amount),
-        expenseDate: new Date(expense.expenseDate).toISOString().split('T')[0],
-      });
+      return reply.code(201).send(formatExpenseResponse(expense as Record<string, unknown>));
     },
   );
 
@@ -348,11 +357,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       }
 
       const expense = result.rows[0];
-      return {
-        ...expense,
-        amount: parseFloat(expense.amount),
-        expenseDate: new Date(expense.expenseDate).toISOString().split('T')[0],
-      };
+      return formatExpenseResponse(expense as Record<string, unknown>);
     },
   );
 

--- a/server/routes/invoices.ts
+++ b/server/routes/invoices.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { query } from '../db/index.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
 import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
+import { normalizeNullableDateOnly } from '../utils/date.ts';
 import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
@@ -132,6 +133,36 @@ const invoiceUpdateBodySchema = {
   },
 } as const;
 
+const toRequiredDateOnly = (value: unknown, fieldName: string) => {
+  const normalizedDate = normalizeNullableDateOnly(value, fieldName);
+  if (!normalizedDate) {
+    throw new TypeError(`Invalid date value for ${fieldName}`);
+  }
+  return normalizedDate;
+};
+
+const formatInvoiceItem = (item: Record<string, unknown>) => ({
+  ...item,
+  quantity: parseFloat(String(item.quantity ?? 0)),
+  unitPrice: parseFloat(String(item.unitPrice ?? 0)),
+  taxRate: parseFloat(String(item.taxRate ?? 0)),
+  discount: parseFloat(String(item.discount ?? 0)),
+});
+
+const formatInvoiceResponse = (
+  invoice: Record<string, unknown>,
+  items: Record<string, unknown>[],
+) => ({
+  ...invoice,
+  issueDate: toRequiredDateOnly(invoice.issueDate, 'invoice.issueDate'),
+  dueDate: toRequiredDateOnly(invoice.dueDate, 'invoice.dueDate'),
+  subtotal: parseFloat(String(invoice.subtotal ?? 0)),
+  taxAmount: parseFloat(String(invoice.taxAmount ?? 0)),
+  total: parseFloat(String(invoice.total ?? 0)),
+  amountPaid: parseFloat(String(invoice.amountPaid ?? 0)),
+  items: items.map(formatInvoiceItem),
+});
+
 export default async function (fastify: FastifyInstance, _opts: unknown) {
   // All invoices routes require authentication
   fastify.addHook('onRequest', authenticateToken);
@@ -201,39 +232,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       });
 
       // Attach items to invoices
-      const invoices = invoicesResult.rows.map(
-        (invoice: {
-          id: string;
-          issueDate: { toISOString: () => string };
-          dueDate: { toISOString: () => string };
-          subtotal: string;
-          taxAmount: string;
-          total: string;
-          amountPaid: string;
-        }) => ({
-          ...invoice,
-          issueDate: invoice.issueDate.toISOString().split('T')[0],
-          dueDate: invoice.dueDate.toISOString().split('T')[0],
-          subtotal: parseFloat(invoice.subtotal),
-          taxAmount: parseFloat(invoice.taxAmount),
-          total: parseFloat(invoice.total),
-          amountPaid: parseFloat(invoice.amountPaid),
-          items: (itemsByInvoice[invoice.id] || []).map((item: unknown) => {
-            const typedItem = item as {
-              quantity: string;
-              unitPrice: string;
-              taxRate: string;
-              discount: string;
-            };
-            return {
-              ...typedItem,
-              quantity: parseFloat(typedItem.quantity),
-              unitPrice: parseFloat(typedItem.unitPrice),
-              taxRate: parseFloat(typedItem.taxRate),
-              discount: parseFloat(typedItem.discount),
-            };
-          }),
-        }),
+      const invoices = invoicesResult.rows.map((invoice) =>
+        formatInvoiceResponse(
+          invoice as Record<string, unknown>,
+          (itemsByInvoice[invoice.id] || []) as Record<string, unknown>[],
+        ),
       );
 
       return invoices;
@@ -301,7 +304,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const dueDateResult = parseDateString(dueDate, 'dueDate');
       if (!dueDateResult.ok) return badRequest(reply, dueDateResult.message);
 
-      if (new Date(dueDateResult.value) < new Date(issueDateResult.value)) {
+      if (dueDateResult.value < issueDateResult.value) {
         return badRequest(reply, 'dueDate must be on or after issueDate');
       }
 
@@ -428,22 +431,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       }
 
       const invoice = invoiceResult.rows[0];
-      return reply.code(201).send({
-        ...invoice,
-        issueDate: new Date(invoice.issueDate).toISOString().split('T')[0],
-        dueDate: new Date(invoice.dueDate).toISOString().split('T')[0],
-        subtotal: parseFloat(invoice.subtotal),
-        taxAmount: parseFloat(invoice.taxAmount),
-        total: parseFloat(invoice.total),
-        amountPaid: parseFloat(invoice.amountPaid),
-        items: createdItems.map((item) => ({
-          ...item,
-          quantity: parseFloat(item.quantity),
-          unitPrice: parseFloat(item.unitPrice),
-          taxRate: parseFloat(item.taxRate),
-          discount: parseFloat(item.discount),
-        })),
-      });
+      return reply
+        .code(201)
+        .send(formatInvoiceResponse(invoice as Record<string, unknown>, createdItems));
     },
   );
 
@@ -531,7 +521,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       }
 
       if (issueDate && dueDate) {
-        if (new Date(dueDate as string) < new Date(issueDate as string)) {
+        if ((dueDate as string) < (issueDate as string)) {
           return badRequest(reply, 'dueDate must be on or after issueDate');
         }
       }
@@ -712,22 +702,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       }
 
       const invoice = invoiceResult.rows[0];
-      return {
-        ...invoice,
-        issueDate: new Date(invoice.issueDate).toISOString().split('T')[0],
-        dueDate: new Date(invoice.dueDate).toISOString().split('T')[0],
-        subtotal: parseFloat(invoice.subtotal),
-        taxAmount: parseFloat(invoice.taxAmount),
-        total: parseFloat(invoice.total),
-        amountPaid: parseFloat(invoice.amountPaid),
-        items: updatedItems.map((item) => ({
-          ...item,
-          quantity: parseFloat(item.quantity),
-          unitPrice: parseFloat(item.unitPrice),
-          taxRate: parseFloat(item.taxRate),
-          discount: parseFloat(item.discount),
-        })),
-      };
+      return formatInvoiceResponse(
+        invoice as Record<string, unknown>,
+        updatedItems as Record<string, unknown>[],
+      );
     },
   );
 

--- a/server/routes/payments.ts
+++ b/server/routes/payments.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { query } from '../db/index.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
 import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
+import { normalizeNullableDateOnly } from '../utils/date.ts';
 import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
@@ -62,6 +63,20 @@ const paymentUpdateBodySchema = {
   },
 } as const;
 
+const toRequiredDateOnly = (value: unknown, fieldName: string) => {
+  const normalizedDate = normalizeNullableDateOnly(value, fieldName);
+  if (!normalizedDate) {
+    throw new TypeError(`Invalid date value for ${fieldName}`);
+  }
+  return normalizedDate;
+};
+
+const formatPaymentResponse = (payment: Record<string, unknown>) => ({
+  ...payment,
+  amount: parseFloat(String(payment.amount ?? 0)),
+  paymentDate: toRequiredDateOnly(payment.paymentDate, 'payment.paymentDate'),
+});
+
 export default async function (fastify: FastifyInstance, _opts: unknown) {
   // All payments routes require authentication
   fastify.addHook('onRequest', authenticateToken);
@@ -104,11 +119,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       // Actually, let's left join clients to get client name if needed, but existing `payments` table doesn't store client_name cache like others.
       // We stored client_id.
 
-      const payments = result.rows.map((payment) => ({
-        ...payment,
-        amount: parseFloat(payment.amount),
-        paymentDate: payment.paymentDate.toISOString().split('T')[0],
-      }));
+      const payments = result.rows.map((payment) =>
+        formatPaymentResponse(payment as Record<string, unknown>),
+      );
 
       return payments;
     },
@@ -226,11 +239,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         await query('COMMIT');
 
         const payment = result.rows[0];
-        return reply.code(201).send({
-          ...payment,
-          amount: parseFloat(payment.amount),
-          paymentDate: new Date(payment.paymentDate).toISOString().split('T')[0],
-        });
+        return reply.code(201).send(formatPaymentResponse(payment as Record<string, unknown>));
       } catch (err) {
         await query('ROLLBACK');
         throw err;
@@ -360,11 +369,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
 
         await query('COMMIT');
 
-        return {
-          ...updatedPayment,
-          amount: parseFloat(updatedPayment.amount),
-          paymentDate: new Date(updatedPayment.paymentDate).toISOString().split('T')[0],
-        };
+        return formatPaymentResponse(updatedPayment as Record<string, unknown>);
       } catch (err) {
         await query('ROLLBACK');
         throw err;

--- a/server/routes/supplier-invoices.ts
+++ b/server/routes/supplier-invoices.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { query } from '../db/index.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
 import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
+import { normalizeNullableDateOnly } from '../utils/date.ts';
 import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
@@ -209,6 +210,14 @@ const normalizeItems = (items: SupplierInvoiceItemInput[], reply: FastifyReply) 
   return normalizedItems;
 };
 
+const toRequiredDateOnly = (value: unknown, fieldName: string) => {
+  const normalizedDate = normalizeNullableDateOnly(value, fieldName);
+  if (!normalizedDate) {
+    throw new TypeError(`Invalid date value for ${fieldName}`);
+  }
+  return normalizedDate;
+};
+
 const syncExpenseForInvoice = async (invoice: {
   id: string;
   supplierName: string;
@@ -217,10 +226,7 @@ const syncExpenseForInvoice = async (invoice: {
   total: string | number;
   notes?: string | null;
 }) => {
-  const expenseDate =
-    invoice.issueDate instanceof Date
-      ? invoice.issueDate.toISOString().split('T')[0]
-      : String(invoice.issueDate).split('T')[0];
+  const expenseDate = toRequiredDateOnly(invoice.issueDate, 'supplierInvoice.issueDate');
   const description = `Supplier invoice ${invoice.invoiceNumber}`;
 
   const existingExpenseResult = await query(
@@ -300,14 +306,8 @@ const formatInvoiceResponse = (
   items: Array<Record<string, unknown>>,
 ) => ({
   ...invoice,
-  issueDate:
-    invoice.issueDate instanceof Date
-      ? invoice.issueDate.toISOString().split('T')[0]
-      : String(invoice.issueDate).split('T')[0],
-  dueDate:
-    invoice.dueDate instanceof Date
-      ? invoice.dueDate.toISOString().split('T')[0]
-      : String(invoice.dueDate).split('T')[0],
+  issueDate: toRequiredDateOnly(invoice.issueDate, 'supplierInvoice.issueDate'),
+  dueDate: toRequiredDateOnly(invoice.dueDate, 'supplierInvoice.dueDate'),
   subtotal: Number(invoice.subtotal ?? 0),
   taxAmount: Number(invoice.taxAmount ?? 0),
   total: Number(invoice.total ?? 0),
@@ -466,7 +466,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const dueDateResult = parseDateString(dueDate, 'dueDate');
       if (!dueDateResult.ok) return badRequest(reply, dueDateResult.message);
 
-      if (new Date(dueDateResult.value) < new Date(issueDateResult.value)) {
+      if (dueDateResult.value < issueDateResult.value) {
         return badRequest(reply, 'dueDate must be on or after issueDate');
       }
 
@@ -751,10 +751,16 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         });
       }
 
-      const effectiveIssueDate = issueDateValue ?? existingInvoiceResult.rows[0].issueDate;
-      const effectiveDueDate = dueDateValue ?? existingInvoiceResult.rows[0].dueDate;
+      const effectiveIssueDate = toRequiredDateOnly(
+        issueDateValue ?? existingInvoiceResult.rows[0].issueDate,
+        'supplierInvoice.issueDate',
+      );
+      const effectiveDueDate = toRequiredDateOnly(
+        dueDateValue ?? existingInvoiceResult.rows[0].dueDate,
+        'supplierInvoice.dueDate',
+      );
 
-      if (new Date(String(effectiveDueDate)) < new Date(String(effectiveIssueDate))) {
+      if (effectiveDueDate < effectiveIssueDate) {
         return badRequest(reply, 'dueDate must be on or after issueDate');
       }
 

--- a/server/routes/supplier-offers.ts
+++ b/server/routes/supplier-offers.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { query } from '../db/index.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
 import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
+import { normalizeNullableDateOnly } from '../utils/date.ts';
 import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
@@ -188,6 +189,11 @@ const normalizeItems = (items: SupplierOfferItemInput[], reply: FastifyReply) =>
 export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.addHook('onRequest', authenticateToken);
 
+  const normalizeSupplierOfferRow = (offer: Record<string, unknown>) => ({
+    ...offer,
+    expirationDate: normalizeNullableDateOnly(offer.expirationDate, 'supplierOffer.expirationDate'),
+  });
+
   fastify.get(
     '/',
     {
@@ -249,7 +255,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       });
 
       return offersResult.rows.map((offer: { id: string }) => ({
-        ...offer,
+        ...normalizeSupplierOfferRow(offer as Record<string, unknown>),
         items: itemsByOffer[offer.id] || [],
       }));
     },
@@ -406,7 +412,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       }
 
       return reply.code(201).send({
-        ...createdOfferResult.rows[0],
+        ...normalizeSupplierOfferRow(createdOfferResult.rows[0] as Record<string, unknown>),
         items: createdItems,
       });
     },
@@ -665,7 +671,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       }
 
       return {
-        ...updatedOfferResult.rows[0],
+        ...normalizeSupplierOfferRow(updatedOfferResult.rows[0] as Record<string, unknown>),
         items: updatedItems,
       };
     },

--- a/server/routes/supplier-quotes.ts
+++ b/server/routes/supplier-quotes.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { query } from '../db/index.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
 import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
+import { normalizeNullableDateOnly } from '../utils/date.ts';
 import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
@@ -125,6 +126,12 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
     return status;
   };
 
+  const normalizeSupplierQuoteRow = (quote: Record<string, unknown>) => ({
+    ...quote,
+    status: normalizeSupplierQuoteStatus(String(quote.status)),
+    expirationDate: normalizeNullableDateOnly(quote.expirationDate, 'supplierQuote.expirationDate'),
+  });
+
   fastify.get(
     '/',
     {
@@ -190,8 +197,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       });
 
       return quotesResult.rows.map((quote) => ({
-        ...quote,
-        status: normalizeSupplierQuoteStatus((quote as { status: string }).status),
+        ...normalizeSupplierQuoteRow(quote as Record<string, unknown>),
         items: itemsByQuote[quote.id] || [],
       }));
     },
@@ -355,8 +361,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       }
 
       return reply.code(201).send({
-        ...quoteResult.rows[0],
-        status: normalizeSupplierQuoteStatus(quoteResult.rows[0].status),
+        ...normalizeSupplierQuoteRow(quoteResult.rows[0] as Record<string, unknown>),
         items: createdItems,
       });
     },
@@ -589,8 +594,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       }
 
       return {
-        ...quoteResult.rows[0],
-        status: normalizeSupplierQuoteStatus(quoteResult.rows[0].status),
+        ...normalizeSupplierQuoteRow(quoteResult.rows[0] as Record<string, unknown>),
         items: updatedItems,
       };
     },

--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -14,6 +14,7 @@ import {
   TTL_LIST_SECONDS,
 } from '../services/cache.ts';
 import { assertAuthenticated } from '../utils/auth-assert.ts';
+import { normalizeNullableDateOnly, todayLocalDateOnly } from '../utils/date.ts';
 import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
@@ -158,12 +159,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
             description: t.description,
             isRecurring: t.is_recurring,
             recurrencePattern: t.recurrence_pattern,
-            recurrenceStart: t.recurrence_start
-              ? t.recurrence_start.toISOString().split('T')[0]
-              : undefined,
-            recurrenceEnd: t.recurrence_end
-              ? t.recurrence_end.toISOString().split('T')[0]
-              : undefined,
+            recurrenceStart:
+              normalizeNullableDateOnly(t.recurrence_start, 'task.recurrenceStart') ?? undefined,
+            recurrenceEnd:
+              normalizeNullableDateOnly(t.recurrence_end, 'task.recurrenceEnd') ?? undefined,
             recurrenceDuration: parseFloat(t.recurrence_duration || 0),
             isDisabled: t.is_disabled,
           }));
@@ -222,7 +221,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         if (!patternResult.ok) return badRequest(reply, patternResult.message);
         const recurrenceStartResult = optionalDateString(recurrenceStart, 'recurrenceStart');
         if (!recurrenceStartResult.ok) return badRequest(reply, recurrenceStartResult.message);
-        start = recurrenceStartResult.value || new Date().toISOString().split('T')[0];
+        start = recurrenceStartResult.value || todayLocalDateOnly();
       }
 
       const id = 't-' + Date.now();
@@ -364,10 +363,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         description: t.description,
         isRecurring: t.is_recurring,
         recurrencePattern: t.recurrence_pattern,
-        recurrenceStart: t.recurrence_start
-          ? t.recurrence_start.toISOString().split('T')[0]
-          : undefined,
-        recurrenceEnd: t.recurrence_end ? t.recurrence_end.toISOString().split('T')[0] : undefined,
+        recurrenceStart:
+          normalizeNullableDateOnly(t.recurrence_start, 'task.recurrenceStart') ?? undefined,
+        recurrenceEnd:
+          normalizeNullableDateOnly(t.recurrence_end, 'task.recurrenceEnd') ?? undefined,
         recurrenceDuration: parseFloat(t.recurrence_duration || 0),
         isDisabled: t.is_disabled,
       };

--- a/server/utils/date.ts
+++ b/server/utils/date.ts
@@ -1,0 +1,25 @@
+const padDatePart = (value: number) => String(value).padStart(2, '0');
+
+const extractDateOnlyString = (value: string) => {
+  const separatorIndex = value.indexOf('T');
+  return separatorIndex >= 0 ? value.slice(0, separatorIndex) : value;
+};
+
+export const formatLocalDateOnly = (date: Date) => {
+  const year = date.getFullYear();
+  const month = padDatePart(date.getMonth() + 1);
+  const day = padDatePart(date.getDate());
+  return `${year}-${month}-${day}`;
+};
+
+export const normalizeNullableDateOnly = (value: unknown, fieldName: string) => {
+  if (value === undefined || value === null) return null;
+  if (value instanceof Date) return formatLocalDateOnly(value);
+  if (typeof value === 'string') return extractDateOnlyString(value);
+  throw new TypeError(`Invalid date value for ${fieldName}`);
+};
+
+export const todayLocalDateOnly = (now: Date = new Date()) => formatLocalDateOnly(now);
+
+export const isPastLocalDate = (dateOnly: string, now: Date = new Date()) =>
+  extractDateOnlyString(dateOnly) < formatLocalDateOnly(now);

--- a/types.ts
+++ b/types.ts
@@ -250,7 +250,7 @@ export interface Quote {
     | '365gg';
   discount: number; // global discount percentage
   status: 'draft' | 'sent' | 'accepted' | 'denied';
-  expirationDate: string; // ISO date string
+  expirationDate: string; // YYYY-MM-DD date-only string
   isExpired?: boolean;
   linkedOfferId?: string;
   notes?: string;

--- a/utils/date.ts
+++ b/utils/date.ts
@@ -8,3 +8,51 @@ export const getLocalDateString = (date: Date = new Date()): string => {
   const day = String(date.getDate()).padStart(2, '0');
   return `${year}-${month}-${day}`;
 };
+
+export const normalizeDateOnlyString = (value: string): string => {
+  const separatorIndex = value.indexOf('T');
+  return separatorIndex >= 0 ? value.slice(0, separatorIndex) : value;
+};
+
+export const dateOnlyStringToLocalDate = (dateOnly: string): Date => {
+  const normalizedDate = normalizeDateOnlyString(dateOnly);
+  const [year, month, day] = normalizedDate.split('-').map(Number);
+  return new Date(year, month - 1, day);
+};
+
+export const formatDateOnlyForLocale = (
+  dateOnly: string,
+  locales?: string | string[],
+  options?: Intl.DateTimeFormatOptions,
+): string => dateOnlyStringToLocalDate(dateOnly).toLocaleDateString(locales, options);
+
+export const addDaysToDateOnly = (dateOnly: string, days: number): string => {
+  const nextDate = dateOnlyStringToLocalDate(dateOnly);
+  nextDate.setDate(nextDate.getDate() + days);
+  return getLocalDateString(nextDate);
+};
+
+export const isDateOnlyBeforeToday = (
+  dateOnly: string,
+  today: string = getLocalDateString(),
+): boolean => normalizeDateOnlyString(dateOnly) < normalizeDateOnlyString(today);
+
+export const isDateOnlyAfterToday = (
+  dateOnly: string,
+  today: string = getLocalDateString(),
+): boolean => normalizeDateOnlyString(dateOnly) > normalizeDateOnlyString(today);
+
+export const isDateOnlyWithinInclusiveRange = (
+  targetDate: string,
+  startDate?: string | null,
+  endDate?: string | null,
+): boolean => {
+  const normalizedTargetDate = normalizeDateOnlyString(targetDate);
+  if (startDate && normalizedTargetDate < normalizeDateOnlyString(startDate)) {
+    return false;
+  }
+  if (endDate && normalizedTargetDate > normalizeDateOnlyString(endDate)) {
+    return false;
+  }
+  return true;
+};


### PR DESCRIPTION
## Summary
- normalize server-side SQL DATE serialization with shared date-only helpers instead of UTC toISOString conversions
- update affected UI flows to use shared date-only utilities for defaults, display formatting, and date-range checks
- align quote and special-bid expiry logic around normalized YYYY-MM-DD values

## Verification
- bun run build
- cd server && bun run build