### PR TITLE
fix(catalog): show cost unit label in ClientQuotes line items

### DIFF
--- a/components/sales/ClientQuotesView.tsx
+++ b/components/sales/ClientQuotesView.tsx
@@ -1297,6 +1297,11 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                               disabled={isReadOnly}
                               className="w-full text-sm px-3 py-2 bg-white border border-slate-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
                             />
+                            <span className="text-xs font-semibold text-slate-400 whitespace-nowrap text-center block mt-0.5">
+                              {products.find((p) => p.id === item.productId)?.costUnit === 'hours'
+                                ? t('crm:internalListing.hour')
+                                : t('crm:internalListing.unit')}
+                            </span>
                           </div>
                           <div className="rounded-lg border border-slate-200 bg-white px-3 py-2 space-y-1">
                             <div className="text-[10px] font-black text-slate-400 uppercase tracking-wider">
@@ -1397,6 +1402,11 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                                 disabled={isReadOnly}
                                 className="w-full text-sm px-2 py-2 bg-white border border-slate-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
                               />
+                              <span className="text-xs font-semibold text-slate-400 whitespace-nowrap text-center block">
+                                {products.find((p) => p.id === item.productId)?.costUnit === 'hours'
+                                  ? t('crm:internalListing.hour')
+                                  : t('crm:internalListing.unit')}
+                              </span>
                             </div>
                             <div className="col-span-1 flex flex-col items-center justify-center gap-1">
                               {selectedBid && (


### PR DESCRIPTION
## Summary
- Adds a per-row cost unit indicator (`hours` or `unit`) beneath the quantity field in ClientQuotesView
- Keeps the quote UI in sync with catalog product definitions (costUnit)
- Follows the same pattern established in previous catalog costUnit fixes

## Test plan
- [ ] Open a client quote with products that have `costUnit: 'hours'` — verify "hour" label shows
- [ ] Open a client quote with products that have `costUnit: 'units'` — verify "unit" label shows
- [ ] Verify labels update when changing product type in the quote editor
- [ ] Check read-only mode displays the label correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xbounceit/praetor/pull/78" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
