### PR TITLE
fix: make office count optional when creating client

### DIFF
--- a/components/CRM/ClientsView.tsx
+++ b/components/CRM/ClientsView.tsx
@@ -189,9 +189,6 @@ const ClientsView: React.FC<ClientsViewProps> = ({
     if (!trimmedFiscalCode) {
       newErrors.fiscalCode = t('common:validation.fiscalCodeRequired');
     }
-    if (!officeCountRange) {
-      newErrors.officeCountRange = t('common:validation.required');
-    }
 
     if (Object.keys(newErrors).length > 0) {
       setErrors(newErrors);


### PR DESCRIPTION
## Summary
Removes the required validation for the "Numero di sedi" (Number of offices) field when creating a new client.

## Changes
- Removed the validation check that enforced `officeCountRange` as a required field in the client creation form
- The field is already optional in the TypeScript types and can now be left empty

## Testing
- [x] Field no longer shows "Questo campo è obbligatorio" error when left empty
- [x] Form can be submitted without selecting an office count
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xbounceit/praetor/pull/94" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
