### PR TITLE
fix: improve standard table overflow layout

### DIFF
--- a/components/accounting/ClientsInvoicesView.tsx
+++ b/components/accounting/ClientsInvoicesView.tsx
@@ -268,6 +268,8 @@ const ClientsInvoicesView: React.FC<ClientsInvoicesViewProps> = ({
       {
         header: t('accounting:clientsInvoices.invoiceNumber'),
         accessorFn: (row: Invoice) => row.invoiceNumber,
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[8rem]',
         cell: ({ row }: { row: Invoice }) => (
           <span className="font-bold text-slate-700">{row.invoiceNumber}</span>
         ),
@@ -282,6 +284,8 @@ const ClientsInvoicesView: React.FC<ClientsInvoicesViewProps> = ({
       {
         header: t('common:labels.date'),
         accessorFn: (row: Invoice) => formatDateOnlyForLocale(row.issueDate),
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[8rem]',
         cell: ({ row }: { row: Invoice }) => (
           <span className="text-sm text-slate-600">{formatDateOnlyForLocale(row.issueDate)}</span>
         ),
@@ -289,6 +293,8 @@ const ClientsInvoicesView: React.FC<ClientsInvoicesViewProps> = ({
       {
         header: t('accounting:clientsInvoices.dueDate'),
         accessorFn: (row: Invoice) => formatDateOnlyForLocale(row.dueDate),
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[8rem]',
         cell: ({ row }: { row: Invoice }) => (
           <span className="text-sm text-slate-600">{formatDateOnlyForLocale(row.dueDate)}</span>
         ),
@@ -296,6 +302,8 @@ const ClientsInvoicesView: React.FC<ClientsInvoicesViewProps> = ({
       {
         header: t('common:labels.amount'),
         accessorFn: (row: Invoice) => row.total,
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[8rem]',
         cell: ({ row }: { row: Invoice }) => (
           <span className="font-bold text-slate-700">
             {(row.total ?? 0).toFixed(2)} {currency}
@@ -306,6 +314,8 @@ const ClientsInvoicesView: React.FC<ClientsInvoicesViewProps> = ({
       {
         header: t('accounting:clientsInvoices.balance'),
         accessorFn: (row: Invoice) => row.total - row.amountPaid,
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[8rem]',
         cell: ({ row }: { row: Invoice }) => {
           const balance = row.total - row.amountPaid;
           return (
@@ -320,6 +330,8 @@ const ClientsInvoicesView: React.FC<ClientsInvoicesViewProps> = ({
         header: t('accounting:clientsInvoices.status'),
         accessorFn: (row: Invoice) =>
           statusOptions.find((opt) => opt.id === row.status)?.name || row.status,
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[9rem]',
         cell: ({ row }: { row: Invoice }) => (
           <StatusBadge
             type={row.status as StatusType}
@@ -330,6 +342,8 @@ const ClientsInvoicesView: React.FC<ClientsInvoicesViewProps> = ({
       {
         header: t('common:common.more'),
         id: 'actions',
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[8rem]',
         disableSorting: true,
         disableFiltering: true,
         align: 'right' as const,

--- a/components/accounting/ClientsOrdersView.tsx
+++ b/components/accounting/ClientsOrdersView.tsx
@@ -423,6 +423,8 @@ const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
           const { total } = calculateTotals(row.items, row.discount);
           return total;
         },
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[8rem]',
         cell: ({ row }: { row: ClientsOrder }) => {
           const { total } = calculateTotals(row.items, row.discount);
           return (
@@ -439,6 +441,8 @@ const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
         header: t('accounting:clientsOrders.paymentTermsColumn'),
         accessorFn: (row: ClientsOrder) =>
           row.paymentTerms === 'immediate' ? t('crm:paymentTerms.immediate') : row.paymentTerms,
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[10rem]',
         cell: ({ row }: { row: ClientsOrder }) => (
           <span
             className={`text-sm font-semibold ${row.status === 'confirmed' || row.status === 'denied' ? 'text-slate-400' : 'text-slate-600'}`}
@@ -450,6 +454,8 @@ const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
       {
         header: t('accounting:clientsOrders.statusColumn'),
         accessorFn: (row: ClientsOrder) => getOrderStatusLabel(row.status, t),
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[9rem]',
         cell: ({ row }: { row: ClientsOrder }) => (
           <div
             className={row.status === 'confirmed' || row.status === 'denied' ? 'opacity-60' : ''}
@@ -464,6 +470,8 @@ const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
       {
         header: t('accounting:clientsOrders.actionsColumn'),
         id: 'actions',
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[9rem]',
         disableSorting: true,
         disableFiltering: true,
         align: 'right' as const,

--- a/components/accounting/SupplierInvoicesView.tsx
+++ b/components/accounting/SupplierInvoicesView.tsx
@@ -198,6 +198,8 @@ const SupplierInvoicesView: React.FC<SupplierInvoicesViewProps> = ({
         header: t('accounting:supplierInvoices.invoiceNumber'),
         id: 'invoiceNumber',
         accessorFn: (row: SupplierInvoice) => row.invoiceNumber,
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[8rem]',
         cell: ({ row }: { row: SupplierInvoice }) => (
           <span className="font-mono text-sm font-bold text-slate-600">{row.invoiceNumber}</span>
         ),
@@ -206,6 +208,8 @@ const SupplierInvoicesView: React.FC<SupplierInvoicesViewProps> = ({
         header: t('accounting:supplierInvoices.total'),
         id: 'invoiceTotal',
         accessorFn: (row: SupplierInvoice) => Number(row.total),
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[8rem]',
         cell: ({ row }: { row: SupplierInvoice }) => {
           const isMuted = row.status === 'paid' || row.status === 'cancelled';
 
@@ -221,6 +225,8 @@ const SupplierInvoicesView: React.FC<SupplierInvoicesViewProps> = ({
         header: t('accounting:supplierInvoices.status'),
         id: 'invoiceStatus',
         accessorFn: (row: SupplierInvoice) => getStatusLabel(row.status, t),
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[9rem]',
         cell: ({ row }: { row: SupplierInvoice }) => (
           <div className={row.status === 'paid' || row.status === 'cancelled' ? 'opacity-60' : ''}>
             <StatusBadge type={row.status as StatusType} label={getStatusLabel(row.status, t)} />
@@ -230,6 +236,8 @@ const SupplierInvoicesView: React.FC<SupplierInvoicesViewProps> = ({
       {
         header: t('accounting:supplierInvoices.actionsColumn', { defaultValue: 'Actions' }),
         id: 'actions',
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[8rem]',
         disableSorting: true,
         disableFiltering: true,
         align: 'right' as const,

--- a/components/accounting/SupplierOrdersView.tsx
+++ b/components/accounting/SupplierOrdersView.tsx
@@ -232,6 +232,8 @@ const SupplierOrdersView: React.FC<SupplierOrdersViewProps> = ({
         header: t('accounting:supplierOrders.total'),
         id: 'orderTotal',
         accessorFn: (row: SupplierSaleOrder) => calculateTotals(row.items, row.discount).total,
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[8rem]',
         cell: ({ row }: { row: SupplierSaleOrder }) => {
           const { total } = calculateTotals(row.items, row.discount);
           const isMuted = row.status === 'confirmed' || row.status === 'denied';
@@ -248,6 +250,8 @@ const SupplierOrdersView: React.FC<SupplierOrdersViewProps> = ({
         header: t('accounting:supplierOrders.paymentTerms'),
         id: 'paymentTerms',
         accessorFn: (row: SupplierSaleOrder) => getPaymentTermsLabel(row.paymentTerms, t),
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[10rem]',
         cell: ({ row }: { row: SupplierSaleOrder }) => {
           const isMuted = row.status === 'confirmed' || row.status === 'denied';
 
@@ -264,6 +268,8 @@ const SupplierOrdersView: React.FC<SupplierOrdersViewProps> = ({
         header: t('accounting:supplierOrders.status'),
         id: 'orderStatus',
         accessorFn: (row: SupplierSaleOrder) => getOrderStatusLabel(row.status, t),
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[9rem]',
         cell: ({ row }: { row: SupplierSaleOrder }) => (
           <div
             className={row.status === 'confirmed' || row.status === 'denied' ? 'opacity-60' : ''}
@@ -278,6 +284,8 @@ const SupplierOrdersView: React.FC<SupplierOrdersViewProps> = ({
       {
         header: t('accounting:supplierOrders.actionsColumn', { defaultValue: 'Actions' }),
         id: 'actions',
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[9rem]',
         disableSorting: true,
         disableFiltering: true,
         align: 'right' as const,

--- a/components/sales/ClientOffersView.tsx
+++ b/components/sales/ClientOffersView.tsx
@@ -194,6 +194,8 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
       {
         header: t('sales:clientOffers.offerCodeColumn', { defaultValue: 'Offer Code' }),
         accessorKey: 'offerCode',
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[8rem]',
         cell: ({ row }) => (
           <div className="font-mono text-sm font-bold text-slate-500">{row.offerCode}</div>
         ),
@@ -202,6 +204,8 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
         header: t('sales:clientOffers.totalColumn', { defaultValue: 'Total' }),
         id: 'total',
         accessorFn: (row) => calculateTotals(row.items, row.discount).total,
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[8rem]',
         disableFiltering: true,
         cell: ({ row }) => {
           const { total } = calculateTotals(row.items, row.discount);
@@ -215,6 +219,8 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
       {
         header: t('sales:clientOffers.statusColumn', { defaultValue: 'Status' }),
         accessorKey: 'status',
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[9rem]',
         cell: ({ row }) => {
           return <StatusBadge type={row.status as StatusType} label={getStatusLabel(row.status)} />;
         },
@@ -223,6 +229,8 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
         header: t('sales:clientOffers.actionsColumn', { defaultValue: 'Actions' }),
         id: 'actions',
         align: 'right',
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[9rem]',
         disableSorting: true,
         disableFiltering: true,
         cell: ({ row }) => {

--- a/components/sales/ClientQuotesView.tsx
+++ b/components/sales/ClientQuotesView.tsx
@@ -632,6 +632,8 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
       {
         header: t('sales:clientQuotes.quoteCodeColumn'),
         accessorKey: 'quoteCode',
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[8rem]',
         cell: ({ row }) => (
           <div className="font-mono text-sm font-bold text-slate-500">{row.quoteCode}</div>
         ),
@@ -640,6 +642,8 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
         header: t('sales:clientQuotes.totalColumn'),
         id: 'total',
         accessorFn: (row) => calculateQuoteTotals(row.items, row.discount).total,
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[8rem]',
         disableFiltering: true,
         cell: ({ row }) => {
           const { total } = calculateQuoteTotals(row.items, row.discount);
@@ -654,6 +658,8 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
       {
         header: t('sales:clientQuotes.paymentTermsColumn'),
         accessorKey: 'paymentTerms',
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[10rem]',
         cell: ({ row }) => {
           const history = isHistoryRow(row);
           return (
@@ -670,6 +676,8 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
       {
         header: t('sales:clientQuotes.expirationColumn'),
         accessorKey: 'expirationDate',
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[9rem]',
         cell: ({ row }) => {
           const expired = isQuoteExpired(row);
           const history = isHistoryRow(row);
@@ -692,6 +700,8 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
       {
         header: t('sales:clientQuotes.statusColumn'),
         accessorKey: 'status',
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[9rem]',
         cell: ({ row }) => {
           const expired = isQuoteExpired(row);
           const history = isHistoryRow(row);
@@ -709,6 +719,8 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
         header: t('sales:clientQuotes.actionsColumn'),
         id: 'actions',
         align: 'right',
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[9rem]',
         disableSorting: true,
         disableFiltering: true,
         cell: ({ row }) => {

--- a/components/sales/SupplierOffersView.tsx
+++ b/components/sales/SupplierOffersView.tsx
@@ -179,6 +179,8 @@ const SupplierOffersView: React.FC<SupplierOffersViewProps> = ({
       {
         header: t('sales:supplierOffers.offerCode', { defaultValue: 'Offer Code' }),
         accessorKey: 'offerCode',
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[8rem]',
         cell: ({ row }) => (
           <div className="font-mono text-sm font-bold text-slate-500">{row.offerCode}</div>
         ),
@@ -187,6 +189,8 @@ const SupplierOffersView: React.FC<SupplierOffersViewProps> = ({
         header: t('sales:supplierOffers.total', { defaultValue: 'Total' }),
         id: 'total',
         accessorFn: (row) => calculateTotals(row.items, row.discount).total,
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[8rem]',
         disableFiltering: true,
         cell: ({ row }) => (
           <span className="text-sm font-bold text-slate-700">
@@ -197,6 +201,8 @@ const SupplierOffersView: React.FC<SupplierOffersViewProps> = ({
       {
         header: t('sales:supplierOffers.status', { defaultValue: 'Status' }),
         accessorKey: 'status',
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[9rem]',
         cell: ({ row }) => (
           <StatusBadge type={row.status as StatusType} label={getStatusLabel(row.status)} />
         ),
@@ -205,6 +211,8 @@ const SupplierOffersView: React.FC<SupplierOffersViewProps> = ({
         header: t('sales:supplierOffers.actionsColumn', { defaultValue: 'Actions' }),
         id: 'actions',
         align: 'right',
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[9rem]',
         disableSorting: true,
         disableFiltering: true,
         cell: ({ row }) => (

--- a/components/sales/SupplierQuotesView.tsx
+++ b/components/sales/SupplierQuotesView.tsx
@@ -239,6 +239,8 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
         header: t('sales:supplierQuotes.quoteCode', { defaultValue: 'Quote Code' }),
         id: 'quoteCode',
         accessorFn: (row) => row.quoteCode || row.purchaseOrderNumber || '',
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[8rem]',
         cell: ({ row }) => (
           <div className="font-mono text-sm font-bold text-slate-500">
             {row.quoteCode || row.purchaseOrderNumber}
@@ -249,6 +251,8 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
         header: t('sales:supplierQuotes.total', { defaultValue: 'Total' }),
         id: 'total',
         accessorFn: (row) => calculateTotals(row.items, row.discount, products),
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[8rem]',
         disableFiltering: true,
         cell: ({ row }) => (
           <span className="text-sm font-bold text-slate-700">
@@ -259,6 +263,8 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
       {
         header: t('sales:supplierQuotes.status', { defaultValue: 'Status' }),
         accessorKey: 'status',
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[9rem]',
         cell: ({ row }) => (
           <StatusBadge type={row.status as StatusType} label={getStatusLabel(row.status)} />
         ),
@@ -267,6 +273,8 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
         header: t('sales:supplierQuotes.actionsColumn', { defaultValue: 'Actions' }),
         id: 'actions',
         align: 'right',
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[9rem]',
         disableSorting: true,
         disableFiltering: true,
         cell: ({ row }) => (

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -308,7 +308,7 @@ const StandardTable = <T extends object>({
 
       <div className={tableContainerClassName ?? 'overflow-x-auto custom-horizontal-scrollbar'}>
         {columns && data ? (
-          <table className="w-full text-left border-collapse">
+          <table className="w-max min-w-full text-left border-collapse">
             <thead className="bg-slate-50 border-b border-slate-100">
               <tr>
                 {columns.map((col, colIdx) => {


### PR DESCRIPTION
## Summary
- switch `StandardTable` to a content-driven width model so horizontal scrolling exposes overflow instead of compressing columns
- add nowrap/min-width classes to dense sales and accounting table columns for codes, totals, dates, statuses, payment terms, and actions
- keep descriptive/name columns flexible while stabilizing structured values

## Verification
- bun run lint
- bun run build