### PR TITLE
style(SupplierQuotesView): move quote code column first and remove supplier subtext

### DIFF
--- a/components/sales/SupplierQuotesView.tsx
+++ b/components/sales/SupplierQuotesView.tsx
@@ -257,29 +257,6 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
   const columns = useMemo<Column<SupplierQuote>[]>(
     () => [
       {
-        header: t('sales:supplierQuotes.supplier', { defaultValue: 'Supplier' }),
-        accessorKey: 'supplierName',
-        cell: ({ row }) => {
-          const history = isHistoryRow(row);
-          return (
-            <div>
-              <div className={history ? 'font-bold text-slate-400' : 'font-bold text-slate-800'}>
-                {row.supplierName}
-              </div>
-              <div className="text-xs text-slate-400">
-                {row.linkedOfferId
-                  ? `${t('sales:supplierQuotes.linkedOffer', {
-                      defaultValue: 'Linked to offer',
-                    })} ${row.linkedOfferId}`
-                  : row.expirationDate
-                    ? formatDateOnlyForLocale(row.expirationDate)
-                    : ''}
-              </div>
-            </div>
-          );
-        },
-      },
-      {
         header: t('sales:supplierQuotes.quoteCode', { defaultValue: 'Quote Code' }),
         id: 'quoteCode',
         accessorFn: (row) => row.quoteCode || row.purchaseOrderNumber || '',


### PR DESCRIPTION
## Summary
- Move the Quote Code column to first position in the supplier quotes table
- Remove duplicate supplier column with subtext (linked offer info and expiration date)
- Keep only the simple supplier name column without additional details

This aligns the supplier quotes view with the recent table styling updates for other views.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xbounceit/praetor/pull/61" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
