### PR TITLE
feat(sales): add Total cost column to client quotes

### DIFF
--- a/components/sales/ClientQuotesView.tsx
+++ b/components/sales/ClientQuotesView.tsx
@@ -1413,7 +1413,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
             </div>
 
             {/* Products */}
-            <div className="space-y-2">
+            <div className="space-y-2 border-t border-slate-100 pt-4">
               <div className="flex justify-between items-center">
                 <h4 className="text-xs font-black text-praetor uppercase tracking-widest flex items-center gap-2">
                   <span className="w-1.5 h-1.5 rounded-full bg-praetor"></span>
@@ -1434,7 +1434,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
 
               {formData.items && formData.items.length > 0 && (
                 <div className="hidden lg:flex gap-2 px-3 mb-1 items-center">
-                  <div className="flex-1 min-w-0 grid grid-cols-14 gap-2">
+                  <div className="flex-1 min-w-0 grid grid-cols-13 gap-2">
                     <div className="col-span-3 text-[10px] font-black text-slate-400 uppercase tracking-wider ml-1">
                       {t('sales:clientQuotes.supplierQuoteColumn')}
                     </div>
@@ -1444,13 +1444,13 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                     <div className="col-span-2 text-[10px] font-black text-slate-400 uppercase tracking-wider text-center">
                       {t('sales:clientQuotes.qty')}
                     </div>
-                    <div className="col-span-2 text-[10px] font-black text-slate-400 uppercase tracking-wider text-center">
+                    <div className="col-span-1 text-[10px] font-black text-slate-400 uppercase tracking-wider text-center">
                       {t('crm:internalListing.cost')}
                     </div>
-                    <div className="col-span-1 text-[10px] font-black text-slate-400 uppercase tracking-wider text-center">
-                      MOL (%)
+                    <div className="col-span-1 text-[10px] font-black text-slate-400 uppercase tracking-wider text-center whitespace-nowrap">
+                      MOL
                     </div>
-                    <div className="col-span-1 text-[10px] font-black text-slate-400 uppercase tracking-wider text-center">
+                    <div className="col-span-1 text-[10px] font-black text-slate-400 uppercase tracking-wider text-center whitespace-nowrap">
                       {t('sales:clientQuotes.totalCost', { defaultValue: 'Total cost' })}
                     </div>
                     <div className="col-span-1 text-[10px] font-black text-slate-400 uppercase tracking-wider text-center">
@@ -1678,7 +1678,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                           </div>
                         </div>
                         <div className="hidden lg:flex gap-2 items-center">
-                          <div className="flex-1 min-w-0 grid grid-cols-14 gap-2 items-center">
+                          <div className="flex-1 min-w-0 grid grid-cols-13 gap-2 items-center">
                             <div className="col-span-3 min-w-0">
                               <CustomSelect
                                 options={[
@@ -1738,7 +1738,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                                 {renderUnitSelector(index, item)}
                               </div>
                             </div>
-                            <div className="col-span-2 flex flex-col items-center justify-center gap-1">
+                            <div className="col-span-1 flex flex-col items-center justify-center gap-1">
                               {selectedSupplierQuote && (
                                 <span className="px-2 py-0.5 rounded-full bg-emerald-600 text-white text-[8px] font-black uppercase tracking-wider">
                                   {t('sales:clientQuotes.supplierQuoteBadge')}
@@ -1749,30 +1749,20 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                                   {t('sales:clientQuotes.bidBadge')}
                                 </span>
                               )}
-                              <div className="flex items-center gap-0.5 w-full">
-                                <ValidatedNumberInput
-                                  value={cost.toFixed(2)}
-                                  onValueChange={handleCostChange}
-                                  disabled={isReadOnly}
-                                  className="w-full text-sm px-1 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
-                                />
-                                <span className="text-[9px] font-semibold text-slate-400 shrink-0">
-                                  {currency}
-                                </span>
-                              </div>
+                              <ValidatedNumberInput
+                                value={cost.toFixed(2)}
+                                onValueChange={handleCostChange}
+                                disabled={isReadOnly}
+                                className="w-full text-sm px-1 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
+                              />
                             </div>
                             <div className="col-span-1 flex items-center justify-center">
-                              <div className="flex items-center gap-0.5 w-full">
-                                <ValidatedNumberInput
-                                  value={molPercentage.toFixed(1)}
-                                  onValueChange={handleMolChange}
-                                  disabled={isReadOnly}
-                                  className="w-full text-sm px-1 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
-                                />
-                                <span className="text-[9px] font-semibold text-slate-400 shrink-0">
-                                  %
-                                </span>
-                              </div>
+                              <ValidatedNumberInput
+                                value={molPercentage.toFixed(1)}
+                                onValueChange={handleMolChange}
+                                disabled={isReadOnly}
+                                className="w-full text-sm px-1 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
+                              />
                             </div>
                             <div className="col-span-1 flex items-center justify-center">
                               <span className="text-xs font-bold text-slate-700 whitespace-nowrap">
@@ -1786,7 +1776,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                             </div>
                             <div className="col-span-1 flex items-center justify-center">
                               <span
-                                className={`text-sm font-semibold whitespace-nowrap ${selectedSupplierQuote ? 'text-emerald-600' : selectedBid ? 'text-praetor' : 'text-slate-800'}`}
+                                className={`text-xs font-semibold whitespace-nowrap ${selectedSupplierQuote ? 'text-emerald-600' : selectedBid ? 'text-praetor' : 'text-slate-800'}`}
                               >
                                 {lineSalePrice.toFixed(2)} {currency}
                               </span>

--- a/components/sales/ClientQuotesView.tsx
+++ b/components/sales/ClientQuotesView.tsx
@@ -1434,7 +1434,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
 
               {formData.items && formData.items.length > 0 && (
                 <div className="hidden lg:flex gap-3 px-3 mb-1 items-center">
-                  <div className="flex-1 min-w-0 grid grid-cols-13 gap-3">
+                  <div className="flex-1 min-w-0 grid grid-cols-14 gap-3">
                     <div className="col-span-3 text-[10px] font-black text-slate-400 uppercase tracking-wider ml-1">
                       {t('sales:clientQuotes.supplierQuoteColumn')}
                     </div>
@@ -1449,6 +1449,9 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                     </div>
                     <div className="col-span-1 text-[10px] font-black text-slate-400 uppercase tracking-wider text-center">
                       MOL (%)
+                    </div>
+                    <div className="col-span-1 text-[10px] font-black text-slate-400 uppercase tracking-wider text-center">
+                      {t('sales:clientQuotes.totalCost', { defaultValue: 'Total cost' })}
                     </div>
                     <div className="col-span-1 text-[10px] font-black text-slate-400 uppercase tracking-wider text-center">
                       {t('sales:clientQuotes.marginLabel')}
@@ -1576,7 +1579,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                             <i className="fa-solid fa-trash-can"></i>
                           </button>
                         </div>
-                        <div className="grid grid-cols-2 gap-3 md:grid-cols-5 lg:hidden">
+                        <div className="grid grid-cols-2 gap-3 md:grid-cols-6 lg:hidden">
                           <div>
                             <div className="mb-1 text-[10px] font-black text-slate-400 uppercase tracking-wider">
                               {t('sales:clientQuotes.qty')}
@@ -1649,6 +1652,14 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                           </div>
                           <div className="rounded-lg border border-slate-200 bg-white px-3 py-2 space-y-1">
                             <div className="text-[10px] font-black text-slate-400 uppercase tracking-wider">
+                              {t('sales:clientQuotes.totalCost', { defaultValue: 'Total cost' })}
+                            </div>
+                            <div className="text-xs font-bold text-slate-700 whitespace-nowrap">
+                              {lineCost.toFixed(2)} {currency}
+                            </div>
+                          </div>
+                          <div className="rounded-lg border border-slate-200 bg-white px-3 py-2 space-y-1">
+                            <div className="text-[10px] font-black text-slate-400 uppercase tracking-wider">
                               {t('sales:clientQuotes.marginLabel')}
                             </div>
                             <div className="text-xs font-bold text-emerald-600 whitespace-nowrap">
@@ -1667,7 +1678,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                           </div>
                         </div>
                         <div className="hidden lg:flex gap-3 items-center">
-                          <div className="flex-1 min-w-0 grid grid-cols-13 gap-3 items-center">
+                          <div className="flex-1 min-w-0 grid grid-cols-14 gap-3 items-center">
                             <div className="col-span-3 min-w-0">
                               <CustomSelect
                                 options={[
@@ -1762,6 +1773,11 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                                   %
                                 </span>
                               </div>
+                            </div>
+                            <div className="col-span-1 flex items-center justify-center">
+                              <span className="text-xs font-bold text-slate-700 whitespace-nowrap">
+                                {lineCost.toFixed(2)} {currency}
+                              </span>
                             </div>
                             <div className="col-span-1 flex items-center justify-center">
                               <span className="text-xs font-bold text-emerald-600 whitespace-nowrap">

--- a/components/sales/ClientQuotesView.tsx
+++ b/components/sales/ClientQuotesView.tsx
@@ -1444,7 +1444,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                     <div className="col-span-2 text-[10px] font-black text-slate-400 uppercase tracking-wider text-center">
                       {t('sales:clientQuotes.qty')}
                     </div>
-                    <div className="col-span-1 text-[10px] font-black text-slate-400 uppercase tracking-wider text-center">
+                    <div className="col-span-2 text-[10px] font-black text-slate-400 uppercase tracking-wider text-center">
                       {t('crm:internalListing.cost')}
                     </div>
                     <div className="col-span-1 text-[10px] font-black text-slate-400 uppercase tracking-wider text-center">
@@ -1456,7 +1456,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                     <div className="col-span-1 text-[10px] font-black text-slate-400 uppercase tracking-wider text-center">
                       {t('sales:clientQuotes.marginLabel')}
                     </div>
-                    <div className="col-span-2 text-[10px] font-black text-slate-400 uppercase tracking-wider text-center">
+                    <div className="col-span-1 text-[10px] font-black text-slate-400 uppercase tracking-wider text-center">
                       {t('sales:clientQuotes.revenue')}
                     </div>
                   </div>
@@ -1738,7 +1738,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                                 {renderUnitSelector(index, item)}
                               </div>
                             </div>
-                            <div className="col-span-1 flex flex-col items-center justify-center gap-1">
+                            <div className="col-span-2 flex flex-col items-center justify-center gap-1">
                               {selectedSupplierQuote && (
                                 <span className="px-2 py-0.5 rounded-full bg-emerald-600 text-white text-[8px] font-black uppercase tracking-wider">
                                   {t('sales:clientQuotes.supplierQuoteBadge')}
@@ -1749,7 +1749,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                                   {t('sales:clientQuotes.bidBadge')}
                                 </span>
                               )}
-                              <div className="flex items-center gap-0.5 w-full min-w-[5.5rem]">
+                              <div className="flex items-center gap-0.5 w-full">
                                 <ValidatedNumberInput
                                   value={cost.toFixed(2)}
                                   onValueChange={handleCostChange}
@@ -1784,7 +1784,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                                 {lineMargin.toFixed(2)} {currency}
                               </span>
                             </div>
-                            <div className="col-span-2 flex items-center justify-center">
+                            <div className="col-span-1 flex items-center justify-center">
                               <span
                                 className={`text-sm font-semibold whitespace-nowrap ${selectedSupplierQuote ? 'text-emerald-600' : selectedBid ? 'text-praetor' : 'text-slate-800'}`}
                               >

--- a/components/sales/ClientQuotesView.tsx
+++ b/components/sales/ClientQuotesView.tsx
@@ -1267,7 +1267,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
     <div className="space-y-8 animate-in fade-in duration-500">
       {/* Add/Edit Modal */}
       <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)}>
-        <div className="flex max-h-[90vh] w-full max-w-6xl flex-col overflow-hidden rounded-2xl bg-white shadow-2xl animate-in zoom-in duration-200">
+        <div className="flex max-h-[90vh] w-full max-w-7xl flex-col overflow-hidden rounded-2xl bg-white shadow-2xl animate-in zoom-in duration-200">
           <div className="p-6 border-b border-slate-100 flex justify-between items-center bg-slate-50/50">
             <h3 className="text-xl font-black text-slate-800 flex items-center gap-3">
               <div className="w-10 h-10 bg-slate-100 rounded-xl flex items-center justify-center text-praetor">
@@ -1433,8 +1433,8 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
               )}
 
               {formData.items && formData.items.length > 0 && (
-                <div className="hidden lg:flex gap-3 px-3 mb-1 items-center">
-                  <div className="flex-1 min-w-0 grid grid-cols-14 gap-3">
+                <div className="hidden lg:flex gap-2 px-3 mb-1 items-center">
+                  <div className="flex-1 min-w-0 grid grid-cols-14 gap-2">
                     <div className="col-span-3 text-[10px] font-black text-slate-400 uppercase tracking-wider ml-1">
                       {t('sales:clientQuotes.supplierQuoteColumn')}
                     </div>
@@ -1677,8 +1677,8 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                             </div>
                           </div>
                         </div>
-                        <div className="hidden lg:flex gap-3 items-center">
-                          <div className="flex-1 min-w-0 grid grid-cols-14 gap-3 items-center">
+                        <div className="hidden lg:flex gap-2 items-center">
+                          <div className="flex-1 min-w-0 grid grid-cols-14 gap-2 items-center">
                             <div className="col-span-3 min-w-0">
                               <CustomSelect
                                 options={[
@@ -1749,7 +1749,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                                   {t('sales:clientQuotes.bidBadge')}
                                 </span>
                               )}
-                              <div className="flex items-center gap-0.5 w-full">
+                              <div className="flex items-center gap-0.5 w-full min-w-[5.5rem]">
                                 <ValidatedNumberInput
                                   value={cost.toFixed(2)}
                                   onValueChange={handleCostChange}

--- a/components/sales/ClientQuotesView.tsx
+++ b/components/sales/ClientQuotesView.tsx
@@ -1837,7 +1837,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                 {errors.total && (
                   <p className="text-red-500 text-[10px] font-bold mb-2">{errors.total}</p>
                 )}
-                <div className="flex justify-between items-center">
+                <div className="flex justify-between items-center mb-1">
                   <span className="text-sm font-bold text-slate-500">
                     {t('sales:clientQuotes.globalDiscount')}
                   </span>

--- a/locales/en/sales.json
+++ b/locales/en/sales.json
@@ -85,6 +85,7 @@
     "cannotRevertLinkedSale": "Cannot revert: linked sale order exists",
     "discountAmount": "Discount ({{discount}}%)",
     "totalLabel": "Total",
+    "totalCost": "Total cost",
     "marginLabel": "Margin",
     "selectAClient": "Select a client...",
     "noSpecialBidOption": "No Special Bid",

--- a/locales/it/sales.json
+++ b/locales/it/sales.json
@@ -85,6 +85,7 @@
     "cannotRevertLinkedSale": "Impossibile ripristinare: esiste un ordine di vendita collegato",
     "discountAmount": "Sconto ({{discount}}%)",
     "totalLabel": "Totale",
+    "totalCost": "Costo totale",
     "marginLabel": "Margine",
     "selectAClient": "Seleziona un cliente...",
     "noSpecialBidOption": "Nessuna Offerta Speciale",


### PR DESCRIPTION
## Summary
- Add a `Total cost` column (cost x quantity) to the client quotes item table, placed before the Margin column
- Add i18n translations for the new column (en/it)
- Polish the quote modal layout: wider modal (max-w-7xl), tighter grid gaps, section separator between client info and products, consistent font sizes across value cells, removed redundant currency/% suffixes from input boxes

## Files changed
- `components/sales/ClientQuotesView.tsx` - new Total cost column in both desktop and mobile layouts, layout polish
- `locales/en/sales.json` - totalCost translation
- `locales/it/sales.json` - Costo totale translation
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xbounceit/praetor/pull/117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
