### PR TITLE
fix(catalog): show cost unit label in listing modals

### DIFF
--- a/components/catalog/ExternalListingView.tsx
+++ b/components/catalog/ExternalListingView.tsx
@@ -717,7 +717,7 @@ const ExternalListingView: React.FC<ExternalListingViewProps> = ({
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div className="space-y-1.5">
                   <label className="text-xs font-bold text-slate-500 ml-1">
-                    {t('crm:internalListing.cost')}
+                    {t('crm:internalListing.cost')}<span className="text-slate-400 font-semibold">/{formData.costUnit || 'unit'}</span>
                   </label>
                   <div className="flex gap-2">
                     <ValidatedNumberInput

--- a/components/catalog/ExternalListingView.tsx
+++ b/components/catalog/ExternalListingView.tsx
@@ -717,7 +717,7 @@ const ExternalListingView: React.FC<ExternalListingViewProps> = ({
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div className="space-y-1.5">
                   <label className="text-xs font-bold text-slate-500 ml-1">
-                    {t('crm:internalListing.cost')}<span className="text-slate-400 font-semibold">/{formData.costUnit || 'unit'}</span>
+                    {t('crm:internalListing.cost')}<span className="text-slate-400 font-semibold">/{formData.costUnit === 'hours' ? t('crm:internalListing.hour') : t('crm:internalListing.unit')}</span>
                   </label>
                   <div className="flex gap-2">
                     <ValidatedNumberInput

--- a/components/catalog/InternalListingView.tsx
+++ b/components/catalog/InternalListingView.tsx
@@ -661,7 +661,7 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div className="space-y-1.5">
                   <label className="text-xs font-bold text-slate-500 ml-1">
-                    {t('crm:internalListing.cost')}<span className="text-slate-400 font-semibold">/{formData.costUnit || 'unit'}</span>
+                    {t('crm:internalListing.cost')}<span className="text-slate-400 font-semibold">/{formData.costUnit === 'hours' ? t('crm:internalListing.hour') : t('crm:internalListing.unit')}</span>
                   </label>
                   <div className="flex gap-2">
                     <ValidatedNumberInput

--- a/components/catalog/InternalListingView.tsx
+++ b/components/catalog/InternalListingView.tsx
@@ -661,7 +661,7 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div className="space-y-1.5">
                   <label className="text-xs font-bold text-slate-500 ml-1">
-                    {t('crm:internalListing.cost')}
+                    {t('crm:internalListing.cost')}<span className="text-slate-400 font-semibold">/{formData.costUnit || 'unit'}</span>
                   </label>
                   <div className="flex gap-2">
                     <ValidatedNumberInput


### PR DESCRIPTION
## Summary
- Add cost unit label (e.g. `/unit`, `/hours`) beside the Cost field label in InternalListingView and ExternalListingView add/edit modals
- Unit dynamically updates when product type changes (supply → `/unit`, service/consulting → `/hours`)
- No layout changes to MOL input — only the label text was modified

## Test plan
- [ ] Open Catalog → Internal Listing, click "Add", note the Cost label shows `/unit`
- [ ] Change type to Service, confirm label changes to `/hours`
- [ ] Repeat for External Listing
- [ ] Verify MOL input field width is unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xbounceit/praetor/pull/79" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
