### PR TITLE
fix(quotes): resolve PR #107 review bugs — nullable product_id and stale memo

### DIFF
--- a/components/sales/ClientQuotesView.tsx
+++ b/components/sales/ClientQuotesView.tsx
@@ -790,9 +790,9 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
   const acceptedSupplierQuotes = useMemo(
     () =>
       supplierQuotes.filter(
-        (q) => q.status === 'accepted' && !isDateOnlyBeforeToday(q.expirationDate),
+        (q) => q.status === 'accepted' && !isDateOnlyBeforeToday(q.expirationDate, today),
       ),
-    [supplierQuotes],
+    [supplierQuotes, today],
   );
 
   const supplierQuoteItemOptions = useMemo(() => {

--- a/server/db/schema.sql
+++ b/server/db/schema.sql
@@ -843,6 +843,18 @@ BEGIN
     END IF;
 END $$;
 
+-- Migration: Allow quote_items.product_id to be NULL for supplier-quote-sourced items
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'quote_items'
+          AND column_name = 'product_id' AND is_nullable = 'NO'
+    ) THEN
+        ALTER TABLE quote_items ALTER COLUMN product_id DROP NOT NULL;
+    END IF;
+END $$;
+
 -- Customer offers
 CREATE TABLE IF NOT EXISTS customer_offers (
     id VARCHAR(100) PRIMARY KEY,
@@ -1210,6 +1222,18 @@ BEGIN
           AND column_name = 'unit_price' AND numeric_scale != 2
     ) THEN
         ALTER TABLE supplier_quote_items ALTER COLUMN unit_price TYPE DECIMAL(15, 2);
+    END IF;
+END $$;
+
+-- Migration: Allow supplier_quote_items.product_id to be NULL (supplier quotes rework)
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'supplier_quote_items'
+          AND column_name = 'product_id' AND is_nullable = 'NO'
+    ) THEN
+        ALTER TABLE supplier_quote_items ALTER COLUMN product_id DROP NOT NULL;
     END IF;
 END $$;
 


### PR DESCRIPTION
- Drop NOT NULL on quote_items.product_id so client quotes linked to supplier quote items (without a product) don't crash on insert
- Drop NOT NULL on supplier_quote_items.product_id via schema.sql (the standalone migration file was never executed on startup)
- Add `today` to acceptedSupplierQuotes useMemo deps so the filter recomputes correctly when the date changes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xbounceit/praetor/pull/108" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
