### PR TITLE
fix(catalog): sync costUnit in form state when type changes

### DIFF
--- a/components/catalog/ExternalListingView.tsx
+++ b/components/catalog/ExternalListingView.tsx
@@ -363,6 +363,7 @@ const ExternalListingView: React.FC<ExternalListingViewProps> = ({
     setFormData({
       ...formData,
       type,
+      costUnit: type === 'supply' ? 'unit' : 'hours',
       category: '', // Reset category as it depends on type
       subcategory: '', // Reset subcategory as it depends on category
     });

--- a/components/catalog/InternalListingView.tsx
+++ b/components/catalog/InternalListingView.tsx
@@ -330,6 +330,7 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
     setFormData({
       ...formData,
       type,
+      costUnit: type === 'supply' ? 'unit' : 'hours',
       category: '', // Reset category as it depends on type
       subcategory: '', // Reset subcategory as it depends on category
     });


### PR DESCRIPTION
## Summary
- Syncs `costUnit` in form state when changing product type (supply → 'unit', service/consulting → 'hours')
- UI now correctly reflects the backend's auto-derived value
- Applied to both `InternalListingView` and `ExternalListingView`

## Context
The previous fixes stripped `costUnit` from the API payload and removed the backend validation block. This PR adds the final piece: the form state itself stays in sync with the selected type.

## Test plan
- [ ] Open Internal Listing, create a product with type "Service" — should succeed
- [ ] Create a product with type "Consulting" — should succeed
- [ ] Create a Supply product — should still work
- [ ] Edit a Supply product → change type to Service → save — should work
- [ ] Repeat the same steps in External Listing view

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xbounceit/praetor/pull/77" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
