### PR TITLE
feat(quotes): allow returning quotes to draft status

### DIFF
--- a/components/sales/ClientQuotesView.tsx
+++ b/components/sales/ClientQuotesView.tsx
@@ -1223,7 +1223,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                   )}
                 </Tooltip>
               )}
-              {row.status !== 'draft' && row.status !== 'sent' && !row.linkedOfferId && (
+              {!row.linkedOfferId && (row.status === 'accepted' || row.status === 'denied' || isQuoteExpired(row)) && (
                 <Tooltip label={restoreTitle}>
                   {() => (
                     <button

--- a/components/sales/ClientQuotesView.tsx
+++ b/components/sales/ClientQuotesView.tsx
@@ -219,7 +219,6 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
   const isReadOnly = Boolean(
     editingQuote &&
       (editingQuote.linkedOfferId ||
-        editingQuote.status === 'sent' ||
         editingQuote.status === 'accepted' ||
         editingQuote.status === 'denied'),
   );
@@ -1291,9 +1290,15 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
             {isReadOnly && (
               <div className="flex items-center gap-3 px-4 py-3 rounded-xl border border-amber-200 bg-amber-50">
                 <span className="text-amber-700 text-xs font-bold">
-                  {t('sales:clientQuotes.readOnlyBecauseOffer', {
-                    defaultValue: 'This quote is read-only because an offer was created from it.',
-                  })}
+                  {editingQuote?.linkedOfferId
+                    ? t('sales:clientQuotes.readOnlyBecauseOffer', {
+                        defaultValue:
+                          'This quote is read-only because an offer was created from it.',
+                      })
+                    : t('sales:clientQuotes.readOnlyBecauseFinal', {
+                        defaultValue:
+                          'This quote is read-only because it was already accepted or denied.',
+                      })}
                 </span>
               </div>
             )}

--- a/components/sales/ClientQuotesView.tsx
+++ b/components/sales/ClientQuotesView.tsx
@@ -1223,7 +1223,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                   )}
                 </Tooltip>
               )}
-              {history && (
+              {history && !row.linkedOfferId && (
                 <Tooltip label={restoreTitle}>
                   {() => (
                     <button

--- a/components/sales/ClientQuotesView.tsx
+++ b/components/sales/ClientQuotesView.tsx
@@ -1223,7 +1223,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                   )}
                 </Tooltip>
               )}
-              {history && !row.linkedOfferId && (
+              {row.status !== 'draft' && row.status !== 'sent' && !row.linkedOfferId && (
                 <Tooltip label={restoreTitle}>
                   {() => (
                     <button

--- a/locales/en/sales.json
+++ b/locales/en/sales.json
@@ -35,6 +35,7 @@
     "convertConfirm": "Convert this quote to a sale?",
     "readOnlyStatus": "{{status}} quotes are read-only",
     "readOnlyBecauseOffer": "This quote is read-only because an offer was created from it.",
+    "readOnlyBecauseFinal": "This quote is read-only because it was already accepted or denied.",
     "linkedOffer": "Linked Offer",
     "linkedOfferInfo": "Offer #{{number}}",
     "offerDetailsReadOnly": "(Quote details are read-only)",

--- a/locales/it/sales.json
+++ b/locales/it/sales.json
@@ -35,6 +35,7 @@
     "convertConfirm": "Convertire questo preventivo in una vendita?",
     "readOnlyStatus": "I preventivi in stato {{status}} sono in sola lettura",
     "readOnlyBecauseOffer": "Questo preventivo è in sola lettura perché è stata creata un'offerta da esso.",
+    "readOnlyBecauseFinal": "Questo preventivo è in sola lettura perché è già stato accettato o rifiutato.",
     "linkedOffer": "Offerta Collegata",
     "linkedOfferInfo": "Offerta #{{number}}",
     "offerDetailsReadOnly": "(I dettagli del preventivo sono in sola lettura)",


### PR DESCRIPTION
## Summary

- Allow sent quotes to be edited by removing the `sent` status from the read-only check
- Show a Restore to draft button for all non-draft/sent quotes that don't have a linked offer
- Add a distinct read-only banner message for quotes that were accepted/denied (vs. linked to an offer)
- Add English and Italian translations for the new read-only message
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xbounceit/praetor/pull/116" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
