### PR TITLE
fix(auth): canonicalize and validate role payloads

### DIFF
--- a/services/api/auth.ts
+++ b/services/api/auth.ts
@@ -1,20 +1,86 @@
 import type { User } from '../../types';
-import { fetchApi } from './client';
+import { fetchApi, getAuthToken, setAuthToken } from './client';
 import type { LoginResponse } from './contracts';
 import { normalizeUser } from './normalizers';
 
+const INVALID_AUTH_RESPONSE_ERROR = 'Invalid authentication response';
+
+const ensureToken = (token: unknown): string => {
+  const normalizedToken = typeof token === 'string' ? token.trim() : '';
+  if (!normalizedToken) {
+    throw new Error(INVALID_AUTH_RESPONSE_ERROR);
+  }
+  return normalizedToken;
+};
+
+const normalizeAuthUser = (user: User): User => {
+  const normalizedUser = normalizeUser(user);
+  if (
+    !normalizedUser.id ||
+    !normalizedUser.name ||
+    !normalizedUser.username ||
+    !normalizedUser.role ||
+    !normalizedUser.avatarInitials
+  ) {
+    throw new Error(INVALID_AUTH_RESPONSE_ERROR);
+  }
+
+  if (!normalizedUser.availableRoles || normalizedUser.availableRoles.length === 0) {
+    throw new Error(INVALID_AUTH_RESPONSE_ERROR);
+  }
+
+  const hasActiveRole = normalizedUser.availableRoles.some(
+    (availableRole) => availableRole.id === normalizedUser.role,
+  );
+  if (!hasActiveRole) {
+    throw new Error(INVALID_AUTH_RESPONSE_ERROR);
+  }
+
+  return normalizedUser;
+};
+
+const fetchCanonicalAuthUser = async (): Promise<User> => {
+  const authUser = await fetchApi<User>('/auth/me');
+  return normalizeAuthUser(authUser);
+};
+
+const runCanonicalAuthFlow = async (
+  operation: () => Promise<LoginResponse>,
+): Promise<LoginResponse> => {
+  const previousToken = getAuthToken();
+
+  try {
+    const response = await operation();
+    const token = ensureToken(response.token);
+    setAuthToken(token);
+
+    const user = await fetchCanonicalAuthUser();
+    return {
+      token: getAuthToken() || token,
+      user,
+    };
+  } catch (err) {
+    setAuthToken(previousToken);
+    throw err;
+  }
+};
+
 export const authApi = {
   login: (username: string, password: string): Promise<LoginResponse> =>
-    fetchApi('/auth/login', {
-      method: 'POST',
-      body: JSON.stringify({ username, password }),
-    }),
+    runCanonicalAuthFlow(() =>
+      fetchApi('/auth/login', {
+        method: 'POST',
+        body: JSON.stringify({ username, password }),
+      }),
+    ),
 
-  me: (): Promise<User> => fetchApi<User>('/auth/me').then(normalizeUser),
+  me: (): Promise<User> => fetchCanonicalAuthUser(),
 
   switchRole: (roleId: string): Promise<LoginResponse> =>
-    fetchApi('/auth/switch-role', {
-      method: 'POST',
-      body: JSON.stringify({ roleId }),
-    }),
+    runCanonicalAuthFlow(() =>
+      fetchApi('/auth/switch-role', {
+        method: 'POST',
+        body: JSON.stringify({ roleId }),
+      }),
+    ),
 };

--- a/services/api/normalizers.ts
+++ b/services/api/normalizers.ts
@@ -4,6 +4,7 @@ import type {
   ClientOfferItem,
   ClientsOrder,
   ClientsOrderItem,
+  EmployeeType,
   GeneralSettings,
   Invoice,
   InvoiceItem,
@@ -11,6 +12,7 @@ import type {
   ProjectTask,
   Quote,
   QuoteItem,
+  RoleSummary,
   SpecialBid,
   SupplierInvoice,
   SupplierInvoiceItem,
@@ -44,15 +46,66 @@ export const normalizeClient = (c: Client): Client => ({
   taxCode: c.taxCode ?? undefined,
 });
 
-export const normalizeUser = (u: User): User => ({
-  ...u,
-  hasTopManagerRole: !!u.hasTopManagerRole,
-  isAdminOnly: !!u.isAdminOnly,
-  email: u.email || undefined,
-  permissions: u.permissions || [],
-  costPerHour: u.costPerHour ? Number(u.costPerHour) : 0,
-  employeeType: u.employeeType || 'app_user',
-});
+const normalizeTrimmedString = (value: unknown): string =>
+  typeof value === 'string' ? value.trim() : '';
+
+const normalizeStringArray = (value: unknown): string[] => {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((entry) => normalizeTrimmedString(entry))
+    .filter((entry): entry is string => entry.length > 0);
+};
+
+const normalizeEmployeeType = (value: unknown): EmployeeType => {
+  if (value === 'internal' || value === 'external' || value === 'app_user') {
+    return value;
+  }
+  return 'app_user';
+};
+
+const normalizeAvailableRoles = (value: unknown): RoleSummary[] | undefined => {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) return [];
+
+  const normalizedRoles: RoleSummary[] = [];
+  for (const entry of value) {
+    if (!entry || typeof entry !== 'object') continue;
+
+    const role = entry as Partial<RoleSummary>;
+    const id = normalizeTrimmedString(role.id);
+    const name = normalizeTrimmedString(role.name);
+    if (!id || !name) continue;
+
+    normalizedRoles.push({
+      id,
+      name,
+      isSystem: !!role.isSystem,
+      isAdmin: !!role.isAdmin,
+    });
+  }
+
+  return normalizedRoles;
+};
+
+export const normalizeUser = (u: User): User => {
+  const normalizedCostPerHour = Number(u.costPerHour ?? 0);
+
+  return {
+    ...u,
+    id: normalizeTrimmedString(u.id),
+    name: normalizeTrimmedString(u.name),
+    role: normalizeTrimmedString(u.role),
+    avatarInitials: normalizeTrimmedString(u.avatarInitials),
+    username: normalizeTrimmedString(u.username),
+    hasTopManagerRole: !!u.hasTopManagerRole,
+    isAdminOnly: !!u.isAdminOnly,
+    email: normalizeTrimmedString(u.email) || undefined,
+    permissions: normalizeStringArray(u.permissions),
+    availableRoles: normalizeAvailableRoles(u.availableRoles),
+    costPerHour: Number.isFinite(normalizedCostPerHour) ? normalizedCostPerHour : 0,
+    employeeType: normalizeEmployeeType(u.employeeType),
+  };
+};
 
 export const normalizeProduct = (p: Product): Product => ({
   ...p,


### PR DESCRIPTION
## Summary
- canonicalize auth session user data by rehydrating login/switch-role through /auth/me
- reject malformed auth user payloads and roll back to the previous token on canonicalization failure
- harden user normalization for role-related fields (trimmed strings, filtered permissions, validated availableRoles, safe employeeType/costPerHour defaults)

## Validation
- bun run lint
- bun run build
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xbounceit/praetor/pull/74" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
