### PR TITLE
style(ExternalListingView): move product code first and match ClientsOrdersView

### DIFF
--- a/components/catalog/ExternalListingView.tsx
+++ b/components/catalog/ExternalListingView.tsx
@@ -859,22 +859,17 @@ const ExternalListingView: React.FC<ExternalListingViewProps> = ({
         onRowClick={openEditModal}
         columns={[
           {
+            header: t('crm:internalListing.productCode'),
+            accessorKey: 'productCode',
+            cell: ({ row: p }) => (
+              <span className="font-bold text-slate-700">{p.productCode || '-'}</span>
+            ),
+          },
+          {
             header: t('common:labels.name'),
             accessorKey: 'name',
             className: 'px-6 py-5 font-bold text-slate-800 min-w-[200px]',
             cell: ({ row: p }) => <div className="font-bold text-slate-800">{p.name}</div>,
-          },
-          {
-            header: t('crm:internalListing.productCode'),
-            accessorKey: 'productCode',
-            cell: ({ row: p }) =>
-              p.productCode ? (
-                <span className="text-[10px] font-black bg-slate-100 text-slate-500 px-2 py-0.5 rounded uppercase shrink-0 whitespace-nowrap">
-                  {p.productCode}
-                </span>
-              ) : (
-                <span className="text-slate-300">-</span>
-              ),
           },
           {
             header: t('crm:internalListing.supplier'),


### PR DESCRIPTION
## Summary

- **Move product code column first** in the external listing table, giving it prominence as the primary identifier.
- **Restyle product code cell** from the previous badge pill (`bg-slate-100 text-slate-500 px-2 py-0.5 rounded`) to a clean text style (`font-bold text-slate-700`), matching the order number column in `ClientsOrdersView.tsx`.

## Changes

| File | What changed |
|---|---|
| `components/catalog/ExternalListingView.tsx` | Moved `productCode` column before `name`; simplified cell render from pill badge to plain `font-bold text-slate-700` span, consistent with `ClientsOrdersView` order number style. |

## Visual

Product code is now the first column with clean, bold text — no more pill background.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xbounceit/praetor/pull/58" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
