### PR TITLE
fix(catalog): strip costUnit from product payload to avoid type mismatch

### DIFF
--- a/components/catalog/InternalListingView.tsx
+++ b/components/catalog/InternalListingView.tsx
@@ -201,9 +201,10 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
     }
 
     try {
+      const { costUnit: _costUnit, ...productPayload } = formData;
       if (editingProduct) {
         await onUpdateProduct(editingProduct.id, {
-          ...formData,
+          ...productPayload,
           costo: formData.costo !== undefined ? roundToTwoDecimals(formData.costo) : undefined,
           molPercentage:
             formData.molPercentage !== undefined
@@ -212,7 +213,7 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
         });
       } else {
         await onAddProduct({
-          ...formData,
+          ...productPayload,
           costo: formData.costo !== undefined ? roundToTwoDecimals(formData.costo) : undefined,
           molPercentage:
             formData.molPercentage !== undefined


### PR DESCRIPTION
The form defaults costUnit to 'unit' but never updates it when the user switches type. The backend rejects requests where costUnit contradicts the type (e.g. unit + service), so service/consulting creation always failed. Since the backend auto-derives costUnit from type, we simply omit it from the request.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xbounceit/praetor/pull/75" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
