### PR TITLE
fix(catalog): extend costUnit fix to ExternalListingView and harden backend

### DIFF
--- a/components/catalog/ExternalListingView.tsx
+++ b/components/catalog/ExternalListingView.tsx
@@ -220,9 +220,10 @@ const ExternalListingView: React.FC<ExternalListingViewProps> = ({
     }
 
     try {
+      const { costUnit: _costUnit, ...productPayload } = formData;
       if (editingProduct) {
         await onUpdateProduct(editingProduct.id, {
-          ...formData,
+          ...productPayload,
           costo: formData.costo !== undefined ? roundToTwoDecimals(formData.costo) : undefined,
           molPercentage:
             formData.molPercentage !== undefined
@@ -231,7 +232,7 @@ const ExternalListingView: React.FC<ExternalListingViewProps> = ({
         });
       } else {
         await onAddProduct({
-          ...formData,
+          ...productPayload,
           costo: formData.costo !== undefined ? roundToTwoDecimals(formData.costo) : undefined,
           molPercentage:
             formData.molPercentage !== undefined

--- a/server/routes/products.ts
+++ b/server/routes/products.ts
@@ -166,7 +166,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         taxRate,
         type,
         supplierId,
-        costUnit,
       } = request.body as {
         name: unknown;
         productCode: unknown;
@@ -178,7 +177,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         taxRate: unknown;
         type: unknown;
         supplierId: unknown;
-        costUnit: unknown;
       };
 
       const nameResult = requireNonEmptyString(name, 'name');
@@ -243,20 +241,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const typeResult = validateEnum(type, ['supply', 'service', 'consulting'], 'type');
       if (!typeResult.ok) return badRequest(reply, typeResult.message);
 
-      // Auto-derive costUnit from type (frontend should not send costUnit)
+      // Auto-derive costUnit from type (always ignore frontend-supplied costUnit)
       const expectedCostUnit = typeResult.value === 'supply' ? 'unit' : 'hours';
-
-      // If costUnit is provided, validate it matches the expected value for the type
-      if (costUnit !== undefined && costUnit !== null && costUnit !== '') {
-        const costUnitResult = validateEnum(costUnit, ['unit', 'hours'], 'costUnit');
-        if (!costUnitResult.ok) return badRequest(reply, costUnitResult.message);
-        if (costUnitResult.value !== expectedCostUnit) {
-          return badRequest(
-            reply,
-            `costUnit must be '${expectedCostUnit}' for type '${typeResult.value}'`,
-          );
-        }
-      }
 
       const id = 'p-' + Date.now();
       const result = await query(


### PR DESCRIPTION
- Strip costUnit from ExternalListingView payload (same fix as InternalListingView)
- Remove costUnit validation from POST /products — value is always auto-derived from type, so any client-supplied costUnit is now silently ignored
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xbounceit/praetor/pull/76" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
