### PR TITLE
chore: bump app version to 0.3.0

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Praetor API",
     "description": "Praetor API documentation",
-    "version": "0.2.0"
+    "version": "0.3.0"
   },
   "components": {
     "securitySchemes": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praetor",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "praetor-server",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Praetor API Server",
   "main": "dist/index.ts",
   "type": "module",


### PR DESCRIPTION
Bumps version from 0.2.0 to 0.3.0 in:
- `package.json`
- `server/package.json`
- `docs/api/openapi.json`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xbounceit/praetor/pull/56" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
