### PR TITLE
feat(suppliers): add createdAt field and shared date utility

### DIFF
--- a/components/CRM/ClientsView.tsx
+++ b/components/CRM/ClientsView.tsx
@@ -2,6 +2,7 @@ import type React from 'react';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Client } from '../../types';
+import { formatInsertDate } from '../../utils/date';
 import { buildPermission, hasPermission } from '../../utils/permissions';
 import CustomSelect from '../shared/CustomSelect';
 import Modal from '../shared/Modal';
@@ -254,14 +255,6 @@ const ClientsView: React.FC<ClientsViewProps> = ({
   };
 
   const canSubmit = editingClient ? canUpdateClients : canCreateClients;
-  const formatInsertDate = useCallback((timestamp: number) => {
-    const date = new Date(timestamp);
-    if (Number.isNaN(date.getTime())) return '-';
-    const day = String(date.getDate()).padStart(2, '0');
-    const month = String(date.getMonth() + 1).padStart(2, '0');
-    const year = date.getFullYear();
-    return `${day}/${month}/${year}`;
-  }, []);
 
   // Column definitions
   const columns = useMemo<Column<Client>[]>(
@@ -454,7 +447,7 @@ const ClientsView: React.FC<ClientsViewProps> = ({
         ),
       },
     ],
-    [t, i18n, canUpdateClients, canDeleteClients, onUpdateClient, confirmDelete, formatInsertDate],
+    [t, i18n, canUpdateClients, canDeleteClients, onUpdateClient, confirmDelete],
   );
 
   return (

--- a/components/CRM/SuppliersView.tsx
+++ b/components/CRM/SuppliersView.tsx
@@ -2,6 +2,7 @@ import type React from 'react';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Supplier, SupplierSaleOrder, SupplierSaleOrderItem } from '../../types';
+import { formatInsertDate } from '../../utils/date';
 import { buildPermission, hasPermission } from '../../utils/permissions';
 import Modal from '../shared/Modal';
 import StandardTable, { type Column } from '../shared/StandardTable';
@@ -206,6 +207,28 @@ const SuppliersView: React.FC<SuppliersViewProps> = ({
           ) : null,
       },
       {
+        header: t('crm:suppliers.tableHeaders.insertDate'),
+        id: 'createdAt',
+        accessorFn: (row) => row.createdAt ?? 0,
+        cell: ({ row }) => {
+          if (!row.createdAt) {
+            return <span className="text-xs text-slate-400">-</span>;
+          }
+          return (
+            <span className="text-xs text-slate-500 whitespace-nowrap">
+              {formatInsertDate(row.createdAt)}
+            </span>
+          );
+        },
+        filterFormat: (value) => {
+          const timestamp = typeof value === 'number' ? value : Number(value);
+          if (!Number.isFinite(timestamp) || timestamp <= 0) {
+            return '-';
+          }
+          return formatInsertDate(timestamp);
+        },
+      },
+      {
         header: t('crm:suppliers.tableHeaders.contact'),
         id: 'contact',
         accessorFn: (row) => row.contactName || row.email || row.phone || '',
@@ -250,8 +273,8 @@ const SuppliersView: React.FC<SuppliersViewProps> = ({
         },
         className: 'whitespace-nowrap font-mono text-xs',
         align: 'right',
-        cell: ({ value }: { value: number }) => {
-          const totalValue = value;
+        cell: ({ value }) => {
+          const totalValue = value as number;
           return (
             <span
               className={`font-semibold ${totalValue > 0 ? 'text-emerald-600' : 'text-slate-400'}`}

--- a/locales/en/crm.json
+++ b/locales/en/crm.json
@@ -383,6 +383,7 @@
     "tableHeaders": {
       "name": "Name",
       "code": "Code",
+      "insertDate": "Insert Date",
       "contact": "Contact",
       "vat": "VAT",
       "taxCode": "Tax Code",

--- a/locales/it/crm.json
+++ b/locales/it/crm.json
@@ -379,6 +379,7 @@
     "tableHeaders": {
       "name": "Nome",
       "code": "Codice",
+      "insertDate": "Data inserimento",
       "contact": "Contatto",
       "vat": "P.IVA",
       "taxCode": "C.F.",

--- a/server/routes/suppliers.ts
+++ b/server/routes/suppliers.ts
@@ -35,6 +35,7 @@ const supplierSchema = {
     taxCode: { type: ['string', 'null'] },
     paymentTerms: { type: ['string', 'null'] },
     notes: { type: ['string', 'null'] },
+    createdAt: { type: 'number' },
   },
   required: ['id', 'name', 'isDisabled'],
 } as const;
@@ -114,6 +115,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         taxCode: s.tax_code,
         paymentTerms: s.payment_terms,
         notes: s.notes,
+        createdAt: s.created_at ? new Date(s.created_at).getTime() : undefined,
       }));
     },
   );
@@ -187,12 +189,13 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const notesResult = optionalNonEmptyString(notes, 'notes');
       if (!notesResult.ok) return badRequest(reply, notesResult.message);
 
-      const id = 's-' + Date.now();
+      const now = Date.now();
+      const id = 's-' + now;
       await query(
         `INSERT INTO suppliers (
         id, name, is_disabled, supplier_code, contact_name, email, phone,
-        address, vat_number, tax_code, payment_terms, notes
-      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
+        address, vat_number, tax_code, payment_terms, notes, created_at
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, to_timestamp($13 / 1000.0))`,
         [
           id,
           nameResult.value,
@@ -206,6 +209,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           taxCodeResult.value,
           paymentTermsResult.value,
           notesResult.value,
+          now,
         ],
       );
 
@@ -232,6 +236,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         taxCode: taxCodeResult.value,
         paymentTerms: paymentTermsResult.value,
         notes: notesResult.value,
+        createdAt: now,
       });
     },
   );
@@ -395,6 +400,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         taxCode: s.tax_code,
         paymentTerms: s.payment_terms,
         notes: s.notes,
+        createdAt: s.created_at ? new Date(s.created_at).getTime() : undefined,
       };
     },
   );

--- a/types.ts
+++ b/types.ts
@@ -497,6 +497,7 @@ export interface Supplier {
   taxCode?: string;
   paymentTerms?: string;
   notes?: string;
+  createdAt?: number;
 }
 
 export interface SupplierQuoteItem {

--- a/utils/date.ts
+++ b/utils/date.ts
@@ -56,3 +56,17 @@ export const isDateOnlyWithinInclusiveRange = (
   }
   return true;
 };
+
+/**
+ * Formats a Unix timestamp (milliseconds) to a DD/MM/YYYY date string.
+ * Returns '-' for invalid, null, or undefined timestamps.
+ */
+export const formatInsertDate = (timestamp: number | null | undefined): string => {
+  if (timestamp === null || timestamp === undefined) return '-';
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return '-';
+  const day = String(date.getDate()).padStart(2, '0');
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const year = date.getFullYear();
+  return `${day}/${month}/${year}`;
+};


### PR DESCRIPTION
## Summary

Adds an "Insert Date" column to the suppliers table, extracts `formatInsertDate` to a shared utility, and wires `createdAt` through the supplier API endpoints.

## Changes

- **API** (`server/routes/suppliers.ts`): Add `createdAt` field to GET, POST, and PUT endpoints; use single `Date.now()` for both ID and timestamp
- **Type** (`types.ts`): Add optional `createdAt?: number` to `Supplier` interface
- **UI** (`components/CRM/SuppliersView.tsx`): Add "Insert Date" column following the same pattern as `ClientsView`
- **Utility** (`utils/date.ts`): Extract `formatInsertDate` from `ClientsView` for reuse
- **i18n** (`locales/en/crm.json`, `locales/it/crm.json`): Add translation key for insert date column header

## Notes

- No database migration needed - `suppliers.created_at` already exists with `DEFAULT CURRENT_TIMESTAMP`
- Also fixes a pre-existing TypeScript error in `SuppliersView.tsx` cell renderer

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xbounceit/praetor/pull/99" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
