### PR TITLE
fix(shared): make Tooltip screen-aware with auto-flip and viewport clamping

### DIFF
--- a/components/shared/Tooltip.tsx
+++ b/components/shared/Tooltip.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 export type TooltipPosition = 'top' | 'right' | 'bottom' | 'left';
@@ -27,6 +27,8 @@ const arrowClasses: Record<TooltipPosition, string> = {
   left: '-right-1 top-1/2 -translate-y-1/2 border-r border-t',
 };
 
+const VIEWPORT_PADDING = 8;
+
 const Tooltip: React.FC<TooltipProps> = ({
   label,
   position = 'top',
@@ -36,49 +38,53 @@ const Tooltip: React.FC<TooltipProps> = ({
   children,
 }) => {
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const tooltipRef = useRef<HTMLDivElement>(null);
+  const hasFlippedRef = useRef(false);
+  const clampAppliedRef = useRef(false);
+  const effectivePositionRef = useRef<TooltipPosition>(position);
+
   const [isVisible, setIsVisible] = useState(false);
   const [coords, setCoords] = useState<{ top: number; left: number } | null>(null);
+  const [effectivePosition, setEffectivePosition] = useState<TooltipPosition>(position);
+  const [arrowOffset, setArrowOffset] = useState<{ x: number; y: number }>({ x: 0, y: 0 });
 
-  const updatePosition = useCallback(() => {
-    if (!wrapperRef.current) return;
-
+  const calcCoords = useCallback((pos: TooltipPosition) => {
+    if (!wrapperRef.current) return null;
     const rect = wrapperRef.current.getBoundingClientRect();
     const offset = 8;
     const scrollX = window.scrollX;
     const scrollY = window.scrollY;
 
-    switch (position) {
+    switch (pos) {
       case 'top':
-        setCoords({
-          top: rect.top + scrollY - offset,
-          left: rect.left + scrollX + rect.width / 2,
-        });
-        break;
+        return { top: rect.top + scrollY - offset, left: rect.left + scrollX + rect.width / 2 };
       case 'bottom':
-        setCoords({
-          top: rect.bottom + scrollY + offset,
-          left: rect.left + scrollX + rect.width / 2,
-        });
-        break;
+        return { top: rect.bottom + scrollY + offset, left: rect.left + scrollX + rect.width / 2 };
       case 'left':
-        setCoords({
-          top: rect.top + scrollY + rect.height / 2,
-          left: rect.left + scrollX - offset,
-        });
-        break;
+        return { top: rect.top + scrollY + rect.height / 2, left: rect.left + scrollX - offset };
       case 'right':
-        setCoords({
-          top: rect.top + scrollY + rect.height / 2,
-          left: rect.right + scrollX + offset,
-        });
-        break;
-      default:
-        setCoords({
-          top: rect.top + scrollY - offset,
-          left: rect.left + scrollX + rect.width / 2,
-        });
+        return { top: rect.top + scrollY + rect.height / 2, left: rect.right + scrollX + offset };
     }
-  }, [position]);
+  }, []);
+
+  useEffect(() => {
+    if (!isVisible) {
+      setEffectivePosition(position);
+      effectivePositionRef.current = position;
+      hasFlippedRef.current = false;
+      clampAppliedRef.current = false;
+    }
+  }, [isVisible, position]);
+
+  const updatePosition = useCallback(() => {
+    hasFlippedRef.current = false;
+    clampAppliedRef.current = false;
+    effectivePositionRef.current = position;
+    setEffectivePosition(position);
+    setArrowOffset({ x: 0, y: 0 });
+    const newCoords = calcCoords(position);
+    if (newCoords) setCoords(newCoords);
+  }, [calcCoords, position]);
 
   useEffect(() => {
     if (!isVisible) return;
@@ -103,6 +109,70 @@ const Tooltip: React.FC<TooltipProps> = ({
       document.removeEventListener('mousedown', handleClickOutside);
     };
   }, [isVisible, updatePosition]);
+
+  useLayoutEffect(() => {
+    if (!isVisible || !tooltipRef.current || !coords) return;
+
+    const el = tooltipRef.current;
+    const rect = el.getBoundingClientRect();
+
+    if (!hasFlippedRef.current) {
+      let flipped: TooltipPosition | null = null;
+
+      switch (effectivePosition) {
+        case 'top':
+          if (rect.top < VIEWPORT_PADDING) flipped = 'bottom';
+          break;
+        case 'bottom':
+          if (rect.bottom > window.innerHeight - VIEWPORT_PADDING) flipped = 'top';
+          break;
+        case 'left':
+          if (rect.left < VIEWPORT_PADDING) flipped = 'right';
+          break;
+        case 'right':
+          if (rect.right > window.innerWidth - VIEWPORT_PADDING) flipped = 'left';
+          break;
+      }
+
+      if (flipped) {
+        const newCoords = calcCoords(flipped);
+        if (newCoords) {
+          hasFlippedRef.current = true;
+          effectivePositionRef.current = flipped;
+          setEffectivePosition(flipped);
+          setCoords(newCoords);
+          return;
+        }
+      }
+    }
+
+    let dx = 0;
+    let dy = 0;
+
+    if (rect.left < VIEWPORT_PADDING) dx = VIEWPORT_PADDING - rect.left;
+    else if (rect.right > window.innerWidth - VIEWPORT_PADDING)
+      dx = window.innerWidth - VIEWPORT_PADDING - rect.right;
+
+    if (rect.top < VIEWPORT_PADDING) dy = VIEWPORT_PADDING - rect.top;
+    else if (rect.bottom > window.innerHeight - VIEWPORT_PADDING)
+      dy = window.innerHeight - VIEWPORT_PADDING - rect.bottom;
+
+    if ((dx !== 0 || dy !== 0) && !clampAppliedRef.current) {
+      clampAppliedRef.current = true;
+      setCoords((prev) => (prev ? { top: prev.top + dy, left: prev.left + dx } : prev));
+      const isVertical = effectivePosition === 'top' || effectivePosition === 'bottom';
+      const maxOffset = 4;
+      if (isVertical) {
+        const maxX = rect.width / 2 - maxOffset;
+        const clampedX = Math.max(-maxX, Math.min(maxX, -dx));
+        setArrowOffset({ x: clampedX, y: 0 });
+      } else {
+        const maxY = rect.height / 2 - maxOffset;
+        const clampedY = Math.max(-maxY, Math.min(maxY, -dy));
+        setArrowOffset({ x: 0, y: clampedY });
+      }
+    }
+  }, [isVisible, coords, effectivePosition, calcCoords]);
 
   const handleShow = () => {
     updatePosition();
@@ -130,12 +200,14 @@ const Tooltip: React.FC<TooltipProps> = ({
       {isVisible && coords
         ? createPortal(
             <div
+              ref={tooltipRef}
               style={{ top: coords.top, left: coords.left }}
-              className={`absolute ${positionClasses[position]} px-3 py-1 bg-slate-800 text-white text-xs font-bold rounded pointer-events-none transition-opacity whitespace-nowrap z-50 shadow-xl border border-slate-700 ${tooltipClassName}`}
+              className={`absolute ${positionClasses[effectivePosition]} px-3 py-1 bg-slate-800 text-white text-xs font-bold rounded pointer-events-none transition-opacity whitespace-nowrap z-50 shadow-xl border border-slate-700 ${tooltipClassName}`}
             >
               {label}
               <div
-                className={`absolute w-2 h-2 bg-slate-800 border-slate-700 rotate-45 ${arrowClasses[position]}`}
+                className={`absolute w-2 h-2 bg-slate-800 border-slate-700 rotate-45 ${arrowClasses[effectivePosition]}`}
+                style={{ marginLeft: arrowOffset.x, marginTop: arrowOffset.y }}
               ></div>
             </div>,
             document.body,


### PR DESCRIPTION
## Summary

- The Tooltip component now detects when it would overflow the viewport and **auto-flips** to the opposite side (e.g. top to bottom) when the preferred direction has no room.
- After flipping (or when no flip is needed), the tooltip is **clamped** to stay within 8px of all viewport edges so text is never cut off.
- The **arrow** compensates for the viewport clamp shift, keeping it pointed at the trigger element. The offset is bounds-checked to stay within the tooltip rectangle.
- Flip and clamp are **re-evaluated on every scroll/resize**, so the tooltip adapts as the trigger element moves.

## Changes

- **components/shared/Tooltip.tsx**: Extracted calcCoords pure function, added effectivePosition state for auto-flip tracking, added useLayoutEffect for flip + clamp logic, added arrowOffset state for arrow tracking, reset all guards on scroll/resize/hide.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xbounceit/praetor/pull/121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
