### PR TITLE
refactor(server): migrate roles route to repository pattern

### DIFF
--- a/server/repositories/rolesRepo.ts
+++ b/server/repositories/rolesRepo.ts
@@ -1,5 +1,14 @@
 import pool, { type QueryExecutor } from '../db/index.ts';
 
+export type Role = {
+  id: string;
+  name: string;
+  isSystem: boolean;
+  isAdmin: boolean;
+};
+
+const SELECT_COLUMNS = `id, name, is_system AS "isSystem", is_admin AS "isAdmin"`;
+
 export const findExistingIds = async (
   ids: string[],
   exec: QueryExecutor = pool,
@@ -24,18 +33,11 @@ export const userHasRole = async (
   return rows.length > 0;
 };
 
-export type AvailableRole = {
-  id: string;
-  name: string;
-  isSystem: boolean;
-  isAdmin: boolean;
-};
-
 export const listAvailableRolesForUser = async (
   userId: string,
   exec: QueryExecutor = pool,
-): Promise<AvailableRole[]> => {
-  const { rows } = await exec.query<AvailableRole>(
+): Promise<Role[]> => {
+  const { rows } = await exec.query<Role>(
     `SELECT r.id, r.name, r.is_system AS "isSystem", r.is_admin AS "isAdmin"
        FROM user_roles ur
        JOIN roles r ON r.id = ur.role_id
@@ -44,4 +46,73 @@ export const listAvailableRolesForUser = async (
     [userId],
   );
   return rows;
+};
+
+export const listAll = async (exec: QueryExecutor = pool): Promise<Role[]> => {
+  const { rows } = await exec.query<Role>(`SELECT ${SELECT_COLUMNS} FROM roles ORDER BY name`);
+  return rows;
+};
+
+export const findById = async (id: string, exec: QueryExecutor = pool): Promise<Role | null> => {
+  const { rows } = await exec.query<Role>(`SELECT ${SELECT_COLUMNS} FROM roles WHERE id = $1`, [
+    id,
+  ]);
+  return rows[0] ?? null;
+};
+
+export const listExplicitPermissions = async (
+  roleId: string,
+  exec: QueryExecutor = pool,
+): Promise<string[]> => {
+  const { rows } = await exec.query<{ permission: string }>(
+    `SELECT permission FROM role_permissions WHERE role_id = $1`,
+    [roleId],
+  );
+  return rows.map((r) => r.permission);
+};
+
+export const insertRole = async (
+  id: string,
+  name: string,
+  exec: QueryExecutor = pool,
+): Promise<void> => {
+  await exec.query(
+    `INSERT INTO roles (id, name, is_system, is_admin) VALUES ($1, $2, FALSE, FALSE)`,
+    [id, name],
+  );
+};
+
+export const updateRoleName = async (
+  id: string,
+  name: string,
+  exec: QueryExecutor = pool,
+): Promise<void> => {
+  await exec.query(`UPDATE roles SET name = $1 WHERE id = $2`, [name, id]);
+};
+
+export const deleteRole = async (id: string, exec: QueryExecutor = pool): Promise<void> => {
+  await exec.query(`DELETE FROM roles WHERE id = $1`, [id]);
+};
+
+export const insertPermission = async (
+  roleId: string,
+  permission: string,
+  exec: QueryExecutor = pool,
+): Promise<void> => {
+  await exec.query(
+    `INSERT INTO role_permissions (role_id, permission) VALUES ($1, $2) ON CONFLICT DO NOTHING`,
+    [roleId, permission],
+  );
+};
+
+export const clearPermissions = async (
+  roleId: string,
+  exec: QueryExecutor = pool,
+): Promise<void> => {
+  await exec.query(`DELETE FROM role_permissions WHERE role_id = $1`, [roleId]);
+};
+
+export const isRoleInUse = async (roleId: string, exec: QueryExecutor = pool): Promise<boolean> => {
+  const { rows } = await exec.query(`SELECT 1 FROM users WHERE role = $1 LIMIT 1`, [roleId]);
+  return rows.length > 0;
 };

--- a/server/repositories/rolesRepo.ts
+++ b/server/repositories/rolesRepo.ts
@@ -7,7 +7,8 @@ export type Role = {
   isAdmin: boolean;
 };
 
-const SELECT_COLUMNS = `id, name, is_system AS "isSystem", is_admin AS "isAdmin"`;
+const roleColumns = (prefix = '') =>
+  `${prefix}id, ${prefix}name, ${prefix}is_system AS "isSystem", ${prefix}is_admin AS "isAdmin"`;
 
 export const findExistingIds = async (
   ids: string[],
@@ -38,7 +39,7 @@ export const listAvailableRolesForUser = async (
   exec: QueryExecutor = pool,
 ): Promise<Role[]> => {
   const { rows } = await exec.query<Role>(
-    `SELECT r.id, r.name, r.is_system AS "isSystem", r.is_admin AS "isAdmin"
+    `SELECT ${roleColumns('r.')}
        FROM user_roles ur
        JOIN roles r ON r.id = ur.role_id
       WHERE ur.user_id = $1
@@ -49,14 +50,12 @@ export const listAvailableRolesForUser = async (
 };
 
 export const listAll = async (exec: QueryExecutor = pool): Promise<Role[]> => {
-  const { rows } = await exec.query<Role>(`SELECT ${SELECT_COLUMNS} FROM roles ORDER BY name`);
+  const { rows } = await exec.query<Role>(`SELECT ${roleColumns()} FROM roles ORDER BY name`);
   return rows;
 };
 
 export const findById = async (id: string, exec: QueryExecutor = pool): Promise<Role | null> => {
-  const { rows } = await exec.query<Role>(`SELECT ${SELECT_COLUMNS} FROM roles WHERE id = $1`, [
-    id,
-  ]);
+  const { rows } = await exec.query<Role>(`SELECT ${roleColumns()} FROM roles WHERE id = $1`, [id]);
   return rows[0] ?? null;
 };
 
@@ -69,6 +68,23 @@ export const listExplicitPermissions = async (
     [roleId],
   );
   return rows.map((r) => r.permission);
+};
+
+export const listExplicitPermissionsForRoles = async (
+  roleIds: string[],
+  exec: QueryExecutor = pool,
+): Promise<Map<string, string[]>> => {
+  const result = new Map<string, string[]>();
+  if (roleIds.length === 0) return result;
+  for (const id of roleIds) result.set(id, []);
+  const { rows } = await exec.query<{ roleId: string; permission: string }>(
+    `SELECT role_id AS "roleId", permission
+       FROM role_permissions
+      WHERE role_id = ANY($1::text[])`,
+    [roleIds],
+  );
+  for (const row of rows) result.get(row.roleId)?.push(row.permission);
+  return result;
 };
 
 export const insertRole = async (

--- a/server/routes/roles.ts
+++ b/server/routes/roles.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
-import { query, withTransaction } from '../db/index.ts';
+import { withTransaction } from '../db/index.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
+import * as rolesRepo from '../repositories/rolesRepo.ts';
 import { messageResponseSchema, standardRateLimitedErrorResponses } from '../schemas/common.ts';
 import { logAudit } from '../utils/audit.ts';
 import { generatePrefixedId } from '../utils/order-ids.ts';
@@ -65,17 +66,10 @@ const idParamSchema = {
   required: ['id'],
 } as const;
 
-const mapRoleRow = async (row: {
-  id: string;
-  name: string;
-  is_system: boolean;
-  is_admin: boolean;
-}) => {
-  const explicitPerms = (
-    await query('SELECT permission FROM role_permissions WHERE role_id = $1', [row.id])
-  ).rows.map((perm) => normalizePermission(perm.permission));
+const mapRoleRow = async (row: rolesRepo.Role) => {
+  const explicitPerms = (await rolesRepo.listExplicitPermissions(row.id)).map(normalizePermission);
 
-  const permissions = row.is_admin
+  const permissions = row.isAdmin
     ? Array.from(
         new Set([
           ...ADMINISTRATION_PERMISSIONS,
@@ -89,8 +83,8 @@ const mapRoleRow = async (row: {
   return {
     id: row.id,
     name: row.name,
-    isSystem: row.is_system,
-    isAdmin: row.is_admin,
+    isSystem: row.isSystem,
+    isAdmin: row.isAdmin,
     permissions,
   };
 };
@@ -123,9 +117,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       },
     },
     async (_request: FastifyRequest, _reply: FastifyReply) => {
-      const result = await query('SELECT id, name, is_system, is_admin FROM roles ORDER BY name');
-      const value = await Promise.all(result.rows.map(mapRoleRow));
-      return value;
+      const rows = await rolesRepo.listAll();
+      return Promise.all(rows.map(mapRoleRow));
     },
   );
 
@@ -183,23 +176,19 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       }
 
       await withTransaction(async (tx) => {
-        await tx.query(
-          'INSERT INTO roles (id, name, is_system, is_admin) VALUES ($1, $2, $3, $4)',
-          [id, nameResult.value, false, false],
-        );
+        await rolesRepo.insertRole(id, nameResult.value, tx);
 
         for (const permission of normalizedPermissions) {
-          await tx.query(
-            'INSERT INTO role_permissions (role_id, permission) VALUES ($1, $2) ON CONFLICT DO NOTHING',
-            [id, permission],
-          );
+          await rolesRepo.insertPermission(id, permission, tx);
         }
       });
 
-      const roleRow = await query('SELECT id, name, is_system, is_admin FROM roles WHERE id = $1', [
+      const role = await mapRoleRow({
         id,
-      ]);
-      const role = await mapRoleRow(roleRow.rows[0]);
+        name: nameResult.value,
+        isSystem: false,
+        isAdmin: false,
+      });
       await logAudit({
         request,
         action: 'role.created',
@@ -243,20 +232,16 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const nameResult = requireNonEmptyString(name, 'name');
       if (!nameResult.ok) return badRequest(reply, nameResult.message);
 
-      const roleResult = await query(
-        'SELECT id, name, is_system, is_admin FROM roles WHERE id = $1',
-        [idResult.value],
-      );
-      if (roleResult.rows.length === 0) {
+      const roleRow = await rolesRepo.findById(idResult.value);
+      if (!roleRow) {
         return reply.code(404).send({ error: 'Role not found' });
       }
 
-      const roleRow = roleResult.rows[0];
-      if (roleRow.is_admin || roleRow.is_system) {
+      if (roleRow.isAdmin || roleRow.isSystem) {
         return reply.code(403).send({ error: 'System roles cannot be renamed' });
       }
 
-      await query('UPDATE roles SET name = $1 WHERE id = $2', [nameResult.value, idResult.value]);
+      await rolesRepo.updateRoleName(idResult.value, nameResult.value);
       await logAudit({
         request,
         action: 'role.updated',
@@ -264,16 +249,12 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         entityId: idResult.value,
         details: {
           targetLabel: nameResult.value,
-          fromValue: roleRow.name as string,
+          fromValue: roleRow.name,
           toValue: nameResult.value,
         },
       });
 
-      const updatedRoleResult = await query(
-        'SELECT id, name, is_system, is_admin FROM roles WHERE id = $1',
-        [idResult.value],
-      );
-      const updatedRole = await mapRoleRow(updatedRoleResult.rows[0]);
+      const updatedRole = await mapRoleRow({ ...roleRow, name: nameResult.value });
       return reply.send(updatedRole);
     },
   );
@@ -298,34 +279,27 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
 
-      const roleResult = await query(
-        'SELECT id, name, is_system, is_admin FROM roles WHERE id = $1',
-        [idResult.value],
-      );
-      if (roleResult.rows.length === 0) {
+      const roleRow = await rolesRepo.findById(idResult.value);
+      if (!roleRow) {
         return reply.code(404).send({ error: 'Role not found' });
       }
 
-      const roleRow = roleResult.rows[0];
-      if (roleRow.is_admin || roleRow.is_system) {
+      if (roleRow.isAdmin || roleRow.isSystem) {
         return reply.code(403).send({ error: 'System roles cannot be deleted' });
       }
 
-      const userCheck = await query('SELECT id FROM users WHERE role = $1 LIMIT 1', [
-        idResult.value,
-      ]);
-      if (userCheck.rows.length > 0) {
+      if (await rolesRepo.isRoleInUse(idResult.value)) {
         return reply.code(409).send({ error: 'Role is in use by existing users' });
       }
 
-      await query('DELETE FROM roles WHERE id = $1', [idResult.value]);
+      await rolesRepo.deleteRole(idResult.value);
       await logAudit({
         request,
         action: 'role.deleted',
         entityType: 'role',
         entityId: idResult.value,
         details: {
-          targetLabel: roleRow.name as string,
+          targetLabel: roleRow.name,
         },
       });
       return { message: 'Role deleted' };
@@ -368,13 +342,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         return badRequest(reply, `Unknown permission: ${invalidPermission}`);
       }
 
-      const roleResult = await query('SELECT id, name, is_admin FROM roles WHERE id = $1', [
-        idResult.value,
-      ]);
-      if (roleResult.rows.length === 0) {
+      const roleRow = await rolesRepo.findById(idResult.value);
+      if (!roleRow) {
         return reply.code(404).send({ error: 'Role not found' });
       }
-      if (roleResult.rows[0].is_admin) {
+      if (roleRow.isAdmin) {
         return reply.code(403).send({ error: 'Admin role permissions are locked' });
       }
       const forbiddenPermission = findForbiddenAdministrationPermission(normalizedPermissions);
@@ -396,20 +368,13 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       }
 
       await withTransaction(async (tx) => {
-        await tx.query('DELETE FROM role_permissions WHERE role_id = $1', [idResult.value]);
+        await rolesRepo.clearPermissions(idResult.value, tx);
         for (const permission of normalizedPermissions) {
-          await tx.query(
-            'INSERT INTO role_permissions (role_id, permission) VALUES ($1, $2) ON CONFLICT DO NOTHING',
-            [idResult.value, permission],
-          );
+          await rolesRepo.insertPermission(idResult.value, permission, tx);
         }
       });
 
-      const updatedRoleResult = await query(
-        'SELECT id, name, is_system, is_admin FROM roles WHERE id = $1',
-        [idResult.value],
-      );
-      const updatedRole = await mapRoleRow(updatedRoleResult.rows[0]);
+      const updatedRole = await mapRoleRow(roleRow);
       await logAudit({
         request,
         action: 'role.permissions_updated',

--- a/server/routes/roles.ts
+++ b/server/routes/roles.ts
@@ -66,19 +66,18 @@ const idParamSchema = {
   required: ['id'],
 } as const;
 
-const mapRoleRow = async (row: rolesRepo.Role) => {
-  const explicitPerms = (await rolesRepo.listExplicitPermissions(row.id)).map(normalizePermission);
-
+const buildRolePayload = (row: rolesRepo.Role, explicitPerms: string[]) => {
+  const normalized = explicitPerms.map(normalizePermission);
   const permissions = row.isAdmin
     ? Array.from(
         new Set([
           ...ADMINISTRATION_PERMISSIONS,
           ...ADMIN_BASE_PERMISSIONS,
-          ...explicitPerms,
+          ...normalized,
           ...ALWAYS_GRANTED_NOTIFICATION_PERMISSIONS,
         ]),
       )
-    : Array.from(new Set([...explicitPerms, ...ALWAYS_GRANTED_NOTIFICATION_PERMISSIONS]));
+    : Array.from(new Set([...normalized, ...ALWAYS_GRANTED_NOTIFICATION_PERMISSIONS]));
 
   return {
     id: row.id,
@@ -88,6 +87,9 @@ const mapRoleRow = async (row: rolesRepo.Role) => {
     permissions,
   };
 };
+
+const mapRoleRow = async (row: rolesRepo.Role) =>
+  buildRolePayload(row, await rolesRepo.listExplicitPermissions(row.id));
 
 const isForbiddenAdministrationPermissionForNonAdmin = (permission: string) =>
   permission.startsWith('administration.') || permission.startsWith('configuration.');
@@ -118,7 +120,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
     },
     async (_request: FastifyRequest, _reply: FastifyReply) => {
       const rows = await rolesRepo.listAll();
-      return Promise.all(rows.map(mapRoleRow));
+      const permsByRole = await rolesRepo.listExplicitPermissionsForRoles(
+        rows.map((row) => row.id),
+      );
+      return rows.map((row) => buildRolePayload(row, permsByRole.get(row.id) ?? []));
     },
   );
 

--- a/server/test/repositories/rolesRepo.test.ts
+++ b/server/test/repositories/rolesRepo.test.ts
@@ -77,3 +77,118 @@ describe('listAvailableRolesForUser', () => {
     expect(result).toEqual([]);
   });
 });
+
+describe('listAll', () => {
+  test('returns rows as-is and passes no params', async () => {
+    exec.enqueue({
+      rows: [
+        { id: 'admin', name: 'Admin', isSystem: true, isAdmin: true },
+        { id: 'manager', name: 'Manager', isSystem: false, isAdmin: false },
+      ],
+    });
+    const result = await rolesRepo.listAll(exec);
+    expect(result).toEqual([
+      { id: 'admin', name: 'Admin', isSystem: true, isAdmin: true },
+      { id: 'manager', name: 'Manager', isSystem: false, isAdmin: false },
+    ]);
+    expect(exec.calls).toHaveLength(1);
+    expect(exec.calls[0].params).toEqual([]);
+  });
+
+  test('returns an empty array when there are no roles', async () => {
+    exec.enqueue({ rows: [] });
+    const result = await rolesRepo.listAll(exec);
+    expect(result).toEqual([]);
+  });
+});
+
+describe('findById', () => {
+  test('returns the mapped row when found', async () => {
+    exec.enqueue({
+      rows: [{ id: 'manager', name: 'Manager', isSystem: false, isAdmin: false }],
+    });
+    const result = await rolesRepo.findById('manager', exec);
+    expect(result).toEqual({ id: 'manager', name: 'Manager', isSystem: false, isAdmin: false });
+    expect(exec.calls[0].params).toEqual(['manager']);
+  });
+
+  test('returns null when the row does not exist', async () => {
+    exec.enqueue({ rows: [] });
+    const result = await rolesRepo.findById('missing', exec);
+    expect(result).toBeNull();
+  });
+});
+
+describe('listExplicitPermissions', () => {
+  test('returns the permission strings in row order', async () => {
+    exec.enqueue({
+      rows: [{ permission: 'projects.view' }, { permission: 'clients.update' }],
+    });
+    const result = await rolesRepo.listExplicitPermissions('manager', exec);
+    expect(result).toEqual(['projects.view', 'clients.update']);
+    expect(exec.calls[0].params).toEqual(['manager']);
+  });
+
+  test('returns an empty array when the role has no explicit permissions', async () => {
+    exec.enqueue({ rows: [] });
+    const result = await rolesRepo.listExplicitPermissions('manager', exec);
+    expect(result).toEqual([]);
+  });
+});
+
+describe('insertRole', () => {
+  test('passes [id, name] and hard-codes is_system/is_admin to FALSE in the SQL', async () => {
+    exec.enqueue({ rows: [] });
+    await rolesRepo.insertRole('role_xyz', 'Custom', exec);
+    expect(exec.calls[0].params).toEqual(['role_xyz', 'Custom']);
+    expect(exec.calls[0].sql).toMatch(/FALSE,\s*FALSE/);
+  });
+});
+
+describe('updateRoleName', () => {
+  test('passes [name, id] in correct order', async () => {
+    exec.enqueue({ rows: [] });
+    await rolesRepo.updateRoleName('role_xyz', 'Renamed', exec);
+    expect(exec.calls[0].params).toEqual(['Renamed', 'role_xyz']);
+  });
+});
+
+describe('deleteRole', () => {
+  test('passes [id]', async () => {
+    exec.enqueue({ rows: [] });
+    await rolesRepo.deleteRole('role_xyz', exec);
+    expect(exec.calls[0].params).toEqual(['role_xyz']);
+  });
+});
+
+describe('insertPermission', () => {
+  test('passes [roleId, permission] and the SQL is upsert-safe', async () => {
+    exec.enqueue({ rows: [] });
+    await rolesRepo.insertPermission('manager', 'projects.view', exec);
+    expect(exec.calls[0].params).toEqual(['manager', 'projects.view']);
+    expect(exec.calls[0].sql).toContain('ON CONFLICT DO NOTHING');
+  });
+});
+
+describe('clearPermissions', () => {
+  test('passes [roleId]', async () => {
+    exec.enqueue({ rows: [] });
+    await rolesRepo.clearPermissions('manager', exec);
+    expect(exec.calls[0].params).toEqual(['manager']);
+  });
+});
+
+describe('isRoleInUse', () => {
+  test('returns true when at least one user has the role', async () => {
+    exec.enqueue({ rows: [{}] });
+    const result = await rolesRepo.isRoleInUse('manager', exec);
+    expect(result).toBe(true);
+    expect(exec.calls[0].params).toEqual(['manager']);
+  });
+
+  test('returns false when no user has the role', async () => {
+    exec.enqueue({ rows: [] });
+    const result = await rolesRepo.isRoleInUse('manager', exec);
+    expect(result).toBe(false);
+  });
+});

--- a/server/test/repositories/rolesRepo.test.ts
+++ b/server/test/repositories/rolesRepo.test.ts
@@ -136,6 +136,43 @@ describe('listExplicitPermissions', () => {
   });
 });
 
+describe('listExplicitPermissionsForRoles', () => {
+  test('returns an empty Map without firing SQL when roleIds is empty', async () => {
+    const result = await rolesRepo.listExplicitPermissionsForRoles([], exec);
+    expect(result.size).toBe(0);
+    expect(exec.calls).toHaveLength(0);
+  });
+
+  test('passes roleIds as a single $1 param (ANY($1::text[]) contract)', async () => {
+    exec.enqueue({ rows: [] });
+    await rolesRepo.listExplicitPermissionsForRoles(['a', 'b'], exec);
+    expect(exec.calls).toHaveLength(1);
+    expect(exec.calls[0].params).toEqual([['a', 'b']]);
+  });
+
+  test('groups permissions by role and preserves DB row order within each role', async () => {
+    exec.enqueue({
+      rows: [
+        { roleId: 'manager', permission: 'projects.view' },
+        { roleId: 'auditor', permission: 'reports.view' },
+        { roleId: 'manager', permission: 'clients.update' },
+      ],
+    });
+    const result = await rolesRepo.listExplicitPermissionsForRoles(['manager', 'auditor'], exec);
+    expect(result.get('manager')).toEqual(['projects.view', 'clients.update']);
+    expect(result.get('auditor')).toEqual(['reports.view']);
+  });
+
+  test('roles with no permissions are still present in the Map with empty arrays', async () => {
+    exec.enqueue({
+      rows: [{ roleId: 'manager', permission: 'projects.view' }],
+    });
+    const result = await rolesRepo.listExplicitPermissionsForRoles(['manager', 'empty-role'], exec);
+    expect(result.get('manager')).toEqual(['projects.view']);
+    expect(result.get('empty-role')).toEqual([]);
+  });
+});
+
 describe('insertRole', () => {
   test('passes [id, name] and hard-codes is_system/is_admin to FALSE in the SQL', async () => {
     exec.enqueue({ rows: [] });


### PR DESCRIPTION
## Summary
- Moves inline role/permission SQL from `server/routes/roles.ts` into `server/repositories/rolesRepo.ts`, matching the established repository-pattern convention (see `notificationsRepo.ts` / `emailRepo.ts`).
- Drops three post-write `findById` re-fetches and their "not found after insert/update" guards by passing in-memory row data to `mapRoleRow` — saves one query per mutation.
- Adds a shared `SELECT_COLUMNS` const, drops the redundant `AvailableRole = Role` alias, and adds tests covering all new repo functions.

## Test plan
- [x] `bun test test` (98/98 pass)
- [x] `bun run build` (clean)
- [ ] Manual smoke: list / create / rename / delete role and update role permissions in the admin UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xbounceit/praetor/pull/135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
