### PR TITLE
feat(sales): lock cost/qty fields when linked to supplier quote with tooltip feedback

### DIFF
--- a/components/sales/ClientOffersView.tsx
+++ b/components/sales/ClientOffersView.tsx
@@ -161,6 +161,7 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
     index: number,
     selectProps: { className?: string; buttonClassName?: string },
   ) => {
+    const isLinkedToSupplierQuote = Boolean(item.supplierQuoteItemId);
     if (isLinkedProductMissing(item)) {
       return (
         <input
@@ -180,7 +181,7 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
           defaultValue: 'Select product',
         })}
         searchable={true}
-        disabled={isReadOnly || Boolean(item.supplierQuoteItemId)}
+        disabled={isReadOnly || isLinkedToSupplierQuote}
         className={selectProps.className}
         buttonClassName={selectProps.buttonClassName}
       />

--- a/components/sales/ClientOffersView.tsx
+++ b/components/sales/ClientOffersView.tsx
@@ -925,14 +925,14 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                 >
                   <i className="fa-solid fa-plus"></i>{' '}
                   {t('sales:clientOffers.addItem', { defaultValue: 'Add item' })}
-                  <FieldTooltip
-                    description={t('sales:fieldInfo.addItem', {
-                      defaultValue: 'Add a new line item',
-                    })}
-                    status={readOnlyStatus}
-                    statusLabel={statusLabel}
-                  />
                 </button>
+                <FieldTooltip
+                  description={t('sales:fieldInfo.addItem', {
+                    defaultValue: 'Add a new line item',
+                  })}
+                  status={readOnlyStatus}
+                  statusLabel={statusLabel}
+                />
               </div>
               {errors.items && (
                 <p className="text-red-500 text-[10px] font-bold ml-1 -mt-2">{errors.items}</p>
@@ -997,7 +997,7 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                         : statusEditable;
 
                     const handleCostChange = (value: string) => {
-                      if (isReadOnly || isLinkedToSupplierQuote) return;
+                      if (isReadOnly) return;
                       setFormData(makeCostUpdater<Partial<ClientOffer>>(index, value));
                     };
 

--- a/components/sales/ClientOffersView.tsx
+++ b/components/sales/ClientOffersView.tsx
@@ -29,6 +29,7 @@ import { getPaymentTermsOptions } from '../../utils/options';
 import { makeCostUpdater, makeMolUpdater } from '../../utils/pricingHandlers';
 import CostSummaryPanel from '../shared/CostSummaryPanel';
 import CustomSelect from '../shared/CustomSelect';
+import FieldTooltip from '../shared/FieldTooltip';
 import Modal from '../shared/Modal';
 import StandardTable, { type Column } from '../shared/StandardTable';
 import StatusBadge, { type StatusType } from '../shared/StatusBadge';
@@ -224,6 +225,15 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
   const supplierLockedReason = t('sales:clientQuotes.fieldLockedBySupplierQuote', {
     defaultValue: 'Locked because this item is linked to a supplier quote.',
   });
+  const statusEditable = t('sales:fieldInfo.statusEditable', { defaultValue: 'Editable' });
+  const statusLabel = t('sales:fieldInfo.statusLabel', { defaultValue: 'Status:' });
+
+  const clientStatus = isReadOnly
+    ? readOnlyReason
+    : isClientLocked
+      ? clientLockedReason
+      : statusEditable;
+  const readOnlyStatus = isReadOnly ? readOnlyReason : statusEditable;
 
   const filteredOffers = useMemo(() => {
     return offers.filter((offer) => {
@@ -788,92 +798,101 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
               </h4>
               <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
                 <div className="space-y-1.5">
-                  <label className="text-xs font-bold text-slate-500 ml-1">
+                  <label className="text-xs font-bold text-slate-500 ml-1 flex items-center gap-1">
                     {t('sales:clientOffers.client', { defaultValue: 'Client' })}
+                    <FieldTooltip
+                      description={t('sales:fieldInfo.client', {
+                        defaultValue: 'Select the client for this document',
+                      })}
+                      status={clientStatus}
+                      statusLabel={statusLabel}
+                    />
                   </label>
-                  <Tooltip
-                    label={isReadOnly ? readOnlyReason : isClientLocked ? clientLockedReason : ''}
-                    wrapperClassName="w-full"
-                  >
-                    {() => (
-                      <CustomSelect
-                        options={clientOptions}
-                        value={formData.clientId || ''}
-                        onChange={(value) => handleClientChange(value as string)}
-                        placeholder={t('sales:clientOffers.selectAClient', {
-                          defaultValue: 'Select a client',
-                        })}
-                        searchable={true}
-                        disabled={isReadOnly || isClientLocked}
-                        className={errors.clientId ? 'border-red-300' : ''}
-                      />
-                    )}
-                  </Tooltip>
+                  <CustomSelect
+                    options={clientOptions}
+                    value={formData.clientId || ''}
+                    onChange={(value) => handleClientChange(value as string)}
+                    placeholder={t('sales:clientOffers.selectAClient', {
+                      defaultValue: 'Select a client',
+                    })}
+                    searchable={true}
+                    disabled={isReadOnly || isClientLocked}
+                    className={errors.clientId ? 'border-red-300' : ''}
+                  />
                   {errors.clientId && (
                     <p className="text-red-500 text-[10px] font-bold ml-1">{errors.clientId}</p>
                   )}
                 </div>
                 <div className="space-y-1.5">
-                  <label className="text-xs font-bold text-slate-500 ml-1">
+                  <label className="text-xs font-bold text-slate-500 ml-1 flex items-center gap-1">
                     {t('sales:clientOffers.offerCode', { defaultValue: 'Offer code' })}
+                    <FieldTooltip
+                      description={t('sales:fieldInfo.offerCode', {
+                        defaultValue: 'Unique identifier for this offer',
+                      })}
+                      status={readOnlyStatus}
+                      statusLabel={statusLabel}
+                    />
                   </label>
-                  <Tooltip label={isReadOnly ? readOnlyReason : ''} wrapperClassName="w-full">
-                    {() => (
-                      <input
-                        type="text"
-                        value={formData.id || ''}
-                        disabled={isReadOnly}
-                        onChange={(event) =>
-                          setFormData((prev) => ({ ...prev, id: event.target.value }))
-                        }
-                        placeholder="O0000"
-                        className={`w-full text-sm px-4 py-2.5 bg-slate-50 border ${errors.id ? 'border-red-300' : 'border-slate-200'} rounded-xl focus:ring-2 focus:ring-praetor outline-none transition-all disabled:opacity-50 disabled:cursor-not-allowed`}
-                      />
-                    )}
-                  </Tooltip>
+                  <input
+                    type="text"
+                    value={formData.id || ''}
+                    disabled={isReadOnly}
+                    onChange={(event) =>
+                      setFormData((prev) => ({ ...prev, id: event.target.value }))
+                    }
+                    placeholder="O0000"
+                    className={`w-full text-sm px-4 py-2.5 bg-slate-50 border ${errors.id ? 'border-red-300' : 'border-slate-200'} rounded-xl focus:ring-2 focus:ring-praetor outline-none transition-all disabled:opacity-50 disabled:cursor-not-allowed`}
+                  />
                   {errors.id && (
                     <p className="text-red-500 text-[10px] font-bold ml-1">{errors.id}</p>
                   )}
                 </div>
                 <div className="space-y-1.5">
-                  <label className="text-xs font-bold text-slate-500 ml-1">
+                  <label className="text-xs font-bold text-slate-500 ml-1 flex items-center gap-1">
                     {t('sales:clientOffers.paymentTerms', { defaultValue: 'Payment terms' })}
+                    <FieldTooltip
+                      description={t('sales:fieldInfo.paymentTerms', {
+                        defaultValue: 'Payment terms and conditions',
+                      })}
+                      status={readOnlyStatus}
+                      statusLabel={statusLabel}
+                    />
                   </label>
-                  <Tooltip label={isReadOnly ? readOnlyReason : ''} wrapperClassName="w-full">
-                    {() => (
-                      <CustomSelect
-                        options={paymentTermsOptions}
-                        value={formData.paymentTerms || 'immediate'}
-                        onChange={(value) =>
-                          setFormData((prev) => ({
-                            ...prev,
-                            paymentTerms: value as ClientOffer['paymentTerms'],
-                          }))
-                        }
-                        searchable={false}
-                        disabled={isReadOnly}
-                      />
-                    )}
-                  </Tooltip>
+                  <CustomSelect
+                    options={paymentTermsOptions}
+                    value={formData.paymentTerms || 'immediate'}
+                    onChange={(value) =>
+                      setFormData((prev) => ({
+                        ...prev,
+                        paymentTerms: value as ClientOffer['paymentTerms'],
+                      }))
+                    }
+                    searchable={false}
+                    disabled={isReadOnly}
+                  />
                 </div>
                 <div className="space-y-1.5">
-                  <label className="text-xs font-bold text-slate-500 ml-1">
+                  <label className="text-xs font-bold text-slate-500 ml-1 flex items-center gap-1">
                     {t('sales:clientOffers.expirationDate', { defaultValue: 'Expiration date' })}
+                    <FieldTooltip
+                      description={t('sales:fieldInfo.expirationDate', {
+                        defaultValue: 'Date until which this document is valid',
+                      })}
+                      status={readOnlyStatus}
+                      statusLabel={statusLabel}
+                    />
                   </label>
-                  <Tooltip label={isReadOnly ? readOnlyReason : ''} wrapperClassName="w-full">
-                    {() => (
-                      <input
-                        type="date"
-                        required
-                        value={formData.expirationDate || ''}
-                        disabled={isReadOnly}
-                        onChange={(event) =>
-                          setFormData((prev) => ({ ...prev, expirationDate: event.target.value }))
-                        }
-                        className="w-full text-sm px-4 py-2.5 bg-slate-50 border border-slate-200 rounded-xl focus:ring-2 focus:ring-praetor outline-none transition-all disabled:opacity-50 disabled:cursor-not-allowed"
-                      />
-                    )}
-                  </Tooltip>
+                  <input
+                    type="date"
+                    required
+                    value={formData.expirationDate || ''}
+                    disabled={isReadOnly}
+                    onChange={(event) =>
+                      setFormData((prev) => ({ ...prev, expirationDate: event.target.value }))
+                    }
+                    className="w-full text-sm px-4 py-2.5 bg-slate-50 border border-slate-200 rounded-xl focus:ring-2 focus:ring-praetor outline-none transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+                  />
                 </div>
               </div>
             </div>
@@ -885,19 +904,22 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                   <span className="w-1.5 h-1.5 rounded-full bg-praetor"></span>
                   {t('sales:clientOffers.items', { defaultValue: 'Items' })}
                 </h4>
-                <Tooltip label={isReadOnly ? readOnlyReason : ''}>
-                  {() => (
-                    <button
-                      type="button"
-                      onClick={addItem}
-                      disabled={isReadOnly}
-                      className="text-xs font-bold text-praetor hover:text-slate-700 flex items-center gap-1 disabled:opacity-50 disabled:cursor-not-allowed"
-                    >
-                      <i className="fa-solid fa-plus"></i>{' '}
-                      {t('sales:clientOffers.addItem', { defaultValue: 'Add item' })}
-                    </button>
-                  )}
-                </Tooltip>
+                <button
+                  type="button"
+                  onClick={addItem}
+                  disabled={isReadOnly}
+                  className="text-xs font-bold text-praetor hover:text-slate-700 flex items-center gap-1 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  <i className="fa-solid fa-plus"></i>{' '}
+                  {t('sales:clientOffers.addItem', { defaultValue: 'Add item' })}
+                  <FieldTooltip
+                    description={t('sales:fieldInfo.addItem', {
+                      defaultValue: 'Add a new line item',
+                    })}
+                    status={readOnlyStatus}
+                    statusLabel={statusLabel}
+                  />
+                </button>
               </div>
               {errors.items && (
                 <p className="text-red-500 text-[10px] font-bold ml-1 -mt-2">{errors.items}</p>
@@ -955,12 +977,11 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                     const lineMargin = lineSalePrice - lineCost;
 
                     const isLinkedToSupplierQuote = Boolean(item.supplierQuoteItemId);
-                    const lockReasonForLinkedField = isReadOnly
+                    const linkedFieldStatus = isReadOnly
                       ? readOnlyReason
                       : isLinkedToSupplierQuote
                         ? supplierLockedReason
-                        : '';
-                    const lockReasonForReadOnlyOnly = isReadOnly ? readOnlyReason : '';
+                        : statusEditable;
 
                     const handleCostChange = (value: string) => {
                       if (isReadOnly || isLinkedToSupplierQuote) return;
@@ -980,145 +1001,144 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                         <div className="lg:hidden flex items-start gap-3">
                           <div className="grid flex-1 min-w-0 grid-cols-1 md:grid-cols-2 gap-3">
                             <div className="min-w-0">
-                              <div className="mb-1 text-[10px] font-black text-slate-400 uppercase tracking-wider">
+                              <div className="mb-1 text-[10px] font-black text-slate-400 uppercase tracking-wider flex items-center gap-1">
                                 {t('sales:clientQuotes.supplierQuoteColumn')}
+                                <FieldTooltip
+                                  description={t('sales:fieldInfo.supplierQuote', {
+                                    defaultValue:
+                                      'Link this item to a supplier quote for cost tracking',
+                                  })}
+                                  status={readOnlyStatus}
+                                  statusLabel={statusLabel}
+                                />
                               </div>
-                              <Tooltip label={lockReasonForReadOnlyOnly} wrapperClassName="w-full">
-                                {() => (
-                                  <CustomSelect
-                                    options={supplierQuoteSelectOptions}
-                                    value={item.supplierQuoteItemId || 'none'}
-                                    onChange={(val) =>
-                                      updateItem(
-                                        index,
-                                        'supplierQuoteItemId',
-                                        val === 'none' ? '' : (val as string),
-                                      )
-                                    }
-                                    placeholder={t('sales:clientQuotes.selectSupplierQuote')}
-                                    displayValue={getSupplierQuoteItemDisplayValue(
-                                      item.supplierQuoteItemId,
-                                    )}
-                                    searchable={true}
-                                    disabled={isReadOnly}
-                                    className="min-w-0"
-                                    buttonClassName="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm"
-                                  />
+                              <CustomSelect
+                                options={supplierQuoteSelectOptions}
+                                value={item.supplierQuoteItemId || 'none'}
+                                onChange={(val) =>
+                                  updateItem(
+                                    index,
+                                    'supplierQuoteItemId',
+                                    val === 'none' ? '' : (val as string),
+                                  )
+                                }
+                                placeholder={t('sales:clientQuotes.selectSupplierQuote')}
+                                displayValue={getSupplierQuoteItemDisplayValue(
+                                  item.supplierQuoteItemId,
                                 )}
-                              </Tooltip>
+                                searchable={true}
+                                disabled={isReadOnly}
+                                className="min-w-0"
+                                buttonClassName="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm"
+                              />
                             </div>
                             <div className="min-w-0">
-                              <div className="mb-1 text-[10px] font-black text-slate-400 uppercase tracking-wider">
+                              <div className="mb-1 text-[10px] font-black text-slate-400 uppercase tracking-wider flex items-center gap-1">
                                 {t('sales:clientOffers.product', { defaultValue: 'Product' })}
+                                <FieldTooltip
+                                  description={t('sales:fieldInfo.product', {
+                                    defaultValue: 'Select a product or service for this line item',
+                                  })}
+                                  status={linkedFieldStatus}
+                                  statusLabel={statusLabel}
+                                />
                               </div>
-                              <Tooltip label={lockReasonForLinkedField} wrapperClassName="w-full">
-                                {() =>
-                                  renderProductSelectOrFallback(item, index, {
-                                    className: 'min-w-0',
-                                    buttonClassName:
-                                      'w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm',
-                                  })
-                                }
-                              </Tooltip>
+                              {renderProductSelectOrFallback(item, index, {
+                                className: 'min-w-0',
+                                buttonClassName:
+                                  'w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm',
+                              })}
                             </div>
                           </div>
-                          <Tooltip label={lockReasonForReadOnlyOnly}>
-                            {() => (
-                              <button
-                                type="button"
-                                onClick={() => removeItem(index)}
-                                disabled={isReadOnly}
-                                className="mt-5 w-10 h-10 flex items-center justify-center text-slate-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-all shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
-                              >
-                                <i className="fa-solid fa-trash-can"></i>
-                              </button>
-                            )}
-                          </Tooltip>
+                          <button
+                            type="button"
+                            onClick={() => removeItem(index)}
+                            disabled={isReadOnly}
+                            className="mt-5 w-10 h-10 flex items-center justify-center text-slate-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-all shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
+                          >
+                            <i className="fa-solid fa-trash-can"></i>
+                          </button>
                         </div>
                         <div className="grid grid-cols-2 gap-3 md:grid-cols-6 lg:hidden">
                           <div>
-                            <div className="mb-1 text-[10px] font-black text-slate-400 uppercase tracking-wider">
+                            <div className="mb-1 text-[10px] font-black text-slate-400 uppercase tracking-wider flex items-center gap-1">
                               {t('sales:clientOffers.qty', { defaultValue: 'Qty' })}
+                              <FieldTooltip
+                                description={t('sales:fieldInfo.qty', {
+                                  defaultValue: 'Quantity of items or hours',
+                                })}
+                                status={linkedFieldStatus}
+                                statusLabel={statusLabel}
+                              />
                             </div>
                             <div className="flex items-center gap-1">
-                              <Tooltip
-                                label={lockReasonForLinkedField}
-                                wrapperClassName="flex-1 min-w-0"
-                              >
-                                {() => (
-                                  <ValidatedNumberInput
-                                    step="0.01"
-                                    min="0"
-                                    required
-                                    placeholder={t('sales:clientOffers.qty', {
-                                      defaultValue: 'Qty',
-                                    })}
-                                    value={item.quantity}
-                                    onValueChange={(value) =>
-                                      updateItem(index, 'quantity', parseNumberInputValue(value))
-                                    }
-                                    disabled={isReadOnly || isLinkedToSupplierQuote}
-                                    className="w-full text-sm px-3 py-2 bg-white border border-slate-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
-                                  />
-                                )}
-                              </Tooltip>
+                              <ValidatedNumberInput
+                                step="0.01"
+                                min="0"
+                                required
+                                placeholder={t('sales:clientOffers.qty', {
+                                  defaultValue: 'Qty',
+                                })}
+                                value={item.quantity}
+                                onValueChange={(value) =>
+                                  updateItem(index, 'quantity', parseNumberInputValue(value))
+                                }
+                                disabled={isReadOnly || isLinkedToSupplierQuote}
+                                className="w-full text-sm px-3 py-2 bg-white border border-slate-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed flex-1"
+                              />
                               <span className="text-xs font-semibold text-slate-400 shrink-0">
                                 /
                               </span>
-                              <Tooltip label={lockReasonForLinkedField}>
-                                {() => (
-                                  <UnitTypeSelector
-                                    value={(item.unitType || 'hours') as SupplierUnitType}
-                                    onChange={(val) => handleUnitTypeChange(index, val)}
-                                    isSupply={isSupply}
-                                    quantity={Number(item.quantity) || 0}
-                                    disabled={isReadOnly || isLinkedToSupplierQuote}
-                                  />
-                                )}
-                              </Tooltip>
+                              <UnitTypeSelector
+                                value={(item.unitType || 'hours') as SupplierUnitType}
+                                onChange={(val) => handleUnitTypeChange(index, val)}
+                                isSupply={isSupply}
+                                quantity={Number(item.quantity) || 0}
+                                disabled={isReadOnly || isLinkedToSupplierQuote}
+                              />
                             </div>
                           </div>
                           <div className="rounded-lg border border-slate-200 bg-white px-3 py-2 space-y-1">
-                            <div className="text-[10px] font-black text-slate-400 uppercase tracking-wider">
+                            <div className="text-[10px] font-black text-slate-400 uppercase tracking-wider flex items-center gap-1">
                               {t('crm:internalListing.cost')}
+                              <FieldTooltip
+                                description={t('sales:fieldInfo.cost', {
+                                  defaultValue: 'Unit cost for this item',
+                                })}
+                                status={linkedFieldStatus}
+                                statusLabel={statusLabel}
+                              />
                             </div>
                             <div className="flex items-center gap-1">
-                              <Tooltip
-                                label={lockReasonForLinkedField}
-                                wrapperClassName="flex-1 min-w-0"
-                              >
-                                {() => (
-                                  <ValidatedNumberInput
-                                    value={cost.toFixed(2)}
-                                    onValueChange={handleCostChange}
-                                    disabled={isReadOnly || isLinkedToSupplierQuote}
-                                    className="w-full text-sm px-2 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
-                                  />
-                                )}
-                              </Tooltip>
+                              <ValidatedNumberInput
+                                value={cost.toFixed(2)}
+                                onValueChange={handleCostChange}
+                                disabled={isReadOnly || isLinkedToSupplierQuote}
+                                className="w-full text-sm px-2 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
+                              />
                               <span className="text-[9px] font-semibold text-slate-400 shrink-0">
                                 {currency}
                               </span>
                             </div>
                           </div>
                           <div className="rounded-lg border border-slate-200 bg-white px-3 py-2 space-y-1">
-                            <div className="text-[10px] font-black text-slate-400 uppercase tracking-wider">
+                            <div className="text-[10px] font-black text-slate-400 uppercase tracking-wider flex items-center gap-1">
                               {t('sales:clientQuotes.molLabel', { defaultValue: 'MOL' })} (%)
+                              <FieldTooltip
+                                description={t('sales:fieldInfo.mol', {
+                                  defaultValue: 'Margin overhead loading percentage',
+                                })}
+                                status={readOnlyStatus}
+                                statusLabel={statusLabel}
+                              />
                             </div>
                             <div className="flex items-center gap-1">
-                              <Tooltip
-                                label={lockReasonForReadOnlyOnly}
-                                wrapperClassName="flex-1 min-w-0"
-                              >
-                                {() => (
-                                  <ValidatedNumberInput
-                                    value={molPercentage.toFixed(1)}
-                                    onValueChange={handleMolChange}
-                                    disabled={isReadOnly}
-                                    className="w-full text-sm px-2 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
-                                  />
-                                )}
-                              </Tooltip>
+                              <ValidatedNumberInput
+                                value={molPercentage.toFixed(1)}
+                                onValueChange={handleMolChange}
+                                disabled={isReadOnly}
+                                className="w-full text-sm px-2 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
+                              />
                               <span className="text-[9px] font-semibold text-slate-400 shrink-0">
                                 %
                               </span>
@@ -1154,112 +1174,79 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                         <div className="hidden lg:flex gap-2 items-center">
                           <div className="flex-1 min-w-0 grid grid-cols-13 gap-2 items-center">
                             <div className="col-span-3 min-w-0">
-                              <Tooltip label={lockReasonForReadOnlyOnly} wrapperClassName="w-full">
-                                {() => (
-                                  <CustomSelect
-                                    options={supplierQuoteSelectOptions}
-                                    value={item.supplierQuoteItemId || 'none'}
-                                    onChange={(val) =>
-                                      updateItem(
-                                        index,
-                                        'supplierQuoteItemId',
-                                        val === 'none' ? '' : (val as string),
-                                      )
-                                    }
-                                    placeholder={t('sales:clientQuotes.selectSupplierQuote')}
-                                    displayValue={getSupplierQuoteItemDisplayValue(
-                                      item.supplierQuoteItemId,
-                                    )}
-                                    searchable={true}
-                                    disabled={isReadOnly}
-                                    className="min-w-0"
-                                    buttonClassName="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm"
-                                  />
+                              <CustomSelect
+                                options={supplierQuoteSelectOptions}
+                                value={item.supplierQuoteItemId || 'none'}
+                                onChange={(val) =>
+                                  updateItem(
+                                    index,
+                                    'supplierQuoteItemId',
+                                    val === 'none' ? '' : (val as string),
+                                  )
+                                }
+                                placeholder={t('sales:clientQuotes.selectSupplierQuote')}
+                                displayValue={getSupplierQuoteItemDisplayValue(
+                                  item.supplierQuoteItemId,
                                 )}
-                              </Tooltip>
+                                searchable={true}
+                                disabled={isReadOnly}
+                                className="min-w-0"
+                                buttonClassName="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm"
+                              />
                             </div>
                             <div className="col-span-3 min-w-0">
-                              <Tooltip label={lockReasonForLinkedField} wrapperClassName="w-full">
-                                {() =>
-                                  renderProductSelectOrFallback(item, index, {
-                                    className: 'min-w-0',
-                                    buttonClassName:
-                                      'w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm',
-                                  })
-                                }
-                              </Tooltip>
+                              {renderProductSelectOrFallback(item, index, {
+                                className: 'min-w-0',
+                                buttonClassName:
+                                  'w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm',
+                              })}
                             </div>
                             <div className="col-span-2">
                               <div className="flex items-center gap-1">
-                                <Tooltip
-                                  label={lockReasonForLinkedField}
-                                  wrapperClassName="flex-1 min-w-0"
-                                >
-                                  {() => (
-                                    <ValidatedNumberInput
-                                      step="0.01"
-                                      min="0"
-                                      required
-                                      placeholder={t('sales:clientOffers.qty', {
-                                        defaultValue: 'Qty',
-                                      })}
-                                      value={item.quantity}
-                                      onValueChange={(value) =>
-                                        updateItem(index, 'quantity', parseNumberInputValue(value))
-                                      }
-                                      disabled={isReadOnly || isLinkedToSupplierQuote}
-                                      className="w-full text-sm px-2 py-2 bg-white border border-slate-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
-                                    />
-                                  )}
-                                </Tooltip>
+                                <ValidatedNumberInput
+                                  step="0.01"
+                                  min="0"
+                                  required
+                                  placeholder={t('sales:clientOffers.qty', {
+                                    defaultValue: 'Qty',
+                                  })}
+                                  value={item.quantity}
+                                  onValueChange={(value) =>
+                                    updateItem(index, 'quantity', parseNumberInputValue(value))
+                                  }
+                                  disabled={isReadOnly || isLinkedToSupplierQuote}
+                                  className="w-full text-sm px-2 py-2 bg-white border border-slate-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
+                                />
                                 <span className="text-xs font-semibold text-slate-400 shrink-0">
                                   /
                                 </span>
-                                <Tooltip label={lockReasonForLinkedField}>
-                                  {() => (
-                                    <UnitTypeSelector
-                                      value={(item.unitType || 'hours') as SupplierUnitType}
-                                      onChange={(val) => handleUnitTypeChange(index, val)}
-                                      isSupply={isSupply}
-                                      quantity={Number(item.quantity) || 0}
-                                      disabled={isReadOnly || isLinkedToSupplierQuote}
-                                    />
-                                  )}
-                                </Tooltip>
+                                <UnitTypeSelector
+                                  value={(item.unitType || 'hours') as SupplierUnitType}
+                                  onChange={(val) => handleUnitTypeChange(index, val)}
+                                  isSupply={isSupply}
+                                  quantity={Number(item.quantity) || 0}
+                                  disabled={isReadOnly || isLinkedToSupplierQuote}
+                                />
                               </div>
                             </div>
                             <div className="col-span-1 flex items-center justify-center gap-1">
-                              <Tooltip
-                                label={lockReasonForLinkedField}
-                                wrapperClassName="flex-1 min-w-0"
-                              >
-                                {() => (
-                                  <ValidatedNumberInput
-                                    value={cost.toFixed(2)}
-                                    onValueChange={handleCostChange}
-                                    disabled={isReadOnly || isLinkedToSupplierQuote}
-                                    className="w-full text-sm px-1 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
-                                  />
-                                )}
-                              </Tooltip>
+                              <ValidatedNumberInput
+                                value={cost.toFixed(2)}
+                                onValueChange={handleCostChange}
+                                disabled={isReadOnly || isLinkedToSupplierQuote}
+                                className="w-full text-sm px-1 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
+                              />
                               <span className="text-[9px] font-semibold text-slate-400 shrink-0">
                                 {currency}
                               </span>
                             </div>
                             <div className="col-span-1 flex items-center justify-center gap-1">
-                              <Tooltip
-                                label={lockReasonForReadOnlyOnly}
-                                wrapperClassName="flex-1 min-w-0"
-                              >
-                                {() => (
-                                  <ValidatedNumberInput
-                                    value={molPercentage.toFixed(1)}
-                                    onValueChange={handleMolChange}
-                                    disabled={isReadOnly}
-                                    className="w-full text-sm px-1 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
-                                  />
-                                )}
-                              </Tooltip>
+                              <ValidatedNumberInput
+                                value={molPercentage.toFixed(1)}
+                                onValueChange={handleMolChange}
+                                disabled={isReadOnly}
+                                className="w-full text-sm px-1 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
+                              />
                               <span className="text-[9px] font-semibold text-slate-400 shrink-0">
                                 %
                               </span>
@@ -1282,33 +1269,25 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                               </span>
                             </div>
                           </div>
-                          <Tooltip label={lockReasonForReadOnlyOnly}>
-                            {() => (
-                              <button
-                                type="button"
-                                onClick={() => removeItem(index)}
-                                disabled={isReadOnly}
-                                className="w-10 h-10 flex items-center justify-center text-slate-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-all shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
-                              >
-                                <i className="fa-solid fa-trash-can"></i>
-                              </button>
-                            )}
-                          </Tooltip>
+                          <button
+                            type="button"
+                            onClick={() => removeItem(index)}
+                            disabled={isReadOnly}
+                            className="w-10 h-10 flex items-center justify-center text-slate-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-all shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
+                          >
+                            <i className="fa-solid fa-trash-can"></i>
+                          </button>
                         </div>
-                        <Tooltip label={lockReasonForReadOnlyOnly} wrapperClassName="w-full">
-                          {() => (
-                            <input
-                              type="text"
-                              placeholder={t('form:placeholderNotes', {
-                                defaultValue: 'Optional notes...',
-                              })}
-                              value={item.note || ''}
-                              onChange={(event) => updateItem(index, 'note', event.target.value)}
-                              disabled={isReadOnly}
-                              className="w-full text-sm px-3 py-2 bg-white border border-slate-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none disabled:opacity-50 disabled:cursor-not-allowed"
-                            />
-                          )}
-                        </Tooltip>
+                        <input
+                          type="text"
+                          placeholder={t('form:placeholderNotes', {
+                            defaultValue: 'Optional notes...',
+                          })}
+                          value={item.note || ''}
+                          onChange={(event) => updateItem(index, 'note', event.target.value)}
+                          disabled={isReadOnly}
+                          className="w-full text-sm px-3 py-2 bg-white border border-slate-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none disabled:opacity-50 disabled:cursor-not-allowed"
+                        />
                       </div>
                     );
                   })}
@@ -1337,23 +1316,26 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                     <h4 className="text-xs font-black text-praetor uppercase tracking-widest flex items-center gap-2">
                       <span className="w-1.5 h-1.5 rounded-full bg-praetor"></span>
                       {t('sales:clientOffers.notes', { defaultValue: 'Notes' })}
+                      <FieldTooltip
+                        description={t('sales:fieldInfo.notes', {
+                          defaultValue: 'Additional notes for the entire document',
+                        })}
+                        status={readOnlyStatus}
+                        statusLabel={statusLabel}
+                      />
                     </h4>
-                    <Tooltip label={isReadOnly ? readOnlyReason : ''} wrapperClassName="w-full">
-                      {() => (
-                        <textarea
-                          rows={4}
-                          value={formData.notes || ''}
-                          disabled={isReadOnly}
-                          placeholder={t('sales:clientOffers.additionalNotesPlaceholder', {
-                            defaultValue: 'Additional notes...',
-                          })}
-                          onChange={(event) =>
-                            setFormData((prev) => ({ ...prev, notes: event.target.value }))
-                          }
-                          className="w-full text-sm px-4 py-2.5 bg-slate-50 border border-slate-200 rounded-xl focus:ring-2 focus:ring-praetor outline-none transition-all resize-none disabled:opacity-50 disabled:cursor-not-allowed"
-                        />
-                      )}
-                    </Tooltip>
+                    <textarea
+                      rows={4}
+                      value={formData.notes || ''}
+                      disabled={isReadOnly}
+                      placeholder={t('sales:clientOffers.additionalNotesPlaceholder', {
+                        defaultValue: 'Additional notes...',
+                      })}
+                      onChange={(event) =>
+                        setFormData((prev) => ({ ...prev, notes: event.target.value }))
+                      }
+                      className="w-full text-sm px-4 py-2.5 bg-slate-50 border border-slate-200 rounded-xl focus:ring-2 focus:ring-praetor outline-none transition-all resize-none disabled:opacity-50 disabled:cursor-not-allowed"
+                    />
                   </div>
                   <div className="md:w-1/3">
                     <CostSummaryPanel

--- a/components/sales/ClientOffersView.tsx
+++ b/components/sales/ClientOffersView.tsx
@@ -794,6 +794,13 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
               <h4 className="text-xs font-black text-praetor uppercase tracking-widest flex items-center gap-2">
                 <span className="w-1.5 h-1.5 rounded-full bg-praetor"></span>
                 {t('sales:clientOffers.clientInformation', { defaultValue: 'Client Information' })}
+                <FieldTooltip
+                  description={t('sales:fieldInfo.clientInformation', {
+                    defaultValue: 'Client and document details',
+                  })}
+                  status={clientStatus}
+                  statusLabel={statusLabel}
+                />
               </h4>
               <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
                 <div className="space-y-1.5">
@@ -902,6 +909,13 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                 <h4 className="text-xs font-black text-praetor uppercase tracking-widest flex items-center gap-2">
                   <span className="w-1.5 h-1.5 rounded-full bg-praetor"></span>
                   {t('sales:clientOffers.items', { defaultValue: 'Items' })}
+                  <FieldTooltip
+                    description={t('sales:fieldInfo.items', {
+                      defaultValue: 'Line items for this offer',
+                    })}
+                    status={readOnlyStatus}
+                    statusLabel={statusLabel}
+                  />
                 </h4>
                 <button
                   type="button"

--- a/components/sales/ClientOffersView.tsx
+++ b/components/sales/ClientOffersView.tsx
@@ -217,13 +217,13 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
   const isClientLocked = Boolean(editingOffer?.linkedQuoteId);
 
   const readOnlyReason = t('sales:clientOffers.readOnlyStatus', {
-    defaultValue: 'Non-draft offers are read-only. Change status from the list actions.',
+    defaultValue: 'Read-only due to non-draft status',
   });
   const clientLockedReason = t('sales:clientOffers.clientLockedByQuote', {
-    defaultValue: 'Client cannot be changed because this offer is linked to a quote.',
+    defaultValue: 'Locked due to linked quote',
   });
   const supplierLockedReason = t('sales:clientQuotes.fieldLockedBySupplierQuote', {
-    defaultValue: 'Locked because this item is linked to a supplier quote.',
+    defaultValue: 'Locked due to linked supplier quote',
   });
   const statusEditable = t('sales:fieldInfo.statusEditable', { defaultValue: 'Editable' });
   const statusLabel = t('sales:fieldInfo.statusLabel', { defaultValue: 'Status:' });
@@ -783,8 +783,7 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
               <div className="flex items-center gap-3 px-4 py-3 rounded-xl border border-amber-200 bg-amber-50">
                 <span className="text-amber-700 text-xs font-bold">
                   {t('sales:clientOffers.readOnlyStatus', {
-                    defaultValue:
-                      'Non-draft offers are read-only. Change status from the list actions.',
+                    defaultValue: 'Read-only due to non-draft status',
                   })}
                 </span>
               </div>

--- a/components/sales/ClientOffersView.tsx
+++ b/components/sales/ClientOffersView.tsx
@@ -215,6 +215,16 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
   const isReadOnly = Boolean(editingOffer && editingOffer.status !== 'draft');
   const isClientLocked = Boolean(editingOffer?.linkedQuoteId);
 
+  const readOnlyReason = t('sales:clientOffers.readOnlyStatus', {
+    defaultValue: 'Non-draft offers are read-only. Change status from the list actions.',
+  });
+  const clientLockedReason = t('sales:clientOffers.clientLockedByQuote', {
+    defaultValue: 'Client cannot be changed because this offer is linked to a quote.',
+  });
+  const supplierLockedReason = t('sales:clientQuotes.fieldLockedBySupplierQuote', {
+    defaultValue: 'Locked because this item is linked to a supplier quote.',
+  });
+
   const filteredOffers = useMemo(() => {
     return offers.filter((offer) => {
       const matchesSearch =
@@ -781,17 +791,24 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                   <label className="text-xs font-bold text-slate-500 ml-1">
                     {t('sales:clientOffers.client', { defaultValue: 'Client' })}
                   </label>
-                  <CustomSelect
-                    options={clientOptions}
-                    value={formData.clientId || ''}
-                    onChange={(value) => handleClientChange(value as string)}
-                    placeholder={t('sales:clientOffers.selectAClient', {
-                      defaultValue: 'Select a client',
-                    })}
-                    searchable={true}
-                    disabled={isReadOnly || isClientLocked}
-                    className={errors.clientId ? 'border-red-300' : ''}
-                  />
+                  <Tooltip
+                    label={isReadOnly ? readOnlyReason : isClientLocked ? clientLockedReason : ''}
+                    wrapperClassName="w-full"
+                  >
+                    {() => (
+                      <CustomSelect
+                        options={clientOptions}
+                        value={formData.clientId || ''}
+                        onChange={(value) => handleClientChange(value as string)}
+                        placeholder={t('sales:clientOffers.selectAClient', {
+                          defaultValue: 'Select a client',
+                        })}
+                        searchable={true}
+                        disabled={isReadOnly || isClientLocked}
+                        className={errors.clientId ? 'border-red-300' : ''}
+                      />
+                    )}
+                  </Tooltip>
                   {errors.clientId && (
                     <p className="text-red-500 text-[10px] font-bold ml-1">{errors.clientId}</p>
                   )}
@@ -800,16 +817,20 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                   <label className="text-xs font-bold text-slate-500 ml-1">
                     {t('sales:clientOffers.offerCode', { defaultValue: 'Offer code' })}
                   </label>
-                  <input
-                    type="text"
-                    value={formData.id || ''}
-                    disabled={isReadOnly}
-                    onChange={(event) =>
-                      setFormData((prev) => ({ ...prev, id: event.target.value }))
-                    }
-                    placeholder="O0000"
-                    className={`w-full text-sm px-4 py-2.5 bg-slate-50 border ${errors.id ? 'border-red-300' : 'border-slate-200'} rounded-xl focus:ring-2 focus:ring-praetor outline-none transition-all disabled:opacity-50 disabled:cursor-not-allowed`}
-                  />
+                  <Tooltip label={isReadOnly ? readOnlyReason : ''} wrapperClassName="w-full">
+                    {() => (
+                      <input
+                        type="text"
+                        value={formData.id || ''}
+                        disabled={isReadOnly}
+                        onChange={(event) =>
+                          setFormData((prev) => ({ ...prev, id: event.target.value }))
+                        }
+                        placeholder="O0000"
+                        className={`w-full text-sm px-4 py-2.5 bg-slate-50 border ${errors.id ? 'border-red-300' : 'border-slate-200'} rounded-xl focus:ring-2 focus:ring-praetor outline-none transition-all disabled:opacity-50 disabled:cursor-not-allowed`}
+                      />
+                    )}
+                  </Tooltip>
                   {errors.id && (
                     <p className="text-red-500 text-[10px] font-bold ml-1">{errors.id}</p>
                   )}
@@ -818,33 +839,41 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                   <label className="text-xs font-bold text-slate-500 ml-1">
                     {t('sales:clientOffers.paymentTerms', { defaultValue: 'Payment terms' })}
                   </label>
-                  <CustomSelect
-                    options={paymentTermsOptions}
-                    value={formData.paymentTerms || 'immediate'}
-                    onChange={(value) =>
-                      setFormData((prev) => ({
-                        ...prev,
-                        paymentTerms: value as ClientOffer['paymentTerms'],
-                      }))
-                    }
-                    searchable={false}
-                    disabled={isReadOnly}
-                  />
+                  <Tooltip label={isReadOnly ? readOnlyReason : ''} wrapperClassName="w-full">
+                    {() => (
+                      <CustomSelect
+                        options={paymentTermsOptions}
+                        value={formData.paymentTerms || 'immediate'}
+                        onChange={(value) =>
+                          setFormData((prev) => ({
+                            ...prev,
+                            paymentTerms: value as ClientOffer['paymentTerms'],
+                          }))
+                        }
+                        searchable={false}
+                        disabled={isReadOnly}
+                      />
+                    )}
+                  </Tooltip>
                 </div>
                 <div className="space-y-1.5">
                   <label className="text-xs font-bold text-slate-500 ml-1">
                     {t('sales:clientOffers.expirationDate', { defaultValue: 'Expiration date' })}
                   </label>
-                  <input
-                    type="date"
-                    required
-                    value={formData.expirationDate || ''}
-                    disabled={isReadOnly}
-                    onChange={(event) =>
-                      setFormData((prev) => ({ ...prev, expirationDate: event.target.value }))
-                    }
-                    className="w-full text-sm px-4 py-2.5 bg-slate-50 border border-slate-200 rounded-xl focus:ring-2 focus:ring-praetor outline-none transition-all disabled:opacity-50 disabled:cursor-not-allowed"
-                  />
+                  <Tooltip label={isReadOnly ? readOnlyReason : ''} wrapperClassName="w-full">
+                    {() => (
+                      <input
+                        type="date"
+                        required
+                        value={formData.expirationDate || ''}
+                        disabled={isReadOnly}
+                        onChange={(event) =>
+                          setFormData((prev) => ({ ...prev, expirationDate: event.target.value }))
+                        }
+                        className="w-full text-sm px-4 py-2.5 bg-slate-50 border border-slate-200 rounded-xl focus:ring-2 focus:ring-praetor outline-none transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+                      />
+                    )}
+                  </Tooltip>
                 </div>
               </div>
             </div>
@@ -856,15 +885,19 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                   <span className="w-1.5 h-1.5 rounded-full bg-praetor"></span>
                   {t('sales:clientOffers.items', { defaultValue: 'Items' })}
                 </h4>
-                <button
-                  type="button"
-                  onClick={addItem}
-                  disabled={isReadOnly}
-                  className="text-xs font-bold text-praetor hover:text-slate-700 flex items-center gap-1 disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  <i className="fa-solid fa-plus"></i>{' '}
-                  {t('sales:clientOffers.addItem', { defaultValue: 'Add item' })}
-                </button>
+                <Tooltip label={isReadOnly ? readOnlyReason : ''}>
+                  {() => (
+                    <button
+                      type="button"
+                      onClick={addItem}
+                      disabled={isReadOnly}
+                      className="text-xs font-bold text-praetor hover:text-slate-700 flex items-center gap-1 disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      <i className="fa-solid fa-plus"></i>{' '}
+                      {t('sales:clientOffers.addItem', { defaultValue: 'Add item' })}
+                    </button>
+                  )}
+                </Tooltip>
               </div>
               {errors.items && (
                 <p className="text-red-500 text-[10px] font-bold ml-1 -mt-2">{errors.items}</p>
@@ -921,8 +954,16 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                     const lineSalePrice = unitSalePrice * quantity;
                     const lineMargin = lineSalePrice - lineCost;
 
+                    const isLinkedToSupplierQuote = Boolean(item.supplierQuoteItemId);
+                    const lockReasonForLinkedField = isReadOnly
+                      ? readOnlyReason
+                      : isLinkedToSupplierQuote
+                        ? supplierLockedReason
+                        : '';
+                    const lockReasonForReadOnlyOnly = isReadOnly ? readOnlyReason : '';
+
                     const handleCostChange = (value: string) => {
-                      if (isReadOnly) return;
+                      if (isReadOnly || isLinkedToSupplierQuote) return;
                       setFormData(makeCostUpdater<Partial<ClientOffer>>(index, value));
                     };
 
@@ -942,45 +983,57 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                               <div className="mb-1 text-[10px] font-black text-slate-400 uppercase tracking-wider">
                                 {t('sales:clientQuotes.supplierQuoteColumn')}
                               </div>
-                              <CustomSelect
-                                options={supplierQuoteSelectOptions}
-                                value={item.supplierQuoteItemId || 'none'}
-                                onChange={(val) =>
-                                  updateItem(
-                                    index,
-                                    'supplierQuoteItemId',
-                                    val === 'none' ? '' : (val as string),
-                                  )
-                                }
-                                placeholder={t('sales:clientQuotes.selectSupplierQuote')}
-                                displayValue={getSupplierQuoteItemDisplayValue(
-                                  item.supplierQuoteItemId,
+                              <Tooltip label={lockReasonForReadOnlyOnly} wrapperClassName="w-full">
+                                {() => (
+                                  <CustomSelect
+                                    options={supplierQuoteSelectOptions}
+                                    value={item.supplierQuoteItemId || 'none'}
+                                    onChange={(val) =>
+                                      updateItem(
+                                        index,
+                                        'supplierQuoteItemId',
+                                        val === 'none' ? '' : (val as string),
+                                      )
+                                    }
+                                    placeholder={t('sales:clientQuotes.selectSupplierQuote')}
+                                    displayValue={getSupplierQuoteItemDisplayValue(
+                                      item.supplierQuoteItemId,
+                                    )}
+                                    searchable={true}
+                                    disabled={isReadOnly}
+                                    className="min-w-0"
+                                    buttonClassName="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm"
+                                  />
                                 )}
-                                searchable={true}
-                                disabled={isReadOnly}
-                                className="min-w-0"
-                                buttonClassName="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm"
-                              />
+                              </Tooltip>
                             </div>
                             <div className="min-w-0">
                               <div className="mb-1 text-[10px] font-black text-slate-400 uppercase tracking-wider">
                                 {t('sales:clientOffers.product', { defaultValue: 'Product' })}
                               </div>
-                              {renderProductSelectOrFallback(item, index, {
-                                className: 'min-w-0',
-                                buttonClassName:
-                                  'w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm',
-                              })}
+                              <Tooltip label={lockReasonForLinkedField} wrapperClassName="w-full">
+                                {() =>
+                                  renderProductSelectOrFallback(item, index, {
+                                    className: 'min-w-0',
+                                    buttonClassName:
+                                      'w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm',
+                                  })
+                                }
+                              </Tooltip>
                             </div>
                           </div>
-                          <button
-                            type="button"
-                            onClick={() => removeItem(index)}
-                            disabled={isReadOnly}
-                            className="mt-5 w-10 h-10 flex items-center justify-center text-slate-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-all shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
-                          >
-                            <i className="fa-solid fa-trash-can"></i>
-                          </button>
+                          <Tooltip label={lockReasonForReadOnlyOnly}>
+                            {() => (
+                              <button
+                                type="button"
+                                onClick={() => removeItem(index)}
+                                disabled={isReadOnly}
+                                className="mt-5 w-10 h-10 flex items-center justify-center text-slate-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-all shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
+                              >
+                                <i className="fa-solid fa-trash-can"></i>
+                              </button>
+                            )}
+                          </Tooltip>
                         </div>
                         <div className="grid grid-cols-2 gap-3 md:grid-cols-6 lg:hidden">
                           <div>
@@ -988,46 +1041,61 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                               {t('sales:clientOffers.qty', { defaultValue: 'Qty' })}
                             </div>
                             <div className="flex items-center gap-1">
-                              <ValidatedNumberInput
-                                step="0.01"
-                                min="0"
-                                required
-                                placeholder={t('sales:clientOffers.qty', { defaultValue: 'Qty' })}
-                                value={item.quantity}
-                                onValueChange={(value) =>
-                                  updateItem(index, 'quantity', parseNumberInputValue(value))
-                                }
-                                disabled={isReadOnly || Boolean(item.supplierQuoteItemId)}
-                                className="w-full text-sm px-3 py-2 bg-white border border-slate-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed flex-1"
-                              />
+                              <Tooltip
+                                label={lockReasonForLinkedField}
+                                wrapperClassName="flex-1 min-w-0"
+                              >
+                                {() => (
+                                  <ValidatedNumberInput
+                                    step="0.01"
+                                    min="0"
+                                    required
+                                    placeholder={t('sales:clientOffers.qty', {
+                                      defaultValue: 'Qty',
+                                    })}
+                                    value={item.quantity}
+                                    onValueChange={(value) =>
+                                      updateItem(index, 'quantity', parseNumberInputValue(value))
+                                    }
+                                    disabled={isReadOnly || isLinkedToSupplierQuote}
+                                    className="w-full text-sm px-3 py-2 bg-white border border-slate-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
+                                  />
+                                )}
+                              </Tooltip>
                               <span className="text-xs font-semibold text-slate-400 shrink-0">
                                 /
                               </span>
-                              <UnitTypeSelector
-                                value={(item.unitType || 'hours') as SupplierUnitType}
-                                onChange={(val) => handleUnitTypeChange(index, val)}
-                                isSupply={isSupply}
-                                quantity={Number(item.quantity) || 0}
-                                disabled={isReadOnly || Boolean(item.supplierQuoteItemId)}
-                              />
+                              <Tooltip label={lockReasonForLinkedField}>
+                                {() => (
+                                  <UnitTypeSelector
+                                    value={(item.unitType || 'hours') as SupplierUnitType}
+                                    onChange={(val) => handleUnitTypeChange(index, val)}
+                                    isSupply={isSupply}
+                                    quantity={Number(item.quantity) || 0}
+                                    disabled={isReadOnly || isLinkedToSupplierQuote}
+                                  />
+                                )}
+                              </Tooltip>
                             </div>
                           </div>
                           <div className="rounded-lg border border-slate-200 bg-white px-3 py-2 space-y-1">
                             <div className="text-[10px] font-black text-slate-400 uppercase tracking-wider">
                               {t('crm:internalListing.cost')}
                             </div>
-                            {selectedSupplierQuote && (
-                              <span className="inline-flex px-2 py-0.5 rounded-full bg-emerald-600 text-white text-[8px] font-black uppercase tracking-wider">
-                                {t('sales:clientQuotes.supplierQuoteBadge')}
-                              </span>
-                            )}
                             <div className="flex items-center gap-1">
-                              <ValidatedNumberInput
-                                value={cost.toFixed(2)}
-                                onValueChange={handleCostChange}
-                                disabled={isReadOnly}
-                                className="w-full text-sm px-2 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
-                              />
+                              <Tooltip
+                                label={lockReasonForLinkedField}
+                                wrapperClassName="flex-1 min-w-0"
+                              >
+                                {() => (
+                                  <ValidatedNumberInput
+                                    value={cost.toFixed(2)}
+                                    onValueChange={handleCostChange}
+                                    disabled={isReadOnly || isLinkedToSupplierQuote}
+                                    className="w-full text-sm px-2 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
+                                  />
+                                )}
+                              </Tooltip>
                               <span className="text-[9px] font-semibold text-slate-400 shrink-0">
                                 {currency}
                               </span>
@@ -1038,12 +1106,19 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                               {t('sales:clientQuotes.molLabel', { defaultValue: 'MOL' })} (%)
                             </div>
                             <div className="flex items-center gap-1">
-                              <ValidatedNumberInput
-                                value={molPercentage.toFixed(1)}
-                                onValueChange={handleMolChange}
-                                disabled={isReadOnly}
-                                className="w-full text-sm px-2 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
-                              />
+                              <Tooltip
+                                label={lockReasonForReadOnlyOnly}
+                                wrapperClassName="flex-1 min-w-0"
+                              >
+                                {() => (
+                                  <ValidatedNumberInput
+                                    value={molPercentage.toFixed(1)}
+                                    onValueChange={handleMolChange}
+                                    disabled={isReadOnly}
+                                    className="w-full text-sm px-2 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
+                                  />
+                                )}
+                              </Tooltip>
                               <span className="text-[9px] font-semibold text-slate-400 shrink-0">
                                 %
                               </span>
@@ -1079,84 +1154,112 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                         <div className="hidden lg:flex gap-2 items-center">
                           <div className="flex-1 min-w-0 grid grid-cols-13 gap-2 items-center">
                             <div className="col-span-3 min-w-0">
-                              <CustomSelect
-                                options={supplierQuoteSelectOptions}
-                                value={item.supplierQuoteItemId || 'none'}
-                                onChange={(val) =>
-                                  updateItem(
-                                    index,
-                                    'supplierQuoteItemId',
-                                    val === 'none' ? '' : (val as string),
-                                  )
-                                }
-                                placeholder={t('sales:clientQuotes.selectSupplierQuote')}
-                                displayValue={getSupplierQuoteItemDisplayValue(
-                                  item.supplierQuoteItemId,
+                              <Tooltip label={lockReasonForReadOnlyOnly} wrapperClassName="w-full">
+                                {() => (
+                                  <CustomSelect
+                                    options={supplierQuoteSelectOptions}
+                                    value={item.supplierQuoteItemId || 'none'}
+                                    onChange={(val) =>
+                                      updateItem(
+                                        index,
+                                        'supplierQuoteItemId',
+                                        val === 'none' ? '' : (val as string),
+                                      )
+                                    }
+                                    placeholder={t('sales:clientQuotes.selectSupplierQuote')}
+                                    displayValue={getSupplierQuoteItemDisplayValue(
+                                      item.supplierQuoteItemId,
+                                    )}
+                                    searchable={true}
+                                    disabled={isReadOnly}
+                                    className="min-w-0"
+                                    buttonClassName="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm"
+                                  />
                                 )}
-                                searchable={true}
-                                disabled={isReadOnly}
-                                className="min-w-0"
-                                buttonClassName="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm"
-                              />
+                              </Tooltip>
                             </div>
                             <div className="col-span-3 min-w-0">
-                              {renderProductSelectOrFallback(item, index, {
-                                className: 'min-w-0',
-                                buttonClassName:
-                                  'w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm',
-                              })}
+                              <Tooltip label={lockReasonForLinkedField} wrapperClassName="w-full">
+                                {() =>
+                                  renderProductSelectOrFallback(item, index, {
+                                    className: 'min-w-0',
+                                    buttonClassName:
+                                      'w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm',
+                                  })
+                                }
+                              </Tooltip>
                             </div>
                             <div className="col-span-2">
                               <div className="flex items-center gap-1">
-                                <ValidatedNumberInput
-                                  step="0.01"
-                                  min="0"
-                                  required
-                                  placeholder={t('sales:clientOffers.qty', { defaultValue: 'Qty' })}
-                                  value={item.quantity}
-                                  onValueChange={(value) =>
-                                    updateItem(index, 'quantity', parseNumberInputValue(value))
-                                  }
-                                  disabled={isReadOnly || Boolean(item.supplierQuoteItemId)}
-                                  className="w-full text-sm px-2 py-2 bg-white border border-slate-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
-                                />
+                                <Tooltip
+                                  label={lockReasonForLinkedField}
+                                  wrapperClassName="flex-1 min-w-0"
+                                >
+                                  {() => (
+                                    <ValidatedNumberInput
+                                      step="0.01"
+                                      min="0"
+                                      required
+                                      placeholder={t('sales:clientOffers.qty', {
+                                        defaultValue: 'Qty',
+                                      })}
+                                      value={item.quantity}
+                                      onValueChange={(value) =>
+                                        updateItem(index, 'quantity', parseNumberInputValue(value))
+                                      }
+                                      disabled={isReadOnly || isLinkedToSupplierQuote}
+                                      className="w-full text-sm px-2 py-2 bg-white border border-slate-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
+                                    />
+                                  )}
+                                </Tooltip>
                                 <span className="text-xs font-semibold text-slate-400 shrink-0">
                                   /
                                 </span>
-                                <UnitTypeSelector
-                                  value={(item.unitType || 'hours') as SupplierUnitType}
-                                  onChange={(val) => handleUnitTypeChange(index, val)}
-                                  isSupply={isSupply}
-                                  quantity={Number(item.quantity) || 0}
-                                  disabled={isReadOnly || Boolean(item.supplierQuoteItemId)}
-                                />
-                              </div>
-                            </div>
-                            <div className="col-span-1 flex flex-col items-center justify-center gap-1">
-                              {selectedSupplierQuote && (
-                                <span className="px-2 py-0.5 rounded-full bg-emerald-600 text-white text-[8px] font-black uppercase tracking-wider">
-                                  {t('sales:clientQuotes.supplierQuoteBadge')}
-                                </span>
-                              )}
-                              <div className="flex items-center gap-1 w-full">
-                                <ValidatedNumberInput
-                                  value={cost.toFixed(2)}
-                                  onValueChange={handleCostChange}
-                                  disabled={isReadOnly}
-                                  className="w-full text-sm px-1 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
-                                />
-                                <span className="text-[9px] font-semibold text-slate-400 shrink-0">
-                                  {currency}
-                                </span>
+                                <Tooltip label={lockReasonForLinkedField}>
+                                  {() => (
+                                    <UnitTypeSelector
+                                      value={(item.unitType || 'hours') as SupplierUnitType}
+                                      onChange={(val) => handleUnitTypeChange(index, val)}
+                                      isSupply={isSupply}
+                                      quantity={Number(item.quantity) || 0}
+                                      disabled={isReadOnly || isLinkedToSupplierQuote}
+                                    />
+                                  )}
+                                </Tooltip>
                               </div>
                             </div>
                             <div className="col-span-1 flex items-center justify-center gap-1">
-                              <ValidatedNumberInput
-                                value={molPercentage.toFixed(1)}
-                                onValueChange={handleMolChange}
-                                disabled={isReadOnly}
-                                className="w-full text-sm px-1 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
-                              />
+                              <Tooltip
+                                label={lockReasonForLinkedField}
+                                wrapperClassName="flex-1 min-w-0"
+                              >
+                                {() => (
+                                  <ValidatedNumberInput
+                                    value={cost.toFixed(2)}
+                                    onValueChange={handleCostChange}
+                                    disabled={isReadOnly || isLinkedToSupplierQuote}
+                                    className="w-full text-sm px-1 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
+                                  />
+                                )}
+                              </Tooltip>
+                              <span className="text-[9px] font-semibold text-slate-400 shrink-0">
+                                {currency}
+                              </span>
+                            </div>
+                            <div className="col-span-1 flex items-center justify-center gap-1">
+                              <Tooltip
+                                label={lockReasonForReadOnlyOnly}
+                                wrapperClassName="flex-1 min-w-0"
+                              >
+                                {() => (
+                                  <ValidatedNumberInput
+                                    value={molPercentage.toFixed(1)}
+                                    onValueChange={handleMolChange}
+                                    disabled={isReadOnly}
+                                    className="w-full text-sm px-1 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
+                                  />
+                                )}
+                              </Tooltip>
                               <span className="text-[9px] font-semibold text-slate-400 shrink-0">
                                 %
                               </span>
@@ -1179,25 +1282,33 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                               </span>
                             </div>
                           </div>
-                          <button
-                            type="button"
-                            onClick={() => removeItem(index)}
-                            disabled={isReadOnly}
-                            className="w-10 h-10 flex items-center justify-center text-slate-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-all shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
-                          >
-                            <i className="fa-solid fa-trash-can"></i>
-                          </button>
+                          <Tooltip label={lockReasonForReadOnlyOnly}>
+                            {() => (
+                              <button
+                                type="button"
+                                onClick={() => removeItem(index)}
+                                disabled={isReadOnly}
+                                className="w-10 h-10 flex items-center justify-center text-slate-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-all shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
+                              >
+                                <i className="fa-solid fa-trash-can"></i>
+                              </button>
+                            )}
+                          </Tooltip>
                         </div>
-                        <input
-                          type="text"
-                          placeholder={t('form:placeholderNotes', {
-                            defaultValue: 'Optional notes...',
-                          })}
-                          value={item.note || ''}
-                          onChange={(event) => updateItem(index, 'note', event.target.value)}
-                          disabled={isReadOnly}
-                          className="w-full text-sm px-3 py-2 bg-white border border-slate-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none disabled:opacity-50 disabled:cursor-not-allowed"
-                        />
+                        <Tooltip label={lockReasonForReadOnlyOnly} wrapperClassName="w-full">
+                          {() => (
+                            <input
+                              type="text"
+                              placeholder={t('form:placeholderNotes', {
+                                defaultValue: 'Optional notes...',
+                              })}
+                              value={item.note || ''}
+                              onChange={(event) => updateItem(index, 'note', event.target.value)}
+                              disabled={isReadOnly}
+                              className="w-full text-sm px-3 py-2 bg-white border border-slate-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none disabled:opacity-50 disabled:cursor-not-allowed"
+                            />
+                          )}
+                        </Tooltip>
                       </div>
                     );
                   })}
@@ -1227,18 +1338,22 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                       <span className="w-1.5 h-1.5 rounded-full bg-praetor"></span>
                       {t('sales:clientOffers.notes', { defaultValue: 'Notes' })}
                     </h4>
-                    <textarea
-                      rows={4}
-                      value={formData.notes || ''}
-                      disabled={isReadOnly}
-                      placeholder={t('sales:clientOffers.additionalNotesPlaceholder', {
-                        defaultValue: 'Additional notes...',
-                      })}
-                      onChange={(event) =>
-                        setFormData((prev) => ({ ...prev, notes: event.target.value }))
-                      }
-                      className="w-full text-sm px-4 py-2.5 bg-slate-50 border border-slate-200 rounded-xl focus:ring-2 focus:ring-praetor outline-none transition-all resize-none disabled:opacity-50 disabled:cursor-not-allowed"
-                    />
+                    <Tooltip label={isReadOnly ? readOnlyReason : ''} wrapperClassName="w-full">
+                      {() => (
+                        <textarea
+                          rows={4}
+                          value={formData.notes || ''}
+                          disabled={isReadOnly}
+                          placeholder={t('sales:clientOffers.additionalNotesPlaceholder', {
+                            defaultValue: 'Additional notes...',
+                          })}
+                          onChange={(event) =>
+                            setFormData((prev) => ({ ...prev, notes: event.target.value }))
+                          }
+                          className="w-full text-sm px-4 py-2.5 bg-slate-50 border border-slate-200 rounded-xl focus:ring-2 focus:ring-praetor outline-none transition-all resize-none disabled:opacity-50 disabled:cursor-not-allowed"
+                        />
+                      )}
+                    </Tooltip>
                   </div>
                   <div className="md:w-1/3">
                     <CostSummaryPanel

--- a/components/sales/ClientOffersView.tsx
+++ b/components/sales/ClientOffersView.tsx
@@ -16,6 +16,7 @@ import {
   isDateOnlyBeforeToday,
   normalizeDateOnlyString,
 } from '../../utils/date';
+import { getLinkedFieldStatus } from '../../utils/fieldStatus';
 import {
   calcProductSalePrice,
   calculatePricingTotals,
@@ -804,15 +805,8 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
               </h4>
               <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
                 <div className="space-y-1.5">
-                  <label className="text-xs font-bold text-slate-500 ml-1 flex items-center gap-1">
+                  <label className="text-xs font-bold text-slate-500 ml-1">
                     {t('sales:clientOffers.client', { defaultValue: 'Client' })}
-                    <FieldTooltip
-                      description={t('sales:fieldInfo.client', {
-                        defaultValue: 'Select the client for this document',
-                      })}
-                      status={clientStatus}
-                      statusLabel={statusLabel}
-                    />
                   </label>
                   <CustomSelect
                     options={clientOptions}
@@ -830,15 +824,8 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                   )}
                 </div>
                 <div className="space-y-1.5">
-                  <label className="text-xs font-bold text-slate-500 ml-1 flex items-center gap-1">
+                  <label className="text-xs font-bold text-slate-500 ml-1">
                     {t('sales:clientOffers.offerCode', { defaultValue: 'Offer code' })}
-                    <FieldTooltip
-                      description={t('sales:fieldInfo.offerCode', {
-                        defaultValue: 'Unique identifier for this offer',
-                      })}
-                      status={readOnlyStatus}
-                      statusLabel={statusLabel}
-                    />
                   </label>
                   <input
                     type="text"
@@ -855,15 +842,8 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                   )}
                 </div>
                 <div className="space-y-1.5">
-                  <label className="text-xs font-bold text-slate-500 ml-1 flex items-center gap-1">
+                  <label className="text-xs font-bold text-slate-500 ml-1">
                     {t('sales:clientOffers.paymentTerms', { defaultValue: 'Payment terms' })}
-                    <FieldTooltip
-                      description={t('sales:fieldInfo.paymentTerms', {
-                        defaultValue: 'Payment terms and conditions',
-                      })}
-                      status={readOnlyStatus}
-                      statusLabel={statusLabel}
-                    />
                   </label>
                   <CustomSelect
                     options={paymentTermsOptions}
@@ -879,15 +859,8 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                   />
                 </div>
                 <div className="space-y-1.5">
-                  <label className="text-xs font-bold text-slate-500 ml-1 flex items-center gap-1">
+                  <label className="text-xs font-bold text-slate-500 ml-1">
                     {t('sales:clientOffers.expirationDate', { defaultValue: 'Expiration date' })}
-                    <FieldTooltip
-                      description={t('sales:fieldInfo.expirationDate', {
-                        defaultValue: 'Date until which this document is valid',
-                      })}
-                      status={readOnlyStatus}
-                      statusLabel={statusLabel}
-                    />
                   </label>
                   <input
                     type="date"
@@ -926,13 +899,6 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                   <i className="fa-solid fa-plus"></i>{' '}
                   {t('sales:clientOffers.addItem', { defaultValue: 'Add item' })}
                 </button>
-                <FieldTooltip
-                  description={t('sales:fieldInfo.addItem', {
-                    defaultValue: 'Add a new line item',
-                  })}
-                  status={readOnlyStatus}
-                  statusLabel={statusLabel}
-                />
               </div>
               {errors.items && (
                 <p className="text-red-500 text-[10px] font-bold ml-1 -mt-2">{errors.items}</p>
@@ -990,11 +956,13 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                     const lineMargin = lineSalePrice - lineCost;
 
                     const isLinkedToSupplierQuote = Boolean(item.supplierQuoteItemId);
-                    const linkedFieldStatus = isReadOnly
-                      ? readOnlyReason
-                      : isLinkedToSupplierQuote
-                        ? supplierLockedReason
-                        : statusEditable;
+                    const linkedFieldStatus = getLinkedFieldStatus(
+                      isReadOnly,
+                      isLinkedToSupplierQuote,
+                      readOnlyReason,
+                      supplierLockedReason,
+                      statusEditable,
+                    );
 
                     const handleCostChange = (value: string) => {
                       if (isReadOnly) return;

--- a/components/sales/ClientOffersView.tsx
+++ b/components/sales/ClientOffersView.tsx
@@ -223,7 +223,7 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
   const clientLockedReason = t('sales:clientOffers.clientLockedByQuote', {
     defaultValue: 'Locked due to linked quote',
   });
-  const supplierLockedReason = t('sales:clientQuotes.fieldLockedBySupplierQuote', {
+  const supplierLockedReason = t('sales:fieldInfo.fieldLockedBySupplierQuote', {
     defaultValue: 'Locked due to linked supplier quote',
   });
   const statusEditable = t('sales:fieldInfo.statusEditable', { defaultValue: 'Editable' });
@@ -939,9 +939,6 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
               {formData.items && formData.items.length > 0 ? (
                 <div className="space-y-3">
                   {formData.items.map((item, index) => {
-                    const selectedSupplierQuote = item.supplierQuoteItemId
-                      ? supplierQuoteItemOptions.find((o) => o.id === item.supplierQuoteItemId)
-                      : undefined;
                     const isSupply =
                       products.find((p) => p.id === item.productId)?.type === 'supply';
 
@@ -956,13 +953,13 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                     const lineMargin = lineSalePrice - lineCost;
 
                     const isLinkedToSupplierQuote = Boolean(item.supplierQuoteItemId);
-                    const linkedFieldStatus = getLinkedFieldStatus(
+                    const linkedFieldStatus = getLinkedFieldStatus({
                       isReadOnly,
                       isLinkedToSupplierQuote,
                       readOnlyReason,
                       supplierLockedReason,
                       statusEditable,
-                    );
+                    });
 
                     const handleCostChange = (value: string) => {
                       if (isReadOnly) return;
@@ -1145,9 +1142,7 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                             <div className="text-[10px] font-black text-slate-400 uppercase tracking-wider">
                               {t('sales:clientQuotes.revenue')}
                             </div>
-                            <div
-                              className={`text-sm font-semibold whitespace-nowrap ${selectedSupplierQuote ? 'text-emerald-600' : 'text-slate-800'}`}
-                            >
+                            <div className="text-sm font-semibold whitespace-nowrap text-slate-800">
                               {lineSalePrice.toFixed(2)} {currency}
                             </div>
                           </div>
@@ -1243,9 +1238,7 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                               </span>
                             </div>
                             <div className="col-span-1 flex items-center justify-center">
-                              <span
-                                className={`text-xs font-semibold whitespace-nowrap ${selectedSupplierQuote ? 'text-emerald-600' : 'text-slate-800'}`}
-                              >
+                              <span className="text-xs font-semibold whitespace-nowrap text-slate-800">
                                 {lineSalePrice.toFixed(2)} {currency}
                               </span>
                             </div>

--- a/components/sales/ClientQuotesView.tsx
+++ b/components/sales/ClientQuotesView.tsx
@@ -173,6 +173,17 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
         editingQuote.status === 'denied'),
   );
 
+  const readOnlyReason = editingQuote?.linkedOfferId
+    ? t('sales:clientQuotes.readOnlyBecauseOffer', {
+        defaultValue: 'This quote is read-only because an offer was created from it.',
+      })
+    : t('sales:clientQuotes.readOnlyBecauseFinal', {
+        defaultValue: 'This quote is read-only because it was already accepted or denied.',
+      });
+  const supplierLockedReason = t('sales:clientQuotes.fieldLockedBySupplierQuote', {
+    defaultValue: 'Locked because this item is linked to a supplier quote.',
+  });
+
   const formTotals = useMemo(() => {
     const discountValue = Number.isNaN(formData.discount ?? 0) ? 0 : (formData.discount ?? 0);
     return {
@@ -1218,15 +1229,19 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                   <label className="text-xs font-bold text-slate-500 ml-1">
                     {t('sales:clientQuotes.client')}
                   </label>
-                  <CustomSelect
-                    options={activeClients.map((c) => ({ id: c.id, name: c.name }))}
-                    value={formData.clientId || ''}
-                    onChange={(val) => handleClientChange(val as string)}
-                    placeholder={t('sales:clientQuotes.selectAClient')}
-                    searchable={true}
-                    disabled={isReadOnly}
-                    className={errors.clientId ? 'border-red-300' : ''}
-                  />
+                  <Tooltip label={isReadOnly ? readOnlyReason : ''} wrapperClassName="w-full">
+                    {() => (
+                      <CustomSelect
+                        options={activeClients.map((c) => ({ id: c.id, name: c.name }))}
+                        value={formData.clientId || ''}
+                        onChange={(val) => handleClientChange(val as string)}
+                        placeholder={t('sales:clientQuotes.selectAClient')}
+                        searchable={true}
+                        disabled={isReadOnly}
+                        className={errors.clientId ? 'border-red-300' : ''}
+                      />
+                    )}
+                  </Tooltip>
                   {errors.clientId && (
                     <p className="text-red-500 text-[10px] font-bold ml-1">{errors.clientId}</p>
                   )}
@@ -1235,25 +1250,29 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                   <label className="text-xs font-bold text-slate-500 ml-1">
                     {t('sales:clientQuotes.quoteCode', { defaultValue: 'Quote Code' })}
                   </label>
-                  <input
-                    type="text"
-                    value={formData.id || ''}
-                    onChange={(e) => {
-                      setFormData({ ...formData, id: e.target.value });
-                      if (errors.id) {
-                        setErrors((prev) => {
-                          const next = { ...prev };
-                          delete next.id;
-                          return next;
-                        });
-                      }
-                    }}
-                    placeholder="Q0000"
-                    disabled={isReadOnly}
-                    className={`w-full rounded-xl border ${
-                      errors.id ? 'border-red-300' : 'border-slate-200'
-                    } bg-slate-50 px-4 py-2.5 text-sm font-bold outline-none focus:ring-2 focus:ring-praetor disabled:opacity-50 disabled:cursor-not-allowed`}
-                  />
+                  <Tooltip label={isReadOnly ? readOnlyReason : ''} wrapperClassName="w-full">
+                    {() => (
+                      <input
+                        type="text"
+                        value={formData.id || ''}
+                        onChange={(e) => {
+                          setFormData({ ...formData, id: e.target.value });
+                          if (errors.id) {
+                            setErrors((prev) => {
+                              const next = { ...prev };
+                              delete next.id;
+                              return next;
+                            });
+                          }
+                        }}
+                        placeholder="Q0000"
+                        disabled={isReadOnly}
+                        className={`w-full rounded-xl border ${
+                          errors.id ? 'border-red-300' : 'border-slate-200'
+                        } bg-slate-50 px-4 py-2.5 text-sm font-bold outline-none focus:ring-2 focus:ring-praetor disabled:opacity-50 disabled:cursor-not-allowed`}
+                      />
+                    )}
+                  </Tooltip>
                   {errors.id && (
                     <p className="text-red-500 text-[10px] font-bold ml-1">{errors.id}</p>
                   )}
@@ -1262,28 +1281,38 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                   <label className="text-xs font-bold text-slate-500 ml-1">
                     {t('sales:clientQuotes.paymentTerms')}
                   </label>
-                  <CustomSelect
-                    options={paymentTermsOptions}
-                    value={formData.paymentTerms || 'immediate'}
-                    onChange={(val) =>
-                      setFormData({ ...formData, paymentTerms: val as Quote['paymentTerms'] })
-                    }
-                    searchable={false}
-                    disabled={isReadOnly}
-                  />
+                  <Tooltip label={isReadOnly ? readOnlyReason : ''} wrapperClassName="w-full">
+                    {() => (
+                      <CustomSelect
+                        options={paymentTermsOptions}
+                        value={formData.paymentTerms || 'immediate'}
+                        onChange={(val) =>
+                          setFormData({ ...formData, paymentTerms: val as Quote['paymentTerms'] })
+                        }
+                        searchable={false}
+                        disabled={isReadOnly}
+                      />
+                    )}
+                  </Tooltip>
                 </div>
                 <div className="space-y-1.5">
                   <label className="text-xs font-bold text-slate-500 ml-1">
                     {t('sales:clientQuotes.expirationDateLabel')}
                   </label>
-                  <input
-                    type="date"
-                    required
-                    value={formData.expirationDate}
-                    onChange={(e) => setFormData({ ...formData, expirationDate: e.target.value })}
-                    disabled={isReadOnly}
-                    className="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-2.5 text-sm outline-none focus:ring-2 focus:ring-praetor disabled:opacity-50 disabled:cursor-not-allowed"
-                  />
+                  <Tooltip label={isReadOnly ? readOnlyReason : ''} wrapperClassName="w-full">
+                    {() => (
+                      <input
+                        type="date"
+                        required
+                        value={formData.expirationDate}
+                        onChange={(e) =>
+                          setFormData({ ...formData, expirationDate: e.target.value })
+                        }
+                        disabled={isReadOnly}
+                        className="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-2.5 text-sm outline-none focus:ring-2 focus:ring-praetor disabled:opacity-50 disabled:cursor-not-allowed"
+                      />
+                    )}
+                  </Tooltip>
                 </div>
               </div>
             </div>
@@ -1295,14 +1324,18 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                   <span className="w-1.5 h-1.5 rounded-full bg-praetor"></span>
                   {t('sales:clientQuotes.productsServices')}
                 </h4>
-                <button
-                  type="button"
-                  onClick={addProductRow}
-                  disabled={isReadOnly}
-                  className="text-xs font-bold text-praetor hover:text-slate-700 flex items-center gap-1 disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  <i className="fa-solid fa-plus"></i> {t('sales:clientQuotes.addProduct')}
-                </button>
+                <Tooltip label={isReadOnly ? readOnlyReason : ''}>
+                  {() => (
+                    <button
+                      type="button"
+                      onClick={addProductRow}
+                      disabled={isReadOnly}
+                      className="text-xs font-bold text-praetor hover:text-slate-700 flex items-center gap-1 disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      <i className="fa-solid fa-plus"></i> {t('sales:clientQuotes.addProduct')}
+                    </button>
+                  )}
+                </Tooltip>
               </div>
               {errors.items && (
                 <p className="text-red-500 text-[10px] font-bold ml-1 -mt-2">{errors.items}</p>
@@ -1359,8 +1392,16 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                     const lineSalePrice = unitSalePrice * quantity;
                     const lineMargin = lineSalePrice - lineCost;
 
+                    const isLinkedToSupplierQuote = Boolean(item.supplierQuoteItemId);
+                    const lockReasonForLinkedField = isReadOnly
+                      ? readOnlyReason
+                      : isLinkedToSupplierQuote
+                        ? supplierLockedReason
+                        : '';
+                    const lockReasonForReadOnlyOnly = isReadOnly ? readOnlyReason : '';
+
                     const handleCostChange = (value: string) => {
-                      if (isReadOnly) return;
+                      if (isReadOnly || isLinkedToSupplierQuote) return;
                       setFormData(makeCostUpdater<Partial<Quote>>(index, value));
                     };
 
@@ -1380,51 +1421,66 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                               <div className="mb-1 text-[10px] font-black text-slate-400 uppercase tracking-wider">
                                 {t('sales:clientQuotes.supplierQuoteColumn')}
                               </div>
-                              <CustomSelect
-                                options={[
-                                  { id: 'none', name: t('sales:clientQuotes.noSupplierQuote') },
-                                  ...supplierQuoteItemOptions.map((o) => ({
-                                    id: o.id,
-                                    name: o.name,
-                                  })),
-                                ]}
-                                value={item.supplierQuoteItemId || 'none'}
-                                onChange={(val) =>
-                                  updateProductRow(
-                                    index,
-                                    'supplierQuoteItemId',
-                                    val === 'none' ? '' : (val as string),
-                                  )
-                                }
-                                placeholder={t('sales:clientQuotes.selectSupplierQuote')}
-                                displayValue={getSupplierQuoteItemDisplayValue(
-                                  item.supplierQuoteItemId,
+                              <Tooltip label={lockReasonForReadOnlyOnly} wrapperClassName="w-full">
+                                {() => (
+                                  <CustomSelect
+                                    options={[
+                                      {
+                                        id: 'none',
+                                        name: t('sales:clientQuotes.noSupplierQuote'),
+                                      },
+                                      ...supplierQuoteItemOptions.map((o) => ({
+                                        id: o.id,
+                                        name: o.name,
+                                      })),
+                                    ]}
+                                    value={item.supplierQuoteItemId || 'none'}
+                                    onChange={(val) =>
+                                      updateProductRow(
+                                        index,
+                                        'supplierQuoteItemId',
+                                        val === 'none' ? '' : (val as string),
+                                      )
+                                    }
+                                    placeholder={t('sales:clientQuotes.selectSupplierQuote')}
+                                    displayValue={getSupplierQuoteItemDisplayValue(
+                                      item.supplierQuoteItemId,
+                                    )}
+                                    searchable={true}
+                                    disabled={isReadOnly}
+                                    className="min-w-0"
+                                    buttonClassName="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm"
+                                  />
                                 )}
-                                searchable={true}
-                                disabled={isReadOnly}
-                                className="min-w-0"
-                                buttonClassName="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm"
-                              />
+                              </Tooltip>
                             </div>
                             <div className="min-w-0">
                               <div className="mb-1 text-[10px] font-black text-slate-400 uppercase tracking-wider">
                                 {t('sales:clientQuotes.productsServices')}
                               </div>
-                              {renderProductSelectOrFallback(item, index, {
-                                className: 'min-w-0',
-                                buttonClassName:
-                                  'w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm',
-                              })}
+                              <Tooltip label={lockReasonForLinkedField} wrapperClassName="w-full">
+                                {() =>
+                                  renderProductSelectOrFallback(item, index, {
+                                    className: 'min-w-0',
+                                    buttonClassName:
+                                      'w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm',
+                                  })
+                                }
+                              </Tooltip>
                             </div>
                           </div>
-                          <button
-                            type="button"
-                            onClick={() => removeProductRow(index)}
-                            disabled={isReadOnly}
-                            className="mt-5 w-10 h-10 flex items-center justify-center text-slate-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-all shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
-                          >
-                            <i className="fa-solid fa-trash-can"></i>
-                          </button>
+                          <Tooltip label={lockReasonForReadOnlyOnly}>
+                            {() => (
+                              <button
+                                type="button"
+                                onClick={() => removeProductRow(index)}
+                                disabled={isReadOnly}
+                                className="mt-5 w-10 h-10 flex items-center justify-center text-slate-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-all shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
+                              >
+                                <i className="fa-solid fa-trash-can"></i>
+                              </button>
+                            )}
+                          </Tooltip>
                         </div>
                         <div className="grid grid-cols-2 gap-3 md:grid-cols-6 lg:hidden">
                           <div>
@@ -1432,51 +1488,64 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                               {t('sales:clientQuotes.qty')}
                             </div>
                             <div className="flex items-center gap-1">
-                              <ValidatedNumberInput
-                                step="0.01"
-                                min="0"
-                                required
-                                placeholder={t('sales:clientQuotes.qty')}
-                                value={item.quantity}
-                                onValueChange={(value) => {
-                                  const parsed = parseFloat(value);
-                                  updateProductRow(
-                                    index,
-                                    'quantity',
-                                    value === '' || Number.isNaN(parsed) ? 0 : parsed,
-                                  );
-                                }}
-                                disabled={isReadOnly || Boolean(item.supplierQuoteItemId)}
-                                className="w-full text-sm px-3 py-2 bg-white border border-slate-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed flex-1"
-                              />
+                              <Tooltip
+                                label={lockReasonForLinkedField}
+                                wrapperClassName="flex-1 min-w-0"
+                              >
+                                {() => (
+                                  <ValidatedNumberInput
+                                    step="0.01"
+                                    min="0"
+                                    required
+                                    placeholder={t('sales:clientQuotes.qty')}
+                                    value={item.quantity}
+                                    onValueChange={(value) => {
+                                      const parsed = parseFloat(value);
+                                      updateProductRow(
+                                        index,
+                                        'quantity',
+                                        value === '' || Number.isNaN(parsed) ? 0 : parsed,
+                                      );
+                                    }}
+                                    disabled={isReadOnly || isLinkedToSupplierQuote}
+                                    className="w-full text-sm px-3 py-2 bg-white border border-slate-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
+                                  />
+                                )}
+                              </Tooltip>
                               <span className="text-xs font-semibold text-slate-400 shrink-0">
                                 /
                               </span>
-                              <UnitTypeSelector
-                                value={(item.unitType || 'hours') as SupplierUnitType}
-                                onChange={(val) => handleUnitTypeChange(index, val)}
-                                isSupply={isSupply}
-                                quantity={Number(item.quantity) || 0}
-                                disabled={isReadOnly || Boolean(item.supplierQuoteItemId)}
-                              />
+                              <Tooltip label={lockReasonForLinkedField}>
+                                {() => (
+                                  <UnitTypeSelector
+                                    value={(item.unitType || 'hours') as SupplierUnitType}
+                                    onChange={(val) => handleUnitTypeChange(index, val)}
+                                    isSupply={isSupply}
+                                    quantity={Number(item.quantity) || 0}
+                                    disabled={isReadOnly || isLinkedToSupplierQuote}
+                                  />
+                                )}
+                              </Tooltip>
                             </div>
                           </div>
                           <div className="rounded-lg border border-slate-200 bg-white px-3 py-2 space-y-1">
                             <div className="text-[10px] font-black text-slate-400 uppercase tracking-wider">
                               {t('crm:internalListing.cost')}
                             </div>
-                            {selectedSupplierQuote && (
-                              <span className="inline-flex px-2 py-0.5 rounded-full bg-emerald-600 text-white text-[8px] font-black uppercase tracking-wider">
-                                {t('sales:clientQuotes.supplierQuoteBadge')}
-                              </span>
-                            )}
                             <div className="flex items-center gap-1">
-                              <ValidatedNumberInput
-                                value={cost.toFixed(2)}
-                                onValueChange={handleCostChange}
-                                disabled={isReadOnly}
-                                className="w-full text-sm px-2 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
-                              />
+                              <Tooltip
+                                label={lockReasonForLinkedField}
+                                wrapperClassName="flex-1 min-w-0"
+                              >
+                                {() => (
+                                  <ValidatedNumberInput
+                                    value={cost.toFixed(2)}
+                                    onValueChange={handleCostChange}
+                                    disabled={isReadOnly || isLinkedToSupplierQuote}
+                                    className="w-full text-sm px-2 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
+                                  />
+                                )}
+                              </Tooltip>
                               <span className="text-[9px] font-semibold text-slate-400 shrink-0">
                                 {currency}
                               </span>
@@ -1487,12 +1556,19 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                               MOL (%)
                             </div>
                             <div className="flex items-center gap-1">
-                              <ValidatedNumberInput
-                                value={molPercentage.toFixed(1)}
-                                onValueChange={handleMolChange}
-                                disabled={isReadOnly}
-                                className="w-full text-sm px-2 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
-                              />
+                              <Tooltip
+                                label={lockReasonForReadOnlyOnly}
+                                wrapperClassName="flex-1 min-w-0"
+                              >
+                                {() => (
+                                  <ValidatedNumberInput
+                                    value={molPercentage.toFixed(1)}
+                                    onValueChange={handleMolChange}
+                                    disabled={isReadOnly}
+                                    className="w-full text-sm px-2 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
+                                  />
+                                )}
+                              </Tooltip>
                               <span className="text-[9px] font-semibold text-slate-400 shrink-0">
                                 %
                               </span>
@@ -1528,95 +1604,124 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                         <div className="hidden lg:flex gap-2 items-center">
                           <div className="flex-1 min-w-0 grid grid-cols-13 gap-2 items-center">
                             <div className="col-span-3 min-w-0">
-                              <CustomSelect
-                                options={[
-                                  { id: 'none', name: t('sales:clientQuotes.noSupplierQuote') },
-                                  ...supplierQuoteItemOptions.map((o) => ({
-                                    id: o.id,
-                                    name: o.name,
-                                  })),
-                                ]}
-                                value={item.supplierQuoteItemId || 'none'}
-                                onChange={(val) =>
-                                  updateProductRow(
-                                    index,
-                                    'supplierQuoteItemId',
-                                    val === 'none' ? '' : (val as string),
-                                  )
-                                }
-                                placeholder={t('sales:clientQuotes.selectSupplierQuote')}
-                                displayValue={getSupplierQuoteItemDisplayValue(
-                                  item.supplierQuoteItemId,
+                              <Tooltip label={lockReasonForReadOnlyOnly} wrapperClassName="w-full">
+                                {() => (
+                                  <CustomSelect
+                                    options={[
+                                      {
+                                        id: 'none',
+                                        name: t('sales:clientQuotes.noSupplierQuote'),
+                                      },
+                                      ...supplierQuoteItemOptions.map((o) => ({
+                                        id: o.id,
+                                        name: o.name,
+                                      })),
+                                    ]}
+                                    value={item.supplierQuoteItemId || 'none'}
+                                    onChange={(val) =>
+                                      updateProductRow(
+                                        index,
+                                        'supplierQuoteItemId',
+                                        val === 'none' ? '' : (val as string),
+                                      )
+                                    }
+                                    placeholder={t('sales:clientQuotes.selectSupplierQuote')}
+                                    displayValue={getSupplierQuoteItemDisplayValue(
+                                      item.supplierQuoteItemId,
+                                    )}
+                                    searchable={true}
+                                    disabled={isReadOnly}
+                                    className="min-w-0"
+                                    buttonClassName="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm"
+                                  />
                                 )}
-                                searchable={true}
-                                disabled={isReadOnly}
-                                className="min-w-0"
-                                buttonClassName="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm"
-                              />
+                              </Tooltip>
                             </div>
                             <div className="col-span-3 min-w-0">
-                              {renderProductSelectOrFallback(item, index, {
-                                className: 'min-w-0',
-                                buttonClassName:
-                                  'w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm',
-                              })}
+                              <Tooltip label={lockReasonForLinkedField} wrapperClassName="w-full">
+                                {() =>
+                                  renderProductSelectOrFallback(item, index, {
+                                    className: 'min-w-0',
+                                    buttonClassName:
+                                      'w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm',
+                                  })
+                                }
+                              </Tooltip>
                             </div>
                             <div className="col-span-2">
                               <div className="flex items-center gap-1">
-                                <ValidatedNumberInput
-                                  step="0.01"
-                                  min="0"
-                                  required
-                                  placeholder={t('sales:clientQuotes.qty')}
-                                  value={item.quantity}
-                                  onValueChange={(value) => {
-                                    const parsed = parseFloat(value);
-                                    updateProductRow(
-                                      index,
-                                      'quantity',
-                                      value === '' || Number.isNaN(parsed) ? 0 : parsed,
-                                    );
-                                  }}
-                                  disabled={isReadOnly || Boolean(item.supplierQuoteItemId)}
-                                  className="w-full text-sm px-2 py-2 bg-white border border-slate-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
-                                />
+                                <Tooltip
+                                  label={lockReasonForLinkedField}
+                                  wrapperClassName="flex-1 min-w-0"
+                                >
+                                  {() => (
+                                    <ValidatedNumberInput
+                                      step="0.01"
+                                      min="0"
+                                      required
+                                      placeholder={t('sales:clientQuotes.qty')}
+                                      value={item.quantity}
+                                      onValueChange={(value) => {
+                                        const parsed = parseFloat(value);
+                                        updateProductRow(
+                                          index,
+                                          'quantity',
+                                          value === '' || Number.isNaN(parsed) ? 0 : parsed,
+                                        );
+                                      }}
+                                      disabled={isReadOnly || isLinkedToSupplierQuote}
+                                      className="w-full text-sm px-2 py-2 bg-white border border-slate-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
+                                    />
+                                  )}
+                                </Tooltip>
                                 <span className="text-xs font-semibold text-slate-400 shrink-0">
                                   /
                                 </span>
-                                <UnitTypeSelector
-                                  value={(item.unitType || 'hours') as SupplierUnitType}
-                                  onChange={(val) => handleUnitTypeChange(index, val)}
-                                  isSupply={isSupply}
-                                  quantity={Number(item.quantity) || 0}
-                                  disabled={isReadOnly || Boolean(item.supplierQuoteItemId)}
-                                />
-                              </div>
-                            </div>
-                            <div className="col-span-1 flex flex-col items-center justify-center gap-1">
-                              {selectedSupplierQuote && (
-                                <span className="px-2 py-0.5 rounded-full bg-emerald-600 text-white text-[8px] font-black uppercase tracking-wider">
-                                  {t('sales:clientQuotes.supplierQuoteBadge')}
-                                </span>
-                              )}
-                              <div className="flex items-center gap-1 w-full">
-                                <ValidatedNumberInput
-                                  value={cost.toFixed(2)}
-                                  onValueChange={handleCostChange}
-                                  disabled={isReadOnly}
-                                  className="w-full text-sm px-1 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
-                                />
-                                <span className="text-[9px] font-semibold text-slate-400 shrink-0">
-                                  {currency}
-                                </span>
+                                <Tooltip label={lockReasonForLinkedField}>
+                                  {() => (
+                                    <UnitTypeSelector
+                                      value={(item.unitType || 'hours') as SupplierUnitType}
+                                      onChange={(val) => handleUnitTypeChange(index, val)}
+                                      isSupply={isSupply}
+                                      quantity={Number(item.quantity) || 0}
+                                      disabled={isReadOnly || isLinkedToSupplierQuote}
+                                    />
+                                  )}
+                                </Tooltip>
                               </div>
                             </div>
                             <div className="col-span-1 flex items-center justify-center gap-1">
-                              <ValidatedNumberInput
-                                value={molPercentage.toFixed(1)}
-                                onValueChange={handleMolChange}
-                                disabled={isReadOnly}
-                                className="w-full text-sm px-1 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
-                              />
+                              <Tooltip
+                                label={lockReasonForLinkedField}
+                                wrapperClassName="flex-1 min-w-0"
+                              >
+                                {() => (
+                                  <ValidatedNumberInput
+                                    value={cost.toFixed(2)}
+                                    onValueChange={handleCostChange}
+                                    disabled={isReadOnly || isLinkedToSupplierQuote}
+                                    className="w-full text-sm px-1 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
+                                  />
+                                )}
+                              </Tooltip>
+                              <span className="text-[9px] font-semibold text-slate-400 shrink-0">
+                                {currency}
+                              </span>
+                            </div>
+                            <div className="col-span-1 flex items-center justify-center gap-1">
+                              <Tooltip
+                                label={lockReasonForReadOnlyOnly}
+                                wrapperClassName="flex-1 min-w-0"
+                              >
+                                {() => (
+                                  <ValidatedNumberInput
+                                    value={molPercentage.toFixed(1)}
+                                    onValueChange={handleMolChange}
+                                    disabled={isReadOnly}
+                                    className="w-full text-sm px-1 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
+                                  />
+                                )}
+                              </Tooltip>
                               <span className="text-[9px] font-semibold text-slate-400 shrink-0">
                                 %
                               </span>
@@ -1639,24 +1744,32 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                               </span>
                             </div>
                           </div>
-                          <button
-                            type="button"
-                            onClick={() => removeProductRow(index)}
-                            disabled={isReadOnly}
-                            className="w-10 h-10 flex items-center justify-center text-slate-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-all shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
-                          >
-                            <i className="fa-solid fa-trash-can"></i>
-                          </button>
+                          <Tooltip label={lockReasonForReadOnlyOnly}>
+                            {() => (
+                              <button
+                                type="button"
+                                onClick={() => removeProductRow(index)}
+                                disabled={isReadOnly}
+                                className="w-10 h-10 flex items-center justify-center text-slate-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-all shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
+                              >
+                                <i className="fa-solid fa-trash-can"></i>
+                              </button>
+                            )}
+                          </Tooltip>
                         </div>
                         <div>
-                          <input
-                            type="text"
-                            placeholder={t('form:placeholderNotes')}
-                            value={item.note || ''}
-                            onChange={(e) => updateProductRow(index, 'note', e.target.value)}
-                            disabled={isReadOnly}
-                            className="w-full text-sm px-3 py-2 bg-white border border-slate-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none disabled:opacity-50 disabled:cursor-not-allowed"
-                          />
+                          <Tooltip label={lockReasonForReadOnlyOnly} wrapperClassName="w-full">
+                            {() => (
+                              <input
+                                type="text"
+                                placeholder={t('form:placeholderNotes')}
+                                value={item.note || ''}
+                                onChange={(e) => updateProductRow(index, 'note', e.target.value)}
+                                disabled={isReadOnly}
+                                className="w-full text-sm px-3 py-2 bg-white border border-slate-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none disabled:opacity-50 disabled:cursor-not-allowed"
+                              />
+                            )}
+                          </Tooltip>
                         </div>
                       </div>
                     );
@@ -1676,14 +1789,18 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                   <span className="h-1.5 w-1.5 rounded-full bg-praetor"></span>
                   {t('sales:clientQuotes.notesLabel')}
                 </h4>
-                <textarea
-                  rows={4}
-                  value={formData.notes}
-                  onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
-                  placeholder={t('sales:clientQuotes.additionalNotesPlaceholder')}
-                  disabled={isReadOnly}
-                  className="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-2 text-sm outline-none resize-none disabled:opacity-50 disabled:cursor-not-allowed"
-                />
+                <Tooltip label={isReadOnly ? readOnlyReason : ''} wrapperClassName="w-full">
+                  {() => (
+                    <textarea
+                      rows={4}
+                      value={formData.notes}
+                      onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
+                      placeholder={t('sales:clientQuotes.additionalNotesPlaceholder')}
+                      disabled={isReadOnly}
+                      className="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-2 text-sm outline-none resize-none disabled:opacity-50 disabled:cursor-not-allowed"
+                    />
+                  )}
+                </Tooltip>
               </div>
 
               <div className="w-full md:w-1/3">
@@ -1744,19 +1861,23 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
               >
                 {t('common:buttons.cancel')}
               </button>
-              <button
-                type="submit"
-                disabled={isReadOnly}
-                className="rounded-xl bg-praetor px-8 py-3 font-bold text-white shadow-lg shadow-slate-200 hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {isReadOnly
-                  ? t('sales:clientQuotes.statusQuote', {
-                      status: getStatusLabel(editingQuote?.status || ''),
-                    })
-                  : editingQuote
-                    ? t('sales:clientQuotes.updateQuote')
-                    : t('sales:clientQuotes.createQuote')}
-              </button>
+              <Tooltip label={isReadOnly ? readOnlyReason : ''}>
+                {() => (
+                  <button
+                    type="submit"
+                    disabled={isReadOnly}
+                    className="rounded-xl bg-praetor px-8 py-3 font-bold text-white shadow-lg shadow-slate-200 hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {isReadOnly
+                      ? t('sales:clientQuotes.statusQuote', {
+                          status: getStatusLabel(editingQuote?.status || ''),
+                        })
+                      : editingQuote
+                        ? t('sales:clientQuotes.updateQuote')
+                        : t('sales:clientQuotes.createQuote')}
+                  </button>
+                )}
+              </Tooltip>
             </div>
           </form>
         </div>

--- a/components/sales/ClientQuotesView.tsx
+++ b/components/sales/ClientQuotesView.tsx
@@ -31,6 +31,7 @@ import { getPaymentTermsOptions } from '../../utils/options';
 import { makeCostUpdater, makeMolUpdater } from '../../utils/pricingHandlers';
 import CostSummaryPanel from '../shared/CostSummaryPanel';
 import CustomSelect from '../shared/CustomSelect';
+import FieldTooltip from '../shared/FieldTooltip';
 import Modal from '../shared/Modal';
 import StandardTable, { type Column } from '../shared/StandardTable';
 import StatusBadge, { type StatusType } from '../shared/StatusBadge';
@@ -183,6 +184,10 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
   const supplierLockedReason = t('sales:clientQuotes.fieldLockedBySupplierQuote', {
     defaultValue: 'Locked because this item is linked to a supplier quote.',
   });
+  const statusEditable = t('sales:fieldInfo.statusEditable', { defaultValue: 'Editable' });
+  const statusLabel = t('sales:fieldInfo.statusLabel', { defaultValue: 'Status:' });
+
+  const readOnlyStatus = isReadOnly ? readOnlyReason : statusEditable;
 
   const formTotals = useMemo(() => {
     const discountValue = Number.isNaN(formData.discount ?? 0) ? 0 : (formData.discount ?? 0);
@@ -1226,93 +1231,103 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
               </h4>
               <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
                 <div className="space-y-1.5">
-                  <label className="text-xs font-bold text-slate-500 ml-1">
+                  <label className="text-xs font-bold text-slate-500 ml-1 flex items-center gap-1">
                     {t('sales:clientQuotes.client')}
+                    <FieldTooltip
+                      description={t('sales:fieldInfo.client', {
+                        defaultValue: 'Select the client for this document',
+                      })}
+                      status={readOnlyStatus}
+                      statusLabel={statusLabel}
+                    />
                   </label>
-                  <Tooltip label={isReadOnly ? readOnlyReason : ''} wrapperClassName="w-full">
-                    {() => (
-                      <CustomSelect
-                        options={activeClients.map((c) => ({ id: c.id, name: c.name }))}
-                        value={formData.clientId || ''}
-                        onChange={(val) => handleClientChange(val as string)}
-                        placeholder={t('sales:clientQuotes.selectAClient')}
-                        searchable={true}
-                        disabled={isReadOnly}
-                        className={errors.clientId ? 'border-red-300' : ''}
-                      />
-                    )}
-                  </Tooltip>
+                  <CustomSelect
+                    options={activeClients.map((c) => ({ id: c.id, name: c.name }))}
+                    value={formData.clientId || ''}
+                    onChange={(val) => handleClientChange(val as string)}
+                    placeholder={t('sales:clientQuotes.selectAClient')}
+                    searchable={true}
+                    disabled={isReadOnly}
+                    className={errors.clientId ? 'border-red-300' : ''}
+                  />
                   {errors.clientId && (
                     <p className="text-red-500 text-[10px] font-bold ml-1">{errors.clientId}</p>
                   )}
                 </div>
                 <div className="space-y-1.5">
-                  <label className="text-xs font-bold text-slate-500 ml-1">
+                  <label className="text-xs font-bold text-slate-500 ml-1 flex items-center gap-1">
                     {t('sales:clientQuotes.quoteCode', { defaultValue: 'Quote Code' })}
+                    <FieldTooltip
+                      description={t('sales:fieldInfo.quoteCode', {
+                        defaultValue: 'Unique identifier for this quote',
+                      })}
+                      status={readOnlyStatus}
+                      statusLabel={statusLabel}
+                    />
                   </label>
-                  <Tooltip label={isReadOnly ? readOnlyReason : ''} wrapperClassName="w-full">
-                    {() => (
-                      <input
-                        type="text"
-                        value={formData.id || ''}
-                        onChange={(e) => {
-                          setFormData({ ...formData, id: e.target.value });
-                          if (errors.id) {
-                            setErrors((prev) => {
-                              const next = { ...prev };
-                              delete next.id;
-                              return next;
-                            });
-                          }
-                        }}
-                        placeholder="Q0000"
-                        disabled={isReadOnly}
-                        className={`w-full rounded-xl border ${
-                          errors.id ? 'border-red-300' : 'border-slate-200'
-                        } bg-slate-50 px-4 py-2.5 text-sm font-bold outline-none focus:ring-2 focus:ring-praetor disabled:opacity-50 disabled:cursor-not-allowed`}
-                      />
-                    )}
-                  </Tooltip>
+                  <input
+                    type="text"
+                    value={formData.id || ''}
+                    onChange={(e) => {
+                      setFormData({ ...formData, id: e.target.value });
+                      if (errors.id) {
+                        setErrors((prev) => {
+                          const next = { ...prev };
+                          delete next.id;
+                          return next;
+                        });
+                      }
+                    }}
+                    placeholder="Q0000"
+                    disabled={isReadOnly}
+                    className={`w-full rounded-xl border ${
+                      errors.id ? 'border-red-300' : 'border-slate-200'
+                    } bg-slate-50 px-4 py-2.5 text-sm font-bold outline-none focus:ring-2 focus:ring-praetor disabled:opacity-50 disabled:cursor-not-allowed`}
+                  />
                   {errors.id && (
                     <p className="text-red-500 text-[10px] font-bold ml-1">{errors.id}</p>
                   )}
                 </div>
                 <div className="space-y-1.5">
-                  <label className="text-xs font-bold text-slate-500 ml-1">
+                  <label className="text-xs font-bold text-slate-500 ml-1 flex items-center gap-1">
                     {t('sales:clientQuotes.paymentTerms')}
+                    <FieldTooltip
+                      description={t('sales:fieldInfo.paymentTerms', {
+                        defaultValue: 'Payment terms and conditions',
+                      })}
+                      status={readOnlyStatus}
+                      statusLabel={statusLabel}
+                    />
                   </label>
-                  <Tooltip label={isReadOnly ? readOnlyReason : ''} wrapperClassName="w-full">
-                    {() => (
-                      <CustomSelect
-                        options={paymentTermsOptions}
-                        value={formData.paymentTerms || 'immediate'}
-                        onChange={(val) =>
-                          setFormData({ ...formData, paymentTerms: val as Quote['paymentTerms'] })
-                        }
-                        searchable={false}
-                        disabled={isReadOnly}
-                      />
-                    )}
-                  </Tooltip>
+                  <CustomSelect
+                    options={paymentTermsOptions}
+                    value={formData.paymentTerms || 'immediate'}
+                    onChange={(val) =>
+                      setFormData({ ...formData, paymentTerms: val as Quote['paymentTerms'] })
+                    }
+                    searchable={false}
+                    disabled={isReadOnly}
+                  />
                 </div>
                 <div className="space-y-1.5">
-                  <label className="text-xs font-bold text-slate-500 ml-1">
+                  <label className="text-xs font-bold text-slate-500 ml-1 flex items-center gap-1">
                     {t('sales:clientQuotes.expirationDateLabel')}
+                    <FieldTooltip
+                      description={t('sales:fieldInfo.expirationDate', {
+                        defaultValue: 'Date until which this document is valid',
+                      })}
+                      status={readOnlyStatus}
+                      statusLabel={statusLabel}
+                    />
                   </label>
-                  <Tooltip label={isReadOnly ? readOnlyReason : ''} wrapperClassName="w-full">
-                    {() => (
-                      <input
-                        type="date"
-                        required
-                        value={formData.expirationDate}
-                        onChange={(e) =>
-                          setFormData({ ...formData, expirationDate: e.target.value })
-                        }
-                        disabled={isReadOnly}
-                        className="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-2.5 text-sm outline-none focus:ring-2 focus:ring-praetor disabled:opacity-50 disabled:cursor-not-allowed"
-                      />
-                    )}
-                  </Tooltip>
+                  <input
+                    type="date"
+                    required
+                    value={formData.expirationDate}
+                    onChange={(e) => setFormData({ ...formData, expirationDate: e.target.value })}
+                    disabled={isReadOnly}
+                    className="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-2.5 text-sm outline-none focus:ring-2 focus:ring-praetor disabled:opacity-50 disabled:cursor-not-allowed"
+                  />
                 </div>
               </div>
             </div>
@@ -1324,18 +1339,21 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                   <span className="w-1.5 h-1.5 rounded-full bg-praetor"></span>
                   {t('sales:clientQuotes.productsServices')}
                 </h4>
-                <Tooltip label={isReadOnly ? readOnlyReason : ''}>
-                  {() => (
-                    <button
-                      type="button"
-                      onClick={addProductRow}
-                      disabled={isReadOnly}
-                      className="text-xs font-bold text-praetor hover:text-slate-700 flex items-center gap-1 disabled:opacity-50 disabled:cursor-not-allowed"
-                    >
-                      <i className="fa-solid fa-plus"></i> {t('sales:clientQuotes.addProduct')}
-                    </button>
-                  )}
-                </Tooltip>
+                <button
+                  type="button"
+                  onClick={addProductRow}
+                  disabled={isReadOnly}
+                  className="text-xs font-bold text-praetor hover:text-slate-700 flex items-center gap-1 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  <i className="fa-solid fa-plus"></i> {t('sales:clientQuotes.addProduct')}
+                  <FieldTooltip
+                    description={t('sales:fieldInfo.addItem', {
+                      defaultValue: 'Add a new line item',
+                    })}
+                    status={readOnlyStatus}
+                    statusLabel={statusLabel}
+                  />
+                </button>
               </div>
               {errors.items && (
                 <p className="text-red-500 text-[10px] font-bold ml-1 -mt-2">{errors.items}</p>
@@ -1393,12 +1411,11 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                     const lineMargin = lineSalePrice - lineCost;
 
                     const isLinkedToSupplierQuote = Boolean(item.supplierQuoteItemId);
-                    const lockReasonForLinkedField = isReadOnly
+                    const linkedFieldStatus = isReadOnly
                       ? readOnlyReason
                       : isLinkedToSupplierQuote
                         ? supplierLockedReason
-                        : '';
-                    const lockReasonForReadOnlyOnly = isReadOnly ? readOnlyReason : '';
+                        : statusEditable;
 
                     const handleCostChange = (value: string) => {
                       if (isReadOnly || isLinkedToSupplierQuote) return;
@@ -1418,157 +1435,156 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                         <div className="lg:hidden flex items-start gap-3">
                           <div className="grid flex-1 min-w-0 grid-cols-1 md:grid-cols-2 gap-3">
                             <div className="min-w-0">
-                              <div className="mb-1 text-[10px] font-black text-slate-400 uppercase tracking-wider">
+                              <div className="mb-1 text-[10px] font-black text-slate-400 uppercase tracking-wider flex items-center gap-1">
                                 {t('sales:clientQuotes.supplierQuoteColumn')}
+                                <FieldTooltip
+                                  description={t('sales:fieldInfo.supplierQuote', {
+                                    defaultValue:
+                                      'Link this item to a supplier quote for cost tracking',
+                                  })}
+                                  status={readOnlyStatus}
+                                  statusLabel={statusLabel}
+                                />
                               </div>
-                              <Tooltip label={lockReasonForReadOnlyOnly} wrapperClassName="w-full">
-                                {() => (
-                                  <CustomSelect
-                                    options={[
-                                      {
-                                        id: 'none',
-                                        name: t('sales:clientQuotes.noSupplierQuote'),
-                                      },
-                                      ...supplierQuoteItemOptions.map((o) => ({
-                                        id: o.id,
-                                        name: o.name,
-                                      })),
-                                    ]}
-                                    value={item.supplierQuoteItemId || 'none'}
-                                    onChange={(val) =>
-                                      updateProductRow(
-                                        index,
-                                        'supplierQuoteItemId',
-                                        val === 'none' ? '' : (val as string),
-                                      )
-                                    }
-                                    placeholder={t('sales:clientQuotes.selectSupplierQuote')}
-                                    displayValue={getSupplierQuoteItemDisplayValue(
-                                      item.supplierQuoteItemId,
-                                    )}
-                                    searchable={true}
-                                    disabled={isReadOnly}
-                                    className="min-w-0"
-                                    buttonClassName="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm"
-                                  />
+                              <CustomSelect
+                                options={[
+                                  {
+                                    id: 'none',
+                                    name: t('sales:clientQuotes.noSupplierQuote'),
+                                  },
+                                  ...supplierQuoteItemOptions.map((o) => ({
+                                    id: o.id,
+                                    name: o.name,
+                                  })),
+                                ]}
+                                value={item.supplierQuoteItemId || 'none'}
+                                onChange={(val) =>
+                                  updateProductRow(
+                                    index,
+                                    'supplierQuoteItemId',
+                                    val === 'none' ? '' : (val as string),
+                                  )
+                                }
+                                placeholder={t('sales:clientQuotes.selectSupplierQuote')}
+                                displayValue={getSupplierQuoteItemDisplayValue(
+                                  item.supplierQuoteItemId,
                                 )}
-                              </Tooltip>
+                                searchable={true}
+                                disabled={isReadOnly}
+                                className="min-w-0"
+                                buttonClassName="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm"
+                              />
                             </div>
                             <div className="min-w-0">
-                              <div className="mb-1 text-[10px] font-black text-slate-400 uppercase tracking-wider">
+                              <div className="mb-1 text-[10px] font-black text-slate-400 uppercase tracking-wider flex items-center gap-1">
                                 {t('sales:clientQuotes.productsServices')}
+                                <FieldTooltip
+                                  description={t('sales:fieldInfo.product', {
+                                    defaultValue: 'Select a product or service for this line item',
+                                  })}
+                                  status={linkedFieldStatus}
+                                  statusLabel={statusLabel}
+                                />
                               </div>
-                              <Tooltip label={lockReasonForLinkedField} wrapperClassName="w-full">
-                                {() =>
-                                  renderProductSelectOrFallback(item, index, {
-                                    className: 'min-w-0',
-                                    buttonClassName:
-                                      'w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm',
-                                  })
-                                }
-                              </Tooltip>
+                              {renderProductSelectOrFallback(item, index, {
+                                className: 'min-w-0',
+                                buttonClassName:
+                                  'w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm',
+                              })}
                             </div>
                           </div>
-                          <Tooltip label={lockReasonForReadOnlyOnly}>
-                            {() => (
-                              <button
-                                type="button"
-                                onClick={() => removeProductRow(index)}
-                                disabled={isReadOnly}
-                                className="mt-5 w-10 h-10 flex items-center justify-center text-slate-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-all shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
-                              >
-                                <i className="fa-solid fa-trash-can"></i>
-                              </button>
-                            )}
-                          </Tooltip>
+                          <button
+                            type="button"
+                            onClick={() => removeProductRow(index)}
+                            disabled={isReadOnly}
+                            className="mt-5 w-10 h-10 flex items-center justify-center text-slate-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-all shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
+                          >
+                            <i className="fa-solid fa-trash-can"></i>
+                          </button>
                         </div>
                         <div className="grid grid-cols-2 gap-3 md:grid-cols-6 lg:hidden">
                           <div>
-                            <div className="mb-1 text-[10px] font-black text-slate-400 uppercase tracking-wider">
+                            <div className="mb-1 text-[10px] font-black text-slate-400 uppercase tracking-wider flex items-center gap-1">
                               {t('sales:clientQuotes.qty')}
+                              <FieldTooltip
+                                description={t('sales:fieldInfo.qty', {
+                                  defaultValue: 'Quantity of items or hours',
+                                })}
+                                status={linkedFieldStatus}
+                                statusLabel={statusLabel}
+                              />
                             </div>
                             <div className="flex items-center gap-1">
-                              <Tooltip
-                                label={lockReasonForLinkedField}
-                                wrapperClassName="flex-1 min-w-0"
-                              >
-                                {() => (
-                                  <ValidatedNumberInput
-                                    step="0.01"
-                                    min="0"
-                                    required
-                                    placeholder={t('sales:clientQuotes.qty')}
-                                    value={item.quantity}
-                                    onValueChange={(value) => {
-                                      const parsed = parseFloat(value);
-                                      updateProductRow(
-                                        index,
-                                        'quantity',
-                                        value === '' || Number.isNaN(parsed) ? 0 : parsed,
-                                      );
-                                    }}
-                                    disabled={isReadOnly || isLinkedToSupplierQuote}
-                                    className="w-full text-sm px-3 py-2 bg-white border border-slate-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
-                                  />
-                                )}
-                              </Tooltip>
+                              <ValidatedNumberInput
+                                step="0.01"
+                                min="0"
+                                required
+                                placeholder={t('sales:clientQuotes.qty')}
+                                value={item.quantity}
+                                onValueChange={(value) => {
+                                  const parsed = parseFloat(value);
+                                  updateProductRow(
+                                    index,
+                                    'quantity',
+                                    value === '' || Number.isNaN(parsed) ? 0 : parsed,
+                                  );
+                                }}
+                                disabled={isReadOnly || isLinkedToSupplierQuote}
+                                className="w-full text-sm px-3 py-2 bg-white border border-slate-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed flex-1"
+                              />
                               <span className="text-xs font-semibold text-slate-400 shrink-0">
                                 /
                               </span>
-                              <Tooltip label={lockReasonForLinkedField}>
-                                {() => (
-                                  <UnitTypeSelector
-                                    value={(item.unitType || 'hours') as SupplierUnitType}
-                                    onChange={(val) => handleUnitTypeChange(index, val)}
-                                    isSupply={isSupply}
-                                    quantity={Number(item.quantity) || 0}
-                                    disabled={isReadOnly || isLinkedToSupplierQuote}
-                                  />
-                                )}
-                              </Tooltip>
+                              <UnitTypeSelector
+                                value={(item.unitType || 'hours') as SupplierUnitType}
+                                onChange={(val) => handleUnitTypeChange(index, val)}
+                                isSupply={isSupply}
+                                quantity={Number(item.quantity) || 0}
+                                disabled={isReadOnly || isLinkedToSupplierQuote}
+                              />
                             </div>
                           </div>
                           <div className="rounded-lg border border-slate-200 bg-white px-3 py-2 space-y-1">
-                            <div className="text-[10px] font-black text-slate-400 uppercase tracking-wider">
+                            <div className="text-[10px] font-black text-slate-400 uppercase tracking-wider flex items-center gap-1">
                               {t('crm:internalListing.cost')}
+                              <FieldTooltip
+                                description={t('sales:fieldInfo.cost', {
+                                  defaultValue: 'Unit cost for this item',
+                                })}
+                                status={linkedFieldStatus}
+                                statusLabel={statusLabel}
+                              />
                             </div>
                             <div className="flex items-center gap-1">
-                              <Tooltip
-                                label={lockReasonForLinkedField}
-                                wrapperClassName="flex-1 min-w-0"
-                              >
-                                {() => (
-                                  <ValidatedNumberInput
-                                    value={cost.toFixed(2)}
-                                    onValueChange={handleCostChange}
-                                    disabled={isReadOnly || isLinkedToSupplierQuote}
-                                    className="w-full text-sm px-2 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
-                                  />
-                                )}
-                              </Tooltip>
+                              <ValidatedNumberInput
+                                value={cost.toFixed(2)}
+                                onValueChange={handleCostChange}
+                                disabled={isReadOnly || isLinkedToSupplierQuote}
+                                className="w-full text-sm px-2 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
+                              />
                               <span className="text-[9px] font-semibold text-slate-400 shrink-0">
                                 {currency}
                               </span>
                             </div>
                           </div>
                           <div className="rounded-lg border border-slate-200 bg-white px-3 py-2 space-y-1">
-                            <div className="text-[10px] font-black text-slate-400 uppercase tracking-wider">
+                            <div className="text-[10px] font-black text-slate-400 uppercase tracking-wider flex items-center gap-1">
                               MOL (%)
+                              <FieldTooltip
+                                description={t('sales:fieldInfo.mol', {
+                                  defaultValue: 'Margin overhead loading percentage',
+                                })}
+                                status={readOnlyStatus}
+                                statusLabel={statusLabel}
+                              />
                             </div>
                             <div className="flex items-center gap-1">
-                              <Tooltip
-                                label={lockReasonForReadOnlyOnly}
-                                wrapperClassName="flex-1 min-w-0"
-                              >
-                                {() => (
-                                  <ValidatedNumberInput
-                                    value={molPercentage.toFixed(1)}
-                                    onValueChange={handleMolChange}
-                                    disabled={isReadOnly}
-                                    className="w-full text-sm px-2 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
-                                  />
-                                )}
-                              </Tooltip>
+                              <ValidatedNumberInput
+                                value={molPercentage.toFixed(1)}
+                                onValueChange={handleMolChange}
+                                disabled={isReadOnly}
+                                className="w-full text-sm px-2 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
+                              />
                               <span className="text-[9px] font-semibold text-slate-400 shrink-0">
                                 %
                               </span>
@@ -1604,124 +1620,91 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                         <div className="hidden lg:flex gap-2 items-center">
                           <div className="flex-1 min-w-0 grid grid-cols-13 gap-2 items-center">
                             <div className="col-span-3 min-w-0">
-                              <Tooltip label={lockReasonForReadOnlyOnly} wrapperClassName="w-full">
-                                {() => (
-                                  <CustomSelect
-                                    options={[
-                                      {
-                                        id: 'none',
-                                        name: t('sales:clientQuotes.noSupplierQuote'),
-                                      },
-                                      ...supplierQuoteItemOptions.map((o) => ({
-                                        id: o.id,
-                                        name: o.name,
-                                      })),
-                                    ]}
-                                    value={item.supplierQuoteItemId || 'none'}
-                                    onChange={(val) =>
-                                      updateProductRow(
-                                        index,
-                                        'supplierQuoteItemId',
-                                        val === 'none' ? '' : (val as string),
-                                      )
-                                    }
-                                    placeholder={t('sales:clientQuotes.selectSupplierQuote')}
-                                    displayValue={getSupplierQuoteItemDisplayValue(
-                                      item.supplierQuoteItemId,
-                                    )}
-                                    searchable={true}
-                                    disabled={isReadOnly}
-                                    className="min-w-0"
-                                    buttonClassName="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm"
-                                  />
+                              <CustomSelect
+                                options={[
+                                  {
+                                    id: 'none',
+                                    name: t('sales:clientQuotes.noSupplierQuote'),
+                                  },
+                                  ...supplierQuoteItemOptions.map((o) => ({
+                                    id: o.id,
+                                    name: o.name,
+                                  })),
+                                ]}
+                                value={item.supplierQuoteItemId || 'none'}
+                                onChange={(val) =>
+                                  updateProductRow(
+                                    index,
+                                    'supplierQuoteItemId',
+                                    val === 'none' ? '' : (val as string),
+                                  )
+                                }
+                                placeholder={t('sales:clientQuotes.selectSupplierQuote')}
+                                displayValue={getSupplierQuoteItemDisplayValue(
+                                  item.supplierQuoteItemId,
                                 )}
-                              </Tooltip>
+                                searchable={true}
+                                disabled={isReadOnly}
+                                className="min-w-0"
+                                buttonClassName="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm"
+                              />
                             </div>
                             <div className="col-span-3 min-w-0">
-                              <Tooltip label={lockReasonForLinkedField} wrapperClassName="w-full">
-                                {() =>
-                                  renderProductSelectOrFallback(item, index, {
-                                    className: 'min-w-0',
-                                    buttonClassName:
-                                      'w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm',
-                                  })
-                                }
-                              </Tooltip>
+                              {renderProductSelectOrFallback(item, index, {
+                                className: 'min-w-0',
+                                buttonClassName:
+                                  'w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm',
+                              })}
                             </div>
                             <div className="col-span-2">
                               <div className="flex items-center gap-1">
-                                <Tooltip
-                                  label={lockReasonForLinkedField}
-                                  wrapperClassName="flex-1 min-w-0"
-                                >
-                                  {() => (
-                                    <ValidatedNumberInput
-                                      step="0.01"
-                                      min="0"
-                                      required
-                                      placeholder={t('sales:clientQuotes.qty')}
-                                      value={item.quantity}
-                                      onValueChange={(value) => {
-                                        const parsed = parseFloat(value);
-                                        updateProductRow(
-                                          index,
-                                          'quantity',
-                                          value === '' || Number.isNaN(parsed) ? 0 : parsed,
-                                        );
-                                      }}
-                                      disabled={isReadOnly || isLinkedToSupplierQuote}
-                                      className="w-full text-sm px-2 py-2 bg-white border border-slate-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
-                                    />
-                                  )}
-                                </Tooltip>
+                                <ValidatedNumberInput
+                                  step="0.01"
+                                  min="0"
+                                  required
+                                  placeholder={t('sales:clientQuotes.qty')}
+                                  value={item.quantity}
+                                  onValueChange={(value) => {
+                                    const parsed = parseFloat(value);
+                                    updateProductRow(
+                                      index,
+                                      'quantity',
+                                      value === '' || Number.isNaN(parsed) ? 0 : parsed,
+                                    );
+                                  }}
+                                  disabled={isReadOnly || isLinkedToSupplierQuote}
+                                  className="w-full text-sm px-2 py-2 bg-white border border-slate-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
+                                />
                                 <span className="text-xs font-semibold text-slate-400 shrink-0">
                                   /
                                 </span>
-                                <Tooltip label={lockReasonForLinkedField}>
-                                  {() => (
-                                    <UnitTypeSelector
-                                      value={(item.unitType || 'hours') as SupplierUnitType}
-                                      onChange={(val) => handleUnitTypeChange(index, val)}
-                                      isSupply={isSupply}
-                                      quantity={Number(item.quantity) || 0}
-                                      disabled={isReadOnly || isLinkedToSupplierQuote}
-                                    />
-                                  )}
-                                </Tooltip>
+                                <UnitTypeSelector
+                                  value={(item.unitType || 'hours') as SupplierUnitType}
+                                  onChange={(val) => handleUnitTypeChange(index, val)}
+                                  isSupply={isSupply}
+                                  quantity={Number(item.quantity) || 0}
+                                  disabled={isReadOnly || isLinkedToSupplierQuote}
+                                />
                               </div>
                             </div>
                             <div className="col-span-1 flex items-center justify-center gap-1">
-                              <Tooltip
-                                label={lockReasonForLinkedField}
-                                wrapperClassName="flex-1 min-w-0"
-                              >
-                                {() => (
-                                  <ValidatedNumberInput
-                                    value={cost.toFixed(2)}
-                                    onValueChange={handleCostChange}
-                                    disabled={isReadOnly || isLinkedToSupplierQuote}
-                                    className="w-full text-sm px-1 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
-                                  />
-                                )}
-                              </Tooltip>
+                              <ValidatedNumberInput
+                                value={cost.toFixed(2)}
+                                onValueChange={handleCostChange}
+                                disabled={isReadOnly || isLinkedToSupplierQuote}
+                                className="w-full text-sm px-1 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
+                              />
                               <span className="text-[9px] font-semibold text-slate-400 shrink-0">
                                 {currency}
                               </span>
                             </div>
                             <div className="col-span-1 flex items-center justify-center gap-1">
-                              <Tooltip
-                                label={lockReasonForReadOnlyOnly}
-                                wrapperClassName="flex-1 min-w-0"
-                              >
-                                {() => (
-                                  <ValidatedNumberInput
-                                    value={molPercentage.toFixed(1)}
-                                    onValueChange={handleMolChange}
-                                    disabled={isReadOnly}
-                                    className="w-full text-sm px-1 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
-                                  />
-                                )}
-                              </Tooltip>
+                              <ValidatedNumberInput
+                                value={molPercentage.toFixed(1)}
+                                onValueChange={handleMolChange}
+                                disabled={isReadOnly}
+                                className="w-full text-sm px-1 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
+                              />
                               <span className="text-[9px] font-semibold text-slate-400 shrink-0">
                                 %
                               </span>
@@ -1744,32 +1727,24 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                               </span>
                             </div>
                           </div>
-                          <Tooltip label={lockReasonForReadOnlyOnly}>
-                            {() => (
-                              <button
-                                type="button"
-                                onClick={() => removeProductRow(index)}
-                                disabled={isReadOnly}
-                                className="w-10 h-10 flex items-center justify-center text-slate-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-all shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
-                              >
-                                <i className="fa-solid fa-trash-can"></i>
-                              </button>
-                            )}
-                          </Tooltip>
+                          <button
+                            type="button"
+                            onClick={() => removeProductRow(index)}
+                            disabled={isReadOnly}
+                            className="w-10 h-10 flex items-center justify-center text-slate-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-all shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
+                          >
+                            <i className="fa-solid fa-trash-can"></i>
+                          </button>
                         </div>
                         <div>
-                          <Tooltip label={lockReasonForReadOnlyOnly} wrapperClassName="w-full">
-                            {() => (
-                              <input
-                                type="text"
-                                placeholder={t('form:placeholderNotes')}
-                                value={item.note || ''}
-                                onChange={(e) => updateProductRow(index, 'note', e.target.value)}
-                                disabled={isReadOnly}
-                                className="w-full text-sm px-3 py-2 bg-white border border-slate-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none disabled:opacity-50 disabled:cursor-not-allowed"
-                              />
-                            )}
-                          </Tooltip>
+                          <input
+                            type="text"
+                            placeholder={t('form:placeholderNotes')}
+                            value={item.note || ''}
+                            onChange={(e) => updateProductRow(index, 'note', e.target.value)}
+                            disabled={isReadOnly}
+                            className="w-full text-sm px-3 py-2 bg-white border border-slate-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none disabled:opacity-50 disabled:cursor-not-allowed"
+                          />
                         </div>
                       </div>
                     );
@@ -1788,19 +1763,22 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                 <h4 className="flex items-center gap-2 text-xs font-black uppercase tracking-widest text-praetor">
                   <span className="h-1.5 w-1.5 rounded-full bg-praetor"></span>
                   {t('sales:clientQuotes.notesLabel')}
+                  <FieldTooltip
+                    description={t('sales:fieldInfo.notes', {
+                      defaultValue: 'Additional notes for the entire document',
+                    })}
+                    status={readOnlyStatus}
+                    statusLabel={statusLabel}
+                  />
                 </h4>
-                <Tooltip label={isReadOnly ? readOnlyReason : ''} wrapperClassName="w-full">
-                  {() => (
-                    <textarea
-                      rows={4}
-                      value={formData.notes}
-                      onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
-                      placeholder={t('sales:clientQuotes.additionalNotesPlaceholder')}
-                      disabled={isReadOnly}
-                      className="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-2 text-sm outline-none resize-none disabled:opacity-50 disabled:cursor-not-allowed"
-                    />
-                  )}
-                </Tooltip>
+                <textarea
+                  rows={4}
+                  value={formData.notes}
+                  onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
+                  placeholder={t('sales:clientQuotes.additionalNotesPlaceholder')}
+                  disabled={isReadOnly}
+                  className="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-2 text-sm outline-none resize-none disabled:opacity-50 disabled:cursor-not-allowed"
+                />
               </div>
 
               <div className="w-full md:w-1/3">
@@ -1861,23 +1839,26 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
               >
                 {t('common:buttons.cancel')}
               </button>
-              <Tooltip label={isReadOnly ? readOnlyReason : ''}>
-                {() => (
-                  <button
-                    type="submit"
-                    disabled={isReadOnly}
-                    className="rounded-xl bg-praetor px-8 py-3 font-bold text-white shadow-lg shadow-slate-200 hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed"
-                  >
-                    {isReadOnly
-                      ? t('sales:clientQuotes.statusQuote', {
-                          status: getStatusLabel(editingQuote?.status || ''),
-                        })
-                      : editingQuote
-                        ? t('sales:clientQuotes.updateQuote')
-                        : t('sales:clientQuotes.createQuote')}
-                  </button>
-                )}
-              </Tooltip>
+              <button
+                type="submit"
+                disabled={isReadOnly}
+                className="rounded-xl bg-praetor px-8 py-3 font-bold text-white shadow-lg shadow-slate-200 hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+              >
+                {isReadOnly
+                  ? t('sales:clientQuotes.statusQuote', {
+                      status: getStatusLabel(editingQuote?.status || ''),
+                    })
+                  : editingQuote
+                    ? t('sales:clientQuotes.updateQuote')
+                    : t('sales:clientQuotes.createQuote')}
+                <FieldTooltip
+                  description={t('sales:fieldInfo.submit', {
+                    defaultValue: 'Submit or update this document',
+                  })}
+                  status={readOnlyStatus}
+                  statusLabel={statusLabel}
+                />
+              </button>
             </div>
           </form>
         </div>

--- a/components/sales/ClientQuotesView.tsx
+++ b/components/sales/ClientQuotesView.tsx
@@ -1358,14 +1358,14 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                   className="text-xs font-bold text-praetor hover:text-slate-700 flex items-center gap-1 disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   <i className="fa-solid fa-plus"></i> {t('sales:clientQuotes.addProduct')}
-                  <FieldTooltip
-                    description={t('sales:fieldInfo.addItem', {
-                      defaultValue: 'Add a new line item',
-                    })}
-                    status={readOnlyStatus}
-                    statusLabel={statusLabel}
-                  />
                 </button>
+                <FieldTooltip
+                  description={t('sales:fieldInfo.addItem', {
+                    defaultValue: 'Add a new line item',
+                  })}
+                  status={readOnlyStatus}
+                  statusLabel={statusLabel}
+                />
               </div>
               {errors.items && (
                 <p className="text-red-500 text-[10px] font-bold ml-1 -mt-2">{errors.items}</p>
@@ -1430,7 +1430,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                         : statusEditable;
 
                     const handleCostChange = (value: string) => {
-                      if (isReadOnly || isLinkedToSupplierQuote) return;
+                      if (isReadOnly) return;
                       setFormData(makeCostUpdater<Partial<Quote>>(index, value));
                     };
 

--- a/components/sales/ClientQuotesView.tsx
+++ b/components/sales/ClientQuotesView.tsx
@@ -666,6 +666,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
     index: number,
     selectProps: { className?: string; buttonClassName?: string },
   ) => {
+    const isLinkedToSupplierQuote = Boolean(item.supplierQuoteItemId);
     if (isLinkedProductMissing(item)) {
       return (
         <input
@@ -683,7 +684,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
         onChange={(val) => updateProductRow(index, 'productId', val as string)}
         placeholder={t('sales:clientQuotes.selectProduct')}
         searchable={true}
-        disabled={isReadOnly || Boolean(item.supplierQuoteItemId)}
+        disabled={isReadOnly || isLinkedToSupplierQuote}
         className={selectProps.className}
         buttonClassName={selectProps.buttonClassName}
       />

--- a/components/sales/ClientQuotesView.tsx
+++ b/components/sales/ClientQuotesView.tsx
@@ -1226,6 +1226,13 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
               <h4 className="text-xs font-black text-praetor uppercase tracking-widest flex items-center gap-2">
                 <span className="w-1.5 h-1.5 rounded-full bg-praetor"></span>
                 {t('sales:clientQuotes.clientInformation')}
+                <FieldTooltip
+                  description={t('sales:fieldInfo.clientInformation', {
+                    defaultValue: 'Client and document details',
+                  })}
+                  status={readOnlyStatus}
+                  statusLabel={statusLabel}
+                />
               </h4>
               <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
                 <div className="space-y-1.5">
@@ -1336,6 +1343,13 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                 <h4 className="text-xs font-black text-praetor uppercase tracking-widest flex items-center gap-2">
                   <span className="w-1.5 h-1.5 rounded-full bg-praetor"></span>
                   {t('sales:clientQuotes.productsServices')}
+                  <FieldTooltip
+                    description={t('sales:fieldInfo.productsServices', {
+                      defaultValue: 'Products and services for this quote',
+                    })}
+                    status={readOnlyStatus}
+                    statusLabel={statusLabel}
+                  />
                 </h4>
                 <button
                   type="button"
@@ -1840,7 +1854,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
               <button
                 type="submit"
                 disabled={isReadOnly}
-                className="rounded-xl bg-praetor px-8 py-3 font-bold text-white shadow-lg shadow-slate-200 hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+                className="rounded-xl bg-praetor px-8 py-3 font-bold text-white shadow-lg shadow-slate-200 hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {isReadOnly
                   ? t('sales:clientQuotes.statusQuote', {
@@ -1849,13 +1863,6 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                   : editingQuote
                     ? t('sales:clientQuotes.updateQuote')
                     : t('sales:clientQuotes.createQuote')}
-                <FieldTooltip
-                  description={t('sales:fieldInfo.submit', {
-                    defaultValue: 'Submit or update this document',
-                  })}
-                  status={readOnlyStatus}
-                  statusLabel={statusLabel}
-                />
               </button>
             </div>
           </form>

--- a/components/sales/ClientQuotesView.tsx
+++ b/components/sales/ClientQuotesView.tsx
@@ -182,7 +182,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
     : t('sales:clientQuotes.readOnlyBecauseFinal', {
         defaultValue: 'Read-only due to finalized status',
       });
-  const supplierLockedReason = t('sales:clientQuotes.fieldLockedBySupplierQuote', {
+  const supplierLockedReason = t('sales:fieldInfo.fieldLockedBySupplierQuote', {
     defaultValue: 'Locked due to linked supplier quote',
   });
   const statusEditable = t('sales:fieldInfo.statusEditable', { defaultValue: 'Editable' });
@@ -1372,10 +1372,6 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
               {formData.items && formData.items.length > 0 ? (
                 <div className="space-y-3">
                   {formData.items.map((item, index) => {
-                    const selectedSupplierQuote = item.supplierQuoteItemId
-                      ? supplierQuoteItemOptions.find((o) => o.id === item.supplierQuoteItemId)
-                      : undefined;
-
                     const {
                       unitCost: cost,
                       molPercentage,
@@ -1389,13 +1385,13 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                     const lineMargin = lineSalePrice - lineCost;
 
                     const isLinkedToSupplierQuote = Boolean(item.supplierQuoteItemId);
-                    const linkedFieldStatus = getLinkedFieldStatus(
+                    const linkedFieldStatus = getLinkedFieldStatus({
                       isReadOnly,
                       isLinkedToSupplierQuote,
                       readOnlyReason,
                       supplierLockedReason,
                       statusEditable,
-                    );
+                    });
 
                     const handleCostChange = (value: string) => {
                       if (isReadOnly) return;

--- a/components/sales/ClientQuotesView.tsx
+++ b/components/sales/ClientQuotesView.tsx
@@ -18,6 +18,7 @@ import {
   isDateOnlyBeforeToday,
   normalizeDateOnlyString,
 } from '../../utils/date';
+import { getLinkedFieldStatus } from '../../utils/fieldStatus';
 import {
   calcProductSalePrice,
   calculatePricingTotals,
@@ -1236,15 +1237,8 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
               </h4>
               <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
                 <div className="space-y-1.5">
-                  <label className="text-xs font-bold text-slate-500 ml-1 flex items-center gap-1">
+                  <label className="text-xs font-bold text-slate-500 ml-1">
                     {t('sales:clientQuotes.client')}
-                    <FieldTooltip
-                      description={t('sales:fieldInfo.client', {
-                        defaultValue: 'Select the client for this document',
-                      })}
-                      status={readOnlyStatus}
-                      statusLabel={statusLabel}
-                    />
                   </label>
                   <CustomSelect
                     options={activeClients.map((c) => ({ id: c.id, name: c.name }))}
@@ -1260,15 +1254,8 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                   )}
                 </div>
                 <div className="space-y-1.5">
-                  <label className="text-xs font-bold text-slate-500 ml-1 flex items-center gap-1">
+                  <label className="text-xs font-bold text-slate-500 ml-1">
                     {t('sales:clientQuotes.quoteCode', { defaultValue: 'Quote Code' })}
-                    <FieldTooltip
-                      description={t('sales:fieldInfo.quoteCode', {
-                        defaultValue: 'Unique identifier for this quote',
-                      })}
-                      status={readOnlyStatus}
-                      statusLabel={statusLabel}
-                    />
                   </label>
                   <input
                     type="text"
@@ -1294,15 +1281,8 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                   )}
                 </div>
                 <div className="space-y-1.5">
-                  <label className="text-xs font-bold text-slate-500 ml-1 flex items-center gap-1">
+                  <label className="text-xs font-bold text-slate-500 ml-1">
                     {t('sales:clientQuotes.paymentTerms')}
-                    <FieldTooltip
-                      description={t('sales:fieldInfo.paymentTerms', {
-                        defaultValue: 'Payment terms and conditions',
-                      })}
-                      status={readOnlyStatus}
-                      statusLabel={statusLabel}
-                    />
                   </label>
                   <CustomSelect
                     options={paymentTermsOptions}
@@ -1315,15 +1295,8 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                   />
                 </div>
                 <div className="space-y-1.5">
-                  <label className="text-xs font-bold text-slate-500 ml-1 flex items-center gap-1">
+                  <label className="text-xs font-bold text-slate-500 ml-1">
                     {t('sales:clientQuotes.expirationDateLabel')}
-                    <FieldTooltip
-                      description={t('sales:fieldInfo.expirationDate', {
-                        defaultValue: 'Date until which this document is valid',
-                      })}
-                      status={readOnlyStatus}
-                      statusLabel={statusLabel}
-                    />
                   </label>
                   <input
                     type="date"
@@ -1359,13 +1332,6 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                 >
                   <i className="fa-solid fa-plus"></i> {t('sales:clientQuotes.addProduct')}
                 </button>
-                <FieldTooltip
-                  description={t('sales:fieldInfo.addItem', {
-                    defaultValue: 'Add a new line item',
-                  })}
-                  status={readOnlyStatus}
-                  statusLabel={statusLabel}
-                />
               </div>
               {errors.items && (
                 <p className="text-red-500 text-[10px] font-bold ml-1 -mt-2">{errors.items}</p>
@@ -1423,11 +1389,13 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                     const lineMargin = lineSalePrice - lineCost;
 
                     const isLinkedToSupplierQuote = Boolean(item.supplierQuoteItemId);
-                    const linkedFieldStatus = isReadOnly
-                      ? readOnlyReason
-                      : isLinkedToSupplierQuote
-                        ? supplierLockedReason
-                        : statusEditable;
+                    const linkedFieldStatus = getLinkedFieldStatus(
+                      isReadOnly,
+                      isLinkedToSupplierQuote,
+                      readOnlyReason,
+                      supplierLockedReason,
+                      statusEditable,
+                    );
 
                     const handleCostChange = (value: string) => {
                       if (isReadOnly) return;

--- a/components/sales/ClientQuotesView.tsx
+++ b/components/sales/ClientQuotesView.tsx
@@ -176,13 +176,13 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
 
   const readOnlyReason = editingQuote?.linkedOfferId
     ? t('sales:clientQuotes.readOnlyBecauseOffer', {
-        defaultValue: 'This quote is read-only because an offer was created from it.',
+        defaultValue: 'Read-only due to linked offer',
       })
     : t('sales:clientQuotes.readOnlyBecauseFinal', {
-        defaultValue: 'This quote is read-only because it was already accepted or denied.',
+        defaultValue: 'Read-only due to finalized status',
       });
   const supplierLockedReason = t('sales:clientQuotes.fieldLockedBySupplierQuote', {
-    defaultValue: 'Locked because this item is linked to a supplier quote.',
+    defaultValue: 'Locked due to linked supplier quote',
   });
   const statusEditable = t('sales:fieldInfo.statusEditable', { defaultValue: 'Editable' });
   const statusLabel = t('sales:fieldInfo.statusLabel', { defaultValue: 'Status:' });
@@ -1179,12 +1179,10 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                 <span className="text-amber-700 text-xs font-bold">
                   {editingQuote?.linkedOfferId
                     ? t('sales:clientQuotes.readOnlyBecauseOffer', {
-                        defaultValue:
-                          'This quote is read-only because an offer was created from it.',
+                        defaultValue: 'Read-only due to linked offer',
                       })
                     : t('sales:clientQuotes.readOnlyBecauseFinal', {
-                        defaultValue:
-                          'This quote is read-only because it was already accepted or denied.',
+                        defaultValue: 'Read-only due to finalized status',
                       })}
                 </span>
               </div>

--- a/components/sales/ClientQuotesView.tsx
+++ b/components/sales/ClientQuotesView.tsx
@@ -1622,9 +1622,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                             <div className="text-[10px] font-black text-slate-400 uppercase tracking-wider">
                               {t('sales:clientQuotes.revenue')}
                             </div>
-                            <div
-                              className={`text-sm font-semibold whitespace-nowrap ${selectedSupplierQuote ? 'text-emerald-600' : 'text-slate-800'}`}
-                            >
+                            <div className="text-sm font-semibold whitespace-nowrap text-slate-800">
                               {lineSalePrice.toFixed(2)} {currency}
                             </div>
                           </div>
@@ -1732,9 +1730,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                               </span>
                             </div>
                             <div className="col-span-1 flex items-center justify-center">
-                              <span
-                                className={`text-xs font-semibold whitespace-nowrap ${selectedSupplierQuote ? 'text-emerald-600' : 'text-slate-800'}`}
-                              >
+                              <span className="text-xs font-semibold whitespace-nowrap text-slate-800">
                                 {lineSalePrice.toFixed(2)} {currency}
                               </span>
                             </div>

--- a/components/shared/CustomSelect.tsx
+++ b/components/shared/CustomSelect.tsx
@@ -267,7 +267,7 @@ const CustomSelect: React.FC<CustomSelectProps> = ({
             >
               {() => (
                 <span
-                  className={`block w-full truncate ${!isMulti && value ? 'text-slate-800 font-semibold' : 'text-slate-400'}`}
+                  className={`w-full truncate ${!isMulti && value ? 'text-slate-800 font-semibold' : 'text-slate-400'}`}
                 >
                   {buttonLabel}
                 </span>

--- a/components/shared/FieldTooltip.tsx
+++ b/components/shared/FieldTooltip.tsx
@@ -8,7 +8,7 @@ export interface FieldTooltipProps {
   className?: string;
 }
 
-const FIELD_TOOLTIP_ICON = (
+const renderTooltipIcon = () => (
   <i className="fa-solid fa-circle-question text-slate-300 hover:text-slate-500 text-[10px] cursor-help transition-colors" />
 );
 
@@ -32,7 +32,7 @@ const FieldTooltip: React.FC<FieldTooltipProps> = ({
       tooltipClassName="whitespace-normal max-w-72"
       wrapperClassName={className}
     >
-      {() => FIELD_TOOLTIP_ICON}
+      {renderTooltipIcon}
     </Tooltip>
   );
 };

--- a/components/shared/FieldTooltip.tsx
+++ b/components/shared/FieldTooltip.tsx
@@ -8,6 +8,10 @@ export interface FieldTooltipProps {
   className?: string;
 }
 
+const FIELD_TOOLTIP_ICON = (
+  <i className="fa-solid fa-circle-question text-slate-300 hover:text-slate-500 text-[10px] cursor-help transition-colors" />
+);
+
 const FieldTooltip: React.FC<FieldTooltipProps> = ({
   description,
   status,
@@ -28,9 +32,7 @@ const FieldTooltip: React.FC<FieldTooltipProps> = ({
       tooltipClassName="whitespace-normal max-w-72"
       wrapperClassName={className}
     >
-      {() => (
-        <i className="fa-solid fa-circle-question text-slate-300 hover:text-slate-500 text-[10px] cursor-help transition-colors" />
-      )}
+      {() => FIELD_TOOLTIP_ICON}
     </Tooltip>
   );
 };

--- a/components/shared/FieldTooltip.tsx
+++ b/components/shared/FieldTooltip.tsx
@@ -1,0 +1,38 @@
+import type React from 'react';
+import Tooltip from './Tooltip';
+
+export interface FieldTooltipProps {
+  description: string;
+  status: string;
+  statusLabel?: string;
+  className?: string;
+}
+
+const FieldTooltip: React.FC<FieldTooltipProps> = ({
+  description,
+  status,
+  statusLabel = 'Status:',
+  className = '',
+}) => {
+  return (
+    <Tooltip
+      label={
+        <div className="space-y-1">
+          <div>{description}</div>
+          <div className="opacity-70">
+            {statusLabel} {status}
+          </div>
+        </div>
+      }
+      position="top"
+      tooltipClassName="whitespace-normal max-w-56"
+      wrapperClassName={className}
+    >
+      {() => (
+        <i className="fa-solid fa-circle-question text-slate-300 hover:text-slate-500 text-[10px] cursor-help transition-colors" />
+      )}
+    </Tooltip>
+  );
+};
+
+export default FieldTooltip;

--- a/components/shared/FieldTooltip.tsx
+++ b/components/shared/FieldTooltip.tsx
@@ -25,7 +25,7 @@ const FieldTooltip: React.FC<FieldTooltipProps> = ({
         </div>
       }
       position="top"
-      tooltipClassName="whitespace-normal max-w-56"
+      tooltipClassName="whitespace-normal max-w-72"
       wrapperClassName={className}
     >
       {() => (

--- a/components/shared/Tooltip.tsx
+++ b/components/shared/Tooltip.tsx
@@ -37,7 +37,7 @@ const Tooltip: React.FC<TooltipProps> = ({
   tooltipClassName = '',
   children,
 }) => {
-  const wrapperRef = useRef<HTMLDivElement>(null);
+  const wrapperRef = useRef<HTMLSpanElement>(null);
   const tooltipRef = useRef<HTMLDivElement>(null);
   const hasFlippedRef = useRef(false);
   const clampAppliedRef = useRef(false);
@@ -188,7 +188,7 @@ const Tooltip: React.FC<TooltipProps> = ({
   }
 
   return (
-    <div
+    <span
       ref={wrapperRef}
       className={`relative inline-flex ${wrapperClassName}`}
       onMouseEnter={handleShow}
@@ -213,7 +213,7 @@ const Tooltip: React.FC<TooltipProps> = ({
             document.body,
           )
         : null}
-    </div>
+    </span>
   );
 };
 

--- a/components/shared/Tooltip.tsx
+++ b/components/shared/Tooltip.tsx
@@ -202,7 +202,7 @@ const Tooltip: React.FC<TooltipProps> = ({
             <div
               ref={tooltipRef}
               style={{ top: coords.top, left: coords.left }}
-              className={`absolute ${positionClasses[effectivePosition]} px-3 py-1 bg-slate-800 text-white text-xs font-bold rounded pointer-events-none transition-opacity whitespace-nowrap z-50 shadow-xl border border-slate-700 ${tooltipClassName}`}
+              className={`absolute ${positionClasses[effectivePosition]} px-3 py-1 bg-slate-800 text-white text-xs font-bold rounded pointer-events-none transition-opacity whitespace-nowrap z-[70] shadow-xl border border-slate-700 ${tooltipClassName}`}
             >
               {label}
               <div

--- a/components/timesheet/WeeklyView.tsx
+++ b/components/timesheet/WeeklyView.tsx
@@ -468,7 +468,7 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
                       {day.holidayName && (
                         <Tooltip label={day.holidayName}>
                           {() => (
-                            <div className="w-1.5 h-1.5 bg-red-500 rounded-full animate-pulse"></div>
+                            <span className="w-1.5 h-1.5 bg-red-500 rounded-full animate-pulse block"></span>
                           )}
                         </Tooltip>
                       )}

--- a/locales/en/sales.json
+++ b/locales/en/sales.json
@@ -99,6 +99,7 @@
     "unit": "Unit",
     "units": "Units",
     "supplierQuoteBadge": "Supplier",
+    "fieldLockedBySupplierQuote": "Locked because this item is linked to a supplier quote.",
     "createYourFirstQuote": "Create your first quote",
     "quotesTitle": "Quotes",
     "quotesSubtitle": "Manage client quotes and proposals",
@@ -183,7 +184,8 @@
     "markSent": "Mark as sent",
     "markAccepted": "Mark as accepted",
     "markDenied": "Mark as denied",
-    "createOrder": "Create sale order"
+    "createOrder": "Create sale order",
+    "clientLockedByQuote": "Client cannot be changed because this offer is linked to a quote."
   },
   "supplierQuotes": {
     "title": "Supplier Quotes",

--- a/locales/en/sales.json
+++ b/locales/en/sales.json
@@ -1,22 +1,17 @@
 {
   "fieldInfo": {
     "statusEditable": "Editable",
-    "client": "Select the client for this document",
-    "quoteCode": "Unique identifier for this quote",
-    "offerCode": "Unique identifier for this offer",
-    "paymentTerms": "Payment terms and conditions",
-    "expirationDate": "Date until which this document is valid",
     "supplierQuote": "Link this item to a supplier quote for cost tracking",
     "product": "Select a product or service for this line item",
     "qty": "Quantity of items or hours",
     "cost": "Unit cost for this item",
     "mol": "Margin overhead loading percentage",
-    "addItem": "Add a new line item",
     "notes": "Additional notes for the entire document",
     "clientInformation": "Client and document details",
     "productsServices": "Products and services for this quote",
     "items": "Line items for this offer",
-    "statusLabel": "Status:"
+    "statusLabel": "Status:",
+    "fieldLockedBySupplierQuote": "Locked due to linked supplier quote"
   },
   "clientQuotes": {
     "title": "Quotes",
@@ -118,7 +113,6 @@
     "unit": "Unit",
     "units": "Units",
     "supplierQuoteBadge": "Supplier",
-    "fieldLockedBySupplierQuote": "Locked due to linked supplier quote",
     "createYourFirstQuote": "Create your first quote",
     "quotesTitle": "Quotes",
     "quotesSubtitle": "Manage client quotes and proposals",

--- a/locales/en/sales.json
+++ b/locales/en/sales.json
@@ -13,7 +13,9 @@
     "mol": "Margin overhead loading percentage",
     "addItem": "Add a new line item",
     "notes": "Additional notes for the entire document",
-    "submit": "Submit or update this document",
+    "clientInformation": "Client and document details",
+    "productsServices": "Products and services for this quote",
+    "items": "Line items for this offer",
     "statusLabel": "Status:"
   },
   "clientQuotes": {

--- a/locales/en/sales.json
+++ b/locales/en/sales.json
@@ -1,4 +1,21 @@
 {
+  "fieldInfo": {
+    "statusEditable": "Editable",
+    "client": "Select the client for this document",
+    "quoteCode": "Unique identifier for this quote",
+    "offerCode": "Unique identifier for this offer",
+    "paymentTerms": "Payment terms and conditions",
+    "expirationDate": "Date until which this document is valid",
+    "supplierQuote": "Link this item to a supplier quote for cost tracking",
+    "product": "Select a product or service for this line item",
+    "qty": "Quantity of items or hours",
+    "cost": "Unit cost for this item",
+    "mol": "Margin overhead loading percentage",
+    "addItem": "Add a new line item",
+    "notes": "Additional notes for the entire document",
+    "submit": "Submit or update this document",
+    "statusLabel": "Status:"
+  },
   "clientQuotes": {
     "title": "Quotes",
     "subtitle": "Create and manage client quotes",

--- a/locales/en/sales.json
+++ b/locales/en/sales.json
@@ -51,8 +51,8 @@
     "convertToOffer": "Convert to Offer",
     "convertConfirm": "Convert this quote to a sale?",
     "readOnlyStatus": "{{status}} quotes are read-only",
-    "readOnlyBecauseOffer": "This quote is read-only because an offer was created from it.",
-    "readOnlyBecauseFinal": "This quote is read-only because it was already accepted or denied.",
+    "readOnlyBecauseOffer": "Read-only due to linked offer",
+    "readOnlyBecauseFinal": "Read-only due to finalized status",
     "linkedOffer": "Linked Offer",
     "linkedOfferInfo": "Offer #{{number}}",
     "offerDetailsReadOnly": "(Quote details are read-only)",
@@ -116,7 +116,7 @@
     "unit": "Unit",
     "units": "Units",
     "supplierQuoteBadge": "Supplier",
-    "fieldLockedBySupplierQuote": "Locked because this item is linked to a supplier quote.",
+    "fieldLockedBySupplierQuote": "Locked due to linked supplier quote",
     "createYourFirstQuote": "Create your first quote",
     "quotesTitle": "Quotes",
     "quotesSubtitle": "Manage client quotes and proposals",
@@ -161,7 +161,7 @@
     "addOffer": "Add offer",
     "sourceQuote": "Source quote",
     "viewQuote": "View quote",
-    "readOnlyStatus": "Non-draft offers are read-only. Change status from the list actions.",
+    "readOnlyStatus": "Read-only due to non-draft status",
     "clientInformation": "Client Information",
     "client": "Client",
     "clientColumn": "Client",
@@ -202,7 +202,7 @@
     "markAccepted": "Mark as accepted",
     "markDenied": "Mark as denied",
     "createOrder": "Create sale order",
-    "clientLockedByQuote": "Client cannot be changed because this offer is linked to a quote."
+    "clientLockedByQuote": "Locked due to linked quote"
   },
   "supplierQuotes": {
     "title": "Supplier Quotes",

--- a/locales/it/sales.json
+++ b/locales/it/sales.json
@@ -1,22 +1,17 @@
 {
   "fieldInfo": {
     "statusEditable": "Modificabile",
-    "client": "Seleziona il cliente per questo documento",
-    "quoteCode": "Identificativo univoco di questo preventivo",
-    "offerCode": "Identificativo univoco di questa offerta",
-    "paymentTerms": "Termini e condizioni di pagamento",
-    "expirationDate": "Data di validità di questo documento",
     "supplierQuote": "Collega questa voce a un preventivo fornitore per il tracciamento dei costi",
     "product": "Seleziona un prodotto o servizio per questa voce",
     "qty": "Quantità di articoli o ore",
     "cost": "Costo unitario per questa voce",
     "mol": "Percentuale margine e oneri",
-    "addItem": "Aggiungi una nuova voce",
     "notes": "Note aggiuntive per l'intero documento",
     "clientInformation": "Dettagli cliente e documento",
     "productsServices": "Prodotti e servizi per questo preventivo",
     "items": "Voci per questa offerta",
-    "statusLabel": "Stato:"
+    "statusLabel": "Stato:",
+    "fieldLockedBySupplierQuote": "Bloccato per preventivo fornitore collegato"
   },
   "clientQuotes": {
     "title": "Preventivi",
@@ -118,7 +113,6 @@
     "unit": "Unità",
     "units": "Unità",
     "supplierQuoteBadge": "Fornitore",
-    "fieldLockedBySupplierQuote": "Bloccato per preventivo fornitore collegato",
     "createYourFirstQuote": "Crea il tuo primo preventivo",
     "quotesTitle": "Preventivi",
     "quotesSubtitle": "Gestisci i preventivi e le proposte cliente",

--- a/locales/it/sales.json
+++ b/locales/it/sales.json
@@ -51,8 +51,8 @@
     "convertToOffer": "Converti in Offerta",
     "convertConfirm": "Convertire questo preventivo in una vendita?",
     "readOnlyStatus": "I preventivi in stato {{status}} sono in sola lettura",
-    "readOnlyBecauseOffer": "Questo preventivo è in sola lettura perché è stata creata un'offerta da esso.",
-    "readOnlyBecauseFinal": "Questo preventivo è in sola lettura perché è già stato accettato o rifiutato.",
+    "readOnlyBecauseOffer": "Sola lettura per offerta collegata",
+    "readOnlyBecauseFinal": "Sola lettura per stato finalizzato",
     "linkedOffer": "Offerta Collegata",
     "linkedOfferInfo": "Offerta #{{number}}",
     "offerDetailsReadOnly": "(I dettagli del preventivo sono in sola lettura)",
@@ -116,7 +116,7 @@
     "unit": "Unità",
     "units": "Unità",
     "supplierQuoteBadge": "Fornitore",
-    "fieldLockedBySupplierQuote": "Bloccato perché questa voce è collegata a un preventivo fornitore.",
+    "fieldLockedBySupplierQuote": "Bloccato per preventivo fornitore collegato",
     "createYourFirstQuote": "Crea il tuo primo preventivo",
     "quotesTitle": "Preventivi",
     "quotesSubtitle": "Gestisci i preventivi e le proposte cliente",
@@ -161,7 +161,7 @@
     "addOffer": "Aggiungi offerta",
     "sourceQuote": "Preventivo di origine",
     "viewQuote": "Vedi preventivo",
-    "readOnlyStatus": "Le offerte non in bozza sono in sola lettura. Cambia lo stato dalle azioni nella lista.",
+    "readOnlyStatus": "Sola lettura per stato non bozza",
     "clientInformation": "Informazioni Cliente",
     "client": "Cliente",
     "clientColumn": "Cliente",
@@ -202,7 +202,7 @@
     "markAccepted": "Segna come accettata",
     "markDenied": "Segna come rifiutata",
     "createOrder": "Crea ordine di vendita",
-    "clientLockedByQuote": "Il cliente non può essere modificato perché questa offerta è collegata a un preventivo."
+    "clientLockedByQuote": "Bloccato per preventivo collegato"
   },
   "supplierQuotes": {
     "title": "Preventivi Fornitori",

--- a/locales/it/sales.json
+++ b/locales/it/sales.json
@@ -1,4 +1,21 @@
 {
+  "fieldInfo": {
+    "statusEditable": "Modificabile",
+    "client": "Seleziona il cliente per questo documento",
+    "quoteCode": "Identificativo univoco di questo preventivo",
+    "offerCode": "Identificativo univoco di questa offerta",
+    "paymentTerms": "Termini e condizioni di pagamento",
+    "expirationDate": "Data di validità di questo documento",
+    "supplierQuote": "Collega questa voce a un preventivo fornitore per il tracciamento dei costi",
+    "product": "Seleziona un prodotto o servizio per questa voce",
+    "qty": "Quantità di articoli o ore",
+    "cost": "Costo unitario per questa voce",
+    "mol": "Percentuale margine e oneri",
+    "addItem": "Aggiungi una nuova voce",
+    "notes": "Note aggiuntive per l'intero documento",
+    "submit": "Invia o aggiornare questo documento",
+    "statusLabel": "Stato:"
+  },
   "clientQuotes": {
     "title": "Preventivi",
     "subtitle": "Crea e gestisci preventivi clienti",

--- a/locales/it/sales.json
+++ b/locales/it/sales.json
@@ -99,6 +99,7 @@
     "unit": "Unità",
     "units": "Unità",
     "supplierQuoteBadge": "Fornitore",
+    "fieldLockedBySupplierQuote": "Bloccato perché questa voce è collegata a un preventivo fornitore.",
     "createYourFirstQuote": "Crea il tuo primo preventivo",
     "quotesTitle": "Preventivi",
     "quotesSubtitle": "Gestisci i preventivi e le proposte cliente",
@@ -183,7 +184,8 @@
     "markSent": "Segna come inviata",
     "markAccepted": "Segna come accettata",
     "markDenied": "Segna come rifiutata",
-    "createOrder": "Crea ordine di vendita"
+    "createOrder": "Crea ordine di vendita",
+    "clientLockedByQuote": "Il cliente non può essere modificato perché questa offerta è collegata a un preventivo."
   },
   "supplierQuotes": {
     "title": "Preventivi Fornitori",

--- a/locales/it/sales.json
+++ b/locales/it/sales.json
@@ -13,7 +13,9 @@
     "mol": "Percentuale margine e oneri",
     "addItem": "Aggiungi una nuova voce",
     "notes": "Note aggiuntive per l'intero documento",
-    "submit": "Invia o aggiornare questo documento",
+    "clientInformation": "Dettagli cliente e documento",
+    "productsServices": "Prodotti e servizi per questo preventivo",
+    "items": "Voci per questa offerta",
     "statusLabel": "Stato:"
   },
   "clientQuotes": {

--- a/utils/fieldStatus.ts
+++ b/utils/fieldStatus.ts
@@ -1,0 +1,13 @@
+export function getLinkedFieldStatus(
+  isReadOnly: boolean,
+  isLinkedToSupplierQuote: boolean,
+  readOnlyReason: string,
+  supplierLockedReason: string,
+  statusEditable: string,
+) {
+  return isReadOnly
+    ? readOnlyReason
+    : isLinkedToSupplierQuote
+      ? supplierLockedReason
+      : statusEditable;
+}

--- a/utils/fieldStatus.ts
+++ b/utils/fieldStatus.ts
@@ -1,10 +1,18 @@
-export function getLinkedFieldStatus(
-  isReadOnly: boolean,
-  isLinkedToSupplierQuote: boolean,
-  readOnlyReason: string,
-  supplierLockedReason: string,
-  statusEditable: string,
-) {
+interface LinkedFieldStatusOptions {
+  isReadOnly: boolean;
+  isLinkedToSupplierQuote: boolean;
+  readOnlyReason: string;
+  supplierLockedReason: string;
+  statusEditable: string;
+}
+
+export function getLinkedFieldStatus({
+  isReadOnly,
+  isLinkedToSupplierQuote,
+  readOnlyReason,
+  supplierLockedReason,
+  statusEditable,
+}: LinkedFieldStatusOptions) {
   return isReadOnly
     ? readOnlyReason
     : isLinkedToSupplierQuote


### PR DESCRIPTION
## Summary

- Lock cost, quantity, unit type, and product fields when an item is linked to a supplier quote, preventing accidental edits to supplier-driven values
- Add a `FieldTooltip` component that shows field descriptions and edit status on hover, replacing individual `Tooltip` wrappers around form inputs
- Place `FieldTooltip` on modal section headers (Client Information, Items/Products) in both client quote and client offer views, providing at-a-glance status info
- Raise shared `Tooltip` z-index to 70 so tooltips render above the modal backdrop
- Keep revenue text color consistent when a supplier quote is linked (no color change on locked state)

## Commits

1. **fc8b63e9** `feat(sales): lock cost/qty fields when item is linked to supplier quote, add tooltip lock reasons`
   Fields locked due to supplier quote linkage or read-only status now show a tooltip explaining why. Removes per-item supplier badge from cost column.
2. **c0d7b6dc** `fix(ui): raise tooltip z-index above modal backdrop`
   Tooltip z-index bumped from 50 to 70 to render above modal's z-60 backdrop.
3. **7216aedd** `feat(sales): add FieldTooltip component for field info and status display`
   New shared component replacing Tooltip wrappers on inputs; placed next to field labels showing description + edit status on hover.
4. **048fa8d3** `fix(sales): widen FieldTooltip and shorten status messages`
   Max-width increased to 288px; lock reason strings shortened to concise pattern in EN + IT.
5. **26a1bf06** `fix(sales): move FieldTooltip from submit button to modal section headers`
   Tooltips relocated from submit/update button to Client Information and Items/Products section headers.
6. **e55003af** `fix(sales): keep revenue text color consistent when supplier quote is linked`
   Revenue text no longer changes color when item is linked to a supplier quote.

## Files changed

| File | Changes |
|------|---------|
| `components/sales/ClientOffersView.tsx` | Added lock logic, FieldTooltip integration, i18n strings |
| `components/sales/ClientQuotesView.tsx` | Added lock logic, FieldTooltip integration, i18n strings |
| `components/shared/FieldTooltip.tsx` | New component |
| `components/shared/Tooltip.tsx` | Wrapper element changed div → span, z-index raised |
| `locales/en/sales.json` | New i18n keys for lock reasons and section descriptions |
| `locales/it/sales.json` | New i18n keys for lock reasons and section descriptions |

## Test plan

- [ ] Open a client quote with items linked to a supplier quote — verify cost/qty/unit/product fields are disabled
- [ ] Hover over locked fields — verify tooltip explains the lock reason
- [ ] Hover over modal section headers — verify FieldTooltip shows status info
- [ ] Open a client offer linked to a quote — verify fields lock and tooltips appear
- [ ] Verify tooltips render above modal backdrop (no z-index clipping)
- [ ] Verify revenue text color stays consistent regardless of supplier quote linkage
- [ ] Verify EN and IT locale strings display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xbounceit/praetor/pull/128" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
