### PR TITLE
style(catalog): simplify product code column and move it first

### DIFF
--- a/components/catalog/InternalListingView.tsx
+++ b/components/catalog/InternalListingView.tsx
@@ -801,22 +801,17 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
         onRowClick={openEditModal}
         columns={[
           {
+            header: t('crm:internalListing.productCode'),
+            accessorKey: 'productCode',
+            cell: ({ row: p }) => (
+              <span className="font-bold text-slate-700">{p.productCode || '-'}</span>
+            ),
+          },
+          {
             header: t('common:labels.name'),
             accessorKey: 'name',
             className: 'px-6 py-5 font-bold text-slate-800 min-w-[200px]',
             cell: ({ row: p }) => <div className="font-bold text-slate-800">{p.name}</div>,
-          },
-          {
-            header: t('crm:internalListing.productCode'),
-            accessorKey: 'productCode',
-            cell: ({ row: p }) =>
-              p.productCode ? (
-                <span className="text-[10px] font-black bg-slate-100 text-slate-500 px-2 py-0.5 rounded uppercase shrink-0 whitespace-nowrap">
-                  {p.productCode}
-                </span>
-              ) : (
-                <span className="text-slate-300">-</span>
-              ),
           },
           {
             header: t('crm:internalListing.category'),


### PR DESCRIPTION
## Summary
- Simplified the product code column styling to match the order number column in ClientsOrdersView (bold text instead of pill/badge)
- Moved the product code column to be the first column in the table

## Changes
- `components/catalog/InternalListingView.tsx`: Swapped column order and updated cell renderer to use `font-bold text-slate-700`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xbounceit/praetor/pull/57" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
