### PR TITLE
fix(db): add bid_code to special_bids demo seed data

### DIFF
--- a/server/db/demoSeedManifest.ts
+++ b/server/db/demoSeedManifest.ts
@@ -120,9 +120,9 @@ export const DEMO_PRODUCTS = [
 ] as const;
 
 export const DEMO_SPECIAL_BIDS = [
-  { id: 'dm_bid_01', clientId: 'dm_cli_01', productId: 'dm_prd_06' },
-  { id: 'dm_bid_02', clientId: 'dm_cli_02', productId: 'dm_prd_05' },
-  { id: 'dm_bid_03', clientId: 'dm_cli_03', productId: 'dm_prd_08' },
+  { id: 'dm_bid_01', bidCode: 'DM-BID-001', clientId: 'dm_cli_01', productId: 'dm_prd_06' },
+  { id: 'dm_bid_02', bidCode: 'DM-BID-002', clientId: 'dm_cli_02', productId: 'dm_prd_05' },
+  { id: 'dm_bid_03', bidCode: 'DM-BID-003', clientId: 'dm_cli_03', productId: 'dm_prd_08' },
 ] as const;
 
 export const DEMO_QUOTES = [

--- a/server/db/seed.sql
+++ b/server/db/seed.sql
@@ -470,6 +470,7 @@ ON CONFLICT (id) DO UPDATE SET
 
 INSERT INTO special_bids (
     id,
+    bid_code,
     client_id,
     client_name,
     product_id,
@@ -483,6 +484,7 @@ INSERT INTO special_bids (
 ) VALUES
     (
         'dm_bid_01',
+        'DM-BID-001',
         'dm_cli_01',
         'Northwind Retail Italia S.p.A.',
         'dm_prd_06',
@@ -496,6 +498,7 @@ INSERT INTO special_bids (
     ),
     (
         'dm_bid_02',
+        'DM-BID-002',
         'dm_cli_02',
         'Helios Energy Services S.r.l.',
         'dm_prd_05',
@@ -509,6 +512,7 @@ INSERT INTO special_bids (
     ),
     (
         'dm_bid_03',
+        'DM-BID-003',
         'dm_cli_03',
         'Comune di Verona - Innovazione Digitale',
         'dm_prd_08',
@@ -521,6 +525,7 @@ INSERT INTO special_bids (
         CURRENT_TIMESTAMP - INTERVAL '2 days'
     )
 ON CONFLICT (id) DO UPDATE SET
+    bid_code = EXCLUDED.bid_code,
     client_id = EXCLUDED.client_id,
     client_name = EXCLUDED.client_name,
     product_id = EXCLUDED.product_id,


### PR DESCRIPTION
## Problem

Demo seeding crashes on startup when `DEMO_SEEDING=true`:

```
null value in column "bid_code" of relation "special_bids" violates not-null constraint
```

The `bid_code` column was added to `special_bids` as `NOT NULL` in the [feat/add-specialbid-code](https://github.com/xBounceIT/praetor/pull/53) merge, but the demo seed data (`seed.sql` + `demoSeedManifest.ts`) was never updated to include it.

## Changes

- **`server/db/seed.sql`**: Added `bid_code` column and demo values (`DM-BID-001`, `DM-BID-002`, `DM-BID-003`) to the `special_bids` INSERT statement, and `bid_code = EXCLUDED.bid_code` to the `ON CONFLICT DO UPDATE SET` clause.
- **`server/db/demoSeedManifest.ts`**: Added `bidCode` field to each entry in `DEMO_SPECIAL_BIDS` to keep the manifest consistent with the seed data.

## Verification

With these changes, demo seeding runs to completion without errors. The `DM-BID-` code prefix follows the existing convention (`DM-Q-` for quotes, `DM-OFF-` for offers).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xbounceit/praetor/pull/54" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
