### PR TITLE
chore: upgrade postgres to 18

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@
 SERVER_IP=localhost
 
 # Database Credentials
+# Fresh PostgreSQL 18 installs only. This compose file is not an in-place upgrade path for
+# an existing PostgreSQL 17 volume.
 POSTGRES_USER=praetor
 POSTGRES_PASSWORD=praetor
 POSTGRES_DB=praetor

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ cp .env.example .env
 docker compose up -d --build
 ```
 
+The bundled database now targets fresh PostgreSQL 18 installs and pins `PGDATA` to the
+official PG18 container layout. Do not point this compose file at an existing PostgreSQL 17
+data volume.
+
 The compose setup defaults backend `TRUST_PROXY=1` for the bundled Caddy -> API hop.
 Set `DEMO_SEEDING=true` in `.env` when you want the stack to provision the canonical demo users and demo business data.
 That refresh flow is intended for demo and test stacks, owns the canonical demo namespace, and supports reused Docker volumes.
@@ -81,6 +85,10 @@ cp deploy/.env.customer.example .env
 docker compose --env-file .env -f deploy/docker-compose.customer.yml pull
 docker compose --env-file .env -f deploy/docker-compose.customer.yml up -d
 ```
+
+This deployment defaults to PostgreSQL 18 for fresh installs only. The documented `pull` and
+`up -d` flow is an application rollout path, not an in-place PostgreSQL major-version upgrade
+procedure for an existing volume.
 
 That deployment also defaults backend `TRUST_PROXY=1`; override it if your proxy chain differs.
 

--- a/deploy/.env.customer.example
+++ b/deploy/.env.customer.example
@@ -12,6 +12,8 @@ FRONTEND_URL=http://localhost:3000
 FRONTEND_PORT=3000
 
 # Database credentials
+# Fresh PostgreSQL 18 installs only. Do not reuse a PostgreSQL 17 data volume with this
+# compose file.
 POSTGRES_USER=praetor
 POSTGRES_PASSWORD=change-me-strong-password
 POSTGRES_DB=praetor

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -33,7 +33,13 @@ docker compose --env-file .env -f deploy/docker-compose.customer.yml pull
 docker compose --env-file .env -f deploy/docker-compose.customer.yml up -d
 ```
 
+This compose file provisions PostgreSQL 18 for fresh installs and uses the official PG18
+container data layout. Do not attach it to an existing PostgreSQL 17 data volume.
+
 ## Upgrades
+
+The steps below are for Praetor application image updates only. They are not an in-place
+PostgreSQL major-version upgrade path.
 
 1. Change `PRAETOR_VERSION` in `.env`.
 2. Pull and restart:
@@ -46,3 +52,5 @@ docker compose --env-file .env -f deploy/docker-compose.customer.yml up -d
 ## Rollback
 
 Set `PRAETOR_VERSION` back to the previous tag and run the same pull/up commands.
+This rollback guidance applies to the application images only, assuming the same PostgreSQL 18
+cluster is still in use.

--- a/deploy/docker-compose.customer.yml
+++ b/deploy/docker-compose.customer.yml
@@ -1,13 +1,14 @@
 services:
   postgres:
-    image: postgres:17-alpine
+    image: postgres:18-alpine
     container_name: praetor-postgres
     environment:
       POSTGRES_USER: ${POSTGRES_USER:?POSTGRES_USER is required}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
       POSTGRES_DB: ${POSTGRES_DB:?POSTGRES_DB is required}
+      PGDATA: /var/lib/postgresql/18/docker
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     expose:
       - '5432'
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,14 +2,15 @@ services:
   # Developer compose (builds images from local source).
   # PostgreSQL Database
   postgres:
-    image: postgres:17-alpine
+    image: postgres:18-alpine
     container_name: praetor-postgres
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-praetor}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-praetor}
       POSTGRES_DB: ${POSTGRES_DB:-praetor}
+      PGDATA: /var/lib/postgresql/18/docker
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
       - ./server/db/schema.sql:/docker-entrypoint-initdb.d/01-schema.sql:ro
     expose:
       - '5432'


### PR DESCRIPTION
## Summary

- Bumps the PostgreSQL image from `postgres:17-alpine` to `postgres:18-alpine` in both `docker-compose.yml` and `deploy/docker-compose.customer.yml`
- Pins `PGDATA` to `/var/lib/postgresql/18/docker` and updates the volume mount accordingly to match the official PG18 container layout
- Adds clear warnings in `.env.example`, `deploy/.env.customer.example`, `README.md`, and `deploy/README.md` that this compose file targets **fresh installs only** and is not an in-place upgrade path from PostgreSQL 17

## Test plan

- [x] Fresh stack spins up cleanly with `docker compose up -d --build`
- [x] Database initialises from schema and demo seed runs without errors
- [x] Customer deployment stack starts correctly with `deploy/docker-compose.customer.yml`
- [x] Confirm existing PG17 volumes are **not** reused (intentional breaking change, documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xbounceit/praetor/pull/64" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
