### PR TITLE
refactor(server): extend repository pattern to email, users, roles, audit

### DIFF
--- a/server/bun.lock
+++ b/server/bun.lock
@@ -18,7 +18,6 @@
         "pino": "^10.3.1",
         "pino-pretty": "^13.1.2",
         "selfsigned": "^2.4.1",
-        "uuid": "^11.1.0",
       },
       "devDependencies": {
         "@types/bcryptjs": "^2.4.6",
@@ -274,8 +273,6 @@
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
-
-    "uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
 
     "vasync": ["vasync@2.2.1", "", { "dependencies": { "verror": "1.10.0" } }, "sha512-Hq72JaTpcTFdWiNA4Y22Amej2GH3BFmBaKPPlDZ4/oC8HNn2ISHLkFrJU4Ds8R3jcUi7oo5Y9jcMHKjES+N9wQ=="],
 

--- a/server/db/bootstrapAdmin.ts
+++ b/server/db/bootstrapAdmin.ts
@@ -1,7 +1,7 @@
 import bcrypt from 'bcryptjs';
-import { randomUUID } from 'crypto';
 import * as usersRepo from '../repositories/usersRepo.ts';
 import { createChildLogger } from '../utils/logger.ts';
+import { generatePrefixedId } from '../utils/order-ids.ts';
 import { query } from './index.ts';
 
 export const ADMIN_USERNAME = 'admin';
@@ -23,7 +23,7 @@ export const ensureBootstrapAdmin = async () => {
     const defaultIdCheck = await query('SELECT 1 FROM users WHERE id = $1 LIMIT 1', [
       DEFAULT_ADMIN_USER_ID,
     ]);
-    adminId = defaultIdCheck.rows.length === 0 ? DEFAULT_ADMIN_USER_ID : randomUUID();
+    adminId = defaultIdCheck.rows.length === 0 ? DEFAULT_ADMIN_USER_ID : generatePrefixedId('u');
 
     const rawPassword = process.env.ADMIN_DEFAULT_PASSWORD?.trim();
     const adminPassword =

--- a/server/db/bootstrapAdmin.ts
+++ b/server/db/bootstrapAdmin.ts
@@ -1,5 +1,6 @@
 import bcrypt from 'bcryptjs';
 import { randomUUID } from 'crypto';
+import * as usersRepo from '../repositories/usersRepo.ts';
 import { createChildLogger } from '../utils/logger.ts';
 import { query } from './index.ts';
 
@@ -29,11 +30,14 @@ export const ensureBootstrapAdmin = async () => {
       rawPassword && rawPassword.length > 0 ? rawPassword : DEFAULT_ADMIN_PASSWORD;
     const passwordHash = await bcrypt.hash(adminPassword, 12);
 
-    await query(
-      `INSERT INTO users (id, name, username, password_hash, role, avatar_initials)
-       VALUES ($1, $2, $3, $4, $5, $6)`,
-      [adminId, 'Admin User', ADMIN_USERNAME, passwordHash, 'admin', 'AD'],
-    );
+    await usersRepo.createUser({
+      id: adminId,
+      name: 'Admin User',
+      username: ADMIN_USERNAME,
+      passwordHash,
+      role: 'admin',
+      avatarInitials: 'AD',
+    });
     logger.info(
       {
         passwordSource:

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -1,6 +1,7 @@
 import type { FastifyReply, FastifyRequest } from 'fastify';
 import jwt, { type JwtPayload } from 'jsonwebtoken';
-import { query } from '../db/index.ts';
+import * as rolesRepo from '../repositories/rolesRepo.ts';
+import * as usersRepo from '../repositories/usersRepo.ts';
 import { getRolePermissions } from '../utils/permissions.ts';
 
 const JWT_SECRET = process.env.JWT_SECRET || 'praetor-secret-key-change-in-production';
@@ -33,44 +34,33 @@ export const authenticateToken = async (request: FastifyRequest, reply: FastifyR
 
     request.auth = { userId: decoded.userId, sessionStart };
 
-    // Fetch user data from Postgres.
-    type AuthUserRow = {
-      id: string;
-      name: string;
-      username: string;
-      role: string;
-      avatar_initials: string | null;
-      is_disabled: boolean;
-    };
-
-    const result = await query(
-      `SELECT u.id, u.name, u.username, u.role, u.avatar_initials, u.is_disabled
-       FROM users u
-       WHERE u.id = $1`,
-      [decoded.userId],
-    );
-    const user = result.rows.length === 0 ? null : (result.rows[0] as AuthUserRow);
+    const user = await usersRepo.findAuthUserById(decoded.userId);
 
     if (!user) {
       return reply.code(401).send({ error: 'User not found' });
     }
 
-    if (user.is_disabled) {
+    if (user.isDisabled) {
       return reply.code(401).send({ error: 'Invalid or expired token' });
     }
 
     const effectiveRole = decoded.activeRole ?? user.role;
 
-    const membership = await query(
-      'SELECT 1 FROM user_roles WHERE user_id = $1 AND role_id = $2 LIMIT 1',
-      [user.id, effectiveRole],
-    );
-    if (membership.rows.length === 0) {
+    const [hasRole, permissions] = await Promise.all([
+      rolesRepo.userHasRole(user.id, effectiveRole),
+      getRolePermissions(effectiveRole),
+    ]);
+    if (!hasRole) {
       return reply.code(403).send({ error: 'Invalid or expired token' });
     }
-
-    const permissions = await getRolePermissions(effectiveRole);
-    request.user = { ...user, role: effectiveRole, permissions };
+    request.user = {
+      id: user.id,
+      name: user.name,
+      username: user.username,
+      role: effectiveRole,
+      avatarInitials: user.avatarInitials,
+      permissions,
+    };
 
     // Sliding window: Issue new token with same sessionStart
     // This resets the 30m idle timer but keeps the 8h max session limit

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -46,6 +46,9 @@ export const authenticateToken = async (request: FastifyRequest, reply: FastifyR
 
     const effectiveRole = decoded.activeRole ?? user.role;
 
+    // Run in parallel: this middleware fires on every authenticated request and the success path
+    // (user has the role) is the hot case. The wasted permissions lookup on a 403 is cheap
+    // compared to the latency saved on the 99%+ success path.
     const [hasRole, permissions] = await Promise.all([
       rolesRepo.userHasRole(user.id, effectiveRole),
       getRolePermissions(effectiveRole),

--- a/server/package.json
+++ b/server/package.json
@@ -23,8 +23,7 @@
     "pg": "^8.20.0",
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.2",
-    "selfsigned": "^2.4.1",
-    "uuid": "^11.1.0"
+    "selfsigned": "^2.4.1"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",

--- a/server/repositories/auditLogsRepo.ts
+++ b/server/repositories/auditLogsRepo.ts
@@ -1,5 +1,6 @@
 import pool, { type QueryExecutor } from '../db/index.ts';
 import type { AuditLogDetails } from '../utils/audit.ts';
+import { generatePrefixedId } from '../utils/order-ids.ts';
 
 export type AuditLog = {
   id: string;
@@ -56,4 +57,29 @@ export const list = async (
 
   const { rows } = await exec.query<AuditLog>(sql, params);
   return rows;
+};
+
+export type AuditLogInsert = {
+  userId: string;
+  action: string;
+  entityType: string | null;
+  entityId: string | null;
+  ipAddress: string;
+  details: AuditLogDetails | null;
+};
+
+export const create = async (input: AuditLogInsert, exec: QueryExecutor = pool): Promise<void> => {
+  await exec.query(
+    `INSERT INTO audit_logs (id, user_id, action, entity_type, entity_id, ip_address, details)
+     VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)`,
+    [
+      generatePrefixedId('audit'),
+      input.userId,
+      input.action,
+      input.entityType,
+      input.entityId,
+      input.ipAddress,
+      input.details ? JSON.stringify(input.details) : null,
+    ],
+  );
 };

--- a/server/repositories/emailRepo.ts
+++ b/server/repositories/emailRepo.ts
@@ -10,6 +10,7 @@ export type EmailConfig = {
   smtpEncryption: SmtpEncryption;
   smtpRejectUnauthorized: boolean;
   smtpUser: string;
+  // Encrypted ciphertext when stored; callers must `decrypt()` before passing to a transporter.
   smtpPassword: string;
   fromEmail: string;
   fromName: string;

--- a/server/repositories/emailRepo.ts
+++ b/server/repositories/emailRepo.ts
@@ -16,7 +16,12 @@ export type EmailConfig = {
   fromName: string;
 };
 
-export type EmailConfigPatch = Partial<EmailConfig>;
+// Patch shape for `update`. The password field is renamed to make the ciphertext-only
+// invariant explicit at the type level — `update` writes its value verbatim to
+// `email_config.smtp_password`, so callers must encrypt first (see `EmailService.saveConfig`).
+export type EmailConfigPatch = Partial<Omit<EmailConfig, 'smtpPassword'>> & {
+  smtpPasswordCiphertext?: string;
+};
 
 export const DEFAULT_CONFIG: EmailConfig = {
   enabled: false,
@@ -72,7 +77,7 @@ export const update = async (
       patch.smtpEncryption,
       patch.smtpRejectUnauthorized,
       patch.smtpUser,
-      patch.smtpPassword,
+      patch.smtpPasswordCiphertext,
       patch.fromEmail,
       patch.fromName,
     ],

--- a/server/repositories/emailRepo.ts
+++ b/server/repositories/emailRepo.ts
@@ -35,6 +35,17 @@ export const DEFAULT_CONFIG: EmailConfig = {
   fromName: 'Praetor',
 };
 
+// Older versions of email_config accepted any string for smtp_encryption (see commit a1f1fcac).
+// Normalize at the boundary so consumers can rely on the union type.
+type EmailConfigRow = Omit<EmailConfig, 'smtpEncryption'> & { smtpEncryption: string };
+
+const mapRow = (row: EmailConfigRow): EmailConfig => ({
+  ...row,
+  smtpEncryption: (SMTP_ENCRYPTIONS as readonly string[]).includes(row.smtpEncryption)
+    ? (row.smtpEncryption as SmtpEncryption)
+    : 'tls',
+});
+
 const SELECT_COLUMNS = `enabled,
         smtp_host as "smtpHost",
         smtp_port as "smtpPort",
@@ -46,17 +57,17 @@ const SELECT_COLUMNS = `enabled,
         from_name as "fromName"`;
 
 export const get = async (exec: QueryExecutor = pool): Promise<EmailConfig | null> => {
-  const { rows } = await exec.query<EmailConfig>(
+  const { rows } = await exec.query<EmailConfigRow>(
     `SELECT ${SELECT_COLUMNS} FROM email_config WHERE id = 1`,
   );
-  return rows[0] ?? null;
+  return rows[0] ? mapRow(rows[0]) : null;
 };
 
 export const update = async (
   patch: EmailConfigPatch,
   exec: QueryExecutor = pool,
 ): Promise<EmailConfig> => {
-  const { rows } = await exec.query<EmailConfig>(
+  const { rows } = await exec.query<EmailConfigRow>(
     `UPDATE email_config
         SET enabled = COALESCE($1, enabled),
             smtp_host = COALESCE($2, smtp_host),
@@ -85,5 +96,5 @@ export const update = async (
   if (rows.length === 0) {
     throw new Error('email_config row (id=1) not found; seed missing');
   }
-  return rows[0];
+  return mapRow(rows[0]);
 };

--- a/server/repositories/emailRepo.ts
+++ b/server/repositories/emailRepo.ts
@@ -1,0 +1,72 @@
+import pool, { type QueryExecutor } from '../db/index.ts';
+
+export const SMTP_ENCRYPTIONS = ['insecure', 'ssl', 'tls'] as const;
+export type SmtpEncryption = (typeof SMTP_ENCRYPTIONS)[number];
+
+export type EmailConfig = {
+  enabled: boolean;
+  smtpHost: string;
+  smtpPort: number;
+  smtpEncryption: SmtpEncryption;
+  smtpRejectUnauthorized: boolean;
+  smtpUser: string;
+  smtpPassword: string;
+  fromEmail: string;
+  fromName: string;
+};
+
+export type EmailConfigPatch = Partial<EmailConfig>;
+
+const SELECT_COLUMNS = `enabled,
+        smtp_host as "smtpHost",
+        smtp_port as "smtpPort",
+        smtp_encryption as "smtpEncryption",
+        smtp_reject_unauthorized as "smtpRejectUnauthorized",
+        smtp_user as "smtpUser",
+        smtp_password as "smtpPassword",
+        from_email as "fromEmail",
+        from_name as "fromName"`;
+
+const SEED_MISSING_ERROR = 'email_config row (id=1) not found; seed missing';
+
+export const get = async (exec: QueryExecutor = pool): Promise<EmailConfig> => {
+  const { rows } = await exec.query<EmailConfig>(
+    `SELECT ${SELECT_COLUMNS} FROM email_config WHERE id = 1`,
+  );
+  if (rows.length === 0) throw new Error(SEED_MISSING_ERROR);
+  return rows[0];
+};
+
+export const update = async (
+  patch: EmailConfigPatch,
+  exec: QueryExecutor = pool,
+): Promise<EmailConfig> => {
+  const { rows } = await exec.query<EmailConfig>(
+    `UPDATE email_config
+        SET enabled = COALESCE($1, enabled),
+            smtp_host = COALESCE($2, smtp_host),
+            smtp_port = COALESCE($3, smtp_port),
+            smtp_encryption = COALESCE($4, smtp_encryption),
+            smtp_reject_unauthorized = COALESCE($5, smtp_reject_unauthorized),
+            smtp_user = COALESCE($6, smtp_user),
+            smtp_password = COALESCE($7, smtp_password),
+            from_email = COALESCE($8, from_email),
+            from_name = COALESCE($9, from_name),
+            updated_at = CURRENT_TIMESTAMP
+      WHERE id = 1
+      RETURNING ${SELECT_COLUMNS}`,
+    [
+      patch.enabled,
+      patch.smtpHost,
+      patch.smtpPort,
+      patch.smtpEncryption,
+      patch.smtpRejectUnauthorized,
+      patch.smtpUser,
+      patch.smtpPassword,
+      patch.fromEmail,
+      patch.fromName,
+    ],
+  );
+  if (rows.length === 0) throw new Error(SEED_MISSING_ERROR);
+  return rows[0];
+};

--- a/server/repositories/emailRepo.ts
+++ b/server/repositories/emailRepo.ts
@@ -17,6 +17,18 @@ export type EmailConfig = {
 
 export type EmailConfigPatch = Partial<EmailConfig>;
 
+export const DEFAULT_CONFIG: EmailConfig = {
+  enabled: false,
+  smtpHost: '',
+  smtpPort: 587,
+  smtpEncryption: 'tls',
+  smtpRejectUnauthorized: true,
+  smtpUser: '',
+  smtpPassword: '',
+  fromEmail: '',
+  fromName: 'Praetor',
+};
+
 const SELECT_COLUMNS = `enabled,
         smtp_host as "smtpHost",
         smtp_port as "smtpPort",
@@ -27,14 +39,11 @@ const SELECT_COLUMNS = `enabled,
         from_email as "fromEmail",
         from_name as "fromName"`;
 
-const SEED_MISSING_ERROR = 'email_config row (id=1) not found; seed missing';
-
-export const get = async (exec: QueryExecutor = pool): Promise<EmailConfig> => {
+export const get = async (exec: QueryExecutor = pool): Promise<EmailConfig | null> => {
   const { rows } = await exec.query<EmailConfig>(
     `SELECT ${SELECT_COLUMNS} FROM email_config WHERE id = 1`,
   );
-  if (rows.length === 0) throw new Error(SEED_MISSING_ERROR);
-  return rows[0];
+  return rows[0] ?? null;
 };
 
 export const update = async (
@@ -67,6 +76,8 @@ export const update = async (
       patch.fromName,
     ],
   );
-  if (rows.length === 0) throw new Error(SEED_MISSING_ERROR);
+  if (rows.length === 0) {
+    throw new Error('email_config row (id=1) not found; seed missing');
+  }
   return rows[0];
 };

--- a/server/repositories/rolesRepo.ts
+++ b/server/repositories/rolesRepo.ts
@@ -11,3 +11,37 @@ export const findExistingIds = async (
   );
   return new Set(rows.map((r) => r.id));
 };
+
+export const userHasRole = async (
+  userId: string,
+  roleId: string,
+  exec: QueryExecutor = pool,
+): Promise<boolean> => {
+  const { rows } = await exec.query(
+    `SELECT 1 FROM user_roles WHERE user_id = $1 AND role_id = $2 LIMIT 1`,
+    [userId, roleId],
+  );
+  return rows.length > 0;
+};
+
+export type AvailableRole = {
+  id: string;
+  name: string;
+  isSystem: boolean;
+  isAdmin: boolean;
+};
+
+export const listAvailableRolesForUser = async (
+  userId: string,
+  exec: QueryExecutor = pool,
+): Promise<AvailableRole[]> => {
+  const { rows } = await exec.query<AvailableRole>(
+    `SELECT r.id, r.name, r.is_system AS "isSystem", r.is_admin AS "isAdmin"
+       FROM user_roles ur
+       JOIN roles r ON r.id = ur.role_id
+      WHERE ur.user_id = $1
+      ORDER BY r.name`,
+    [userId],
+  );
+  return rows;
+};

--- a/server/repositories/usersRepo.ts
+++ b/server/repositories/usersRepo.ts
@@ -77,6 +77,10 @@ export const updateNameByUsername = async (
   await exec.query(`UPDATE users SET name = $2 WHERE username = $1`, [username, name]);
 };
 
+// For users that authenticate externally (e.g. LDAP) and must never log in locally. Satisfies
+// the `password_hash NOT NULL` column with a malformed bcrypt that no plaintext can match.
+export const LDAP_PLACEHOLDER_PASSWORD_HASH = '$2a$10$invalidpasswordhashforldapuser00000000000000';
+
 export type NewUser = {
   id: string;
   name: string;

--- a/server/repositories/usersRepo.ts
+++ b/server/repositories/usersRepo.ts
@@ -68,3 +68,28 @@ export const updatePasswordHash = async (
 ): Promise<void> => {
   await exec.query(`UPDATE users SET password_hash = $1 WHERE id = $2`, [passwordHash, userId]);
 };
+
+export const updateNameByUsername = async (
+  username: string,
+  name: string,
+  exec: QueryExecutor = pool,
+): Promise<void> => {
+  await exec.query(`UPDATE users SET name = $2 WHERE username = $1`, [username, name]);
+};
+
+export type NewUser = {
+  id: string;
+  name: string;
+  username: string;
+  passwordHash: string;
+  role: string;
+  avatarInitials: string;
+};
+
+export const createUser = async (user: NewUser, exec: QueryExecutor = pool): Promise<void> => {
+  await exec.query(
+    `INSERT INTO users (id, name, username, password_hash, role, avatar_initials)
+     VALUES ($1, $2, $3, $4, $5, $6)`,
+    [user.id, user.name, user.username, user.passwordHash, user.role, user.avatarInitials],
+  );
+};

--- a/server/repositories/usersRepo.ts
+++ b/server/repositories/usersRepo.ts
@@ -1,5 +1,55 @@
 import pool, { type QueryExecutor } from '../db/index.ts';
 
+export type AuthUser = {
+  id: string;
+  name: string;
+  username: string;
+  role: string;
+  avatarInitials: string;
+  isDisabled: boolean;
+};
+
+export type LoginUser = AuthUser & { passwordHash: string | null };
+
+export const findAuthUserById = async (
+  userId: string,
+  exec: QueryExecutor = pool,
+): Promise<AuthUser | null> => {
+  const { rows } = await exec.query<AuthUser>(
+    `SELECT
+        id,
+        name,
+        username,
+        role,
+        avatar_initials AS "avatarInitials",
+        is_disabled AS "isDisabled"
+      FROM users
+      WHERE id = $1`,
+    [userId],
+  );
+  return rows[0] ?? null;
+};
+
+export const findLoginUserByUsername = async (
+  username: string,
+  exec: QueryExecutor = pool,
+): Promise<LoginUser | null> => {
+  const { rows } = await exec.query<LoginUser>(
+    `SELECT
+        id,
+        name,
+        username,
+        role,
+        password_hash AS "passwordHash",
+        avatar_initials AS "avatarInitials",
+        is_disabled AS "isDisabled"
+      FROM users
+      WHERE username = $1`,
+    [username],
+  );
+  return rows[0] ?? null;
+};
+
 export const getPasswordHash = async (
   userId: string,
   exec: QueryExecutor = pool,

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -1,7 +1,8 @@
 import bcrypt from 'bcryptjs';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
-import { query } from '../db/index.ts';
 import { authenticateToken, generateToken } from '../middleware/auth.ts';
+import * as rolesRepo from '../repositories/rolesRepo.ts';
+import * as usersRepo from '../repositories/usersRepo.ts';
 import { standardRateLimitedErrorResponses } from '../schemas/common.ts';
 import { logAudit } from '../utils/audit.ts';
 import { getRolePermissions } from '../utils/permissions.ts';
@@ -60,24 +61,6 @@ const loginResponseSchema = {
   required: ['token', 'user'],
 } as const;
 
-const getAvailableRolesForUser = async (userId: string) => {
-  const result = await query(
-    `SELECT r.id, r.name, r.is_system, r.is_admin
-       FROM user_roles ur
-       JOIN roles r ON r.id = ur.role_id
-      WHERE ur.user_id = $1
-      ORDER BY r.name`,
-    [userId],
-  );
-
-  return result.rows.map((r) => ({
-    id: r.id as string,
-    name: r.name as string,
-    isSystem: !!r.is_system,
-    isAdmin: !!r.is_admin,
-  }));
-};
-
 export default async function (fastify: FastifyInstance, _opts: unknown) {
   // POST /login
   fastify.post(
@@ -108,18 +91,13 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         return badRequest(reply, passwordResult.message);
       }
 
-      const result = await query(
-        'SELECT id, name, username, password_hash, role, avatar_initials, is_disabled FROM users WHERE username = $1',
-        [usernameResult.value],
-      );
+      const user = await usersRepo.findLoginUserByUsername(usernameResult.value);
 
-      if (result.rows.length === 0) {
+      if (!user) {
         return reply.code(401).send({ error: 'Invalid username or password' });
       }
 
-      const user = result.rows[0];
-
-      if (user.is_disabled) {
+      if (user.isDisabled) {
         return reply.code(401).send({ error: 'Invalid username or password' });
       }
 
@@ -142,8 +120,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       let validPassword = false;
       if (ldapAuthSuccess) {
         validPassword = true;
-      } else {
-        validPassword = await bcrypt.compare(passwordResult.value, user.password_hash);
+      } else if (user.passwordHash) {
+        validPassword = await bcrypt.compare(passwordResult.value, user.passwordHash);
       }
 
       if (!validPassword) {
@@ -159,19 +137,19 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         entityType: 'user',
         entityId: user.id,
         details: {
-          targetLabel: user.name as string,
-          secondaryLabel: user.role as string,
+          targetLabel: user.name,
+          secondaryLabel: user.role,
         },
         userId: user.id,
       });
-      const availableRoles = await getAvailableRolesForUser(user.id);
+      const availableRoles = await rolesRepo.listAvailableRolesForUser(user.id);
       const effectiveAvailableRoles =
         availableRoles.length > 0
           ? availableRoles
           : [
               {
-                id: user.role as string,
-                name: user.role as string,
+                id: user.role,
+                name: user.role,
                 isSystem: false,
                 isAdmin: user.role === 'admin',
               },
@@ -184,7 +162,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           name: user.name,
           username: user.username,
           role: user.role,
-          avatarInitials: user.avatar_initials,
+          avatarInitials: user.avatarInitials,
           permissions,
           availableRoles: effectiveAvailableRoles,
         },
@@ -208,7 +186,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
     },
     async (request: FastifyRequest, _reply: FastifyReply) => {
       const availableRoles = request.user?.id
-        ? await getAvailableRolesForUser(request.user.id)
+        ? await rolesRepo.listAvailableRolesForUser(request.user.id)
         : [];
       const effectiveAvailableRoles =
         availableRoles.length > 0
@@ -226,7 +204,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         name: request.user?.name,
         username: request.user?.username,
         role: request.user?.role,
-        avatarInitials: request.user?.avatar_initials,
+        avatarInitials: request.user?.avatarInitials,
         permissions: request.user?.permissions || [],
         availableRoles: effectiveAvailableRoles,
       };
@@ -256,16 +234,13 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const userId = request.user?.id;
       if (!userId) return reply.code(401).send({ error: 'Authentication required' });
 
-      const membership = await query(
-        'SELECT 1 FROM user_roles WHERE user_id = $1 AND role_id = $2 LIMIT 1',
-        [userId, roleIdResult.value],
-      );
-      if (membership.rows.length === 0) {
+      const hasRole = await rolesRepo.userHasRole(userId, roleIdResult.value);
+      if (!hasRole) {
         return reply.code(403).send({ error: 'Insufficient permissions' });
       }
 
       const permissions = await getRolePermissions(roleIdResult.value);
-      const availableRoles = await getAvailableRolesForUser(userId);
+      const availableRoles = await rolesRepo.listAvailableRolesForUser(userId);
       const effectiveAvailableRoles =
         availableRoles.length > 0
           ? availableRoles
@@ -304,7 +279,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           name: request.user?.name,
           username: request.user?.username,
           role: roleIdResult.value,
-          avatarInitials: request.user?.avatar_initials,
+          avatarInitials: request.user?.avatarInitials,
           permissions,
           availableRoles: effectiveAvailableRoles,
         },

--- a/server/routes/clients.ts
+++ b/server/routes/clients.ts
@@ -8,6 +8,7 @@ import {
 } from '../schemas/common.ts';
 import { logAudit } from '../utils/audit.ts';
 import { assertAuthenticated } from '../utils/auth-assert.ts';
+import { generatePrefixedId } from '../utils/order-ids.ts';
 import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import { assignClientToTopManagers, assignClientToUser } from '../utils/top-manager-assignments.ts';
 import {
@@ -1220,7 +1221,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         [categoryResult.value],
       );
       const nextSortOrder = Number(computedSortOrderResult.rows[0]?.next_sort_order ?? 1);
-      const id = `cpo-${crypto.randomUUID()}`;
+      const id = generatePrefixedId('cpo');
 
       const insertResult = await query(
         `INSERT INTO client_profile_options (id, category, value, sort_order)

--- a/server/routes/email.ts
+++ b/server/routes/email.ts
@@ -2,9 +2,9 @@ import type { FastifyInstance, FastifyRequest } from 'fastify';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
 import * as emailRepo from '../repositories/emailRepo.ts';
 import { errorResponseSchema, standardRateLimitedErrorResponses } from '../schemas/common.ts';
-import emailService from '../services/email.ts';
+import emailService, { type EmailConfigInput } from '../services/email.ts';
 import { logAudit } from '../utils/audit.ts';
-import { encrypt, MASKED_SECRET } from '../utils/crypto.ts';
+import { MASKED_SECRET } from '../utils/crypto.ts';
 
 const sharedConfigProperties = {
   enabled: { type: 'boolean' },
@@ -110,17 +110,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       },
     },
     async (request: FastifyRequest, _reply) => {
-      const body = request.body as Partial<emailRepo.EmailConfig>;
-
-      const updated = await emailRepo.update({
-        ...body,
-        smtpPassword:
-          body.smtpPassword && body.smtpPassword !== MASKED_SECRET
-            ? encrypt(body.smtpPassword)
-            : undefined,
-      });
-
-      emailService.setConfig(updated);
+      const updated = await emailService.saveConfig(request.body as EmailConfigInput);
 
       await logAudit({
         request,

--- a/server/routes/email.ts
+++ b/server/routes/email.ts
@@ -80,7 +80,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       },
     },
     async (_request, _reply) => {
-      return serializeForResponse(await emailRepo.get());
+      return serializeForResponse((await emailRepo.get()) ?? emailRepo.DEFAULT_CONFIG);
     },
   );
 

--- a/server/routes/email.ts
+++ b/server/routes/email.ts
@@ -6,11 +6,10 @@ import emailService from '../services/email.ts';
 import { logAudit } from '../utils/audit.ts';
 import { encrypt, MASKED_SECRET } from '../utils/crypto.ts';
 
-const emailConfigProperties = {
+const sharedConfigProperties = {
   enabled: { type: 'boolean' },
   smtpHost: { type: 'string' },
   smtpPort: { type: 'number' },
-  smtpEncryption: { type: 'string', enum: [...emailRepo.SMTP_ENCRYPTIONS] },
   smtpRejectUnauthorized: { type: 'boolean' },
   smtpUser: { type: 'string' },
   smtpPassword: { type: 'string' },
@@ -18,15 +17,27 @@ const emailConfigProperties = {
   fromName: { type: 'string' },
 } as const;
 
+// Response tolerates any smtpEncryption string so legacy DB values (older
+// versions accepted any string) still load — otherwise the admin UI can't
+// reach the form to correct them. EmailService falls back to STARTTLS for
+// unknown values. Writes are still constrained by the body schema below.
+const emailConfigResponseProperties = {
+  ...sharedConfigProperties,
+  smtpEncryption: { type: 'string' },
+} as const;
+
 const emailConfigSchema = {
   type: 'object',
-  properties: emailConfigProperties,
-  required: Object.keys(emailConfigProperties),
+  properties: emailConfigResponseProperties,
+  required: Object.keys(emailConfigResponseProperties),
 } as const;
 
 const emailConfigUpdateBodySchema = {
   type: 'object',
-  properties: emailConfigProperties,
+  properties: {
+    ...sharedConfigProperties,
+    smtpEncryption: { type: 'string', enum: [...emailRepo.SMTP_ENCRYPTIONS] },
+  },
 } as const;
 
 const emailTestBodySchema = {

--- a/server/routes/email.ts
+++ b/server/routes/email.ts
@@ -1,50 +1,32 @@
 import type { FastifyInstance, FastifyRequest } from 'fastify';
-import { query } from '../db/index.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
+import * as emailRepo from '../repositories/emailRepo.ts';
 import { errorResponseSchema, standardRateLimitedErrorResponses } from '../schemas/common.ts';
 import emailService from '../services/email.ts';
 import { logAudit } from '../utils/audit.ts';
-import { encrypt } from '../utils/crypto.ts';
+import { encrypt, MASKED_SECRET } from '../utils/crypto.ts';
+
+const emailConfigProperties = {
+  enabled: { type: 'boolean' },
+  smtpHost: { type: 'string' },
+  smtpPort: { type: 'number' },
+  smtpEncryption: { type: 'string', enum: [...emailRepo.SMTP_ENCRYPTIONS] },
+  smtpRejectUnauthorized: { type: 'boolean' },
+  smtpUser: { type: 'string' },
+  smtpPassword: { type: 'string' },
+  fromEmail: { type: 'string' },
+  fromName: { type: 'string' },
+} as const;
 
 const emailConfigSchema = {
   type: 'object',
-  properties: {
-    enabled: { type: 'boolean' },
-    smtpHost: { type: 'string' },
-    smtpPort: { type: 'number' },
-    smtpEncryption: { type: 'string' },
-    smtpRejectUnauthorized: { type: 'boolean' },
-    smtpUser: { type: 'string' },
-    smtpPassword: { type: 'string' },
-    fromEmail: { type: 'string' },
-    fromName: { type: 'string' },
-  },
-  required: [
-    'enabled',
-    'smtpHost',
-    'smtpPort',
-    'smtpEncryption',
-    'smtpRejectUnauthorized',
-    'smtpUser',
-    'smtpPassword',
-    'fromEmail',
-    'fromName',
-  ],
+  properties: emailConfigProperties,
+  required: Object.keys(emailConfigProperties),
 } as const;
 
 const emailConfigUpdateBodySchema = {
   type: 'object',
-  properties: {
-    enabled: { type: 'boolean' },
-    smtpHost: { type: 'string' },
-    smtpPort: { type: 'number' },
-    smtpEncryption: { type: 'string' },
-    smtpRejectUnauthorized: { type: 'boolean' },
-    smtpUser: { type: 'string' },
-    smtpPassword: { type: 'string' },
-    fromEmail: { type: 'string' },
-    fromName: { type: 'string' },
-  },
+  properties: emailConfigProperties,
 } as const;
 
 const emailTestBodySchema = {
@@ -78,8 +60,12 @@ const emailTestConnectionResponseSchema = {
   additionalProperties: true,
 } as const;
 
+const serializeForResponse = (config: emailRepo.EmailConfig) => ({
+  ...config,
+  smtpPassword: config.smtpPassword ? MASKED_SECRET : '',
+});
+
 export default async function (fastify: FastifyInstance, _opts: unknown) {
-  // GET /config - Get email configuration (Admin only)
   fastify.get(
     '/config',
     {
@@ -94,36 +80,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       },
     },
     async (_request, _reply) => {
-      const result = await query('SELECT * FROM email_config WHERE id = 1');
-      if (result.rows.length === 0) {
-        return {
-          enabled: false,
-          smtpHost: '',
-          smtpPort: 587,
-          smtpEncryption: 'tls',
-          smtpRejectUnauthorized: true,
-          smtpUser: '',
-          smtpPassword: '',
-          fromEmail: '',
-          fromName: 'Praetor',
-        };
-      }
-      const c = result.rows[0];
-      return {
-        enabled: c.enabled,
-        smtpHost: c.smtp_host || '',
-        smtpPort: c.smtp_port,
-        smtpEncryption: c.smtp_encryption || 'tls',
-        smtpRejectUnauthorized: c.smtp_reject_unauthorized,
-        smtpUser: c.smtp_user || '',
-        smtpPassword: c.smtp_password ? '********' : '',
-        fromEmail: c.from_email || '',
-        fromName: c.from_name || 'Praetor',
-      };
+      return serializeForResponse(await emailRepo.get());
     },
   );
 
-  // PUT /config - Update email configuration (Admin only)
   fastify.put(
     '/config',
     {
@@ -139,91 +99,30 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       },
     },
     async (request: FastifyRequest, _reply) => {
-      const {
-        enabled,
-        smtpHost,
-        smtpPort,
-        smtpEncryption,
-        smtpRejectUnauthorized,
-        smtpUser,
-        smtpPassword,
-        fromEmail,
-        fromName,
-      } = request.body as {
-        enabled?: boolean;
-        smtpHost?: string;
-        smtpPort?: number;
-        smtpEncryption?: string;
-        smtpRejectUnauthorized?: boolean;
-        smtpUser?: string;
-        smtpPassword?: string;
-        fromEmail?: string;
-        fromName?: string;
-      };
+      const body = request.body as Partial<emailRepo.EmailConfig>;
 
-      // Don't update password if it's masked
-      const shouldUpdatePassword = smtpPassword && smtpPassword !== '********';
-      // Encrypt password before storing
-      const encryptedPassword = shouldUpdatePassword ? encrypt(smtpPassword) : null;
+      const updated = await emailRepo.update({
+        ...body,
+        smtpPassword:
+          body.smtpPassword && body.smtpPassword !== MASKED_SECRET
+            ? encrypt(body.smtpPassword)
+            : undefined,
+      });
 
-      const result = await query(
-        `UPDATE email_config
-         SET enabled = COALESCE($1, enabled),
-             smtp_host = COALESCE($2, smtp_host),
-             smtp_port = COALESCE($3, smtp_port),
-             smtp_encryption = COALESCE($4, smtp_encryption),
-             smtp_reject_unauthorized = COALESCE($5, smtp_reject_unauthorized),
-             smtp_user = COALESCE($6, smtp_user),
-             smtp_password = CASE WHEN $7::boolean THEN $8 ELSE smtp_password END,
-             from_email = COALESCE($9, from_email),
-             from_name = COALESCE($10, from_name),
-             updated_at = CURRENT_TIMESTAMP
-         WHERE id = 1
-         RETURNING *`,
-        [
-          enabled,
-          smtpHost,
-          smtpPort,
-          smtpEncryption,
-          smtpRejectUnauthorized,
-          smtpUser,
-          shouldUpdatePassword,
-          encryptedPassword,
-          fromEmail,
-          fromName,
-        ],
-      );
+      emailService.setConfig(updated);
 
-      // Reload email service config
-      await emailService.loadConfig();
-
-      const c = result.rows[0];
       await logAudit({
         request,
         action: 'email_config.updated',
         entityType: 'email_config',
         details: {
-          secondaryLabel:
-            (typeof c.from_email === 'string' && c.from_email.length > 0
-              ? c.from_email
-              : c.smtp_host) || undefined,
+          secondaryLabel: updated.fromEmail || updated.smtpHost || undefined,
         },
       });
-      return {
-        enabled: c.enabled,
-        smtpHost: c.smtp_host || '',
-        smtpPort: c.smtp_port,
-        smtpEncryption: c.smtp_encryption || 'tls',
-        smtpRejectUnauthorized: c.smtp_reject_unauthorized,
-        smtpUser: c.smtp_user || '',
-        smtpPassword: c.smtp_password ? '********' : '',
-        fromEmail: c.from_email || '',
-        fromName: c.from_name || 'Praetor',
-      };
+      return serializeForResponse(updated);
     },
   );
 
-  // POST /test - Send test email (Admin only)
   fastify.post(
     '/test',
     {
@@ -247,9 +146,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         return reply.code(400).send({ error: 'INVALID_RECIPIENT', code: 'INVALID_RECIPIENT' });
       }
 
-      // Reload config before testing
-      await emailService.loadConfig();
-
       const result = await emailService.sendTestEmail(recipientEmail);
 
       if (!result.success) {
@@ -269,7 +165,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
     },
   );
 
-  // POST /test-connection - Test SMTP connection without sending email (Admin only)
   fastify.post(
     '/test-connection',
     {
@@ -285,9 +180,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       },
     },
     async (_request, reply) => {
-      // Reload config before testing
-      await emailService.loadConfig();
-
       const result = await emailService.testConnection();
 
       if (!result.success) {

--- a/server/routes/general-settings.ts
+++ b/server/routes/general-settings.ts
@@ -3,6 +3,7 @@ import { authenticateToken, requirePermission } from '../middleware/auth.ts';
 import * as generalSettingsRepo from '../repositories/generalSettingsRepo.ts';
 import { standardRateLimitedErrorResponses } from '../schemas/common.ts';
 import { logAudit } from '../utils/audit.ts';
+import { MASKED_SECRET } from '../utils/crypto.ts';
 import {
   badRequest,
   optionalEnum,
@@ -80,7 +81,7 @@ const DEFAULT_SETTINGS: generalSettingsRepo.GeneralSettings = {
 };
 
 const maskApiKey = (value: string | null, reveal: boolean) =>
-  reveal ? (value ?? '') : value ? '********' : '';
+  reveal ? (value ?? '') : value ? MASKED_SECRET : '';
 
 const toResponse = (settings: generalSettingsRepo.GeneralSettings, revealApiKeys: boolean) => ({
   currency: settings.currency,

--- a/server/routes/products.ts
+++ b/server/routes/products.ts
@@ -3,6 +3,7 @@ import { query, withTransaction } from '../db/index.ts';
 import { authenticateToken, requireAnyPermission } from '../middleware/auth.ts';
 import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
 import { logAudit } from '../utils/audit.ts';
+import { generatePrefixedId } from '../utils/order-ids.ts';
 import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
@@ -803,7 +804,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         return badRequest(reply, 'Category with this name already exists for this type');
       }
 
-      const id = 'ipc-' + crypto.randomUUID();
+      const id = generatePrefixedId('ipc');
       const costUnit = await getCostUnitForType(typeResult.value);
       const result = await query(
         `INSERT INTO internal_product_categories (id, name, type, cost_unit) 
@@ -1167,7 +1168,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       }
 
       // Create the subcategory
-      const id = 'ips-' + crypto.randomUUID();
+      const id = generatePrefixedId('ips');
       const result = await query(
         `INSERT INTO internal_product_subcategories (id, category_id, name)
          VALUES ($1, $2, $3)
@@ -1544,7 +1545,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         return badRequest(reply, 'Product type with this name already exists');
       }
 
-      const id = 'pt-' + crypto.randomUUID();
+      const id = generatePrefixedId('pt');
       const result = await query(
         `INSERT INTO product_types (id, name, cost_unit)
          VALUES ($1, $2, $3)

--- a/server/routes/reports.ts
+++ b/server/routes/reports.ts
@@ -1,10 +1,10 @@
 import { AsyncLocalStorage } from 'async_hooks';
-import { randomUUID } from 'crypto';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { query as dbQuery } from '../db/index.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
 import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
 import { normalizeGeminiModelPath } from '../utils/ai-models.ts';
+import { generatePrefixedId } from '../utils/order-ids.ts';
 import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import { badRequest, optionalNonEmptyString, requireNonEmptyString } from '../utils/validation.ts';
 
@@ -2653,7 +2653,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const cfg = await getGeneralAiConfig();
       if (!ensureAiEnabled(cfg, reply)) return;
 
-      const id = `rpt-chat-${randomUUID()}`;
+      const id = generatePrefixedId('rpt-chat');
       await query(
         `INSERT INTO report_chat_sessions (id, user_id, title, is_archived, created_at, updated_at)
          VALUES ($1, $2, $3, FALSE, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
@@ -2875,7 +2875,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         if (owned.rows.length === 0) return reply.code(404).send({ error: 'Session not found' });
         shouldAutoTitle = ['AI Reporting', ''].includes(String(owned.rows[0]?.title || '').trim());
       } else {
-        resolvedSessionId = `rpt-chat-${randomUUID()}`;
+        resolvedSessionId = generatePrefixedId('rpt-chat');
         await query(
           `INSERT INTO report_chat_sessions (id, user_id, title, is_archived, created_at, updated_at)
            VALUES ($1, $2, $3, FALSE, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
@@ -2884,12 +2884,12 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         shouldAutoTitle = true;
       }
 
-      const assistantMessageId = `rpt-msg-${randomUUID()}`;
+      const assistantMessageId = generatePrefixedId('rpt-msg');
 
       try {
         const isRetryRewrite = isRetryRewritePrompt(messageResult.value);
         if (!isRetryRewrite) {
-          const userMessageId = `rpt-msg-${randomUUID()}`;
+          const userMessageId = generatePrefixedId('rpt-msg');
           await query(
             `INSERT INTO report_chat_messages (id, session_id, role, content, created_at)
              VALUES ($1, $2, 'user', $3, CURRENT_TIMESTAMP)`,
@@ -3212,7 +3212,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         messageIdResult.value,
       ]);
 
-      const assistantMessageId = `rpt-msg-${randomUUID()}`;
+      const assistantMessageId = generatePrefixedId('rpt-msg');
 
       try {
         // Build context from messages up to and including the edited message
@@ -3464,7 +3464,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         if (owned.rows.length === 0) return reply.code(404).send({ error: 'Session not found' });
         shouldAutoTitle = ['AI Reporting', ''].includes(String(owned.rows[0]?.title || '').trim());
       } else {
-        resolvedSessionId = `rpt-chat-${randomUUID()}`;
+        resolvedSessionId = generatePrefixedId('rpt-chat');
         await query(
           `INSERT INTO report_chat_sessions (id, user_id, title, is_archived, created_at, updated_at)
            VALUES ($1, $2, $3, FALSE, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
@@ -3476,7 +3476,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       try {
         const isRetryRewrite = isRetryRewritePrompt(messageResult.value);
         if (!isRetryRewrite) {
-          const userMessageId = `rpt-msg-${randomUUID()}`;
+          const userMessageId = generatePrefixedId('rpt-msg');
           await query(
             `INSERT INTO report_chat_messages (id, session_id, role, content, created_at)
              VALUES ($1, $2, 'user', $3, CURRENT_TIMESTAMP)`,
@@ -3555,7 +3555,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         const assistantText = cleaned || 'No response.';
         const assistantThoughtContent = String(thoughtContent || '').trim();
 
-        const assistantMessageId = `rpt-msg-${randomUUID()}`;
+        const assistantMessageId = generatePrefixedId('rpt-msg');
         await query(
           `INSERT INTO report_chat_messages (id, session_id, role, content, thought_content, created_at)
            VALUES ($1, $2, 'assistant', $3, $4, CURRENT_TIMESTAMP)`,

--- a/server/routes/roles.ts
+++ b/server/routes/roles.ts
@@ -1,9 +1,9 @@
-import { randomUUID } from 'crypto';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { query, withTransaction } from '../db/index.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
 import { messageResponseSchema, standardRateLimitedErrorResponses } from '../schemas/common.ts';
 import { logAudit } from '../utils/audit.ts';
+import { generatePrefixedId } from '../utils/order-ids.ts';
 import {
   ADMIN_BASE_PERMISSIONS,
   ADMINISTRATION_PERMISSIONS,
@@ -169,7 +169,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           `Non-admin roles cannot include administration permissions: ${forbiddenPermission}`,
         );
       }
-      const id = `role-${randomUUID()}`;
+      const id = generatePrefixedId('role');
 
       const forbiddenTopManagerPermission = findForbiddenTopManagerOnlyPermission(
         id,

--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -9,6 +9,7 @@ import {
 import { logAudit } from '../utils/audit.ts';
 import { assertAuthenticated } from '../utils/auth-assert.ts';
 import { normalizeNullableDateOnly, todayLocalDateOnly } from '../utils/date.ts';
+import { generatePrefixedId } from '../utils/order-ids.ts';
 import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   assignClientToTopManagers,
@@ -243,7 +244,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         start = recurrenceStartResult.value || todayLocalDateOnly();
       }
 
-      const id = 't-' + crypto.randomUUID();
+      const id = generatePrefixedId('t');
 
       try {
         await query(

--- a/server/routes/users.ts
+++ b/server/routes/users.ts
@@ -10,6 +10,7 @@ import {
 } from '../schemas/common.ts';
 import { getAuditCounts, logAudit } from '../utils/audit.ts';
 import { assertAuthenticated } from '../utils/auth-assert.ts';
+import { generatePrefixedId } from '../utils/order-ids.ts';
 import { TOP_MANAGER_ROLE_ID } from '../utils/permissions.ts';
 import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
@@ -380,7 +381,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
 
       if (effectiveEmployeeType === 'internal' || effectiveEmployeeType === 'external') {
         // Internal/external employees: generate dummy username, placeholder password, user role
-        usernameValue = `emp-${randomUUID()}`;
+        usernameValue = generatePrefixedId('emp');
         passwordHash = await bcrypt.hash(randomUUID(), 12); // Random unguessable password
         roleValue = 'user'; // Internal/external employees have user role but cannot login
       } else {

--- a/server/routes/users.ts
+++ b/server/routes/users.ts
@@ -414,7 +414,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       }
 
       const avatarInitials = computeAvatarInitials(nameResult.value);
-      const id = 'u-' + Date.now();
+      const id = generatePrefixedId('u');
 
       try {
         await query(

--- a/server/routes/users.ts
+++ b/server/routes/users.ts
@@ -10,6 +10,7 @@ import {
 } from '../schemas/common.ts';
 import { getAuditCounts, logAudit } from '../utils/audit.ts';
 import { assertAuthenticated } from '../utils/auth-assert.ts';
+import { computeAvatarInitials } from '../utils/initials.ts';
 import { generatePrefixedId } from '../utils/order-ids.ts';
 import { TOP_MANAGER_ROLE_ID } from '../utils/permissions.ts';
 import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
@@ -412,12 +413,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         }
       }
 
-      const avatarInitials = nameResult.value
-        .split(' ')
-        .map((n) => n[0])
-        .join('')
-        .substring(0, 2)
-        .toUpperCase();
+      const avatarInitials = computeAvatarInitials(nameResult.value);
       const id = 'u-' + Date.now();
 
       try {

--- a/server/services/email.ts
+++ b/server/services/email.ts
@@ -1,7 +1,14 @@
 import nodemailer from 'nodemailer';
 import type { EmailConfig } from '../repositories/emailRepo.ts';
 import * as emailRepo from '../repositories/emailRepo.ts';
-import { decrypt } from '../utils/crypto.ts';
+import { decrypt, encrypt, MASKED_SECRET } from '../utils/crypto.ts';
+
+// Plaintext input for `saveConfig`. Distinct from `EmailConfigPatch` (which carries
+// `smtpPasswordCiphertext`) so the encrypt step can't be skipped: anything reaching the repo
+// has already passed through this service's encryption boundary.
+export type EmailConfigInput = Partial<Omit<EmailConfig, 'smtpPassword'>> & {
+  smtpPassword?: string;
+};
 
 class EmailService {
   private config: EmailConfig | null;
@@ -14,8 +21,15 @@ class EmailService {
     this.config = (await emailRepo.get()) ?? emailRepo.DEFAULT_CONFIG;
   }
 
-  setConfig(config: EmailConfig) {
-    this.config = config;
+  async saveConfig(input: EmailConfigInput): Promise<EmailConfig> {
+    const { smtpPassword, ...rest } = input;
+    const updated = await emailRepo.update({
+      ...rest,
+      smtpPasswordCiphertext:
+        smtpPassword && smtpPassword !== MASKED_SECRET ? encrypt(smtpPassword) : undefined,
+    });
+    this.config = updated;
+    return updated;
   }
 
   private async ensureReady(): Promise<

--- a/server/services/email.ts
+++ b/server/services/email.ts
@@ -11,7 +11,7 @@ class EmailService {
   }
 
   private async loadConfig() {
-    this.config = await emailRepo.get();
+    this.config = (await emailRepo.get()) ?? emailRepo.DEFAULT_CONFIG;
   }
 
   setConfig(config: EmailConfig) {

--- a/server/services/email.ts
+++ b/server/services/email.ts
@@ -11,6 +11,10 @@ export type EmailConfigInput = Partial<Omit<EmailConfig, 'smtpPassword'>> & {
 };
 
 class EmailService {
+  // Per-instance cache, only invalidated by `saveConfig`. `ensureReady` populates it on first
+  // miss; subsequent reads are sticky until `saveConfig` overwrites it. External DB mutation or
+  // multi-instance deployments would see stale config until restart — fine for single-instance
+  // Praetor today, since writes flow through `saveConfig`.
   private config: EmailConfig | null;
 
   constructor() {

--- a/server/services/email.ts
+++ b/server/services/email.ts
@@ -1,33 +1,30 @@
 import nodemailer from 'nodemailer';
-import { query } from '../db/index.ts';
+import type { EmailConfig } from '../repositories/emailRepo.ts';
+import * as emailRepo from '../repositories/emailRepo.ts';
 import { decrypt } from '../utils/crypto.ts';
 
-type SmtpEncryption = 'insecure' | 'ssl' | 'tls';
-
-type EmailConfig = {
-  enabled: boolean;
-  smtp_host: string;
-  smtp_port: number;
-  smtp_encryption: SmtpEncryption;
-  smtp_reject_unauthorized: boolean;
-  smtp_user: string;
-  smtp_password: string;
-  from_email: string;
-  from_name: string;
-};
-
 class EmailService {
-  config: EmailConfig | null;
+  private config: EmailConfig | null;
 
   constructor() {
     this.config = null;
   }
 
-  async loadConfig() {
-    const result = await query('SELECT * FROM email_config WHERE id = 1');
-    if (result.rows.length > 0) {
-      this.config = result.rows[0];
-    }
+  private async loadConfig() {
+    this.config = await emailRepo.get();
+  }
+
+  setConfig(config: EmailConfig) {
+    this.config = config;
+  }
+
+  private async ensureReady(): Promise<
+    { ok: true; config: EmailConfig } | { ok: false; code: string }
+  > {
+    if (!this.config) await this.loadConfig();
+    if (!this.config?.enabled) return { ok: false, code: 'EMAIL_NOT_ENABLED' };
+    if (!this.config.smtpHost) return { ok: false, code: 'SMTP_NOT_CONFIGURED' };
+    return { ok: true, config: this.config };
   }
 
   private createTransporter() {
@@ -35,7 +32,6 @@ class EmailService {
       throw new Error('Email configuration not loaded');
     }
 
-    // Map encryption setting to nodemailer options
     let transportOptions: {
       host: string;
       port: number;
@@ -45,44 +41,40 @@ class EmailService {
       tls?: { rejectUnauthorized: boolean };
     };
 
-    switch (this.config.smtp_encryption) {
+    switch (this.config.smtpEncryption) {
       case 'ssl':
-        // SSL: implicit encryption (typically port 465)
         transportOptions = {
-          host: this.config.smtp_host,
-          port: this.config.smtp_port,
+          host: this.config.smtpHost,
+          port: this.config.smtpPort,
           secure: true,
         };
         break;
       case 'insecure':
-        // No encryption (cleartext, for OAuth2 proxy)
         transportOptions = {
-          host: this.config.smtp_host,
-          port: this.config.smtp_port,
+          host: this.config.smtpHost,
+          port: this.config.smtpPort,
           secure: false,
           ignoreTLS: true,
         };
         break;
       default:
-        // TLS/STARTTLS: upgrades connection (typically port 587)
+        // TLS/STARTTLS: nodemailer upgrades the connection via STARTTLS when secure=false
         transportOptions = {
-          host: this.config.smtp_host,
-          port: this.config.smtp_port,
+          host: this.config.smtpHost,
+          port: this.config.smtpPort,
           secure: false,
         };
         break;
     }
 
-    // Add authentication if credentials provided
-    if (this.config.smtp_user && this.config.smtp_password) {
+    if (this.config.smtpUser && this.config.smtpPassword) {
       transportOptions.auth = {
-        user: this.config.smtp_user,
-        pass: decrypt(this.config.smtp_password),
+        user: this.config.smtpUser,
+        pass: decrypt(this.config.smtpPassword),
       };
     }
 
-    // Handle self-signed certificates
-    if (!this.config.smtp_reject_unauthorized) {
+    if (!this.config.smtpRejectUnauthorized) {
       transportOptions.tls = {
         rejectUnauthorized: false,
       };
@@ -97,17 +89,8 @@ class EmailService {
     params?: Record<string, string>;
   }> {
     try {
-      if (!this.config) {
-        await this.loadConfig();
-      }
-
-      if (!this.config?.enabled) {
-        return { success: false, code: 'EMAIL_NOT_ENABLED' };
-      }
-
-      if (!this.config.smtp_host) {
-        return { success: false, code: 'SMTP_NOT_CONFIGURED' };
-      }
+      const ready = await this.ensureReady();
+      if (!ready.ok) return { success: false, code: ready.code };
 
       const transporter = this.createTransporter();
       await transporter.verify();
@@ -134,23 +117,15 @@ class EmailService {
     messageId?: string;
   }> {
     try {
-      if (!this.config) {
-        await this.loadConfig();
-      }
+      const ready = await this.ensureReady();
+      if (!ready.ok) return { success: false, code: ready.code };
 
-      if (!this.config?.enabled) {
-        return { success: false, code: 'EMAIL_NOT_ENABLED' };
-      }
-
-      if (!this.config.smtp_host) {
-        return { success: false, code: 'SMTP_NOT_CONFIGURED' };
-      }
-
+      const { config } = ready;
       const transporter = this.createTransporter();
 
-      const fromAddress = this.config.from_name
-        ? `"${this.config.from_name}" <${this.config.from_email}>`
-        : this.config.from_email;
+      const fromAddress = config.fromName
+        ? `"${config.fromName}" <${config.fromEmail}>`
+        : config.fromEmail;
 
       const info = await transporter.sendMail({
         from: fromAddress,

--- a/server/services/ldap.ts
+++ b/server/services/ldap.ts
@@ -10,10 +10,6 @@ import { generatePrefixedId } from '../utils/order-ids.ts';
 
 const logger = createChildLogger({ module: 'ldap' });
 
-// LDAP users authenticate via LDAP, not against a local password hash. We store an unmatchable
-// bcrypt placeholder so the NOT NULL column is satisfied without enabling local login.
-const LDAP_PLACEHOLDER_PASSWORD_HASH = '$2a$10$invalidpasswordhashforldapuser00000000000000';
-
 interface LdapEntry {
   objectName: string;
   uid?: string | string[];
@@ -274,7 +270,7 @@ class LDAPService {
             id: generatePrefixedId('u'),
             name,
             username,
-            passwordHash: LDAP_PLACEHOLDER_PASSWORD_HASH,
+            passwordHash: usersRepo.LDAP_PLACEHOLDER_PASSWORD_HASH,
             role: 'user',
             avatarInitials: computeAvatarInitials(name),
           });

--- a/server/services/ldap.ts
+++ b/server/services/ldap.ts
@@ -10,8 +10,8 @@ import { createChildLogger, serializeError } from '../utils/logger.ts';
 
 const logger = createChildLogger({ module: 'ldap' });
 
-// LDAP users authenticate via LDAP, not against a local password hash. We store a well-formed but
-// unmatchable bcrypt placeholder so the NOT NULL column is satisfied without enabling local login.
+// LDAP users authenticate via LDAP, not against a local password hash. We store an unmatchable
+// bcrypt placeholder so the NOT NULL column is satisfied without enabling local login.
 const LDAP_PLACEHOLDER_PASSWORD_HASH = '$2a$10$invalidpasswordhashforldapuser00000000000000';
 
 interface LdapEntry {

--- a/server/services/ldap.ts
+++ b/server/services/ldap.ts
@@ -1,20 +1,18 @@
+import { randomUUID } from 'crypto';
 import fs from 'fs';
 import ldap from 'ldapjs';
-import { v4 as uuidv4 } from 'uuid';
-import { query } from '../db/index.ts';
+import type { LdapConfig } from '../repositories/ldapRepo.ts';
+import * as ldapRepo from '../repositories/ldapRepo.ts';
+import * as usersRepo from '../repositories/usersRepo.ts';
+import { computeAvatarInitials } from '../utils/initials.ts';
 import { buildUserLookupFilter, buildUserSyncFilter } from '../utils/ldap-filter.ts';
 import { createChildLogger, serializeError } from '../utils/logger.ts';
 
 const logger = createChildLogger({ module: 'ldap' });
 
-type LdapConfig = {
-  enabled: boolean;
-  server_url: string;
-  bind_dn: string;
-  bind_password: string;
-  base_dn: string;
-  user_filter: string;
-};
+// LDAP users authenticate via LDAP, not against a local password hash. We store a well-formed but
+// unmatchable bcrypt placeholder so the NOT NULL column is satisfied without enabling local login.
+const LDAP_PLACEHOLDER_PASSWORD_HASH = '$2a$10$invalidpasswordhashforldapuser00000000000000';
 
 interface LdapEntry {
   objectName: string;
@@ -58,10 +56,7 @@ class LDAPService {
   }
 
   async loadConfig() {
-    const result = await query('SELECT * FROM ldap_config WHERE id = 1');
-    if (result.rows.length > 0) {
-      this.config = result.rows[0];
-    }
+    this.config = await ldapRepo.get();
   }
 
   async getClient(): Promise<LdapClient | null> {
@@ -95,7 +90,7 @@ class LDAPService {
     }
 
     return ldap.createClient({
-      url: this.config.server_url,
+      url: this.config.serverUrl,
       tlsOptions: tlsOptions,
     }) as LdapClient;
   }
@@ -115,7 +110,7 @@ class LDAPService {
 
       // Bind with service account first to find the user's DN
       await new Promise<void>((resolve, reject) => {
-        ldapClient.bind(config.bind_dn, config.bind_password, (err) => {
+        ldapClient.bind(config.bindDn, config.bindPassword, (err) => {
           if (err) reject(err);
           else resolve();
         });
@@ -159,11 +154,11 @@ class LDAPService {
     }
     const searchOptions = {
       scope: 'sub',
-      filter: buildUserLookupFilter(config.user_filter, username),
+      filter: buildUserLookupFilter(config.userFilter, username),
     };
 
     return new Promise((resolve, reject) => {
-      client.search(config.base_dn, searchOptions, (err, res) => {
+      client.search(config.baseDn, searchOptions, (err, res) => {
         if (err) return reject(err);
 
         let foundDn: string | null = null;
@@ -209,7 +204,7 @@ class LDAPService {
       }
 
       await new Promise<void>((resolve, reject) => {
-        ldapClient.bind(config.bind_dn, config.bind_password, (err) => {
+        ldapClient.bind(config.bindDn, config.bindPassword, (err) => {
           if (err) reject(err);
           else resolve();
         });
@@ -217,14 +212,14 @@ class LDAPService {
 
       const searchOptions = {
         scope: 'sub',
-        filter: buildUserSyncFilter(config.user_filter),
+        filter: buildUserSyncFilter(config.userFilter),
         attributes: ['uid', 'cn', 'sn', 'givenName', 'mail', 'displayName', 'sAMAccountName'],
       };
 
       const entries: LdapEntry[] = [];
 
       await new Promise<void>((resolve, reject) => {
-        ldapClient.search(config.base_dn, searchOptions, (err, res) => {
+        ldapClient.search(config.baseDn, searchOptions, (err, res) => {
           if (err) return reject(err);
 
           res.on('searchEntry', (entry: LdapSearchEntry) => {
@@ -247,13 +242,10 @@ class LDAPService {
       let createdCount = 0;
 
       for (const entry of entries) {
-        // Extract username. Depending on schema it might be 'uid' or 'sAMAccountName' (AD).
-        // We'll try common fields or rely on what mapped to 'uid' in the object based on filter.
-        // But usually 'uid' is the attribute.
         let username = entry.uid;
         if (Array.isArray(username)) username = username[0];
 
-        // Fallback for AD
+        // Fallback for AD, where the username attribute is sAMAccountName rather than uid.
         if (!username && entry.sAMAccountName) {
           username = entry.sAMAccountName;
           if (Array.isArray(username)) username = username[0];
@@ -264,7 +256,6 @@ class LDAPService {
           continue;
         }
 
-        // Name
         const nameValue: string | string[] | undefined = entry.cn || entry.displayName;
         let name: string;
         if (nameValue) {
@@ -273,44 +264,20 @@ class LDAPService {
           name = username;
         }
 
-        // Check dependencies
-        // We matched local users by username
-        const res = await query('SELECT * FROM users WHERE username = $1', [username]);
+        const existing = await usersRepo.findLoginUserByUsername(username);
 
-        if (res.rows.length > 0) {
-          // Update existing
-          await query('UPDATE users SET name = $1 WHERE username = $2', [name, username]);
+        if (existing) {
+          await usersRepo.updateNameByUsername(username, name);
           syncedCount++;
         } else {
-          // Create new
-          // We need a dummy password hash or maybe handle it.
-          // Since we don't have their password, we can set a random unguessable hash
-          // or flag them. But for now invalid hash is fine?
-          // Or let's just leave it empty string?
-          // The 'users' table has `password_hash` NOT NULL.
-          // We'll set a placeholder that bcrypt won't match.
-
-          // Initials
-          const initials = name
-            .split(' ')
-            .map((n) => n[0])
-            .join('')
-            .substring(0, 2)
-            .toUpperCase();
-
-          const newId = uuidv4();
-          await query(
-            `INSERT INTO users (id, name, username, password_hash, role, avatar_initials)
-                         VALUES ($1, $2, $3, $4, $5, $6)`,
-            [
-              newId,
-              name,
-              username,
-              '$2a$10$invalidpasswordhashforldapuser00000000000000',
-              'user',
-              initials,
-            ],
-          );
+          await usersRepo.createUser({
+            id: randomUUID(),
+            name,
+            username,
+            passwordHash: LDAP_PLACEHOLDER_PASSWORD_HASH,
+            role: 'user',
+            avatarInitials: computeAvatarInitials(name),
+          });
           createdCount++;
         }
       }

--- a/server/services/ldap.ts
+++ b/server/services/ldap.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'crypto';
 import fs from 'fs';
 import ldap from 'ldapjs';
 import type { LdapConfig } from '../repositories/ldapRepo.ts';
@@ -7,6 +6,7 @@ import * as usersRepo from '../repositories/usersRepo.ts';
 import { computeAvatarInitials } from '../utils/initials.ts';
 import { buildUserLookupFilter, buildUserSyncFilter } from '../utils/ldap-filter.ts';
 import { createChildLogger, serializeError } from '../utils/logger.ts';
+import { generatePrefixedId } from '../utils/order-ids.ts';
 
 const logger = createChildLogger({ module: 'ldap' });
 
@@ -271,7 +271,7 @@ class LDAPService {
           syncedCount++;
         } else {
           await usersRepo.createUser({
-            id: randomUUID(),
+            id: generatePrefixedId('u'),
             name,
             username,
             passwordHash: LDAP_PLACEHOLDER_PASSWORD_HASH,

--- a/server/test/repositories/auditLogsRepo.test.ts
+++ b/server/test/repositories/auditLogsRepo.test.ts
@@ -58,3 +58,76 @@ describe('list', () => {
     expect(result[0].createdAt).toBe(1700000000000);
   });
 });
+
+describe('create', () => {
+  const baseInput = {
+    userId: 'user-1',
+    action: 'login',
+    entityType: null,
+    entityId: null,
+    ipAddress: '127.0.0.1',
+    details: null,
+  } as const;
+
+  test('targets audit_logs and lists the 7 columns in declared order', async () => {
+    exec.enqueue({ rows: [] });
+    await auditLogsRepo.create(baseInput, exec);
+    const sql = exec.calls[0].sql;
+    expect(sql).toContain('INSERT INTO audit_logs');
+    expect(sql).toContain('(id, user_id, action, entity_type, entity_id, ip_address, details)');
+    expect(sql).toContain('$7::jsonb');
+  });
+
+  test('binds params $1..$7 in declared order with id first', async () => {
+    exec.enqueue({ rows: [] });
+    await auditLogsRepo.create(
+      {
+        userId: 'user-1',
+        action: 'user.update',
+        entityType: 'user',
+        entityId: 'user-2',
+        ipAddress: '10.0.0.1',
+        details: null,
+      },
+      exec,
+    );
+    const params = exec.calls[0].params;
+    expect(params).toHaveLength(7);
+    expect(params[0]).toMatch(/^audit-/);
+    expect(params.slice(1)).toEqual(['user-1', 'user.update', 'user', 'user-2', '10.0.0.1', null]);
+  });
+
+  test('generates a fresh id per call', async () => {
+    exec.enqueue({ rows: [] });
+    exec.enqueue({ rows: [] });
+    await auditLogsRepo.create(baseInput, exec);
+    await auditLogsRepo.create(baseInput, exec);
+    expect(exec.calls[0].params[0]).not.toBe(exec.calls[1].params[0]);
+  });
+
+  test('passes details: null through as a literal null (not the string "null")', async () => {
+    exec.enqueue({ rows: [] });
+    await auditLogsRepo.create({ ...baseInput, details: null }, exec);
+    expect(exec.calls[0].params[6]).toBeNull();
+  });
+
+  test('JSON-stringifies a non-null details object', async () => {
+    exec.enqueue({ rows: [] });
+    await auditLogsRepo.create(
+      { ...baseInput, details: { targetLabel: 'Acme', counts: { items: 3 } } },
+      exec,
+    );
+    const detailsParam = exec.calls[0].params[6];
+    expect(typeof detailsParam).toBe('string');
+    expect(JSON.parse(detailsParam as string)).toEqual({
+      targetLabel: 'Acme',
+      counts: { items: 3 },
+    });
+  });
+
+  test('resolves to undefined', async () => {
+    exec.enqueue({ rows: [] });
+    const result = await auditLogsRepo.create(baseInput, exec);
+    expect(result).toBeUndefined();
+  });
+});

--- a/server/test/repositories/emailRepo.test.ts
+++ b/server/test/repositories/emailRepo.test.ts
@@ -21,9 +21,10 @@ const baseRow = {
 };
 
 describe('get', () => {
-  test('throws the seed-missing guard when SELECT returns 0 rows', async () => {
+  test('returns null when SELECT returns 0 rows', async () => {
     exec.enqueue({ rows: [] });
-    await expect(emailRepo.get(exec)).rejects.toThrow(/email_config row \(id=1\) not found/);
+    const result = await emailRepo.get(exec);
+    expect(result).toBeNull();
   });
 
   test('returns the row verbatim when present', async () => {
@@ -112,5 +113,21 @@ describe('update', () => {
     exec.enqueue({ rows: [{ ...baseRow, fromName: 'Acme' }] });
     const result = await emailRepo.update({ fromName: 'Acme' }, exec);
     expect(result.fromName).toBe('Acme');
+  });
+});
+
+describe('DEFAULT_CONFIG', () => {
+  test('matches the schema-default shape used as a fallback when seed is absent', () => {
+    expect(emailRepo.DEFAULT_CONFIG).toEqual({
+      enabled: false,
+      smtpHost: '',
+      smtpPort: 587,
+      smtpEncryption: 'tls',
+      smtpRejectUnauthorized: true,
+      smtpUser: '',
+      smtpPassword: '',
+      fromEmail: '',
+      fromName: 'Praetor',
+    });
   });
 });

--- a/server/test/repositories/emailRepo.test.ts
+++ b/server/test/repositories/emailRepo.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import * as emailRepo from '../../repositories/emailRepo.ts';
+import { type FakeExecutor, makeFakeExecutor } from '../helpers/fakeExecutor.ts';
+
+let exec: FakeExecutor;
+
+beforeEach(() => {
+  exec = makeFakeExecutor();
+});
+
+const baseRow = {
+  enabled: false,
+  smtpHost: '',
+  smtpPort: 587,
+  smtpEncryption: 'tls',
+  smtpRejectUnauthorized: true,
+  smtpUser: '',
+  smtpPassword: '',
+  fromEmail: '',
+  fromName: 'Praetor',
+};
+
+describe('get', () => {
+  test('throws the seed-missing guard when SELECT returns 0 rows', async () => {
+    exec.enqueue({ rows: [] });
+    await expect(emailRepo.get(exec)).rejects.toThrow(/email_config row \(id=1\) not found/);
+  });
+
+  test('returns the row verbatim when present', async () => {
+    exec.enqueue({
+      rows: [
+        {
+          ...baseRow,
+          enabled: true,
+          smtpHost: 'smtp.example.com',
+          smtpPort: 465,
+          smtpEncryption: 'ssl',
+          smtpUser: 'noreply@example.com',
+          smtpPassword: 'enc:ciphertext',
+          fromEmail: 'noreply@example.com',
+          fromName: 'Acme',
+        },
+      ],
+    });
+    const result = await emailRepo.get(exec);
+    expect(result).toEqual({
+      enabled: true,
+      smtpHost: 'smtp.example.com',
+      smtpPort: 465,
+      smtpEncryption: 'ssl',
+      smtpRejectUnauthorized: true,
+      smtpUser: 'noreply@example.com',
+      smtpPassword: 'enc:ciphertext',
+      fromEmail: 'noreply@example.com',
+      fromName: 'Acme',
+    });
+  });
+});
+
+describe('update', () => {
+  test('throws the seed-missing guard when UPDATE returns 0 rows', async () => {
+    exec.enqueue({ rows: [] });
+    await expect(emailRepo.update({}, exec)).rejects.toThrow(/email_config row \(id=1\) not found/);
+  });
+
+  test('passes patch values in declared column order', async () => {
+    exec.enqueue({ rows: [baseRow] });
+    await emailRepo.update(
+      {
+        enabled: true,
+        smtpHost: 'smtp.example.com',
+        smtpPort: 465,
+        smtpEncryption: 'ssl',
+        smtpRejectUnauthorized: false,
+        smtpUser: 'noreply@example.com',
+        smtpPassword: 'enc:ciphertext',
+        fromEmail: 'noreply@example.com',
+        fromName: 'Acme',
+      },
+      exec,
+    );
+    expect(exec.calls[0].params).toEqual([
+      true,
+      'smtp.example.com',
+      465,
+      'ssl',
+      false,
+      'noreply@example.com',
+      'enc:ciphertext',
+      'noreply@example.com',
+      'Acme',
+    ]);
+  });
+
+  test('passes undefined for omitted patch fields', async () => {
+    exec.enqueue({ rows: [baseRow] });
+    await emailRepo.update({ fromName: 'Acme' }, exec);
+    const params = exec.calls[0].params;
+    expect(params).toHaveLength(9);
+    expect(params[8]).toBe('Acme');
+    expect(params[0]).toBeUndefined();
+    expect(params[6]).toBeUndefined();
+  });
+
+  test('passes the encrypted string for smtpPassword when set', async () => {
+    exec.enqueue({ rows: [baseRow] });
+    await emailRepo.update({ smtpPassword: 'enc:ciphertext' }, exec);
+    expect(exec.calls[0].params[6]).toBe('enc:ciphertext');
+  });
+
+  test('returns the row from RETURNING', async () => {
+    exec.enqueue({ rows: [{ ...baseRow, fromName: 'Acme' }] });
+    const result = await emailRepo.update({ fromName: 'Acme' }, exec);
+    expect(result.fromName).toBe('Acme');
+  });
+});

--- a/server/test/repositories/emailRepo.test.ts
+++ b/server/test/repositories/emailRepo.test.ts
@@ -74,7 +74,7 @@ describe('update', () => {
         smtpEncryption: 'ssl',
         smtpRejectUnauthorized: false,
         smtpUser: 'noreply@example.com',
-        smtpPassword: 'enc:ciphertext',
+        smtpPasswordCiphertext: 'enc:ciphertext',
         fromEmail: 'noreply@example.com',
         fromName: 'Acme',
       },
@@ -103,9 +103,9 @@ describe('update', () => {
     expect(params[6]).toBeUndefined();
   });
 
-  test('passes the encrypted string for smtpPassword when set', async () => {
+  test('passes the ciphertext through to $7 when set', async () => {
     exec.enqueue({ rows: [baseRow] });
-    await emailRepo.update({ smtpPassword: 'enc:ciphertext' }, exec);
+    await emailRepo.update({ smtpPasswordCiphertext: 'enc:ciphertext' }, exec);
     expect(exec.calls[0].params[6]).toBe('enc:ciphertext');
   });
 

--- a/server/test/repositories/emailRepo.test.ts
+++ b/server/test/repositories/emailRepo.test.ts
@@ -56,6 +56,12 @@ describe('get', () => {
       fromName: 'Acme',
     });
   });
+
+  test('normalizes a legacy smtpEncryption value to tls', async () => {
+    exec.enqueue({ rows: [{ ...baseRow, smtpEncryption: 'starttls' }] });
+    const result = await emailRepo.get(exec);
+    expect(result?.smtpEncryption).toBe('tls');
+  });
 });
 
 describe('update', () => {
@@ -113,6 +119,12 @@ describe('update', () => {
     exec.enqueue({ rows: [{ ...baseRow, fromName: 'Acme' }] });
     const result = await emailRepo.update({ fromName: 'Acme' }, exec);
     expect(result.fromName).toBe('Acme');
+  });
+
+  test('normalizes a legacy smtpEncryption from RETURNING to tls', async () => {
+    exec.enqueue({ rows: [{ ...baseRow, smtpEncryption: 'starttls' }] });
+    const result = await emailRepo.update({ fromName: 'Acme' }, exec);
+    expect(result.smtpEncryption).toBe('tls');
   });
 });
 

--- a/server/test/repositories/rolesRepo.test.ts
+++ b/server/test/repositories/rolesRepo.test.ts
@@ -39,3 +39,41 @@ describe('findExistingIds', () => {
     expect(result.has('c')).toBe(false);
   });
 });
+
+describe('userHasRole', () => {
+  test('returns true when the DB returns a row', async () => {
+    exec.enqueue({ rows: [{}] });
+    const result = await rolesRepo.userHasRole('user-1', 'manager', exec);
+    expect(result).toBe(true);
+    expect(exec.calls[0].params).toEqual(['user-1', 'manager']);
+  });
+
+  test('returns false when no row is returned', async () => {
+    exec.enqueue({ rows: [] });
+    const result = await rolesRepo.userHasRole('user-1', 'manager', exec);
+    expect(result).toBe(false);
+  });
+});
+
+describe('listAvailableRolesForUser', () => {
+  test('returns the rows as-is and passes [userId]', async () => {
+    exec.enqueue({
+      rows: [
+        { id: 'admin', name: 'Admin', isSystem: true, isAdmin: true },
+        { id: 'manager', name: 'Manager', isSystem: false, isAdmin: false },
+      ],
+    });
+    const result = await rolesRepo.listAvailableRolesForUser('user-1', exec);
+    expect(result).toEqual([
+      { id: 'admin', name: 'Admin', isSystem: true, isAdmin: true },
+      { id: 'manager', name: 'Manager', isSystem: false, isAdmin: false },
+    ]);
+    expect(exec.calls[0].params).toEqual(['user-1']);
+  });
+
+  test('returns an empty array when the user has no roles', async () => {
+    exec.enqueue({ rows: [] });
+    const result = await rolesRepo.listAvailableRolesForUser('user-1', exec);
+    expect(result).toEqual([]);
+  });
+});

--- a/server/test/repositories/usersRepo.test.ts
+++ b/server/test/repositories/usersRepo.test.ts
@@ -29,6 +29,74 @@ describe('getPasswordHash', () => {
   });
 });
 
+describe('findAuthUserById', () => {
+  test('returns the mapped user when the row exists', async () => {
+    exec.enqueue({
+      rows: [
+        {
+          id: 'user-1',
+          name: 'Alice',
+          username: 'alice',
+          role: 'manager',
+          avatarInitials: 'AL',
+          isDisabled: false,
+        },
+      ],
+    });
+    const result = await usersRepo.findAuthUserById('user-1', exec);
+    expect(result).toEqual({
+      id: 'user-1',
+      name: 'Alice',
+      username: 'alice',
+      role: 'manager',
+      avatarInitials: 'AL',
+      isDisabled: false,
+    });
+    expect(exec.calls[0].params).toEqual(['user-1']);
+  });
+
+  test('returns null when no row exists', async () => {
+    exec.enqueue({ rows: [] });
+    const result = await usersRepo.findAuthUserById('user-1', exec);
+    expect(result).toBeNull();
+  });
+});
+
+describe('findLoginUserByUsername', () => {
+  test('returns the mapped login user when the row exists', async () => {
+    exec.enqueue({
+      rows: [
+        {
+          id: 'user-1',
+          name: 'Alice',
+          username: 'alice',
+          role: 'manager',
+          passwordHash: '$2b$10$abc',
+          avatarInitials: 'AL',
+          isDisabled: false,
+        },
+      ],
+    });
+    const result = await usersRepo.findLoginUserByUsername('alice', exec);
+    expect(result).toEqual({
+      id: 'user-1',
+      name: 'Alice',
+      username: 'alice',
+      role: 'manager',
+      passwordHash: '$2b$10$abc',
+      avatarInitials: 'AL',
+      isDisabled: false,
+    });
+    expect(exec.calls[0].params).toEqual(['alice']);
+  });
+
+  test('returns null when no row exists', async () => {
+    exec.enqueue({ rows: [] });
+    const result = await usersRepo.findLoginUserByUsername('alice', exec);
+    expect(result).toBeNull();
+  });
+});
+
 describe('updatePasswordHash', () => {
   test('passes [hash, userId] in that order', async () => {
     exec.enqueue({ rows: [], rowCount: 1 });

--- a/server/test/repositories/usersRepo.test.ts
+++ b/server/test/repositories/usersRepo.test.ts
@@ -110,3 +110,36 @@ describe('updatePasswordHash', () => {
     expect(result).toBeUndefined();
   });
 });
+
+describe('updateNameByUsername', () => {
+  test('passes [username, name] in that order', async () => {
+    exec.enqueue({ rows: [], rowCount: 1 });
+    await usersRepo.updateNameByUsername('alice', 'Alice Smith', exec);
+    expect(exec.calls[0].params).toEqual(['alice', 'Alice Smith']);
+  });
+});
+
+describe('createUser', () => {
+  test('passes params in [id, name, username, passwordHash, role, avatarInitials] order', async () => {
+    exec.enqueue({ rows: [], rowCount: 1 });
+    await usersRepo.createUser(
+      {
+        id: 'user-1',
+        name: 'Alice Smith',
+        username: 'alice',
+        passwordHash: '$2a$10$placeholder',
+        role: 'user',
+        avatarInitials: 'AS',
+      },
+      exec,
+    );
+    expect(exec.calls[0].params).toEqual([
+      'user-1',
+      'Alice Smith',
+      'alice',
+      '$2a$10$placeholder',
+      'user',
+      'AS',
+    ]);
+  });
+});

--- a/server/test/utils/order-ids.test.ts
+++ b/server/test/utils/order-ids.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'bun:test';
+import { generatePrefixedId } from '../../utils/order-ids.ts';
+
+describe('generatePrefixedId', () => {
+  test('formats id as `${prefix}-${uuid}`', () => {
+    const id = generatePrefixedId('audit');
+    expect(id).toMatch(/^audit-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+  });
+
+  test('produces a fresh id per call', () => {
+    expect(generatePrefixedId('x')).not.toBe(generatePrefixedId('x'));
+  });
+
+  test('preserves multi-segment prefixes verbatim', () => {
+    const id = generatePrefixedId('rpt-chat');
+    expect(id.startsWith('rpt-chat-')).toBe(true);
+  });
+});

--- a/server/types/fastify.d.ts
+++ b/server/types/fastify.d.ts
@@ -12,7 +12,7 @@ declare module 'fastify' {
       username: string;
       role: string;
       avatarInitials: string;
-      permissions?: string[];
+      permissions: string[];
     };
   }
 }

--- a/server/types/fastify.d.ts
+++ b/server/types/fastify.d.ts
@@ -11,7 +11,7 @@ declare module 'fastify' {
       name: string;
       username: string;
       role: string;
-      avatar_initials?: string | null;
+      avatarInitials: string;
       permissions?: string[];
     };
   }

--- a/server/utils/audit.ts
+++ b/server/utils/audit.ts
@@ -1,6 +1,5 @@
-import { randomUUID } from 'crypto';
 import type { FastifyRequest } from 'fastify';
-import { query } from '../db/index.ts';
+import * as auditLogsRepo from '../repositories/auditLogsRepo.ts';
 import { createChildLogger, serializeError } from './logger.ts';
 
 const logger = createChildLogger({ module: 'audit' });
@@ -115,19 +114,14 @@ export async function logAudit({
   }
 
   try {
-    const normalizedDetails = normalizeAuditDetails(details);
-    await query(
-      'INSERT INTO audit_logs (id, user_id, action, entity_type, entity_id, ip_address, details) VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)',
-      [
-        `audit-${randomUUID()}`,
-        effectiveUserId,
-        action,
-        entityType ?? null,
-        entityId ?? null,
-        request.ip || 'unknown',
-        normalizedDetails ? JSON.stringify(normalizedDetails) : null,
-      ],
-    );
+    await auditLogsRepo.create({
+      userId: effectiveUserId,
+      action,
+      entityType: entityType ?? null,
+      entityId: entityId ?? null,
+      ipAddress: request.ip || 'unknown',
+      details: normalizeAuditDetails(details),
+    });
   } catch (err) {
     logger.error(
       { err: serializeError(err), userId: effectiveUserId, action },

--- a/server/utils/crypto.ts
+++ b/server/utils/crypto.ts
@@ -3,6 +3,8 @@ import crypto from 'crypto';
 const ALGORITHM = 'aes-256-gcm';
 const IV_LENGTH = 16;
 
+export const MASKED_SECRET = '********';
+
 function getEncryptionKey(): Buffer {
   const key = process.env.ENCRYPTION_KEY;
   if (!key) {

--- a/server/utils/initials.ts
+++ b/server/utils/initials.ts
@@ -1,0 +1,7 @@
+export const computeAvatarInitials = (name: string): string =>
+  name
+    .split(' ')
+    .map((part) => part[0] ?? '')
+    .join('')
+    .slice(0, 2)
+    .toUpperCase();

--- a/server/utils/order-ids.ts
+++ b/server/utils/order-ids.ts
@@ -1,4 +1,7 @@
+import { randomUUID } from 'crypto';
 import { type QueryExecutor, query } from '../db/index.ts';
+
+export const generatePrefixedId = (prefix: string): string => `${prefix}-${randomUUID()}`;
 
 const generateSequentialId = async (
   prefix: string,

--- a/server/utils/top-manager-assignments.ts
+++ b/server/utils/top-manager-assignments.ts
@@ -1,4 +1,5 @@
 import { query } from '../db/index.ts';
+import * as rolesRepo from '../repositories/rolesRepo.ts';
 import { TOP_MANAGER_ROLE_ID } from './permissions.ts';
 
 export const MANUAL_ASSIGNMENT_SOURCE = 'manual';
@@ -58,13 +59,8 @@ const assignAllTopManagersSql = (table: string, targetColumn: string) => `
   END
 `;
 
-export const userHasTopManagerRole = async (userId: string) => {
-  const result = await query(
-    'SELECT 1 FROM user_roles WHERE user_id = $1 AND role_id = $2 LIMIT 1',
-    [userId, TOP_MANAGER_ROLE_ID],
-  );
-  return result.rows.length > 0;
-};
+export const userHasTopManagerRole = (userId: string) =>
+  rolesRepo.userHasRole(userId, TOP_MANAGER_ROLE_ID);
 
 export const assignClientToUser = async (
   userId: string,


### PR DESCRIPTION
## Summary

Continues the repository-pattern migration started in #131, moving more inline SQL out of routes/middleware/services into typed repos with `QueryExecutor` and bun:test coverage.

- **auditLogsRepo** — centralizes the audit `INSERT`; `utils/audit.ts` keeps the Fastify-aware wrapper. Adds `generatePrefixedId(prefix)` and migrates 16 inline `${prefix}-${randomUUID()}` sites across audit, clients, products, reports, roles, tasks, and users routes.
- **usersRepo / rolesRepo** — moves auth/role lookups out of `middleware/auth.ts` and `routes/auth.ts` (`findAuthUserById`, `findLoginUserByUsername`, `userHasRole`, `listAvailableRolesForUser`). Switches `request.user` to camelCase `avatarInitials` and parallelizes role-check + permission lookup in the auth middleware.
- **usersRepo (create/rename)** — replaces the inline `INSERT` in `bootstrapAdmin` and the SELECT/INSERT/UPDATE dance in LDAP sync with `createUser` / `updateNameByUsername`. Extracts avatar-initials into a shared util and drops the `uuid` dep in favor of `crypto.randomUUID`.
- **emailRepo** — mirrors the singleton-config pattern from `generalSettingsRepo` / `ldapRepo` (get/update with `COALESCE`, seed-missing guard). Drive-bys: share `MASKED_SECRET` from `utils/crypto.ts`, extract `EmailService.ensureReady()`, and replace the post-PUT `loadConfig()` reload with `setConfig(updated)`.

Repo tests cover all four new repos plus the prefixed-id helper via `FakeExecutor` — no DB required.

## Test plan

- [ ] `cd server && bun test test/repositories test/utils/order-ids.test.ts` passes
- [ ] Login flow (local + LDAP) still works; \`request.user.avatarInitials\` populated
- [ ] Role gate on a manager-only route still blocks a \`user\`-role account
- [ ] Email settings PUT round-trips (mask preserved, password updated when supplied)
- [ ] Bootstrap-admin path creates the seeded admin on a fresh DB
- [ ] An audited mutation (e.g. creating a client) writes an \`audit_logs\` row with a prefixed id

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xbounceit/praetor/pull/133" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
