### PR TITLE
Add insert date column to internal product listing

### DIFF
--- a/components/catalog/InternalListingView.tsx
+++ b/components/catalog/InternalListingView.tsx
@@ -1567,7 +1567,7 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
           {
             header: t('crm:internalListing.insertDate'),
             id: 'createdAt',
-            accessorFn: (row) => row.createdAt ?? null,
+            accessorFn: (row) => row.createdAt ?? 0,
             cell: ({ value }) => (
               <span className="text-xs text-slate-500 whitespace-nowrap">
                 {formatInsertDate(value as number | null)}

--- a/components/catalog/InternalListingView.tsx
+++ b/components/catalog/InternalListingView.tsx
@@ -8,6 +8,7 @@ import type {
   InternalProductType,
 } from '../../services/api/products';
 import type { Product } from '../../types';
+import { formatInsertDate } from '../../utils/date';
 import { parseNumberInputValue, roundToTwoDecimals } from '../../utils/numbers';
 import CustomSelect, { type Option } from '../shared/CustomSelect';
 import Modal from '../shared/Modal';
@@ -1562,6 +1563,17 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
             cell: ({ row: p }) => (
               <span className="font-bold text-slate-700">{p.productCode || '-'}</span>
             ),
+          },
+          {
+            header: t('crm:internalListing.insertDate'),
+            id: 'createdAt',
+            accessorFn: (row) => row.createdAt ?? 0,
+            cell: ({ row: p }) => (
+              <span className="text-xs text-slate-500 whitespace-nowrap">
+                {formatInsertDate(p.createdAt)}
+              </span>
+            ),
+            filterFormat: (value) => formatInsertDate(value as number),
           },
           {
             header: t('common:labels.name'),

--- a/components/catalog/InternalListingView.tsx
+++ b/components/catalog/InternalListingView.tsx
@@ -1567,13 +1567,13 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
           {
             header: t('crm:internalListing.insertDate'),
             id: 'createdAt',
-            accessorFn: (row) => row.createdAt ?? 0,
-            cell: ({ row: p }) => (
+            accessorFn: (row) => row.createdAt ?? null,
+            cell: ({ value }) => (
               <span className="text-xs text-slate-500 whitespace-nowrap">
-                {formatInsertDate(p.createdAt)}
+                {formatInsertDate(value as number | null)}
               </span>
             ),
-            filterFormat: (value) => formatInsertDate(value as number),
+            filterFormat: (value) => formatInsertDate(value as number | null),
           },
           {
             header: t('common:labels.name'),

--- a/locales/en/crm.json
+++ b/locales/en/crm.json
@@ -105,6 +105,7 @@
     "typeItem": "Item",
     "typeService": "Service",
     "productCode": "Code",
+    "insertDate": "Insert Date",
     "productCodeHint": "Only letters, numbers, underscores, and hyphens allowed",
     "supplier": "Supplier",
     "noProducts": "No products found",

--- a/locales/it/crm.json
+++ b/locales/it/crm.json
@@ -105,6 +105,7 @@
     "typeItem": "Articolo",
     "typeService": "Servizio",
     "productCode": "Codice",
+    "insertDate": "Data inserimento",
     "productCodeHint": "Sono ammessi solo lettere, numeri, trattini bassi e trattini",
     "supplier": "Fornitore",
     "noProducts": "Nessun prodotto trovato",

--- a/server/routes/products.ts
+++ b/server/routes/products.ts
@@ -260,7 +260,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const result = await query(
         `INSERT INTO products (id, name, product_code, description, costo, mol_percentage, cost_unit, category, subcategory, type, supplier_id) 
              VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) 
-             RETURNING id, name, product_code as "productCode", (EXTRACT(EPOCH FROM created_at) * 1000)::bigint as "createdAt", description, costo, mol_percentage as "molPercentage", cost_unit as "costUnit", category, subcategory, type, supplier_id as "supplierId"`,
+             RETURNING id, name, product_code as "productCode", EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt", description, costo, mol_percentage as "molPercentage", cost_unit as "costUnit", category, subcategory, type, supplier_id as "supplierId"`,
         [
           id,
           nameResult.value,
@@ -484,7 +484,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       if (fields.length === 0) {
         // No updates
         const result = await query(
-          `SELECT id, name, product_code as "productCode", (EXTRACT(EPOCH FROM created_at) * 1000)::bigint as "createdAt", description, costo, mol_percentage as "molPercentage", cost_unit as "costUnit", category, subcategory, type, is_disabled as "isDisabled", supplier_id as "supplierId"
+          `SELECT id, name, product_code as "productCode", EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt", description, costo, mol_percentage as "molPercentage", cost_unit as "costUnit", category, subcategory, type, is_disabled as "isDisabled", supplier_id as "supplierId"
                  FROM products WHERE id = $1`,
           [idResult.value],
         );
@@ -507,7 +507,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
             UPDATE products 
             SET ${fields.join(', ')}
             WHERE id = $${paramIndex}
-            RETURNING id, name, product_code as "productCode", (EXTRACT(EPOCH FROM created_at) * 1000)::bigint as "createdAt", description, costo, mol_percentage as "molPercentage", cost_unit as "costUnit", category, subcategory, type, is_disabled as "isDisabled", supplier_id as "supplierId"
+            RETURNING id, name, product_code as "productCode", EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt", description, costo, mol_percentage as "molPercentage", cost_unit as "costUnit", category, subcategory, type, is_disabled as "isDisabled", supplier_id as "supplierId"
         `;
 
       const result = await query(queryText, values);

--- a/server/routes/products.ts
+++ b/server/routes/products.ts
@@ -41,6 +41,13 @@ const productSchema = {
   required: ['id', 'name', 'productCode', 'costo', 'molPercentage', 'costUnit', 'type'],
 } as const;
 
+function mapProductRow(row: Record<string, unknown>) {
+  return {
+    ...row,
+    createdAt: row.createdAt ? new Date(row.createdAt as string).getTime() : null,
+  };
+}
+
 const productCreateBodySchema = {
   type: 'object',
   properties: {
@@ -140,12 +147,12 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
     },
     async (request: FastifyRequest, reply: FastifyReply) => {
       const result = await query(
-        `SELECT p.id, p.name, p.product_code as "productCode", EXTRACT(EPOCH FROM p.created_at) * 1000 as "createdAt", p.description, p.costo, p.mol_percentage as "molPercentage", p.cost_unit as "costUnit", p.category, p.subcategory, p.type, p.supplier_id as "supplierId", s.name as "supplierName", p.is_disabled as "isDisabled"
+        `SELECT p.id, p.name, p.product_code as "productCode", p.created_at as "createdAt", p.description, p.costo, p.mol_percentage as "molPercentage", p.cost_unit as "costUnit", p.category, p.subcategory, p.type, p.supplier_id as "supplierId", s.name as "supplierName", p.is_disabled as "isDisabled"
          FROM products p 
          LEFT JOIN suppliers s ON p.supplier_id = s.id 
          ORDER BY p.name ASC`,
       );
-      return result.rows;
+      return result.rows.map(mapProductRow);
     },
   );
 
@@ -260,7 +267,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const result = await query(
         `INSERT INTO products (id, name, product_code, description, costo, mol_percentage, cost_unit, category, subcategory, type, supplier_id) 
              VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) 
-             RETURNING id, name, product_code as "productCode", EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt", description, costo, mol_percentage as "molPercentage", cost_unit as "costUnit", category, subcategory, type, supplier_id as "supplierId"`,
+             RETURNING id, name, product_code as "productCode", created_at as "createdAt", description, costo, mol_percentage as "molPercentage", cost_unit as "costUnit", category, subcategory, type, supplier_id as "supplierId"`,
         [
           id,
           nameResult.value,
@@ -296,7 +303,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           secondaryLabel: result.rows[0].productCode as string,
         },
       });
-      return reply.code(201).send(result.rows[0]);
+      return reply.code(201).send(mapProductRow(result.rows[0]));
     },
   );
 
@@ -484,7 +491,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       if (fields.length === 0) {
         // No updates
         const result = await query(
-          `SELECT id, name, product_code as "productCode", EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt", description, costo, mol_percentage as "molPercentage", cost_unit as "costUnit", category, subcategory, type, is_disabled as "isDisabled", supplier_id as "supplierId"
+          `SELECT id, name, product_code as "productCode", created_at as "createdAt", description, costo, mol_percentage as "molPercentage", cost_unit as "costUnit", category, subcategory, type, is_disabled as "isDisabled", supplier_id as "supplierId"
                  FROM products WHERE id = $1`,
           [idResult.value],
         );
@@ -499,7 +506,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
             result.rows[0].supplierName = supplierResult.rows[0].name;
           }
         }
-        return result.rows[0];
+        return mapProductRow(result.rows[0]);
       }
 
       values.push(idResult.value); // Add ID as last parameter
@@ -507,7 +514,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
             UPDATE products 
             SET ${fields.join(', ')}
             WHERE id = $${paramIndex}
-            RETURNING id, name, product_code as "productCode", EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt", description, costo, mol_percentage as "molPercentage", cost_unit as "costUnit", category, subcategory, type, is_disabled as "isDisabled", supplier_id as "supplierId"
+            RETURNING id, name, product_code as "productCode", created_at as "createdAt", description, costo, mol_percentage as "molPercentage", cost_unit as "costUnit", category, subcategory, type, is_disabled as "isDisabled", supplier_id as "supplierId"
         `;
 
       const result = await query(queryText, values);
@@ -557,7 +564,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           secondaryLabel: result.rows[0].productCode as string,
         },
       });
-      return result.rows[0];
+      return mapProductRow(result.rows[0]);
     },
   );
 

--- a/server/routes/products.ts
+++ b/server/routes/products.ts
@@ -36,6 +36,7 @@ const productSchema = {
     supplierId: { type: ['string', 'null'] },
     supplierName: { type: ['string', 'null'] },
     isDisabled: { type: 'boolean' },
+    createdAt: { type: ['number', 'null'] },
   },
   required: ['id', 'name', 'productCode', 'costo', 'molPercentage', 'costUnit', 'type'],
 } as const;
@@ -139,7 +140,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
     },
     async (request: FastifyRequest, reply: FastifyReply) => {
       const result = await query(
-        `SELECT p.id, p.name, p.product_code as "productCode", p.description, p.costo, p.mol_percentage as "molPercentage", p.cost_unit as "costUnit", p.category, p.subcategory, p.type, p.supplier_id as "supplierId", s.name as "supplierName", p.is_disabled as "isDisabled" 
+        `SELECT p.id, p.name, p.product_code as "productCode", EXTRACT(EPOCH FROM p.created_at) * 1000 as "createdAt", p.description, p.costo, p.mol_percentage as "molPercentage", p.cost_unit as "costUnit", p.category, p.subcategory, p.type, p.supplier_id as "supplierId", s.name as "supplierName", p.is_disabled as "isDisabled"
          FROM products p 
          LEFT JOIN suppliers s ON p.supplier_id = s.id 
          ORDER BY p.name ASC`,
@@ -259,7 +260,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const result = await query(
         `INSERT INTO products (id, name, product_code, description, costo, mol_percentage, cost_unit, category, subcategory, type, supplier_id) 
              VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) 
-             RETURNING id, name, product_code as "productCode", description, costo, mol_percentage as "molPercentage", cost_unit as "costUnit", category, subcategory, type, supplier_id as "supplierId"`,
+             RETURNING id, name, product_code as "productCode", EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt", description, costo, mol_percentage as "molPercentage", cost_unit as "costUnit", category, subcategory, type, supplier_id as "supplierId"`,
         [
           id,
           nameResult.value,
@@ -483,7 +484,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       if (fields.length === 0) {
         // No updates
         const result = await query(
-          `SELECT id, name, product_code as "productCode", description, costo, mol_percentage as "molPercentage", cost_unit as "costUnit", category, subcategory, type, is_disabled as "isDisabled", supplier_id as "supplierId" 
+          `SELECT id, name, product_code as "productCode", EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt", description, costo, mol_percentage as "molPercentage", cost_unit as "costUnit", category, subcategory, type, is_disabled as "isDisabled", supplier_id as "supplierId"
                  FROM products WHERE id = $1`,
           [idResult.value],
         );
@@ -506,7 +507,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
             UPDATE products 
             SET ${fields.join(', ')}
             WHERE id = $${paramIndex}
-            RETURNING id, name, product_code as "productCode", description, costo, mol_percentage as "molPercentage", cost_unit as "costUnit", category, subcategory, type, is_disabled as "isDisabled", supplier_id as "supplierId"
+            RETURNING id, name, product_code as "productCode", EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt", description, costo, mol_percentage as "molPercentage", cost_unit as "costUnit", category, subcategory, type, is_disabled as "isDisabled", supplier_id as "supplierId"
         `;
 
       const result = await query(queryText, values);

--- a/server/routes/products.ts
+++ b/server/routes/products.ts
@@ -260,7 +260,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const result = await query(
         `INSERT INTO products (id, name, product_code, description, costo, mol_percentage, cost_unit, category, subcategory, type, supplier_id) 
              VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) 
-             RETURNING id, name, product_code as "productCode", EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt", description, costo, mol_percentage as "molPercentage", cost_unit as "costUnit", category, subcategory, type, supplier_id as "supplierId"`,
+             RETURNING id, name, product_code as "productCode", (EXTRACT(EPOCH FROM created_at) * 1000)::bigint as "createdAt", description, costo, mol_percentage as "molPercentage", cost_unit as "costUnit", category, subcategory, type, supplier_id as "supplierId"`,
         [
           id,
           nameResult.value,
@@ -484,7 +484,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       if (fields.length === 0) {
         // No updates
         const result = await query(
-          `SELECT id, name, product_code as "productCode", EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt", description, costo, mol_percentage as "molPercentage", cost_unit as "costUnit", category, subcategory, type, is_disabled as "isDisabled", supplier_id as "supplierId"
+          `SELECT id, name, product_code as "productCode", (EXTRACT(EPOCH FROM created_at) * 1000)::bigint as "createdAt", description, costo, mol_percentage as "molPercentage", cost_unit as "costUnit", category, subcategory, type, is_disabled as "isDisabled", supplier_id as "supplierId"
                  FROM products WHERE id = $1`,
           [idResult.value],
         );
@@ -507,7 +507,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
             UPDATE products 
             SET ${fields.join(', ')}
             WHERE id = $${paramIndex}
-            RETURNING id, name, product_code as "productCode", EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt", description, costo, mol_percentage as "molPercentage", cost_unit as "costUnit", category, subcategory, type, is_disabled as "isDisabled", supplier_id as "supplierId"
+            RETURNING id, name, product_code as "productCode", (EXTRACT(EPOCH FROM created_at) * 1000)::bigint as "createdAt", description, costo, mol_percentage as "molPercentage", cost_unit as "costUnit", category, subcategory, type, is_disabled as "isDisabled", supplier_id as "supplierId"
         `;
 
       const result = await query(queryText, values);

--- a/types.ts
+++ b/types.ts
@@ -195,6 +195,7 @@ export interface Product {
   supplierId?: string;
   supplierName?: string;
   isDisabled?: boolean;
+  createdAt?: number;
 }
 
 export interface SpecialBid {


### PR DESCRIPTION
## Summary
- Add `createdAt` timestamp (ms epoch) to all product SQL queries (list, create, update)
- Display insert date as a formatted DD/MM/YYYY column in the internal listing table
- Add i18n keys for en/it locales and update `Product` type

## Test plan
- [ ] Verify the "Insert Date" column appears in the internal product listing
- [ ] Confirm dates display correctly for existing products
- [ ] Verify dash (`-`) shows for products without a `createdAt` value
- [ ] Check the column filters work correctly
- [ ] Verify Italian locale shows "Data inserimento"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xbounceit/praetor/pull/101" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
