### PR TITLE
fix(ui): stop auto-navigating when expanding sidebar modules

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -168,16 +168,7 @@ const Layout: React.FC<LayoutProps> = ({
       // Toggle collapse if clicking the already expanded module
       setExpandedModuleId(null);
     } else {
-      // Expand and navigate if clicking a different module
       setExpandedModuleId(module.id);
-
-      // Navigate to default route if we're not already in this module
-      // This ensures that expanding a module also shows its content if we were elsewhere
-      if (activeModule.id !== module.id) {
-        const routes = moduleRoutes[module.id] || [];
-        const defaultRoute = routes.find((route) => canAccessView(route)) || routes[0];
-        if (defaultRoute) onViewChange(defaultRoute);
-      }
     }
   };
 


### PR DESCRIPTION
Expanding a module in the sidebar now only opens the submenu without automatically navigating to the first page, letting users choose.