### PR TITLE
feat(crm): add total orders column to suppliers view

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -3375,6 +3375,8 @@ const App: React.FC = () => {
               activeView === 'crm/suppliers' && (
                 <SuppliersView
                   suppliers={suppliers}
+                  supplierOrders={supplierOrders}
+                  currency={generalSettings.currency}
                   onAddSupplier={addSupplier}
                   onUpdateSupplier={handleUpdateSupplier}
                   onDeleteSupplier={handleDeleteSupplier}

--- a/components/CRM/SuppliersView.tsx
+++ b/components/CRM/SuppliersView.tsx
@@ -250,14 +250,8 @@ const SuppliersView: React.FC<SuppliersViewProps> = ({
         },
         className: 'whitespace-nowrap font-mono text-xs',
         align: 'right',
-        cell: ({ row }: { row: Supplier }) => {
-          const sentOrders = supplierOrders.filter(
-            (order) => order.supplierId === row.id && order.status === 'sent',
-          );
-          const totalValue = sentOrders.reduce((total, order) => {
-            return total + calculateOrderTotal(order.items, order.discount);
-          }, 0);
-
+        cell: ({ value }: { value: number }) => {
+          const totalValue = value;
           return (
             <span
               className={`font-semibold ${totalValue > 0 ? 'text-emerald-600' : 'text-slate-400'}`}

--- a/components/CRM/SuppliersView.tsx
+++ b/components/CRM/SuppliersView.tsx
@@ -1,7 +1,7 @@
 import type React from 'react';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import type { Supplier } from '../../types';
+import type { Supplier, SupplierSaleOrder, SupplierSaleOrderItem } from '../../types';
 import { buildPermission, hasPermission } from '../../utils/permissions';
 import Modal from '../shared/Modal';
 import StandardTable, { type Column } from '../shared/StandardTable';
@@ -10,14 +10,30 @@ import Tooltip from '../shared/Tooltip';
 
 export interface SuppliersViewProps {
   suppliers: Supplier[];
+  supplierOrders: SupplierSaleOrder[];
+  currency: string;
   onAddSupplier: (supplierData: Partial<Supplier>) => Promise<void>;
   onUpdateSupplier: (id: string, updates: Partial<Supplier>) => Promise<void>;
   onDeleteSupplier: (id: string) => Promise<void>;
   permissions: string[];
 }
 
+const calculateOrderTotal = (items: SupplierSaleOrderItem[], discount: number): number => {
+  let subtotal = 0;
+  items.forEach((item) => {
+    const lineSubtotal = Number(item.quantity ?? 0) * Number(item.unitPrice ?? 0);
+    const lineDiscount = (lineSubtotal * Number(item.discount ?? 0)) / 100;
+    const lineNet = lineSubtotal - lineDiscount;
+    subtotal += lineNet;
+  });
+  const discountAmount = subtotal * (discount / 100);
+  return subtotal - discountAmount;
+};
+
 const SuppliersView: React.FC<SuppliersViewProps> = ({
   suppliers,
+  supplierOrders,
+  currency,
   onAddSupplier,
   onUpdateSupplier,
   onDeleteSupplier,
@@ -222,6 +238,37 @@ const SuppliersView: React.FC<SuppliersViewProps> = ({
         className: 'font-mono text-xs text-slate-400',
       },
       {
+        header: t('crm:suppliers.tableHeaders.totalOrders'),
+        id: 'totalOrders',
+        accessorFn: (row: Supplier) => {
+          const sentOrders = supplierOrders.filter(
+            (order) => order.supplierId === row.id && order.status === 'sent',
+          );
+          return sentOrders.reduce((total, order) => {
+            return total + calculateOrderTotal(order.items, order.discount);
+          }, 0);
+        },
+        className: 'whitespace-nowrap font-mono text-xs',
+        align: 'right',
+        cell: ({ row }: { row: Supplier }) => {
+          const sentOrders = supplierOrders.filter(
+            (order) => order.supplierId === row.id && order.status === 'sent',
+          );
+          const totalValue = sentOrders.reduce((total, order) => {
+            return total + calculateOrderTotal(order.items, order.discount);
+          }, 0);
+
+          return (
+            <span
+              className={`font-semibold ${totalValue > 0 ? 'text-emerald-600' : 'text-slate-400'}`}
+            >
+              {totalValue.toFixed(2)} {currency}
+            </span>
+          );
+        },
+        filterFormat: (value: unknown) => (value as number).toFixed(2),
+      },
+      {
         header: t('crm:suppliers.tableHeaders.status'),
         id: 'status',
         accessorFn: (row) =>
@@ -281,7 +328,15 @@ const SuppliersView: React.FC<SuppliersViewProps> = ({
         ),
       },
     ],
-    [t, canUpdateSuppliers, canDeleteSuppliers, onUpdateSupplier, confirmDelete],
+    [
+      t,
+      canUpdateSuppliers,
+      canDeleteSuppliers,
+      onUpdateSupplier,
+      confirmDelete,
+      supplierOrders,
+      currency,
+    ],
   );
 
   return (

--- a/locales/en/crm.json
+++ b/locales/en/crm.json
@@ -384,7 +384,8 @@
       "contact": "Contact",
       "vat": "VAT",
       "taxCode": "Tax Code",
-      "status": "Status"
+      "status": "Status",
+      "totalOrders": "Total orders"
     }
   },
   "paymentTerms": {

--- a/locales/it/crm.json
+++ b/locales/it/crm.json
@@ -380,7 +380,8 @@
       "contact": "Contatto",
       "vat": "P.IVA",
       "taxCode": "C.F.",
-      "status": "Stato"
+      "status": "Stato",
+      "totalOrders": "Totale ordini"
     }
   },
   "paymentTerms": {


### PR DESCRIPTION
## Summary
Add a new "Total orders" column to the Suppliers table that displays the total monetary value of all orders in "Sent" status for each supplier.

## Changes
- **SuppliersView.tsx**:
  - Added `supplierOrders` and `currency` props
  - Added `calculateOrderTotal` helper function
  - Added new "Total orders" column with right-aligned monetary values
  - Optimized to use StandardTable's `value` param (avoids redundant calculation)
- **App.tsx**: Pass `supplierOrders` and `currency` to SuppliersView
- **locales/en/crm.json**: Added "totalOrders": "Total orders" translation
- **locales/it/crm.json**: Added "totalOrders": "Totale ordini" translation

## Features
- Shows green color for values > 0, gray for zero
- Monospace font for consistent number alignment
- Proper sorting and filtering support
- Calculates totals using: Σ(quantity × unitPrice - line discount) - global discount

## Testing
Navigate to **CRM → Anagrafica Fornitori** to see the new column.