### PR TITLE
feat: Expand demo seeding with work units, more users, and time entries

### DIFF
--- a/server/db/demoSeed.ts
+++ b/server/db/demoSeed.ts
@@ -8,6 +8,7 @@ import {
   DEMO_CACHE_NAMESPACES,
   DEMO_CLIENTS,
   DEMO_CUSTOMER_OFFERS,
+  DEMO_ENTRIES_CACHE_NAMESPACES,
   DEMO_EXPECTED_COUNTS,
   DEMO_IDS,
   DEMO_INVOICES,
@@ -26,6 +27,7 @@ import {
   DEMO_SUPPLIERS,
   DEMO_USER_IDS,
   DEMO_USERS,
+  DEMO_WORK_UNITS,
 } from './demoSeedManifest.ts';
 import pool, { query } from './index.ts';
 
@@ -184,13 +186,15 @@ const insertDemoUsersAndSettings = async (client: PoolClient, counts: Record<str
       DEMO_PASSWORD_HASH,
       user.role,
       user.avatarInitials,
+      user.costPerHour,
+      'app_user',
     );
-    const index = userValues.length - 5;
-    return `($${index}, $${index + 1}, $${index + 2}, $${index + 3}, $${index + 4}, $${index + 5})`;
+    const index = userValues.length - 7;
+    return `($${index}, $${index + 1}, $${index + 2}, $${index + 3}, $${index + 4}, $${index + 5}, $${index + 6}, $${index + 7})`;
   });
   const usersResult = await executeStatement(
     client,
-    `INSERT INTO users (id, name, username, password_hash, role, avatar_initials)
+    `INSERT INTO users (id, name, username, password_hash, role, avatar_initials, cost_per_hour, employee_type)
      VALUES ${userTuples.join(', ')}
      ON CONFLICT (id) DO UPDATE SET
        name = EXCLUDED.name,
@@ -198,19 +202,25 @@ const insertDemoUsersAndSettings = async (client: PoolClient, counts: Record<str
        password_hash = EXCLUDED.password_hash,
        role = EXCLUDED.role,
        avatar_initials = EXCLUDED.avatar_initials,
+       cost_per_hour = EXCLUDED.cost_per_hour,
+       employee_type = EXCLUDED.employee_type,
        is_disabled = FALSE`,
     userValues,
   );
   incrementCount(counts, 'users', usersResult.rowCount ?? 0);
 
+  const userRolesValues: unknown[] = [];
+  const userRolesTuples = DEMO_USERS.map((user) => {
+    userRolesValues.push(user.id, user.role);
+    const idx = userRolesValues.length - 1;
+    return `($${idx}, $${idx + 1})`;
+  });
   const userRolesResult = await executeStatement(
     client,
     `INSERT INTO user_roles (user_id, role_id)
-     SELECT user_id, role_id
-     FROM (
-       VALUES ('u2', 'manager'), ('u3', 'user')
-     ) AS v(user_id, role_id)
+     VALUES ${userRolesTuples.join(', ')}
      ON CONFLICT DO NOTHING`,
+    userRolesValues,
   );
   incrementCount(counts, 'user_roles', userRolesResult.rowCount ?? 0);
 
@@ -235,6 +245,43 @@ const insertDemoUsersAndSettings = async (client: PoolClient, counts: Record<str
 
 const cleanupDemoNamespace = async (client: PoolClient, demoUserIdsToDelete: string[]) => {
   const cleanupCountsByTable: Record<string, number> = {};
+
+  incrementCount(
+    cleanupCountsByTable,
+    'time_entries',
+    await executeDelete(client, 'time_entries', (builder) => {
+      pushTextArrayPredicate(builder, 'id', DEMO_IDS.timeEntries);
+    }),
+  );
+
+  incrementCount(
+    cleanupCountsByTable,
+    'user_work_units',
+    await executeDelete(client, 'user_work_units', (builder) => {
+      pushTextArrayPredicate(builder, 'work_unit_id', DEMO_IDS.workUnits);
+    }),
+  );
+
+  incrementCount(
+    cleanupCountsByTable,
+    'work_unit_managers',
+    await executeDelete(client, 'work_unit_managers', (builder) => {
+      pushTextArrayPredicate(builder, 'work_unit_id', DEMO_IDS.workUnits);
+    }),
+  );
+
+  incrementCount(
+    cleanupCountsByTable,
+    'work_units',
+    await executeDelete(client, 'work_units', (builder) => {
+      pushTextArrayPredicate(builder, 'id', DEMO_IDS.workUnits);
+      pushTextArrayPredicate(
+        builder,
+        'name',
+        DEMO_WORK_UNITS.map((wu) => wu.name),
+      );
+    }),
+  );
 
   incrementCount(
     cleanupCountsByTable,
@@ -691,6 +738,20 @@ const verificationSteps: VerificationStep[] = [
     ids: DEMO_IDS.notifications,
     expected: DEMO_EXPECTED_COUNTS.notifications,
   },
+  { table: 'work_units', ids: DEMO_IDS.workUnits, expected: DEMO_EXPECTED_COUNTS.work_units },
+  {
+    table: 'work_unit_managers',
+    countColumn: 'work_unit_id',
+    ids: DEMO_IDS.workUnits,
+    expected: DEMO_EXPECTED_COUNTS.work_unit_managers,
+  },
+  {
+    table: 'user_work_units',
+    countColumn: 'work_unit_id',
+    ids: DEMO_IDS.workUnits,
+    expected: DEMO_EXPECTED_COUNTS.user_work_units,
+  },
+  { table: 'time_entries', ids: DEMO_IDS.timeEntries, expected: DEMO_EXPECTED_COUNTS.time_entries },
 ];
 
 const verifyDemoDataset = async () => {
@@ -719,6 +780,10 @@ const invalidateDemoCaches = async () => {
   }
 
   for (const namespace of DEMO_SETTINGS_CACHE_NAMESPACES) {
+    await bumpNamespaceVersion(namespace);
+  }
+
+  for (const namespace of DEMO_ENTRIES_CACHE_NAMESPACES) {
     await bumpNamespaceVersion(namespace);
   }
 };

--- a/server/db/demoSeedManifest.ts
+++ b/server/db/demoSeedManifest.ts
@@ -6,7 +6,6 @@ const currentYear = new Date().getFullYear();
 export const DEMO_PASSWORD_HASH = '$2a$12$z5H7VrzTpLImYWSH3xufKufCiGB0n9CSlNMOrRBRIxq.6mvuVS7uy';
 
 export const DEMO_CACHE_NAMESPACES = ['clients', 'products', 'projects', 'tasks', 'users'] as const;
-export const DEMO_SETTINGS_CACHE_NAMESPACES = ['settings:user:u2', 'settings:user:u3'] as const;
 
 export const DEMO_USERS = [
   {
@@ -17,6 +16,7 @@ export const DEMO_USERS = [
     avatarInitials: 'MG',
     fullName: 'Manager User',
     email: 'manager@example.com',
+    costPerHour: 65.0,
   },
   {
     id: 'u3',
@@ -26,11 +26,64 @@ export const DEMO_USERS = [
     avatarInitials: 'US',
     fullName: 'Standard User',
     email: 'user@example.com',
+    costPerHour: 45.0,
+  },
+  {
+    id: 'u4',
+    name: 'Sales Manager',
+    username: 'salesmanager',
+    role: 'manager',
+    avatarInitials: 'SM',
+    fullName: 'Sales Manager',
+    email: 'salesmanager@example.com',
+    costPerHour: 60.0,
+  },
+  {
+    id: 'u5',
+    name: 'Elena Rossi',
+    username: 'erossi',
+    role: 'user',
+    avatarInitials: 'ER',
+    fullName: 'Elena Rossi',
+    email: 'erossi@example.com',
+    costPerHour: 50.0,
+  },
+  {
+    id: 'u6',
+    name: 'Marco Bianchi',
+    username: 'mbianchi',
+    role: 'user',
+    avatarInitials: 'MB',
+    fullName: 'Marco Bianchi',
+    email: 'mbianchi@example.com',
+    costPerHour: 40.0,
+  },
+  {
+    id: 'u7',
+    name: 'Sofia Conti',
+    username: 'sconti',
+    role: 'user',
+    avatarInitials: 'SC',
+    fullName: 'Sofia Conti',
+    email: 'sconti@example.com',
+    costPerHour: 55.0,
+  },
+  {
+    id: 'u8',
+    name: 'Luca Moretti',
+    username: 'lmoretti',
+    role: 'user',
+    avatarInitials: 'LM',
+    fullName: 'Luca Moretti',
+    email: 'lmoretti@example.com',
+    costPerHour: 35.0,
   },
 ] as const;
 
 export const DEMO_USER_IDS = DEMO_USERS.map((user) => user.id);
 export const DEMO_USERNAMES = DEMO_USERS.map((user) => user.username);
+export const DEMO_SETTINGS_CACHE_NAMESPACES = DEMO_USERS.map((user) => `settings:user:${user.id}`);
+export const DEMO_ENTRIES_CACHE_NAMESPACES = DEMO_USERS.map((user) => `entries:user:${user.id}`);
 
 export const COMPATIBILITY_DEFAULTS = {
   clients: ['c1', 'c2'],
@@ -161,6 +214,43 @@ export const DEMO_PROJECTS = [
 
 export const DEMO_NOTIFICATIONS = ['dm_notif_01', 'dm_notif_02'] as const;
 
+export const DEMO_WORK_UNITS = [
+  { id: 'dm_wu_01', name: 'Development Team', description: 'Frontend and backend engineering.' },
+  {
+    id: 'dm_wu_02',
+    name: 'Sales & Marketing',
+    description: 'Customer acquisition and brand management.',
+  },
+  {
+    id: 'dm_wu_03',
+    name: 'IT Operations',
+    description: 'Infrastructure, support, and cross-team ops.',
+  },
+] as const;
+
+export const DEMO_WORK_UNIT_MANAGERS = [
+  { workUnitId: 'dm_wu_01', userId: 'u2' },
+  { workUnitId: 'dm_wu_02', userId: 'u4' },
+  { workUnitId: 'dm_wu_03', userId: 'u2' },
+  { workUnitId: 'dm_wu_03', userId: 'u4' },
+] as const;
+
+export const DEMO_USER_WORK_UNITS = [
+  { userId: 'u2', workUnitId: 'dm_wu_01' },
+  { userId: 'u3', workUnitId: 'dm_wu_01' },
+  { userId: 'u5', workUnitId: 'dm_wu_01' },
+  { userId: 'u6', workUnitId: 'dm_wu_01' },
+  { userId: 'u4', workUnitId: 'dm_wu_02' },
+  { userId: 'u7', workUnitId: 'dm_wu_02' },
+  { userId: 'u8', workUnitId: 'dm_wu_02' },
+  { userId: 'u2', workUnitId: 'dm_wu_03' },
+  { userId: 'u4', workUnitId: 'dm_wu_03' },
+  { userId: 'u5', workUnitId: 'dm_wu_03' },
+  { userId: 'u7', workUnitId: 'dm_wu_03' },
+] as const;
+
+export const DEMO_TIME_ENTRY_IDS = rangeIds('dm_te_', 25);
+
 export const DEMO_ITEM_IDS = {
   quoteItems: rangeIds('dm_cqi_', 14),
   customerOfferItems: rangeIds('dm_coi_', 7),
@@ -187,6 +277,8 @@ export const DEMO_IDS = {
   supplierInvoices: DEMO_SUPPLIER_INVOICES.map((item) => item.id),
   projects: DEMO_PROJECTS.map((item) => item.id),
   notifications: [...DEMO_NOTIFICATIONS],
+  workUnits: DEMO_WORK_UNITS.map((item) => item.id),
+  timeEntries: [...DEMO_TIME_ENTRY_IDS],
   users: [...DEMO_USER_IDS],
   settingsUserIds: [...DEMO_USER_IDS],
 } as const;
@@ -216,4 +308,8 @@ export const DEMO_EXPECTED_COUNTS = {
   supplier_invoice_items: DEMO_ITEM_IDS.supplierInvoiceItems.length,
   projects: DEMO_PROJECTS.length,
   notifications: DEMO_NOTIFICATIONS.length,
+  work_units: DEMO_WORK_UNITS.length,
+  work_unit_managers: DEMO_WORK_UNIT_MANAGERS.length,
+  user_work_units: DEMO_USER_WORK_UNITS.length,
+  time_entries: DEMO_TIME_ENTRY_IDS.length,
 } as const;

--- a/server/db/seed.sql
+++ b/server/db/seed.sql
@@ -1272,3 +1272,103 @@ ON CONFLICT (id) DO UPDATE SET
     data = EXCLUDED.data,
     is_read = EXCLUDED.is_read,
     created_at = EXCLUDED.created_at;
+
+INSERT INTO work_units (id, name, description, is_disabled, created_at) VALUES
+    ('dm_wu_01', 'Development Team', 'Frontend and backend engineering.', FALSE, CURRENT_TIMESTAMP - INTERVAL '180 days'),
+    ('dm_wu_02', 'Sales & Marketing', 'Customer acquisition and brand management.', FALSE, CURRENT_TIMESTAMP - INTERVAL '160 days'),
+    ('dm_wu_03', 'IT Operations', 'Infrastructure, support, and cross-team ops.', FALSE, CURRENT_TIMESTAMP - INTERVAL '140 days')
+ON CONFLICT (id) DO UPDATE SET
+    name = EXCLUDED.name,
+    description = EXCLUDED.description,
+    is_disabled = EXCLUDED.is_disabled,
+    created_at = EXCLUDED.created_at;
+
+INSERT INTO work_unit_managers (work_unit_id, user_id) VALUES
+    ('dm_wu_01', 'u2'),
+    ('dm_wu_02', 'u4'),
+    ('dm_wu_03', 'u2'),
+    ('dm_wu_03', 'u4')
+ON CONFLICT (work_unit_id, user_id) DO NOTHING;
+
+INSERT INTO user_work_units (user_id, work_unit_id) VALUES
+    ('u2', 'dm_wu_01'),
+    ('u3', 'dm_wu_01'),
+    ('u5', 'dm_wu_01'),
+    ('u6', 'dm_wu_01'),
+    ('u4', 'dm_wu_02'),
+    ('u7', 'dm_wu_02'),
+    ('u8', 'dm_wu_02'),
+    ('u2', 'dm_wu_03'),
+    ('u4', 'dm_wu_03'),
+    ('u5', 'dm_wu_03'),
+    ('u7', 'dm_wu_03')
+ON CONFLICT (user_id, work_unit_id) DO NOTHING;
+
+INSERT INTO time_entries (
+    id, user_id, date, client_id, client_name, project_id, project_name,
+    task, notes, duration, hourly_cost, is_placeholder, location
+) VALUES
+    ('dm_te_01', 'u3',  CURRENT_DATE - INTERVAL '28 days', 'c1', 'Acme Corp',    'p1', 'Website Redesign',   'Initial Design',       'Wireframe sketches for homepage',          6.00, 45.00, FALSE, 'office'),
+    ('dm_te_02', 'u3',  CURRENT_DATE - INTERVAL '27 days', 'c1', 'Acme Corp',    'p1', 'Website Redesign',   'Frontend Dev',         'Implement header and nav components',      7.50, 45.00, FALSE, 'office'),
+    ('dm_te_03', 'u5',  CURRENT_DATE - INTERVAL '26 days', 'c1', 'Acme Corp',    'p1', 'Website Redesign',   'Frontend Dev',         'Build hero section and CTA blocks',        8.00, 50.00, FALSE, 'remote'),
+    ('dm_te_04', 'u5',  CURRENT_DATE - INTERVAL '25 days', 'c1', 'Acme Corp',    'p2', 'Mobile App',         'API Integration',      'Wire up authentication endpoints',         4.00, 50.00, FALSE, 'remote'),
+    ('dm_te_05', 'u6',  CURRENT_DATE - INTERVAL '24 days', 'c1', 'Acme Corp',    'p1', 'Website Redesign',   'Frontend Dev',         'Responsive layout for mobile breakpoints', 7.00, 40.00, FALSE, 'office'),
+    ('dm_te_06', 'u6',  CURRENT_DATE - INTERVAL '23 days', 'c1', 'Acme Corp',    'p2', 'Mobile App',         'API Integration',      'Connect product listing to backend',       5.50, 40.00, FALSE, 'remote'),
+    ('dm_te_07', 'u2',  CURRENT_DATE - INTERVAL '22 days', 'c2', 'Global Tech',  'p3', 'Internal Research',  'General Support',      'Sprint kickoff and backlog grooming',      3.00, 65.00, FALSE, 'office'),
+    ('dm_te_08', 'u7',  CURRENT_DATE - INTERVAL '21 days', 'c2', 'Global Tech',  'p3', 'Internal Research',  'Market Analysis',      'Competitive landscape research',           6.00, 55.00, FALSE, 'remote'),
+    ('dm_te_09', 'u3',  CURRENT_DATE - INTERVAL '20 days', 'c1', 'Acme Corp',    'p1', 'Website Redesign',   'Frontend Dev',         'Code review and refactor pass',            4.50, 45.00, FALSE, 'remote'),
+    ('dm_te_10', 'u5',  CURRENT_DATE - INTERVAL '19 days', 'c1', 'Acme Corp',    'p1', 'Website Redesign',   'Frontend Dev',         'Accessibility audit and fixes',            3.50, 50.00, FALSE, 'remote'),
+    ('dm_te_11', 'u6',  CURRENT_DATE - INTERVAL '18 days', 'c1', 'Acme Corp',    'p2', 'Mobile App',         'API Integration',      'UI polish on product detail screen',       6.00, 40.00, FALSE, 'office'),
+    ('dm_te_12', 'u2',  CURRENT_DATE - INTERVAL '17 days', 'c1', 'Acme Corp',    'p1', 'Website Redesign',   'Initial Design',       'Sprint planning and story pointing',       2.00, 65.00, FALSE, 'office'),
+    ('dm_te_13', 'u7',  CURRENT_DATE - INTERVAL '15 days', 'c2', 'Global Tech',  'p3', 'Internal Research',  'Market Analysis',      'Competitor pricing analysis report',       7.00, 55.00, FALSE, 'remote'),
+    ('dm_te_14', 'u3',  CURRENT_DATE - INTERVAL '14 days', 'c1', 'Acme Corp',    'p2', 'Mobile App',         'API Integration',      'Integration testing against staging env',  5.00, 45.00, FALSE, 'office'),
+    ('dm_te_15', 'u5',  CURRENT_DATE - INTERVAL '12 days', 'c1', 'Acme Corp',    'p1', 'Website Redesign',   'Frontend Dev',         'Performance profiling and bundle tuning',  4.00, 50.00, FALSE, 'remote'),
+    ('dm_te_16', 'u6',  CURRENT_DATE - INTERVAL '10 days', 'c1', 'Acme Corp',    'p2', 'Mobile App',         'API Integration',      'Bug fixes from QA round two',              6.50, 40.00, FALSE, 'office'),
+    ('dm_te_17', 'u2',  CURRENT_DATE - INTERVAL '8 days',  'c2', 'Global Tech',  'p3', 'Internal Research',  'General Support',      'Status report for stakeholders',           1.50, 65.00, FALSE, 'remote'),
+    ('dm_te_18', 'u7',  CURRENT_DATE - INTERVAL '6 days',  'c2', 'Global Tech',  'p3', 'Internal Research',  'Market Analysis',      'On-site data collection interviews',       5.00, 55.00, FALSE, 'customer_premise'),
+    ('dm_te_19', 'u3',  CURRENT_DATE - INTERVAL '4 days',  'c1', 'Acme Corp',    'p1', 'Website Redesign',   'Frontend Dev',         'Final QA pass before handoff',             8.00, 45.00, FALSE, 'office'),
+    ('dm_te_20', 'u5',  CURRENT_DATE - INTERVAL '2 days',  'c1', 'Acme Corp',    'p1', 'Website Redesign',   'Frontend Dev',         'Deployment preparation and smoke test',    3.00, 50.00, FALSE, 'remote')
+ON CONFLICT (id) DO UPDATE SET
+    user_id = EXCLUDED.user_id,
+    date = EXCLUDED.date,
+    client_id = EXCLUDED.client_id,
+    client_name = EXCLUDED.client_name,
+    project_id = EXCLUDED.project_id,
+    project_name = EXCLUDED.project_name,
+    task = EXCLUDED.task,
+    notes = EXCLUDED.notes,
+    duration = EXCLUDED.duration,
+    hourly_cost = EXCLUDED.hourly_cost,
+    is_placeholder = EXCLUDED.is_placeholder,
+    location = EXCLUDED.location;
+
+INSERT INTO time_entries (
+    id, user_id, date, client_id, client_name, project_id, project_name,
+    task, notes, duration, hourly_cost, is_placeholder, location
+)
+SELECT
+    v.id, v.user_id, v.entry_date::date,
+    v.client_id, v.client_name, v.project_id,
+    p.name,
+    v.task, v.notes, v.duration, v.hourly_cost, v.is_placeholder, v.location
+FROM (VALUES
+    ('dm_te_21', 'u2',  CURRENT_DATE - INTERVAL '16 days', 'dm_cli_01', 'Northwind Retail Italia S.p.A.', 'dm_proj_01', 'Security audit review',         'Reviewed pen-test findings with client',          3.00, 65.00, FALSE, 'office'),
+    ('dm_te_22', 'u5',  CURRENT_DATE - INTERVAL '13 days', 'dm_cli_01', 'Northwind Retail Italia S.p.A.', 'dm_proj_02', 'Deployment configuration',      'Set up CI pipeline and staging environment',      5.00, 50.00, FALSE, 'remote'),
+    ('dm_te_23', 'u6',  CURRENT_DATE - INTERVAL '9 days',  'dm_cli_01', 'Northwind Retail Italia S.p.A.', 'dm_proj_01', 'Assessment report draft',       'Drafted executive summary and findings',          4.50, 40.00, FALSE, 'office'),
+    ('dm_te_24', 'u3',  CURRENT_DATE - INTERVAL '7 days',  'dm_cli_01', 'Northwind Retail Italia S.p.A.', 'dm_proj_02', 'Infra provisioning',            'Provisioned cloud resources for first wave',      6.00, 45.00, FALSE, 'remote'),
+    ('dm_te_25', 'u2',  CURRENT_DATE - INTERVAL '3 days',  'dm_cli_01', 'Northwind Retail Italia S.p.A.', 'dm_proj_01', 'Final review sign-off',         'Client sign-off meeting and deliverable handoff', 2.00, 65.00, FALSE, 'customer_premise')
+) AS v(id, user_id, entry_date, client_id, client_name, project_id, task, notes, duration, hourly_cost, is_placeholder, location)
+JOIN projects p ON p.id = v.project_id
+ON CONFLICT (id) DO UPDATE SET
+    user_id = EXCLUDED.user_id,
+    date = EXCLUDED.date,
+    client_id = EXCLUDED.client_id,
+    client_name = EXCLUDED.client_name,
+    project_id = EXCLUDED.project_id,
+    project_name = EXCLUDED.project_name,
+    task = EXCLUDED.task,
+    notes = EXCLUDED.notes,
+    duration = EXCLUDED.duration,
+    hourly_cost = EXCLUDED.hourly_cost,
+    is_placeholder = EXCLUDED.is_placeholder,
+    location = EXCLUDED.location;


### PR DESCRIPTION
## Summary

- **5 new demo users** (u4–u8): one extra manager (`salesmanager`) and four standard users (`erossi`, `mbianchi`, `sconti`, `lmoretti`) with varied `cost_per_hour` values; users INSERT now includes `cost_per_hour` and `employee_type` and `user_roles` is dynamically generated from `DEMO_USERS`
- **3 work units** seeded (`Development Team`, `Sales & Marketing`, `IT Operations`) with manager assignments (`work_unit_managers`) and 11 team memberships (`user_work_units`)
- **25 time entries** spread across the last 30 days covering 5 users, 5 projects, and a mix of locations, tasks, and durations
- `DEMO_SETTINGS_CACHE_NAMESPACES` and new `DEMO_ENTRIES_CACHE_NAMESPACES` are now derived dynamically from `DEMO_USERS` so they auto-expand as users are added
- Cleanup, verification, and cache invalidation added for all four new entity types

## Test plan

- [ ] Deploy with `DEMO_SEEDING=true` and verify startup logs show correct counts for all new entities (work_units: 3, work_unit_managers: 4, user_work_units: 11, time_entries: 25)
- [ ] Log in as `manager` (u2): verify Development Team and IT Operations work units are visible; verify time entries for managed users (u3, u5, u6) appear in tracker
- [ ] Log in as `salesmanager` (u4): verify Sales & Marketing and IT Operations work units are visible
- [ ] Log in as `erossi` (u5): verify own time entries are visible and not others
- [ ] Verify re-seed is idempotent (restart container a second time, no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xbounceit/praetor/pull/52" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
