### PR TITLE
refactor(server): extract supplier route SQL into per-domain repos

### DIFF
--- a/server/repositories/supplierInvoicesRepo.ts
+++ b/server/repositories/supplierInvoicesRepo.ts
@@ -1,0 +1,370 @@
+import pool, { type QueryExecutor } from '../db/index.ts';
+import { normalizeNullableDateOnly } from '../utils/date.ts';
+import { parseDbNumber } from '../utils/parse.ts';
+
+export type SupplierInvoice = {
+  id: string;
+  linkedSaleId: string | null;
+  supplierId: string;
+  supplierName: string;
+  issueDate: string;
+  dueDate: string;
+  status: string;
+  subtotal: number;
+  total: number;
+  amountPaid: number;
+  notes: string | null;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type SupplierInvoiceItem = {
+  id: string;
+  invoiceId: string;
+  productId: string | null;
+  description: string;
+  quantity: number;
+  unitPrice: number;
+  discount: number;
+};
+
+type SupplierInvoiceRow = {
+  id: string;
+  linkedSaleId: string | null;
+  supplierId: string;
+  supplierName: string;
+  issueDate: string | Date;
+  dueDate: string | Date;
+  status: string;
+  subtotal: string | number | null;
+  total: string | number | null;
+  amountPaid: string | number | null;
+  notes: string | null;
+  createdAt: string | number;
+  updatedAt: string | number;
+};
+
+type SupplierInvoiceItemRow = {
+  id: string;
+  invoiceId: string;
+  productId: string | null;
+  description: string;
+  quantity: string | number;
+  unitPrice: string | number;
+  discount: string | number | null;
+};
+
+const INVOICE_COLUMNS = `
+  id,
+  linked_sale_id as "linkedSaleId",
+  supplier_id as "supplierId",
+  supplier_name as "supplierName",
+  issue_date as "issueDate",
+  due_date as "dueDate",
+  status,
+  subtotal,
+  total,
+  amount_paid as "amountPaid",
+  notes,
+  EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt",
+  EXTRACT(EPOCH FROM updated_at) * 1000 as "updatedAt"
+`;
+
+const ITEM_COLUMNS = `
+  id,
+  invoice_id as "invoiceId",
+  product_id as "productId",
+  description,
+  quantity,
+  unit_price as "unitPrice",
+  discount
+`;
+
+const requireDateOnly = (value: unknown, fieldName: string): string => {
+  const normalized = normalizeNullableDateOnly(value, fieldName);
+  if (!normalized) {
+    throw new TypeError(`Invalid date value for ${fieldName}`);
+  }
+  return normalized;
+};
+
+const mapInvoice = (row: SupplierInvoiceRow): SupplierInvoice => ({
+  id: row.id,
+  linkedSaleId: row.linkedSaleId,
+  supplierId: row.supplierId,
+  supplierName: row.supplierName,
+  issueDate: requireDateOnly(row.issueDate, 'supplierInvoice.issueDate'),
+  dueDate: requireDateOnly(row.dueDate, 'supplierInvoice.dueDate'),
+  status: row.status,
+  subtotal: parseDbNumber(row.subtotal, 0),
+  total: parseDbNumber(row.total, 0),
+  amountPaid: parseDbNumber(row.amountPaid, 0),
+  notes: row.notes,
+  createdAt: parseDbNumber(row.createdAt, 0),
+  updatedAt: parseDbNumber(row.updatedAt, 0),
+});
+
+const mapItem = (row: SupplierInvoiceItemRow): SupplierInvoiceItem => ({
+  id: row.id,
+  invoiceId: row.invoiceId,
+  productId: row.productId,
+  description: row.description,
+  quantity: parseDbNumber(row.quantity, 0),
+  unitPrice: parseDbNumber(row.unitPrice, 0),
+  discount: parseDbNumber(row.discount, 0),
+});
+
+export const listAll = async (exec: QueryExecutor = pool): Promise<SupplierInvoice[]> => {
+  const { rows } = await exec.query<SupplierInvoiceRow>(
+    `SELECT ${INVOICE_COLUMNS} FROM supplier_invoices ORDER BY created_at DESC`,
+  );
+  return rows.map(mapInvoice);
+};
+
+export const listAllItems = async (exec: QueryExecutor = pool): Promise<SupplierInvoiceItem[]> => {
+  const { rows } = await exec.query<SupplierInvoiceItemRow>(
+    `SELECT ${ITEM_COLUMNS} FROM supplier_invoice_items ORDER BY created_at ASC`,
+  );
+  return rows.map(mapItem);
+};
+
+export const findById = async (
+  id: string,
+  exec: QueryExecutor = pool,
+): Promise<SupplierInvoice | null> => {
+  const { rows } = await exec.query<SupplierInvoiceRow>(
+    `SELECT ${INVOICE_COLUMNS} FROM supplier_invoices WHERE id = $1`,
+    [id],
+  );
+  return rows[0] ? mapInvoice(rows[0]) : null;
+};
+
+export const findItemsForInvoice = async (
+  invoiceId: string,
+  exec: QueryExecutor = pool,
+): Promise<SupplierInvoiceItem[]> => {
+  const { rows } = await exec.query<SupplierInvoiceItemRow>(
+    `SELECT ${ITEM_COLUMNS} FROM supplier_invoice_items WHERE invoice_id = $1`,
+    [invoiceId],
+  );
+  return rows.map(mapItem);
+};
+
+export const findInvoiceForLinkedSale = async (
+  saleId: string,
+  exec: QueryExecutor = pool,
+): Promise<string | null> => {
+  const { rows } = await exec.query<{ id: string }>(
+    `SELECT id FROM supplier_invoices WHERE linked_sale_id = $1 LIMIT 1`,
+    [saleId],
+  );
+  return rows[0]?.id ?? null;
+};
+
+export const findExistingForUpdate = async (
+  id: string,
+  exec: QueryExecutor = pool,
+): Promise<{
+  id: string;
+  status: string;
+  issueDate: string;
+  dueDate: string;
+} | null> => {
+  const { rows } = await exec.query<{
+    id: string;
+    status: string;
+    issueDate: string | Date;
+    dueDate: string | Date;
+  }>(
+    `SELECT id, status, issue_date as "issueDate", due_date as "dueDate"
+       FROM supplier_invoices WHERE id = $1`,
+    [id],
+  );
+  if (!rows[0]) return null;
+  return {
+    id: rows[0].id,
+    status: rows[0].status,
+    issueDate: requireDateOnly(rows[0].issueDate, 'supplierInvoice.issueDate'),
+    dueDate: requireDateOnly(rows[0].dueDate, 'supplierInvoice.dueDate'),
+  };
+};
+
+export const findStatusAndSupplierName = async (
+  id: string,
+  exec: QueryExecutor = pool,
+): Promise<{ status: string; supplierName: string } | null> => {
+  const { rows } = await exec.query<{ status: string; supplierName: string }>(
+    `SELECT status, supplier_name as "supplierName" FROM supplier_invoices WHERE id = $1`,
+    [id],
+  );
+  return rows[0] ?? null;
+};
+
+export const findIdConflict = async (
+  newId: string,
+  currentId: string,
+  exec: QueryExecutor = pool,
+): Promise<boolean> => {
+  const { rows } = await exec.query<{ id: string }>(
+    `SELECT id FROM supplier_invoices WHERE id = $1 AND id <> $2`,
+    [newId, currentId],
+  );
+  return rows.length > 0;
+};
+
+export const maxSequenceForYear = async (
+  year: string,
+  exec: QueryExecutor = pool,
+): Promise<number> => {
+  const { rows } = await exec.query<{ maxSequence: string | number | null }>(
+    `SELECT COALESCE(MAX(CAST(split_part(id, '-', 3) AS INTEGER)), 0) as "maxSequence"
+       FROM supplier_invoices
+      WHERE id ~ $1`,
+    [`^SINV-${year}-[0-9]+$`],
+  );
+  return Number(rows[0]?.maxSequence ?? 0);
+};
+
+export type NewSupplierInvoice = {
+  id: string;
+  linkedSaleId: string | null;
+  supplierId: string;
+  supplierName: string;
+  issueDate: string;
+  dueDate: string;
+  status: string;
+  subtotal: number;
+  total: number;
+  amountPaid: number;
+  notes: string | null;
+};
+
+export const create = async (
+  input: NewSupplierInvoice,
+  exec: QueryExecutor = pool,
+): Promise<SupplierInvoice> => {
+  const { rows } = await exec.query<SupplierInvoiceRow>(
+    `INSERT INTO supplier_invoices
+       (id, linked_sale_id, supplier_id, supplier_name, issue_date, due_date, status, subtotal, total, amount_paid, notes)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+     RETURNING ${INVOICE_COLUMNS}`,
+    [
+      input.id,
+      input.linkedSaleId,
+      input.supplierId,
+      input.supplierName,
+      input.issueDate,
+      input.dueDate,
+      input.status,
+      input.subtotal,
+      input.total,
+      input.amountPaid,
+      input.notes,
+    ],
+  );
+  return mapInvoice(rows[0]);
+};
+
+export type SupplierInvoiceUpdate = {
+  id?: string;
+  supplierId?: string;
+  supplierName?: string;
+  issueDate?: string;
+  dueDate?: string;
+  status?: string;
+  subtotal?: number;
+  total?: number;
+  amountPaid?: number;
+  notes?: string | null;
+};
+
+export const update = async (
+  id: string,
+  patch: SupplierInvoiceUpdate,
+  exec: QueryExecutor = pool,
+): Promise<SupplierInvoice | null> => {
+  const sets: string[] = [];
+  const params: unknown[] = [];
+  let idx = 1;
+  const fields: Array<[string, unknown]> = [
+    ['id', patch.id],
+    ['supplier_id', patch.supplierId],
+    ['supplier_name', patch.supplierName],
+    ['issue_date', patch.issueDate],
+    ['due_date', patch.dueDate],
+    ['status', patch.status],
+    ['subtotal', patch.subtotal],
+    ['total', patch.total],
+    ['amount_paid', patch.amountPaid],
+    ['notes', patch.notes],
+  ];
+  for (const [col, value] of fields) {
+    if (value !== undefined) {
+      sets.push(`${col} = $${idx++}`);
+      params.push(value);
+    }
+  }
+
+  if (sets.length === 0) {
+    const { rows } = await exec.query<SupplierInvoiceRow>(
+      `SELECT ${INVOICE_COLUMNS} FROM supplier_invoices WHERE id = $1`,
+      [id],
+    );
+    return rows[0] ? mapInvoice(rows[0]) : null;
+  }
+
+  sets.push(`updated_at = CURRENT_TIMESTAMP`);
+  params.push(id);
+  const { rows } = await exec.query<SupplierInvoiceRow>(
+    `UPDATE supplier_invoices SET ${sets.join(', ')} WHERE id = $${idx} RETURNING ${INVOICE_COLUMNS}`,
+    params,
+  );
+  return rows[0] ? mapInvoice(rows[0]) : null;
+};
+
+export const deleteById = async (id: string, exec: QueryExecutor = pool): Promise<boolean> => {
+  const { rowCount } = await exec.query(`DELETE FROM supplier_invoices WHERE id = $1`, [id]);
+  return (rowCount ?? 0) > 0;
+};
+
+export type NewSupplierInvoiceItem = {
+  id: string;
+  productId: string | null;
+  description: string;
+  quantity: number;
+  unitPrice: number;
+  discount: number;
+};
+
+export const replaceItems = async (
+  invoiceId: string,
+  items: NewSupplierInvoiceItem[],
+  exec: QueryExecutor,
+): Promise<SupplierInvoiceItem[]> => {
+  await exec.query(`DELETE FROM supplier_invoice_items WHERE invoice_id = $1`, [invoiceId]);
+  if (items.length === 0) return [];
+  const FIELDS_PER_ROW = 7;
+  const placeholders = items
+    .map((_, i) => {
+      const base = i * FIELDS_PER_ROW;
+      return `($${base + 1}, $${base + 2}, $${base + 3}, $${base + 4}, $${base + 5}, $${base + 6}, $${base + 7})`;
+    })
+    .join(', ');
+  const params = items.flatMap((item) => [
+    item.id,
+    invoiceId,
+    item.productId,
+    item.description,
+    item.quantity,
+    item.unitPrice,
+    item.discount,
+  ]);
+  const { rows } = await exec.query<SupplierInvoiceItemRow>(
+    `INSERT INTO supplier_invoice_items
+       (id, invoice_id, product_id, description, quantity, unit_price, discount)
+     VALUES ${placeholders}
+     RETURNING ${ITEM_COLUMNS}`,
+    params,
+  );
+  return rows.map(mapItem);
+};

--- a/server/repositories/supplierOrdersRepo.ts
+++ b/server/repositories/supplierOrdersRepo.ts
@@ -1,0 +1,349 @@
+import pool, { type QueryExecutor } from '../db/index.ts';
+import { parseDbNumber } from '../utils/parse.ts';
+
+export type SupplierOrder = {
+  id: string;
+  linkedQuoteId: string | null;
+  supplierId: string;
+  supplierName: string;
+  paymentTerms: string | null;
+  discount: number;
+  discountType: 'percentage' | 'currency';
+  status: string;
+  notes: string | null;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type SupplierOrderItem = {
+  id: string;
+  orderId: string;
+  productId: string | null;
+  productName: string;
+  quantity: number;
+  unitPrice: number;
+  discount: number;
+  note: string | null;
+};
+
+type SupplierOrderRow = {
+  id: string;
+  linkedQuoteId: string | null;
+  supplierId: string;
+  supplierName: string;
+  paymentTerms: string | null;
+  discount: string | number;
+  discountType: string;
+  status: string;
+  notes: string | null;
+  createdAt: string | number;
+  updatedAt: string | number;
+};
+
+type SupplierOrderItemRow = {
+  id: string;
+  orderId: string;
+  productId: string | null;
+  productName: string;
+  quantity: string | number;
+  unitPrice: string | number;
+  discount: string | number;
+  note: string | null;
+};
+
+const ORDER_COLUMNS = `
+  id,
+  linked_quote_id as "linkedQuoteId",
+  supplier_id as "supplierId",
+  supplier_name as "supplierName",
+  payment_terms as "paymentTerms",
+  discount,
+  discount_type as "discountType",
+  status,
+  notes,
+  EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt",
+  EXTRACT(EPOCH FROM updated_at) * 1000 as "updatedAt"
+`;
+
+const ITEM_COLUMNS = `
+  id,
+  sale_id as "orderId",
+  product_id as "productId",
+  product_name as "productName",
+  quantity,
+  unit_price as "unitPrice",
+  discount,
+  note
+`;
+
+const mapOrder = (row: SupplierOrderRow): SupplierOrder => ({
+  id: row.id,
+  linkedQuoteId: row.linkedQuoteId,
+  supplierId: row.supplierId,
+  supplierName: row.supplierName,
+  paymentTerms: row.paymentTerms,
+  discount: parseDbNumber(row.discount, 0),
+  discountType: row.discountType === 'currency' ? 'currency' : 'percentage',
+  status: row.status,
+  notes: row.notes,
+  createdAt: parseDbNumber(row.createdAt, 0),
+  updatedAt: parseDbNumber(row.updatedAt, 0),
+});
+
+const mapItem = (row: SupplierOrderItemRow): SupplierOrderItem => ({
+  id: row.id,
+  orderId: row.orderId,
+  productId: row.productId,
+  productName: row.productName,
+  quantity: parseDbNumber(row.quantity, 0),
+  unitPrice: parseDbNumber(row.unitPrice, 0),
+  discount: parseDbNumber(row.discount, 0),
+  note: row.note,
+});
+
+export const listAll = async (exec: QueryExecutor = pool): Promise<SupplierOrder[]> => {
+  const { rows } = await exec.query<SupplierOrderRow>(
+    `SELECT ${ORDER_COLUMNS} FROM supplier_sales ORDER BY created_at DESC`,
+  );
+  return rows.map(mapOrder);
+};
+
+export const listAllItems = async (exec: QueryExecutor = pool): Promise<SupplierOrderItem[]> => {
+  const { rows } = await exec.query<SupplierOrderItemRow>(
+    `SELECT ${ITEM_COLUMNS} FROM supplier_sale_items ORDER BY created_at ASC`,
+  );
+  return rows.map(mapItem);
+};
+
+export const findById = async (
+  id: string,
+  exec: QueryExecutor = pool,
+): Promise<SupplierOrder | null> => {
+  const { rows } = await exec.query<SupplierOrderRow>(
+    `SELECT ${ORDER_COLUMNS} FROM supplier_sales WHERE id = $1`,
+    [id],
+  );
+  return rows[0] ? mapOrder(rows[0]) : null;
+};
+
+export const findItemsForOrder = async (
+  orderId: string,
+  exec: QueryExecutor = pool,
+): Promise<SupplierOrderItem[]> => {
+  const { rows } = await exec.query<SupplierOrderItemRow>(
+    `SELECT ${ITEM_COLUMNS} FROM supplier_sale_items WHERE sale_id = $1`,
+    [orderId],
+  );
+  return rows.map(mapItem);
+};
+
+export const findLinkedInvoiceId = async (
+  orderId: string,
+  exec: QueryExecutor = pool,
+): Promise<string | null> => {
+  const { rows } = await exec.query<{ id: string }>(
+    `SELECT id FROM supplier_invoices WHERE linked_sale_id = $1 LIMIT 1`,
+    [orderId],
+  );
+  return rows[0]?.id ?? null;
+};
+
+export const findExistingByLinkedQuote = async (
+  quoteId: string,
+  exec: QueryExecutor = pool,
+): Promise<string | null> => {
+  const { rows } = await exec.query<{ id: string }>(
+    `SELECT id FROM supplier_sales WHERE linked_quote_id = $1 LIMIT 1`,
+    [quoteId],
+  );
+  return rows[0]?.id ?? null;
+};
+
+export const findExistingForUpdate = async (
+  id: string,
+  exec: QueryExecutor = pool,
+): Promise<{
+  id: string;
+  linkedQuoteId: string | null;
+  supplierId: string;
+  supplierName: string;
+  status: string;
+} | null> => {
+  const { rows } = await exec.query<{
+    id: string;
+    linkedQuoteId: string | null;
+    supplierId: string;
+    supplierName: string;
+    status: string;
+  }>(
+    `SELECT id,
+            linked_quote_id as "linkedQuoteId",
+            supplier_id as "supplierId",
+            supplier_name as "supplierName",
+            status
+       FROM supplier_sales WHERE id = $1`,
+    [id],
+  );
+  return rows[0] ?? null;
+};
+
+export const findStatusAndSupplierName = async (
+  id: string,
+  exec: QueryExecutor = pool,
+): Promise<{ status: string; supplierName: string } | null> => {
+  const { rows } = await exec.query<{ status: string; supplierName: string }>(
+    `SELECT status, supplier_name as "supplierName" FROM supplier_sales WHERE id = $1`,
+    [id],
+  );
+  return rows[0] ?? null;
+};
+
+export const findIdConflict = async (
+  newId: string,
+  currentId: string,
+  exec: QueryExecutor = pool,
+): Promise<boolean> => {
+  const { rows } = await exec.query<{ id: string }>(
+    `SELECT id FROM supplier_sales WHERE id = $1 AND id <> $2`,
+    [newId, currentId],
+  );
+  return rows.length > 0;
+};
+
+export type NewSupplierOrder = {
+  id: string;
+  linkedQuoteId: string;
+  supplierId: string;
+  supplierName: string;
+  paymentTerms: string;
+  discount: number;
+  discountType: 'percentage' | 'currency';
+  status: string;
+  notes: string | null;
+};
+
+export const create = async (
+  input: NewSupplierOrder,
+  exec: QueryExecutor = pool,
+): Promise<SupplierOrder> => {
+  const { rows } = await exec.query<SupplierOrderRow>(
+    `INSERT INTO supplier_sales
+       (id, linked_quote_id, supplier_id, supplier_name, payment_terms, discount, discount_type, status, notes)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+     RETURNING ${ORDER_COLUMNS}`,
+    [
+      input.id,
+      input.linkedQuoteId,
+      input.supplierId,
+      input.supplierName,
+      input.paymentTerms,
+      input.discount,
+      input.discountType,
+      input.status,
+      input.notes,
+    ],
+  );
+  return mapOrder(rows[0]);
+};
+
+export type SupplierOrderUpdate = {
+  id?: string;
+  supplierId?: string;
+  supplierName?: string;
+  paymentTerms?: string;
+  discount?: number;
+  discountType?: 'percentage' | 'currency';
+  status?: string;
+  notes?: string | null;
+};
+
+export const update = async (
+  id: string,
+  patch: SupplierOrderUpdate,
+  exec: QueryExecutor = pool,
+): Promise<SupplierOrder | null> => {
+  const sets: string[] = [];
+  const params: unknown[] = [];
+  let idx = 1;
+  const fields: Array<[string, unknown]> = [
+    ['id', patch.id],
+    ['supplier_id', patch.supplierId],
+    ['supplier_name', patch.supplierName],
+    ['payment_terms', patch.paymentTerms],
+    ['discount', patch.discount],
+    ['discount_type', patch.discountType],
+    ['status', patch.status],
+    ['notes', patch.notes],
+  ];
+  for (const [col, value] of fields) {
+    if (value !== undefined) {
+      sets.push(`${col} = $${idx++}`);
+      params.push(value);
+    }
+  }
+
+  if (sets.length === 0) {
+    const { rows } = await exec.query<SupplierOrderRow>(
+      `SELECT ${ORDER_COLUMNS} FROM supplier_sales WHERE id = $1`,
+      [id],
+    );
+    return rows[0] ? mapOrder(rows[0]) : null;
+  }
+
+  sets.push(`updated_at = CURRENT_TIMESTAMP`);
+  params.push(id);
+  const { rows } = await exec.query<SupplierOrderRow>(
+    `UPDATE supplier_sales SET ${sets.join(', ')} WHERE id = $${idx} RETURNING ${ORDER_COLUMNS}`,
+    params,
+  );
+  return rows[0] ? mapOrder(rows[0]) : null;
+};
+
+export const deleteById = async (id: string, exec: QueryExecutor = pool): Promise<boolean> => {
+  const { rowCount } = await exec.query(`DELETE FROM supplier_sales WHERE id = $1`, [id]);
+  return (rowCount ?? 0) > 0;
+};
+
+export type NewSupplierOrderItem = {
+  id: string;
+  productId: string | null;
+  productName: string;
+  quantity: number;
+  unitPrice: number;
+  discount: number;
+  note: string | null;
+};
+
+export const replaceItems = async (
+  orderId: string,
+  items: NewSupplierOrderItem[],
+  exec: QueryExecutor,
+): Promise<SupplierOrderItem[]> => {
+  await exec.query(`DELETE FROM supplier_sale_items WHERE sale_id = $1`, [orderId]);
+  if (items.length === 0) return [];
+  const FIELDS_PER_ROW = 8;
+  const placeholders = items
+    .map((_, i) => {
+      const base = i * FIELDS_PER_ROW;
+      return `($${base + 1}, $${base + 2}, $${base + 3}, $${base + 4}, $${base + 5}, $${base + 6}, $${base + 7}, $${base + 8})`;
+    })
+    .join(', ');
+  const params = items.flatMap((item) => [
+    item.id,
+    orderId,
+    item.productId,
+    item.productName,
+    item.quantity,
+    item.unitPrice,
+    item.discount,
+    item.note,
+  ]);
+  const { rows } = await exec.query<SupplierOrderItemRow>(
+    `INSERT INTO supplier_sale_items
+       (id, sale_id, product_id, product_name, quantity, unit_price, discount, note)
+     VALUES ${placeholders}
+     RETURNING ${ITEM_COLUMNS}`,
+    params,
+  );
+  return rows.map(mapItem);
+};

--- a/server/repositories/supplierQuotesRepo.ts
+++ b/server/repositories/supplierQuotesRepo.ts
@@ -1,0 +1,322 @@
+import pool, { type QueryExecutor } from '../db/index.ts';
+import { normalizeNullableDateOnly } from '../utils/date.ts';
+import { parseDbNumber } from '../utils/parse.ts';
+
+export type SupplierQuote = {
+  id: string;
+  supplierId: string;
+  supplierName: string;
+  paymentTerms: string | null;
+  status: string;
+  expirationDate: string | null;
+  linkedOrderId: string | null;
+  notes: string | null;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type SupplierQuoteItem = {
+  id: string;
+  quoteId: string;
+  productId: string | null;
+  productName: string;
+  quantity: number;
+  unitPrice: number;
+  note: string | null;
+  unitType: string;
+};
+
+type SupplierQuoteRow = {
+  id: string;
+  supplierId: string;
+  supplierName: string;
+  paymentTerms: string | null;
+  status: string;
+  expirationDate: string | Date | null;
+  linkedOrderId: string | null;
+  notes: string | null;
+  createdAt: string | number;
+  updatedAt: string | number;
+};
+
+type SupplierQuoteItemRow = {
+  id: string;
+  quoteId: string;
+  productId: string | null;
+  productName: string;
+  quantity: string | number;
+  unitPrice: string | number;
+  note: string | null;
+  unitType: string | null;
+};
+
+const QUOTE_BASE_COLUMNS = `
+  id,
+  supplier_id as "supplierId",
+  supplier_name as "supplierName",
+  payment_terms as "paymentTerms",
+  status,
+  expiration_date as "expirationDate",
+  null::varchar as "linkedOrderId",
+  notes,
+  EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt",
+  EXTRACT(EPOCH FROM updated_at) * 1000 as "updatedAt"
+`;
+
+const QUOTE_LIST_COLUMNS = `
+  id,
+  supplier_id as "supplierId",
+  supplier_name as "supplierName",
+  payment_terms as "paymentTerms",
+  status,
+  expiration_date as "expirationDate",
+  (
+    SELECT ss.id
+    FROM supplier_sales ss
+    WHERE ss.linked_quote_id = supplier_quotes.id
+    LIMIT 1
+  ) as "linkedOrderId",
+  notes,
+  EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt",
+  EXTRACT(EPOCH FROM updated_at) * 1000 as "updatedAt"
+`;
+
+const ITEM_COLUMNS = `
+  id,
+  quote_id as "quoteId",
+  product_id as "productId",
+  product_name as "productName",
+  quantity,
+  unit_price as "unitPrice",
+  note,
+  unit_type as "unitType"
+`;
+
+const mapQuote = (row: SupplierQuoteRow): SupplierQuote => ({
+  id: row.id,
+  supplierId: row.supplierId,
+  supplierName: row.supplierName,
+  paymentTerms: row.paymentTerms,
+  status: row.status,
+  expirationDate: normalizeNullableDateOnly(row.expirationDate, 'supplierQuote.expirationDate'),
+  linkedOrderId: row.linkedOrderId,
+  notes: row.notes,
+  createdAt: parseDbNumber(row.createdAt, 0),
+  updatedAt: parseDbNumber(row.updatedAt, 0),
+});
+
+const mapItem = (row: SupplierQuoteItemRow): SupplierQuoteItem => ({
+  id: row.id,
+  quoteId: row.quoteId,
+  productId: row.productId,
+  productName: row.productName,
+  quantity: parseDbNumber(row.quantity, 0),
+  unitPrice: parseDbNumber(row.unitPrice, 0),
+  note: row.note,
+  unitType: row.unitType ?? 'unit',
+});
+
+export const listAll = async (exec: QueryExecutor = pool): Promise<SupplierQuote[]> => {
+  const { rows } = await exec.query<SupplierQuoteRow>(
+    `SELECT ${QUOTE_LIST_COLUMNS}
+       FROM supplier_quotes
+       ORDER BY created_at DESC`,
+  );
+  return rows.map(mapQuote);
+};
+
+export const listAllItems = async (exec: QueryExecutor = pool): Promise<SupplierQuoteItem[]> => {
+  const { rows } = await exec.query<SupplierQuoteItemRow>(
+    `SELECT ${ITEM_COLUMNS}
+       FROM supplier_quote_items
+       ORDER BY created_at ASC`,
+  );
+  return rows.map(mapItem);
+};
+
+export const findById = async (
+  id: string,
+  exec: QueryExecutor = pool,
+): Promise<SupplierQuote | null> => {
+  const { rows } = await exec.query<SupplierQuoteRow>(
+    `SELECT ${QUOTE_BASE_COLUMNS} FROM supplier_quotes WHERE id = $1`,
+    [id],
+  );
+  if (!rows[0]) return null;
+  return mapQuote(rows[0]);
+};
+
+export const findItemsForQuote = async (
+  quoteId: string,
+  exec: QueryExecutor = pool,
+): Promise<SupplierQuoteItem[]> => {
+  const { rows } = await exec.query<SupplierQuoteItemRow>(
+    `SELECT ${ITEM_COLUMNS} FROM supplier_quote_items WHERE quote_id = $1`,
+    [quoteId],
+  );
+  return rows.map(mapItem);
+};
+
+export const findLinkedOrderId = async (
+  quoteId: string,
+  exec: QueryExecutor = pool,
+): Promise<string | null> => {
+  const { rows } = await exec.query<{ id: string }>(
+    `SELECT id FROM supplier_sales WHERE linked_quote_id = $1 LIMIT 1`,
+    [quoteId],
+  );
+  return rows[0]?.id ?? null;
+};
+
+export const findIdConflict = async (
+  newId: string,
+  currentId: string,
+  exec: QueryExecutor = pool,
+): Promise<boolean> => {
+  const { rows } = await exec.query<{ id: string }>(
+    `SELECT id FROM supplier_quotes WHERE id = $1 AND id <> $2`,
+    [newId, currentId],
+  );
+  return rows.length > 0;
+};
+
+export type NewSupplierQuote = {
+  id: string;
+  supplierId: string;
+  supplierName: string;
+  paymentTerms: string;
+  status: string;
+  expirationDate: string;
+  notes: string | null;
+};
+
+export const create = async (
+  input: NewSupplierQuote,
+  exec: QueryExecutor = pool,
+): Promise<SupplierQuote> => {
+  const { rows } = await exec.query<SupplierQuoteRow>(
+    `INSERT INTO supplier_quotes (
+       id, supplier_id, supplier_name, payment_terms, status, expiration_date, notes
+     ) VALUES ($1, $2, $3, $4, $5, $6, $7)
+     RETURNING ${QUOTE_BASE_COLUMNS}`,
+    [
+      input.id,
+      input.supplierId,
+      input.supplierName,
+      input.paymentTerms,
+      input.status,
+      input.expirationDate,
+      input.notes,
+    ],
+  );
+  return mapQuote(rows[0]);
+};
+
+export type SupplierQuoteUpdate = {
+  id?: string;
+  supplierId?: string | null;
+  supplierName?: string | null;
+  paymentTerms?: string;
+  status?: string;
+  expirationDate?: string | null;
+  notes?: string | null;
+};
+
+export const update = async (
+  id: string,
+  patch: SupplierQuoteUpdate,
+  exec: QueryExecutor = pool,
+): Promise<SupplierQuote | null> => {
+  const sets: string[] = [];
+  const params: unknown[] = [];
+  let idx = 1;
+  const fields: Array<[string, unknown]> = [
+    ['id', patch.id],
+    ['supplier_id', patch.supplierId],
+    ['supplier_name', patch.supplierName],
+    ['payment_terms', patch.paymentTerms],
+    ['status', patch.status],
+    ['expiration_date', patch.expirationDate],
+    ['notes', patch.notes],
+  ];
+  for (const [col, value] of fields) {
+    if (value !== undefined) {
+      sets.push(`${col} = $${idx++}`);
+      params.push(value);
+    }
+  }
+
+  if (sets.length === 0) {
+    const { rows } = await exec.query<SupplierQuoteRow>(
+      `SELECT ${QUOTE_BASE_COLUMNS} FROM supplier_quotes WHERE id = $1`,
+      [id],
+    );
+    if (!rows[0]) return null;
+    return mapQuote(rows[0]);
+  }
+
+  sets.push(`updated_at = CURRENT_TIMESTAMP`);
+  params.push(id);
+  const { rows } = await exec.query<SupplierQuoteRow>(
+    `UPDATE supplier_quotes SET ${sets.join(', ')} WHERE id = $${idx} RETURNING ${QUOTE_BASE_COLUMNS}`,
+    params,
+  );
+  if (!rows[0]) return null;
+  return mapQuote(rows[0]);
+};
+
+export const deleteById = async (
+  id: string,
+  exec: QueryExecutor = pool,
+): Promise<{ supplierName: string } | null> => {
+  const { rows } = await exec.query<{ supplier_name: string }>(
+    `DELETE FROM supplier_quotes WHERE id = $1 RETURNING supplier_name`,
+    [id],
+  );
+  if (!rows[0]) return null;
+  return { supplierName: rows[0].supplier_name };
+};
+
+export type NewSupplierQuoteItem = {
+  id: string;
+  productId: string | null;
+  productName: string;
+  quantity: number;
+  unitPrice: number;
+  note: string | null;
+  unitType: string;
+};
+
+export const replaceItems = async (
+  quoteId: string,
+  items: NewSupplierQuoteItem[],
+  exec: QueryExecutor,
+): Promise<SupplierQuoteItem[]> => {
+  await exec.query(`DELETE FROM supplier_quote_items WHERE quote_id = $1`, [quoteId]);
+  if (items.length === 0) return [];
+  const FIELDS_PER_ROW = 8;
+  const placeholders = items
+    .map((_, i) => {
+      const base = i * FIELDS_PER_ROW;
+      return `($${base + 1}, $${base + 2}, $${base + 3}, $${base + 4}, $${base + 5}, $${base + 6}, $${base + 7}, $${base + 8})`;
+    })
+    .join(', ');
+  const params = items.flatMap((item) => [
+    item.id,
+    quoteId,
+    item.productId,
+    item.productName,
+    item.quantity,
+    item.unitPrice,
+    item.note,
+    item.unitType,
+  ]);
+  const { rows } = await exec.query<SupplierQuoteItemRow>(
+    `INSERT INTO supplier_quote_items (
+       id, quote_id, product_id, product_name, quantity, unit_price, note, unit_type
+     ) VALUES ${placeholders}
+     RETURNING ${ITEM_COLUMNS}`,
+    params,
+  );
+  return rows.map(mapItem);
+};

--- a/server/repositories/suppliersRepo.ts
+++ b/server/repositories/suppliersRepo.ts
@@ -1,0 +1,180 @@
+import pool, { type QueryExecutor } from '../db/index.ts';
+
+export type Supplier = {
+  id: string;
+  name: string;
+  isDisabled: boolean;
+  supplierCode: string | null;
+  contactName: string | null;
+  email: string | null;
+  phone: string | null;
+  address: string | null;
+  vatNumber: string | null;
+  taxCode: string | null;
+  paymentTerms: string | null;
+  notes: string | null;
+  createdAt: number | undefined;
+};
+
+type SupplierRaw = {
+  id: string;
+  name: string;
+  is_disabled: boolean;
+  supplier_code: string | null;
+  contact_name: string | null;
+  email: string | null;
+  phone: string | null;
+  address: string | null;
+  vat_number: string | null;
+  tax_code: string | null;
+  payment_terms: string | null;
+  notes: string | null;
+  created_at: string | Date | null;
+};
+
+const SUPPLIER_COLUMNS = `id, name, is_disabled, supplier_code, contact_name, email, phone, address, vat_number, tax_code, payment_terms, notes, created_at`;
+
+const mapRow = (row: SupplierRaw): Supplier => ({
+  id: row.id,
+  name: row.name,
+  isDisabled: row.is_disabled,
+  supplierCode: row.supplier_code,
+  contactName: row.contact_name,
+  email: row.email,
+  phone: row.phone,
+  address: row.address,
+  vatNumber: row.vat_number,
+  taxCode: row.tax_code,
+  paymentTerms: row.payment_terms,
+  notes: row.notes,
+  createdAt: row.created_at ? new Date(row.created_at).getTime() : undefined,
+});
+
+export const listAll = async (exec: QueryExecutor = pool): Promise<Supplier[]> => {
+  const { rows } = await exec.query<SupplierRaw>(
+    `SELECT ${SUPPLIER_COLUMNS} FROM suppliers ORDER BY name`,
+  );
+  return rows.map(mapRow);
+};
+
+export const findById = async (
+  id: string,
+  exec: QueryExecutor = pool,
+): Promise<Supplier | null> => {
+  const { rows } = await exec.query<SupplierRaw>(
+    `SELECT ${SUPPLIER_COLUMNS} FROM suppliers WHERE id = $1`,
+    [id],
+  );
+  return rows[0] ? mapRow(rows[0]) : null;
+};
+
+export type NewSupplier = {
+  id: string;
+  name: string;
+  supplierCode: string | null;
+  contactName: string | null;
+  email: string | null;
+  phone: string | null;
+  address: string | null;
+  vatNumber: string | null;
+  taxCode: string | null;
+  paymentTerms: string | null;
+  notes: string | null;
+  createdAt: number;
+};
+
+export const create = async (input: NewSupplier, exec: QueryExecutor = pool): Promise<Supplier> => {
+  const { rows } = await exec.query<SupplierRaw>(
+    `INSERT INTO suppliers (
+       id, name, is_disabled, supplier_code, contact_name, email, phone,
+       address, vat_number, tax_code, payment_terms, notes, created_at
+     ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, to_timestamp($13 / 1000.0))
+     RETURNING ${SUPPLIER_COLUMNS}`,
+    [
+      input.id,
+      input.name,
+      false,
+      input.supplierCode,
+      input.contactName,
+      input.email,
+      input.phone,
+      input.address,
+      input.vatNumber,
+      input.taxCode,
+      input.paymentTerms,
+      input.notes,
+      input.createdAt,
+    ],
+  );
+  return mapRow(rows[0]);
+};
+
+export type SupplierUpdate = {
+  name?: string;
+  isDisabled?: boolean;
+  supplierCode?: string | null;
+  contactName?: string | null;
+  email?: string | null;
+  phone?: string | null;
+  address?: string | null;
+  vatNumber?: string | null;
+  taxCode?: string | null;
+  paymentTerms?: string | null;
+  notes?: string | null;
+};
+
+export const update = async (
+  id: string,
+  patch: SupplierUpdate,
+  exec: QueryExecutor = pool,
+): Promise<Supplier | null> => {
+  const sets: string[] = [];
+  const params: unknown[] = [];
+  let idx = 1;
+  const fields: Array<[string, unknown]> = [
+    ['name', patch.name],
+    ['is_disabled', patch.isDisabled],
+    ['supplier_code', patch.supplierCode],
+    ['contact_name', patch.contactName],
+    ['email', patch.email],
+    ['phone', patch.phone],
+    ['address', patch.address],
+    ['vat_number', patch.vatNumber],
+    ['tax_code', patch.taxCode],
+    ['payment_terms', patch.paymentTerms],
+    ['notes', patch.notes],
+  ];
+  for (const [col, value] of fields) {
+    if (value !== undefined) {
+      sets.push(`${col} = $${idx++}`);
+      params.push(value);
+    }
+  }
+
+  if (sets.length === 0) {
+    const { rows } = await exec.query<SupplierRaw>(
+      `SELECT ${SUPPLIER_COLUMNS} FROM suppliers WHERE id = $1`,
+      [id],
+    );
+    return rows[0] ? mapRow(rows[0]) : null;
+  }
+
+  params.push(id);
+  const { rows } = await exec.query<SupplierRaw>(
+    `UPDATE suppliers SET ${sets.join(', ')} WHERE id = $${idx} RETURNING ${SUPPLIER_COLUMNS}`,
+    params,
+  );
+  return rows[0] ? mapRow(rows[0]) : null;
+};
+
+export const deleteById = async (
+  id: string,
+  exec: QueryExecutor = pool,
+): Promise<{ name: string; supplierCode: string | null } | null> => {
+  const { rows } = await exec.query<{ name: string; supplier_code: string | null }>(
+    `DELETE FROM suppliers WHERE id = $1 RETURNING name, supplier_code`,
+    [id],
+  );
+  if (!rows[0]) return null;
+  return { name: rows[0].name, supplierCode: rows[0].supplier_code };
+};

--- a/server/routes/supplier-invoices.ts
+++ b/server/routes/supplier-invoices.ts
@@ -1,10 +1,12 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
-import { query } from '../db/index.ts';
+import { withTransaction } from '../db/index.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
+import * as supplierInvoicesRepo from '../repositories/supplierInvoicesRepo.ts';
+import * as supplierOrdersRepo from '../repositories/supplierOrdersRepo.ts';
 import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
 import { logAudit } from '../utils/audit.ts';
-import { normalizeNullableDateOnly } from '../utils/date.ts';
 import { type DatabaseError, isUniqueViolation } from '../utils/db-errors.ts';
+import { generateItemId } from '../utils/order-ids.ts';
 import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
@@ -148,8 +150,11 @@ type SupplierInvoiceItemInput = {
   discount?: string | number;
 };
 
-const normalizeItems = (items: SupplierInvoiceItemInput[], reply: FastifyReply) => {
-  const normalizedItems: Array<Record<string, unknown>> = [];
+const normalizeItems = (
+  items: SupplierInvoiceItemInput[],
+  reply: FastifyReply,
+): supplierInvoicesRepo.NewSupplierInvoiceItem[] | null => {
+  const normalizedItems: supplierInvoicesRepo.NewSupplierInvoiceItem[] = [];
   for (let i = 0; i < items.length; i++) {
     const item = items[i];
     const descriptionResult = requireNonEmptyString(item.description, `items[${i}].description`);
@@ -179,6 +184,7 @@ const normalizeItems = (items: SupplierInvoiceItemInput[], reply: FastifyReply) 
       return null;
     }
     normalizedItems.push({
+      id: generateItemId('sinv-item-'),
       productId: item.productId || null,
       description: descriptionResult.value,
       quantity: quantityResult.value,
@@ -189,49 +195,12 @@ const normalizeItems = (items: SupplierInvoiceItemInput[], reply: FastifyReply) 
   return normalizedItems;
 };
 
-const toRequiredDateOnly = (value: unknown, fieldName: string) => {
-  const normalizedDate = normalizeNullableDateOnly(value, fieldName);
-  if (!normalizedDate) {
-    throw new TypeError(`Invalid date value for ${fieldName}`);
-  }
-  return normalizedDate;
-};
-
 const generateSupplierInvoiceId = async (issueDate: string) => {
   const year = issueDate.split('-')[0];
-  const matchingInvoicesResult = await query(
-    `SELECT COALESCE(MAX(CAST(split_part(id, '-', 3) AS INTEGER)), 0) as "maxSequence"
-     FROM supplier_invoices
-     WHERE id ~ $1`,
-    [`^SINV-${year}-[0-9]+$`],
-  );
-  const nextSequence = Number(matchingInvoicesResult.rows[0]?.maxSequence ?? 0) + 1;
+  const maxSequence = await supplierInvoicesRepo.maxSequenceForYear(year);
+  const nextSequence = maxSequence + 1;
   return `SINV-${year}-${String(nextSequence).padStart(4, '0')}`;
 };
-
-const formatInvoiceResponse = (
-  invoice: {
-    issueDate: string | Date;
-    dueDate: string | Date;
-    subtotal: string | number;
-    total: string | number;
-    amountPaid: string | number;
-  } & Record<string, unknown>,
-  items: Array<Record<string, unknown>>,
-) => ({
-  ...invoice,
-  issueDate: toRequiredDateOnly(invoice.issueDate, 'supplierInvoice.issueDate'),
-  dueDate: toRequiredDateOnly(invoice.dueDate, 'supplierInvoice.dueDate'),
-  subtotal: Number(invoice.subtotal ?? 0),
-  total: Number(invoice.total ?? 0),
-  amountPaid: Number(invoice.amountPaid ?? 0),
-  items: items.map((item) => ({
-    ...item,
-    quantity: Number(item.quantity ?? 0),
-    unitPrice: Number(item.unitPrice ?? 0),
-    discount: Number(item.discount ?? 0),
-  })),
-});
 
 export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.addHook('onRequest', authenticateToken);
@@ -253,58 +222,19 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       },
     },
     async () => {
-      const invoicesResult = await query(
-        `SELECT
-            si.id,
-            si.linked_sale_id as "linkedSaleId",
-            si.supplier_id as "supplierId",
-            si.supplier_name as "supplierName",
-            si.issue_date as "issueDate",
-            si.due_date as "dueDate",
-            si.status,
-            si.subtotal,
-            si.total,
-            si.amount_paid as "amountPaid",
-            si.notes,
-            EXTRACT(EPOCH FROM si.created_at) * 1000 as "createdAt",
-            EXTRACT(EPOCH FROM si.updated_at) * 1000 as "updatedAt"
-         FROM supplier_invoices si
-         ORDER BY si.created_at DESC`,
-      );
-
-      const itemsResult = await query(
-        `SELECT
-            id,
-            invoice_id as "invoiceId",
-            product_id as "productId",
-            description,
-            quantity,
-            unit_price as "unitPrice",
-            discount
-         FROM supplier_invoice_items
-         ORDER BY created_at ASC`,
-      );
-
-      const itemsByInvoice: Record<string, Array<Record<string, unknown>>> = {};
-      itemsResult.rows.forEach((item: { invoiceId: string } & Record<string, unknown>) => {
-        if (!itemsByInvoice[item.invoiceId]) {
-          itemsByInvoice[item.invoiceId] = [];
-        }
+      const [invoices, items] = await Promise.all([
+        supplierInvoicesRepo.listAll(),
+        supplierInvoicesRepo.listAllItems(),
+      ]);
+      const itemsByInvoice: Record<string, supplierInvoicesRepo.SupplierInvoiceItem[]> = {};
+      for (const item of items) {
+        if (!itemsByInvoice[item.invoiceId]) itemsByInvoice[item.invoiceId] = [];
         itemsByInvoice[item.invoiceId].push(item);
-      });
-
-      return invoicesResult.rows.map(
-        (
-          invoice: {
-            id: string;
-            issueDate: string | Date;
-            dueDate: string | Date;
-            subtotal: string | number;
-            total: string | number;
-            amountPaid: string | number;
-          } & Record<string, unknown>,
-        ) => formatInvoiceResponse(invoice, itemsByInvoice[invoice.id] || []),
-      );
+      }
+      return invoices.map((invoice) => ({
+        ...invoice,
+        items: itemsByInvoice[invoice.id] || [],
+      }));
     },
   );
 
@@ -387,69 +317,61 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       if (!amountPaidResult.ok) return badRequest(reply, amountPaidResult.message);
 
       if (linkedSaleIdResult.value) {
-        const orderResult = await query('SELECT id, status FROM supplier_sales WHERE id = $1', [
-          linkedSaleIdResult.value,
+        const [sourceOrder, existingInvoiceId] = await Promise.all([
+          supplierOrdersRepo.findById(linkedSaleIdResult.value),
+          supplierInvoicesRepo.findInvoiceForLinkedSale(linkedSaleIdResult.value),
         ]);
-        if (orderResult.rows.length === 0) {
+        if (!sourceOrder) {
           return reply.code(404).send({ error: 'Source order not found' });
         }
-        if (orderResult.rows[0].status !== 'sent') {
+        if (sourceOrder.status !== 'sent') {
           return reply.code(409).send({ error: 'Invoices can only be created from sent orders' });
         }
-
-        const existingInvoiceResult = await query(
-          'SELECT id FROM supplier_invoices WHERE linked_sale_id = $1 LIMIT 1',
-          [linkedSaleIdResult.value],
-        );
-        if (existingInvoiceResult.rows.length > 0) {
+        if (existingInvoiceId) {
           return reply.code(409).send({ error: 'An invoice already exists for this order' });
         }
       }
 
       const maxInsertAttempts = nextIdResult.value ? 1 : 5;
 
-      try {
-        let invoiceResult: Awaited<ReturnType<typeof query>> | null = null;
-        let resolvedInvoiceId = nextIdResult.value;
+      let resolvedInvoiceId: string | null = nextIdResult.value;
+      let result: {
+        invoice: supplierInvoicesRepo.SupplierInvoice;
+        items: supplierInvoicesRepo.SupplierInvoiceItem[];
+      } | null = null;
 
+      try {
         for (let attempt = 0; attempt < maxInsertAttempts; attempt++) {
           if (!resolvedInvoiceId) {
             resolvedInvoiceId = await generateSupplierInvoiceId(issueDateResult.value);
           }
 
           try {
-            invoiceResult = await query(
-              `INSERT INTO supplier_invoices
-                (id, linked_sale_id, supplier_id, supplier_name, issue_date, due_date, status, subtotal, total, amount_paid, notes)
-               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-               RETURNING
-                  id,
-                  linked_sale_id as "linkedSaleId",
-                  supplier_id as "supplierId",
-                  supplier_name as "supplierName",
-                  issue_date as "issueDate",
-                  due_date as "dueDate",
-                  status,
-                  subtotal,
-                  total,
-                  amount_paid as "amountPaid",
-                  notes,
-                  EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt",
-                  EXTRACT(EPOCH FROM updated_at) * 1000 as "updatedAt"`,
-              [
-                resolvedInvoiceId,
-                linkedSaleIdResult.value || null,
-                supplierIdResult.value,
-                supplierNameResult.value,
-                issueDateResult.value,
-                dueDateResult.value,
-                status || 'draft',
-                subtotalResult.value || 0,
-                totalResult.value || 0,
-                amountPaidResult.value || 0,
-                notes || null,
-              ],
-            );
+            const idForAttempt = resolvedInvoiceId;
+            result = await withTransaction(async (tx) => {
+              const invoice = await supplierInvoicesRepo.create(
+                {
+                  id: idForAttempt,
+                  linkedSaleId: linkedSaleIdResult.value || null,
+                  supplierId: supplierIdResult.value,
+                  supplierName: supplierNameResult.value,
+                  issueDate: issueDateResult.value,
+                  dueDate: dueDateResult.value,
+                  status: typeof status === 'string' && status.length > 0 ? status : 'draft',
+                  subtotal: subtotalResult.value || 0,
+                  total: totalResult.value || 0,
+                  amountPaid: amountPaidResult.value || 0,
+                  notes: typeof notes === 'string' ? notes : null,
+                },
+                tx,
+              );
+              const createdItems = await supplierInvoicesRepo.replaceItems(
+                invoice.id,
+                normalizedItems,
+                tx,
+              );
+              return { invoice, items: createdItems };
+            });
             break;
           } catch (error) {
             if (
@@ -465,49 +387,24 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           }
         }
 
-        if (!invoiceResult || !resolvedInvoiceId) {
+        if (!result) {
           return reply.code(409).send({ error: 'Invoice ID already exists' });
-        }
-
-        const createdItems: Array<Record<string, unknown>> = [];
-        for (const item of normalizedItems) {
-          const itemId = `sinv-item-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
-          const itemResult = await query(
-            `INSERT INTO supplier_invoice_items
-              (id, invoice_id, product_id, description, quantity, unit_price, discount)
-             VALUES ($1, $2, $3, $4, $5, $6, $7)
-             RETURNING
-                id,
-                invoice_id as "invoiceId",
-                product_id as "productId",
-                description,
-                quantity,
-                unit_price as "unitPrice",
-                discount`,
-            [
-              itemId,
-              resolvedInvoiceId,
-              item.productId || null,
-              item.description,
-              item.quantity,
-              item.unitPrice,
-              item.discount || 0,
-            ],
-          );
-          createdItems.push(itemResult.rows[0]);
         }
 
         await logAudit({
           request,
           action: 'supplier_invoice.created',
           entityType: 'supplier_invoice',
-          entityId: resolvedInvoiceId,
+          entityId: result.invoice.id,
           details: {
-            targetLabel: resolvedInvoiceId,
-            secondaryLabel: supplierNameResult.value,
+            targetLabel: result.invoice.id,
+            secondaryLabel: result.invoice.supplierName,
           },
         });
-        return reply.code(201).send(formatInvoiceResponse(invoiceResult.rows[0], createdItems));
+        return reply.code(201).send({
+          ...result.invoice,
+          items: result.items,
+        });
       } catch (error) {
         if (isUniqueViolation(error)) {
           return reply.code(409).send({ error: duplicateInvoiceError(error) });
@@ -563,65 +460,54 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
 
-      let supplierIdValue = supplierId;
+      const patch: supplierInvoicesRepo.SupplierInvoiceUpdate = {};
+
       if (supplierId !== undefined) {
         const supplierIdResult = optionalNonEmptyString(supplierId, 'supplierId');
         if (!supplierIdResult.ok) return badRequest(reply, supplierIdResult.message);
-        supplierIdValue = supplierIdResult.value;
+        if (supplierIdResult.value !== null) patch.supplierId = supplierIdResult.value;
       }
 
-      let supplierNameValue = supplierName;
       if (supplierName !== undefined) {
         const supplierNameResult = optionalNonEmptyString(supplierName, 'supplierName');
         if (!supplierNameResult.ok) return badRequest(reply, supplierNameResult.message);
-        supplierNameValue = supplierNameResult.value;
+        if (supplierNameResult.value !== null) patch.supplierName = supplierNameResult.value;
       }
 
-      let nextIdValue = nextId;
+      let nextIdValue: string | null = null;
       if (nextId !== undefined) {
         const nextIdResult = optionalNonEmptyString(nextId, 'id');
         if (!nextIdResult.ok) return badRequest(reply, nextIdResult.message);
         nextIdValue = nextIdResult.value;
-        if (nextIdResult.value) {
-          const existingIdResult = await query(
-            'SELECT id FROM supplier_invoices WHERE id = $1 AND id <> $2',
-            [nextIdResult.value, idResult.value],
-          );
-          if (existingIdResult.rows.length > 0) {
-            return reply.code(409).send({ error: 'Invoice ID already exists' });
-          }
-        }
       }
 
-      let issueDateValue = issueDate;
       if (issueDate !== undefined) {
         const issueDateResult = optionalDateString(issueDate, 'issueDate');
         if (!issueDateResult.ok) return badRequest(reply, issueDateResult.message);
-        issueDateValue = issueDateResult.value;
+        if (issueDateResult.value !== null) patch.issueDate = issueDateResult.value;
       }
 
-      let dueDateValue = dueDate;
       if (dueDate !== undefined) {
         const dueDateResult = optionalDateString(dueDate, 'dueDate');
         if (!dueDateResult.ok) return badRequest(reply, dueDateResult.message);
-        dueDateValue = dueDateResult.value;
+        if (dueDateResult.value !== null) patch.dueDate = dueDateResult.value;
       }
 
-      const existingInvoiceResult = await query(
-        `SELECT
-            id,
-            status,
-            issue_date as "issueDate",
-            due_date as "dueDate"
-         FROM supplier_invoices
-         WHERE id = $1`,
-        [idResult.value],
-      );
-      if (existingInvoiceResult.rows.length === 0) {
+      const [existingInvoice, idConflict] = await Promise.all([
+        supplierInvoicesRepo.findExistingForUpdate(idResult.value),
+        nextIdValue
+          ? supplierInvoicesRepo.findIdConflict(nextIdValue, idResult.value)
+          : Promise.resolve(false),
+      ]);
+
+      if (!existingInvoice) {
         return reply.code(404).send({ error: 'Invoice not found' });
       }
+      if (idConflict) {
+        return reply.code(409).send({ error: 'Invoice ID already exists' });
+      }
+      if (nextIdValue !== null) patch.id = nextIdValue;
 
-      const existingInvoice = existingInvoiceResult.rows[0];
       const hasLockedFieldUpdates =
         supplierId !== undefined ||
         supplierName !== undefined ||
@@ -639,165 +525,86 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         });
       }
 
-      const effectiveIssueDate = toRequiredDateOnly(
-        issueDateValue ?? existingInvoiceResult.rows[0].issueDate,
-        'supplierInvoice.issueDate',
-      );
-      const effectiveDueDate = toRequiredDateOnly(
-        dueDateValue ?? existingInvoiceResult.rows[0].dueDate,
-        'supplierInvoice.dueDate',
-      );
+      const effectiveIssueDate = patch.issueDate ?? existingInvoice.issueDate;
+      const effectiveDueDate = patch.dueDate ?? existingInvoice.dueDate;
 
       if (effectiveDueDate < effectiveIssueDate) {
         return badRequest(reply, 'dueDate must be on or after issueDate');
       }
 
-      let subtotalValue = subtotal;
       if (subtotal !== undefined) {
         const subtotalResult = optionalLocalizedNonNegativeNumber(subtotal, 'subtotal');
         if (!subtotalResult.ok) return badRequest(reply, subtotalResult.message);
-        subtotalValue = subtotalResult.value;
+        if (subtotalResult.value !== null) patch.subtotal = subtotalResult.value;
       }
 
-      let totalValue = total;
       if (total !== undefined) {
         const totalResult = optionalLocalizedNonNegativeNumber(total, 'total');
         if (!totalResult.ok) return badRequest(reply, totalResult.message);
-        totalValue = totalResult.value;
+        if (totalResult.value !== null) patch.total = totalResult.value;
       }
 
-      let amountPaidValue = amountPaid;
       if (amountPaid !== undefined) {
         const amountPaidResult = optionalLocalizedNonNegativeNumber(amountPaid, 'amountPaid');
         if (!amountPaidResult.ok) return badRequest(reply, amountPaidResult.message);
-        amountPaidValue = amountPaidResult.value;
+        if (amountPaidResult.value !== null) patch.amountPaid = amountPaidResult.value;
       }
 
-      try {
-        const invoiceResult = await query(
-          `UPDATE supplier_invoices
-           SET id = COALESCE($1, id),
-               supplier_id = COALESCE($2, supplier_id),
-               supplier_name = COALESCE($3, supplier_name),
-               issue_date = COALESCE($4, issue_date),
-               due_date = COALESCE($5, due_date),
-               status = COALESCE($6, status),
-               subtotal = COALESCE($7, subtotal),
-               total = COALESCE($8, total),
-               amount_paid = COALESCE($9, amount_paid),
-               notes = COALESCE($10, notes),
-               updated_at = CURRENT_TIMESTAMP
-           WHERE id = $11
-           RETURNING
-              id,
-              linked_sale_id as "linkedSaleId",
-              supplier_id as "supplierId",
-              supplier_name as "supplierName",
-              issue_date as "issueDate",
-              due_date as "dueDate",
-              status,
-              subtotal,
-              total,
-              amount_paid as "amountPaid",
-              notes,
-              EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt",
-              EXTRACT(EPOCH FROM updated_at) * 1000 as "updatedAt"`,
-          [
-            nextIdValue,
-            supplierIdValue,
-            supplierNameValue,
-            issueDateValue,
-            dueDateValue,
-            status,
-            subtotalValue,
-            totalValue,
-            amountPaidValue,
-            notes,
-            idResult.value,
-          ],
-        );
+      if (typeof status === 'string') patch.status = status;
+      if (typeof notes === 'string') patch.notes = notes;
 
-        const updatedInvoiceId = String(invoiceResult.rows[0].id);
-
-        let updatedItems: Array<Record<string, unknown>> = [];
-        if (items !== undefined) {
-          if (!Array.isArray(items) || items.length === 0) {
-            return badRequest(reply, 'Items must be a non-empty array');
-          }
-          const normalizedItems = normalizeItems(items, reply);
-          if (!normalizedItems) return;
-
-          await query('DELETE FROM supplier_invoice_items WHERE invoice_id = $1', [
-            updatedInvoiceId,
-          ]);
-
-          for (const item of normalizedItems) {
-            const itemId = `sinv-item-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
-            const itemResult = await query(
-              `INSERT INTO supplier_invoice_items
-                (id, invoice_id, product_id, description, quantity, unit_price, discount)
-               VALUES ($1, $2, $3, $4, $5, $6, $7)
-               RETURNING
-                  id,
-                  invoice_id as "invoiceId",
-                  product_id as "productId",
-                  description,
-                  quantity,
-                  unit_price as "unitPrice",
-                  discount`,
-              [
-                itemId,
-                updatedInvoiceId,
-                item.productId || null,
-                item.description,
-                item.quantity,
-                item.unitPrice,
-                item.discount || 0,
-              ],
-            );
-            updatedItems.push(itemResult.rows[0]);
-          }
-        } else {
-          const itemsResult = await query(
-            `SELECT
-                id,
-                invoice_id as "invoiceId",
-                product_id as "productId",
-                description,
-                quantity,
-                unit_price as "unitPrice",
-                discount
-             FROM supplier_invoice_items
-             WHERE invoice_id = $1`,
-            [updatedInvoiceId],
-          );
-          updatedItems = itemsResult.rows;
+      let normalizedItems: supplierInvoicesRepo.NewSupplierInvoiceItem[] | null = null;
+      if (items !== undefined) {
+        if (!Array.isArray(items) || items.length === 0) {
+          return badRequest(reply, 'Items must be a non-empty array');
         }
+        normalizedItems = normalizeItems(items, reply);
+        if (!normalizedItems) return;
+      }
 
-        const nextStatus =
-          typeof status === 'string'
-            ? status
-            : String(invoiceResult.rows[0].status ?? existingInvoice.status);
-        const didStatusChange = status !== undefined && existingInvoice.status !== nextStatus;
-        await logAudit({
-          request,
-          action: 'supplier_invoice.updated',
-          entityType: 'supplier_invoice',
-          entityId: updatedInvoiceId,
-          details: {
-            targetLabel: updatedInvoiceId,
-            secondaryLabel: String(invoiceResult.rows[0].supplierName ?? ''),
-            fromValue: didStatusChange ? String(existingInvoice.status) : undefined,
-            toValue: didStatusChange ? nextStatus : undefined,
-          },
+      let updated: supplierInvoicesRepo.SupplierInvoice | null;
+      let resultItems: supplierInvoicesRepo.SupplierInvoiceItem[];
+      try {
+        const txResult = await withTransaction(async (tx) => {
+          const invoice = await supplierInvoicesRepo.update(idResult.value, patch, tx);
+          if (!invoice)
+            return { invoice: null, items: [] as supplierInvoicesRepo.SupplierInvoiceItem[] };
+          const finalItems = normalizedItems
+            ? await supplierInvoicesRepo.replaceItems(invoice.id, normalizedItems, tx)
+            : await supplierInvoicesRepo.findItemsForInvoice(invoice.id, tx);
+          return { invoice, items: finalItems };
         });
-        return formatInvoiceResponse(invoiceResult.rows[0], updatedItems);
+        updated = txResult.invoice;
+        resultItems = txResult.items;
       } catch (error) {
         if (isUniqueViolation(error)) {
           return reply.code(409).send({ error: duplicateInvoiceError(error) });
         }
         throw error;
       }
+
+      if (!updated) {
+        return reply.code(404).send({ error: 'Invoice not found' });
+      }
+
+      const didStatusChange =
+        typeof status === 'string' && existingInvoice.status !== updated.status;
+      await logAudit({
+        request,
+        action: 'supplier_invoice.updated',
+        entityType: 'supplier_invoice',
+        entityId: updated.id,
+        details: {
+          targetLabel: updated.id,
+          secondaryLabel: updated.supplierName,
+          fromValue: didStatusChange ? existingInvoice.status : undefined,
+          toValue: didStatusChange ? updated.status : undefined,
+        },
+      });
+      return {
+        ...updated,
+        items: resultItems,
+      };
     },
   );
 
@@ -820,18 +627,15 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
 
-      const invoiceResult = await query(
-        'SELECT id, status, supplier_name as "supplierName" FROM supplier_invoices WHERE id = $1',
-        [idResult.value],
-      );
-      if (invoiceResult.rows.length === 0) {
+      const existing = await supplierInvoicesRepo.findStatusAndSupplierName(idResult.value);
+      if (!existing) {
         return reply.code(404).send({ error: 'Invoice not found' });
       }
-      if (invoiceResult.rows[0].status !== 'draft') {
+      if (existing.status !== 'draft') {
         return reply.code(409).send({ error: 'Only draft invoices can be deleted' });
       }
 
-      await query('DELETE FROM supplier_invoices WHERE id = $1', [idResult.value]);
+      await supplierInvoicesRepo.deleteById(idResult.value);
 
       await logAudit({
         request,
@@ -840,7 +644,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         entityId: idResult.value,
         details: {
           targetLabel: idResult.value,
-          secondaryLabel: String(invoiceResult.rows[0].supplierName ?? ''),
+          secondaryLabel: existing.supplierName,
         },
       });
       return reply.code(204).send();

--- a/server/routes/supplier-orders.ts
+++ b/server/routes/supplier-orders.ts
@@ -1,19 +1,24 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
-import { query } from '../db/index.ts';
+import { withTransaction } from '../db/index.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
+import * as supplierOrdersRepo from '../repositories/supplierOrdersRepo.ts';
+import * as supplierQuotesRepo from '../repositories/supplierQuotesRepo.ts';
 import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
 import { logAudit } from '../utils/audit.ts';
 import { isUniqueViolation } from '../utils/db-errors.ts';
-import { generateSupplierOrderId } from '../utils/order-ids.ts';
+import { generateItemId, generateSupplierOrderId } from '../utils/order-ids.ts';
 import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
+  optionalEnum,
   optionalLocalizedNonNegativeNumber,
   optionalNonEmptyString,
   parseLocalizedNonNegativeNumber,
   parseLocalizedPositiveNumber,
   requireNonEmptyString,
 } from '../utils/validation.ts';
+
+const SUPPLIER_ORDER_STATUSES = ['draft', 'sent'] as const;
 
 const idParamSchema = {
   type: 'object',
@@ -122,26 +127,11 @@ type SupplierOrderItemInput = {
   note?: string;
 };
 
-const parseSupplierOrderStatus = (status: unknown) => {
-  if (status === undefined || status === null || status === '') {
-    return { ok: true as const, value: undefined };
-  }
-
-  if (status !== 'draft' && status !== 'sent') {
-    return {
-      ok: false as const,
-      message: 'status must be one of: draft, sent',
-    };
-  }
-
-  return {
-    ok: true as const,
-    value: status,
-  };
-};
-
-const normalizeItems = (items: SupplierOrderItemInput[], reply: FastifyReply) => {
-  const normalizedItems: Array<Record<string, unknown>> = [];
+const normalizeItems = (
+  items: SupplierOrderItemInput[],
+  reply: FastifyReply,
+): supplierOrdersRepo.NewSupplierOrderItem[] | null => {
+  const normalizedItems: supplierOrdersRepo.NewSupplierOrderItem[] = [];
   for (let i = 0; i < items.length; i++) {
     const item = items[i];
     const productNameResult = requireNonEmptyString(item.productName, `items[${i}].productName`);
@@ -171,6 +161,7 @@ const normalizeItems = (items: SupplierOrderItemInput[], reply: FastifyReply) =>
       return null;
     }
     normalizedItems.push({
+      id: generateItemId('ssi-'),
       productId: item.productId || null,
       productName: productNameResult.value,
       quantity: quantityResult.value,
@@ -202,46 +193,16 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       },
     },
     async () => {
-      const ordersResult = await query(
-        `SELECT
-            id,
-            linked_quote_id as "linkedQuoteId",
-            supplier_id as "supplierId",
-            supplier_name as "supplierName",
-            payment_terms as "paymentTerms",
-            discount,
-            discount_type as "discountType",
-            status,
-            notes,
-            EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt",
-            EXTRACT(EPOCH FROM updated_at) * 1000 as "updatedAt"
-         FROM supplier_sales
-         ORDER BY created_at DESC`,
-      );
-
-      const itemsResult = await query(
-        `SELECT
-            id,
-            sale_id as "orderId",
-            product_id as "productId",
-            product_name as "productName",
-            quantity,
-            unit_price as "unitPrice",
-            note,
-            discount
-         FROM supplier_sale_items
-         ORDER BY created_at ASC`,
-      );
-
-      const itemsByOrder: Record<string, unknown[]> = {};
-      itemsResult.rows.forEach((item: { orderId: string }) => {
-        if (!itemsByOrder[item.orderId]) {
-          itemsByOrder[item.orderId] = [];
-        }
+      const [orders, items] = await Promise.all([
+        supplierOrdersRepo.listAll(),
+        supplierOrdersRepo.listAllItems(),
+      ]);
+      const itemsByOrder: Record<string, supplierOrdersRepo.SupplierOrderItem[]> = {};
+      for (const item of items) {
+        if (!itemsByOrder[item.orderId]) itemsByOrder[item.orderId] = [];
         itemsByOrder[item.orderId].push(item);
-      });
-
-      return ordersResult.rows.map((order: { id: string }) => ({
+      }
+      return orders.map((order) => ({
         ...order,
         items: itemsByOrder[order.id] || [],
       }));
@@ -299,35 +260,24 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         return badRequest(reply, 'Items must be a non-empty array');
       }
 
-      const quoteResult = await query(
-        `SELECT
-            id,
-            supplier_id as "supplierId",
-            supplier_name as "supplierName",
-            status
-         FROM supplier_quotes
-         WHERE id = $1`,
-        [linkedQuoteIdResult.value],
-      );
-      if (quoteResult.rows.length === 0) {
+      const [sourceQuote, existingOrderId] = await Promise.all([
+        supplierQuotesRepo.findById(linkedQuoteIdResult.value),
+        supplierOrdersRepo.findExistingByLinkedQuote(linkedQuoteIdResult.value),
+      ]);
+      if (!sourceQuote) {
         return reply.code(404).send({ error: 'Source quote not found' });
       }
-      if (quoteResult.rows[0].status !== 'accepted') {
+      if (sourceQuote.status !== 'accepted') {
         return reply
           .code(409)
           .send({ error: 'Supplier orders can only be created from accepted quotes' });
       }
-
-      const existingOrderResult = await query(
-        'SELECT id FROM supplier_sales WHERE linked_quote_id = $1 LIMIT 1',
-        [linkedQuoteIdResult.value],
-      );
-      if (existingOrderResult.rows.length > 0) {
+      if (existingOrderId) {
         return reply.code(409).send({ error: 'A supplier order already exists for this quote' });
       }
       if (
-        supplierIdResult.value !== quoteResult.rows[0].supplierId ||
-        supplierNameResult.value !== quoteResult.rows[0].supplierName
+        supplierIdResult.value !== sourceQuote.supplierId ||
+        supplierNameResult.value !== sourceQuote.supplierName
       ) {
         return reply.code(409).send({ error: 'Supplier details must match the source quote' });
       }
@@ -335,42 +285,39 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const discountResult = optionalLocalizedNonNegativeNumber(discount, 'discount');
       if (!discountResult.ok) return badRequest(reply, discountResult.message);
       const discountTypeValue = discountType === 'currency' ? 'currency' : 'percentage';
-      const statusResult = parseSupplierOrderStatus(status);
+      const statusResult = optionalEnum(status, SUPPLIER_ORDER_STATUSES, 'status');
       if (!statusResult.ok) return badRequest(reply, statusResult.message);
       const normalizedItems = normalizeItems(items, reply);
       if (!normalizedItems) return;
 
       const orderId = nextIdResult.value || (await generateSupplierOrderId());
-      let createdOrderResult: Awaited<ReturnType<typeof query>>;
+
+      let result: {
+        order: supplierOrdersRepo.SupplierOrder;
+        items: supplierOrdersRepo.SupplierOrderItem[];
+      };
       try {
-        createdOrderResult = await query(
-          `INSERT INTO supplier_sales
-            (id, linked_quote_id, supplier_id, supplier_name, payment_terms, discount, discount_type, status, notes)
-           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-            RETURNING
-              id,
-              linked_quote_id as "linkedQuoteId",
-              supplier_id as "supplierId",
-              supplier_name as "supplierName",
-              payment_terms as "paymentTerms",
-              discount,
-              discount_type as "discountType",
-              status,
-              notes,
-              EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt",
-              EXTRACT(EPOCH FROM updated_at) * 1000 as "updatedAt"`,
-          [
-            orderId,
-            linkedQuoteIdResult.value,
-            supplierIdResult.value,
-            supplierNameResult.value,
-            paymentTerms || 'immediate',
-            discountResult.value || 0,
-            discountTypeValue,
-            statusResult.value || 'draft',
-            notes,
-          ],
-        );
+        result = await withTransaction(async (tx) => {
+          const order = await supplierOrdersRepo.create(
+            {
+              id: orderId,
+              linkedQuoteId: linkedQuoteIdResult.value,
+              supplierId: supplierIdResult.value,
+              supplierName: supplierNameResult.value,
+              paymentTerms:
+                typeof paymentTerms === 'string' && paymentTerms.length > 0
+                  ? paymentTerms
+                  : 'immediate',
+              discount: discountResult.value || 0,
+              discountType: discountTypeValue,
+              status: statusResult.value || 'draft',
+              notes: typeof notes === 'string' ? notes : null,
+            },
+            tx,
+          );
+          const createdItems = await supplierOrdersRepo.replaceItems(order.id, normalizedItems, tx);
+          return { order, items: createdItems };
+        });
       } catch (error) {
         if (isUniqueViolation(error)) {
           if (error.constraint === 'supplier_sales_pkey' || error.detail?.includes('(id)')) {
@@ -388,49 +335,19 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         throw error;
       }
 
-      const createdItems: unknown[] = [];
-      for (const item of normalizedItems) {
-        const itemId = 'ssi-' + Date.now() + '-' + Math.random().toString(36).slice(2, 9);
-        const itemResult = await query(
-          `INSERT INTO supplier_sale_items
-            (id, sale_id, product_id, product_name, quantity, unit_price, discount, note)
-           VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-           RETURNING
-             id,
-             sale_id as "orderId",
-             product_id as "productId",
-             product_name as "productName",
-             quantity,
-             unit_price as "unitPrice",
-             discount,
-             note`,
-          [
-            itemId,
-            orderId,
-            item.productId,
-            item.productName,
-            item.quantity,
-            item.unitPrice,
-            item.discount,
-            item.note,
-          ],
-        );
-        createdItems.push(itemResult.rows[0]);
-      }
-
       await logAudit({
         request,
         action: 'supplier_order.created',
         entityType: 'supplier_order',
-        entityId: orderId,
+        entityId: result.order.id,
         details: {
-          targetLabel: orderId,
-          secondaryLabel: supplierNameResult.value,
+          targetLabel: result.order.id,
+          secondaryLabel: result.order.supplierName,
         },
       });
       return reply.code(201).send({
-        ...createdOrderResult.rows[0],
-        items: createdItems,
+        ...result.order,
+        items: result.items,
       });
     },
   );
@@ -477,34 +394,29 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
 
-      let nextIdValue = nextId;
+      const patch: supplierOrdersRepo.SupplierOrderUpdate = {};
+
+      let nextIdValue: string | null = null;
       if (nextId !== undefined) {
         const nextIdResult = optionalNonEmptyString(nextId, 'id');
         if (!nextIdResult.ok) return badRequest(reply, nextIdResult.message);
         nextIdValue = nextIdResult.value;
-        if (nextIdResult.value) {
-          const existingIdResult = await query(
-            'SELECT id FROM supplier_sales WHERE id = $1 AND id <> $2',
-            [nextIdResult.value, idResult.value],
-          );
-          if (existingIdResult.rows.length > 0) {
-            return reply.code(409).send({ error: 'Order ID already exists' });
-          }
-        }
       }
 
-      const existingOrderResult = await query(
-        `SELECT id,
-                linked_quote_id as "linkedQuoteId",
-                supplier_id as "supplierId", supplier_name as "supplierName", status
-         FROM supplier_sales WHERE id = $1`,
-        [idResult.value],
-      );
-      if (existingOrderResult.rows.length === 0) {
+      const [existingOrder, idConflict] = await Promise.all([
+        supplierOrdersRepo.findExistingForUpdate(idResult.value),
+        nextIdValue
+          ? supplierOrdersRepo.findIdConflict(nextIdValue, idResult.value)
+          : Promise.resolve(false),
+      ]);
+
+      if (!existingOrder) {
         return reply.code(404).send({ error: 'Order not found' });
       }
-
-      const existingOrder = existingOrderResult.rows[0];
+      if (idConflict) {
+        return reply.code(409).send({ error: 'Order ID already exists' });
+      }
+      if (nextIdValue !== null) patch.id = nextIdValue;
 
       const hasLockedFieldUpdates =
         supplierId !== undefined ||
@@ -521,34 +433,24 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         });
       }
 
-      let supplierIdValue = supplierId;
       if (supplierId !== undefined) {
         const supplierIdResult = optionalNonEmptyString(supplierId, 'supplierId');
         if (!supplierIdResult.ok) return badRequest(reply, supplierIdResult.message);
-        supplierIdValue = supplierIdResult.value;
+        if (supplierIdResult.value !== null) patch.supplierId = supplierIdResult.value;
       }
 
-      let supplierNameValue = supplierName;
       if (supplierName !== undefined) {
         const supplierNameResult = optionalNonEmptyString(supplierName, 'supplierName');
         if (!supplierNameResult.ok) return badRequest(reply, supplierNameResult.message);
-        supplierNameValue = supplierNameResult.value;
+        if (supplierNameResult.value !== null) patch.supplierName = supplierNameResult.value;
       }
 
       if (existingOrder.linkedQuoteId) {
         const lockedFields: string[] = [];
-        if (
-          supplierIdValue !== undefined &&
-          supplierIdValue !== null &&
-          supplierIdValue !== existingOrder.supplierId
-        ) {
+        if (patch.supplierId !== undefined && patch.supplierId !== existingOrder.supplierId) {
           lockedFields.push('supplierId');
         }
-        if (
-          supplierNameValue !== undefined &&
-          supplierNameValue !== null &&
-          supplierNameValue !== existingOrder.supplierName
-        ) {
+        if (patch.supplierName !== undefined && patch.supplierName !== existingOrder.supplierName) {
           lockedFields.push('supplierName');
         }
         if (lockedFields.length > 0) {
@@ -559,61 +461,45 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         }
       }
 
-      let discountValue = discount;
       if (discount !== undefined) {
         const discountResult = optionalLocalizedNonNegativeNumber(discount, 'discount');
         if (!discountResult.ok) return badRequest(reply, discountResult.message);
-        discountValue = discountResult.value;
+        if (discountResult.value !== null) patch.discount = discountResult.value;
       }
 
-      const discountTypeValue =
-        discountType !== undefined
-          ? discountType === 'currency'
-            ? 'currency'
-            : 'percentage'
-          : undefined;
+      if (discountType !== undefined) {
+        patch.discountType = discountType === 'currency' ? 'currency' : 'percentage';
+      }
 
-      const statusResult = parseSupplierOrderStatus(status);
+      const statusResult = optionalEnum(status, SUPPLIER_ORDER_STATUSES, 'status');
       if (!statusResult.ok) return badRequest(reply, statusResult.message);
+      if (statusResult.value !== null) patch.status = statusResult.value;
 
-      let updatedOrderResult: Awaited<ReturnType<typeof query>>;
+      if (typeof paymentTerms === 'string') patch.paymentTerms = paymentTerms;
+      if (typeof notes === 'string') patch.notes = notes;
+
+      let normalizedItems: supplierOrdersRepo.NewSupplierOrderItem[] | null = null;
+      if (items !== undefined) {
+        if (!Array.isArray(items) || items.length === 0) {
+          return badRequest(reply, 'Items must be a non-empty array');
+        }
+        normalizedItems = normalizeItems(items, reply);
+        if (!normalizedItems) return;
+      }
+
+      let updated: supplierOrdersRepo.SupplierOrder | null;
+      let resultItems: supplierOrdersRepo.SupplierOrderItem[];
       try {
-        updatedOrderResult = await query(
-          `UPDATE supplier_sales
-           SET id = COALESCE($1, id),
-               supplier_id = COALESCE($2, supplier_id),
-               supplier_name = COALESCE($3, supplier_name),
-               payment_terms = COALESCE($4, payment_terms),
-               discount = COALESCE($5, discount),
-               discount_type = COALESCE($6, discount_type),
-               status = COALESCE($7, status),
-               notes = COALESCE($8, notes),
-               updated_at = CURRENT_TIMESTAMP
-            WHERE id = $9
-            RETURNING
-               id,
-               linked_quote_id as "linkedQuoteId",
-               supplier_id as "supplierId",
-               supplier_name as "supplierName",
-               payment_terms as "paymentTerms",
-              discount,
-              discount_type as "discountType",
-              status,
-              notes,
-              EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt",
-              EXTRACT(EPOCH FROM updated_at) * 1000 as "updatedAt"`,
-          [
-            nextIdValue,
-            supplierIdValue,
-            supplierNameValue,
-            paymentTerms,
-            discountValue,
-            discountTypeValue,
-            statusResult.value,
-            notes,
-            idResult.value,
-          ],
-        );
+        const txResult = await withTransaction(async (tx) => {
+          const order = await supplierOrdersRepo.update(idResult.value, patch, tx);
+          if (!order) return { order: null, items: [] as supplierOrdersRepo.SupplierOrderItem[] };
+          const finalItems = normalizedItems
+            ? await supplierOrdersRepo.replaceItems(order.id, normalizedItems, tx)
+            : await supplierOrdersRepo.findItemsForOrder(order.id, tx);
+          return { order, items: finalItems };
+        });
+        updated = txResult.order;
+        resultItems = txResult.items;
       } catch (error) {
         if (
           isUniqueViolation(error) &&
@@ -624,84 +510,27 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         throw error;
       }
 
-      if (updatedOrderResult.rows.length === 0) {
+      if (!updated) {
         return reply.code(404).send({ error: 'Order not found' });
       }
 
-      const updatedOrderId = String(updatedOrderResult.rows[0].id);
-
-      let updatedItems: unknown[] = [];
-      if (items !== undefined) {
-        if (!Array.isArray(items) || items.length === 0) {
-          return badRequest(reply, 'Items must be a non-empty array');
-        }
-        const normalizedItems = normalizeItems(items, reply);
-        if (!normalizedItems) return;
-        await query('DELETE FROM supplier_sale_items WHERE sale_id = $1', [updatedOrderId]);
-        for (const item of normalizedItems) {
-          const itemId = 'ssi-' + Date.now() + '-' + Math.random().toString(36).slice(2, 9);
-          const itemResult = await query(
-            `INSERT INTO supplier_sale_items
-              (id, sale_id, product_id, product_name, quantity, unit_price, discount, note)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-             RETURNING
-               id,
-               sale_id as "orderId",
-               product_id as "productId",
-               product_name as "productName",
-               quantity,
-               unit_price as "unitPrice",
-               discount,
-               note`,
-            [
-              itemId,
-              updatedOrderId,
-              item.productId,
-              item.productName,
-              item.quantity,
-              item.unitPrice,
-              item.discount,
-              item.note,
-            ],
-          );
-          updatedItems.push(itemResult.rows[0]);
-        }
-      } else {
-        const itemsResult = await query(
-          `SELECT
-              id,
-              sale_id as "orderId",
-              product_id as "productId",
-              product_name as "productName",
-              quantity,
-              unit_price as "unitPrice",
-              discount,
-              note
-           FROM supplier_sale_items
-           WHERE sale_id = $1`,
-          [updatedOrderId],
-        );
-        updatedItems = itemsResult.rows;
-      }
-
-      const nextStatus = String(updatedOrderResult.rows[0].status ?? existingOrder.status);
       const didStatusChange =
-        statusResult.value !== undefined && existingOrder.status !== nextStatus;
+        statusResult.value !== null && existingOrder.status !== updated.status;
       await logAudit({
         request,
         action: 'supplier_order.updated',
         entityType: 'supplier_order',
-        entityId: updatedOrderId,
+        entityId: updated.id,
         details: {
-          targetLabel: updatedOrderId,
-          secondaryLabel: String(updatedOrderResult.rows[0].supplierName ?? ''),
-          fromValue: didStatusChange ? String(existingOrder.status) : undefined,
-          toValue: didStatusChange ? nextStatus : undefined,
+          targetLabel: updated.id,
+          secondaryLabel: updated.supplierName,
+          fromValue: didStatusChange ? existingOrder.status : undefined,
+          toValue: didStatusChange ? updated.status : undefined,
         },
       });
       return {
-        ...updatedOrderResult.rows[0],
-        items: updatedItems,
+        ...updated,
+        items: resultItems,
       };
     },
   );
@@ -725,24 +554,19 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
 
-      const linkedInvoiceResult = await query(
-        'SELECT id FROM supplier_invoices WHERE linked_sale_id = $1 LIMIT 1',
-        [idResult.value],
-      );
-      if (linkedInvoiceResult.rows.length > 0) {
+      const [linkedInvoiceId, existing] = await Promise.all([
+        supplierOrdersRepo.findLinkedInvoiceId(idResult.value),
+        supplierOrdersRepo.findStatusAndSupplierName(idResult.value),
+      ]);
+      if (linkedInvoiceId) {
         return reply
           .code(409)
           .send({ error: 'Cannot delete an order once an invoice has been created from it' });
       }
-
-      const orderResult = await query(
-        'SELECT id, status, supplier_name as "supplierName" FROM supplier_sales WHERE id = $1',
-        [idResult.value],
-      );
-      if (orderResult.rows.length === 0) {
+      if (!existing) {
         return reply.code(404).send({ error: 'Order not found' });
       }
-      if (orderResult.rows[0].status !== 'draft') {
+      if (existing.status !== 'draft') {
         return reply.code(409).send({ error: 'Only draft orders can be deleted' });
       }
 
@@ -753,10 +577,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         entityId: idResult.value,
         details: {
           targetLabel: idResult.value,
-          secondaryLabel: String(orderResult.rows[0].supplierName ?? ''),
+          secondaryLabel: existing.supplierName,
         },
       });
-      await query('DELETE FROM supplier_sales WHERE id = $1', [idResult.value]);
+      await supplierOrdersRepo.deleteById(idResult.value);
       return reply.code(204).send();
     },
   );

--- a/server/routes/supplier-quotes.ts
+++ b/server/routes/supplier-quotes.ts
@@ -1,10 +1,11 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
-import { query } from '../db/index.ts';
+import { withTransaction } from '../db/index.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
+import * as supplierQuotesRepo from '../repositories/supplierQuotesRepo.ts';
 import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
 import { logAudit } from '../utils/audit.ts';
-import { normalizeNullableDateOnly } from '../utils/date.ts';
 import { isUniqueViolation } from '../utils/db-errors.ts';
+import { generateItemId } from '../utils/order-ids.ts';
 import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
@@ -30,7 +31,19 @@ const normalizeUnitType = (value: unknown): 'hours' | 'days' | 'unit' => {
   return 'unit';
 };
 
-const normalizeSupplierQuoteItemRow = (item: Record<string, unknown>) => ({
+const normalizeSupplierQuoteStatus = (status: string) => {
+  if (status === 'received') return 'sent';
+  if (status === 'approved') return 'accepted';
+  if (status === 'rejected') return 'denied';
+  return status;
+};
+
+const projectQuote = (quote: supplierQuotesRepo.SupplierQuote) => ({
+  ...quote,
+  status: normalizeSupplierQuoteStatus(quote.status),
+});
+
+const projectItem = (item: supplierQuotesRepo.SupplierQuoteItem) => ({
   ...item,
   unitType: normalizeUnitType(item.unitType),
 });
@@ -110,21 +123,55 @@ const supplierQuoteUpdateBodySchema = {
   },
 } as const;
 
+type ItemBody = {
+  productId?: string;
+  productName?: string;
+  quantity?: string | number;
+  unitPrice?: string | number;
+  note?: string;
+  unitType?: 'hours' | 'days' | 'unit';
+};
+
+const validateAndNormalizeItems = (
+  items: ItemBody[],
+  reply: FastifyReply,
+): supplierQuotesRepo.NewSupplierQuoteItem[] | null => {
+  const result: supplierQuotesRepo.NewSupplierQuoteItem[] = [];
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    const productNameResult = requireNonEmptyString(item.productName, `items[${i}].productName`);
+    if (!productNameResult.ok) {
+      badRequest(reply, productNameResult.message);
+      return null;
+    }
+    const quantityResult = parseLocalizedPositiveNumber(item.quantity, `items[${i}].quantity`);
+    if (!quantityResult.ok) {
+      badRequest(reply, quantityResult.message);
+      return null;
+    }
+    const unitPriceResult = parseLocalizedNonNegativeNumber(
+      item.unitPrice,
+      `items[${i}].unitPrice`,
+    );
+    if (!unitPriceResult.ok) {
+      badRequest(reply, unitPriceResult.message);
+      return null;
+    }
+    result.push({
+      id: generateItemId('sqi-'),
+      productId: item.productId || null,
+      productName: productNameResult.value,
+      quantity: quantityResult.value,
+      unitPrice: unitPriceResult.value,
+      note: item.note || null,
+      unitType: normalizeUnitType(item.unitType),
+    });
+  }
+  return result;
+};
+
 export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.addHook('onRequest', authenticateToken);
-
-  const normalizeSupplierQuoteStatus = (status: string) => {
-    if (status === 'received') return 'sent';
-    if (status === 'approved') return 'accepted';
-    if (status === 'rejected') return 'denied';
-    return status;
-  };
-
-  const normalizeSupplierQuoteRow = (quote: Record<string, unknown>) => ({
-    ...quote,
-    status: normalizeSupplierQuoteStatus(String(quote.status)),
-    expirationDate: normalizeNullableDateOnly(quote.expirationDate, 'supplierQuote.expirationDate'),
-  });
 
   fastify.get(
     '/',
@@ -143,52 +190,17 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       },
     },
     async () => {
-      const quotesResult = await query(
-        `SELECT
-        id,
-        supplier_id as "supplierId",
-        supplier_name as "supplierName",
-        payment_terms as "paymentTerms",
-        status,
-        expiration_date as "expirationDate",
-        (
-          SELECT ss.id
-          FROM supplier_sales ss
-          WHERE ss.linked_quote_id = supplier_quotes.id
-          LIMIT 1
-        ) as "linkedOrderId",
-        notes,
-        EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt",
-        EXTRACT(EPOCH FROM updated_at) * 1000 as "updatedAt"
-       FROM supplier_quotes
-       ORDER BY created_at DESC`,
-      );
-
-      const itemsResult = await query(
-        `SELECT
-        id,
-        quote_id as "quoteId",
-        product_id as "productId",
-        product_name as "productName",
-        quantity,
-        unit_price as "unitPrice",
-        note,
-        unit_type as "unitType"
-       FROM supplier_quote_items
-       ORDER BY created_at ASC`,
-      );
-
-      const itemsByQuote: Record<string, unknown[]> = {};
-      itemsResult.rows.forEach((item) => {
-        const quoteId = (item as { quoteId: string }).quoteId;
-        if (!itemsByQuote[quoteId]) {
-          itemsByQuote[quoteId] = [];
-        }
-        itemsByQuote[quoteId].push(normalizeSupplierQuoteItemRow(item as Record<string, unknown>));
-      });
-
-      return quotesResult.rows.map((quote) => ({
-        ...normalizeSupplierQuoteRow(quote as Record<string, unknown>),
+      const [quotes, items] = await Promise.all([
+        supplierQuotesRepo.listAll(),
+        supplierQuotesRepo.listAllItems(),
+      ]);
+      const itemsByQuote: Record<string, ReturnType<typeof projectItem>[]> = {};
+      for (const item of items) {
+        if (!itemsByQuote[item.quoteId]) itemsByQuote[item.quoteId] = [];
+        itemsByQuote[item.quoteId].push(projectItem(item));
+      }
+      return quotes.map((quote) => ({
+        ...projectQuote(quote),
         items: itemsByQuote[quote.id] || [],
       }));
     },
@@ -222,14 +234,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         id?: string;
         supplierId?: string;
         supplierName?: string;
-        items?: Array<{
-          productId?: string;
-          productName?: string;
-          quantity?: string | number;
-          unitPrice?: string | number;
-          note?: string;
-          unitType?: 'hours' | 'days' | 'unit';
-        }>;
+        items?: ItemBody[];
         paymentTerms?: string;
         status?: string;
         expirationDate?: string;
@@ -248,60 +253,33 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         return badRequest(reply, 'Items must be a non-empty array');
       }
 
-      const normalizedItems = [];
-      for (let i = 0; i < items.length; i++) {
-        const item = items[i];
-        const productNameResult = requireNonEmptyString(
-          item.productName,
-          `items[${i}].productName`,
-        );
-        if (!productNameResult.ok) return badRequest(reply, productNameResult.message);
-        const quantityResult = parseLocalizedPositiveNumber(item.quantity, `items[${i}].quantity`);
-        if (!quantityResult.ok) return badRequest(reply, quantityResult.message);
-        const unitPriceResult = parseLocalizedNonNegativeNumber(
-          item.unitPrice,
-          `items[${i}].unitPrice`,
-        );
-        if (!unitPriceResult.ok) return badRequest(reply, unitPriceResult.message);
-        normalizedItems.push({
-          ...item,
-          productName: productNameResult.value,
-          quantity: quantityResult.value,
-          unitPrice: unitPriceResult.value,
-          unitType: normalizeUnitType(item.unitType),
-        });
-      }
+      const normalizedItems = validateAndNormalizeItems(items, reply);
+      if (!normalizedItems) return;
 
       const expirationDateResult = parseDateString(expirationDate, 'expirationDate');
       if (!expirationDateResult.ok) return badRequest(reply, expirationDateResult.message);
 
-      let quoteResult: Awaited<ReturnType<typeof query>>;
+      let result: {
+        quote: supplierQuotesRepo.SupplierQuote;
+        items: supplierQuotesRepo.SupplierQuoteItem[];
+      };
       try {
-        quoteResult = await query(
-          `INSERT INTO supplier_quotes (
-          id, supplier_id, supplier_name, payment_terms, status, expiration_date, notes
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7)
-         RETURNING
-          id,
-          supplier_id as "supplierId",
-          supplier_name as "supplierName",
-          payment_terms as "paymentTerms",
-          status,
-          expiration_date as "expirationDate",
-          null::varchar as "linkedOrderId",
-          notes,
-          EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt",
-          EXTRACT(EPOCH FROM updated_at) * 1000 as "updatedAt"`,
-          [
-            nextIdResult.value,
-            supplierIdResult.value,
-            supplierNameResult.value,
-            paymentTerms || 'immediate',
-            status || 'draft',
-            expirationDateResult.value,
-            notes,
-          ],
-        );
+        result = await withTransaction(async (tx) => {
+          const quote = await supplierQuotesRepo.create(
+            {
+              id: nextIdResult.value,
+              supplierId: supplierIdResult.value,
+              supplierName: supplierNameResult.value,
+              paymentTerms: paymentTerms || 'immediate',
+              status: status || 'draft',
+              expirationDate: expirationDateResult.value,
+              notes: notes ?? null,
+            },
+            tx,
+          );
+          const createdItems = await supplierQuotesRepo.replaceItems(quote.id, normalizedItems, tx);
+          return { quote, items: createdItems };
+        });
       } catch (error) {
         if (
           isUniqueViolation(error) &&
@@ -312,51 +290,19 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         throw error;
       }
 
-      const createdItems = [];
-      for (const item of normalizedItems) {
-        const itemId = 'sqi-' + Date.now() + '-' + Math.random().toString(36).substring(2, 11);
-        const itemResult = await query(
-          `INSERT INTO supplier_quote_items (
-          id, quote_id, product_id, product_name, quantity, unit_price, note, unit_type
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-         RETURNING
-          id,
-          quote_id as "quoteId",
-          product_id as "productId",
-          product_name as "productName",
-          quantity,
-          unit_price as "unitPrice",
-          note,
-          unit_type as "unitType"`,
-          [
-            itemId,
-            nextIdResult.value,
-            item.productId || null,
-            item.productName,
-            item.quantity,
-            item.unitPrice,
-            item.note || null,
-            item.unitType || 'unit',
-          ],
-        );
-        createdItems.push(
-          normalizeSupplierQuoteItemRow(itemResult.rows[0] as Record<string, unknown>),
-        );
-      }
-
       await logAudit({
         request,
         action: 'supplier_quote.created',
         entityType: 'supplier_quote',
-        entityId: nextIdResult.value,
+        entityId: result.quote.id,
         details: {
-          targetLabel: nextIdResult.value,
-          secondaryLabel: supplierNameResult.value,
+          targetLabel: result.quote.id,
+          secondaryLabel: result.quote.supplierName,
         },
       });
       return reply.code(201).send({
-        ...normalizeSupplierQuoteRow(quoteResult.rows[0] as Record<string, unknown>),
-        items: createdItems,
+        ...projectQuote(result.quote),
+        items: result.items.map(projectItem),
       });
     },
   );
@@ -391,14 +337,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         id?: string;
         supplierId?: string;
         supplierName?: string;
-        items?: Array<{
-          productId?: string;
-          productName?: string;
-          quantity?: string | number;
-          unitPrice?: string | number;
-          note?: string;
-          unitType?: 'hours' | 'days' | 'unit';
-        }>;
+        items?: ItemBody[];
         paymentTerms?: string;
         status?: string;
         expirationDate?: string;
@@ -418,86 +357,75 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         expirationDate === undefined &&
         notes === undefined;
 
-      const linkedOrderResult = await query(
-        'SELECT id FROM supplier_sales WHERE linked_quote_id = $1 LIMIT 1',
-        [idResult.value],
-      );
-      if (linkedOrderResult.rows.length > 0 && !isIdOnlyUpdate) {
-        return reply.code(409).send({ error: 'Quotes become read-only once an order exists' });
-      }
+      const patch: supplierQuotesRepo.SupplierQuoteUpdate = {};
 
-      let supplierIdValue: string | undefined | null = supplierId;
       if (supplierId !== undefined) {
         const supplierIdResult = optionalNonEmptyString(supplierId, 'supplierId');
         if (!supplierIdResult.ok) return badRequest(reply, supplierIdResult.message);
-        supplierIdValue = supplierIdResult.value;
+        if (supplierIdResult.value !== null) patch.supplierId = supplierIdResult.value;
       }
 
-      let supplierNameValue: string | undefined | null = supplierName;
       if (supplierName !== undefined) {
         const supplierNameResult = optionalNonEmptyString(supplierName, 'supplierName');
         if (!supplierNameResult.ok) return badRequest(reply, supplierNameResult.message);
-        supplierNameValue = supplierNameResult.value;
+        if (supplierNameResult.value !== null) patch.supplierName = supplierNameResult.value;
       }
 
-      let nextIdValue: string | undefined | null = nextId;
+      let nextIdValue: string | null = null;
       if (nextId !== undefined) {
         const nextIdResult = optionalNonEmptyString(nextId, 'id');
         if (!nextIdResult.ok) return badRequest(reply, nextIdResult.message);
         nextIdValue = nextIdResult.value;
-        if (nextIdResult.value) {
-          const existingIdResult = await query(
-            'SELECT id FROM supplier_quotes WHERE id = $1 AND id <> $2',
-            [nextIdResult.value, idResult.value],
-          );
-          if (existingIdResult.rows.length > 0) {
-            return reply.code(409).send({ error: 'Quote ID already exists' });
-          }
-        }
       }
 
-      let expirationDateValue: string | undefined | null = expirationDate;
+      if (paymentTerms !== undefined) patch.paymentTerms = paymentTerms;
+      if (status !== undefined) patch.status = status;
+      if (notes !== undefined) patch.notes = notes;
+
       if (expirationDate !== undefined) {
         const expirationDateResult = optionalDateString(expirationDate, 'expirationDate');
         if (!expirationDateResult.ok) return badRequest(reply, expirationDateResult.message);
-        expirationDateValue = expirationDateResult.value;
+        if (expirationDateResult.value !== null) patch.expirationDate = expirationDateResult.value;
       }
 
-      let quoteResult: Awaited<ReturnType<typeof query>>;
+      let normalizedItems: supplierQuotesRepo.NewSupplierQuoteItem[] | null = null;
+      if (items) {
+        if (!Array.isArray(items) || items.length === 0) {
+          return badRequest(reply, 'Items must be a non-empty array');
+        }
+        normalizedItems = validateAndNormalizeItems(items, reply);
+        if (!normalizedItems) return;
+      }
+
+      const [linkedOrderId, idConflict] = await Promise.all([
+        isIdOnlyUpdate
+          ? Promise.resolve(null)
+          : supplierQuotesRepo.findLinkedOrderId(idResult.value),
+        nextIdValue
+          ? supplierQuotesRepo.findIdConflict(nextIdValue, idResult.value)
+          : Promise.resolve(false),
+      ]);
+      if (linkedOrderId && !isIdOnlyUpdate) {
+        return reply.code(409).send({ error: 'Quotes become read-only once an order exists' });
+      }
+      if (idConflict) {
+        return reply.code(409).send({ error: 'Quote ID already exists' });
+      }
+      if (nextIdValue !== null) patch.id = nextIdValue;
+
+      let updated: supplierQuotesRepo.SupplierQuote | null;
+      let resultItems: supplierQuotesRepo.SupplierQuoteItem[];
       try {
-        quoteResult = await query(
-          `UPDATE supplier_quotes
-         SET id = COALESCE($1, id),
-             supplier_id = COALESCE($2, supplier_id),
-             supplier_name = COALESCE($3, supplier_name),
-             payment_terms = COALESCE($4, payment_terms),
-             status = COALESCE($5, status),
-             expiration_date = COALESCE($6, expiration_date),
-             notes = COALESCE($7, notes),
-             updated_at = CURRENT_TIMESTAMP
-         WHERE id = $8
-         RETURNING
-          id,
-          supplier_id as "supplierId",
-           supplier_name as "supplierName",
-           payment_terms as "paymentTerms",
-           status,
-           expiration_date as "expirationDate",
-           null::varchar as "linkedOrderId",
-           notes,
-          EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt",
-          EXTRACT(EPOCH FROM updated_at) * 1000 as "updatedAt"`,
-          [
-            nextIdValue,
-            supplierIdValue,
-            supplierNameValue,
-            paymentTerms,
-            status,
-            expirationDateValue,
-            notes,
-            idResult.value,
-          ],
-        );
+        const txResult = await withTransaction(async (tx) => {
+          const quote = await supplierQuotesRepo.update(idResult.value, patch, tx);
+          if (!quote) return { quote: null, items: [] as supplierQuotesRepo.SupplierQuoteItem[] };
+          const finalItems = normalizedItems
+            ? await supplierQuotesRepo.replaceItems(quote.id, normalizedItems, tx)
+            : await supplierQuotesRepo.findItemsForQuote(quote.id, tx);
+          return { quote, items: finalItems };
+        });
+        updated = txResult.quote;
+        resultItems = txResult.items;
       } catch (error) {
         if (
           isUniqueViolation(error) &&
@@ -508,109 +436,23 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         throw error;
       }
 
-      if (quoteResult.rows.length === 0) {
+      if (!updated) {
         return reply.code(404).send({ error: 'Supplier quote not found' });
-      }
-
-      const updatedQuoteId = String(quoteResult.rows[0].id);
-
-      let updatedItems = [];
-      if (items) {
-        if (!Array.isArray(items) || items.length === 0) {
-          return badRequest(reply, 'Items must be a non-empty array');
-        }
-        const normalizedItems = [];
-        for (let i = 0; i < items.length; i++) {
-          const item = items[i];
-          const productNameResult = requireNonEmptyString(
-            item.productName,
-            `items[${i}].productName`,
-          );
-          if (!productNameResult.ok) return badRequest(reply, productNameResult.message);
-          const quantityResult = parseLocalizedPositiveNumber(
-            item.quantity,
-            `items[${i}].quantity`,
-          );
-          if (!quantityResult.ok) return badRequest(reply, quantityResult.message);
-          const unitPriceResult = parseLocalizedNonNegativeNumber(
-            item.unitPrice,
-            `items[${i}].unitPrice`,
-          );
-          if (!unitPriceResult.ok) return badRequest(reply, unitPriceResult.message);
-          normalizedItems.push({
-            ...item,
-            productName: productNameResult.value,
-            quantity: quantityResult.value,
-            unitPrice: unitPriceResult.value,
-            unitType: normalizeUnitType(item.unitType),
-          });
-        }
-
-        await query('DELETE FROM supplier_quote_items WHERE quote_id = $1', [updatedQuoteId]);
-
-        for (const item of normalizedItems) {
-          const itemId = 'sqi-' + Date.now() + '-' + Math.random().toString(36).substring(2, 11);
-          const itemResult = await query(
-            `INSERT INTO supplier_quote_items (
-            id, quote_id, product_id, product_name, quantity, unit_price, note, unit_type
-          ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-           RETURNING
-            id,
-            quote_id as "quoteId",
-            product_id as "productId",
-            product_name as "productName",
-            quantity,
-            unit_price as "unitPrice",
-            note,
-            unit_type as "unitType"`,
-            [
-              itemId,
-              updatedQuoteId,
-              item.productId || null,
-              item.productName,
-              item.quantity,
-              item.unitPrice,
-              item.note || null,
-              item.unitType || 'unit',
-            ],
-          );
-          updatedItems.push(
-            normalizeSupplierQuoteItemRow(itemResult.rows[0] as Record<string, unknown>),
-          );
-        }
-      } else {
-        const itemsResult = await query(
-          `SELECT
-          id,
-          quote_id as "quoteId",
-          product_id as "productId",
-          product_name as "productName",
-          quantity,
-          unit_price as "unitPrice",
-          note,
-          unit_type as "unitType"
-         FROM supplier_quote_items
-         WHERE quote_id = $1`,
-          [updatedQuoteId],
-        );
-        updatedItems = itemsResult.rows.map((item) =>
-          normalizeSupplierQuoteItemRow(item as Record<string, unknown>),
-        );
       }
 
       await logAudit({
         request,
         action: 'supplier_quote.updated',
         entityType: 'supplier_quote',
-        entityId: updatedQuoteId,
+        entityId: updated.id,
         details: {
-          targetLabel: updatedQuoteId,
-          secondaryLabel: String(quoteResult.rows[0].supplierName ?? ''),
+          targetLabel: updated.id,
+          secondaryLabel: updated.supplierName,
         },
       });
       return {
-        ...normalizeSupplierQuoteRow(quoteResult.rows[0] as Record<string, unknown>),
-        items: updatedItems,
+        ...projectQuote(updated),
+        items: resultItems.map(projectItem),
       };
     },
   );
@@ -633,21 +475,16 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const { id } = request.params as { id: string };
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
-      const linkedOrderResult = await query(
-        'SELECT id FROM supplier_sales WHERE linked_quote_id = $1 LIMIT 1',
-        [idResult.value],
-      );
-      if (linkedOrderResult.rows.length > 0) {
+
+      const linkedOrderId = await supplierQuotesRepo.findLinkedOrderId(idResult.value);
+      if (linkedOrderId) {
         return reply
           .code(409)
           .send({ error: 'Cannot delete a quote once an order has been created from it' });
       }
-      const result = await query(
-        'DELETE FROM supplier_quotes WHERE id = $1 RETURNING id, supplier_name as "supplierName"',
-        [idResult.value],
-      );
 
-      if (result.rows.length === 0) {
+      const deleted = await supplierQuotesRepo.deleteById(idResult.value);
+      if (!deleted) {
         return reply.code(404).send({ error: 'Supplier quote not found' });
       }
 
@@ -658,7 +495,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         entityId: idResult.value,
         details: {
           targetLabel: idResult.value,
-          secondaryLabel: String(result.rows[0].supplierName ?? ''),
+          secondaryLabel: deleted.supplierName,
         },
       });
       return reply.code(204).send();

--- a/server/routes/suppliers.ts
+++ b/server/routes/suppliers.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
-import { query } from '../db/index.ts';
 import { authenticateToken, requireAnyPermission, requirePermission } from '../middleware/auth.ts';
+import * as suppliersRepo from '../repositories/suppliersRepo.ts';
 import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
 import { logAudit } from '../utils/audit.ts';
 import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
@@ -99,24 +99,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         },
       },
     },
-    async () => {
-      const result = await query('SELECT * FROM suppliers ORDER BY name');
-      return result.rows.map((s) => ({
-        id: s.id,
-        name: s.name,
-        isDisabled: s.is_disabled,
-        supplierCode: s.supplier_code,
-        contactName: s.contact_name,
-        email: s.email,
-        phone: s.phone,
-        address: s.address,
-        vatNumber: s.vat_number,
-        taxCode: s.tax_code,
-        paymentTerms: s.payment_terms,
-        notes: s.notes,
-        createdAt: s.created_at ? new Date(s.created_at).getTime() : undefined,
-      }));
-    },
+    async () => suppliersRepo.listAll(),
   );
 
   fastify.post(
@@ -190,42 +173,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
 
       const now = Date.now();
       const id = 's-' + now;
-      await query(
-        `INSERT INTO suppliers (
-        id, name, is_disabled, supplier_code, contact_name, email, phone,
-        address, vat_number, tax_code, payment_terms, notes, created_at
-      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, to_timestamp($13 / 1000.0))`,
-        [
-          id,
-          nameResult.value,
-          false,
-          supplierCodeResult.value,
-          contactNameResult.value,
-          emailResult.value,
-          phoneResult.value,
-          addressResult.value,
-          vatNumberResult.value,
-          taxCodeResult.value,
-          paymentTermsResult.value,
-          notesResult.value,
-          now,
-        ],
-      );
-
-      await logAudit({
-        request,
-        action: 'supplier.created',
-        entityType: 'supplier',
-        entityId: id,
-        details: {
-          targetLabel: nameResult.value,
-          secondaryLabel: supplierCodeResult.value ?? undefined,
-        },
-      });
-      return reply.code(201).send({
+      const created = await suppliersRepo.create({
         id,
         name: nameResult.value,
-        isDisabled: false,
         supplierCode: supplierCodeResult.value,
         contactName: contactNameResult.value,
         email: emailResult.value,
@@ -237,6 +187,18 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         notes: notesResult.value,
         createdAt: now,
       });
+
+      await logAudit({
+        request,
+        action: 'supplier.created',
+        entityType: 'supplier',
+        entityId: id,
+        details: {
+          targetLabel: nameResult.value,
+          secondaryLabel: supplierCodeResult.value ?? undefined,
+        },
+      });
+      return reply.code(201).send(created);
     },
   );
 
@@ -319,38 +281,30 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
 
       const isDisabledValue = isDisabled !== undefined ? parseBoolean(isDisabled) : undefined;
 
-      const result = await query(
-        `UPDATE suppliers SET
-        name = COALESCE($1, name),
-        is_disabled = COALESCE($2, is_disabled),
-        supplier_code = COALESCE($3, supplier_code),
-        contact_name = COALESCE($4, contact_name),
-        email = COALESCE($5, email),
-        phone = COALESCE($6, phone),
-        address = COALESCE($7, address),
-        vat_number = COALESCE($8, vat_number),
-        tax_code = COALESCE($9, tax_code),
-        payment_terms = COALESCE($10, payment_terms),
-        notes = COALESCE($11, notes)
-       WHERE id = $12
-       RETURNING *`,
-        [
-          nameResult.value,
-          isDisabledValue,
-          supplierCodeResult.value,
-          contactNameResult.value,
-          emailResult.value,
-          phoneResult.value,
-          addressResult.value,
-          vatNumberResult.value,
-          taxCodeResult.value,
-          paymentTermsResult.value,
-          notesResult.value,
-          idResult.value,
-        ],
-      );
+      const patch: suppliersRepo.SupplierUpdate = {};
+      if (Object.hasOwn(body, 'name') && nameResult.value !== null) patch.name = nameResult.value;
+      if (isDisabledValue !== undefined) patch.isDisabled = isDisabledValue;
+      if (Object.hasOwn(body, 'supplierCode') && supplierCodeResult.value !== null)
+        patch.supplierCode = supplierCodeResult.value;
+      if (Object.hasOwn(body, 'contactName') && contactNameResult.value !== null)
+        patch.contactName = contactNameResult.value;
+      if (Object.hasOwn(body, 'email') && emailResult.value !== null)
+        patch.email = emailResult.value;
+      if (Object.hasOwn(body, 'phone') && phoneResult.value !== null)
+        patch.phone = phoneResult.value;
+      if (Object.hasOwn(body, 'address') && addressResult.value !== null)
+        patch.address = addressResult.value;
+      if (Object.hasOwn(body, 'vatNumber') && vatNumberResult.value !== null)
+        patch.vatNumber = vatNumberResult.value;
+      if (Object.hasOwn(body, 'taxCode') && taxCodeResult.value !== null)
+        patch.taxCode = taxCodeResult.value;
+      if (Object.hasOwn(body, 'paymentTerms') && paymentTermsResult.value !== null)
+        patch.paymentTerms = paymentTermsResult.value;
+      if (Object.hasOwn(body, 'notes') && notesResult.value !== null)
+        patch.notes = notesResult.value;
 
-      if (result.rows.length === 0) {
+      const updated = await suppliersRepo.update(idResult.value, patch);
+      if (!updated) {
         return reply.code(404).send({ error: 'Supplier not found' });
       }
 
@@ -368,9 +322,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         Object.hasOwn(body, 'notes') ? 'notes' : null,
       ].filter((field): field is string => field !== null);
 
-      const s = result.rows[0];
-
-      // Determine specific action based on what changed
       let action = 'supplier.updated';
       if (changedFields.length === 1 && changedFields[0] === 'isDisabled') {
         action = body.isDisabled ? 'supplier.disabled' : 'supplier.enabled';
@@ -382,25 +333,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         entityType: 'supplier',
         entityId: idResult.value,
         details: {
-          targetLabel: s.name as string,
-          secondaryLabel: (s.supplier_code as string | null) ?? undefined,
+          targetLabel: updated.name,
+          secondaryLabel: updated.supplierCode ?? undefined,
         },
       });
-      return {
-        id: s.id,
-        name: s.name,
-        isDisabled: s.is_disabled,
-        supplierCode: s.supplier_code,
-        contactName: s.contact_name,
-        email: s.email,
-        phone: s.phone,
-        address: s.address,
-        vatNumber: s.vat_number,
-        taxCode: s.tax_code,
-        paymentTerms: s.payment_terms,
-        notes: s.notes,
-        createdAt: s.created_at ? new Date(s.created_at).getTime() : undefined,
-      };
+      return updated;
     },
   );
 
@@ -422,12 +359,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const { id } = request.params as { id: string };
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
-      const result = await query(
-        'DELETE FROM suppliers WHERE id = $1 RETURNING id, name, supplier_code',
-        [idResult.value],
-      );
 
-      if (result.rows.length === 0) {
+      const deleted = await suppliersRepo.deleteById(idResult.value);
+      if (!deleted) {
         return reply.code(404).send({ error: 'Supplier not found' });
       }
 
@@ -437,8 +371,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         entityType: 'supplier',
         entityId: idResult.value,
         details: {
-          targetLabel: result.rows[0].name as string,
-          secondaryLabel: (result.rows[0].supplier_code as string | null) ?? undefined,
+          targetLabel: deleted.name,
+          secondaryLabel: deleted.supplierCode ?? undefined,
         },
       });
       return reply.code(204).send();

--- a/server/test/repositories/supplierInvoicesRepo.test.ts
+++ b/server/test/repositories/supplierInvoicesRepo.test.ts
@@ -1,0 +1,258 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import * as supplierInvoicesRepo from '../../repositories/supplierInvoicesRepo.ts';
+import { type FakeExecutor, makeFakeExecutor } from '../helpers/fakeExecutor.ts';
+
+let exec: FakeExecutor;
+
+beforeEach(() => {
+  exec = makeFakeExecutor();
+});
+
+const rawInvoiceRow = {
+  id: 'SINV-2026-0001',
+  linkedSaleId: 'so-1',
+  supplierId: 's-1',
+  supplierName: 'Acme',
+  issueDate: new Date('2026-04-01T00:00:00Z'),
+  dueDate: new Date('2026-04-30T00:00:00Z'),
+  status: 'draft',
+  subtotal: '100.50',
+  total: '120.60',
+  amountPaid: '0',
+  notes: null,
+  createdAt: 1735689600000,
+  updatedAt: 1735689700000,
+};
+
+describe('listAll mapInvoice', () => {
+  test('coerces numeric subtotal/total/amountPaid via Number()', async () => {
+    exec.enqueue({ rows: [rawInvoiceRow] });
+    const result = await supplierInvoicesRepo.listAll(exec);
+    expect(result[0].subtotal).toBe(100.5);
+    expect(result[0].total).toBe(120.6);
+    expect(result[0].amountPaid).toBe(0);
+  });
+
+  test('defaults null numerics to 0', async () => {
+    exec.enqueue({
+      rows: [{ ...rawInvoiceRow, subtotal: null, total: null, amountPaid: null }],
+    });
+    const result = await supplierInvoicesRepo.listAll(exec);
+    expect(result[0].subtotal).toBe(0);
+    expect(result[0].total).toBe(0);
+    expect(result[0].amountPaid).toBe(0);
+  });
+
+  test('normalizes Date issueDate/dueDate to YYYY-MM-DD strings', async () => {
+    exec.enqueue({ rows: [rawInvoiceRow] });
+    const result = await supplierInvoicesRepo.listAll(exec);
+    expect(result[0].issueDate).toBe('2026-04-01');
+    expect(result[0].dueDate).toBe('2026-04-30');
+  });
+});
+
+describe('listAllItems', () => {
+  test('coerces item numerics', async () => {
+    exec.enqueue({
+      rows: [
+        {
+          id: 'sinv-item-1',
+          invoiceId: 'SINV-2026-0001',
+          productId: null,
+          description: 'Widget',
+          quantity: '2',
+          unitPrice: '50',
+          discount: null,
+        },
+      ],
+    });
+    const result = await supplierInvoicesRepo.listAllItems(exec);
+    expect(result[0].quantity).toBe(2);
+    expect(result[0].unitPrice).toBe(50);
+    expect(result[0].discount).toBe(0);
+  });
+});
+
+describe('findInvoiceForLinkedSale', () => {
+  test('returns id when found', async () => {
+    exec.enqueue({ rows: [{ id: 'SINV-2026-0001' }] });
+    expect(await supplierInvoicesRepo.findInvoiceForLinkedSale('so-1', exec)).toBe(
+      'SINV-2026-0001',
+    );
+  });
+
+  test('returns null when no match', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await supplierInvoicesRepo.findInvoiceForLinkedSale('so-x', exec)).toBeNull();
+  });
+});
+
+describe('findExistingForUpdate', () => {
+  test('returns id, status, issueDate, dueDate', async () => {
+    exec.enqueue({
+      rows: [
+        {
+          id: 'SINV-2026-0001',
+          status: 'draft',
+          issueDate: '2026-04-01',
+          dueDate: '2026-04-30',
+        },
+      ],
+    });
+    expect(await supplierInvoicesRepo.findExistingForUpdate('SINV-2026-0001', exec)).toEqual({
+      id: 'SINV-2026-0001',
+      status: 'draft',
+      issueDate: '2026-04-01',
+      dueDate: '2026-04-30',
+    });
+  });
+});
+
+describe('maxSequenceForYear', () => {
+  test('parses string maxSequence to Number', async () => {
+    exec.enqueue({ rows: [{ maxSequence: '42' }] });
+    expect(await supplierInvoicesRepo.maxSequenceForYear('2026', exec)).toBe(42);
+  });
+
+  test('parses numeric maxSequence as-is', async () => {
+    exec.enqueue({ rows: [{ maxSequence: 7 }] });
+    expect(await supplierInvoicesRepo.maxSequenceForYear('2026', exec)).toBe(7);
+  });
+
+  test('uses regex parameter for the year', async () => {
+    exec.enqueue({ rows: [{ maxSequence: 0 }] });
+    await supplierInvoicesRepo.maxSequenceForYear('2026', exec);
+    expect(exec.calls[0].params).toEqual(['^SINV-2026-[0-9]+$']);
+  });
+
+  test('returns 0 when no rows or null maxSequence', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await supplierInvoicesRepo.maxSequenceForYear('2026', exec)).toBe(0);
+  });
+});
+
+describe('create', () => {
+  test('does NOT swallow unique-violation errors', async () => {
+    exec.enqueue(() => {
+      const err = new Error('duplicate key') as Error & { code?: string; constraint?: string };
+      err.code = '23505';
+      err.constraint = 'supplier_invoices_pkey';
+      throw err;
+    });
+    await expect(
+      supplierInvoicesRepo.create(
+        {
+          id: 'SINV-2026-0001',
+          linkedSaleId: null,
+          supplierId: 's-1',
+          supplierName: 'Acme',
+          issueDate: '2026-04-01',
+          dueDate: '2026-04-30',
+          status: 'draft',
+          subtotal: 0,
+          total: 0,
+          amountPaid: 0,
+          notes: null,
+        },
+        exec,
+      ),
+    ).rejects.toThrow('duplicate key');
+  });
+
+  test('returns mapped invoice on success', async () => {
+    exec.enqueue({ rows: [rawInvoiceRow] });
+    const result = await supplierInvoicesRepo.create(
+      {
+        id: 'SINV-2026-0001',
+        linkedSaleId: 'so-1',
+        supplierId: 's-1',
+        supplierName: 'Acme',
+        issueDate: '2026-04-01',
+        dueDate: '2026-04-30',
+        status: 'draft',
+        subtotal: 100.5,
+        total: 120.6,
+        amountPaid: 0,
+        notes: null,
+      },
+      exec,
+    );
+    expect(result.id).toBe('SINV-2026-0001');
+    expect(result.subtotal).toBe(100.5);
+    expect(result.issueDate).toBe('2026-04-01');
+  });
+});
+
+describe('update', () => {
+  test('falls back to SELECT on empty patch', async () => {
+    exec.enqueue({ rows: [rawInvoiceRow] });
+    await supplierInvoicesRepo.update('SINV-2026-0001', {}, exec);
+    expect(exec.calls[0].sql.startsWith('SELECT')).toBe(true);
+  });
+
+  test('builds dynamic SET and bumps updated_at', async () => {
+    exec.enqueue({ rows: [rawInvoiceRow] });
+    await supplierInvoicesRepo.update('SINV-2026-0001', { status: 'paid', amountPaid: 100 }, exec);
+    expect(exec.calls[0].sql).toContain('status = $1');
+    expect(exec.calls[0].sql).toContain('amount_paid = $2');
+    expect(exec.calls[0].sql).toContain('updated_at = CURRENT_TIMESTAMP');
+    expect(exec.calls[0].params).toEqual(['paid', 100, 'SINV-2026-0001']);
+  });
+});
+
+describe('replaceItems', () => {
+  test('issues DELETE then a single multi-row INSERT', async () => {
+    exec.enqueue({ rows: [] });
+    exec.enqueue({
+      rows: [
+        {
+          id: 'sinv-item-a',
+          invoiceId: 'SINV-2026-0001',
+          productId: null,
+          description: 'A',
+          quantity: 1,
+          unitPrice: 5,
+          discount: 0,
+        },
+      ],
+    });
+    await supplierInvoicesRepo.replaceItems(
+      'SINV-2026-0001',
+      [
+        {
+          id: 'sinv-item-a',
+          productId: null,
+          description: 'A',
+          quantity: 1,
+          unitPrice: 5,
+          discount: 0,
+        },
+      ],
+      exec,
+    );
+    expect(exec.calls).toHaveLength(2);
+    expect(exec.calls[0].sql).toContain('DELETE FROM supplier_invoice_items');
+    expect(exec.calls[1].sql).toContain('INSERT INTO supplier_invoice_items');
+    expect(exec.calls[1].sql).toContain('VALUES ($1, $2, $3, $4, $5, $6, $7)');
+  });
+
+  test('with empty items, deletes existing and skips INSERT', async () => {
+    exec.enqueue({ rows: [] });
+    const result = await supplierInvoicesRepo.replaceItems('SINV-2026-0001', [], exec);
+    expect(exec.calls).toHaveLength(1);
+    expect(exec.calls[0].sql).toContain('DELETE');
+    expect(result).toEqual([]);
+  });
+});
+
+describe('deleteById', () => {
+  test('returns true when row deleted', async () => {
+    exec.enqueue({ rows: [], rowCount: 1 });
+    expect(await supplierInvoicesRepo.deleteById('SINV-2026-0001', exec)).toBe(true);
+  });
+
+  test('returns false when nothing deleted', async () => {
+    exec.enqueue({ rows: [], rowCount: 0 });
+    expect(await supplierInvoicesRepo.deleteById('SINV-2026-9999', exec)).toBe(false);
+  });
+});

--- a/server/test/repositories/supplierOrdersRepo.test.ts
+++ b/server/test/repositories/supplierOrdersRepo.test.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import * as supplierOrdersRepo from '../../repositories/supplierOrdersRepo.ts';
+import { type FakeExecutor, makeFakeExecutor } from '../helpers/fakeExecutor.ts';
+
+let exec: FakeExecutor;
+
+beforeEach(() => {
+  exec = makeFakeExecutor();
+});
+
+const rawOrderRow = {
+  id: 'so-1',
+  linkedQuoteId: 'q-1',
+  supplierId: 's-1',
+  supplierName: 'Acme',
+  paymentTerms: 'net30',
+  discount: '5',
+  discountType: 'percentage',
+  status: 'draft',
+  notes: null,
+  createdAt: 1735689600000,
+  updatedAt: 1735689700000,
+};
+
+const rawItemRow = {
+  id: 'ssi-1',
+  orderId: 'so-1',
+  productId: null,
+  productName: 'Widget',
+  quantity: '1',
+  unitPrice: '10',
+  discount: '0',
+  note: null,
+};
+
+describe('listAll', () => {
+  test('orders by created_at DESC and maps numeric fields', async () => {
+    exec.enqueue({ rows: [rawOrderRow] });
+    const result = await supplierOrdersRepo.listAll(exec);
+    expect(exec.calls[0].sql).toContain('ORDER BY created_at DESC');
+    expect(result[0].discount).toBe(5);
+    expect(result[0].discountType).toBe('percentage');
+  });
+
+  test('coerces unrecognized discountType to "percentage"', async () => {
+    exec.enqueue({ rows: [{ ...rawOrderRow, discountType: 'weird' }] });
+    const result = await supplierOrdersRepo.listAll(exec);
+    expect(result[0].discountType).toBe('percentage');
+  });
+});
+
+describe('findById', () => {
+  test('returns mapped row', async () => {
+    exec.enqueue({ rows: [rawOrderRow] });
+    const result = await supplierOrdersRepo.findById('so-1', exec);
+    expect(result?.id).toBe('so-1');
+    expect(result?.discount).toBe(5);
+  });
+
+  test('returns null when not found', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await supplierOrdersRepo.findById('so-x', exec)).toBeNull();
+  });
+});
+
+describe('findExistingForUpdate', () => {
+  test('returns mapped object with linkedQuoteId', async () => {
+    exec.enqueue({
+      rows: [
+        {
+          id: 'so-1',
+          linkedQuoteId: 'q-1',
+          supplierId: 's-1',
+          supplierName: 'Acme',
+          status: 'draft',
+        },
+      ],
+    });
+    expect(await supplierOrdersRepo.findExistingForUpdate('so-1', exec)).toEqual({
+      id: 'so-1',
+      linkedQuoteId: 'q-1',
+      supplierId: 's-1',
+      supplierName: 'Acme',
+      status: 'draft',
+    });
+  });
+
+  test('returns null when not found', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await supplierOrdersRepo.findExistingForUpdate('so-x', exec)).toBeNull();
+  });
+});
+
+describe('findLinkedInvoiceId', () => {
+  test('returns id when found', async () => {
+    exec.enqueue({ rows: [{ id: 'inv-1' }] });
+    expect(await supplierOrdersRepo.findLinkedInvoiceId('so-1', exec)).toBe('inv-1');
+  });
+
+  test('returns null when not found', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await supplierOrdersRepo.findLinkedInvoiceId('so-x', exec)).toBeNull();
+  });
+});
+
+describe('findStatusAndSupplierName', () => {
+  test('uses SQL alias to return supplierName directly', async () => {
+    exec.enqueue({ rows: [{ status: 'draft', supplierName: 'Acme' }] });
+    expect(await supplierOrdersRepo.findStatusAndSupplierName('so-1', exec)).toEqual({
+      status: 'draft',
+      supplierName: 'Acme',
+    });
+    expect(exec.calls[0].sql).toContain('supplier_name as "supplierName"');
+  });
+});
+
+describe('findIdConflict', () => {
+  test('excludes self', async () => {
+    exec.enqueue({ rows: [] });
+    await supplierOrdersRepo.findIdConflict('new', 'cur', exec);
+    expect(exec.calls[0].sql).toContain('id <> $2');
+    expect(exec.calls[0].params).toEqual(['new', 'cur']);
+  });
+});
+
+describe('update', () => {
+  test('falls back to SELECT on empty patch', async () => {
+    exec.enqueue({ rows: [rawOrderRow] });
+    await supplierOrdersRepo.update('so-1', {}, exec);
+    expect(exec.calls[0].sql.startsWith('SELECT')).toBe(true);
+  });
+
+  test('builds dynamic SET and bumps updated_at', async () => {
+    exec.enqueue({ rows: [rawOrderRow] });
+    await supplierOrdersRepo.update('so-1', { status: 'sent', discount: 10 }, exec);
+    expect(exec.calls[0].sql).toContain('discount = $1');
+    expect(exec.calls[0].sql).toContain('status = $2');
+    expect(exec.calls[0].sql).toContain('updated_at = CURRENT_TIMESTAMP');
+    expect(exec.calls[0].params).toEqual([10, 'sent', 'so-1']);
+  });
+});
+
+describe('replaceItems', () => {
+  test('issues DELETE then a single multi-row INSERT', async () => {
+    exec.enqueue({ rows: [] });
+    exec.enqueue({ rows: [{ ...rawItemRow, id: 'ssi-a' }] });
+    const result = await supplierOrdersRepo.replaceItems(
+      'so-1',
+      [
+        {
+          id: 'ssi-a',
+          productId: null,
+          productName: 'A',
+          quantity: 1,
+          unitPrice: 5,
+          discount: 0,
+          note: null,
+        },
+      ],
+      exec,
+    );
+    expect(exec.calls).toHaveLength(2);
+    expect(exec.calls[0].sql).toContain('DELETE FROM supplier_sale_items');
+    expect(exec.calls[1].sql).toContain('INSERT INTO supplier_sale_items');
+    expect(exec.calls[1].sql).toContain('VALUES ($1, $2, $3, $4, $5, $6, $7, $8)');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('ssi-a');
+  });
+
+  test('with empty items, deletes existing and skips INSERT', async () => {
+    exec.enqueue({ rows: [] });
+    const result = await supplierOrdersRepo.replaceItems('so-1', [], exec);
+    expect(exec.calls).toHaveLength(1);
+    expect(exec.calls[0].sql).toContain('DELETE');
+    expect(result).toEqual([]);
+  });
+});
+
+describe('deleteById', () => {
+  test('returns true when row deleted', async () => {
+    exec.enqueue({ rows: [], rowCount: 1 });
+    expect(await supplierOrdersRepo.deleteById('so-1', exec)).toBe(true);
+  });
+
+  test('returns false when no row deleted', async () => {
+    exec.enqueue({ rows: [], rowCount: 0 });
+    expect(await supplierOrdersRepo.deleteById('so-x', exec)).toBe(false);
+  });
+});

--- a/server/test/repositories/supplierQuotesRepo.test.ts
+++ b/server/test/repositories/supplierQuotesRepo.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import * as supplierQuotesRepo from '../../repositories/supplierQuotesRepo.ts';
+import { type FakeExecutor, makeFakeExecutor } from '../helpers/fakeExecutor.ts';
+
+let exec: FakeExecutor;
+
+beforeEach(() => {
+  exec = makeFakeExecutor();
+});
+
+const rawQuoteRow = {
+  id: 'q-1',
+  supplierId: 's-1',
+  supplierName: 'Acme',
+  paymentTerms: 'net30',
+  status: 'draft',
+  expirationDate: new Date('2026-06-01T00:00:00Z'),
+  notes: null,
+  createdAt: 1735689600000,
+  updatedAt: 1735689700000,
+};
+
+const rawItemRow = {
+  id: 'sqi-1',
+  quoteId: 'q-1',
+  productId: null,
+  productName: 'Widget',
+  quantity: '2',
+  unitPrice: '10.5',
+  note: null,
+  unitType: 'unit',
+};
+
+describe('listAll', () => {
+  test('issues a query with linkedOrderId correlated subquery', async () => {
+    exec.enqueue({ rows: [{ ...rawQuoteRow, linkedOrderId: 'so-1' }] });
+    const result = await supplierQuotesRepo.listAll(exec);
+    expect(exec.calls[0].sql).toContain('FROM supplier_sales ss');
+    expect(exec.calls[0].sql).toContain('linked_quote_id = supplier_quotes.id');
+    expect(exec.calls[0].sql).toContain('ORDER BY created_at DESC');
+    expect(result[0].linkedOrderId).toBe('so-1');
+    expect(result[0].expirationDate).toBe('2026-06-01');
+  });
+
+  test('returns empty array when no rows', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await supplierQuotesRepo.listAll(exec)).toEqual([]);
+  });
+});
+
+describe('listAllItems', () => {
+  test('orders items by created_at ASC', async () => {
+    exec.enqueue({ rows: [rawItemRow] });
+    const result = await supplierQuotesRepo.listAllItems(exec);
+    expect(exec.calls[0].sql).toContain('ORDER BY created_at ASC');
+    expect(result[0].quantity).toBe(2);
+    expect(result[0].unitPrice).toBe(10.5);
+    expect(result[0].unitType).toBe('unit');
+  });
+
+  test('coerces unitType null to "unit"', async () => {
+    exec.enqueue({ rows: [{ ...rawItemRow, unitType: null }] });
+    const result = await supplierQuotesRepo.listAllItems(exec);
+    expect(result[0].unitType).toBe('unit');
+  });
+});
+
+describe('findLinkedOrderId', () => {
+  test('returns id when found', async () => {
+    exec.enqueue({ rows: [{ id: 'so-1' }] });
+    expect(await supplierQuotesRepo.findLinkedOrderId('q-1', exec)).toBe('so-1');
+  });
+
+  test('returns null when not found', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await supplierQuotesRepo.findLinkedOrderId('q-x', exec)).toBeNull();
+  });
+});
+
+describe('findIdConflict', () => {
+  test('excludes self via id <> $2', async () => {
+    exec.enqueue({ rows: [] });
+    await supplierQuotesRepo.findIdConflict('new-id', 'cur-id', exec);
+    expect(exec.calls[0].sql).toContain('id <> $2');
+    expect(exec.calls[0].params).toEqual(['new-id', 'cur-id']);
+  });
+
+  test('returns true when row matches', async () => {
+    exec.enqueue({ rows: [{ id: 'new-id' }] });
+    expect(await supplierQuotesRepo.findIdConflict('new-id', 'cur-id', exec)).toBe(true);
+  });
+});
+
+describe('update', () => {
+  test('falls back to SELECT on empty patch', async () => {
+    exec.enqueue({ rows: [rawQuoteRow] });
+    await supplierQuotesRepo.update('q-1', {}, exec);
+    expect(exec.calls[0].sql.startsWith('SELECT')).toBe(true);
+  });
+
+  test('writes only changed fields and bumps updated_at', async () => {
+    exec.enqueue({ rows: [rawQuoteRow] });
+    await supplierQuotesRepo.update('q-1', { status: 'sent', notes: 'hi' }, exec);
+    expect(exec.calls[0].sql).toContain('status = $1');
+    expect(exec.calls[0].sql).toContain('notes = $2');
+    expect(exec.calls[0].sql).toContain('updated_at = CURRENT_TIMESTAMP');
+    expect(exec.calls[0].params).toEqual(['sent', 'hi', 'q-1']);
+  });
+});
+
+describe('replaceItems', () => {
+  test('issues DELETE then a single multi-row INSERT and preserves item order', async () => {
+    exec.enqueue({ rows: [] });
+    exec.enqueue({
+      rows: [
+        { ...rawItemRow, id: 'sqi-a' },
+        { ...rawItemRow, id: 'sqi-b' },
+      ],
+    });
+    const items = [
+      {
+        id: 'sqi-a',
+        productId: null,
+        productName: 'A',
+        quantity: 1,
+        unitPrice: 5,
+        note: null,
+        unitType: 'unit',
+      },
+      {
+        id: 'sqi-b',
+        productId: null,
+        productName: 'B',
+        quantity: 2,
+        unitPrice: 6,
+        note: null,
+        unitType: 'unit',
+      },
+    ];
+    const result = await supplierQuotesRepo.replaceItems('q-1', items, exec);
+    expect(exec.calls).toHaveLength(2);
+    expect(exec.calls[0].sql).toContain('DELETE FROM supplier_quote_items');
+    expect(exec.calls[0].params).toEqual(['q-1']);
+    expect(exec.calls[1].sql).toContain('INSERT INTO supplier_quote_items');
+    expect(exec.calls[1].sql).toContain('VALUES ($1, $2, $3, $4, $5, $6, $7, $8), ($9');
+    expect(exec.calls[1].params[0]).toBe('sqi-a');
+    expect(exec.calls[1].params[8]).toBe('sqi-b');
+    expect(result.map((i) => i.id)).toEqual(['sqi-a', 'sqi-b']);
+  });
+
+  test('with empty items, deletes existing and skips INSERT', async () => {
+    exec.enqueue({ rows: [] });
+    const result = await supplierQuotesRepo.replaceItems('q-1', [], exec);
+    expect(exec.calls.length).toBe(1);
+    expect(exec.calls[0].sql).toContain('DELETE');
+    expect(result).toEqual([]);
+  });
+});
+
+describe('deleteById', () => {
+  test('returns supplierName when row deleted', async () => {
+    exec.enqueue({ rows: [{ supplier_name: 'Acme' }] });
+    expect(await supplierQuotesRepo.deleteById('q-1', exec)).toEqual({ supplierName: 'Acme' });
+  });
+
+  test('returns null when no row deleted', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await supplierQuotesRepo.deleteById('q-x', exec)).toBeNull();
+  });
+});

--- a/server/test/repositories/suppliersRepo.test.ts
+++ b/server/test/repositories/suppliersRepo.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import * as suppliersRepo from '../../repositories/suppliersRepo.ts';
+import { type FakeExecutor, makeFakeExecutor } from '../helpers/fakeExecutor.ts';
+
+let exec: FakeExecutor;
+
+beforeEach(() => {
+  exec = makeFakeExecutor();
+});
+
+const rawRow = {
+  id: 's-1',
+  name: 'Acme Co',
+  is_disabled: false,
+  supplier_code: 'ACM',
+  contact_name: 'Jane',
+  email: 'jane@acme.test',
+  phone: '555',
+  address: '1 Main',
+  vat_number: 'IT123',
+  tax_code: 'TC1',
+  payment_terms: 'net30',
+  notes: 'preferred',
+  created_at: new Date('2026-04-30T12:00:00Z'),
+};
+
+const mappedRow = {
+  id: 's-1',
+  name: 'Acme Co',
+  isDisabled: false,
+  supplierCode: 'ACM',
+  contactName: 'Jane',
+  email: 'jane@acme.test',
+  phone: '555',
+  address: '1 Main',
+  vatNumber: 'IT123',
+  taxCode: 'TC1',
+  paymentTerms: 'net30',
+  notes: 'preferred',
+  createdAt: new Date('2026-04-30T12:00:00Z').getTime(),
+};
+
+describe('listAll', () => {
+  test('returns mapped rows ordered by name', async () => {
+    exec.enqueue({ rows: [rawRow] });
+    expect(await suppliersRepo.listAll(exec)).toEqual([mappedRow]);
+    expect(exec.calls[0].sql).toContain('ORDER BY name');
+  });
+
+  test('createdAt is undefined when DB has null timestamp', async () => {
+    exec.enqueue({ rows: [{ ...rawRow, created_at: null }] });
+    const result = await suppliersRepo.listAll(exec);
+    expect(result[0].createdAt).toBeUndefined();
+  });
+});
+
+describe('findById', () => {
+  test('returns mapped row when found', async () => {
+    exec.enqueue({ rows: [rawRow] });
+    expect(await suppliersRepo.findById('s-1', exec)).toEqual(mappedRow);
+    expect(exec.calls[0].params).toEqual(['s-1']);
+  });
+
+  test('returns null when not found', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await suppliersRepo.findById('s-x', exec)).toBeNull();
+  });
+});
+
+describe('create', () => {
+  test('passes createdAt through to_timestamp scaling and forces is_disabled false', async () => {
+    exec.enqueue({ rows: [rawRow] });
+    const now = 1735689600000;
+    await suppliersRepo.create(
+      {
+        id: 's-1',
+        name: 'Acme Co',
+        supplierCode: 'ACM',
+        contactName: 'Jane',
+        email: 'jane@acme.test',
+        phone: '555',
+        address: '1 Main',
+        vatNumber: 'IT123',
+        taxCode: 'TC1',
+        paymentTerms: 'net30',
+        notes: 'preferred',
+        createdAt: now,
+      },
+      exec,
+    );
+    expect(exec.calls[0].sql).toContain('to_timestamp($13 / 1000.0)');
+    expect(exec.calls[0].params[2]).toBe(false);
+    expect(exec.calls[0].params[12]).toBe(now);
+  });
+
+  test('returns mapped row from RETURNING', async () => {
+    exec.enqueue({ rows: [rawRow] });
+    const result = await suppliersRepo.create(
+      {
+        id: 's-1',
+        name: 'Acme Co',
+        supplierCode: null,
+        contactName: null,
+        email: null,
+        phone: null,
+        address: null,
+        vatNumber: null,
+        taxCode: null,
+        paymentTerms: null,
+        notes: null,
+        createdAt: Date.now(),
+      },
+      exec,
+    );
+    expect(result).toEqual(mappedRow);
+  });
+});
+
+describe('update', () => {
+  test('omits unchanged fields and emits dynamic SET', async () => {
+    exec.enqueue({ rows: [rawRow] });
+    await suppliersRepo.update('s-1', { name: 'New Name', isDisabled: true }, exec);
+    expect(exec.calls[0].sql).toContain('UPDATE suppliers SET name = $1, is_disabled = $2');
+    expect(exec.calls[0].sql).not.toContain('email = $');
+    expect(exec.calls[0].params).toEqual(['New Name', true, 's-1']);
+  });
+
+  test('falls back to SELECT when patch is empty', async () => {
+    exec.enqueue({ rows: [rawRow] });
+    await suppliersRepo.update('s-1', {}, exec);
+    expect(exec.calls[0].sql).toContain('SELECT');
+    expect(exec.calls[0].sql).not.toContain('UPDATE');
+    expect(exec.calls[0].params).toEqual(['s-1']);
+  });
+
+  test('returns null when no row matches', async () => {
+    exec.enqueue({ rows: [] });
+    const result = await suppliersRepo.update('s-x', { name: 'Z' }, exec);
+    expect(result).toBeNull();
+  });
+
+  test('writes null when patch field is explicitly null', async () => {
+    exec.enqueue({ rows: [rawRow] });
+    await suppliersRepo.update('s-1', { paymentTerms: null }, exec);
+    expect(exec.calls[0].sql).toContain('payment_terms = $1');
+    expect(exec.calls[0].params).toEqual([null, 's-1']);
+  });
+});
+
+describe('deleteById', () => {
+  test('returns name and supplierCode when row is deleted', async () => {
+    exec.enqueue({ rows: [{ name: 'Acme Co', supplier_code: 'ACM' }] });
+    expect(await suppliersRepo.deleteById('s-1', exec)).toEqual({
+      name: 'Acme Co',
+      supplierCode: 'ACM',
+    });
+    expect(exec.calls[0].sql).toContain('DELETE FROM suppliers');
+    expect(exec.calls[0].sql).toContain('RETURNING name, supplier_code');
+  });
+
+  test('returns null when no row deleted', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await suppliersRepo.deleteById('s-x', exec)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Migrates the four supplier-related Fastify route files to the established repository pattern (`notificationsRepo`/`projectsRepo`/`tasksRepo`), pulling all inline SQL into per-domain modules. As part of the move, the multi-statement operations (parent + items) are now atomic and the per-item INSERT loop is collapsed to a single multi-row INSERT.

- **New repos** under `server/repositories/`: `suppliersRepo.ts`, `supplierQuotesRepo.ts`, `supplierOrdersRepo.ts`, `supplierInvoicesRepo.ts` — each exposes `listAll`, `findById`, `create`, dynamic-SET `update`, `deleteById`, plus the thin reads each route needs (e.g. `findLinkedOrderId`, `findExistingForUpdate`, `findIdConflict`, `maxSequenceForYear`). Children rows go through `replaceItems(parentId, items, exec)` which deletes existing rows then issues a single multi-row `INSERT ... VALUES (...), (...) RETURNING ...`.
- **New repo tests** under `server/test/repositories/`, mirroring `notificationsRepo.test.ts` and using `makeFakeExecutor`.
- **Refactored routes** under `server/routes/`: `suppliers.ts`, `supplier-quotes.ts`, `supplier-orders.ts`, `supplier-invoices.ts` — each consumes the repo via namespace import (`import * as supplierQuotesRepo from '...'`). Validation, auth, audit logging, status normalization (quote `received→sent`/`approved→accepted`/`rejected→denied` aliasing), and ID generation stay in the route.

## Why

`server/CLAUDE.md` mandates incremental migration of inline SQL into `server/repositories/<domain>Repo.ts` and explicitly identifies `notificationsRepo` as the reference. The supplier routes were the largest remaining group on the inline-SQL side (~2,750 LOC across four files). Co-locating the SQL in repos also enables reuse: the linked-quote read in supplier-orders POST now goes through `supplierQuotesRepo.findById`, and the linked-sale status check in supplier-invoices POST goes through `supplierOrdersRepo.findById`.

## Notable changes beyond pure SQL extraction

- **Transactional safety.** POST and PUT in quotes/orders/invoices now wrap parent-write + child-replace in `withTransaction`, matching `projects.ts` precedent. Previously, a child-INSERT failure left orphaned parent rows. Invoice POST keeps the existing 5-attempt retry loop on ID-collision; the transaction lives **inside** each attempt so a rolled-back tx is never reused.
- **Multi-row INSERT** for `replaceItems` — one DB roundtrip per replace instead of N, with empty-input guard.
- **Parallelized pre-checks** via `Promise.all` in PUT/POST/DELETE handlers where reads are independent (e.g., `findExistingForUpdate` + `findIdConflict`, GET parent + items, supplier-orders POST `findById` + `findExistingByLinkedQuote`).
- **Behavior preservation.** The four `update` paths drop `null`-valued patch keys before calling repo `update` so the previous COALESCE-style "ignore null" semantics are retained even though the repos use dynamic SET (which would otherwise write NULL on a `null` patch). The `null::varchar as "linkedOrderId"` shape in quotes' create/update RETURNING is preserved.
- **Reuse cleanup.** Mappers go through `parseDbNumber` (`utils/parse.ts`) and `normalizeNullableDateOnly` (`utils/date.ts`); status validation in supplier-orders uses `optionalEnum` (`utils/validation.ts`); child-item IDs use `generateItemId(prefix)` (`utils/order-ids.ts`); `findStatusAndSupplierName` returns the camelCase shape directly via SQL `as "supplierName"`.

## Out of scope

By design, this PR does not touch:
- The `linkedOrderId` correlated subquery in the quote list query.
- Unifying `generateSupplierInvoiceId` with `utils/order-ids.ts`.
- A real status state machine across quotes/orders/invoices.
- A generic shared helper for `update`'s dynamic-SET builder or for `replaceItems` (each repo inlines its own — matching `projectsRepo`/`tasksRepo` precedent).

## Test plan

- [x] `cd server && bun test test` — 269 tests pass, 489 expectations (was 220 before, +49 new repo tests across 4 files).
- [x] `cd server && bunx tsc --noEmit -p tsconfig.json` — clean.
- [x] `bunx biome check` — clean on touched files.
- [ ] Smoke test on remote container: create → list → update → delete a supplier, a quote, an order, an invoice via the UI; force an invoice ID-collision (insert next sequential ID manually) and confirm the retry loop succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/xbounceit/praetor/pull/137" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
