### PR TITLE
refactor: remove client-side rounding, rely on DB DECIMAL(15,2) precision

### DIFF
--- a/components/accounting/ClientsInvoicesView.tsx
+++ b/components/accounting/ClientsInvoicesView.tsx
@@ -8,7 +8,7 @@ import {
   getLocalDateString,
   isDateOnlyWithinInclusiveRange,
 } from '../../utils/date';
-import { roundToTwoDecimals } from '../../utils/numbers';
+
 import CustomSelect from '../shared/CustomSelect';
 import Modal from '../shared/Modal';
 import StandardTable from '../shared/StandardTable';
@@ -215,7 +215,7 @@ const ClientsInvoicesView: React.FC<ClientsInvoicesViewProps> = ({
       subtotal += lineNet;
     });
 
-    const total = roundToTwoDecimals(subtotal);
+    const total = subtotal;
 
     return { subtotal, total };
   }, []);
@@ -363,18 +363,18 @@ const ClientsInvoicesView: React.FC<ClientsInvoicesViewProps> = ({
       ...item,
       specialBidId: item.specialBidId || undefined,
       unitOfMeasure: normalizeUnitOfMeasure(item.unitOfMeasure),
-      quantity: roundToTwoDecimals(Number(item.quantity ?? 0)),
-      unitPrice: roundToTwoDecimals(Number(item.unitPrice ?? 0)),
-      discount: roundToTwoDecimals(Number(item.discount || 0)),
+      quantity: Number(item.quantity ?? 0),
+      unitPrice: Number(item.unitPrice ?? 0),
+      discount: Number(item.discount || 0),
     }));
 
     const { subtotal, total } = calculateTotals(roundedItems);
     const payload = {
       ...formData,
       items: roundedItems,
-      amountPaid: roundToTwoDecimals(Number(formData.amountPaid || 0)),
-      subtotal: roundToTwoDecimals(subtotal),
-      total: roundToTwoDecimals(total),
+      amountPaid: Number(formData.amountPaid || 0),
+      subtotal,
+      total,
     };
 
     if (editingInvoice) {
@@ -472,9 +472,9 @@ const ClientsInvoicesView: React.FC<ClientsInvoicesViewProps> = ({
       {
         header: t('accounting:clientsInvoices.balance'),
         id: 'balance',
-        accessorFn: (row: Invoice) => roundToTwoDecimals(row.total - row.amountPaid),
+        accessorFn: (row: Invoice) => row.total - row.amountPaid,
         cell: ({ row }: { row: Invoice }) => {
-          const balance = roundToTwoDecimals(row.total - row.amountPaid);
+          const balance = row.total - row.amountPaid;
           return (
             <span className={`font-bold ${balance > 0 ? 'text-red-500' : 'text-emerald-600'}`}>
               {balance.toFixed(2)} {currency}
@@ -934,8 +934,7 @@ const ClientsInvoicesView: React.FC<ClientsInvoicesViewProps> = ({
                     {t('accounting:clientsInvoices.balanceDue')}
                   </span>
                   <span className="font-bold text-red-500">
-                    {roundToTwoDecimals(total - Number(formData.amountPaid || 0)).toFixed(2)}{' '}
-                    {currency}
+                    {(total - Number(formData.amountPaid || 0)).toFixed(2)} {currency}
                   </span>
                 </div>
               </div>

--- a/components/accounting/ClientsOrdersView.tsx
+++ b/components/accounting/ClientsOrdersView.tsx
@@ -3,7 +3,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Client, ClientsOrder, ClientsOrderItem, Product, SpecialBid } from '../../types';
 import { getLocalDateString, isDateOnlyWithinInclusiveRange } from '../../utils/date';
-import { parseNumberInputValue, roundToTwoDecimals } from '../../utils/numbers';
+import { parseNumberInputValue } from '../../utils/numbers';
 import CustomSelect from '../shared/CustomSelect';
 import Modal from '../shared/Modal';
 import StandardTable from '../shared/StandardTable';
@@ -122,27 +122,27 @@ const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
     const itemsWithSnapshots = (formData.items || []).map((item) => {
       return {
         ...item,
-        unitPrice: roundToTwoDecimals(item.unitPrice),
-        discount: item.discount ? roundToTwoDecimals(item.discount) : 0,
-        productCost: roundToTwoDecimals(Number(item.productCost ?? 0)),
+        unitPrice: item.unitPrice,
+        discount: item.discount ? item.discount : 0,
+        productCost: Number(item.productCost ?? 0),
         productMolPercentage:
           item.productMolPercentage === undefined || item.productMolPercentage === null
             ? null
-            : roundToTwoDecimals(Number(item.productMolPercentage)),
+            : Number(item.productMolPercentage),
         specialBidUnitPrice:
           item.specialBidUnitPrice === undefined || item.specialBidUnitPrice === null
             ? null
-            : roundToTwoDecimals(Number(item.specialBidUnitPrice)),
+            : Number(item.specialBidUnitPrice),
         specialBidMolPercentage:
           item.specialBidMolPercentage === undefined || item.specialBidMolPercentage === null
             ? null
-            : roundToTwoDecimals(Number(item.specialBidMolPercentage)),
+            : Number(item.specialBidMolPercentage),
       };
     });
 
     const payload = {
       ...formData,
-      discount: formData.discount ? roundToTwoDecimals(formData.discount) : 0,
+      discount: formData.discount ? formData.discount : 0,
       items: itemsWithSnapshots,
     };
 

--- a/components/accounting/SupplierInvoicesView.tsx
+++ b/components/accounting/SupplierInvoicesView.tsx
@@ -8,7 +8,7 @@ import {
   getLocalDateString,
   normalizeDateOnlyString,
 } from '../../utils/date';
-import { roundToTwoDecimals } from '../../utils/numbers';
+
 import CustomSelect from '../shared/CustomSelect';
 import Modal from '../shared/Modal';
 import StandardTable from '../shared/StandardTable';
@@ -149,12 +149,12 @@ const SupplierInvoicesView: React.FC<SupplierInvoicesViewProps> = ({
       await onUpdateInvoice(editingInvoice.id, {
         ...formData,
         ...totals,
-        amountPaid: roundToTwoDecimals(Number(formData.amountPaid ?? 0)),
+        amountPaid: Number(formData.amountPaid ?? 0),
         items: (formData.items || []).map((item) => ({
           ...item,
-          quantity: roundToTwoDecimals(Number(item.quantity ?? 0)),
-          unitPrice: roundToTwoDecimals(Number(item.unitPrice ?? 0)),
-          discount: roundToTwoDecimals(Number(item.discount ?? 0)),
+          quantity: Number(item.quantity ?? 0),
+          unitPrice: Number(item.unitPrice ?? 0),
+          discount: Number(item.discount ?? 0),
         })),
       });
 
@@ -164,7 +164,7 @@ const SupplierInvoicesView: React.FC<SupplierInvoicesViewProps> = ({
   );
 
   const totals = useMemo(() => calculateTotals(formData.items || []), [formData.items]);
-  const balanceDue = roundToTwoDecimals(Number(totals.total) - Number(formData.amountPaid || 0));
+  const balanceDue = Number(totals.total) - Number(formData.amountPaid || 0);
   const totalDiscount = useMemo(
     () =>
       (formData.items || []).reduce((sum, item) => {

--- a/components/accounting/SupplierOrdersView.tsx
+++ b/components/accounting/SupplierOrdersView.tsx
@@ -2,7 +2,7 @@ import type React from 'react';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Product, Supplier, SupplierSaleOrder, SupplierSaleOrderItem } from '../../types';
-import { roundToTwoDecimals } from '../../utils/numbers';
+
 import CustomSelect from '../shared/CustomSelect';
 import Modal from '../shared/Modal';
 import StandardTable from '../shared/StandardTable';
@@ -170,11 +170,11 @@ const SupplierOrdersView: React.FC<SupplierOrdersViewProps> = ({
 
       await onUpdateOrder(editingOrder.id, {
         ...formData,
-        discount: roundToTwoDecimals(Number(formData.discount ?? 0)),
+        discount: Number(formData.discount ?? 0),
         items: (formData.items || []).map((item) => ({
           ...item,
-          unitPrice: roundToTwoDecimals(Number(item.unitPrice ?? 0)),
-          discount: roundToTwoDecimals(Number(item.discount ?? 0)),
+          unitPrice: Number(item.unitPrice ?? 0),
+          discount: Number(item.discount ?? 0),
         })),
       });
 

--- a/components/catalog/ExternalListingView.tsx
+++ b/components/catalog/ExternalListingView.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import api from '../../services/api';
 import type { InternalProductType } from '../../services/api/products';
 import type { Product, Supplier } from '../../types';
-import { parseNumberInputValue, roundToTwoDecimals } from '../../utils/numbers';
+import { parseNumberInputValue } from '../../utils/numbers';
 import CustomSelect, { type Option } from '../shared/CustomSelect';
 import Modal from '../shared/Modal';
 import StandardTable from '../shared/StandardTable';
@@ -215,20 +215,14 @@ const ExternalListingView: React.FC<ExternalListingViewProps> = ({
       if (editingProduct) {
         await onUpdateProduct(editingProduct.id, {
           ...formData,
-          costo: formData.costo !== undefined ? roundToTwoDecimals(formData.costo) : undefined,
-          molPercentage:
-            formData.molPercentage !== undefined
-              ? roundToTwoDecimals(formData.molPercentage)
-              : undefined,
+          costo: formData.costo !== undefined ? formData.costo : undefined,
+          molPercentage: formData.molPercentage !== undefined ? formData.molPercentage : undefined,
         });
       } else {
         await onAddProduct({
           ...formData,
-          costo: formData.costo !== undefined ? roundToTwoDecimals(formData.costo) : undefined,
-          molPercentage:
-            formData.molPercentage !== undefined
-              ? roundToTwoDecimals(formData.molPercentage)
-              : undefined,
+          costo: formData.costo !== undefined ? formData.costo : undefined,
+          molPercentage: formData.molPercentage !== undefined ? formData.molPercentage : undefined,
         });
       }
       setIsModalOpen(false);

--- a/components/catalog/InternalListingView.tsx
+++ b/components/catalog/InternalListingView.tsx
@@ -9,7 +9,7 @@ import type {
 } from '../../services/api/products';
 import type { Product } from '../../types';
 import { formatInsertDate } from '../../utils/date';
-import { parseNumberInputValue, roundToTwoDecimals } from '../../utils/numbers';
+import { parseNumberInputValue } from '../../utils/numbers';
 import CustomSelect, { type Option } from '../shared/CustomSelect';
 import Modal from '../shared/Modal';
 import StandardTable from '../shared/StandardTable';
@@ -327,20 +327,14 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
       if (editingProduct) {
         await onUpdateProduct(editingProduct.id, {
           ...productPayload,
-          costo: formData.costo !== undefined ? roundToTwoDecimals(formData.costo) : undefined,
-          molPercentage:
-            formData.molPercentage !== undefined
-              ? roundToTwoDecimals(formData.molPercentage)
-              : undefined,
+          costo: formData.costo !== undefined ? formData.costo : undefined,
+          molPercentage: formData.molPercentage !== undefined ? formData.molPercentage : undefined,
         });
       } else {
         await onAddProduct({
           ...productPayload,
-          costo: formData.costo !== undefined ? roundToTwoDecimals(formData.costo) : undefined,
-          molPercentage:
-            formData.molPercentage !== undefined
-              ? roundToTwoDecimals(formData.molPercentage)
-              : undefined,
+          costo: formData.costo !== undefined ? formData.costo : undefined,
+          molPercentage: formData.molPercentage !== undefined ? formData.molPercentage : undefined,
         });
       }
       setIsModalOpen(false);

--- a/components/catalog/SpecialBidsView.tsx
+++ b/components/catalog/SpecialBidsView.tsx
@@ -9,7 +9,7 @@ import {
   isDateOnlyBeforeToday,
   normalizeDateOnlyString,
 } from '../../utils/date';
-import { parseNumberInputValue, roundToTwoDecimals } from '../../utils/numbers';
+import { parseNumberInputValue } from '../../utils/numbers';
 import Calendar from '../shared/Calendar';
 import CustomSelect from '../shared/CustomSelect';
 import Modal from '../shared/Modal';
@@ -170,11 +170,8 @@ const SpecialBidsView: React.FC<SpecialBidsViewProps> = ({
 
     const payload = {
       ...formData,
-      unitPrice: formData.unitPrice !== undefined ? roundToTwoDecimals(formData.unitPrice) : 0,
-      molPercentage:
-        formData.molPercentage !== undefined
-          ? roundToTwoDecimals(formData.molPercentage)
-          : undefined,
+      unitPrice: formData.unitPrice !== undefined ? formData.unitPrice : 0,
+      molPercentage: formData.molPercentage !== undefined ? formData.molPercentage : undefined,
     };
 
     if (editingBid) {

--- a/components/sales/ClientOffersView.tsx
+++ b/components/sales/ClientOffersView.tsx
@@ -7,7 +7,7 @@ import {
   isDateOnlyWithinInclusiveRange,
   normalizeDateOnlyString,
 } from '../../utils/date';
-import { roundToTwoDecimals } from '../../utils/numbers';
+
 import CustomSelect from '../shared/CustomSelect';
 import Modal from '../shared/Modal';
 import StandardTable, { type Column } from '../shared/StandardTable';
@@ -486,12 +486,12 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
 
     const payload: Partial<ClientOffer> = {
       ...formData,
-      discount: roundToTwoDecimals(Number(formData.discount ?? 0)),
+      discount: Number(formData.discount ?? 0),
       items: (formData.items || []).map((item) => ({
         ...item,
-        unitPrice: roundToTwoDecimals(Number(item.unitPrice ?? 0)),
-        productCost: roundToTwoDecimals(Number(item.productCost ?? 0)),
-        discount: roundToTwoDecimals(Number(item.discount ?? 0)),
+        unitPrice: Number(item.unitPrice ?? 0),
+        productCost: Number(item.productCost ?? 0),
+        discount: Number(item.discount ?? 0),
       })),
     };
 

--- a/components/sales/ClientQuotesView.tsx
+++ b/components/sales/ClientQuotesView.tsx
@@ -17,7 +17,7 @@ import {
   isDateOnlyWithinInclusiveRange,
   normalizeDateOnlyString,
 } from '../../utils/date';
-import { parseNumberInputValue, roundToTwoDecimals } from '../../utils/numbers';
+import { parseNumberInputValue } from '../../utils/numbers';
 import CustomSelect from '../shared/CustomSelect';
 import Modal from '../shared/Modal';
 import StandardTable, { type Column } from '../shared/StandardTable';
@@ -319,21 +319,21 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
     const itemsWithSnapshots = (formData.items || []).map((item) => {
       return {
         ...item,
-        unitPrice: roundToTwoDecimals(item.unitPrice),
-        discount: item.discount ? roundToTwoDecimals(item.discount) : 0,
-        productCost: roundToTwoDecimals(Number(item.productCost ?? 0)),
+        unitPrice: item.unitPrice,
+        discount: item.discount ? item.discount : 0,
+        productCost: Number(item.productCost ?? 0),
         productMolPercentage:
           item.productMolPercentage === undefined || item.productMolPercentage === null
             ? null
-            : roundToTwoDecimals(Number(item.productMolPercentage)),
+            : Number(item.productMolPercentage),
         specialBidUnitPrice:
           item.specialBidUnitPrice === undefined || item.specialBidUnitPrice === null
             ? null
-            : roundToTwoDecimals(Number(item.specialBidUnitPrice)),
+            : Number(item.specialBidUnitPrice),
         specialBidMolPercentage:
           item.specialBidMolPercentage === undefined || item.specialBidMolPercentage === null
             ? null
-            : roundToTwoDecimals(Number(item.specialBidMolPercentage)),
+            : Number(item.specialBidMolPercentage),
         // Supplier quote snapshot fields
         supplierQuoteId: item.supplierQuoteId ?? null,
         supplierQuoteItemId: item.supplierQuoteItemId ?? null,
@@ -341,21 +341,21 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
         supplierQuoteUnitPrice:
           item.supplierQuoteUnitPrice === undefined || item.supplierQuoteUnitPrice === null
             ? null
-            : roundToTwoDecimals(Number(item.supplierQuoteUnitPrice)),
+            : Number(item.supplierQuoteUnitPrice),
         supplierQuoteItemDiscount:
           item.supplierQuoteItemDiscount === undefined || item.supplierQuoteItemDiscount === null
             ? null
-            : roundToTwoDecimals(Number(item.supplierQuoteItemDiscount)),
+            : Number(item.supplierQuoteItemDiscount),
         supplierQuoteDiscount:
           item.supplierQuoteDiscount === undefined || item.supplierQuoteDiscount === null
             ? null
-            : roundToTwoDecimals(Number(item.supplierQuoteDiscount)),
+            : Number(item.supplierQuoteDiscount),
       };
     });
 
     const payload = {
       ...formData,
-      discount: formData.discount ? roundToTwoDecimals(formData.discount) : 0,
+      discount: formData.discount ? formData.discount : 0,
       items: itemsWithSnapshots,
     };
 
@@ -424,7 +424,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
             const cost = applicableBid ? Number(applicableBid.unitPrice) : Number(product.costo);
             let unitPrice = calcProductSalePrice(cost, mol);
             if (item.unitType === 'days') {
-              unitPrice = Math.round(unitPrice * 8 * 100) / 100;
+              unitPrice = unitPrice * 8;
             }
 
             return {
@@ -577,7 +577,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
         const mol = product.molPercentage ? Number(product.molPercentage) : 0;
         let newUnitPrice = calcProductSalePrice(Number(product.costo), mol);
         if (newItems[index].unitType === 'days') {
-          newUnitPrice = Math.round(newUnitPrice * 8 * 100) / 100;
+          newUnitPrice = newUnitPrice * 8;
         }
         newItems[index].unitPrice = newUnitPrice;
         newItems[index].productCost = Number(product.costo);
@@ -611,7 +611,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
             const mol = molSource ? Number(molSource) : 0;
             let newUnitPrice = calcProductSalePrice(Number(applicableBid.unitPrice), mol);
             if (newItems[index].unitType === 'days') {
-              newUnitPrice = Math.round(newUnitPrice * 8 * 100) / 100;
+              newUnitPrice = newUnitPrice * 8;
             }
             newItems[index].unitPrice = newUnitPrice;
             newItems[index].productCost = Number(product.costo);
@@ -625,7 +625,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
             const mol = product.molPercentage ? Number(product.molPercentage) : 0;
             let newUnitPrice = calcProductSalePrice(Number(product.costo), mol);
             if (newItems[index].unitType === 'days') {
-              newUnitPrice = Math.round(newUnitPrice * 8 * 100) / 100;
+              newUnitPrice = newUnitPrice * 8;
             }
             newItems[index].specialBidId = '';
             newItems[index].unitPrice = newUnitPrice;
@@ -727,7 +727,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
             const mol = product.molPercentage ? Number(product.molPercentage) : 0;
             let newUnitPrice = calcProductSalePrice(Number(product.costo), mol);
             if (newItems[index].unitType === 'days') {
-              newUnitPrice = Math.round(newUnitPrice * 8 * 100) / 100;
+              newUnitPrice = newUnitPrice * 8;
             }
             newItems[index].unitPrice = newUnitPrice;
             newItems[index].productCost = Number(product.costo);
@@ -751,7 +751,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
           const mol = molSource ? Number(molSource) : 0;
           newItems[index].unitPrice = calcProductSalePrice(Number(bid.unitPrice), mol);
           if (newItems[index].unitType === 'days') {
-            newItems[index].unitPrice = Math.round(newItems[index].unitPrice * 8 * 100) / 100;
+            newItems[index].unitPrice = newItems[index].unitPrice * 8;
           }
           newItems[index].productCost = Number(product.costo);
           newItems[index].productMolPercentage = product.molPercentage;
@@ -861,7 +861,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
     newItems[index] = {
       ...newItems[index],
       unitType: newType,
-      unitPrice: Math.round(adjustedPrice * 100) / 100,
+      unitPrice: adjustedPrice,
     };
     setFormData({ ...formData, items: newItems });
   };

--- a/components/sales/SupplierQuotesView.tsx
+++ b/components/sales/SupplierQuotesView.tsx
@@ -7,7 +7,7 @@ import {
   getLocalDateString,
   normalizeDateOnlyString,
 } from '../../utils/date';
-import { roundToTwoDecimals } from '../../utils/numbers';
+
 import CustomSelect from '../shared/CustomSelect';
 import Modal from '../shared/Modal';
 import StandardTable, { type Column } from '../shared/StandardTable';
@@ -206,7 +206,7 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
             }
             nextItem.unitPrice = Number(product.costo);
             if (nextItem.unitType === 'days') {
-              nextItem.unitPrice = Math.round(nextItem.unitPrice * 8 * 100) / 100;
+              nextItem.unitPrice = nextItem.unitPrice * 8;
             }
           }
         }
@@ -263,7 +263,7 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
         items[index] = {
           ...item,
           unitType: newType,
-          unitPrice: Math.round(adjustedPrice * 100) / 100,
+          unitPrice: adjustedPrice,
         };
         return { ...prev, items };
       });
@@ -616,11 +616,11 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
 
     const payload: Partial<SupplierQuote> = {
       ...formData,
-      discount: roundToTwoDecimals(Number(formData.discount ?? 0)),
+      discount: Number(formData.discount ?? 0),
       items: (formData.items || []).map((item) => ({
         ...item,
-        unitPrice: roundToTwoDecimals(Number(item.unitPrice ?? 0)),
-        discount: roundToTwoDecimals(Number(item.discount ?? 0)),
+        unitPrice: Number(item.unitPrice ?? 0),
+        discount: Number(item.discount ?? 0),
       })),
     };
 

--- a/services/api/normalizers.ts
+++ b/services/api/normalizers.ts
@@ -23,7 +23,6 @@ import type {
   TimeEntry,
   User,
 } from '../../types';
-import { roundToTwoDecimals } from '../../utils/numbers';
 
 export const normalizeClient = (c: Client): Client => ({
   ...c,
@@ -269,9 +268,9 @@ export const normalizeInvoiceItem = (item: InvoiceItem): InvoiceItem => ({
 
 export const normalizeInvoice = (i: Invoice): Invoice => ({
   ...i,
-  subtotal: roundToTwoDecimals(Number(i.subtotal ?? 0)),
-  total: roundToTwoDecimals(Number(i.total ?? 0)),
-  amountPaid: roundToTwoDecimals(Number(i.amountPaid ?? 0)),
+  subtotal: Number(i.subtotal ?? 0),
+  total: Number(i.total ?? 0),
+  amountPaid: Number(i.amountPaid ?? 0),
   items: (i.items || []).map(normalizeInvoiceItem),
 });
 
@@ -314,9 +313,9 @@ export const normalizeSupplierInvoiceItem = (item: SupplierInvoiceItem): Supplie
 
 export const normalizeSupplierInvoice = (invoice: SupplierInvoice): SupplierInvoice => ({
   ...invoice,
-  subtotal: roundToTwoDecimals(Number(invoice.subtotal ?? 0)),
-  total: roundToTwoDecimals(Number(invoice.total ?? 0)),
-  amountPaid: roundToTwoDecimals(Number(invoice.amountPaid ?? 0)),
+  subtotal: Number(invoice.subtotal ?? 0),
+  total: Number(invoice.total ?? 0),
+  amountPaid: Number(invoice.amountPaid ?? 0),
   items: (invoice.items || []).map(normalizeSupplierInvoiceItem),
 });
 

--- a/utils/numbers.ts
+++ b/utils/numbers.ts
@@ -3,7 +3,3 @@ export const parseNumberInputValue = (value: string, fallback: number | undefine
   const parsed = parseFloat(value);
   return Number.isNaN(parsed) ? fallback : parsed;
 };
-
-export const roundToTwoDecimals = (value: number) => {
-  return Number(Math.round(Number(value + 'e2')) + 'e-2');
-};


### PR DESCRIPTION
Remove roundToTwoDecimals utility and all Math.round(x*100)/100 patterns now that monetary columns are standardized to DECIMAL(15,2) server-side.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xbounceit/praetor/pull/105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
