### PR TITLE
feat(ci): add GitHub Action to auto-create releases on tag push

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,26 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            --verify-tag \
+            --generate-notes


### PR DESCRIPTION
Adds a GitHub Actions workflow that automatically creates releases with auto-generated release notes when a version tag (e.g., v0.4.0) is pushed to the repository.

Changes:
- Added `.github/workflows/create-release.yml`
- Workflow triggers on tag pushes matching `v*`
- Creates GitHub release with auto-generated notes from previous tag

Usage:
```bash
git tag -a v0.4.0 -m "v0.4.0"
git push origin v0.4.0
```

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xbounceit/praetor/pull/86" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
