### PR TITLE
fix(server): resolve special-bids molPercentage serialization error

### DIFF
--- a/server/routes/special-bids.ts
+++ b/server/routes/special-bids.ts
@@ -30,7 +30,7 @@ const specialBidSchema = {
     productId: { type: 'string' },
     productName: { type: 'string' },
     unitPrice: { type: 'number' },
-    molPercentage: { type: ['number', 'null'] },
+    molPercentage: { type: 'number', nullable: true },
     startDate: { type: 'string', format: 'date' },
     endDate: { type: 'string', format: 'date' },
     createdAt: { type: 'number' },


### PR DESCRIPTION
Summary:
- change specialBidSchema.molPercentage from type ['number','null'] to type 'number' with nullable true
- keep route/query logic unchanged for a minimal low-risk fix

Why:
pg returns DECIMAL values as strings by default. With fast-json-stringify, type ['number','null'] performs strict runtime checks and rejects numeric strings, causing a 500 serialization error on GET /api/special-bids.

Validation:
- cd server && bun run build