### PR TITLE
feat(ui): add smooth expand/collapse animation to sidebar modules

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -703,11 +703,17 @@ const Layout: React.FC<LayoutProps> = ({
               </Tooltip>
 
               {/* Module Sub-items */}
-              {expandedModuleId === module.id && !isCollapsed && (
+              {!isCollapsed && (
                 <div
-                  className={`animate-in slide-in-from-top-2 duration-200 space-y-1 mt-1 pb-2 ${isCollapsed ? '' : 'bg-black/10 rounded-xl p-2'}`}
+                  className={`grid transition-[grid-template-rows] duration-200 ease-in-out ${
+                    expandedModuleId === module.id ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
+                  }`}
                 >
-                  {renderModuleNavItems(module.id)}
+                  <div className="overflow-hidden min-h-0">
+                    <div className="space-y-1 mt-1 pb-2 bg-black/10 rounded-xl p-2">
+                      {renderModuleNavItems(module.id)}
+                    </div>
+                  </div>
                 </div>
               )}
             </div>


### PR DESCRIPTION
Use CSS Grid grid-template-rows 0fr/1fr transition for smooth height animation when expanding and collapsing module sub-items in the sidebar.