### PR TITLE
feat(accounting,projects): add pricing breakdown, supplier order linkage, and project progress columns

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -3272,7 +3272,6 @@ const App: React.FC = () => {
                   invoices={invoices}
                   clients={clients}
                   products={products}
-                  clientsOrders={clientsOrders}
                   onAddInvoice={addInvoice}
                   onUpdateInvoice={handleUpdateInvoice}
                   onDeleteInvoice={handleDeleteInvoice}

--- a/components/accounting/ClientsInvoicesView.tsx
+++ b/components/accounting/ClientsInvoicesView.tsx
@@ -1,7 +1,7 @@
 import type React from 'react';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import type { Client, ClientsOrder, Invoice, InvoiceItem, Product } from '../../types';
+import type { Client, Invoice, InvoiceItem, Product } from '../../types';
 import { addDaysToDateOnly, formatDateOnlyForLocale, getLocalDateString } from '../../utils/date';
 import { calcProductSalePrice } from '../../utils/numbers';
 import CostSummaryPanel from '../shared/CostSummaryPanel';
@@ -16,7 +16,6 @@ export interface ClientsInvoicesViewProps {
   invoices: Invoice[];
   clients: Client[];
   products: Product[];
-  clientsOrders: ClientsOrder[];
   onAddInvoice: (invoiceData: Partial<Invoice>) => void;
   onUpdateInvoice: (id: string, updates: Partial<Invoice>) => void;
   onDeleteInvoice: (id: string) => void;
@@ -34,7 +33,6 @@ const ClientsInvoicesView: React.FC<ClientsInvoicesViewProps> = ({
   invoices,
   clients,
   products,
-  clientsOrders: _clientsOrders,
   onAddInvoice,
   onUpdateInvoice,
   onDeleteInvoice,

--- a/components/accounting/ClientsOrdersView.tsx
+++ b/components/accounting/ClientsOrdersView.tsx
@@ -29,7 +29,7 @@ import { makeCostUpdater, makeMolUpdater } from '../../utils/pricingHandlers';
 import CostSummaryPanel from '../shared/CostSummaryPanel';
 import CustomSelect from '../shared/CustomSelect';
 import Modal from '../shared/Modal';
-import StandardTable, { type Column } from '../shared/StandardTable';
+import StandardTable from '../shared/StandardTable';
 import StatusBadge, { type StatusType } from '../shared/StatusBadge';
 import Tooltip from '../shared/Tooltip';
 import UnitTypeSelector from '../shared/UnitTypeSelector';
@@ -109,7 +109,7 @@ const computeDueDate = (
   if (!createdAt) return '—';
   const baseDate = getLocalDateString(new Date(createdAt));
   const days = paymentTerms && paymentTerms !== 'immediate' ? Number.parseInt(paymentTerms, 10) : 0;
-  if (days <= 0) return formatDateOnlyForLocale(baseDate);
+  if (!Number.isFinite(days) || days <= 0) return formatDateOnlyForLocale(baseDate);
   return formatDateOnlyForLocale(addDaysToDateOnly(baseDate, days));
 };
 

--- a/components/accounting/ClientsOrdersView.tsx
+++ b/components/accounting/ClientsOrdersView.tsx
@@ -887,7 +887,7 @@ const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
                                 />
                               </div>
                             </div>
-                            <div className="flex flex-col items-center justify-center gap-1 lg:col-span-1">
+                            <div className="flex flex-col items-center justify-center min-h-[42px] gap-1 lg:col-span-1">
                               <label className="text-[10px] font-black uppercase tracking-wider text-slate-400 lg:hidden">
                                 {t('crm:internalListing.cost')}
                               </label>
@@ -915,7 +915,7 @@ const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
                                 </span>
                               </div>
                             </div>
-                            <div className="flex items-center justify-center space-y-1 lg:col-span-1">
+                            <div className="flex flex-col items-center justify-center min-h-[42px] lg:col-span-1">
                               <label className="text-[10px] font-black uppercase tracking-wider text-slate-400 lg:hidden">
                                 {t('sales:clientQuotes.molLabel', { defaultValue: 'MOL' })}
                               </label>
@@ -931,7 +931,7 @@ const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
                                 </span>
                               </div>
                             </div>
-                            <div className="flex items-center justify-center space-y-1 lg:col-span-1">
+                            <div className="flex flex-col items-center justify-center min-h-[42px] lg:col-span-1">
                               <label className="text-[10px] font-black uppercase tracking-wider text-slate-400 lg:hidden">
                                 {t('sales:clientQuotes.totalCost', { defaultValue: 'Total cost' })}
                               </label>
@@ -939,7 +939,7 @@ const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
                                 {lineCost.toFixed(2)} {currency}
                               </span>
                             </div>
-                            <div className="flex items-center justify-center space-y-1 lg:col-span-1">
+                            <div className="flex flex-col items-center justify-center min-h-[42px] lg:col-span-1">
                               <label className="text-[10px] font-black uppercase tracking-wider text-slate-400 lg:hidden">
                                 {t('sales:clientQuotes.marginLabel')}
                               </label>

--- a/components/accounting/ClientsOrdersView.tsx
+++ b/components/accounting/ClientsOrdersView.tsx
@@ -9,11 +9,18 @@ import type {
   SupplierUnitType,
 } from '../../types';
 import {
+  addDaysToDateOnly,
+  formatDateOnlyForLocale,
+  formatInsertDate,
+  getLocalDateString,
+} from '../../utils/date';
+import {
   calcProductSalePrice,
   calculatePricingTotals,
   convertUnitPrice,
   formatDiscountValue,
   getItemPricingContext,
+  type PricingTotals,
   parseNumberInputValue,
   roundToTwoDecimals,
 } from '../../utils/numbers';
@@ -22,7 +29,7 @@ import { makeCostUpdater, makeMolUpdater } from '../../utils/pricingHandlers';
 import CostSummaryPanel from '../shared/CostSummaryPanel';
 import CustomSelect from '../shared/CustomSelect';
 import Modal from '../shared/Modal';
-import StandardTable from '../shared/StandardTable';
+import StandardTable, { type Column } from '../shared/StandardTable';
 import StatusBadge, { type StatusType } from '../shared/StatusBadge';
 import Tooltip from '../shared/Tooltip';
 import UnitTypeSelector from '../shared/UnitTypeSelector';
@@ -54,6 +61,56 @@ const getOrderStatusLabel = (status: ClientsOrder['status'], t: (key: string) =>
   if (status === 'confirmed') return t('accounting:clientsOrders.statusConfirmed');
   if (status === 'denied') return t('accounting:clientsOrders.statusDenied');
   return t('accounting:clientsOrders.statusDraft');
+};
+
+const isHistoryRow = (status: ClientsOrder['status']) =>
+  status === 'confirmed' || status === 'denied';
+
+interface PricingCellProps {
+  value: number;
+  isHistory: boolean;
+  colorClass: string;
+  bold?: boolean;
+  prefix?: string;
+  dashOnZero?: boolean;
+  currency: string;
+}
+
+const PricingCell: React.FC<PricingCellProps> = ({
+  value,
+  isHistory,
+  colorClass,
+  bold = false,
+  prefix = '',
+  dashOnZero = false,
+  currency,
+}) => {
+  if (dashOnZero && value <= 0) {
+    return (
+      <span className={`text-sm font-semibold ${isHistory ? 'text-slate-300' : 'text-slate-400'}`}>
+        -
+      </span>
+    );
+  }
+  return (
+    <span
+      className={`text-sm ${bold ? 'font-bold' : 'font-semibold'} whitespace-nowrap ${isHistory ? 'text-slate-400' : colorClass}`}
+    >
+      {prefix}
+      {value.toFixed(2)} {currency}
+    </span>
+  );
+};
+
+const computeDueDate = (
+  createdAt: number | undefined,
+  paymentTerms: string | undefined | null,
+): string => {
+  if (!createdAt) return '—';
+  const baseDate = getLocalDateString(new Date(createdAt));
+  const days = paymentTerms && paymentTerms !== 'immediate' ? Number.parseInt(paymentTerms, 10) : 0;
+  if (days <= 0) return formatDateOnlyForLocale(baseDate);
+  return formatDateOnlyForLocale(addDaysToDateOnly(baseDate, days));
 };
 
 const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
@@ -258,6 +315,17 @@ const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
     return orders;
   }, [orders, offerFilterId]);
 
+  const orderPricingMap = useMemo(() => {
+    const map = new Map<string, PricingTotals>();
+    for (const order of filteredOrders) {
+      map.set(
+        order.id,
+        calculatePricingTotals(order.items, order.discount, DEFAULT_UNIT_TYPE, order.discountType),
+      );
+    }
+    return map;
+  }, [filteredOrders]);
+
   const paymentTermsOptions = useMemo(() => getPaymentTermsOptions(t), [t]);
 
   // Table columns definition with TableFilter support
@@ -272,51 +340,139 @@ const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
         ),
       },
       {
+        header: t('crm:clients.tableHeaders.insertDate'),
+        id: 'createdAt',
+        accessorFn: (row: ClientsOrder) => row.createdAt ?? 0,
+        className: 'whitespace-nowrap',
+        cell: ({ row }: { row: ClientsOrder }) => {
+          if (!row.createdAt) return <span className="text-xs text-slate-400">-</span>;
+          return (
+            <span className="text-xs text-slate-500 whitespace-nowrap">
+              {formatInsertDate(row.createdAt)}
+            </span>
+          );
+        },
+        filterFormat: (value: unknown) => {
+          const timestamp = typeof value === 'number' ? value : Number(value);
+          if (!Number.isFinite(timestamp) || timestamp <= 0) return '-';
+          return formatInsertDate(timestamp);
+        },
+      },
+      {
         header: t('accounting:clientsOrders.clientColumn'),
         accessorFn: (row: ClientsOrder) => row.clientName,
         cell: ({ row }: { row: ClientsOrder }) => (
           <div>
             <div
-              className={`font-bold ${row.status === 'confirmed' || row.status === 'denied' ? 'text-slate-400' : 'text-slate-800'}`}
+              className={`font-bold ${isHistoryRow(row.status) ? 'text-slate-400' : 'text-slate-800'}`}
             >
               {row.clientName}
             </div>
-            <div
-              className={`text-[10px] font-black uppercase tracking-wider ${row.status === 'confirmed' || row.status === 'denied' ? 'text-slate-400' : 'text-slate-400'}`}
-            >
+            <div className="text-[10px] font-black uppercase tracking-wider text-slate-400">
               {t('accounting:clientsOrders.itemsCount', { count: row.items.length })}
             </div>
           </div>
         ),
       },
       {
-        header: t('accounting:clientsOrders.totalColumn'),
-        accessorFn: (row: ClientsOrder) => {
-          const { total } = calculatePricingTotals(
-            row.items,
-            row.discount,
-            DEFAULT_UNIT_TYPE,
-            row.discountType,
-          );
-          return total;
-        },
+        header: t('sales:clientQuotes.globalDiscount'),
+        id: 'globalDiscount',
         className: 'whitespace-nowrap',
-        headerClassName: 'min-w-[8rem]',
+        headerClassName: 'min-w-[9rem]',
+        disableSorting: true,
+        disableFiltering: true,
         cell: ({ row }: { row: ClientsOrder }) => {
-          const { total } = calculatePricingTotals(
-            row.items,
-            row.discount,
-            DEFAULT_UNIT_TYPE,
-            row.discountType,
-          );
+          const history = isHistoryRow(row.status);
           return (
             <span
-              className={`text-sm font-bold whitespace-nowrap ${row.status === 'confirmed' || row.status === 'denied' ? 'text-slate-400' : 'text-slate-700'}`}
+              className={`text-sm font-semibold whitespace-nowrap ${history ? 'text-slate-400' : 'text-slate-600'}`}
             >
-              {total.toFixed(2)} {currency}
+              {formatDiscountValue(row.discount, row.discountType, currency)}
             </span>
           );
         },
+      },
+      {
+        header: t('accounting:clientsOrders.subtotal', { defaultValue: 'Subtotal' }),
+        id: 'subtotal',
+        accessorFn: (row: ClientsOrder) => orderPricingMap.get(row.id)?.subtotal ?? 0,
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[8rem]',
+        disableFiltering: true,
+        cell: ({ row, value }: { row: ClientsOrder; value: unknown }) => (
+          <PricingCell
+            value={Number(value)}
+            isHistory={isHistoryRow(row.status)}
+            colorClass="text-slate-700"
+            currency={currency}
+          />
+        ),
+      },
+      {
+        header: t('common:labels.discount'),
+        id: 'discountAmount',
+        accessorFn: (row: ClientsOrder) => orderPricingMap.get(row.id)?.discountAmount ?? 0,
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[8rem]',
+        disableFiltering: true,
+        cell: ({ row, value }: { row: ClientsOrder; value: unknown }) => (
+          <PricingCell
+            value={Number(value)}
+            isHistory={isHistoryRow(row.status)}
+            colorClass="text-amber-600"
+            prefix="-"
+            dashOnZero
+            currency={currency}
+          />
+        ),
+      },
+      {
+        header: t('accounting:clientsOrders.margin'),
+        id: 'margin',
+        accessorFn: (row: ClientsOrder) => orderPricingMap.get(row.id)?.margin ?? 0,
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[8rem]',
+        disableFiltering: true,
+        cell: ({ row, value }: { row: ClientsOrder; value: unknown }) => (
+          <PricingCell
+            value={Number(value)}
+            isHistory={isHistoryRow(row.status)}
+            colorClass="text-emerald-600"
+            bold
+            currency={currency}
+          />
+        ),
+      },
+      {
+        header: t('sales:clientQuotes.totalCost', { defaultValue: 'Total cost' }),
+        id: 'totalCost',
+        accessorFn: (row: ClientsOrder) => orderPricingMap.get(row.id)?.totalCost ?? 0,
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[8rem]',
+        disableFiltering: true,
+        cell: ({ row, value }: { row: ClientsOrder; value: unknown }) => (
+          <PricingCell
+            value={Number(value)}
+            isHistory={isHistoryRow(row.status)}
+            colorClass="text-slate-700"
+            currency={currency}
+          />
+        ),
+      },
+      {
+        header: t('accounting:clientsOrders.totalColumn'),
+        accessorFn: (row: ClientsOrder) => orderPricingMap.get(row.id)?.total ?? 0,
+        className: 'whitespace-nowrap',
+        headerClassName: 'min-w-[8rem]',
+        cell: ({ row, value }: { row: ClientsOrder; value: unknown }) => (
+          <PricingCell
+            value={Number(value)}
+            isHistory={isHistoryRow(row.status)}
+            colorClass="text-slate-700"
+            bold
+            currency={currency}
+          />
+        ),
         filterFormat: (val: unknown) => (val as number).toFixed(2),
       },
       {
@@ -327,7 +483,7 @@ const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
         headerClassName: 'min-w-[10rem]',
         cell: ({ row }: { row: ClientsOrder }) => (
           <span
-            className={`text-sm font-semibold ${row.status === 'confirmed' || row.status === 'denied' ? 'text-slate-400' : 'text-slate-600'}`}
+            className={`text-sm font-semibold ${isHistoryRow(row.status) ? 'text-slate-400' : 'text-slate-600'}`}
           >
             {row.paymentTerms === 'immediate' ? t('crm:paymentTerms.immediate') : row.paymentTerms}
           </span>
@@ -339,9 +495,7 @@ const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
         className: 'whitespace-nowrap',
         headerClassName: 'min-w-[9rem]',
         cell: ({ row }: { row: ClientsOrder }) => (
-          <div
-            className={row.status === 'confirmed' || row.status === 'denied' ? 'opacity-60' : ''}
-          >
+          <div className={isHistoryRow(row.status) ? 'opacity-60' : ''}>
             <StatusBadge
               type={row.status as StatusType}
               label={getOrderStatusLabel(row.status, t)}
@@ -446,7 +600,7 @@ const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
         ),
       },
     ],
-    [currency, onUpdateClientsOrder, onViewOffer, t, confirmDelete, openEditModal],
+    [currency, onUpdateClientsOrder, onViewOffer, t, confirmDelete, openEditModal, orderPricingMap],
   );
 
   return (
@@ -521,7 +675,7 @@ const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
                 <span className="h-1.5 w-1.5 rounded-full bg-praetor"></span>
                 {t('accounting:clientsOrders.orderDetails')}
               </h4>
-              <div className="grid grid-cols-2 lg:grid-cols-3 gap-3">
+              <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
                 <div className="space-y-1.5">
                   <label className="ml-1 text-xs font-bold text-slate-500">
                     {t('accounting:clientsOrders.client')}
@@ -564,6 +718,16 @@ const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
                     disabled={isReadOnly}
                   />
                 </div>
+                <div className="space-y-1.5">
+                  <label className="ml-1 text-xs font-bold text-slate-500">
+                    {t('accounting:clientsOrders.paymentDueDate', {
+                      defaultValue: 'Payment due date',
+                    })}
+                  </label>
+                  <div className="w-full text-sm px-4 py-2.5 bg-slate-50 border border-slate-200 rounded-xl text-slate-700 font-bold">
+                    {computeDueDate(editingOrder?.createdAt, formData.paymentTerms)}
+                  </div>
+                </div>
               </div>
             </div>
 
@@ -589,7 +753,12 @@ const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
 
               {formData.items && formData.items.length > 0 && (
                 <div className="hidden lg:flex gap-2 px-3 mb-1 items-center">
-                  <div className="grid flex-1 grid-cols-10 gap-2 text-[10px] font-black uppercase tracking-wider text-slate-400">
+                  <div className="grid flex-1 grid-cols-12 gap-2 text-[10px] font-black uppercase tracking-wider text-slate-400">
+                    <div className="col-span-2">
+                      {t('accounting:clientsOrders.supplierOrderColumn', {
+                        defaultValue: 'Supplier Order',
+                      })}
+                    </div>
                     <div className="col-span-2">{t('sales:clientQuotes.productsServices')}</div>
                     <div className="col-span-2 text-center">{t('sales:clientQuotes.qty')}</div>
                     <div className="col-span-1 text-center">{t('crm:internalListing.cost')}</div>
@@ -643,7 +812,27 @@ const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
                         className="space-y-3 rounded-xl border border-slate-100 bg-slate-50 p-3"
                       >
                         <div className="flex items-start gap-2">
-                          <div className="grid flex-1 grid-cols-1 gap-2 lg:grid-cols-10">
+                          <div className="grid flex-1 grid-cols-1 gap-2 lg:grid-cols-12">
+                            <div className="space-y-1 lg:col-span-2 min-w-0">
+                              <label className="text-[10px] font-black uppercase tracking-wider text-slate-400 lg:hidden">
+                                {t('accounting:clientsOrders.supplierOrderColumn', {
+                                  defaultValue: 'Supplier Order',
+                                })}
+                              </label>
+                              <div className="flex items-center min-h-[42px] px-3 py-2 bg-slate-50 border border-slate-200 rounded-lg">
+                                {item.supplierSaleId ? (
+                                  <span className="text-xs font-semibold text-slate-700 truncate">
+                                    {item.supplierSaleSupplierName ?? '—'} · {item.supplierSaleId}
+                                  </span>
+                                ) : (
+                                  <span className="text-xs text-slate-400">
+                                    {t('accounting:clientsOrders.noSupplierOrder', {
+                                      defaultValue: 'No supplier order',
+                                    })}
+                                  </span>
+                                )}
+                              </div>
+                            </div>
                             <div className="space-y-1 lg:col-span-2 min-w-0">
                               <label className="text-[10px] font-black uppercase tracking-wider text-slate-400 lg:hidden">
                                 {t('sales:clientQuotes.productsServices')}
@@ -702,6 +891,13 @@ const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
                               {item.supplierQuoteItemId && (
                                 <span className={`${pillBadgeClass} bg-emerald-600`}>
                                   {t('sales:clientQuotes.supplierQuoteBadge')}
+                                </span>
+                              )}
+                              {item.supplierSaleId && (
+                                <span className={`${pillBadgeClass} bg-blue-600`}>
+                                  {t('accounting:clientsOrders.supplierOrderBadge', {
+                                    defaultValue: 'Supplier order',
+                                  })}
                                 </span>
                               )}
                               <div className="flex items-center gap-1">
@@ -917,9 +1113,7 @@ const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
         defaultRowsPerPage={10}
         containerClassName="overflow-visible"
         rowClassName={(row: ClientsOrder) =>
-          row.status === 'confirmed' || row.status === 'denied'
-            ? 'bg-slate-50 text-slate-400'
-            : 'hover:bg-slate-50/50'
+          isHistoryRow(row.status) ? 'bg-slate-50 text-slate-400' : 'hover:bg-slate-50/50'
         }
         onRowClick={(row: ClientsOrder) => openEditModal(row)}
       />

--- a/components/accounting/ClientsOrdersView.tsx
+++ b/components/accounting/ClientsOrdersView.tsx
@@ -1,3 +1,4 @@
+import type { TFunction } from 'i18next';
 import type React from 'react';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -105,10 +106,12 @@ const PricingCell: React.FC<PricingCellProps> = ({
 const computeDueDate = (
   createdAt: number | undefined,
   paymentTerms: string | undefined | null,
+  t: TFunction,
 ): string => {
   if (!createdAt) return '—';
+  if (paymentTerms === 'immediate') return t('crm:paymentTerms.immediate');
   const baseDate = getLocalDateString(new Date(createdAt));
-  const days = paymentTerms && paymentTerms !== 'immediate' ? Number.parseInt(paymentTerms, 10) : 0;
+  const days = Number.parseInt(paymentTerms ?? '', 10);
   if (!Number.isFinite(days) || days <= 0) return formatDateOnlyForLocale(baseDate);
   return formatDateOnlyForLocale(addDaysToDateOnly(baseDate, days));
 };
@@ -725,7 +728,7 @@ const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
                     })}
                   </label>
                   <div className="w-full text-sm px-4 py-2.5 bg-slate-50 border border-slate-200 rounded-xl text-slate-700 font-bold">
-                    {computeDueDate(editingOrder?.createdAt, formData.paymentTerms)}
+                    {computeDueDate(editingOrder?.createdAt, formData.paymentTerms, t)}
                   </div>
                 </div>
               </div>

--- a/components/accounting/ClientsOrdersView.tsx
+++ b/components/accounting/ClientsOrdersView.tsx
@@ -887,39 +887,41 @@ const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
                                 />
                               </div>
                             </div>
-                            <div className="flex flex-col items-center justify-center min-h-[42px] gap-1 lg:col-span-1">
+                            <div className="space-y-1 lg:col-span-1">
                               <label className="text-[10px] font-black uppercase tracking-wider text-slate-400 lg:hidden">
                                 {t('crm:internalListing.cost')}
                               </label>
-                              {item.supplierQuoteItemId && (
-                                <span className={`${pillBadgeClass} bg-emerald-600`}>
-                                  {t('sales:clientQuotes.supplierQuoteBadge')}
-                                </span>
-                              )}
-                              {item.supplierSaleId && (
-                                <span className={`${pillBadgeClass} bg-blue-600`}>
-                                  {t('accounting:clientsOrders.supplierOrderBadge', {
-                                    defaultValue: 'Supplier order',
-                                  })}
-                                </span>
-                              )}
-                              <div className="flex items-center gap-1">
-                                <ValidatedNumberInput
-                                  value={unitCost.toFixed(2)}
-                                  onValueChange={handleCostChange}
-                                  disabled={isReadOnly}
-                                  className={compactInputClass}
-                                />
-                                <span className="text-[9px] font-semibold text-slate-400 shrink-0">
-                                  {currency}
-                                </span>
+                              <div className="flex flex-col items-center justify-center min-h-[42px] gap-1">
+                                {item.supplierQuoteItemId && (
+                                  <span className={`${pillBadgeClass} bg-emerald-600`}>
+                                    {t('sales:clientQuotes.supplierQuoteBadge')}
+                                  </span>
+                                )}
+                                {item.supplierSaleId && (
+                                  <span className={`${pillBadgeClass} bg-blue-600`}>
+                                    {t('accounting:clientsOrders.supplierOrderBadge', {
+                                      defaultValue: 'Supplier order',
+                                    })}
+                                  </span>
+                                )}
+                                <div className="flex items-center gap-1">
+                                  <ValidatedNumberInput
+                                    value={unitCost.toFixed(2)}
+                                    onValueChange={handleCostChange}
+                                    disabled={isReadOnly}
+                                    className={compactInputClass}
+                                  />
+                                  <span className="text-[9px] font-semibold text-slate-400 shrink-0">
+                                    {currency}
+                                  </span>
+                                </div>
                               </div>
                             </div>
-                            <div className="flex flex-col items-center justify-center min-h-[42px] lg:col-span-1">
+                            <div className="space-y-1 lg:col-span-1">
                               <label className="text-[10px] font-black uppercase tracking-wider text-slate-400 lg:hidden">
                                 {t('sales:clientQuotes.molLabel', { defaultValue: 'MOL' })}
                               </label>
-                              <div className="flex items-center gap-1">
+                              <div className="flex items-center justify-center min-h-[42px] gap-1">
                                 <ValidatedNumberInput
                                   value={molPercentage.toFixed(1)}
                                   onValueChange={handleMolChange}
@@ -931,21 +933,25 @@ const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
                                 </span>
                               </div>
                             </div>
-                            <div className="flex flex-col items-center justify-center min-h-[42px] lg:col-span-1">
+                            <div className="space-y-1 lg:col-span-1">
                               <label className="text-[10px] font-black uppercase tracking-wider text-slate-400 lg:hidden">
                                 {t('sales:clientQuotes.totalCost', { defaultValue: 'Total cost' })}
                               </label>
-                              <span className="text-xs font-bold text-slate-700 whitespace-nowrap">
-                                {lineCost.toFixed(2)} {currency}
-                              </span>
+                              <div className="flex items-center justify-center min-h-[42px]">
+                                <span className="text-xs font-bold text-slate-700 whitespace-nowrap">
+                                  {lineCost.toFixed(2)} {currency}
+                                </span>
+                              </div>
                             </div>
-                            <div className="flex flex-col items-center justify-center min-h-[42px] lg:col-span-1">
+                            <div className="space-y-1 lg:col-span-1">
                               <label className="text-[10px] font-black uppercase tracking-wider text-slate-400 lg:hidden">
                                 {t('sales:clientQuotes.marginLabel')}
                               </label>
-                              <span className="text-xs font-bold text-emerald-600">
-                                {margin.toFixed(2)} {currency}
-                              </span>
+                              <div className="flex items-center justify-center min-h-[42px]">
+                                <span className="text-xs font-bold text-emerald-600">
+                                  {margin.toFixed(2)} {currency}
+                                </span>
+                              </div>
                             </div>
                             <div className="space-y-1 lg:col-span-2">
                               <label className="text-[10px] font-black uppercase tracking-wider text-slate-400 lg:hidden">

--- a/components/projects/ProjectsView.tsx
+++ b/components/projects/ProjectsView.tsx
@@ -121,7 +121,7 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
   const [taskEdits, setTaskEdits] = useState<Record<string, Record<string, string>>>({});
   const [taskToDelete, setTaskToDelete] = useState<ProjectTask | null>(null);
   const [isTaskDeleteConfirmOpen, setIsTaskDeleteConfirmOpen] = useState(false);
-  const fetchHoursIdRef = useRef<string | null>(null);
+  const fetchHoursAbortRef = useRef<AbortController | null>(null);
   const fetchAllHoursGenRef = useRef(0);
   const [allProjectHours, setAllProjectHours] = useState<Record<
     string,
@@ -137,10 +137,10 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
     }
   };
 
-  const projectIds = useMemo(() => projects.map((p) => p.id).join(','), [projects]);
+  const projectIds = useMemo(() => projects.map((p) => p.id), [projects]);
 
   useEffect(() => {
-    if (projects.length === 0) {
+    if (projectIds.length === 0) {
       setAllProjectHours({});
       return;
     }
@@ -149,10 +149,7 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
     setAllProjectHours(null);
     (async () => {
       try {
-        const map = await tasksApi.getHoursForProjects(
-          projects.map((p) => p.id),
-          abortController.signal,
-        );
+        const map = await tasksApi.getHoursForProjects(projectIds, abortController.signal);
         if (fetchAllHoursGenRef.current !== gen) return;
         setAllProjectHours(map);
       } catch (e) {
@@ -237,17 +234,18 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
     setProjectTaskHours({});
     setHoursLoadState('loading');
     setIsModalOpen(true);
-    const fetchId = project.id;
-    fetchHoursIdRef.current = fetchId;
+    fetchHoursAbortRef.current?.abort();
+    const ac = new AbortController();
+    fetchHoursAbortRef.current = ac;
     tasksApi
-      .getHours(project.id)
+      .getHours(project.id, ac.signal)
       .then((h) => {
-        if (fetchHoursIdRef.current !== fetchId) return;
+        if (ac.signal.aborted) return;
         setProjectTaskHours(h);
         setHoursLoadState('idle');
       })
       .catch(() => {
-        if (fetchHoursIdRef.current !== fetchId) return;
+        if (ac.signal.aborted) return;
         setHoursLoadState('error');
       });
   };

--- a/components/projects/ProjectsView.tsx
+++ b/components/projects/ProjectsView.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { COLORS } from '../../constants';
 import { projectsApi, tasksApi } from '../../services/api';
@@ -13,6 +13,8 @@ import Toggle from '../shared/Toggle';
 import Tooltip from '../shared/Tooltip';
 import UserAssignmentModal from '../shared/UserAssignmentModal';
 import type { RecurringConfig } from './TasksView';
+
+const isValidHex = (v: string) => /^#[0-9a-fA-F]{6}$/.test(v);
 
 type DraftTask = {
   _id: string;
@@ -120,6 +122,88 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
   const [taskToDelete, setTaskToDelete] = useState<ProjectTask | null>(null);
   const [isTaskDeleteConfirmOpen, setIsTaskDeleteConfirmOpen] = useState(false);
   const fetchHoursIdRef = useRef<string | null>(null);
+  const fetchAllHoursGenRef = useRef(0);
+  const [allProjectHours, setAllProjectHours] = useState<Record<
+    string,
+    Record<string, number>
+  > | null>(null);
+  const [hexInput, setHexInput] = useState('');
+
+  const commitHexInput = () => {
+    if (isValidHex(hexInput)) {
+      setColor(hexInput);
+    } else {
+      setHexInput(color);
+    }
+  };
+
+  const projectIds = useMemo(() => projects.map((p) => p.id).join(','), [projects]);
+
+  useEffect(() => {
+    if (projects.length === 0) {
+      setAllProjectHours({});
+      return;
+    }
+    const gen = ++fetchAllHoursGenRef.current;
+    const abortController = new AbortController();
+    setAllProjectHours(null);
+    (async () => {
+      try {
+        const map = await tasksApi.getHoursForProjects(
+          projects.map((p) => p.id),
+          abortController.signal,
+        );
+        if (fetchAllHoursGenRef.current !== gen) return;
+        setAllProjectHours(map);
+      } catch (e) {
+        if (abortController.signal.aborted) return;
+        console.error('Failed to load project hours', e);
+        if (fetchAllHoursGenRef.current !== gen) return;
+        setAllProjectHours({});
+      }
+    })();
+    return () => {
+      abortController.abort();
+    };
+  }, [projectIds]);
+
+  const projectMedianProgress = useMemo(() => {
+    if (!allProjectHours) return {};
+    const tasksByProject = new Map<string, ProjectTask[]>();
+    for (const t of tasks) {
+      const arr = tasksByProject.get(t.projectId);
+      if (arr) arr.push(t);
+      else tasksByProject.set(t.projectId, [t]);
+    }
+    const map: Record<string, number | null> = {};
+    for (const project of projects) {
+      const projectTasks = tasksByProject.get(project.id);
+      const hours = allProjectHours[project.id];
+      if (!hours || !projectTasks || projectTasks.length === 0) {
+        map[project.id] = null;
+        continue;
+      }
+      const progressValues = projectTasks
+        .filter((t) => (t.expectedEffort ?? 0) > 0)
+        .map((t) => {
+          const logged = hours[t.name] ?? 0;
+          const effort = t.expectedEffort as number;
+          return (logged / effort) * 100;
+        });
+      if (progressValues.length === 0) {
+        map[project.id] = null;
+        continue;
+      }
+      progressValues.sort((a, b) => a - b);
+      const mid = Math.floor(progressValues.length / 2);
+      const median =
+        progressValues.length % 2 !== 0
+          ? progressValues[mid]
+          : (progressValues[mid - 1] + progressValues[mid]) / 2;
+      map[project.id] = median;
+    }
+    return map;
+  }, [projects, tasks, allProjectHours]);
 
   // Modal Handlers
   const openAddModal = () => {
@@ -130,6 +214,7 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
     setClientId('');
     setDescription('');
     setColor(COLORS[0]);
+    setHexInput(COLORS[0]);
     setTempIsDisabled(false);
     setDraftTasks([]);
     setErrors({});
@@ -144,6 +229,7 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
     setOrderId('');
     setDescription(project.description || '');
     setColor(project.color);
+    setHexInput(project.color);
     setTempIsDisabled(project.isDisabled || false);
     setDraftTasks([]);
     setErrors({});
@@ -736,19 +822,53 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
                 <label className="text-xs font-bold text-slate-500 ml-1">
                   {t('projects:projects.color')}
                 </label>
-                <div className="flex flex-wrap gap-2 p-3 bg-slate-50 rounded-xl border border-slate-200">
+                <div className="flex flex-wrap items-center gap-2 p-3 bg-slate-50 rounded-xl border border-slate-200">
                   {COLORS.map((c) => (
                     <Tooltip key={c} label={c}>
                       {() => (
                         <button
                           type="button"
-                          onClick={() => setColor(c)}
+                          onClick={() => {
+                            setColor(c);
+                            setHexInput(c);
+                          }}
                           className={`w-8 h-8 rounded-full border-2 transition-all transform active:scale-90 ${color === c ? 'border-praetor scale-110 shadow-md' : 'border-transparent hover:scale-105'}`}
                           style={{ backgroundColor: c }}
                         />
                       )}
                     </Tooltip>
                   ))}
+                  <div className="flex items-center gap-2 ml-1 pl-3 border-l border-slate-300">
+                    <input
+                      type="color"
+                      value={color}
+                      onChange={(e) => {
+                        setColor(e.target.value);
+                        setHexInput(e.target.value);
+                      }}
+                      className="w-8 h-8 rounded-lg cursor-pointer border-2 border-slate-200 p-0.5 bg-transparent [&::-webkit-color-swatch-wrapper]:p-0 [&::-webkit-color-swatch]:rounded-md [&::-moz-color-swatch]:rounded-md [&::-moz-color-swatch]:border-none"
+                    />
+                    <input
+                      type="text"
+                      value={hexInput}
+                      onChange={(e) => {
+                        const val = e.target.value;
+                        setHexInput(val);
+                        if (isValidHex(val)) {
+                          setColor(val);
+                        }
+                      }}
+                      onBlur={commitHexInput}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                          e.preventDefault();
+                          commitHexInput();
+                        }
+                      }}
+                      placeholder="#000000"
+                      className="w-[90px] text-xs px-2 py-1.5 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none font-mono tabular-nums"
+                    />
+                  </div>
                 </div>
               </div>
 
@@ -985,6 +1105,40 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
                   {row.description || t('projects:projects.noDescriptionProvided')}
                 </p>
               ),
+            },
+            {
+              header: t('projects:projects.tableHeaders.progress'),
+              id: 'progress',
+              disableFiltering: true,
+              disableSorting: true,
+              cell: ({ row }) => {
+                if (allProjectHours === null) {
+                  return (
+                    <span className="text-slate-400 text-xs">
+                      <i className="fa-solid fa-spinner fa-spin"></i>
+                    </span>
+                  );
+                }
+                const median = projectMedianProgress[row.id];
+                if (median === null) return <span className="text-slate-400 text-xs">—</span>;
+                const pct = Math.round(median);
+                const overBudget = median > 100;
+                return (
+                  <div className="flex items-center gap-2">
+                    <div className="w-16 h-1.5 bg-slate-100 rounded-full overflow-hidden">
+                      <div
+                        className={`h-full rounded-full transition-all ${overBudget ? 'bg-red-500' : pct >= 80 ? 'bg-amber-500' : 'bg-emerald-500'}`}
+                        style={{ width: `${Math.min(pct, 100)}%` }}
+                      />
+                    </div>
+                    <span
+                      className={`text-xs font-bold tabular-nums ${overBudget ? 'text-red-600' : 'text-slate-600'}`}
+                    >
+                      {pct}%
+                    </span>
+                  </div>
+                );
+              },
             },
             {
               header: t('projects:projects.tableHeaders.status'),

--- a/locales/en/accounting.json
+++ b/locales/en/accounting.json
@@ -40,7 +40,11 @@
     "subtotal": "Subtotal",
     "total": "Total",
     "margin": "Margin",
-    "orderNumber": "Order Number"
+    "orderNumber": "Order Number",
+    "supplierOrderColumn": "Supplier Order",
+    "noSupplierOrder": "No supplier order",
+    "supplierOrderBadge": "Supplier order",
+    "paymentDueDate": "Payment due date"
   },
   "clientsInvoices": {
     "title": "Client's Invoices",

--- a/locales/en/projects.json
+++ b/locales/en/projects.json
@@ -65,6 +65,7 @@
       "client": "Client",
       "projectName": "Project Name",
       "description": "Description",
+      "progress": "Progress",
       "status": "Status",
       "actions": "Actions"
     }

--- a/locales/it/accounting.json
+++ b/locales/it/accounting.json
@@ -40,7 +40,11 @@
     "subtotal": "Imponibile",
     "total": "Totale",
     "margin": "Margine",
-    "orderNumber": "Numero ordine"
+    "orderNumber": "Numero ordine",
+    "supplierOrderColumn": "Ordine fornitore",
+    "noSupplierOrder": "Nessun ordine fornitore",
+    "supplierOrderBadge": "Ordine fornitore",
+    "paymentDueDate": "Data scadenza pagamento"
   },
   "clientsInvoices": {
     "title": "Fatture Clienti",

--- a/locales/it/projects.json
+++ b/locales/it/projects.json
@@ -65,6 +65,7 @@
       "client": "Cliente",
       "projectName": "Nome Progetto",
       "description": "Descrizione",
+      "progress": "Avanzamento",
       "status": "Stato",
       "actions": "Azioni"
     }

--- a/server/db/schema.sql
+++ b/server/db/schema.sql
@@ -1129,8 +1129,21 @@ ALTER TABLE sale_items ADD COLUMN IF NOT EXISTS supplier_quote_item_id VARCHAR(5
 ALTER TABLE sale_items ADD COLUMN IF NOT EXISTS supplier_quote_supplier_name VARCHAR(255);
 ALTER TABLE sale_items ADD COLUMN IF NOT EXISTS supplier_quote_unit_price DECIMAL(15, 2);
 
+-- Supplier-sale-order linkage columns for sale_items
+ALTER TABLE sale_items ADD COLUMN IF NOT EXISTS supplier_sale_id VARCHAR(100);
+ALTER TABLE sale_items ADD COLUMN IF NOT EXISTS supplier_sale_item_id VARCHAR(50);
+ALTER TABLE sale_items ADD COLUMN IF NOT EXISTS supplier_sale_supplier_name VARCHAR(255);
+
+-- Backfill: link existing sale_items to their auto-created supplier_sales via shared supplier_quote_id
+UPDATE sale_items si
+SET supplier_sale_id = ss.id,
+    supplier_sale_supplier_name = ss.supplier_name
+FROM supplier_sales ss
+WHERE ss.linked_quote_id = si.supplier_quote_id
+  AND si.supplier_sale_id IS NULL;
 
 CREATE INDEX IF NOT EXISTS idx_sale_items_sale_id ON sale_items(sale_id);
+CREATE INDEX IF NOT EXISTS idx_sale_items_supplier_sale_id ON sale_items(supplier_sale_id);
 
 -- Migration: Ensure sale_items prices use DECIMAL(15, 2)
 DO $$

--- a/server/routes/clients-orders.ts
+++ b/server/routes/clients-orders.ts
@@ -483,7 +483,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       }
 
       // Insert order items
-      const createdItems: ReturnType<typeof normalizeClientOrderItemRow>[] = [];
       for (const item of normalizedItems) {
         const itemId = 'si-' + Date.now() + '-' + Math.random().toString(36).substring(2, 11);
         const itemResult = await query(
@@ -528,9 +527,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
             item.supplierSaleSupplierName ?? null,
             item.unitType || 'hours',
           ],
-        );
-        createdItems.push(
-          normalizeClientOrderItemRow(itemResult.rows[0] as Record<string, unknown>),
         );
       }
 
@@ -658,6 +654,33 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         }
       }
 
+      // Re-fetch items to pick up supplier_sale_* fields set during auto-creation
+      const refreshedItems = await query(
+        `SELECT
+                id,
+                sale_id as "orderId",
+                product_id as "productId",
+                product_name as "productName",
+                quantity,
+                unit_price as "unitPrice",
+                product_cost as "productCost",
+                product_mol_percentage as "productMolPercentage",
+                supplier_quote_id as "supplierQuoteId",
+                supplier_quote_item_id as "supplierQuoteItemId",
+                supplier_quote_supplier_name as "supplierQuoteSupplierName",
+                supplier_quote_unit_price as "supplierQuoteUnitPrice",
+                supplier_sale_id as "supplierSaleId",
+                supplier_sale_item_id as "supplierSaleItemId",
+                supplier_sale_supplier_name as "supplierSaleSupplierName",
+                unit_type as "unitType",
+                note,
+                discount
+            FROM sale_items
+            WHERE sale_id = $1
+            ORDER BY created_at ASC`,
+        [orderId],
+      );
+
       await logAudit({
         request,
         action: 'client_order.created',
@@ -670,7 +693,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       });
       return reply.code(201).send({
         ...normalizeClientOrderRow(orderResult.rows[0] as Record<string, unknown>),
-        items: createdItems,
+        items: refreshedItems.rows.map((item) =>
+          normalizeClientOrderItemRow(item as Record<string, unknown>),
+        ),
         ...(supplierOrderWarnings.length > 0 ? { warnings: supplierOrderWarnings } : {}),
       });
     },

--- a/server/routes/clients-orders.ts
+++ b/server/routes/clients-orders.ts
@@ -621,6 +621,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
               [supplierOrderId, sq.supplierName, orderId, sqId],
             );
 
+            // Map each supplier_sale_item back to its sale_item via quote_item_id.
+            // Safe because each supplier quote item maps 1:1 to a sale item within
+            // (sale_id, supplier_quote_id) — duplicates prevented by business logic.
             if (insertedSupplierItemIds.length > 0) {
               const valuesPlaceholders = insertedSupplierItemIds
                 .map((_, i) => `($${i * 2 + 3}, $${i * 2 + 4})`)

--- a/server/routes/clients-orders.ts
+++ b/server/routes/clients-orders.ts
@@ -48,6 +48,9 @@ const clientOrderItemSchema = {
     supplierQuoteItemId: { type: ['string', 'null'] },
     supplierQuoteSupplierName: { type: ['string', 'null'] },
     supplierQuoteUnitPrice: { type: ['number', 'null'] },
+    supplierSaleId: { type: ['string', 'null'] },
+    supplierSaleItemId: { type: ['string', 'null'] },
+    supplierSaleSupplierName: { type: ['string', 'null'] },
     unitType: { type: 'string', enum: ['hours', 'days', 'unit'] },
     note: { type: ['string', 'null'] },
     discount: { type: 'number' },
@@ -100,6 +103,9 @@ const clientOrderItemBodySchema = {
     supplierQuoteItemId: { type: 'string' },
     supplierQuoteSupplierName: { type: 'string' },
     supplierQuoteUnitPrice: { type: 'number' },
+    supplierSaleId: { type: 'string' },
+    supplierSaleItemId: { type: 'string' },
+    supplierSaleSupplierName: { type: 'string' },
     unitType: { type: 'string', enum: ['hours', 'days', 'unit'] },
     discount: { type: 'number' },
     note: { type: 'string' },
@@ -178,6 +184,9 @@ const normalizeClientOrderItemRow = (row: Record<string, unknown>) => ({
     row.supplierQuoteUnitPrice,
     'clientOrderItem.supplierQuoteUnitPrice',
   ),
+  supplierSaleId: toNullableString(row.supplierSaleId),
+  supplierSaleItemId: toNullableString(row.supplierSaleItemId),
+  supplierSaleSupplierName: toNullableString(row.supplierSaleSupplierName),
   unitType: normalizeUnitType(row.unitType),
   note: toNullableString(row.note),
   discount: toFiniteNumber(row.discount, 'clientOrderItem.discount'),
@@ -255,6 +264,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
                 supplier_quote_item_id as "supplierQuoteItemId",
                 supplier_quote_supplier_name as "supplierQuoteSupplierName",
                 supplier_quote_unit_price as "supplierQuoteUnitPrice",
+                supplier_sale_id as "supplierSaleId",
+                supplier_sale_item_id as "supplierSaleItemId",
+                supplier_sale_supplier_name as "supplierSaleSupplierName",
                 unit_type as "unitType",
                 note,
                 discount
@@ -475,8 +487,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       for (const item of normalizedItems) {
         const itemId = 'si-' + Date.now() + '-' + Math.random().toString(36).substring(2, 11);
         const itemResult = await query(
-          `INSERT INTO sale_items (id, sale_id, product_id, product_name, quantity, unit_price, product_cost, product_mol_percentage, discount, note, supplier_quote_id, supplier_quote_item_id, supplier_quote_supplier_name, supplier_quote_unit_price, unit_type)
-                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+          `INSERT INTO sale_items (id, sale_id, product_id, product_name, quantity, unit_price, product_cost, product_mol_percentage, discount, note, supplier_quote_id, supplier_quote_item_id, supplier_quote_supplier_name, supplier_quote_unit_price, supplier_sale_id, supplier_sale_item_id, supplier_sale_supplier_name, unit_type)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
                  RETURNING
                     id,
                     sale_id as "orderId",
@@ -490,6 +502,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
                     supplier_quote_item_id as "supplierQuoteItemId",
                     supplier_quote_supplier_name as "supplierQuoteSupplierName",
                     supplier_quote_unit_price as "supplierQuoteUnitPrice",
+                    supplier_sale_id as "supplierSaleId",
+                    supplier_sale_item_id as "supplierSaleItemId",
+                    supplier_sale_supplier_name as "supplierSaleSupplierName",
                     unit_type as "unitType",
                     discount,
                     note`,
@@ -508,6 +523,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
             item.supplierQuoteItemId ?? null,
             item.supplierQuoteSupplierName ?? null,
             item.supplierQuoteUnitPrice ?? null,
+            item.supplierSaleId ?? null,
+            item.supplierSaleItemId ?? null,
+            item.supplierSaleSupplierName ?? null,
             item.unitType || 'hours',
           ],
         );
@@ -566,6 +584,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
               ],
             );
 
+            const insertedSupplierItemIds: { quoteItemId: string; saleItemId: string }[] = [];
+
             if (items.length > 0) {
               const placeholders = items
                 .map(
@@ -573,19 +593,48 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
                     `($${i * 7 + 1}, $${i * 7 + 2}, $${i * 7 + 3}, $${i * 7 + 4}, $${i * 7 + 5}, $${i * 7 + 6}, $${i * 7 + 7})`,
                 )
                 .join(', ');
-              const params = items.flatMap((item) => [
-                generateItemId('ssi-'),
-                supplierOrderId,
-                item.productId,
-                item.productName,
-                item.quantity,
-                item.unitPrice,
-                item.note,
-              ]);
+              const params = items.flatMap((item) => {
+                const saleItemId = generateItemId('ssi-');
+                insertedSupplierItemIds.push({ quoteItemId: item.id, saleItemId });
+                return [
+                  saleItemId,
+                  supplierOrderId,
+                  item.productId,
+                  item.productName,
+                  item.quantity,
+                  item.unitPrice,
+                  item.note,
+                ];
+              });
               await tx.query(
                 `INSERT INTO supplier_sale_items (id, sale_id, product_id, product_name, quantity, unit_price, note)
                  VALUES ${placeholders}`,
                 params,
+              );
+            }
+
+            await tx.query(
+              `UPDATE sale_items
+                 SET supplier_sale_id = $1,
+                     supplier_sale_supplier_name = $2
+               WHERE sale_id = $3 AND supplier_quote_id = $4`,
+              [supplierOrderId, sq.supplierName, orderId, sqId],
+            );
+
+            if (insertedSupplierItemIds.length > 0) {
+              const valuesPlaceholders = insertedSupplierItemIds
+                .map((_, i) => `($${i * 2 + 3}, $${i * 2 + 4})`)
+                .join(', ');
+              const mappingParams = insertedSupplierItemIds.flatMap(
+                ({ quoteItemId, saleItemId }) => [quoteItemId, saleItemId],
+              );
+              await tx.query(
+                `UPDATE sale_items si
+                   SET supplier_sale_item_id = v.sale_item_id
+                 FROM (VALUES ${valuesPlaceholders}) v(quote_item_id, sale_item_id)
+                 WHERE si.sale_id = $1 AND si.supplier_quote_id = $2
+                   AND si.supplier_quote_item_id = v.quote_item_id`,
+                [orderId, sqId, ...mappingParams],
               );
             }
 
@@ -932,6 +981,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
                             supplier_quote_item_id as "supplierQuoteItemId",
                             supplier_quote_supplier_name as "supplierQuoteSupplierName",
                             supplier_quote_unit_price as "supplierQuoteUnitPrice",
+                    supplier_sale_id as "supplierSaleId",
+                    supplier_sale_item_id as "supplierSaleItemId",
+                    supplier_sale_supplier_name as "supplierSaleSupplierName",
                             unit_type as "unitType",
                             discount,
                             note
@@ -1090,6 +1142,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
                         supplier_quote_item_id as "supplierQuoteItemId",
                         supplier_quote_supplier_name as "supplierQuoteSupplierName",
                         supplier_quote_unit_price as "supplierQuoteUnitPrice",
+                    supplier_sale_id as "supplierSaleId",
+                    supplier_sale_item_id as "supplierSaleItemId",
+                    supplier_sale_supplier_name as "supplierSaleSupplierName",
                         unit_type as "unitType",
                         discount,
                          note
@@ -1110,8 +1165,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         for (const item of normalizedItems) {
           const itemId = 'si-' + Date.now() + '-' + Math.random().toString(36).substring(2, 11);
           const itemResult = await query(
-            `INSERT INTO sale_items (id, sale_id, product_id, product_name, quantity, unit_price, product_cost, product_mol_percentage, discount, note, supplier_quote_id, supplier_quote_item_id, supplier_quote_supplier_name, supplier_quote_unit_price, unit_type)
-                     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+            `INSERT INTO sale_items (id, sale_id, product_id, product_name, quantity, unit_price, product_cost, product_mol_percentage, discount, note, supplier_quote_id, supplier_quote_item_id, supplier_quote_supplier_name, supplier_quote_unit_price, supplier_sale_id, supplier_sale_item_id, supplier_sale_supplier_name, unit_type)
+                     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
                      RETURNING
                         id,
                         sale_id as "orderId",
@@ -1125,6 +1180,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
                         supplier_quote_item_id as "supplierQuoteItemId",
                         supplier_quote_supplier_name as "supplierQuoteSupplierName",
                         supplier_quote_unit_price as "supplierQuoteUnitPrice",
+                    supplier_sale_id as "supplierSaleId",
+                    supplier_sale_item_id as "supplierSaleItemId",
+                    supplier_sale_supplier_name as "supplierSaleSupplierName",
                         unit_type as "unitType",
                         discount,
                          note`,
@@ -1143,6 +1201,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
               item.supplierQuoteItemId ?? null,
               item.supplierQuoteSupplierName ?? null,
               item.supplierQuoteUnitPrice ?? null,
+              item.supplierSaleId ?? null,
+              item.supplierSaleItemId ?? null,
+              item.supplierSaleSupplierName ?? null,
               item.unitType || 'hours',
             ],
           );
@@ -1166,6 +1227,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
                     supplier_quote_item_id as "supplierQuoteItemId",
                     supplier_quote_supplier_name as "supplierQuoteSupplierName",
                     supplier_quote_unit_price as "supplierQuoteUnitPrice",
+                    supplier_sale_id as "supplierSaleId",
+                    supplier_sale_item_id as "supplierSaleItemId",
+                    supplier_sale_supplier_name as "supplierSaleSupplierName",
                     unit_type as "unitType",
                     discount,
                     note

--- a/server/routes/invoices.ts
+++ b/server/routes/invoices.ts
@@ -174,11 +174,7 @@ const getInvoiceClientId = async (invoiceId: string) => {
   return (result.rows[0]?.clientId as string | undefined) ?? null;
 };
 
-const validateAndNormalizeItems = async (
-  items: unknown[],
-  reply: FastifyReply,
-  _effectiveClientId: string,
-) => {
+const validateAndNormalizeItems = async (items: unknown[], reply: FastifyReply) => {
   const normalizedItems = [];
 
   for (let i = 0; i < items.length; i++) {
@@ -397,7 +393,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       if (!Array.isArray(items) || items.length === 0) {
         return badRequest(reply, 'Items must be a non-empty array');
       }
-      const normalizedItems = await validateAndNormalizeItems(items, reply, clientIdResult.value);
+      const normalizedItems = await validateAndNormalizeItems(items, reply);
       if (!normalizedItems) return;
 
       const subtotalResult = optionalLocalizedNonNegativeNumber(subtotal, 'subtotal');
@@ -699,11 +695,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         if (!Array.isArray(items) || items.length === 0) {
           return badRequest(reply, 'Items must be a non-empty array');
         }
-        const effectiveClientId =
-          typeof clientIdValue === 'string' && clientIdValue.trim().length > 0
-            ? clientIdValue
-            : existingClientId || '';
-        const normalizedItems = await validateAndNormalizeItems(items, reply, effectiveClientId);
+        const normalizedItems = await validateAndNormalizeItems(items, reply);
         if (!normalizedItems) return;
         // Delete existing items
         await query('DELETE FROM invoice_items WHERE invoice_id = $1', [updatedInvoiceId]);

--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -317,6 +317,88 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
     },
   );
 
+  fastify.get(
+    '/hours/batch',
+    {
+      onRequest: [
+        fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
+        authenticateToken,
+        requireAnyPermission(
+          'projects.tasks.view',
+          'projects.manage.view',
+          'timesheets.tracker.view',
+          'timesheets.recurring.view',
+        ),
+      ],
+      schema: {
+        tags: ['tasks'],
+        summary: 'Get total logged hours per task for multiple projects',
+        querystring: {
+          type: 'object',
+          required: ['projectIds'],
+          properties: { projectIds: { type: 'string' } },
+        },
+        response: {
+          200: {
+            type: 'object',
+            additionalProperties: {
+              type: 'object',
+              additionalProperties: { type: 'number' },
+            },
+          },
+          ...standardErrorResponses,
+        },
+      },
+    },
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      if (!assertAuthenticated(request, reply)) return;
+
+      const { projectIds } = request.query as { projectIds: string };
+      const idsResult = requireNonEmptyString(projectIds, 'projectIds');
+      if (!idsResult.ok) return badRequest(reply, idsResult.message);
+
+      const idArray = idsResult.value
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+      if (idArray.length === 0) return badRequest(reply, 'projectIds must contain at least one ID');
+      if (idArray.length > 200) return badRequest(reply, 'projectIds cannot exceed 200 IDs');
+
+      const canViewAll = hasPermission(request, 'projects.tasks_all.view');
+      let queryText: string;
+      let queryParams: unknown[];
+
+      if (canViewAll) {
+        queryText = `
+          SELECT project_id, task, COALESCE(SUM(duration), 0)::float AS total
+          FROM time_entries
+          WHERE project_id = ANY($1)
+          GROUP BY project_id, task
+        `;
+        queryParams = [idArray];
+      } else {
+        queryText = `
+          SELECT te.project_id, te.task, COALESCE(SUM(te.duration), 0)::float AS total
+          FROM time_entries te
+          INNER JOIN tasks t ON t.name = te.task AND t.project_id = te.project_id
+          INNER JOIN user_tasks ut ON t.id = ut.task_id
+          WHERE te.project_id = ANY($1) AND ut.user_id = $2
+          GROUP BY te.project_id, te.task
+        `;
+        queryParams = [idArray, request.user.id];
+      }
+
+      const result = await query(queryText, queryParams);
+      const hours: Record<string, Record<string, number>> = {};
+      for (const row of result.rows) {
+        const pid = row.project_id as string;
+        if (!hours[pid]) hours[pid] = {};
+        hours[pid][row.task as string] = Number(row.total);
+      }
+      return reply.send(hours);
+    },
+  );
+
   // GET /hours - Get total hours logged per task for a project
   fastify.get(
     '/hours',

--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -317,6 +317,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
     },
   );
 
+  // Literal path — Fastify's radix-tree router matches this before /:id parameterized routes
   fastify.get(
     '/hours/batch',
     {

--- a/services/api/normalizers.ts
+++ b/services/api/normalizers.ts
@@ -23,6 +23,41 @@ import type {
   User,
 } from '../../types';
 
+const nullableNumber = (value: unknown, fallback: number | null = null): number | null =>
+  value === undefined || value === null ? fallback : Number(value);
+
+type PricingItemBase = {
+  quantity?: number;
+  unitPrice?: number;
+  productCost?: number;
+  productMolPercentage?: number | null;
+  supplierQuoteId?: string | null;
+  supplierQuoteItemId?: string | null;
+  supplierQuoteSupplierName?: string | null;
+  supplierQuoteUnitPrice?: number | null;
+  supplierSaleId?: string | null;
+  supplierSaleItemId?: string | null;
+  supplierSaleSupplierName?: string | null;
+  discount?: number;
+  note?: string;
+};
+
+const normalizePricingItemFields = <T extends PricingItemBase>(item: T): T => ({
+  ...item,
+  quantity: Number(item.quantity || 0),
+  unitPrice: Number(item.unitPrice || 0),
+  productCost: nullableNumber(item.productCost, 0) as number,
+  productMolPercentage: nullableNumber(item.productMolPercentage),
+  supplierQuoteId: item.supplierQuoteId ?? null,
+  supplierQuoteItemId: item.supplierQuoteItemId ?? null,
+  supplierQuoteSupplierName: item.supplierQuoteSupplierName ?? null,
+  supplierQuoteUnitPrice: nullableNumber(item.supplierQuoteUnitPrice),
+  supplierSaleId: item.supplierSaleId ?? null,
+  supplierSaleItemId: item.supplierSaleItemId ?? null,
+  supplierSaleSupplierName: item.supplierSaleSupplierName ?? null,
+  discount: Number(item.discount || 0),
+});
+
 export const normalizeClient = (c: Client): Client => ({
   ...c,
   contacts: Array.isArray(c.contacts)
@@ -126,24 +161,7 @@ export const normalizeProduct = (p: Product): Product => ({
 });
 
 export const normalizeQuoteItem = (item: QuoteItem): QuoteItem => ({
-  ...item,
-  quantity: Number(item.quantity || 0),
-  unitPrice: Number(item.unitPrice || 0),
-  productCost:
-    item.productCost === undefined || item.productCost === null ? 0 : Number(item.productCost),
-  productMolPercentage:
-    item.productMolPercentage === undefined || item.productMolPercentage === null
-      ? null
-      : Number(item.productMolPercentage),
-  // Supplier quote fields
-  supplierQuoteId: item.supplierQuoteId ?? null,
-  supplierQuoteItemId: item.supplierQuoteItemId ?? null,
-  supplierQuoteSupplierName: item.supplierQuoteSupplierName ?? null,
-  supplierQuoteUnitPrice:
-    item.supplierQuoteUnitPrice === undefined || item.supplierQuoteUnitPrice === null
-      ? null
-      : Number(item.supplierQuoteUnitPrice),
-  discount: Number(item.discount || 0),
+  ...normalizePricingItemFields(item),
   note: item.note || '',
 });
 
@@ -154,24 +172,7 @@ export const normalizeQuote = (q: Quote): Quote => ({
 });
 
 export const normalizeClientOfferItem = (item: ClientOfferItem): ClientOfferItem => ({
-  ...item,
-  quantity: Number(item.quantity || 0),
-  unitPrice: Number(item.unitPrice || 0),
-  productCost:
-    item.productCost === undefined || item.productCost === null ? 0 : Number(item.productCost),
-  productMolPercentage:
-    item.productMolPercentage === undefined || item.productMolPercentage === null
-      ? null
-      : Number(item.productMolPercentage),
-  // Supplier quote fields
-  supplierQuoteId: item.supplierQuoteId ?? null,
-  supplierQuoteItemId: item.supplierQuoteItemId ?? null,
-  supplierQuoteSupplierName: item.supplierQuoteSupplierName ?? null,
-  supplierQuoteUnitPrice:
-    item.supplierQuoteUnitPrice === undefined || item.supplierQuoteUnitPrice === null
-      ? null
-      : Number(item.supplierQuoteUnitPrice),
-  discount: Number(item.discount || 0),
+  ...normalizePricingItemFields(item),
   note: item.note || '',
 });
 
@@ -182,24 +183,7 @@ export const normalizeClientOffer = (offer: ClientOffer): ClientOffer => ({
 });
 
 export const normalizeClientsOrderItem = (item: ClientsOrderItem): ClientsOrderItem => ({
-  ...item,
-  quantity: Number(item.quantity || 0),
-  unitPrice: Number(item.unitPrice || 0),
-  productCost:
-    item.productCost === undefined || item.productCost === null ? 0 : Number(item.productCost),
-  productMolPercentage:
-    item.productMolPercentage === undefined || item.productMolPercentage === null
-      ? null
-      : Number(item.productMolPercentage),
-  // Supplier quote fields
-  supplierQuoteId: item.supplierQuoteId ?? null,
-  supplierQuoteItemId: item.supplierQuoteItemId ?? null,
-  supplierQuoteSupplierName: item.supplierQuoteSupplierName ?? null,
-  supplierQuoteUnitPrice:
-    item.supplierQuoteUnitPrice === undefined || item.supplierQuoteUnitPrice === null
-      ? null
-      : Number(item.supplierQuoteUnitPrice),
-  discount: Number(item.discount || 0),
+  ...normalizePricingItemFields(item),
 });
 
 export const normalizeClientsOrder = (o: ClientsOrder): ClientsOrder => ({

--- a/services/api/tasks.ts
+++ b/services/api/tasks.ts
@@ -41,6 +41,14 @@ export const tasksApi = {
   getHours: (projectId: string): Promise<Record<string, number>> =>
     fetchApi(`/tasks/hours?projectId=${encodeURIComponent(projectId)}`),
 
+  getHoursForProjects: (
+    projectIds: string[],
+    signal?: AbortSignal,
+  ): Promise<Record<string, Record<string, number>>> =>
+    fetchApi(`/tasks/hours/batch?projectIds=${projectIds.map(encodeURIComponent).join(',')}`, {
+      signal,
+    }),
+
   getUsers: (id: string, signal?: AbortSignal): Promise<string[]> =>
     fetchApi(`/tasks/${id}/users`, { signal }),
 

--- a/services/api/tasks.ts
+++ b/services/api/tasks.ts
@@ -38,8 +38,8 @@ export const tasksApi = {
 
   delete: (id: string): Promise<void> => fetchApi(`/tasks/${id}`, { method: 'DELETE' }),
 
-  getHours: (projectId: string): Promise<Record<string, number>> =>
-    fetchApi(`/tasks/hours?projectId=${encodeURIComponent(projectId)}`),
+  getHours: (projectId: string, signal?: AbortSignal): Promise<Record<string, number>> =>
+    fetchApi(`/tasks/hours?projectId=${encodeURIComponent(projectId)}`, { signal }),
 
   getHoursForProjects: (
     projectIds: string[],

--- a/types.ts
+++ b/types.ts
@@ -335,6 +335,9 @@ export interface ClientsOrderItem {
   supplierQuoteItemId?: string | null;
   supplierQuoteSupplierName?: string | null;
   supplierQuoteUnitPrice?: number | null;
+  supplierSaleId?: string | null;
+  supplierSaleItemId?: string | null;
+  supplierSaleSupplierName?: string | null;
   discount?: number;
   note?: string;
   unitType?: SupplierUnitType;

--- a/utils/date.ts
+++ b/utils/date.ts
@@ -52,21 +52,6 @@ export const isDateOnlyAfterToday = (
   today: string = getLocalDateString(),
 ): boolean => normalizeDateOnlyString(dateOnly) > normalizeDateOnlyString(today);
 
-export const isDateOnlyWithinInclusiveRange = (
-  targetDate: string,
-  startDate?: string | null,
-  endDate?: string | null,
-): boolean => {
-  const normalizedTargetDate = normalizeDateOnlyString(targetDate);
-  if (startDate && normalizedTargetDate < normalizeDateOnlyString(startDate)) {
-    return false;
-  }
-  if (endDate && normalizedTargetDate > normalizeDateOnlyString(endDate)) {
-    return false;
-  }
-  return true;
-};
-
 /**
  * Formats a Unix timestamp (milliseconds) to a DD/MM/YYYY date string.
  * Returns '-' for invalid, null, or undefined timestamps.

--- a/utils/numbers.ts
+++ b/utils/numbers.ts
@@ -70,6 +70,7 @@ export interface PricingTotals {
   subtotal: number;
   discountAmount: number;
   total: number;
+  totalCost: number;
   margin: number;
   marginPercentage: number;
 }
@@ -102,7 +103,7 @@ export const calculatePricingTotals = (
   const margin = total - totalCost;
   const marginPercentage = total > 0 ? (margin / total) * 100 : 0;
 
-  return { subtotal, discountAmount, total, margin, marginPercentage };
+  return { subtotal, discountAmount, total, totalCost, margin, marginPercentage };
 };
 
 export const formatDiscountValue = (


### PR DESCRIPTION
## Summary
- Add insert date, global discount, subtotal, discount amount, margin, total cost, and total columns to the clients orders table with a shared `PricingCell` component and memoized `orderPricingMap`
- Link sale items to auto-created supplier sales via new `supplier_sale_id`/`supplier_sale_item_id`/`supplier_sale_supplier_name` columns (schema, routes, normalizers, types)
- Add project progress bar column based on median task hours vs expected effort, with a batch hours API endpoint (`GET /tasks/hours/batch`)
- Add custom hex color picker for projects and extract shared `normalizePricingItemFields` helper to eliminate duplicate normalizer logic

## Test plan
- [ ] Verify clients orders table shows all new pricing columns with correct values
- [ ] Confirm history rows (confirmed/denied) render with muted styling
- [ ] Create a new client order with supplier quotes and verify supplier sale linkage is persisted
- [ ] Check project progress bars display correctly and update when hours are logged
- [ ] Test custom hex color picker in project create/edit modal
- [ ] Verify EN/IT translations render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xbounceit/praetor/pull/126" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
