### PR TITLE
fix(i18n): localize role permission labels

### DIFF
--- a/components/administration/RolesView.tsx
+++ b/components/administration/RolesView.tsx
@@ -3,11 +3,13 @@ import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Role } from '../../types';
 import {
+  ALWAYS_GRANTED_MODULES,
   buildPermission,
   formatPermissionLabel,
   hasPermission,
   PERMISSION_DEFINITIONS,
   type PermissionAction,
+  ROLE_EDITOR_EXCLUDED_MODULES,
 } from '../../utils/permissions';
 import Checkbox from '../shared/Checkbox';
 import Modal from '../shared/Modal';
@@ -46,9 +48,6 @@ const MODULE_ICONS: Record<string, string> = {
   notifications: 'fa-bell',
 };
 
-const ALWAYS_GRANTED_MODULES = ['docs', 'settings', 'notifications'];
-const ADMINISTRATION_MODULE = 'administration';
-const ROLE_EDITOR_EXCLUDED_MODULES = [...ALWAYS_GRANTED_MODULES, ADMINISTRATION_MODULE];
 const ALWAYS_GRANTED_PERMISSIONS = PERMISSION_DEFINITIONS.filter((def) =>
   ALWAYS_GRANTED_MODULES.includes(def.module),
 ).flatMap((def) => def.actions.map((action) => buildPermission(def.id, action)));

--- a/locales/en/administration.json
+++ b/locales/en/administration.json
@@ -30,7 +30,10 @@
       "suppliers_all": "Suppliers (All)"
     },
     "sales": {
-      "client_quotes": "Client Quotes"
+      "client_quotes": "Client Quotes",
+      "client_offers": "Client Offers",
+      "supplier_quotes": "Supplier Quotes",
+      "supplier_offers": "Supplier Offers"
     },
     "catalog": {
       "internal_listing": "Internal Listing",
@@ -39,7 +42,9 @@
     },
     "accounting": {
       "clients_orders": "Client Orders",
-      "clients_invoices": "Client Invoices"
+      "clients_invoices": "Client Invoices",
+      "supplier_orders": "Supplier Orders",
+      "supplier_invoices": "Supplier Invoices"
     },
     "finances": {
       "payments": "Payments",
@@ -56,7 +61,8 @@
     },
     "hr": {
       "internal": "Internal",
-      "external": "External"
+      "external": "External",
+      "costs": "Costs"
     },
     "reports": {
       "ai_reporting": "AI Reporting"

--- a/locales/it/administration.json
+++ b/locales/it/administration.json
@@ -30,7 +30,10 @@
       "suppliers_all": "Fornitori (Tutti)"
     },
     "sales": {
-      "client_quotes": "Preventivi Clienti"
+      "client_quotes": "Preventivi Clienti",
+      "client_offers": "Offerte Clienti",
+      "supplier_quotes": "Preventivi Fornitori",
+      "supplier_offers": "Offerte Fornitori"
     },
     "catalog": {
       "internal_listing": "Listino Interno",
@@ -39,7 +42,9 @@
     },
     "accounting": {
       "clients_orders": "Ordini Clienti",
-      "clients_invoices": "Fatture Clienti"
+      "clients_invoices": "Fatture Clienti",
+      "supplier_orders": "Ordini Fornitori",
+      "supplier_invoices": "Fatture Fornitori"
     },
     "finances": {
       "payments": "Pagamenti",
@@ -56,7 +61,8 @@
     },
     "hr": {
       "internal": "Interni",
-      "external": "Esterni"
+      "external": "Esterni",
+      "costs": "Costi"
     },
     "reports": {
       "ai_reporting": "Reportistica IA"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "i18n:check": "node scripts/check-i18n-keys.mjs",
+    "i18n:check": "bun scripts/check-i18n-keys.mjs",
     "lint": "bun run i18n:check && biome check .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",

--- a/scripts/check-i18n-keys.mjs
+++ b/scripts/check-i18n-keys.mjs
@@ -1,8 +1,9 @@
-#!/usr/bin/env node
+#!/usr/bin/env bun
 
 import { readdirSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
+import { PERMISSION_DEFINITIONS, ROLE_EDITOR_EXCLUDED_MODULES } from '../utils/permissions.ts';
 
 const ROOT_DIR = process.cwd();
 const SUPPORTED_LANGUAGES = ['en', 'it'];
@@ -161,10 +162,41 @@ const validateTranslations = (files, namespacesByLanguage) => {
   return errors;
 };
 
+const validateRoleEditorPermissionTranslations = (namespacesByLanguage) => {
+  const errors = [];
+  const roleEditorPermissionKeys = PERMISSION_DEFINITIONS.filter(
+    (definition) => !ROLE_EDITOR_EXCLUDED_MODULES.includes(definition.module),
+  ).map((definition) => `permissions.${definition.id}`);
+
+  for (const translationKey of roleEditorPermissionKeys) {
+    const missingLanguages = [];
+
+    for (const language of SUPPORTED_LANGUAGES) {
+      const administrationKeys = namespacesByLanguage.get(language)?.get('administration');
+      if (!administrationKeys?.has(translationKey)) {
+        missingLanguages.push(language);
+      }
+    }
+
+    if (missingLanguages.length > 0) {
+      errors.push({
+        kind: 'role-editor-permission',
+        key: `administration:${translationKey}`,
+        missingLanguages,
+      });
+    }
+  }
+
+  return errors;
+};
+
 const main = () => {
   const namespacesByLanguage = loadLocaleNamespaces();
   const files = collectSourceFiles(ROOT_DIR);
-  const errors = validateTranslations(files, namespacesByLanguage);
+  const errors = [
+    ...validateTranslations(files, namespacesByLanguage),
+    ...validateRoleEditorPermissionTranslations(namespacesByLanguage),
+  ];
 
   if (errors.length === 0) {
     console.log('i18n check passed: no missing translation keys.');
@@ -172,17 +204,24 @@ const main = () => {
   }
 
   errors.sort((left, right) => {
-    if (left.filePath !== right.filePath) {
-      return left.filePath.localeCompare(right.filePath);
+    if ((left.filePath ?? '') !== (right.filePath ?? '')) {
+      return (left.filePath ?? '').localeCompare(right.filePath ?? '');
     }
-    if (left.line !== right.line) {
-      return left.line - right.line;
+    if ((left.line ?? 0) !== (right.line ?? 0)) {
+      return (left.line ?? 0) - (right.line ?? 0);
     }
     return left.key.localeCompare(right.key);
   });
 
   console.error(`i18n check failed: ${errors.length} missing translation reference(s).`);
   for (const error of errors) {
+    if (error.kind === 'role-editor-permission') {
+      console.error(
+        `- role-editor permissions -> ${error.key} missing [${error.missingLanguages.join(', ')}]`,
+      );
+      continue;
+    }
+
     const relativePath = path.relative(ROOT_DIR, error.filePath);
     console.error(
       `- ${relativePath}:${error.line} -> ${error.key} missing [${error.missingLanguages.join(', ')}]`,

--- a/utils/permissions.ts
+++ b/utils/permissions.ts
@@ -17,6 +17,10 @@ export type PermissionDefinition = {
 };
 
 const getModuleId = (resource: string) => resource.split('.')[0];
+const ADMINISTRATION_MODULE = 'administration';
+
+export const ALWAYS_GRANTED_MODULES: string[] = ['docs', 'settings', 'notifications'];
+export const ROLE_EDITOR_EXCLUDED_MODULES = [...ALWAYS_GRANTED_MODULES, ADMINISTRATION_MODULE];
 
 export const PERMISSION_DEFINITIONS: PermissionDefinition[] = [
   // Timesheets


### PR DESCRIPTION
## Summary
- localize the missing permission labels shown in the role creation and edit modal
- share the role-editor excluded-module list from permission metadata instead of duplicating it in the UI
- extend the i18n checker to validate dynamic role-permission translation keys in all supported languages

## Testing
- bun run i18n:check
- bun run lint
- bun run build
- cd server && bun run build