### PR TITLE
style(auth): polish admin auth settings page

### DIFF
--- a/components/administration/AuthSettings.tsx
+++ b/components/administration/AuthSettings.tsx
@@ -50,6 +50,7 @@ const AuthSettings: React.FC<AuthSettingsProps> = ({ config, onSave, roles }) =>
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [testErrors, setTestErrors] = useState<Record<string, string>>({});
   const [activeTab, setActiveTab] = useState<'ldap'>('ldap');
+  const isDirty = JSON.stringify(formData) !== JSON.stringify(config || DEFAULT_CONFIG);
 
   const roleOptions = roles.length
     ? roles.map((role) => ({ id: role.id, name: role.name }))
@@ -483,7 +484,8 @@ const AuthSettings: React.FC<AuthSettingsProps> = ({ config, onSave, roles }) =>
             <div className="flex justify-end pt-4">
               <button
                 type="submit"
-                className="bg-praetor text-white px-8 py-3 rounded-xl font-bold shadow-lg shadow-slate-200 hover:bg-slate-800 transition-all active:scale-95"
+                disabled={!isDirty}
+                className="bg-praetor text-white px-8 py-3 rounded-xl font-bold shadow-lg shadow-slate-200 hover:bg-slate-800 transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {t('admin.ldap.saveConfiguration', 'Save Configuration')}
               </button>

--- a/components/administration/AuthSettings.tsx
+++ b/components/administration/AuthSettings.tsx
@@ -49,6 +49,7 @@ const AuthSettings: React.FC<AuthSettingsProps> = ({ config, onSave, roles }) =>
   const [isSaved, setIsSaved] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [testErrors, setTestErrors] = useState<Record<string, string>>({});
+  const [activeTab, setActiveTab] = useState<'ldap'>('ldap');
 
   const roleOptions = roles.length
     ? roles.map((role) => ({ id: role.id, name: role.name }))
@@ -221,373 +222,409 @@ const AuthSettings: React.FC<AuthSettingsProps> = ({ config, onSave, roles }) =>
         )}
       </div>
 
-      <form onSubmit={handleSave} className="space-y-8">
-        {/* Connection Settings */}
-        <section className="bg-white rounded-2xl border border-slate-200 shadow-sm overflow-hidden">
-          <div className="px-6 py-4 bg-slate-50 border-b border-slate-200 flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <i className="fa-solid fa-server text-praetor"></i>
-              <h3 className="font-bold text-slate-800">{t('admin.ldap.serverConfig')}</h3>
-            </div>
-            <div className="flex items-center gap-3">
-              <Toggle
-                checked={formData.enabled}
-                onChange={(checked) => setFormData({ ...formData, enabled: checked })}
-              />
-              <span className="text-sm font-medium text-slate-600">{t('admin.ldap.enabled')}</span>
-            </div>
-          </div>
-
-          <div
-            className={`p-6 grid grid-cols-1 md:grid-cols-2 gap-6 transition-opacity ${!formData.enabled ? 'opacity-50 pointer-events-none' : ''}`}
-          >
-            <div className="md:col-span-2">
-              <label className="block text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">
-                {t('admin.ldap.serverUrlLabel')}
-              </label>
-              <input
-                type="text"
-                value={formData.serverUrl}
-                onChange={(e) => {
-                  setFormData({ ...formData, serverUrl: e.target.value });
-                  if (errors.serverUrl) setErrors({ ...errors, serverUrl: '' });
-                }}
-                placeholder={t('admin.ldap.serverUrlPlaceholder')}
-                className={`w-full px-4 py-2 bg-slate-50 border rounded-lg focus:ring-2 outline-none font-mono text-sm ${errors.serverUrl ? 'border-red-500 bg-red-50 focus:ring-red-200' : 'border-slate-200 focus:ring-praetor'}`}
-              />
-              {errors.serverUrl && (
-                <p className="text-red-500 text-[10px] font-bold mt-1">{errors.serverUrl}</p>
-              )}
-            </div>
-
-            <div>
-              <label className="block text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">
-                {t('admin.ldap.baseDnLabel')}
-              </label>
-              <input
-                type="text"
-                value={formData.baseDn}
-                onChange={(e) => {
-                  setFormData({ ...formData, baseDn: e.target.value });
-                  if (errors.baseDn) setErrors({ ...errors, baseDn: '' });
-                }}
-                placeholder={t('admin.ldap.baseDnPlaceholder')}
-                className={`w-full px-4 py-2 bg-slate-50 border rounded-lg focus:ring-2 outline-none font-mono text-sm ${errors.baseDn ? 'border-red-500 bg-red-50 focus:ring-red-200' : 'border-slate-200 focus:ring-praetor'}`}
-              />
-              {errors.baseDn && (
-                <p className="text-red-500 text-[10px] font-bold mt-1">{errors.baseDn}</p>
-              )}
-            </div>
-
-            <div>
-              <label className="block text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">
-                {t('admin.ldap.userSearchFilter')}
-              </label>
-              <input
-                type="text"
-                value={formData.userFilter}
-                onChange={(e) => {
-                  setFormData({ ...formData, userFilter: e.target.value });
-                  if (errors.userFilter) setErrors({ ...errors, userFilter: '' });
-                }}
-                placeholder={t('admin.ldap.userFilterPlaceholder')}
-                className={`w-full px-4 py-2 bg-slate-50 border rounded-lg focus:ring-2 outline-none font-mono text-sm ${errors.userFilter ? 'border-red-500 bg-red-50 focus:ring-red-200' : 'border-slate-200 focus:ring-praetor'}`}
-              />
-              {errors.userFilter && (
-                <p className="text-red-500 text-[10px] font-bold mt-1">{errors.userFilter}</p>
-              )}
-              {!errors.userFilter && (
-                <p className="text-slate-500 text-[10px] mt-1">{t('admin.ldap.userFilterHelp')}</p>
-              )}
-            </div>
-
-            <div>
-              <label className="block text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">
-                {t('admin.ldap.bindDnLabel')} {t('common:common.optional', '(Optional)')}
-              </label>
-              <input
-                type="text"
-                value={formData.bindDn}
-                onChange={(e) => {
-                  setFormData({ ...formData, bindDn: e.target.value });
-                  if (errors.bindCredentials) setErrors({ ...errors, bindCredentials: '' });
-                }}
-                placeholder={t('admin.ldap.bindDnPlaceholder')}
-                className={`w-full px-4 py-2 bg-slate-50 border rounded-lg focus:ring-2 outline-none font-mono text-sm ${errors.bindCredentials ? 'border-red-500 bg-red-50 focus:ring-red-200' : 'border-slate-200 focus:ring-praetor'}`}
-              />
-            </div>
-
-            <div>
-              <label className="block text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">
-                {t('admin.ldap.bindPasswordLabel')}
-              </label>
-              <input
-                type="password"
-                value={formData.bindPassword}
-                onChange={(e) => {
-                  setFormData({ ...formData, bindPassword: e.target.value });
-                  if (errors.bindCredentials) setErrors({ ...errors, bindCredentials: '' });
-                }}
-                className={`w-full px-4 py-2 bg-slate-50 border rounded-lg focus:ring-2 outline-none font-mono text-sm ${errors.bindCredentials ? 'border-red-500 bg-red-50 focus:ring-red-200' : 'border-slate-200 focus:ring-praetor'}`}
-              />
-              {errors.bindCredentials && (
-                <p className="text-red-500 text-[10px] font-bold mt-1">{errors.bindCredentials}</p>
-              )}
-            </div>
-          </div>
-        </section>
-
-        {/* Authorization & Provisioning */}
-        <section
-          className={`bg-white rounded-2xl border border-slate-200 shadow-sm transition-opacity ${!formData.enabled ? 'opacity-50 pointer-events-none' : ''}`}
+      <div className="flex border-b border-slate-200 gap-8">
+        <button
+          type="button"
+          onClick={() => setActiveTab('ldap')}
+          className={`pb-4 text-sm font-bold transition-all relative ${activeTab === 'ldap' ? 'text-praetor' : 'text-slate-400 hover:text-slate-600'}`}
         >
-          <div className="px-6 py-4 bg-slate-50 border-b border-slate-200 flex items-center gap-3 rounded-t-2xl">
-            <i className="fa-solid fa-users-gear text-praetor"></i>
-            <h3 className="font-bold text-slate-800">
-              {t('admin.ldap.authorizationProvisioning')}
-            </h3>
-          </div>
+          <i className="fa-solid fa-folder-tree mr-2"></i>
+          {t('admin.tabs.ldap', 'LDAP / Active Directory')}
+          {activeTab === 'ldap' && (
+            <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-praetor rounded-full"></div>
+          )}
+        </button>
+      </div>
 
-          <div className="p-6 space-y-6">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-              <div>
-                <label className="block text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">
-                  {t('admin.ldap.groupSearchBase')}
-                </label>
-                <input
-                  type="text"
-                  value={formData.groupBaseDn}
-                  onChange={(e) => {
-                    setFormData({ ...formData, groupBaseDn: e.target.value });
-                    if (errors.groupBaseDn) setErrors({ ...errors, groupBaseDn: '' });
-                  }}
-                  placeholder={t('admin.ldap.groupBaseDnPlaceholder')}
-                  className={`w-full px-4 py-2 bg-slate-50 border rounded-lg focus:ring-2 outline-none font-mono text-sm ${errors.groupBaseDn ? 'border-red-500 bg-red-50 focus:ring-red-200' : 'border-slate-200 focus:ring-praetor'}`}
-                />
-                {errors.groupBaseDn && (
-                  <p className="text-red-500 text-[10px] font-bold mt-1">{errors.groupBaseDn}</p>
-                )}
-              </div>
-              <div>
-                <label className="block text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">
-                  {t('admin.ldap.groupMemberFilter')}
-                </label>
-                <input
-                  type="text"
-                  value={formData.groupFilter}
-                  onChange={(e) => {
-                    setFormData({ ...formData, groupFilter: e.target.value });
-                    if (errors.groupFilter) setErrors({ ...errors, groupFilter: '' });
-                  }}
-                  placeholder="(member={0}) or (memberUid={0})"
-                  className={`w-full px-4 py-2 bg-slate-50 border rounded-lg focus:ring-2 outline-none font-mono text-sm ${errors.groupFilter ? 'border-red-500 bg-red-50 focus:ring-red-200' : 'border-slate-200 focus:ring-praetor'}`}
-                />
-                {errors.groupFilter && (
-                  <p className="text-red-500 text-[10px] font-bold mt-1">{errors.groupFilter}</p>
-                )}
-              </div>
-            </div>
-
-            <div className="border-t border-slate-100 pt-6">
-              <div className="flex justify-between items-center mb-4">
-                <h4 className="text-sm font-bold text-slate-800">{t('admin.ldap.roleMappings')}</h4>
-                <button
-                  type="button"
-                  onClick={addRoleMapping}
-                  className="text-xs bg-slate-100 text-praetor px-3 py-1.5 rounded-lg font-bold hover:bg-slate-200 transition-colors"
-                >
-                  <i className="fa-solid fa-plus mr-1"></i> {t('admin.ldap.addMapping')}
-                </button>
+      {activeTab === 'ldap' && (
+        <div className="animate-in fade-in slide-in-from-left-4 duration-300">
+          <form onSubmit={handleSave} className="space-y-8">
+            {/* Connection Settings */}
+            <section className="bg-white rounded-2xl border border-slate-200 shadow-sm overflow-hidden">
+              <div className="px-6 py-4 bg-slate-50 border-b border-slate-200 flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  <i className="fa-solid fa-server text-praetor"></i>
+                  <h3 className="font-bold text-slate-800">{t('admin.ldap.serverConfig')}</h3>
+                </div>
+                <div className="flex items-center gap-3">
+                  <Toggle
+                    checked={formData.enabled}
+                    onChange={(checked) => setFormData({ ...formData, enabled: checked })}
+                  />
+                  <span className="text-sm font-medium text-slate-600">
+                    {t('admin.ldap.enabled')}
+                  </span>
+                </div>
               </div>
 
-              <div className="space-y-3">
-                {formData.roleMappings.length === 0 ? (
-                  <p className="text-xs text-slate-400 italic">
-                    {t(
-                      'admin.ldap.noMappingsConfigured',
-                      'No mappings configured. Users will be assigned &apos;User&apos; role by default if not specified.',
+              <div
+                className={`p-6 grid grid-cols-1 md:grid-cols-2 gap-6 transition-opacity ${!formData.enabled ? 'opacity-50 pointer-events-none' : ''}`}
+              >
+                <div className="md:col-span-2">
+                  <label className="block text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">
+                    {t('admin.ldap.serverUrlLabel')}
+                  </label>
+                  <input
+                    type="text"
+                    value={formData.serverUrl}
+                    onChange={(e) => {
+                      setFormData({ ...formData, serverUrl: e.target.value });
+                      if (errors.serverUrl) setErrors({ ...errors, serverUrl: '' });
+                    }}
+                    placeholder={t('admin.ldap.serverUrlPlaceholder')}
+                    className={`w-full px-4 py-2 bg-slate-50 border rounded-lg focus:ring-2 outline-none font-mono text-sm ${errors.serverUrl ? 'border-red-500 bg-red-50 focus:ring-red-200' : 'border-slate-200 focus:ring-praetor'}`}
+                  />
+                  {errors.serverUrl && (
+                    <p className="text-red-500 text-[10px] font-bold mt-1">{errors.serverUrl}</p>
+                  )}
+                </div>
+
+                <div>
+                  <label className="block text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">
+                    {t('admin.ldap.baseDnLabel')}
+                  </label>
+                  <input
+                    type="text"
+                    value={formData.baseDn}
+                    onChange={(e) => {
+                      setFormData({ ...formData, baseDn: e.target.value });
+                      if (errors.baseDn) setErrors({ ...errors, baseDn: '' });
+                    }}
+                    placeholder={t('admin.ldap.baseDnPlaceholder')}
+                    className={`w-full px-4 py-2 bg-slate-50 border rounded-lg focus:ring-2 outline-none font-mono text-sm ${errors.baseDn ? 'border-red-500 bg-red-50 focus:ring-red-200' : 'border-slate-200 focus:ring-praetor'}`}
+                  />
+                  {errors.baseDn && (
+                    <p className="text-red-500 text-[10px] font-bold mt-1">{errors.baseDn}</p>
+                  )}
+                </div>
+
+                <div>
+                  <label className="block text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">
+                    {t('admin.ldap.userSearchFilter')}
+                  </label>
+                  <input
+                    type="text"
+                    value={formData.userFilter}
+                    onChange={(e) => {
+                      setFormData({ ...formData, userFilter: e.target.value });
+                      if (errors.userFilter) setErrors({ ...errors, userFilter: '' });
+                    }}
+                    placeholder={t('admin.ldap.userFilterPlaceholder')}
+                    className={`w-full px-4 py-2 bg-slate-50 border rounded-lg focus:ring-2 outline-none font-mono text-sm ${errors.userFilter ? 'border-red-500 bg-red-50 focus:ring-red-200' : 'border-slate-200 focus:ring-praetor'}`}
+                  />
+                  {errors.userFilter && (
+                    <p className="text-red-500 text-[10px] font-bold mt-1">{errors.userFilter}</p>
+                  )}
+                  {!errors.userFilter && (
+                    <p className="text-slate-500 text-[10px] mt-1">
+                      {t('admin.ldap.userFilterHelp')}
+                    </p>
+                  )}
+                </div>
+
+                <div>
+                  <label className="block text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">
+                    {t('admin.ldap.bindDnLabel')} {t('common:common.optional', '(Optional)')}
+                  </label>
+                  <input
+                    type="text"
+                    value={formData.bindDn}
+                    onChange={(e) => {
+                      setFormData({ ...formData, bindDn: e.target.value });
+                      if (errors.bindCredentials) setErrors({ ...errors, bindCredentials: '' });
+                    }}
+                    placeholder={t('admin.ldap.bindDnPlaceholder')}
+                    className={`w-full px-4 py-2 bg-slate-50 border rounded-lg focus:ring-2 outline-none font-mono text-sm ${errors.bindCredentials ? 'border-red-500 bg-red-50 focus:ring-red-200' : 'border-slate-200 focus:ring-praetor'}`}
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">
+                    {t('admin.ldap.bindPasswordLabel')}
+                  </label>
+                  <input
+                    type="password"
+                    value={formData.bindPassword}
+                    onChange={(e) => {
+                      setFormData({ ...formData, bindPassword: e.target.value });
+                      if (errors.bindCredentials) setErrors({ ...errors, bindCredentials: '' });
+                    }}
+                    className={`w-full px-4 py-2 bg-slate-50 border rounded-lg focus:ring-2 outline-none font-mono text-sm ${errors.bindCredentials ? 'border-red-500 bg-red-50 focus:ring-red-200' : 'border-slate-200 focus:ring-praetor'}`}
+                  />
+                  {errors.bindCredentials && (
+                    <p className="text-red-500 text-[10px] font-bold mt-1">
+                      {errors.bindCredentials}
+                    </p>
+                  )}
+                </div>
+              </div>
+            </section>
+
+            {/* Authorization & Provisioning */}
+            <section
+              className={`bg-white rounded-2xl border border-slate-200 shadow-sm transition-opacity ${!formData.enabled ? 'opacity-50 pointer-events-none' : ''}`}
+            >
+              <div className="px-6 py-4 bg-slate-50 border-b border-slate-200 flex items-center gap-3 rounded-t-2xl">
+                <i className="fa-solid fa-users-gear text-praetor"></i>
+                <h3 className="font-bold text-slate-800">
+                  {t('admin.ldap.authorizationProvisioning')}
+                </h3>
+              </div>
+
+              <div className="p-6 space-y-6">
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                  <div>
+                    <label className="block text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">
+                      {t('admin.ldap.groupSearchBase')}
+                    </label>
+                    <input
+                      type="text"
+                      value={formData.groupBaseDn}
+                      onChange={(e) => {
+                        setFormData({ ...formData, groupBaseDn: e.target.value });
+                        if (errors.groupBaseDn) setErrors({ ...errors, groupBaseDn: '' });
+                      }}
+                      placeholder={t('admin.ldap.groupBaseDnPlaceholder')}
+                      className={`w-full px-4 py-2 bg-slate-50 border rounded-lg focus:ring-2 outline-none font-mono text-sm ${errors.groupBaseDn ? 'border-red-500 bg-red-50 focus:ring-red-200' : 'border-slate-200 focus:ring-praetor'}`}
+                    />
+                    {errors.groupBaseDn && (
+                      <p className="text-red-500 text-[10px] font-bold mt-1">
+                        {errors.groupBaseDn}
+                      </p>
                     )}
-                  </p>
-                ) : (
-                  formData.roleMappings.map((mapping: LdapRoleMapping, idx: number) => (
-                    <div key={idx} className="flex gap-4 items-center">
-                      <div className="flex-1">
-                        <input
-                          type="text"
-                          value={mapping.ldapGroup}
-                          onChange={(e) => updateRoleMapping(idx, 'ldapGroup', e.target.value)}
-                          placeholder={t(
-                            'admin.ldap.ldapGroupPlaceholder',
-                            'LDAP Group CN (e.g. cn=admins)',
-                          )}
-                          className={`w-full px-3 py-2 bg-slate-50 border rounded-lg text-sm font-mono focus:ring-2 outline-none ${errors[`roleMapping_${idx}`] ? 'border-red-500 bg-red-50 focus:ring-red-200' : 'focus:ring-praetor border-slate-200'}`}
-                        />
-                        {errors[`roleMapping_${idx}`] && (
-                          <p className="text-red-500 text-[10px] font-bold mt-1">
-                            {errors[`roleMapping_${idx}`]}
-                          </p>
+                  </div>
+                  <div>
+                    <label className="block text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">
+                      {t('admin.ldap.groupMemberFilter')}
+                    </label>
+                    <input
+                      type="text"
+                      value={formData.groupFilter}
+                      onChange={(e) => {
+                        setFormData({ ...formData, groupFilter: e.target.value });
+                        if (errors.groupFilter) setErrors({ ...errors, groupFilter: '' });
+                      }}
+                      placeholder="(member={0}) or (memberUid={0})"
+                      className={`w-full px-4 py-2 bg-slate-50 border rounded-lg focus:ring-2 outline-none font-mono text-sm ${errors.groupFilter ? 'border-red-500 bg-red-50 focus:ring-red-200' : 'border-slate-200 focus:ring-praetor'}`}
+                    />
+                    {errors.groupFilter && (
+                      <p className="text-red-500 text-[10px] font-bold mt-1">
+                        {errors.groupFilter}
+                      </p>
+                    )}
+                  </div>
+                </div>
+
+                <div className="border-t border-slate-100 pt-6">
+                  <div className="flex justify-between items-center mb-4">
+                    <h4 className="text-sm font-bold text-slate-800">
+                      {t('admin.ldap.roleMappings')}
+                    </h4>
+                    <button
+                      type="button"
+                      onClick={addRoleMapping}
+                      className="text-xs bg-slate-100 text-praetor px-3 py-1.5 rounded-lg font-bold hover:bg-slate-200 transition-colors"
+                    >
+                      <i className="fa-solid fa-plus mr-1"></i> {t('admin.ldap.addMapping')}
+                    </button>
+                  </div>
+
+                  <div className="space-y-3">
+                    {formData.roleMappings.length === 0 ? (
+                      <p className="text-xs text-slate-400 italic">
+                        {t(
+                          'admin.ldap.noMappingsConfigured',
+                          'No mappings configured. Users will be assigned &apos;User&apos; role by default if not specified.',
                         )}
-                      </div>
-                      <i className="fa-solid fa-arrow-right text-slate-300 text-xs"></i>
-                      <div className="w-40">
-                        <CustomSelect
-                          options={roleOptions}
-                          value={mapping.role}
-                          onChange={(val) => updateRoleMapping(idx, 'role', val as string)}
-                        />
-                      </div>
-                      <button
-                        type="button"
-                        onClick={() => removeRoleMapping(idx)}
-                        className="text-slate-400 hover:text-red-500 p-2"
-                      >
-                        <i className="fa-solid fa-trash-can"></i>
-                      </button>
-                    </div>
-                  ))
-                )}
+                      </p>
+                    ) : (
+                      formData.roleMappings.map((mapping: LdapRoleMapping, idx: number) => (
+                        <div key={idx} className="flex gap-4 items-center">
+                          <div className="flex-1">
+                            <input
+                              type="text"
+                              value={mapping.ldapGroup}
+                              onChange={(e) => updateRoleMapping(idx, 'ldapGroup', e.target.value)}
+                              placeholder={t(
+                                'admin.ldap.ldapGroupPlaceholder',
+                                'LDAP Group CN (e.g. cn=admins)',
+                              )}
+                              className={`w-full px-3 py-2 bg-slate-50 border rounded-lg text-sm font-mono focus:ring-2 outline-none ${errors[`roleMapping_${idx}`] ? 'border-red-500 bg-red-50 focus:ring-red-200' : 'focus:ring-praetor border-slate-200'}`}
+                            />
+                            {errors[`roleMapping_${idx}`] && (
+                              <p className="text-red-500 text-[10px] font-bold mt-1">
+                                {errors[`roleMapping_${idx}`]}
+                              </p>
+                            )}
+                          </div>
+                          <i className="fa-solid fa-arrow-right text-slate-300 text-xs"></i>
+                          <div className="w-40">
+                            <CustomSelect
+                              options={roleOptions}
+                              value={mapping.role}
+                              onChange={(val) => updateRoleMapping(idx, 'role', val as string)}
+                            />
+                          </div>
+                          <button
+                            type="button"
+                            onClick={() => removeRoleMapping(idx)}
+                            className="text-slate-400 hover:text-red-500 p-2"
+                          >
+                            <i className="fa-solid fa-trash-can"></i>
+                          </button>
+                        </div>
+                      ))
+                    )}
+                  </div>
+                </div>
               </div>
-            </div>
-          </div>
-        </section>
+            </section>
 
-        <div className="flex justify-end pt-4">
-          <button
-            type="submit"
-            className="bg-praetor text-white px-8 py-3 rounded-xl font-bold shadow-lg shadow-slate-200 hover:bg-slate-800 transition-all active:scale-95"
-          >
-            {t('admin.ldap.saveConfiguration', 'Save Configuration')}
-          </button>
-        </div>
-      </form>
-
-      {/* Tester */}
-      <section
-        className={`bg-white rounded-2xl border border-slate-200 shadow-sm overflow-hidden mt-12 transition-opacity ${!formData.enabled ? 'opacity-50 pointer-events-none' : ''}`}
-      >
-        <div className="px-6 py-4 bg-slate-50 border-b border-slate-200 flex items-center gap-3">
-          <i className="fa-solid fa-vial text-praetor"></i>
-          <h3 className="font-bold text-slate-800">{t('admin.ldap.connectionTester')}</h3>
-        </div>
-        <div className="p-6 grid grid-cols-1 lg:grid-cols-2 gap-8">
-          <div className="space-y-4">
-            <p className="text-xs text-slate-400 mb-4">
-              {t(
-                'admin.ldap.testDescription',
-                'Enter credentials to test authentication and group retrieval against the current configuration.',
-              )}
-            </p>
-            <form onSubmit={handleTest} className="space-y-4">
-              <div>
-                <label className="block text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">
-                  {t('admin.ldap.testUsername')}
-                </label>
-                <input
-                  type="text"
-                  value={testUser}
-                  onChange={(e) => {
-                    setTestUser(e.target.value);
-                    if (testErrors.testUser) setTestErrors({ ...testErrors, testUser: '' });
-                  }}
-                  className={`w-full px-4 py-2 bg-slate-50 border rounded-lg focus:ring-2 outline-none text-sm font-semibold text-slate-700 ${testErrors.testUser ? 'border-red-500 bg-red-50 focus:ring-red-200' : 'border-slate-200 focus:ring-praetor'}`}
-                />
-                {testErrors.testUser && (
-                  <p className="text-red-500 text-[10px] font-bold mt-1">{testErrors.testUser}</p>
-                )}
-              </div>
-              <div>
-                <label className="block text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">
-                  {t('admin.ldap.testPassword')}
-                </label>
-                <input
-                  type="password"
-                  value={testPass}
-                  onChange={(e) => {
-                    setTestPass(e.target.value);
-                    if (testErrors.testPass) setTestErrors({ ...testErrors, testPass: '' });
-                  }}
-                  className={`w-full px-4 py-2 bg-slate-50 border rounded-lg focus:ring-2 outline-none text-sm font-semibold text-slate-700 ${testErrors.testPass ? 'border-red-500 bg-red-50 focus:ring-red-200' : 'border-slate-200 focus:ring-praetor'}`}
-                />
-                {testErrors.testPass && (
-                  <p className="text-red-500 text-[10px] font-bold mt-1">{testErrors.testPass}</p>
-                )}
-                {testErrors.enabled && (
-                  <p className="text-amber-600 text-[10px] font-bold mt-1">{testErrors.enabled}</p>
-                )}
-              </div>
+            <div className="flex justify-end pt-4">
               <button
                 type="submit"
-                disabled={isTestLoading || !formData.enabled}
-                className="w-full bg-praetor text-white py-2 rounded-lg font-bold hover:bg-slate-800 transition-colors disabled:opacity-50 shadow-md shadow-slate-100"
+                className="bg-praetor text-white px-8 py-3 rounded-xl font-bold shadow-lg shadow-slate-200 hover:bg-slate-800 transition-all active:scale-95"
               >
-                {isTestLoading ? (
-                  <i className="fa-solid fa-circle-notch fa-spin"></i>
-                ) : (
-                  t('admin.ldap.testAuthentication')
-                )}
+                {t('admin.ldap.saveConfiguration', 'Save Configuration')}
               </button>
-            </form>
-          </div>
+            </div>
+          </form>
 
-          <div className="bg-slate-900 rounded-xl p-4 font-mono text-xs overflow-y-auto h-64 border border-slate-800 shadow-inner">
-            {isTestLoading ? (
-              <div className="text-slate-400 animate-pulse">
-                {t('admin.ldap.test.connecting', 'Connecting to LDAP server...')}
+          {/* Tester */}
+          <section
+            className={`bg-white rounded-2xl border border-slate-200 shadow-sm overflow-hidden mt-12 transition-opacity ${!formData.enabled ? 'opacity-50 pointer-events-none' : ''}`}
+          >
+            <div className="px-6 py-4 bg-slate-50 border-b border-slate-200 flex items-center gap-3">
+              <i className="fa-solid fa-vial text-praetor"></i>
+              <h3 className="font-bold text-slate-800">{t('admin.ldap.connectionTester')}</h3>
+            </div>
+            <div className="p-6 grid grid-cols-1 lg:grid-cols-2 gap-8">
+              <div className="space-y-4">
+                <p className="text-xs text-slate-400 mb-4">
+                  {t(
+                    'admin.ldap.testDescription',
+                    'Enter credentials to test authentication and group retrieval against the current configuration.',
+                  )}
+                </p>
+                <form onSubmit={handleTest} className="space-y-4">
+                  <div>
+                    <label className="block text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">
+                      {t('admin.ldap.testUsername')}
+                    </label>
+                    <input
+                      type="text"
+                      value={testUser}
+                      onChange={(e) => {
+                        setTestUser(e.target.value);
+                        if (testErrors.testUser) setTestErrors({ ...testErrors, testUser: '' });
+                      }}
+                      className={`w-full px-4 py-2 bg-slate-50 border rounded-lg focus:ring-2 outline-none text-sm font-semibold text-slate-700 ${testErrors.testUser ? 'border-red-500 bg-red-50 focus:ring-red-200' : 'border-slate-200 focus:ring-praetor'}`}
+                    />
+                    {testErrors.testUser && (
+                      <p className="text-red-500 text-[10px] font-bold mt-1">
+                        {testErrors.testUser}
+                      </p>
+                    )}
+                  </div>
+                  <div>
+                    <label className="block text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">
+                      {t('admin.ldap.testPassword')}
+                    </label>
+                    <input
+                      type="password"
+                      value={testPass}
+                      onChange={(e) => {
+                        setTestPass(e.target.value);
+                        if (testErrors.testPass) setTestErrors({ ...testErrors, testPass: '' });
+                      }}
+                      className={`w-full px-4 py-2 bg-slate-50 border rounded-lg focus:ring-2 outline-none text-sm font-semibold text-slate-700 ${testErrors.testPass ? 'border-red-500 bg-red-50 focus:ring-red-200' : 'border-slate-200 focus:ring-praetor'}`}
+                    />
+                    {testErrors.testPass && (
+                      <p className="text-red-500 text-[10px] font-bold mt-1">
+                        {testErrors.testPass}
+                      </p>
+                    )}
+                    {testErrors.enabled && (
+                      <p className="text-amber-600 text-[10px] font-bold mt-1">
+                        {testErrors.enabled}
+                      </p>
+                    )}
+                  </div>
+                  <button
+                    type="submit"
+                    disabled={isTestLoading || !formData.enabled}
+                    className="w-full bg-praetor text-white py-2 rounded-lg font-bold hover:bg-slate-800 transition-colors disabled:opacity-50 shadow-md shadow-slate-100"
+                  >
+                    {isTestLoading ? (
+                      <i className="fa-solid fa-circle-notch fa-spin"></i>
+                    ) : (
+                      t('admin.ldap.testAuthentication')
+                    )}
+                  </button>
+                </form>
               </div>
-            ) : testResult ? (
-              <div className="space-y-2">
-                <div
-                  className={`font-bold ${testResult.success ? 'text-emerald-400' : 'text-red-400'}`}
-                >
-                  [
-                  {testResult.success
-                    ? t('admin.ldap.test.success', 'SUCCESS')
-                    : t('admin.ldap.test.failure', 'FAILURE')}
-                  ] {testResult.message}
-                </div>
-                {testResult.details && (
-                  <>
-                    <div className="text-slate-500 mt-2 border-b border-slate-800 pb-1 mb-2">
-                      {t('admin.ldap.test.provisioningDetails', '-- Provisioning Details --')}
+
+              <div className="bg-slate-900 rounded-xl p-4 font-mono text-xs overflow-y-auto h-64 border border-slate-800 shadow-inner">
+                {isTestLoading ? (
+                  <div className="text-slate-400 animate-pulse">
+                    {t('admin.ldap.test.connecting', 'Connecting to LDAP server...')}
+                  </div>
+                ) : testResult ? (
+                  <div className="space-y-2">
+                    <div
+                      className={`font-bold ${testResult.success ? 'text-emerald-400' : 'text-red-400'}`}
+                    >
+                      [
+                      {testResult.success
+                        ? t('admin.ldap.test.success', 'SUCCESS')
+                        : t('admin.ldap.test.failure', 'FAILURE')}
+                      ] {testResult.message}
                     </div>
-                    <div className="text-slate-400">
-                      DN:{' '}
-                      <span className="text-slate-200">
-                        {(testResult.details as { dn: string }).dn}
-                      </span>
-                    </div>
-                    <div className="text-slate-400">
-                      {t('admin.ldap.test.role', 'Role')}:{' '}
-                      <span className="text-slate-400 uppercase font-bold">
-                        {(testResult.details as { mappedRole: string }).mappedRole}
-                      </span>
-                    </div>
-                    <div className="text-slate-400 mt-2">
-                      {t('admin.ldap.test.groupsFound', 'Groups Found:')}
-                    </div>
-                    <ul className="list-disc pl-4 text-slate-500">
-                      {(testResult.details as { groups: string[] }).groups.map(
-                        (g: string, i: number) => (
-                          <li key={i}>{g}</li>
-                        ),
-                      )}
-                    </ul>
-                  </>
+                    {testResult.details && (
+                      <>
+                        <div className="text-slate-500 mt-2 border-b border-slate-800 pb-1 mb-2">
+                          {t('admin.ldap.test.provisioningDetails', '-- Provisioning Details --')}
+                        </div>
+                        <div className="text-slate-400">
+                          DN:{' '}
+                          <span className="text-slate-200">
+                            {(testResult.details as { dn: string }).dn}
+                          </span>
+                        </div>
+                        <div className="text-slate-400">
+                          {t('admin.ldap.test.role', 'Role')}:{' '}
+                          <span className="text-slate-400 uppercase font-bold">
+                            {(testResult.details as { mappedRole: string }).mappedRole}
+                          </span>
+                        </div>
+                        <div className="text-slate-400 mt-2">
+                          {t('admin.ldap.test.groupsFound', 'Groups Found:')}
+                        </div>
+                        <ul className="list-disc pl-4 text-slate-500">
+                          {(testResult.details as { groups: string[] }).groups.map(
+                            (g: string, i: number) => (
+                              <li key={i}>{g}</li>
+                            ),
+                          )}
+                        </ul>
+                      </>
+                    )}
+                  </div>
+                ) : (
+                  <div className="text-slate-600 italic">
+                    {t('admin.ldap.test.waiting', 'Waiting for test execution...')}
+                    <br />
+                    <br />
+                    <span className="opacity-50">
+                      {t('admin.ldap.test.logOutput', 'Log output will appear here after testing.')}
+                    </span>
+                  </div>
                 )}
               </div>
-            ) : (
-              <div className="text-slate-600 italic">
-                {t('admin.ldap.test.waiting', 'Waiting for test execution...')}
-                <br />
-                <br />
-                <span className="opacity-50">
-                  {t('admin.ldap.test.logOutput', 'Log output will appear here after testing.')}
-                </span>
-              </div>
-            )}
-          </div>
+            </div>
+          </section>
         </div>
-      </section>
+      )}
     </div>
   );
 };

--- a/locales/en/auth.json
+++ b/locales/en/auth.json
@@ -34,7 +34,7 @@
   },
   "admin": {
     "title": "Authentication Settings",
-    "subtitle": "Configure LDAP/Active Directory integration",
+    "subtitle": "Configure authentication and identity provider settings",
     "tabs": {
       "ldap": "LDAP / Active Directory"
     },

--- a/locales/en/auth.json
+++ b/locales/en/auth.json
@@ -35,6 +35,9 @@
   "admin": {
     "title": "Authentication Settings",
     "subtitle": "Configure LDAP/Active Directory integration",
+    "tabs": {
+      "ldap": "LDAP / Active Directory"
+    },
     "ldap": {
       "enabled": "Enabled",
       "serverConfig": "LDAP Server Configuration",

--- a/locales/it/auth.json
+++ b/locales/it/auth.json
@@ -35,6 +35,9 @@
   "admin": {
     "title": "Impostazioni Autenticazione",
     "subtitle": "Configura l'integrazione LDAP/Active Directory",
+    "tabs": {
+      "ldap": "LDAP / Active Directory"
+    },
     "ldap": {
       "enabled": "Abilitato",
       "serverConfig": "Configurazione Server LDAP",

--- a/locales/it/auth.json
+++ b/locales/it/auth.json
@@ -34,7 +34,7 @@
   },
   "admin": {
     "title": "Impostazioni Autenticazione",
-    "subtitle": "Configura l'integrazione LDAP/Active Directory",
+    "subtitle": "Configura le impostazioni di autenticazione e del provider d'identità",
     "tabs": {
       "ldap": "LDAP / Active Directory"
     },


### PR DESCRIPTION
## Summary

- Add tab navigation to `AuthSettings` matching the pattern used in `GeneralSettings` and `LogsView`, ready for future auth provider tabs
- Disable the Save button when the form is unchanged to prevent unnecessary submits
- Generalize the admin page subtitle i18n string to accommodate future auth methods beyond LDAP

## Test plan

- [ ] Open Admin → Authentication Settings
- [ ] Verify tab bar renders and the LDAP tab is active by default
- [ ] Change a field and confirm the Save button becomes enabled; revert and confirm it disables again
- [ ] Verify existing LDAP save/test flows still work
- [ ] Check Italian locale renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xbounceit/praetor/pull/66" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
