### PR TITLE
style: simplify bid code column to match order number styling

### DIFF
--- a/components/catalog/SpecialBidsView.tsx
+++ b/components/catalog/SpecialBidsView.tsx
@@ -294,9 +294,7 @@ const SpecialBidsView: React.FC<SpecialBidsViewProps> = ({
         header: t('externalListing.bidCode'),
         accessorFn: (row: SpecialBid) => row.bidCode,
         cell: ({ row }: { row: SpecialBid }) => (
-          <span className="text-sm font-bold text-slate-700 bg-slate-100 px-2 py-1 rounded">
-            {row.bidCode}
-          </span>
+          <span className="font-bold text-slate-700">{row.bidCode}</span>
         ),
       },
       {


### PR DESCRIPTION
## Summary
- Removed pill/badge styling (`bg-slate-100 px-2 py-1 rounded text-sm`) from the bid code column in `SpecialBidsView.tsx`
- Replaced with clean `font-bold text-slate-700` to match the order number column styling in `ClientsOrdersView.tsx`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xbounceit/praetor/pull/59" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
