### PR TITLE
refactor(server): extract client route SQL into per-domain repos

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
         "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "swagger-ui-react": "^5.32.4",
-        "uuid": "^13.0.0",
+        "uuid": "^14.0.0",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.12",
@@ -1180,7 +1180,7 @@
 
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
-    "uuid": ["uuid@13.0.0", "", { "bin": "dist-node/bin/uuid" }, "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w=="],
+    "uuid": ["uuid@14.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg=="],
 
     "vasync": ["vasync@2.2.1", "", { "dependencies": { "verror": "1.10.0" } }, "sha512-Hq72JaTpcTFdWiNA4Y22Amej2GH3BFmBaKPPlDZ4/oC8HNn2ISHLkFrJU4Ds8R3jcUi7oo5Y9jcMHKjES+N9wQ=="],
 

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -32,12 +32,16 @@ pool.on('error', (err) => {
 
 export const query = (text: string, params?: unknown[]) => pool.query(text, params);
 
-export const buildBulkInsertPlaceholders = (rowCount: number, fieldsPerRow: number): string => {
+export const buildBulkInsertPlaceholders = (
+  rowCount: number,
+  fieldsPerRow: number,
+  startIndex = 1,
+): string => {
   const rows = new Array<string>(rowCount);
   for (let i = 0; i < rowCount; i++) {
-    const base = i * fieldsPerRow;
+    const base = startIndex + i * fieldsPerRow;
     const slots = new Array<string>(fieldsPerRow);
-    for (let n = 0; n < fieldsPerRow; n++) slots[n] = `$${base + n + 1}`;
+    for (let n = 0; n < fieldsPerRow; n++) slots[n] = `$${base + n}`;
     rows[i] = `(${slots.join(', ')})`;
   }
   return rows.join(', ');

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -32,6 +32,17 @@ pool.on('error', (err) => {
 
 export const query = (text: string, params?: unknown[]) => pool.query(text, params);
 
+export const buildBulkInsertPlaceholders = (rowCount: number, fieldsPerRow: number): string => {
+  const rows = new Array<string>(rowCount);
+  for (let i = 0; i < rowCount; i++) {
+    const base = i * fieldsPerRow;
+    const slots = new Array<string>(fieldsPerRow);
+    for (let n = 0; n < fieldsPerRow; n++) slots[n] = `$${base + n + 1}`;
+    rows[i] = `(${slots.join(', ')})`;
+  }
+  return rows.join(', ');
+};
+
 export type QueryExecutor = {
   query: <T extends QueryResultRow = QueryResultRow>(
     text: string,

--- a/server/repositories/clientOffersRepo.ts
+++ b/server/repositories/clientOffersRepo.ts
@@ -1,0 +1,384 @@
+import pool, { buildBulkInsertPlaceholders, type QueryExecutor } from '../db/index.ts';
+import { normalizeNullableDateOnly } from '../utils/date.ts';
+import { parseDbNumber, parseNullableDbNumber } from '../utils/parse.ts';
+import { normalizeUnitType, type UnitType } from '../utils/unit-type.ts';
+
+export type ClientOffer = {
+  id: string;
+  linkedQuoteId: string;
+  clientId: string;
+  clientName: string;
+  paymentTerms: string | null;
+  discount: number;
+  discountType: 'percentage' | 'currency';
+  status: string;
+  expirationDate: string | null;
+  notes: string | null;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type ClientOfferItem = {
+  id: string;
+  offerId: string;
+  productId: string | null;
+  productName: string;
+  quantity: number;
+  unitPrice: number;
+  productCost: number;
+  productMolPercentage: number | null;
+  supplierQuoteId: string | null;
+  supplierQuoteItemId: string | null;
+  supplierQuoteSupplierName: string | null;
+  supplierQuoteUnitPrice: number | null;
+  unitType: UnitType;
+  note: string | null;
+  discount: number;
+};
+
+type ClientOfferRow = {
+  id: string;
+  linkedQuoteId: string;
+  clientId: string;
+  clientName: string;
+  paymentTerms: string | null;
+  discount: string | number;
+  discountType: string;
+  status: string;
+  expirationDate: string | Date | null;
+  notes: string | null;
+  createdAt: string | number;
+  updatedAt: string | number;
+};
+
+type ClientOfferItemRow = {
+  id: string;
+  offerId: string;
+  productId: string | null;
+  productName: string;
+  quantity: string | number;
+  unitPrice: string | number;
+  productCost: string | number;
+  productMolPercentage: string | number | null;
+  supplierQuoteId: string | null;
+  supplierQuoteItemId: string | null;
+  supplierQuoteSupplierName: string | null;
+  supplierQuoteUnitPrice: string | number | null;
+  unitType: string | null;
+  note: string | null;
+  discount: string | number;
+};
+
+const OFFER_COLUMNS = `
+  id,
+  linked_quote_id as "linkedQuoteId",
+  client_id as "clientId",
+  client_name as "clientName",
+  payment_terms as "paymentTerms",
+  discount,
+  discount_type as "discountType",
+  status,
+  expiration_date as "expirationDate",
+  notes,
+  EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt",
+  EXTRACT(EPOCH FROM updated_at) * 1000 as "updatedAt"
+`;
+
+const ITEM_COLUMNS = `
+  id,
+  offer_id as "offerId",
+  product_id as "productId",
+  product_name as "productName",
+  quantity,
+  unit_price as "unitPrice",
+  product_cost as "productCost",
+  product_mol_percentage as "productMolPercentage",
+  supplier_quote_id as "supplierQuoteId",
+  supplier_quote_item_id as "supplierQuoteItemId",
+  supplier_quote_supplier_name as "supplierQuoteSupplierName",
+  supplier_quote_unit_price as "supplierQuoteUnitPrice",
+  unit_type as "unitType",
+  note,
+  discount
+`;
+
+const mapOffer = (row: ClientOfferRow): ClientOffer => ({
+  id: row.id,
+  linkedQuoteId: row.linkedQuoteId,
+  clientId: row.clientId,
+  clientName: row.clientName,
+  paymentTerms: row.paymentTerms,
+  discount: parseDbNumber(row.discount, 0),
+  discountType: row.discountType === 'currency' ? 'currency' : 'percentage',
+  status: row.status,
+  expirationDate: normalizeNullableDateOnly(row.expirationDate, 'offer.expirationDate'),
+  notes: row.notes,
+  createdAt: parseDbNumber(row.createdAt, 0),
+  updatedAt: parseDbNumber(row.updatedAt, 0),
+});
+
+const mapItem = (row: ClientOfferItemRow): ClientOfferItem => ({
+  id: row.id,
+  offerId: row.offerId,
+  productId: row.productId,
+  productName: row.productName,
+  quantity: parseDbNumber(row.quantity, 0),
+  unitPrice: parseDbNumber(row.unitPrice, 0),
+  productCost: parseDbNumber(row.productCost, 0),
+  productMolPercentage: parseNullableDbNumber(row.productMolPercentage),
+  supplierQuoteId: row.supplierQuoteId,
+  supplierQuoteItemId: row.supplierQuoteItemId,
+  supplierQuoteSupplierName: row.supplierQuoteSupplierName,
+  supplierQuoteUnitPrice: parseNullableDbNumber(row.supplierQuoteUnitPrice),
+  unitType: normalizeUnitType(row.unitType),
+  note: row.note,
+  discount: parseDbNumber(row.discount, 0),
+});
+
+export const listAll = async (exec: QueryExecutor = pool): Promise<ClientOffer[]> => {
+  const { rows } = await exec.query<ClientOfferRow>(
+    `SELECT ${OFFER_COLUMNS} FROM customer_offers ORDER BY created_at DESC`,
+  );
+  return rows.map(mapOffer);
+};
+
+export const listAllItems = async (exec: QueryExecutor = pool): Promise<ClientOfferItem[]> => {
+  const { rows } = await exec.query<ClientOfferItemRow>(
+    `SELECT ${ITEM_COLUMNS} FROM customer_offer_items ORDER BY created_at ASC`,
+  );
+  return rows.map(mapItem);
+};
+
+export const existsById = async (id: string, exec: QueryExecutor = pool): Promise<boolean> => {
+  const { rows } = await exec.query<{ id: string }>(
+    `SELECT id FROM customer_offers WHERE id = $1`,
+    [id],
+  );
+  return rows.length > 0;
+};
+
+export const findIdConflict = async (
+  newId: string,
+  currentId: string,
+  exec: QueryExecutor = pool,
+): Promise<boolean> => {
+  const { rows } = await exec.query<{ id: string }>(
+    `SELECT id FROM customer_offers WHERE id = $1 AND id <> $2`,
+    [newId, currentId],
+  );
+  return rows.length > 0;
+};
+
+export type ExistingOffer = {
+  id: string;
+  linkedQuoteId: string | null;
+  clientId: string;
+  clientName: string;
+  status: string;
+};
+
+export const findForUpdate = async (
+  id: string,
+  exec: QueryExecutor = pool,
+): Promise<ExistingOffer | null> => {
+  const { rows } = await exec.query<ExistingOffer>(
+    `SELECT id,
+            linked_quote_id as "linkedQuoteId",
+            client_id as "clientId",
+            client_name as "clientName",
+            status
+       FROM customer_offers
+      WHERE id = $1`,
+    [id],
+  );
+  return rows[0] ?? null;
+};
+
+export const findStatusAndClientName = async (
+  id: string,
+  exec: QueryExecutor = pool,
+): Promise<{ status: string; clientName: string } | null> => {
+  const { rows } = await exec.query<{ status: string; clientName: string }>(
+    `SELECT status, client_name as "clientName" FROM customer_offers WHERE id = $1`,
+    [id],
+  );
+  return rows[0] ?? null;
+};
+
+export const findExistingForQuote = async (
+  quoteId: string,
+  exec: QueryExecutor = pool,
+): Promise<string | null> => {
+  const { rows } = await exec.query<{ id: string }>(
+    `SELECT id FROM customer_offers WHERE linked_quote_id = $1 LIMIT 1`,
+    [quoteId],
+  );
+  return rows[0]?.id ?? null;
+};
+
+export const findLinkedSaleId = async (
+  offerId: string,
+  exec: QueryExecutor = pool,
+): Promise<string | null> => {
+  const { rows } = await exec.query<{ id: string }>(
+    `SELECT id FROM sales WHERE linked_offer_id = $1 LIMIT 1`,
+    [offerId],
+  );
+  return rows[0]?.id ?? null;
+};
+
+export const findItemsForOffer = async (
+  offerId: string,
+  exec: QueryExecutor = pool,
+): Promise<ClientOfferItem[]> => {
+  const { rows } = await exec.query<ClientOfferItemRow>(
+    `SELECT ${ITEM_COLUMNS} FROM customer_offer_items WHERE offer_id = $1`,
+    [offerId],
+  );
+  return rows.map(mapItem);
+};
+
+export type NewClientOffer = {
+  id: string;
+  linkedQuoteId: string;
+  clientId: string;
+  clientName: string;
+  paymentTerms: string;
+  discount: number;
+  discountType: 'percentage' | 'currency';
+  status: string;
+  expirationDate: string;
+  notes: string | null;
+};
+
+export const create = async (
+  input: NewClientOffer,
+  exec: QueryExecutor = pool,
+): Promise<ClientOffer> => {
+  const { rows } = await exec.query<ClientOfferRow>(
+    `INSERT INTO customer_offers
+        (id, linked_quote_id, client_id, client_name, payment_terms, discount, discount_type, status, expiration_date, notes)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+     RETURNING ${OFFER_COLUMNS}`,
+    [
+      input.id,
+      input.linkedQuoteId,
+      input.clientId,
+      input.clientName,
+      input.paymentTerms,
+      input.discount,
+      input.discountType,
+      input.status,
+      input.expirationDate,
+      input.notes,
+    ],
+  );
+  return mapOffer(rows[0]);
+};
+
+export type ClientOfferUpdate = {
+  id?: string | null;
+  clientId?: string | null;
+  clientName?: string | null;
+  paymentTerms?: string | null;
+  discount?: number | null;
+  discountType?: 'percentage' | 'currency' | null;
+  status?: string | null;
+  expirationDate?: string | null;
+  notes?: string | null;
+};
+
+export const update = async (
+  id: string,
+  patch: ClientOfferUpdate,
+  exec: QueryExecutor = pool,
+): Promise<ClientOffer | null> => {
+  const { rows } = await exec.query<ClientOfferRow>(
+    `UPDATE customer_offers
+        SET id = COALESCE($1, id),
+            client_id = COALESCE($2, client_id),
+            client_name = COALESCE($3, client_name),
+            payment_terms = COALESCE($4, payment_terms),
+            discount = COALESCE($5, discount),
+            discount_type = COALESCE($6, discount_type),
+            status = COALESCE($7, status),
+            expiration_date = COALESCE($8, expiration_date),
+            notes = COALESCE($9, notes),
+            updated_at = CURRENT_TIMESTAMP
+      WHERE id = $10
+      RETURNING ${OFFER_COLUMNS}`,
+    [
+      patch.id ?? null,
+      patch.clientId ?? null,
+      patch.clientName ?? null,
+      patch.paymentTerms ?? null,
+      patch.discount ?? null,
+      patch.discountType ?? null,
+      patch.status ?? null,
+      patch.expirationDate ?? null,
+      patch.notes ?? null,
+      id,
+    ],
+  );
+  return rows[0] ? mapOffer(rows[0]) : null;
+};
+
+export type NewClientOfferItem = {
+  id: string;
+  productId: string | null;
+  productName: string;
+  quantity: number;
+  unitPrice: number;
+  productCost: number;
+  productMolPercentage: number | null;
+  discount: number;
+  note: string | null;
+  supplierQuoteId: string | null;
+  supplierQuoteItemId: string | null;
+  supplierQuoteSupplierName: string | null;
+  supplierQuoteUnitPrice: number | null;
+  unitType: UnitType;
+};
+
+export const replaceItems = async (
+  offerId: string,
+  items: NewClientOfferItem[],
+  exec: QueryExecutor = pool,
+): Promise<ClientOfferItem[]> => {
+  await exec.query(`DELETE FROM customer_offer_items WHERE offer_id = $1`, [offerId]);
+  if (items.length === 0) return [];
+  const placeholders = buildBulkInsertPlaceholders(items.length, 15);
+  const params = items.flatMap((item) => [
+    item.id,
+    offerId,
+    item.productId,
+    item.productName,
+    item.quantity,
+    item.unitPrice,
+    item.productCost,
+    item.productMolPercentage,
+    item.discount,
+    item.note,
+    item.supplierQuoteId,
+    item.supplierQuoteItemId,
+    item.supplierQuoteSupplierName,
+    item.supplierQuoteUnitPrice,
+    item.unitType,
+  ]);
+  const { rows } = await exec.query<ClientOfferItemRow>(
+    `INSERT INTO customer_offer_items
+       (id, offer_id, product_id, product_name, quantity, unit_price, product_cost,
+        product_mol_percentage, discount, note,
+        supplier_quote_id, supplier_quote_item_id, supplier_quote_supplier_name,
+        supplier_quote_unit_price, unit_type)
+     VALUES ${placeholders}
+     RETURNING ${ITEM_COLUMNS}`,
+    params,
+  );
+  return rows.map(mapItem);
+};
+
+export const deleteById = async (id: string, exec: QueryExecutor = pool): Promise<boolean> => {
+  const { rowCount } = await exec.query(`DELETE FROM customer_offers WHERE id = $1`, [id]);
+  return (rowCount ?? 0) > 0;
+};

--- a/server/repositories/clientOffersRepo.ts
+++ b/server/repositories/clientOffersRepo.ts
@@ -340,12 +340,11 @@ export type NewClientOfferItem = {
   unitType: UnitType;
 };
 
-export const replaceItems = async (
+export const insertItems = async (
   offerId: string,
   items: NewClientOfferItem[],
   exec: QueryExecutor = pool,
 ): Promise<ClientOfferItem[]> => {
-  await exec.query(`DELETE FROM customer_offer_items WHERE offer_id = $1`, [offerId]);
   if (items.length === 0) return [];
   const placeholders = buildBulkInsertPlaceholders(items.length, 15);
   const params = items.flatMap((item) => [
@@ -376,6 +375,15 @@ export const replaceItems = async (
     params,
   );
   return rows.map(mapItem);
+};
+
+export const replaceItems = async (
+  offerId: string,
+  items: NewClientOfferItem[],
+  exec: QueryExecutor = pool,
+): Promise<ClientOfferItem[]> => {
+  await exec.query(`DELETE FROM customer_offer_items WHERE offer_id = $1`, [offerId]);
+  return insertItems(offerId, items, exec);
 };
 
 export const deleteById = async (id: string, exec: QueryExecutor = pool): Promise<boolean> => {

--- a/server/repositories/clientProfileOptionsRepo.ts
+++ b/server/repositories/clientProfileOptionsRepo.ts
@@ -142,7 +142,7 @@ export const update = async (
   patch: { value: string; sortOrder: number | null; previousValue: string },
   exec: QueryExecutor = pool,
 ): Promise<ProfileOption | null> => {
-  await exec.query(
+  const updateResult = await exec.query(
     `UPDATE client_profile_options
        SET value = $1,
            sort_order = COALESCE($2, sort_order),
@@ -150,6 +150,8 @@ export const update = async (
        WHERE id = $3 AND category = $4`,
     [patch.value, patch.sortOrder, id, category],
   );
+
+  if ((updateResult.rowCount ?? 0) === 0) return null;
 
   if (patch.previousValue !== patch.value) {
     const fieldName = VALUE_FIELD_BY_CATEGORY[category];
@@ -170,8 +172,8 @@ export const update = async (
        o.updated_at,
        ${usageCountExpr} as usage_count
      FROM client_profile_options o
-     WHERE o.id = $1`,
-    [id],
+     WHERE o.id = $1 AND o.category = $2`,
+    [id, category],
   );
   return rows[0] ? mapRow(rows[0]) : null;
 };

--- a/server/repositories/clientProfileOptionsRepo.ts
+++ b/server/repositories/clientProfileOptionsRepo.ts
@@ -1,0 +1,197 @@
+import pool, { type QueryExecutor } from '../db/index.ts';
+
+export const PROFILE_OPTION_CATEGORIES = [
+  'sector',
+  'numberOfEmployees',
+  'revenue',
+  'officeCountRange',
+] as const;
+
+export type ProfileOptionCategory = (typeof PROFILE_OPTION_CATEGORIES)[number];
+
+export type ProfileOption = {
+  id: string;
+  category: ProfileOptionCategory;
+  value: string;
+  sortOrder: number;
+  usageCount: number;
+  createdAt: number | null;
+  updatedAt: number | null;
+};
+
+// Internal allowlist: maps category to the column on `clients` that stores the option's value.
+// Keeping this private prevents any caller from injecting an arbitrary column name into the
+// cascade UPDATE — only this module touches the SQL.
+const VALUE_FIELD_BY_CATEGORY: Record<ProfileOptionCategory, string> = {
+  sector: 'sector',
+  numberOfEmployees: 'number_of_employees',
+  revenue: 'revenue',
+  officeCountRange: 'office_count_range',
+};
+
+const getUsageCountExpression = (category: ProfileOptionCategory): string => {
+  const column = VALUE_FIELD_BY_CATEGORY[category];
+  return `(SELECT COUNT(*) FROM clients c WHERE c.${column} = o.value)`;
+};
+
+const mapRow = (row: Record<string, unknown>): ProfileOption => ({
+  id: String(row.id),
+  category: String(row.category) as ProfileOptionCategory,
+  value: String(row.value),
+  sortOrder: Number(row.sort_order ?? 0),
+  usageCount: Number(row.usage_count ?? 0),
+  createdAt: row.created_at ? new Date(String(row.created_at)).getTime() : null,
+  updatedAt: row.updated_at ? new Date(String(row.updated_at)).getTime() : null,
+});
+
+export const listByCategory = async (
+  category: ProfileOptionCategory,
+  exec: QueryExecutor = pool,
+): Promise<ProfileOption[]> => {
+  const usageCountExpr = getUsageCountExpression(category);
+  const { rows } = await exec.query(
+    `SELECT
+       o.id,
+       o.category,
+       o.value,
+       o.sort_order,
+       o.created_at,
+       o.updated_at,
+       ${usageCountExpr} as usage_count
+     FROM client_profile_options o
+     WHERE o.category = $1
+     ORDER BY o.sort_order ASC, o.value ASC`,
+    [category],
+  );
+  return rows.map(mapRow);
+};
+
+export const findByCategoryAndId = async (
+  category: ProfileOptionCategory,
+  id: string,
+  exec: QueryExecutor = pool,
+): Promise<{ id: string; value: string } | null> => {
+  const { rows } = await exec.query<{ id: string; value: string }>(
+    `SELECT id, value FROM client_profile_options WHERE id = $1 AND category = $2`,
+    [id, category],
+  );
+  return rows[0] ?? null;
+};
+
+export const findByCategoryAndValue = async (
+  category: ProfileOptionCategory,
+  value: string,
+  excludeId: string | null,
+  exec: QueryExecutor = pool,
+): Promise<boolean> => {
+  if (excludeId) {
+    const { rows } = await exec.query<{ id: string }>(
+      `SELECT id FROM client_profile_options
+       WHERE category = $1 AND LOWER(value) = LOWER($2) AND id <> $3`,
+      [category, value, excludeId],
+    );
+    return rows.length > 0;
+  }
+  const { rows } = await exec.query<{ id: string }>(
+    `SELECT id FROM client_profile_options WHERE category = $1 AND LOWER(value) = LOWER($2)`,
+    [category, value],
+  );
+  return rows.length > 0;
+};
+
+export const getNextSortOrder = async (
+  category: ProfileOptionCategory,
+  exec: QueryExecutor = pool,
+): Promise<number> => {
+  const { rows } = await exec.query<{ next_sort_order: string | number | null }>(
+    `SELECT COALESCE(MAX(sort_order), 0) + 1 as next_sort_order
+       FROM client_profile_options WHERE category = $1`,
+    [category],
+  );
+  return Number(rows[0]?.next_sort_order ?? 1);
+};
+
+export type NewProfileOption = {
+  id: string;
+  category: ProfileOptionCategory;
+  value: string;
+  sortOrder: number;
+};
+
+export const create = async (
+  input: NewProfileOption,
+  exec: QueryExecutor = pool,
+): Promise<ProfileOption> => {
+  const { rows } = await exec.query(
+    `INSERT INTO client_profile_options (id, category, value, sort_order)
+     VALUES ($1, $2, $3, $4)
+     RETURNING id, category, value, sort_order, created_at, updated_at`,
+    [input.id, input.category, input.value, input.sortOrder],
+  );
+  return mapRow({ ...rows[0], usage_count: 0 });
+};
+
+/**
+ * Updates the option row and, when the value changed, cascades the new value to all clients
+ * whose corresponding column held the old value. The cascade column is selected internally from
+ * the category allowlist — no caller-supplied column names ever reach the SQL.
+ */
+export const update = async (
+  category: ProfileOptionCategory,
+  id: string,
+  patch: { value: string; sortOrder: number | null; previousValue: string },
+  exec: QueryExecutor = pool,
+): Promise<ProfileOption | null> => {
+  await exec.query(
+    `UPDATE client_profile_options
+       SET value = $1,
+           sort_order = COALESCE($2, sort_order),
+           updated_at = CURRENT_TIMESTAMP
+       WHERE id = $3 AND category = $4`,
+    [patch.value, patch.sortOrder, id, category],
+  );
+
+  if (patch.previousValue !== patch.value) {
+    const fieldName = VALUE_FIELD_BY_CATEGORY[category];
+    await exec.query(`UPDATE clients SET ${fieldName} = $1 WHERE ${fieldName} = $2`, [
+      patch.value,
+      patch.previousValue,
+    ]);
+  }
+
+  const usageCountExpr = getUsageCountExpression(category);
+  const { rows } = await exec.query(
+    `SELECT
+       o.id,
+       o.category,
+       o.value,
+       o.sort_order,
+       o.created_at,
+       o.updated_at,
+       ${usageCountExpr} as usage_count
+     FROM client_profile_options o
+     WHERE o.id = $1`,
+    [id],
+  );
+  return rows[0] ? mapRow(rows[0]) : null;
+};
+
+export const getUsageCount = async (
+  category: ProfileOptionCategory,
+  id: string,
+  exec: QueryExecutor = pool,
+): Promise<number> => {
+  const usageCountExpr = getUsageCountExpression(category);
+  const { rows } = await exec.query<{ usage_count: string | number | null }>(
+    `SELECT ${usageCountExpr} as usage_count
+       FROM client_profile_options o
+       WHERE o.id = $1`,
+    [id],
+  );
+  return Number(rows[0]?.usage_count ?? 0);
+};
+
+export const deleteById = async (id: string, exec: QueryExecutor = pool): Promise<boolean> => {
+  const { rowCount } = await exec.query(`DELETE FROM client_profile_options WHERE id = $1`, [id]);
+  return (rowCount ?? 0) > 0;
+};

--- a/server/repositories/clientQuotesRepo.ts
+++ b/server/repositories/clientQuotesRepo.ts
@@ -1,0 +1,489 @@
+import pool, { buildBulkInsertPlaceholders, type QueryExecutor } from '../db/index.ts';
+import { normalizeNullableDateOnly } from '../utils/date.ts';
+import { parseDbNumber, parseNullableDbNumber } from '../utils/parse.ts';
+import { normalizeUnitType, type UnitType } from '../utils/unit-type.ts';
+
+export type ClientQuote = {
+  id: string;
+  linkedOfferId: string | null;
+  clientId: string;
+  clientName: string;
+  paymentTerms: string | null;
+  discount: number;
+  discountType: 'percentage' | 'currency';
+  status: string;
+  expirationDate: string | null;
+  notes: string | null;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type ClientQuoteItem = {
+  id: string;
+  quoteId: string;
+  productId: string;
+  productName: string;
+  quantity: number;
+  unitPrice: number;
+  productCost: number;
+  productMolPercentage: number | null;
+  supplierQuoteId: string | null;
+  supplierQuoteItemId: string | null;
+  supplierQuoteSupplierName: string | null;
+  supplierQuoteUnitPrice: number | null;
+  discount: number;
+  note: string | null;
+  unitType: UnitType;
+};
+
+type ClientQuoteRow = {
+  id: string;
+  linkedOfferId: string | null;
+  clientId: string;
+  clientName: string;
+  paymentTerms: string | null;
+  discount: string | number;
+  discountType: string;
+  status: string;
+  expirationDate: string | Date | null;
+  notes: string | null;
+  createdAt: string | number;
+  updatedAt: string | number;
+};
+
+type ClientQuoteItemRow = {
+  id: string;
+  quoteId: string;
+  productId: string | null;
+  productName: string;
+  quantity: string | number;
+  unitPrice: string | number;
+  productCost: string | number;
+  productMolPercentage: string | number | null;
+  supplierQuoteId: string | null;
+  supplierQuoteItemId: string | null;
+  supplierQuoteSupplierName: string | null;
+  supplierQuoteUnitPrice: string | number | null;
+  discount: string | number;
+  note: string | null;
+  unitType: string | null;
+};
+
+const QUOTE_LIST_COLUMNS = `
+  id,
+  (
+    SELECT co.id
+    FROM customer_offers co
+    WHERE co.linked_quote_id = quotes.id
+    LIMIT 1
+  ) as "linkedOfferId",
+  client_id as "clientId",
+  client_name as "clientName",
+  payment_terms as "paymentTerms",
+  discount,
+  discount_type as "discountType",
+  status,
+  expiration_date as "expirationDate",
+  notes,
+  EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt",
+  EXTRACT(EPOCH FROM updated_at) * 1000 as "updatedAt"
+`;
+
+const QUOTE_BASE_COLUMNS = `
+  id,
+  null::varchar as "linkedOfferId",
+  client_id as "clientId",
+  client_name as "clientName",
+  payment_terms as "paymentTerms",
+  discount,
+  discount_type as "discountType",
+  status,
+  expiration_date as "expirationDate",
+  notes,
+  EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt",
+  EXTRACT(EPOCH FROM updated_at) * 1000 as "updatedAt"
+`;
+
+const ITEM_COLUMNS = `
+  id,
+  quote_id as "quoteId",
+  product_id as "productId",
+  product_name as "productName",
+  quantity,
+  unit_price as "unitPrice",
+  product_cost as "productCost",
+  product_mol_percentage as "productMolPercentage",
+  supplier_quote_id as "supplierQuoteId",
+  supplier_quote_item_id as "supplierQuoteItemId",
+  supplier_quote_supplier_name as "supplierQuoteSupplierName",
+  supplier_quote_unit_price as "supplierQuoteUnitPrice",
+  discount,
+  note,
+  unit_type as "unitType"
+`;
+
+const mapQuote = (row: ClientQuoteRow): ClientQuote => ({
+  id: row.id,
+  linkedOfferId: row.linkedOfferId,
+  clientId: row.clientId,
+  clientName: row.clientName,
+  paymentTerms: row.paymentTerms,
+  discount: parseDbNumber(row.discount, 0),
+  discountType: row.discountType === 'currency' ? 'currency' : 'percentage',
+  status: row.status,
+  expirationDate: normalizeNullableDateOnly(row.expirationDate, 'quote.expirationDate'),
+  notes: row.notes,
+  createdAt: parseDbNumber(row.createdAt, 0),
+  updatedAt: parseDbNumber(row.updatedAt, 0),
+});
+
+const mapItem = (row: ClientQuoteItemRow): ClientQuoteItem => ({
+  id: row.id,
+  quoteId: row.quoteId,
+  productId: row.productId ?? '',
+  productName: row.productName,
+  quantity: parseDbNumber(row.quantity, 0),
+  unitPrice: parseDbNumber(row.unitPrice, 0),
+  productCost: parseDbNumber(row.productCost, 0),
+  productMolPercentage: parseNullableDbNumber(row.productMolPercentage),
+  supplierQuoteId: row.supplierQuoteId,
+  supplierQuoteItemId: row.supplierQuoteItemId,
+  supplierQuoteSupplierName: row.supplierQuoteSupplierName,
+  supplierQuoteUnitPrice: parseNullableDbNumber(row.supplierQuoteUnitPrice),
+  discount: parseDbNumber(row.discount, 0),
+  note: row.note,
+  unitType: normalizeUnitType(row.unitType),
+});
+
+export const listAll = async (exec: QueryExecutor = pool): Promise<ClientQuote[]> => {
+  const { rows } = await exec.query<ClientQuoteRow>(
+    `SELECT ${QUOTE_LIST_COLUMNS} FROM quotes ORDER BY created_at DESC`,
+  );
+  return rows.map(mapQuote);
+};
+
+export const listAllItems = async (exec: QueryExecutor = pool): Promise<ClientQuoteItem[]> => {
+  const { rows } = await exec.query<ClientQuoteItemRow>(
+    `SELECT ${ITEM_COLUMNS} FROM quote_items ORDER BY created_at ASC`,
+  );
+  return rows.map(mapItem);
+};
+
+export const existsById = async (id: string, exec: QueryExecutor = pool): Promise<boolean> => {
+  const { rows } = await exec.query<{ id: string }>(`SELECT id FROM quotes WHERE id = $1`, [id]);
+  return rows.length > 0;
+};
+
+export const findIdConflict = async (
+  newId: string,
+  currentId: string,
+  exec: QueryExecutor = pool,
+): Promise<boolean> => {
+  const { rows } = await exec.query<{ id: string }>(
+    `SELECT id FROM quotes WHERE id = $1 AND id <> $2`,
+    [newId, currentId],
+  );
+  return rows.length > 0;
+};
+
+export const findCurrentForUpdate = async (
+  id: string,
+  exec: QueryExecutor = pool,
+): Promise<{
+  status: string;
+  discount: number;
+  discountType: 'percentage' | 'currency';
+} | null> => {
+  const { rows } = await exec.query<{
+    status: string;
+    discount: string | number | null;
+    discount_type: string | null;
+  }>(`SELECT status, discount, discount_type FROM quotes WHERE id = $1`, [id]);
+  if (rows.length === 0) return null;
+  return {
+    status: rows[0].status,
+    discount: parseDbNumber(rows[0].discount, 0),
+    discountType: rows[0].discount_type === 'currency' ? 'currency' : 'percentage',
+  };
+};
+
+export const findStatusAndClientName = async (
+  id: string,
+  exec: QueryExecutor = pool,
+): Promise<{ status: string; clientName: string } | null> => {
+  const { rows } = await exec.query<{ status: string; clientName: string }>(
+    `SELECT status, client_name as "clientName" FROM quotes WHERE id = $1`,
+    [id],
+  );
+  return rows[0] ?? null;
+};
+
+export const findLinkedOfferId = async (
+  quoteId: string,
+  exec: QueryExecutor = pool,
+): Promise<string | null> => {
+  const { rows } = await exec.query<{ id: string }>(
+    `SELECT id FROM customer_offers WHERE linked_quote_id = $1 LIMIT 1`,
+    [quoteId],
+  );
+  return rows[0]?.id ?? null;
+};
+
+export const findNonDraftLinkedSale = async (
+  quoteId: string,
+  exec: QueryExecutor = pool,
+): Promise<string | null> => {
+  const { rows } = await exec.query<{ id: string }>(
+    `SELECT id FROM sales WHERE linked_quote_id = $1 AND status <> $2 LIMIT 1`,
+    [quoteId, 'draft'],
+  );
+  return rows[0]?.id ?? null;
+};
+
+export const deleteDraftSalesForQuote = async (
+  quoteId: string,
+  exec: QueryExecutor = pool,
+): Promise<void> => {
+  await exec.query(`DELETE FROM sales WHERE linked_quote_id = $1 AND status = $2`, [
+    quoteId,
+    'draft',
+  ]);
+};
+
+export const findAnyLinkedSale = async (
+  quoteId: string,
+  exec: QueryExecutor = pool,
+): Promise<string | null> => {
+  const { rows } = await exec.query<{ id: string }>(
+    `SELECT id FROM sales WHERE linked_quote_id = $1 LIMIT 1`,
+    [quoteId],
+  );
+  return rows[0]?.id ?? null;
+};
+
+export type ExistingQuoteItemSnapshot = {
+  id: string;
+  productId: string | null;
+  productCost: number;
+  productMolPercentage: number | null;
+  supplierQuoteId: string | null;
+  supplierQuoteItemId: string | null;
+  supplierQuoteSupplierName: string | null;
+  supplierQuoteUnitPrice: number | null;
+  unitType: UnitType;
+};
+
+export const findItemSnapshotsForQuote = async (
+  quoteId: string,
+  exec: QueryExecutor = pool,
+): Promise<ExistingQuoteItemSnapshot[]> => {
+  const { rows } = await exec.query<{
+    id: string;
+    productId: string | null;
+    productCost: string | number | null;
+    productMolPercentage: string | number | null;
+    supplierQuoteId: string | null;
+    supplierQuoteItemId: string | null;
+    supplierQuoteSupplierName: string | null;
+    supplierQuoteUnitPrice: string | number | null;
+    unitType: string | null;
+  }>(
+    `SELECT
+        id,
+        product_id as "productId",
+        product_cost as "productCost",
+        product_mol_percentage as "productMolPercentage",
+        supplier_quote_id as "supplierQuoteId",
+        supplier_quote_item_id as "supplierQuoteItemId",
+        supplier_quote_supplier_name as "supplierQuoteSupplierName",
+        supplier_quote_unit_price as "supplierQuoteUnitPrice",
+        unit_type as "unitType"
+       FROM quote_items
+      WHERE quote_id = $1`,
+    [quoteId],
+  );
+  return rows.map((row) => ({
+    id: row.id,
+    productId: row.productId,
+    productCost: parseDbNumber(row.productCost, 0),
+    productMolPercentage: parseNullableDbNumber(row.productMolPercentage),
+    supplierQuoteId: row.supplierQuoteId,
+    supplierQuoteItemId: row.supplierQuoteItemId,
+    supplierQuoteSupplierName: row.supplierQuoteSupplierName,
+    supplierQuoteUnitPrice: parseNullableDbNumber(row.supplierQuoteUnitPrice),
+    unitType: normalizeUnitType(row.unitType),
+  }));
+};
+
+export const findItemTotals = async (
+  quoteId: string,
+  exec: QueryExecutor = pool,
+): Promise<Array<{ quantity: number; unitPrice: number; discount: number }>> => {
+  const { rows } = await exec.query<{
+    quantity: string | number;
+    unitPrice: string | number;
+    discount: string | number | null;
+  }>(`SELECT quantity, unit_price as "unitPrice", discount FROM quote_items WHERE quote_id = $1`, [
+    quoteId,
+  ]);
+  return rows.map((row) => ({
+    quantity: parseDbNumber(row.quantity, 0),
+    unitPrice: parseDbNumber(row.unitPrice, 0),
+    discount: parseDbNumber(row.discount, 0),
+  }));
+};
+
+export const findItemsForQuote = async (
+  quoteId: string,
+  exec: QueryExecutor = pool,
+): Promise<ClientQuoteItem[]> => {
+  const { rows } = await exec.query<ClientQuoteItemRow>(
+    `SELECT ${ITEM_COLUMNS} FROM quote_items WHERE quote_id = $1`,
+    [quoteId],
+  );
+  return rows.map(mapItem);
+};
+
+export type NewClientQuote = {
+  id: string;
+  clientId: string;
+  clientName: string;
+  paymentTerms: string;
+  discount: number;
+  discountType: 'percentage' | 'currency';
+  status: string;
+  expirationDate: string;
+  notes: string | null;
+};
+
+export const create = async (
+  input: NewClientQuote,
+  exec: QueryExecutor = pool,
+): Promise<ClientQuote> => {
+  const { rows } = await exec.query<ClientQuoteRow>(
+    `INSERT INTO quotes (id, client_id, client_name, payment_terms, discount, discount_type, status, expiration_date, notes)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+     RETURNING ${QUOTE_BASE_COLUMNS}`,
+    [
+      input.id,
+      input.clientId,
+      input.clientName,
+      input.paymentTerms,
+      input.discount,
+      input.discountType,
+      input.status,
+      input.expirationDate,
+      input.notes,
+    ],
+  );
+  return mapQuote(rows[0]);
+};
+
+export type ClientQuoteUpdate = {
+  id?: string | null;
+  clientId?: string | null;
+  clientName?: string | null;
+  paymentTerms?: string | null;
+  discount?: number | null;
+  discountType?: 'percentage' | 'currency' | null;
+  status?: string | null;
+  expirationDate?: string | null;
+  notes?: string | null;
+};
+
+export const update = async (
+  id: string,
+  patch: ClientQuoteUpdate,
+  exec: QueryExecutor = pool,
+): Promise<ClientQuote | null> => {
+  const { rows } = await exec.query<ClientQuoteRow>(
+    `UPDATE quotes
+        SET id = COALESCE($1, id),
+            client_id = COALESCE($2, client_id),
+            client_name = COALESCE($3, client_name),
+            payment_terms = COALESCE($4, payment_terms),
+            discount = COALESCE($5, discount),
+            discount_type = COALESCE($6, discount_type),
+            status = COALESCE($7, status),
+            expiration_date = COALESCE($8, expiration_date),
+            notes = COALESCE($9, notes),
+            updated_at = CURRENT_TIMESTAMP
+      WHERE id = $10
+      RETURNING ${QUOTE_BASE_COLUMNS}`,
+    [
+      patch.id ?? null,
+      patch.clientId ?? null,
+      patch.clientName ?? null,
+      patch.paymentTerms ?? null,
+      patch.discount ?? null,
+      patch.discountType ?? null,
+      patch.status ?? null,
+      patch.expirationDate ?? null,
+      patch.notes ?? null,
+      id,
+    ],
+  );
+  return rows[0] ? mapQuote(rows[0]) : null;
+};
+
+export type NewClientQuoteItem = {
+  id: string;
+  productId: string | null;
+  productName: string;
+  quantity: number;
+  unitPrice: number;
+  productCost: number;
+  productMolPercentage: number | null;
+  discount: number;
+  note: string | null;
+  supplierQuoteId: string | null;
+  supplierQuoteItemId: string | null;
+  supplierQuoteSupplierName: string | null;
+  supplierQuoteUnitPrice: number | null;
+  unitType: UnitType;
+};
+
+export const replaceItems = async (
+  quoteId: string,
+  items: NewClientQuoteItem[],
+  exec: QueryExecutor = pool,
+): Promise<ClientQuoteItem[]> => {
+  await exec.query(`DELETE FROM quote_items WHERE quote_id = $1`, [quoteId]);
+  if (items.length === 0) return [];
+  const placeholders = buildBulkInsertPlaceholders(items.length, 15);
+  const params = items.flatMap((item) => [
+    item.id,
+    quoteId,
+    item.productId,
+    item.productName,
+    item.quantity,
+    item.unitPrice,
+    item.productCost,
+    item.productMolPercentage,
+    item.discount,
+    item.note,
+    item.supplierQuoteId,
+    item.supplierQuoteItemId,
+    item.supplierQuoteSupplierName,
+    item.supplierQuoteUnitPrice,
+    item.unitType,
+  ]);
+  const { rows } = await exec.query<ClientQuoteItemRow>(
+    `INSERT INTO quote_items (
+       id, quote_id, product_id, product_name,
+       quantity, unit_price, product_cost, product_mol_percentage,
+       discount, note,
+       supplier_quote_id, supplier_quote_item_id, supplier_quote_supplier_name,
+       supplier_quote_unit_price,
+       unit_type
+     ) VALUES ${placeholders}
+     RETURNING ${ITEM_COLUMNS}`,
+    params,
+  );
+  return rows.map(mapItem);
+};
+
+export const deleteById = async (id: string, exec: QueryExecutor = pool): Promise<boolean> => {
+  const { rowCount } = await exec.query(`DELETE FROM quotes WHERE id = $1`, [id]);
+  return (rowCount ?? 0) > 0;
+};

--- a/server/repositories/clientQuotesRepo.ts
+++ b/server/repositories/clientQuotesRepo.ts
@@ -443,12 +443,11 @@ export type NewClientQuoteItem = {
   unitType: UnitType;
 };
 
-export const replaceItems = async (
+export const insertItems = async (
   quoteId: string,
   items: NewClientQuoteItem[],
   exec: QueryExecutor = pool,
 ): Promise<ClientQuoteItem[]> => {
-  await exec.query(`DELETE FROM quote_items WHERE quote_id = $1`, [quoteId]);
   if (items.length === 0) return [];
   const placeholders = buildBulkInsertPlaceholders(items.length, 15);
   const params = items.flatMap((item) => [
@@ -481,6 +480,15 @@ export const replaceItems = async (
     params,
   );
   return rows.map(mapItem);
+};
+
+export const replaceItems = async (
+  quoteId: string,
+  items: NewClientQuoteItem[],
+  exec: QueryExecutor = pool,
+): Promise<ClientQuoteItem[]> => {
+  await exec.query(`DELETE FROM quote_items WHERE quote_id = $1`, [quoteId]);
+  return insertItems(quoteId, items, exec);
 };
 
 export const deleteById = async (id: string, exec: QueryExecutor = pool): Promise<boolean> => {

--- a/server/repositories/clientsOrdersRepo.ts
+++ b/server/repositories/clientsOrdersRepo.ts
@@ -543,9 +543,7 @@ export const mapSaleItemsToSupplierItems = async (
   exec: QueryExecutor,
 ): Promise<void> => {
   if (args.mappings.length === 0) return;
-  const valuesPlaceholders = args.mappings
-    .map((_, i) => `($${i * 2 + 3}, $${i * 2 + 4})`)
-    .join(', ');
+  const valuesPlaceholders = buildBulkInsertPlaceholders(args.mappings.length, 2, 3);
   const mappingParams = args.mappings.flatMap(({ quoteItemId, saleItemId }) => [
     quoteItemId,
     saleItemId,

--- a/server/repositories/clientsOrdersRepo.ts
+++ b/server/repositories/clientsOrdersRepo.ts
@@ -1,0 +1,561 @@
+import pool, { buildBulkInsertPlaceholders, type QueryExecutor } from '../db/index.ts';
+import { parseDbNumber, parseNullableDbNumber } from '../utils/parse.ts';
+import { normalizeUnitType, type UnitType } from '../utils/unit-type.ts';
+
+export type ClientOrder = {
+  id: string;
+  linkedQuoteId: string | null;
+  linkedOfferId: string | null;
+  clientId: string;
+  clientName: string;
+  paymentTerms: string | null;
+  discount: number;
+  discountType: 'percentage' | 'currency';
+  status: string;
+  notes: string | null;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type ClientOrderItem = {
+  id: string;
+  orderId: string;
+  productId: string | null;
+  productName: string;
+  quantity: number;
+  unitPrice: number;
+  productCost: number;
+  productMolPercentage: number | null;
+  supplierQuoteId: string | null;
+  supplierQuoteItemId: string | null;
+  supplierQuoteSupplierName: string | null;
+  supplierQuoteUnitPrice: number | null;
+  supplierSaleId: string | null;
+  supplierSaleItemId: string | null;
+  supplierSaleSupplierName: string | null;
+  unitType: UnitType;
+  note: string | null;
+  discount: number;
+};
+
+type ClientOrderRow = {
+  id: string;
+  linkedQuoteId: string | null;
+  linkedOfferId: string | null;
+  clientId: string;
+  clientName: string;
+  paymentTerms: string | null;
+  discount: string | number;
+  discountType: string;
+  status: string;
+  notes: string | null;
+  createdAt: string | number;
+  updatedAt: string | number;
+};
+
+type ClientOrderItemRow = {
+  id: string;
+  orderId: string;
+  productId: string | null;
+  productName: string;
+  quantity: string | number;
+  unitPrice: string | number;
+  productCost: string | number;
+  productMolPercentage: string | number | null;
+  supplierQuoteId: string | null;
+  supplierQuoteItemId: string | null;
+  supplierQuoteSupplierName: string | null;
+  supplierQuoteUnitPrice: string | number | null;
+  supplierSaleId: string | null;
+  supplierSaleItemId: string | null;
+  supplierSaleSupplierName: string | null;
+  unitType: string | null;
+  note: string | null;
+  discount: string | number;
+};
+
+const ORDER_COLUMNS = `
+  id,
+  linked_quote_id as "linkedQuoteId",
+  linked_offer_id as "linkedOfferId",
+  client_id as "clientId",
+  client_name as "clientName",
+  payment_terms as "paymentTerms",
+  discount,
+  discount_type as "discountType",
+  status,
+  notes,
+  EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt",
+  EXTRACT(EPOCH FROM updated_at) * 1000 as "updatedAt"
+`;
+
+const ITEM_COLUMNS = `
+  id,
+  sale_id as "orderId",
+  product_id as "productId",
+  product_name as "productName",
+  quantity,
+  unit_price as "unitPrice",
+  product_cost as "productCost",
+  product_mol_percentage as "productMolPercentage",
+  supplier_quote_id as "supplierQuoteId",
+  supplier_quote_item_id as "supplierQuoteItemId",
+  supplier_quote_supplier_name as "supplierQuoteSupplierName",
+  supplier_quote_unit_price as "supplierQuoteUnitPrice",
+  supplier_sale_id as "supplierSaleId",
+  supplier_sale_item_id as "supplierSaleItemId",
+  supplier_sale_supplier_name as "supplierSaleSupplierName",
+  unit_type as "unitType",
+  note,
+  discount
+`;
+
+const mapOrder = (row: ClientOrderRow): ClientOrder => ({
+  id: row.id,
+  linkedQuoteId: row.linkedQuoteId,
+  linkedOfferId: row.linkedOfferId,
+  clientId: row.clientId,
+  clientName: row.clientName,
+  paymentTerms: row.paymentTerms,
+  discount: parseDbNumber(row.discount, 0),
+  discountType: row.discountType === 'currency' ? 'currency' : 'percentage',
+  status: row.status,
+  notes: row.notes,
+  createdAt: parseDbNumber(row.createdAt, 0),
+  updatedAt: parseDbNumber(row.updatedAt, 0),
+});
+
+const mapItem = (row: ClientOrderItemRow): ClientOrderItem => ({
+  id: row.id,
+  orderId: row.orderId,
+  productId: row.productId,
+  productName: row.productName,
+  quantity: parseDbNumber(row.quantity, 0),
+  unitPrice: parseDbNumber(row.unitPrice, 0),
+  productCost: parseDbNumber(row.productCost, 0),
+  productMolPercentage: parseNullableDbNumber(row.productMolPercentage),
+  supplierQuoteId: row.supplierQuoteId,
+  supplierQuoteItemId: row.supplierQuoteItemId,
+  supplierQuoteSupplierName: row.supplierQuoteSupplierName,
+  supplierQuoteUnitPrice: parseNullableDbNumber(row.supplierQuoteUnitPrice),
+  supplierSaleId: row.supplierSaleId,
+  supplierSaleItemId: row.supplierSaleItemId,
+  supplierSaleSupplierName: row.supplierSaleSupplierName,
+  unitType: normalizeUnitType(row.unitType),
+  note: row.note,
+  discount: parseDbNumber(row.discount, 0),
+});
+
+export const listAll = async (exec: QueryExecutor = pool): Promise<ClientOrder[]> => {
+  const { rows } = await exec.query<ClientOrderRow>(
+    `SELECT ${ORDER_COLUMNS} FROM sales ORDER BY created_at DESC`,
+  );
+  return rows.map(mapOrder);
+};
+
+export const listAllItems = async (exec: QueryExecutor = pool): Promise<ClientOrderItem[]> => {
+  const { rows } = await exec.query<ClientOrderItemRow>(
+    `SELECT ${ITEM_COLUMNS} FROM sale_items ORDER BY created_at ASC`,
+  );
+  return rows.map(mapItem);
+};
+
+export const existsById = async (id: string, exec: QueryExecutor = pool): Promise<boolean> => {
+  const { rows } = await exec.query<{ id: string }>(`SELECT id FROM sales WHERE id = $1`, [id]);
+  return rows.length > 0;
+};
+
+export const findIdConflict = async (
+  newId: string,
+  currentId: string,
+  exec: QueryExecutor = pool,
+): Promise<boolean> => {
+  const { rows } = await exec.query<{ id: string }>(
+    `SELECT id FROM sales WHERE id = $1 AND id <> $2`,
+    [newId, currentId],
+  );
+  return rows.length > 0;
+};
+
+export type ExistingClientOrder = {
+  id: string;
+  linkedQuoteId: string | null;
+  linkedOfferId: string | null;
+  clientId: string;
+  clientName: string;
+  paymentTerms: string | null;
+  discount: number;
+  status: string;
+  notes: string | null;
+};
+
+export const findForUpdate = async (
+  id: string,
+  exec: QueryExecutor = pool,
+): Promise<ExistingClientOrder | null> => {
+  const { rows } = await exec.query<{
+    id: string;
+    linkedQuoteId: string | null;
+    linkedOfferId: string | null;
+    clientId: string;
+    clientName: string;
+    paymentTerms: string | null;
+    discount: string | number;
+    status: string;
+    notes: string | null;
+  }>(
+    `SELECT id,
+            linked_quote_id as "linkedQuoteId",
+            linked_offer_id as "linkedOfferId",
+            client_id as "clientId",
+            client_name as "clientName",
+            payment_terms as "paymentTerms",
+            discount,
+            status,
+            notes
+       FROM sales
+      WHERE id = $1`,
+    [id],
+  );
+  if (!rows[0]) return null;
+  return {
+    id: rows[0].id,
+    linkedQuoteId: rows[0].linkedQuoteId,
+    linkedOfferId: rows[0].linkedOfferId,
+    clientId: rows[0].clientId,
+    clientName: rows[0].clientName,
+    paymentTerms: rows[0].paymentTerms,
+    discount: parseDbNumber(rows[0].discount, 0),
+    status: rows[0].status,
+    notes: rows[0].notes,
+  };
+};
+
+export const findStatusAndClientName = async (
+  id: string,
+  exec: QueryExecutor = pool,
+): Promise<{ status: string; clientName: string } | null> => {
+  const { rows } = await exec.query<{ status: string; clientName: string }>(
+    `SELECT status, client_name as "clientName" FROM sales WHERE id = $1`,
+    [id],
+  );
+  return rows[0] ?? null;
+};
+
+export type OfferLink = {
+  id: string;
+  linkedQuoteId: string | null;
+  status: string;
+};
+
+export const findOfferDetails = async (
+  offerId: string,
+  exec: QueryExecutor = pool,
+): Promise<OfferLink | null> => {
+  const { rows } = await exec.query<OfferLink>(
+    `SELECT id, linked_quote_id as "linkedQuoteId", status FROM customer_offers WHERE id = $1`,
+    [offerId],
+  );
+  return rows[0] ?? null;
+};
+
+export const findExistingForOffer = async (
+  offerId: string,
+  excludeOrderId: string | null = null,
+  exec: QueryExecutor = pool,
+): Promise<string | null> => {
+  if (excludeOrderId) {
+    const { rows } = await exec.query<{ id: string }>(
+      `SELECT id FROM sales WHERE linked_offer_id = $1 AND id <> $2 LIMIT 1`,
+      [offerId, excludeOrderId],
+    );
+    return rows[0]?.id ?? null;
+  }
+  const { rows } = await exec.query<{ id: string }>(
+    `SELECT id FROM sales WHERE linked_offer_id = $1 LIMIT 1`,
+    [offerId],
+  );
+  return rows[0]?.id ?? null;
+};
+
+export const findItemsForOrder = async (
+  orderId: string,
+  exec: QueryExecutor = pool,
+): Promise<ClientOrderItem[]> => {
+  const { rows } = await exec.query<ClientOrderItemRow>(
+    `SELECT ${ITEM_COLUMNS} FROM sale_items WHERE sale_id = $1 ORDER BY created_at ASC`,
+    [orderId],
+  );
+  return rows.map(mapItem);
+};
+
+export type NewClientOrder = {
+  id: string;
+  linkedQuoteId: string | null;
+  linkedOfferId: string | null;
+  clientId: string;
+  clientName: string;
+  paymentTerms: string;
+  discount: number;
+  discountType: 'percentage' | 'currency';
+  status: string;
+  notes: string | null;
+};
+
+export const create = async (
+  input: NewClientOrder,
+  exec: QueryExecutor = pool,
+): Promise<ClientOrder> => {
+  const { rows } = await exec.query<ClientOrderRow>(
+    `INSERT INTO sales (id, linked_quote_id, linked_offer_id, client_id, client_name, payment_terms, discount, discount_type, status, notes)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+     RETURNING ${ORDER_COLUMNS}`,
+    [
+      input.id,
+      input.linkedQuoteId,
+      input.linkedOfferId,
+      input.clientId,
+      input.clientName,
+      input.paymentTerms,
+      input.discount,
+      input.discountType,
+      input.status,
+      input.notes,
+    ],
+  );
+  return mapOrder(rows[0]);
+};
+
+export type ClientOrderUpdate = {
+  id?: string | null;
+  linkedOfferId?: string | null;
+  linkedQuoteId?: string | null;
+  clientId?: string | null;
+  clientName?: string | null;
+  paymentTerms?: string | null;
+  discount?: number | null;
+  discountType?: 'percentage' | 'currency' | null;
+  status?: string | null;
+  notes?: string | null;
+};
+
+export const update = async (
+  id: string,
+  patch: ClientOrderUpdate,
+  exec: QueryExecutor = pool,
+): Promise<ClientOrder | null> => {
+  const { rows } = await exec.query<ClientOrderRow>(
+    `UPDATE sales
+        SET id = COALESCE($1, id),
+            linked_offer_id = COALESCE($2, linked_offer_id),
+            linked_quote_id = COALESCE($3, linked_quote_id),
+            client_id = COALESCE($4, client_id),
+            client_name = COALESCE($5, client_name),
+            payment_terms = COALESCE($6, payment_terms),
+            discount = COALESCE($7, discount),
+            discount_type = COALESCE($8, discount_type),
+            status = COALESCE($9, status),
+            notes = COALESCE($10, notes),
+            updated_at = CURRENT_TIMESTAMP
+      WHERE id = $11
+      RETURNING ${ORDER_COLUMNS}`,
+    [
+      patch.id ?? null,
+      patch.linkedOfferId ?? null,
+      patch.linkedQuoteId ?? null,
+      patch.clientId ?? null,
+      patch.clientName ?? null,
+      patch.paymentTerms ?? null,
+      patch.discount ?? null,
+      patch.discountType ?? null,
+      patch.status ?? null,
+      patch.notes ?? null,
+      id,
+    ],
+  );
+  return rows[0] ? mapOrder(rows[0]) : null;
+};
+
+export type NewClientOrderItem = {
+  id: string;
+  productId: string | null;
+  productName: string;
+  quantity: number;
+  unitPrice: number;
+  productCost: number;
+  productMolPercentage: number | null;
+  discount: number;
+  note: string | null;
+  supplierQuoteId: string | null;
+  supplierQuoteItemId: string | null;
+  supplierQuoteSupplierName: string | null;
+  supplierQuoteUnitPrice: number | null;
+  supplierSaleId: string | null;
+  supplierSaleItemId: string | null;
+  supplierSaleSupplierName: string | null;
+  unitType: UnitType;
+};
+
+const buildItemInsertSql = (rowCount: number) =>
+  `INSERT INTO sale_items
+       (id, sale_id, product_id, product_name, quantity, unit_price, product_cost,
+        product_mol_percentage, discount, note,
+        supplier_quote_id, supplier_quote_item_id, supplier_quote_supplier_name,
+        supplier_quote_unit_price,
+        supplier_sale_id, supplier_sale_item_id, supplier_sale_supplier_name,
+        unit_type)
+     VALUES ${buildBulkInsertPlaceholders(rowCount, 18)}
+     RETURNING ${ITEM_COLUMNS}`;
+
+const itemInsertParams = (orderId: string, items: NewClientOrderItem[]) =>
+  items.flatMap((item) => [
+    item.id,
+    orderId,
+    item.productId,
+    item.productName,
+    item.quantity,
+    item.unitPrice,
+    item.productCost,
+    item.productMolPercentage,
+    item.discount,
+    item.note,
+    item.supplierQuoteId,
+    item.supplierQuoteItemId,
+    item.supplierQuoteSupplierName,
+    item.supplierQuoteUnitPrice,
+    item.supplierSaleId,
+    item.supplierSaleItemId,
+    item.supplierSaleSupplierName,
+    item.unitType,
+  ]);
+
+export const insertItems = async (
+  orderId: string,
+  items: NewClientOrderItem[],
+  exec: QueryExecutor = pool,
+): Promise<ClientOrderItem[]> => {
+  if (items.length === 0) return [];
+  const { rows } = await exec.query<ClientOrderItemRow>(
+    buildItemInsertSql(items.length),
+    itemInsertParams(orderId, items),
+  );
+  return rows.map(mapItem);
+};
+
+export const replaceItems = async (
+  orderId: string,
+  items: NewClientOrderItem[],
+  exec: QueryExecutor = pool,
+): Promise<ClientOrderItem[]> => {
+  await exec.query(`DELETE FROM sale_items WHERE sale_id = $1`, [orderId]);
+  return insertItems(orderId, items, exec);
+};
+
+export const deleteById = async (id: string, exec: QueryExecutor = pool): Promise<boolean> => {
+  const { rowCount } = await exec.query(`DELETE FROM sales WHERE id = $1`, [id]);
+  return (rowCount ?? 0) > 0;
+};
+
+export type NewSupplierOrderForAutoCreate = {
+  id: string;
+  linkedQuoteId: string;
+  supplierId: string;
+  supplierName: string;
+  paymentTerms: string;
+  notes: string | null;
+};
+
+export const createSupplierOrder = async (
+  input: NewSupplierOrderForAutoCreate,
+  exec: QueryExecutor,
+): Promise<void> => {
+  await exec.query(
+    `INSERT INTO supplier_sales
+        (id, linked_quote_id, supplier_id, supplier_name, payment_terms, status, notes)
+     VALUES ($1, $2, $3, $4, $5, 'draft', $6)`,
+    [
+      input.id,
+      input.linkedQuoteId,
+      input.supplierId,
+      input.supplierName,
+      input.paymentTerms,
+      input.notes,
+    ],
+  );
+};
+
+export type NewSupplierOrderItemForAutoCreate = {
+  id: string;
+  productId: string | null;
+  productName: string;
+  quantity: number;
+  unitPrice: number;
+  note: string | null;
+};
+
+export const bulkInsertSupplierOrderItems = async (
+  supplierOrderId: string,
+  items: NewSupplierOrderItemForAutoCreate[],
+  exec: QueryExecutor,
+): Promise<void> => {
+  if (items.length === 0) return;
+  const placeholders = buildBulkInsertPlaceholders(items.length, 7);
+  const params = items.flatMap((item) => [
+    item.id,
+    supplierOrderId,
+    item.productId,
+    item.productName,
+    item.quantity,
+    item.unitPrice,
+    item.note,
+  ]);
+  await exec.query(
+    `INSERT INTO supplier_sale_items (id, sale_id, product_id, product_name, quantity, unit_price, note)
+     VALUES ${placeholders}`,
+    params,
+  );
+};
+
+export const linkSaleItemsToSupplierOrder = async (
+  args: {
+    orderId: string;
+    supplierQuoteId: string;
+    supplierOrderId: string;
+    supplierName: string;
+  },
+  exec: QueryExecutor,
+): Promise<void> => {
+  await exec.query(
+    `UPDATE sale_items
+        SET supplier_sale_id = $1,
+            supplier_sale_supplier_name = $2
+      WHERE sale_id = $3 AND supplier_quote_id = $4`,
+    [args.supplierOrderId, args.supplierName, args.orderId, args.supplierQuoteId],
+  );
+};
+
+export const mapSaleItemsToSupplierItems = async (
+  args: {
+    orderId: string;
+    supplierQuoteId: string;
+    mappings: Array<{ quoteItemId: string; saleItemId: string }>;
+  },
+  exec: QueryExecutor,
+): Promise<void> => {
+  if (args.mappings.length === 0) return;
+  const valuesPlaceholders = args.mappings
+    .map((_, i) => `($${i * 2 + 3}, $${i * 2 + 4})`)
+    .join(', ');
+  const mappingParams = args.mappings.flatMap(({ quoteItemId, saleItemId }) => [
+    quoteItemId,
+    saleItemId,
+  ]);
+  await exec.query(
+    `UPDATE sale_items si
+        SET supplier_sale_item_id = v.sale_item_id
+      FROM (VALUES ${valuesPlaceholders}) v(quote_item_id, sale_item_id)
+      WHERE si.sale_id = $1 AND si.supplier_quote_id = $2
+        AND si.supplier_quote_item_id = v.quote_item_id`,
+    [args.orderId, args.supplierQuoteId, ...mappingParams],
+  );
+};

--- a/server/repositories/clientsRepo.ts
+++ b/server/repositories/clientsRepo.ts
@@ -1,0 +1,443 @@
+import pool, { type QueryExecutor } from '../db/index.ts';
+import { parseDbNumber } from '../utils/parse.ts';
+
+export type ClientContact = {
+  fullName: string;
+  role?: string;
+  email?: string;
+  phone?: string;
+};
+
+export type Client = {
+  id: string;
+  name: string;
+  description: string | null;
+  isDisabled: boolean;
+  type: string;
+  contacts: ClientContact[];
+  contactName: string | null;
+  clientCode: string | null;
+  email: string | null;
+  phone: string | null;
+  address: string | null;
+  addressCountry: string | null;
+  addressState: string | null;
+  addressCap: string | null;
+  addressProvince: string | null;
+  addressCivicNumber: string | null;
+  addressLine: string | null;
+  atecoCode: string | null;
+  website: string | null;
+  sector: string | null;
+  numberOfEmployees: string | null;
+  revenue: string | null;
+  fiscalCode: string | null;
+  officeCountRange: string | null;
+  totalSentQuotes: number | undefined;
+  totalAcceptedOrders: number | undefined;
+  vatNumber: string | null;
+  taxCode: string | null;
+  createdAt: number | undefined;
+};
+
+const parseContactsFromDb = (value: unknown): ClientContact[] => {
+  if (!Array.isArray(value)) return [];
+  const contacts: ClientContact[] = [];
+  for (const raw of value) {
+    if (!raw || typeof raw !== 'object') continue;
+    const item = raw as Record<string, unknown>;
+    const fullName =
+      typeof item.fullName === 'string'
+        ? item.fullName.trim()
+        : typeof item.name === 'string'
+          ? item.name.trim()
+          : '';
+    if (!fullName) continue;
+    const role = typeof item.role === 'string' ? item.role.trim() : '';
+    const email = typeof item.email === 'string' ? item.email.trim() : '';
+    const phone = typeof item.phone === 'string' ? item.phone.trim() : '';
+    contacts.push({
+      fullName,
+      role: role || undefined,
+      email: email || undefined,
+      phone: phone || undefined,
+    });
+  }
+  return contacts;
+};
+
+const formatAddress = ({
+  civicNumber,
+  line,
+  cap,
+  state,
+  province,
+  country,
+}: {
+  civicNumber: string | null;
+  line: string | null;
+  cap: string | null;
+  state: string | null;
+  province: string | null;
+  country: string | null;
+}) => {
+  const street = [line, civicNumber].filter(Boolean).join(' ').trim();
+  const locality = [cap, state].filter(Boolean).join(' ').trim();
+  const provinceChunk = province ? `(${province})` : '';
+  return [street, [locality, provinceChunk].filter(Boolean).join(' ').trim(), country]
+    .filter((chunk) => chunk && chunk.trim().length > 0)
+    .join(', ');
+};
+
+export const mapClientRow = (c: Record<string, unknown>): Client => {
+  const fiscalCode = (c.fiscal_code as string | null) || null;
+  const createdAt = c.created_at ? new Date(c.created_at as string).getTime() : undefined;
+  const contacts = parseContactsFromDb(c.contacts);
+  const primary = contacts[0] ?? null;
+
+  const addressCountry = (c.address_country as string | null) || null;
+  const addressState = (c.address_state as string | null) || null;
+  const addressCap = (c.address_cap as string | null) || null;
+  const addressProvince = (c.address_province as string | null) || null;
+  const addressCivicNumber = (c.address_civic_number as string | null) || null;
+  const addressLine = (c.address_line as string | null) || null;
+
+  const computedAddress = formatAddress({
+    civicNumber: addressCivicNumber,
+    line: addressLine,
+    cap: addressCap,
+    state: addressState,
+    province: addressProvince,
+    country: addressCountry,
+  });
+
+  return {
+    id: c.id as string,
+    name: c.name as string,
+    description: (c.description as string | null) ?? null,
+    isDisabled: c.is_disabled as boolean,
+    type: c.type as string,
+    contacts,
+    contactName: (c.contact_name as string | null) || primary?.fullName || null,
+    clientCode: (c.client_code as string | null) ?? null,
+    email: (c.email as string | null) || primary?.email || null,
+    phone: (c.phone as string | null) || primary?.phone || null,
+    address: (c.address as string | null) || computedAddress || null,
+    addressCountry,
+    addressState,
+    addressCap,
+    addressProvince,
+    addressCivicNumber,
+    addressLine,
+    atecoCode: (c.ateco_code as string | null) ?? null,
+    website: (c.website as string | null) ?? null,
+    sector: (c.sector as string | null) ?? null,
+    numberOfEmployees: (c.number_of_employees as string | null) ?? null,
+    revenue: (c.revenue as string | null) ?? null,
+    fiscalCode,
+    officeCountRange: (c.office_count_range as string | null) ?? null,
+    totalSentQuotes: parseDbNumber(c.total_sent_quotes as string | number | null, undefined),
+    totalAcceptedOrders: parseDbNumber(
+      c.total_accepted_orders as string | number | null,
+      undefined,
+    ),
+    vatNumber: fiscalCode,
+    taxCode: fiscalCode,
+    createdAt,
+  };
+};
+
+export type ListOptions =
+  | { canViewAllClients: true }
+  | { canViewAllClients: false; userId: string };
+
+export const list = async (options: ListOptions, exec: QueryExecutor = pool): Promise<Client[]> => {
+  if (options.canViewAllClients) {
+    const { rows } = await exec.query(
+      `SELECT c.*,
+          COALESCE(sq.total_sent_quotes, 0) as total_sent_quotes,
+          COALESCE(so.total_accepted_orders, 0) as total_accepted_orders
+        FROM clients c
+        LEFT JOIN (
+          SELECT q.client_id,
+            SUM(
+              (SELECT COALESCE(SUM(qi.quantity * qi.unit_price * (1 - COALESCE(qi.discount, 0) / 100.0)), 0)
+               FROM quote_items qi WHERE qi.quote_id = q.id)
+              * (1 - COALESCE(q.discount, 0) / 100.0)
+            ) as total_sent_quotes
+          FROM quotes q
+          WHERE q.status = 'sent'
+          GROUP BY q.client_id
+        ) sq ON sq.client_id = c.id
+        LEFT JOIN (
+          SELECT s.client_id,
+            SUM(
+              (SELECT COALESCE(SUM(si.quantity * si.unit_price * (1 - COALESCE(si.discount, 0) / 100.0)), 0)
+               FROM sale_items si WHERE si.sale_id = s.id)
+              * (1 - COALESCE(s.discount, 0) / 100.0)
+            ) as total_accepted_orders
+          FROM sales s
+          WHERE s.status = 'confirmed'
+          GROUP BY s.client_id
+        ) so ON so.client_id = c.id
+        ORDER BY c.name`,
+    );
+    return rows.map(mapClientRow);
+  }
+
+  const { rows } = await exec.query(
+    `SELECT c.id, c.name, c.description, c.is_disabled, c.type,
+        c.contacts, c.contact_name, c.client_code, c.email, c.phone, c.address,
+        c.address_country, c.address_state, c.address_cap, c.address_province,
+        c.address_civic_number, c.address_line,
+        c.ateco_code, c.website, c.sector, c.number_of_employees,
+        c.revenue, c.fiscal_code, c.office_count_range, c.created_at,
+        NULL::numeric as total_sent_quotes,
+        NULL::numeric as total_accepted_orders
+      FROM clients c
+      INNER JOIN user_clients uc ON c.id = uc.client_id
+      WHERE uc.user_id = $1
+      ORDER BY c.name`,
+    [options.userId],
+  );
+  return rows.map(mapClientRow);
+};
+
+export const findContactsForUpdate = async (
+  id: string,
+  exec: QueryExecutor = pool,
+): Promise<{ contacts: ClientContact[] } | null> => {
+  const { rows } = await exec.query<{ contacts: unknown }>(
+    `SELECT contacts FROM clients WHERE id = $1`,
+    [id],
+  );
+  if (rows.length === 0) return null;
+  return { contacts: parseContactsFromDb(rows[0].contacts) };
+};
+
+export const findByFiscalCode = async (
+  fiscalCode: string,
+  excludeId: string | null,
+  exec: QueryExecutor = pool,
+): Promise<boolean> => {
+  if (excludeId) {
+    const { rows } = await exec.query<{ id: string }>(
+      `SELECT id FROM clients WHERE LOWER(fiscal_code) = LOWER($1) AND id <> $2`,
+      [fiscalCode, excludeId],
+    );
+    return rows.length > 0;
+  }
+  const { rows } = await exec.query<{ id: string }>(
+    `SELECT id FROM clients WHERE LOWER(fiscal_code) = LOWER($1)`,
+    [fiscalCode],
+  );
+  return rows.length > 0;
+};
+
+export const findByClientCode = async (
+  clientCode: string,
+  excludeId: string | null,
+  exec: QueryExecutor = pool,
+): Promise<boolean> => {
+  if (excludeId) {
+    const { rows } = await exec.query<{ id: string }>(
+      `SELECT id FROM clients WHERE client_code = $1 AND id <> $2`,
+      [clientCode, excludeId],
+    );
+    return rows.length > 0;
+  }
+  const { rows } = await exec.query<{ id: string }>(
+    `SELECT id FROM clients WHERE client_code = $1`,
+    [clientCode],
+  );
+  return rows.length > 0;
+};
+
+export type NewClient = {
+  id: string;
+  name: string;
+  type: string;
+  contacts: ClientContact[];
+  contactName: string | null;
+  clientCode: string | null;
+  email: string | null;
+  phone: string | null;
+  address: string | null;
+  addressCountry: string | null;
+  addressState: string | null;
+  addressCap: string | null;
+  addressProvince: string | null;
+  addressCivicNumber: string | null;
+  addressLine: string | null;
+  description: string | null;
+  atecoCode: string | null;
+  website: string | null;
+  sector: string | null;
+  numberOfEmployees: string | null;
+  revenue: string | null;
+  fiscalCode: string;
+  officeCountRange: string | null;
+};
+
+export const create = async (input: NewClient, exec: QueryExecutor = pool): Promise<Client> => {
+  const { rows } = await exec.query(
+    `INSERT INTO clients (
+        id, name, is_disabled, type, contacts, contact_name, client_code,
+        email, phone, address, address_country, address_state, address_cap,
+        address_province, address_civic_number, address_line,
+        description, ateco_code, website, sector,
+        number_of_employees, revenue, fiscal_code, office_count_range
+    ) VALUES (
+        $1, $2, $3, $4, $5::jsonb, $6, $7,
+        $8, $9, $10, $11, $12, $13,
+        $14, $15, $16,
+        $17, $18, $19, $20,
+        $21, $22, $23, $24
+    )
+    RETURNING *`,
+    [
+      input.id,
+      input.name,
+      false,
+      input.type,
+      JSON.stringify(input.contacts),
+      input.contactName,
+      input.clientCode,
+      input.email,
+      input.phone,
+      input.address,
+      input.addressCountry,
+      input.addressState,
+      input.addressCap,
+      input.addressProvince,
+      input.addressCivicNumber,
+      input.addressLine,
+      input.description,
+      input.atecoCode,
+      input.website,
+      input.sector,
+      input.numberOfEmployees,
+      input.revenue,
+      input.fiscalCode,
+      input.officeCountRange,
+    ],
+  );
+  return mapClientRow(rows[0]);
+};
+
+export type ClientUpdate = {
+  // COALESCE fields (null = keep existing)
+  name: string | null;
+  isDisabled: boolean | null;
+  type: string | null;
+  contacts: ClientContact[] | null;
+  clientCode: string | null;
+  address: string | null;
+  addressCountry: string | null;
+  addressState: string | null;
+  addressCap: string | null;
+  addressProvince: string | null;
+  addressCivicNumber: string | null;
+  addressLine: string | null;
+  description: string | null;
+  atecoCode: string | null;
+  website: string | null;
+  fiscalCode: string | null;
+  // CASE WHEN fields (set when *Provided is true)
+  contactName: string | null;
+  contactNameProvided: boolean;
+  email: string | null;
+  emailProvided: boolean;
+  phone: string | null;
+  phoneProvided: boolean;
+  sector: string | null;
+  sectorProvided: boolean;
+  numberOfEmployees: string | null;
+  numberOfEmployeesProvided: boolean;
+  revenue: string | null;
+  revenueProvided: boolean;
+  officeCountRange: string | null;
+  officeCountRangeProvided: boolean;
+};
+
+export const update = async (
+  id: string,
+  patch: ClientUpdate,
+  exec: QueryExecutor = pool,
+): Promise<Client | null> => {
+  const { rows } = await exec.query(
+    `UPDATE clients SET
+        name = COALESCE($1, name),
+        is_disabled = COALESCE($2, is_disabled),
+        type = COALESCE($3, type),
+        contacts = COALESCE($4::jsonb, contacts),
+        contact_name = CASE WHEN $25 THEN $5 ELSE contact_name END,
+        client_code = COALESCE($6, client_code),
+        email = CASE WHEN $26 THEN $7 ELSE email END,
+        phone = CASE WHEN $27 THEN $8 ELSE phone END,
+        address = COALESCE($9, address),
+        address_country = COALESCE($10, address_country),
+        address_state = COALESCE($11, address_state),
+        address_cap = COALESCE($12, address_cap),
+        address_province = COALESCE($13, address_province),
+        address_civic_number = COALESCE($14, address_civic_number),
+        address_line = COALESCE($15, address_line),
+        description = COALESCE($16, description),
+        ateco_code = COALESCE($17, ateco_code),
+        website = COALESCE($18, website),
+        sector = CASE WHEN $28 THEN $19 ELSE sector END,
+        number_of_employees = CASE WHEN $29 THEN $20 ELSE number_of_employees END,
+        revenue = CASE WHEN $30 THEN $21 ELSE revenue END,
+        fiscal_code = COALESCE($22, fiscal_code),
+        office_count_range = CASE WHEN $31 THEN $23 ELSE office_count_range END
+    WHERE id = $24
+    RETURNING *`,
+    [
+      patch.name,
+      patch.isDisabled,
+      patch.type,
+      patch.contacts === null ? null : JSON.stringify(patch.contacts),
+      patch.contactName,
+      patch.clientCode,
+      patch.email,
+      patch.phone,
+      patch.address,
+      patch.addressCountry,
+      patch.addressState,
+      patch.addressCap,
+      patch.addressProvince,
+      patch.addressCivicNumber,
+      patch.addressLine,
+      patch.description,
+      patch.atecoCode,
+      patch.website,
+      patch.sector,
+      patch.numberOfEmployees,
+      patch.revenue,
+      patch.fiscalCode,
+      patch.officeCountRange,
+      id,
+      patch.contactNameProvided,
+      patch.emailProvided,
+      patch.phoneProvided,
+      patch.sectorProvided,
+      patch.numberOfEmployeesProvided,
+      patch.revenueProvided,
+      patch.officeCountRangeProvided,
+    ],
+  );
+  return rows[0] ? mapClientRow(rows[0]) : null;
+};
+
+export const deleteById = async (
+  id: string,
+  exec: QueryExecutor = pool,
+): Promise<{ id: string; name: string; clientCode: string | null } | null> => {
+  const { rows } = await exec.query<{
+    id: string;
+    name: string;
+    client_code: string | null;
+  }>(`DELETE FROM clients WHERE id = $1 RETURNING id, name, client_code`, [id]);
+  if (!rows[0]) return null;
+  return { id: rows[0].id, name: rows[0].name, clientCode: rows[0].client_code };
+};

--- a/server/repositories/invoicesRepo.ts
+++ b/server/repositories/invoicesRepo.ts
@@ -151,15 +151,21 @@ export const listAllWithItems = async (exec: QueryExecutor = pool): Promise<Invo
   }));
 };
 
-export const findClientId = async (
+export const findDates = async (
   invoiceId: string,
   exec: QueryExecutor = pool,
-): Promise<string | null> => {
-  const { rows } = await exec.query<{ clientId: string }>(
-    `SELECT client_id as "clientId" FROM invoices WHERE id = $1`,
-    [invoiceId],
-  );
-  return rows[0]?.clientId ?? null;
+): Promise<{ issueDate: string; dueDate: string } | null> => {
+  const { rows } = await exec.query<{
+    issueDate: string | Date | null;
+    dueDate: string | Date | null;
+  }>(`SELECT issue_date as "issueDate", due_date as "dueDate" FROM invoices WHERE id = $1`, [
+    invoiceId,
+  ]);
+  if (!rows[0]) return null;
+  return {
+    issueDate: requireDateOnly(rows[0].issueDate, 'invoice.issueDate'),
+    dueDate: requireDateOnly(rows[0].dueDate, 'invoice.dueDate'),
+  };
 };
 
 export const findIdConflict = async (
@@ -283,12 +289,11 @@ export type NewInvoiceItem = {
   discount: number;
 };
 
-export const replaceItems = async (
+export const insertItems = async (
   invoiceId: string,
   items: NewInvoiceItem[],
   exec: QueryExecutor = pool,
 ): Promise<InvoiceItem[]> => {
-  await exec.query(`DELETE FROM invoice_items WHERE invoice_id = $1`, [invoiceId]);
   if (items.length === 0) return [];
   const placeholders = buildBulkInsertPlaceholders(items.length, 8);
   const params = items.flatMap((item) => [
@@ -309,6 +314,15 @@ export const replaceItems = async (
     params,
   );
   return rows.map(mapItem);
+};
+
+export const replaceItems = async (
+  invoiceId: string,
+  items: NewInvoiceItem[],
+  exec: QueryExecutor = pool,
+): Promise<InvoiceItem[]> => {
+  await exec.query(`DELETE FROM invoice_items WHERE invoice_id = $1`, [invoiceId]);
+  return insertItems(invoiceId, items, exec);
 };
 
 export const deleteById = async (

--- a/server/repositories/invoicesRepo.ts
+++ b/server/repositories/invoicesRepo.ts
@@ -1,0 +1,323 @@
+import pool, { buildBulkInsertPlaceholders, type QueryExecutor } from '../db/index.ts';
+import { requireDateOnly } from '../utils/date.ts';
+import { parseDbNumber } from '../utils/parse.ts';
+
+export type Invoice = {
+  id: string;
+  linkedSaleId: string | null;
+  clientId: string;
+  clientName: string;
+  issueDate: string;
+  dueDate: string;
+  status: string;
+  subtotal: number;
+  total: number;
+  amountPaid: number;
+  notes: string | null;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type InvoiceItem = {
+  id: string;
+  invoiceId: string;
+  productId: string | null;
+  description: string;
+  unitOfMeasure: 'unit' | 'hours';
+  quantity: number;
+  unitPrice: number;
+  discount: number;
+};
+
+export type InvoiceWithItems = Invoice & { items: InvoiceItem[] };
+
+type InvoiceRow = {
+  id: string;
+  linkedSaleId: string | null;
+  clientId: string;
+  clientName: string;
+  issueDate: string | Date | null;
+  dueDate: string | Date | null;
+  status: string;
+  subtotal: string | number;
+  total: string | number;
+  amountPaid: string | number;
+  notes: string | null;
+  createdAt: string | number;
+  updatedAt: string | number;
+};
+
+type InvoiceItemRow = {
+  id: string;
+  invoiceId: string;
+  productId: string | null;
+  description: string;
+  unitOfMeasure: string | null;
+  quantity: string | number;
+  unitPrice: string | number;
+  discount: string | number;
+};
+
+const INVOICE_COLUMNS = `
+  id,
+  linked_sale_id as "linkedSaleId",
+  client_id as "clientId",
+  client_name as "clientName",
+  issue_date as "issueDate",
+  due_date as "dueDate",
+  status,
+  subtotal,
+  total,
+  amount_paid as "amountPaid",
+  notes,
+  EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt",
+  EXTRACT(EPOCH FROM updated_at) * 1000 as "updatedAt"
+`;
+
+const ITEM_COLUMNS = `
+  id,
+  invoice_id as "invoiceId",
+  product_id as "productId",
+  description,
+  unit_of_measure as "unitOfMeasure",
+  quantity,
+  unit_price as "unitPrice",
+  discount
+`;
+
+const mapInvoice = (row: InvoiceRow): Invoice => ({
+  id: row.id,
+  linkedSaleId: row.linkedSaleId,
+  clientId: row.clientId,
+  clientName: row.clientName,
+  issueDate: requireDateOnly(row.issueDate, 'invoice.issueDate'),
+  dueDate: requireDateOnly(row.dueDate, 'invoice.dueDate'),
+  status: row.status,
+  subtotal: parseDbNumber(row.subtotal, 0),
+  total: parseDbNumber(row.total, 0),
+  amountPaid: parseDbNumber(row.amountPaid, 0),
+  notes: row.notes,
+  createdAt: parseDbNumber(row.createdAt, 0),
+  updatedAt: parseDbNumber(row.updatedAt, 0),
+});
+
+const mapItem = (row: InvoiceItemRow): InvoiceItem => ({
+  id: row.id,
+  invoiceId: row.invoiceId,
+  productId: row.productId,
+  description: row.description,
+  unitOfMeasure: row.unitOfMeasure === 'hours' ? 'hours' : 'unit',
+  quantity: parseDbNumber(row.quantity, 0),
+  unitPrice: parseDbNumber(row.unitPrice, 0),
+  discount: parseDbNumber(row.discount, 0),
+});
+
+export const generateNextId = async (year: string, exec: QueryExecutor = pool): Promise<string> => {
+  const { rows } = await exec.query<{ maxSequence: string | number | null }>(
+    `SELECT COALESCE(MAX(CAST(split_part(id, '-', 3) AS INTEGER)), 0) as "maxSequence"
+       FROM invoices
+       WHERE id ~ $1`,
+    [`^INV-${year}-[0-9]+$`],
+  );
+  const nextSequence = Number(rows[0]?.maxSequence ?? 0) + 1;
+  return `INV-${year}-${String(nextSequence).padStart(4, '0')}`;
+};
+
+export const listAll = async (exec: QueryExecutor = pool): Promise<Invoice[]> => {
+  const { rows } = await exec.query<InvoiceRow>(
+    `SELECT ${INVOICE_COLUMNS} FROM invoices ORDER BY created_at DESC`,
+  );
+  return rows.map(mapInvoice);
+};
+
+export const listAllItems = async (exec: QueryExecutor = pool): Promise<InvoiceItem[]> => {
+  const { rows } = await exec.query<InvoiceItemRow>(
+    `SELECT ${ITEM_COLUMNS} FROM invoice_items ORDER BY created_at ASC`,
+  );
+  return rows.map(mapItem);
+};
+
+export const listAllWithItems = async (exec: QueryExecutor = pool): Promise<InvoiceWithItems[]> => {
+  const [invoices, items] = await Promise.all([listAll(exec), listAllItems(exec)]);
+  const itemsByInvoice = new Map<string, InvoiceItem[]>();
+  for (const item of items) {
+    const list = itemsByInvoice.get(item.invoiceId);
+    if (list) list.push(item);
+    else itemsByInvoice.set(item.invoiceId, [item]);
+  }
+  return invoices.map((invoice) => ({
+    ...invoice,
+    items: itemsByInvoice.get(invoice.id) ?? [],
+  }));
+};
+
+export const findClientId = async (
+  invoiceId: string,
+  exec: QueryExecutor = pool,
+): Promise<string | null> => {
+  const { rows } = await exec.query<{ clientId: string }>(
+    `SELECT client_id as "clientId" FROM invoices WHERE id = $1`,
+    [invoiceId],
+  );
+  return rows[0]?.clientId ?? null;
+};
+
+export const findIdConflict = async (
+  newId: string,
+  currentId: string,
+  exec: QueryExecutor = pool,
+): Promise<boolean> => {
+  const { rows } = await exec.query<{ id: string }>(
+    `SELECT id FROM invoices WHERE id = $1 AND id <> $2`,
+    [newId, currentId],
+  );
+  return rows.length > 0;
+};
+
+export const findItemsForInvoice = async (
+  invoiceId: string,
+  exec: QueryExecutor = pool,
+): Promise<InvoiceItem[]> => {
+  const { rows } = await exec.query<InvoiceItemRow>(
+    `SELECT ${ITEM_COLUMNS} FROM invoice_items WHERE invoice_id = $1`,
+    [invoiceId],
+  );
+  return rows.map(mapItem);
+};
+
+export type NewInvoice = {
+  id: string;
+  linkedSaleId: string | null;
+  clientId: string;
+  clientName: string;
+  issueDate: string;
+  dueDate: string;
+  status: string;
+  subtotal: number;
+  total: number;
+  amountPaid: number;
+  notes: string | null;
+};
+
+export const create = async (input: NewInvoice, exec: QueryExecutor = pool): Promise<Invoice> => {
+  const { rows } = await exec.query<InvoiceRow>(
+    `INSERT INTO invoices (
+       id, linked_sale_id, client_id, client_name, issue_date, due_date,
+       status, subtotal, total, amount_paid, notes
+     ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+     RETURNING ${INVOICE_COLUMNS}`,
+    [
+      input.id,
+      input.linkedSaleId,
+      input.clientId,
+      input.clientName,
+      input.issueDate,
+      input.dueDate,
+      input.status,
+      input.subtotal,
+      input.total,
+      input.amountPaid,
+      input.notes,
+    ],
+  );
+  return mapInvoice(rows[0]);
+};
+
+export type InvoiceUpdate = {
+  id?: string;
+  clientId?: string;
+  clientName?: string;
+  issueDate?: string;
+  dueDate?: string;
+  status?: string;
+  subtotal?: number;
+  total?: number;
+  amountPaid?: number;
+  notes?: string | null;
+};
+
+export const update = async (
+  id: string,
+  patch: InvoiceUpdate,
+  exec: QueryExecutor = pool,
+): Promise<Invoice | null> => {
+  const { rows } = await exec.query<InvoiceRow>(
+    `UPDATE invoices SET
+        id = COALESCE($1, id),
+        client_id = COALESCE($2, client_id),
+        client_name = COALESCE($3, client_name),
+        issue_date = COALESCE($4, issue_date),
+        due_date = COALESCE($5, due_date),
+        status = COALESCE($6, status),
+        subtotal = COALESCE($7, subtotal),
+        total = COALESCE($8, total),
+        amount_paid = COALESCE($9, amount_paid),
+        notes = COALESCE($10, notes),
+        updated_at = CURRENT_TIMESTAMP
+      WHERE id = $11
+      RETURNING ${INVOICE_COLUMNS}`,
+    [
+      patch.id ?? null,
+      patch.clientId ?? null,
+      patch.clientName ?? null,
+      patch.issueDate ?? null,
+      patch.dueDate ?? null,
+      patch.status ?? null,
+      patch.subtotal ?? null,
+      patch.total ?? null,
+      patch.amountPaid ?? null,
+      patch.notes ?? null,
+      id,
+    ],
+  );
+  return rows[0] ? mapInvoice(rows[0]) : null;
+};
+
+export type NewInvoiceItem = {
+  id: string;
+  productId: string | null;
+  description: string;
+  unitOfMeasure: 'unit' | 'hours';
+  quantity: number;
+  unitPrice: number;
+  discount: number;
+};
+
+export const replaceItems = async (
+  invoiceId: string,
+  items: NewInvoiceItem[],
+  exec: QueryExecutor = pool,
+): Promise<InvoiceItem[]> => {
+  await exec.query(`DELETE FROM invoice_items WHERE invoice_id = $1`, [invoiceId]);
+  if (items.length === 0) return [];
+  const placeholders = buildBulkInsertPlaceholders(items.length, 8);
+  const params = items.flatMap((item) => [
+    item.id,
+    invoiceId,
+    item.productId,
+    item.description,
+    item.unitOfMeasure,
+    item.quantity,
+    item.unitPrice,
+    item.discount,
+  ]);
+  const { rows } = await exec.query<InvoiceItemRow>(
+    `INSERT INTO invoice_items (
+       id, invoice_id, product_id, description, unit_of_measure, quantity, unit_price, discount
+     ) VALUES ${placeholders}
+     RETURNING ${ITEM_COLUMNS}`,
+    params,
+  );
+  return rows.map(mapItem);
+};
+
+export const deleteById = async (
+  id: string,
+  exec: QueryExecutor = pool,
+): Promise<{ id: string; clientName: string } | null> => {
+  const { rows } = await exec.query<{ id: string; clientName: string }>(
+    `DELETE FROM invoices WHERE id = $1 RETURNING id, client_name as "clientName"`,
+    [id],
+  );
+  return rows[0] ?? null;
+};

--- a/server/repositories/productsRepo.ts
+++ b/server/repositories/productsRepo.ts
@@ -1,0 +1,39 @@
+import pool, { type QueryExecutor } from '../db/index.ts';
+import { parseDbNumber, parseNullableDbNumber } from '../utils/parse.ts';
+
+export type ProductSnapshot = {
+  productCost: number;
+  productMolPercentage: number | null;
+};
+
+/**
+ * Reads product cost (`costo`) and MOL% (`mol_percentage`) for a set of product ids,
+ * deduplicates the inputs, and returns a Map keyed by product id.
+ */
+export const getSnapshots = async (
+  productIds: string[],
+  exec: QueryExecutor = pool,
+): Promise<Map<string, ProductSnapshot>> => {
+  const uniqueIds = Array.from(new Set(productIds.filter(Boolean)));
+  const snapshots = new Map<string, ProductSnapshot>();
+  if (uniqueIds.length === 0) return snapshots;
+
+  const { rows } = await exec.query<{
+    id: string;
+    costo: string | number | null;
+    molPercentage: string | number | null;
+  }>(
+    `SELECT id, costo, mol_percentage as "molPercentage"
+       FROM products
+      WHERE id = ANY($1)`,
+    [uniqueIds],
+  );
+
+  for (const row of rows) {
+    snapshots.set(row.id, {
+      productCost: parseDbNumber(row.costo, 0),
+      productMolPercentage: parseNullableDbNumber(row.molPercentage),
+    });
+  }
+  return snapshots;
+};

--- a/server/repositories/supplierInvoicesRepo.ts
+++ b/server/repositories/supplierInvoicesRepo.ts
@@ -1,5 +1,5 @@
-import pool, { type QueryExecutor } from '../db/index.ts';
-import { normalizeNullableDateOnly } from '../utils/date.ts';
+import pool, { buildBulkInsertPlaceholders, type QueryExecutor } from '../db/index.ts';
+import { requireDateOnly } from '../utils/date.ts';
 import { parseDbNumber } from '../utils/parse.ts';
 
 export type SupplierInvoice = {
@@ -79,14 +79,6 @@ const ITEM_COLUMNS = `
   unit_price as "unitPrice",
   discount
 `;
-
-const requireDateOnly = (value: unknown, fieldName: string): string => {
-  const normalized = normalizeNullableDateOnly(value, fieldName);
-  if (!normalized) {
-    throw new TypeError(`Invalid date value for ${fieldName}`);
-  }
-  return normalized;
-};
 
 const mapInvoice = (row: SupplierInvoiceRow): SupplierInvoice => ({
   id: row.id,
@@ -343,13 +335,7 @@ export const replaceItems = async (
 ): Promise<SupplierInvoiceItem[]> => {
   await exec.query(`DELETE FROM supplier_invoice_items WHERE invoice_id = $1`, [invoiceId]);
   if (items.length === 0) return [];
-  const FIELDS_PER_ROW = 7;
-  const placeholders = items
-    .map((_, i) => {
-      const base = i * FIELDS_PER_ROW;
-      return `($${base + 1}, $${base + 2}, $${base + 3}, $${base + 4}, $${base + 5}, $${base + 6}, $${base + 7})`;
-    })
-    .join(', ');
+  const placeholders = buildBulkInsertPlaceholders(items.length, 7);
   const params = items.flatMap((item) => [
     item.id,
     invoiceId,

--- a/server/repositories/supplierOrdersRepo.ts
+++ b/server/repositories/supplierOrdersRepo.ts
@@ -1,4 +1,4 @@
-import pool, { type QueryExecutor } from '../db/index.ts';
+import pool, { buildBulkInsertPlaceholders, type QueryExecutor } from '../db/index.ts';
 import { parseDbNumber } from '../utils/parse.ts';
 
 export type SupplierOrder = {
@@ -321,13 +321,7 @@ export const replaceItems = async (
 ): Promise<SupplierOrderItem[]> => {
   await exec.query(`DELETE FROM supplier_sale_items WHERE sale_id = $1`, [orderId]);
   if (items.length === 0) return [];
-  const FIELDS_PER_ROW = 8;
-  const placeholders = items
-    .map((_, i) => {
-      const base = i * FIELDS_PER_ROW;
-      return `($${base + 1}, $${base + 2}, $${base + 3}, $${base + 4}, $${base + 5}, $${base + 6}, $${base + 7}, $${base + 8})`;
-    })
-    .join(', ');
+  const placeholders = buildBulkInsertPlaceholders(items.length, 8);
   const params = items.flatMap((item) => [
     item.id,
     orderId,

--- a/server/repositories/supplierQuotesRepo.ts
+++ b/server/repositories/supplierQuotesRepo.ts
@@ -1,4 +1,4 @@
-import pool, { type QueryExecutor } from '../db/index.ts';
+import pool, { buildBulkInsertPlaceholders, type QueryExecutor } from '../db/index.ts';
 import { normalizeNullableDateOnly } from '../utils/date.ts';
 import { parseDbNumber } from '../utils/parse.ts';
 
@@ -287,6 +287,59 @@ export type NewSupplierQuoteItem = {
   unitType: string;
 };
 
+export type QuoteItemSnapshot = {
+  supplierQuoteId: string;
+  supplierName: string;
+  productId: string | null;
+  unitPrice: number;
+  netCost: number;
+};
+
+/**
+ * Resolves per-item snapshots used by the client-quotes route to lock in supplier-quote pricing
+ * at the moment a client quote is created/updated. Only items belonging to *accepted* supplier
+ * quotes are returned.
+ */
+export const getQuoteItemSnapshots = async (
+  itemIds: string[],
+  exec: QueryExecutor = pool,
+): Promise<Map<string, QuoteItemSnapshot>> => {
+  const uniqueIds = Array.from(new Set(itemIds.filter(Boolean)));
+  const snapshots = new Map<string, QuoteItemSnapshot>();
+  if (uniqueIds.length === 0) return snapshots;
+
+  const { rows } = await exec.query<{
+    itemId: string;
+    quoteId: string;
+    supplierName: string;
+    productId: string | null;
+    unitPrice: string | number | null;
+  }>(
+    `SELECT
+        sqi.id as "itemId",
+        sq.id as "quoteId",
+        sq.supplier_name as "supplierName",
+        sqi.product_id as "productId",
+        sqi.unit_price as "unitPrice"
+       FROM supplier_quote_items sqi
+       JOIN supplier_quotes sq ON sq.id = sqi.quote_id
+      WHERE sqi.id = ANY($1) AND sq.status = 'accepted'`,
+    [uniqueIds],
+  );
+
+  for (const row of rows) {
+    const unitPrice = parseDbNumber(row.unitPrice, 0);
+    snapshots.set(row.itemId, {
+      supplierQuoteId: row.quoteId,
+      supplierName: row.supplierName,
+      productId: row.productId,
+      unitPrice,
+      netCost: unitPrice,
+    });
+  }
+  return snapshots;
+};
+
 export const replaceItems = async (
   quoteId: string,
   items: NewSupplierQuoteItem[],
@@ -294,13 +347,7 @@ export const replaceItems = async (
 ): Promise<SupplierQuoteItem[]> => {
   await exec.query(`DELETE FROM supplier_quote_items WHERE quote_id = $1`, [quoteId]);
   if (items.length === 0) return [];
-  const FIELDS_PER_ROW = 8;
-  const placeholders = items
-    .map((_, i) => {
-      const base = i * FIELDS_PER_ROW;
-      return `($${base + 1}, $${base + 2}, $${base + 3}, $${base + 4}, $${base + 5}, $${base + 6}, $${base + 7}, $${base + 8})`;
-    })
-    .join(', ');
+  const placeholders = buildBulkInsertPlaceholders(items.length, 8);
   const params = items.flatMap((item) => [
     item.id,
     quoteId,

--- a/server/routes/client-offers.ts
+++ b/server/routes/client-offers.ts
@@ -1,10 +1,12 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
-import { query } from '../db/index.ts';
+import { withTransaction } from '../db/index.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
+import * as clientOffersRepo from '../repositories/clientOffersRepo.ts';
+import * as clientQuotesRepo from '../repositories/clientQuotesRepo.ts';
 import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
 import { logAudit } from '../utils/audit.ts';
-import { normalizeNullableDateOnly } from '../utils/date.ts';
 import { isUniqueViolation } from '../utils/db-errors.ts';
+import { generateItemId } from '../utils/order-ids.ts';
 import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import { normalizeUnitType, type UnitType } from '../utils/unit-type.ts';
 import {
@@ -17,8 +19,6 @@ import {
   parseLocalizedPositiveNumber,
   requireNonEmptyString,
 } from '../utils/validation.ts';
-
-type DbQueryResult = Awaited<ReturnType<typeof query>>;
 
 const idParamSchema = {
   type: 'object',
@@ -153,8 +153,27 @@ type OfferItemInput = {
   note?: string;
 };
 
-const normalizeItems = (items: OfferItemInput[], reply: FastifyReply) => {
-  const normalizedItems: Array<Record<string, unknown>> = [];
+type NormalizedOfferItem = {
+  productId: string | null;
+  productName: string;
+  quantity: number;
+  unitPrice: number;
+  productCost: number;
+  productMolPercentage: number | null;
+  supplierQuoteId: string | null;
+  supplierQuoteItemId: string | null;
+  supplierQuoteSupplierName: string | null;
+  supplierQuoteUnitPrice: number | null;
+  unitType: UnitType;
+  discount: number;
+  note: string | null;
+};
+
+const normalizeItems = (
+  items: OfferItemInput[],
+  reply: FastifyReply,
+): NormalizedOfferItem[] | null => {
+  const normalizedItems: NormalizedOfferItem[] = [];
   for (let i = 0; i < items.length; i++) {
     const item = items[i];
     const productNameResult = requireNonEmptyString(item.productName, `items[${i}].productName`);
@@ -184,7 +203,6 @@ const normalizeItems = (items: OfferItemInput[], reply: FastifyReply) => {
       return null;
     }
     normalizedItems.push({
-      ...item,
       productId: item.productId || null,
       productName: productNameResult.value,
       quantity: quantityResult.value,
@@ -219,62 +237,25 @@ const normalizeItems = (items: OfferItemInput[], reply: FastifyReply) => {
   return normalizedItems;
 };
 
-const toFiniteNumber = (value: unknown, fieldName: string) => {
-  const parsedValue = Number(value);
-  if (!Number.isFinite(parsedValue)) {
-    throw new TypeError(`Invalid numeric value for ${fieldName}`);
-  }
-  return parsedValue;
-};
+const generateOfferItemId = () => generateItemId('coi-');
 
-const toNullableFiniteNumber = (value: unknown, fieldName: string) => {
-  if (value === undefined || value === null) return null;
-  return toFiniteNumber(value, fieldName);
-};
-
-const toNullableString = (value: unknown) => {
-  if (value === undefined || value === null) return null;
-  return String(value);
-};
-
-const normalizeOfferItemRow = (row: Record<string, unknown>) => ({
-  id: String(row.id),
-  offerId: String(row.offerId),
-  productId: toNullableString(row.productId),
-  productName: String(row.productName),
-  quantity: toFiniteNumber(row.quantity, 'offerItem.quantity'),
-  unitPrice: toFiniteNumber(row.unitPrice, 'offerItem.unitPrice'),
-  productCost: toFiniteNumber(row.productCost, 'offerItem.productCost'),
-  productMolPercentage: toNullableFiniteNumber(
-    row.productMolPercentage,
-    'offerItem.productMolPercentage',
-  ),
-  supplierQuoteId: toNullableString(row.supplierQuoteId),
-  supplierQuoteItemId: toNullableString(row.supplierQuoteItemId),
-  supplierQuoteSupplierName: toNullableString(row.supplierQuoteSupplierName),
-  supplierQuoteUnitPrice: toNullableFiniteNumber(
-    row.supplierQuoteUnitPrice,
-    'offerItem.supplierQuoteUnitPrice',
-  ),
-  unitType: normalizeUnitType(row.unitType),
-  note: toNullableString(row.note),
-  discount: toFiniteNumber(row.discount, 'offerItem.discount'),
-});
-
-const normalizeOfferRow = (row: Record<string, unknown>) => ({
-  id: String(row.id),
-  linkedQuoteId: String(row.linkedQuoteId),
-  clientId: String(row.clientId),
-  clientName: String(row.clientName),
-  paymentTerms: toNullableString(row.paymentTerms),
-  discount: toFiniteNumber(row.discount, 'offer.discount'),
-  discountType: row.discountType === 'currency' ? 'currency' : 'percentage',
-  status: String(row.status),
-  expirationDate: normalizeNullableDateOnly(row.expirationDate, 'offer.expirationDate'),
-  notes: toNullableString(row.notes),
-  createdAt: toFiniteNumber(row.createdAt, 'offer.createdAt'),
-  updatedAt: toFiniteNumber(row.updatedAt, 'offer.updatedAt'),
-});
+const buildItemsForInsert = (items: NormalizedOfferItem[]): clientOffersRepo.NewClientOfferItem[] =>
+  items.map((item) => ({
+    id: generateOfferItemId(),
+    productId: item.productId,
+    productName: item.productName,
+    quantity: item.quantity,
+    unitPrice: item.unitPrice,
+    productCost: item.productCost,
+    productMolPercentage: item.productMolPercentage,
+    discount: item.discount,
+    note: item.note,
+    supplierQuoteId: item.supplierQuoteId,
+    supplierQuoteItemId: item.supplierQuoteItemId,
+    supplierQuoteSupplierName: item.supplierQuoteSupplierName,
+    supplierQuoteUnitPrice: item.supplierQuoteUnitPrice,
+    unitType: item.unitType,
+  }));
 
 export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.addHook('onRequest', authenticateToken);
@@ -296,63 +277,21 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       },
     },
     async () => {
-      const offersResult = await query(
-        `SELECT
-            id,
-            linked_quote_id as "linkedQuoteId",
-            client_id as "clientId",
-            client_name as "clientName",
-            payment_terms as "paymentTerms",
-            discount,
-            discount_type as "discountType",
-            status,
-            expiration_date as "expirationDate",
-            notes,
-            EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt",
-            EXTRACT(EPOCH FROM updated_at) * 1000 as "updatedAt"
-         FROM customer_offers
-         ORDER BY created_at DESC`,
-      );
+      const [offers, items] = await Promise.all([
+        clientOffersRepo.listAll(),
+        clientOffersRepo.listAllItems(),
+      ]);
 
-      const itemsResult = await query(
-        `SELECT
-            id,
-            offer_id as "offerId",
-            product_id as "productId",
-            product_name as "productName",
-            quantity,
-            unit_price as "unitPrice",
-            product_cost as "productCost",
-            product_mol_percentage as "productMolPercentage",
-            supplier_quote_id as "supplierQuoteId",
-            supplier_quote_item_id as "supplierQuoteItemId",
-            supplier_quote_supplier_name as "supplierQuoteSupplierName",
-            supplier_quote_unit_price as "supplierQuoteUnitPrice",
-            unit_type as "unitType",
-            note,
-            discount
-         FROM customer_offer_items
-         ORDER BY created_at ASC`,
-      );
+      const itemsByOffer = new Map<string, clientOffersRepo.ClientOfferItem[]>();
+      for (const item of items) {
+        const list = itemsByOffer.get(item.offerId);
+        if (list) list.push(item);
+        else itemsByOffer.set(item.offerId, [item]);
+      }
 
-      const normalizedOfferItems = itemsResult.rows.map((item) =>
-        normalizeOfferItemRow(item as Record<string, unknown>),
-      );
-      const normalizedOffers = offersResult.rows.map((offer) =>
-        normalizeOfferRow(offer as Record<string, unknown>),
-      );
-
-      const itemsByOffer: Record<string, ReturnType<typeof normalizeOfferItemRow>[]> = {};
-      normalizedOfferItems.forEach((item) => {
-        if (!itemsByOffer[item.offerId]) {
-          itemsByOffer[item.offerId] = [];
-        }
-        itemsByOffer[item.offerId].push(item);
-      });
-
-      return normalizedOffers.map((offer) => ({
+      return offers.map((offer) => ({
         ...offer,
-        items: itemsByOffer[offer.id] || [],
+        items: itemsByOffer.get(offer.id) ?? [],
       }));
     },
   );
@@ -410,28 +349,15 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         return badRequest(reply, 'Items must be a non-empty array');
       }
 
-      const existingIdResult = await query('SELECT id FROM customer_offers WHERE id = $1', [
-        nextIdResult.value,
-      ]);
-      if (existingIdResult.rows.length > 0) {
-        return reply.code(409).send({ error: 'Offer ID already exists' });
-      }
-
-      const quoteResult = await query('SELECT id, status FROM quotes WHERE id = $1', [
-        linkedQuoteIdResult.value,
-      ]);
-      if (quoteResult.rows.length === 0) {
+      const sourceQuote = await clientQuotesRepo.findStatusAndClientName(linkedQuoteIdResult.value);
+      if (!sourceQuote) {
         return reply.code(404).send({ error: 'Source quote not found' });
       }
-      if (quoteResult.rows[0].status !== 'accepted') {
+      if (sourceQuote.status !== 'accepted') {
         return reply.code(409).send({ error: 'Offers can only be created from accepted quotes' });
       }
 
-      const existingOfferResult = await query(
-        'SELECT id FROM customer_offers WHERE linked_quote_id = $1 LIMIT 1',
-        [linkedQuoteIdResult.value],
-      );
-      if (existingOfferResult.rows.length > 0) {
+      if (await clientOffersRepo.findExistingForQuote(linkedQuoteIdResult.value)) {
         return reply.code(409).send({ error: 'An offer already exists for this quote' });
       }
 
@@ -441,41 +367,38 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       if (!discountResult.ok) return badRequest(reply, discountResult.message);
       const discountTypeValue = discountType === 'currency' ? 'currency' : 'percentage';
 
-      const normalizedItems = normalizeItems(items, reply);
+      const normalizedItems = normalizeItems(items as OfferItemInput[], reply);
       if (!normalizedItems) return;
 
-      let createdOfferResult: DbQueryResult;
+      let result: {
+        offer: clientOffersRepo.ClientOffer;
+        items: clientOffersRepo.ClientOfferItem[];
+      };
       try {
-        createdOfferResult = await query(
-          `INSERT INTO customer_offers
-            (id, linked_quote_id, client_id, client_name, payment_terms, discount, discount_type, status, expiration_date, notes)
-           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-           RETURNING
-              id,
-              linked_quote_id as "linkedQuoteId",
-              client_id as "clientId",
-              client_name as "clientName",
-              payment_terms as "paymentTerms",
-              discount,
-              discount_type as "discountType",
-              status,
-              expiration_date as "expirationDate",
-              notes,
-              EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt",
-              EXTRACT(EPOCH FROM updated_at) * 1000 as "updatedAt"`,
-          [
-            nextIdResult.value,
-            linkedQuoteIdResult.value,
-            clientIdResult.value,
-            clientNameResult.value,
-            paymentTerms || 'immediate',
-            discountResult.value || 0,
-            discountTypeValue,
-            status || 'draft',
-            expirationDateResult.value,
-            notes,
-          ],
-        );
+        result = await withTransaction(async (tx) => {
+          const offer = await clientOffersRepo.create(
+            {
+              id: nextIdResult.value,
+              linkedQuoteId: linkedQuoteIdResult.value,
+              clientId: clientIdResult.value,
+              clientName: clientNameResult.value,
+              paymentTerms:
+                typeof paymentTerms === 'string' && paymentTerms ? paymentTerms : 'immediate',
+              discount: discountResult.value || 0,
+              discountType: discountTypeValue,
+              status: typeof status === 'string' && status ? status : 'draft',
+              expirationDate: expirationDateResult.value,
+              notes: (notes as string | null | undefined) ?? null,
+            },
+            tx,
+          );
+          const createdItems = await clientOffersRepo.replaceItems(
+            offer.id,
+            buildItemsForInsert(normalizedItems),
+            tx,
+          );
+          return { offer, items: createdItems };
+        });
       } catch (err) {
         if (
           isUniqueViolation(err) &&
@@ -486,64 +409,20 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         throw err;
       }
 
-      const createdItems: ReturnType<typeof normalizeOfferItemRow>[] = [];
-      for (const item of normalizedItems) {
-        const itemId = 'coi-' + Date.now() + '-' + Math.random().toString(36).slice(2, 9);
-        const itemResult = await query(
-          `INSERT INTO customer_offer_items
-            (id, offer_id, product_id, product_name, quantity, unit_price, product_cost, product_mol_percentage, discount, note, supplier_quote_id, supplier_quote_item_id, supplier_quote_supplier_name, supplier_quote_unit_price, unit_type)
-           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
-           RETURNING
-             id,
-             offer_id as "offerId",
-             product_id as "productId",
-             product_name as "productName",
-             quantity,
-             unit_price as "unitPrice",
-             product_cost as "productCost",
-             product_mol_percentage as "productMolPercentage",
-             supplier_quote_id as "supplierQuoteId",
-             supplier_quote_item_id as "supplierQuoteItemId",
-             supplier_quote_supplier_name as "supplierQuoteSupplierName",
-             supplier_quote_unit_price as "supplierQuoteUnitPrice",
-             unit_type as "unitType",
-             discount,
-             note`,
-          [
-            itemId,
-            nextIdResult.value,
-            item.productId,
-            item.productName,
-            item.quantity,
-            item.unitPrice,
-            item.productCost,
-            item.productMolPercentage,
-            item.discount,
-            item.note,
-            item.supplierQuoteId,
-            item.supplierQuoteItemId,
-            item.supplierQuoteSupplierName,
-            item.supplierQuoteUnitPrice,
-            item.unitType || 'hours',
-          ],
-        );
-        createdItems.push(normalizeOfferItemRow(itemResult.rows[0] as Record<string, unknown>));
-      }
+      const createdOffer = result.offer;
+      const createdItems = result.items;
 
       await logAudit({
         request,
         action: 'client_offer.created',
         entityType: 'client_offer',
-        entityId: nextIdResult.value,
+        entityId: createdOffer.id,
         details: {
-          targetLabel: nextIdResult.value,
+          targetLabel: createdOffer.id,
           secondaryLabel: clientNameResult.value,
         },
       });
-      return reply.code(201).send({
-        ...normalizeOfferRow(createdOfferResult.rows[0] as Record<string, unknown>),
-        items: createdItems,
-      });
+      return reply.code(201).send({ ...createdOffer, items: createdItems });
     },
   );
 
@@ -591,22 +470,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
 
-      const existingOfferResult = await query(
-        `SELECT
-            id,
-            linked_quote_id as "linkedQuoteId",
-            client_id as "clientId",
-            client_name as "clientName",
-            status
-         FROM customer_offers
-         WHERE id = $1`,
-        [idResult.value],
-      );
-      if (existingOfferResult.rows.length === 0) {
+      const existingOffer = await clientOffersRepo.findForUpdate(idResult.value);
+      if (!existingOffer) {
         return reply.code(404).send({ error: 'Offer not found' });
       }
-
-      const existingOffer = existingOfferResult.rows[0];
 
       const hasLockedFieldUpdates =
         clientId !== undefined ||
@@ -624,17 +491,13 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         });
       }
 
-      let nextIdValue = nextId;
+      let nextIdValue: string | undefined | null = nextId as string | undefined | null;
       if (nextId !== undefined) {
         const nextIdResult = optionalNonEmptyString(nextId, 'id');
         if (!nextIdResult.ok) return badRequest(reply, nextIdResult.message);
         nextIdValue = nextIdResult.value;
         if (nextIdResult.value) {
-          const existingIdResult = await query(
-            'SELECT id FROM customer_offers WHERE id = $1 AND id <> $2',
-            [nextIdResult.value, idResult.value],
-          );
-          if (existingIdResult.rows.length > 0) {
+          if (await clientOffersRepo.findIdConflict(nextIdResult.value, idResult.value)) {
             return reply.code(409).send({ error: 'Offer ID already exists' });
           }
         }
@@ -692,54 +555,53 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         discountValue = discountResult.value;
       }
 
-      const discountTypeValue =
-        discountType !== undefined
-          ? discountType === 'currency'
+      const discountTypeValue: 'currency' | 'percentage' | undefined =
+        discountType === undefined
+          ? undefined
+          : discountType === 'currency'
             ? 'currency'
-            : 'percentage'
-          : undefined;
+            : 'percentage';
 
-      let updatedOfferResult: DbQueryResult;
+      let normalizedItemsForUpdate: NormalizedOfferItem[] | null = null;
+      if (items !== undefined) {
+        if (!Array.isArray(items) || items.length === 0) {
+          return badRequest(reply, 'Items must be a non-empty array');
+        }
+        normalizedItemsForUpdate = normalizeItems(items as OfferItemInput[], reply);
+        if (!normalizedItemsForUpdate) return;
+      }
+
+      let result: {
+        offer: clientOffersRepo.ClientOffer | null;
+        items: clientOffersRepo.ClientOfferItem[];
+      };
       try {
-        updatedOfferResult = await query(
-          `UPDATE customer_offers
-           SET id = COALESCE($1, id),
-               client_id = COALESCE($2, client_id),
-               client_name = COALESCE($3, client_name),
-               payment_terms = COALESCE($4, payment_terms),
-               discount = COALESCE($5, discount),
-               discount_type = COALESCE($6, discount_type),
-               status = COALESCE($7, status),
-               expiration_date = COALESCE($8, expiration_date),
-               notes = COALESCE($9, notes),
-               updated_at = CURRENT_TIMESTAMP
-           WHERE id = $10
-           RETURNING
-              id,
-              linked_quote_id as "linkedQuoteId",
-              client_id as "clientId",
-              client_name as "clientName",
-              payment_terms as "paymentTerms",
-              discount,
-              discount_type as "discountType",
-              status,
-              expiration_date as "expirationDate",
-              notes,
-              EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt",
-              EXTRACT(EPOCH FROM updated_at) * 1000 as "updatedAt"`,
-          [
-            nextIdValue,
-            clientIdValue,
-            clientNameValue,
-            paymentTerms,
-            discountValue,
-            discountTypeValue,
-            status,
-            expirationDateValue,
-            notes,
+        result = await withTransaction(async (tx) => {
+          const offer = await clientOffersRepo.update(
             idResult.value,
-          ],
-        );
+            {
+              id: (nextIdValue as string | null | undefined) ?? null,
+              clientId: (clientIdValue as string | null | undefined) ?? null,
+              clientName: (clientNameValue as string | null | undefined) ?? null,
+              paymentTerms: (paymentTerms as string | null | undefined) ?? null,
+              discount: (discountValue as number | null | undefined) ?? null,
+              discountType: discountTypeValue ?? null,
+              status: (status as string | null | undefined) ?? null,
+              expirationDate: (expirationDateValue as string | null | undefined) ?? null,
+              notes: (notes as string | null | undefined) ?? null,
+            },
+            tx,
+          );
+          if (!offer) return { offer: null, items: [] };
+          const updatedItems = normalizedItemsForUpdate
+            ? await clientOffersRepo.replaceItems(
+                offer.id,
+                buildItemsForInsert(normalizedItemsForUpdate),
+                tx,
+              )
+            : await clientOffersRepo.findItemsForOffer(offer.id, tx);
+          return { offer, items: updatedItems };
+        });
       } catch (err) {
         if (
           isUniqueViolation(err) &&
@@ -750,111 +612,28 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         throw err;
       }
 
-      if (updatedOfferResult.rows.length === 0) {
+      const updatedOffer = result.offer;
+      const updatedItems = result.items;
+      if (!updatedOffer) {
         return reply.code(404).send({ error: 'Offer not found' });
       }
 
-      const updatedOfferId = String(updatedOfferResult.rows[0].id);
-
-      let updatedItems: ReturnType<typeof normalizeOfferItemRow>[] = [];
-      if (items !== undefined) {
-        if (!Array.isArray(items) || items.length === 0) {
-          return badRequest(reply, 'Items must be a non-empty array');
-        }
-        const normalizedItems = normalizeItems(items, reply);
-        if (!normalizedItems) return;
-        await query('DELETE FROM customer_offer_items WHERE offer_id = $1', [updatedOfferId]);
-        for (const item of normalizedItems) {
-          const itemId = 'coi-' + Date.now() + '-' + Math.random().toString(36).slice(2, 9);
-          const itemResult = await query(
-            `INSERT INTO customer_offer_items
-              (id, offer_id, product_id, product_name, quantity, unit_price, product_cost, product_mol_percentage, discount, note, supplier_quote_id, supplier_quote_item_id, supplier_quote_supplier_name, supplier_quote_unit_price, unit_type)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
-             RETURNING
-               id,
-               offer_id as "offerId",
-               product_id as "productId",
-               product_name as "productName",
-               quantity,
-               unit_price as "unitPrice",
-               product_cost as "productCost",
-               product_mol_percentage as "productMolPercentage",
-               supplier_quote_id as "supplierQuoteId",
-               supplier_quote_item_id as "supplierQuoteItemId",
-               supplier_quote_supplier_name as "supplierQuoteSupplierName",
-               supplier_quote_unit_price as "supplierQuoteUnitPrice",
-               unit_type as "unitType",
-               discount,
-               note`,
-            [
-              itemId,
-              updatedOfferId,
-              item.productId,
-              item.productName,
-              item.quantity,
-              item.unitPrice,
-              item.productCost,
-              item.productMolPercentage,
-              item.discount,
-              item.note,
-              item.supplierQuoteId,
-              item.supplierQuoteItemId,
-              item.supplierQuoteSupplierName,
-              item.supplierQuoteUnitPrice,
-              item.unitType || 'hours',
-            ],
-          );
-          updatedItems.push(normalizeOfferItemRow(itemResult.rows[0] as Record<string, unknown>));
-        }
-      } else {
-        const itemsResult = await query(
-          `SELECT
-               id,
-               offer_id as "offerId",
-               product_id as "productId",
-               product_name as "productName",
-               quantity,
-               unit_price as "unitPrice",
-               product_cost as "productCost",
-               product_mol_percentage as "productMolPercentage",
-               supplier_quote_id as "supplierQuoteId",
-                supplier_quote_item_id as "supplierQuoteItemId",
-                supplier_quote_supplier_name as "supplierQuoteSupplierName",
-                supplier_quote_unit_price as "supplierQuoteUnitPrice",
-                unit_type as "unitType",
-                discount,
-                note
-             FROM customer_offer_items
-            WHERE offer_id = $1`,
-          [updatedOfferId],
-        );
-        updatedItems = itemsResult.rows.map((item) =>
-          normalizeOfferItemRow(item as Record<string, unknown>),
-        );
-      }
-
-      const nextStatus =
-        typeof status === 'string'
-          ? status
-          : String(updatedOfferResult.rows[0].status ?? existingOffer.status);
+      const nextStatus = typeof status === 'string' ? status : updatedOffer.status;
       const didStatusChange = status !== undefined && existingOffer.status !== nextStatus;
       await logAudit({
         request,
         action: 'client_offer.updated',
         entityType: 'client_offer',
-        entityId: updatedOfferId,
+        entityId: updatedOffer.id,
         details: {
-          targetLabel: updatedOfferId,
-          secondaryLabel: String(updatedOfferResult.rows[0].clientName ?? ''),
-          fromValue: didStatusChange ? String(existingOffer.status) : undefined,
+          targetLabel: updatedOffer.id,
+          secondaryLabel: updatedOffer.clientName,
+          fromValue: didStatusChange ? existingOffer.status : undefined,
           toValue: didStatusChange ? nextStatus : undefined,
         },
       });
 
-      return {
-        ...normalizeOfferRow(updatedOfferResult.rows[0] as Record<string, unknown>),
-        items: updatedItems,
-      };
+      return { ...updatedOffer, items: updatedItems };
     },
   );
 
@@ -877,24 +656,17 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
 
-      const linkedOrderResult = await query(
-        'SELECT id FROM sales WHERE linked_offer_id = $1 LIMIT 1',
-        [idResult.value],
-      );
-      if (linkedOrderResult.rows.length > 0) {
+      if (await clientOffersRepo.findLinkedSaleId(idResult.value)) {
         return reply
           .code(409)
           .send({ error: 'Cannot delete an offer once a sale order has been created from it' });
       }
 
-      const offerResult = await query(
-        'SELECT id, status, client_name as "clientName" FROM customer_offers WHERE id = $1',
-        [idResult.value],
-      );
-      if (offerResult.rows.length === 0) {
+      const offer = await clientOffersRepo.findStatusAndClientName(idResult.value);
+      if (!offer) {
         return reply.code(404).send({ error: 'Offer not found' });
       }
-      if (offerResult.rows[0].status !== 'draft') {
+      if (offer.status !== 'draft') {
         return reply.code(409).send({ error: 'Only draft offers can be deleted' });
       }
 
@@ -905,10 +677,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         entityId: idResult.value,
         details: {
           targetLabel: idResult.value,
-          secondaryLabel: String(offerResult.rows[0].clientName ?? ''),
+          secondaryLabel: offer.clientName ?? '',
         },
       });
-      await query('DELETE FROM customer_offers WHERE id = $1', [idResult.value]);
+      await clientOffersRepo.deleteById(idResult.value);
       return reply.code(204).send();
     },
   );

--- a/server/routes/client-offers.ts
+++ b/server/routes/client-offers.ts
@@ -392,7 +392,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
             },
             tx,
           );
-          const createdItems = await clientOffersRepo.replaceItems(
+          const createdItems = await clientOffersRepo.insertItems(
             offer.id,
             buildItemsForInsert(normalizedItems),
             tx,

--- a/server/routes/client-quotes.ts
+++ b/server/routes/client-quotes.ts
@@ -552,7 +552,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
             },
             tx,
           );
-          const items = await clientQuotesRepo.replaceItems(
+          const items = await clientQuotesRepo.insertItems(
             created.id,
             buildItemsForInsert(resolvedItems),
             tx,

--- a/server/routes/client-quotes.ts
+++ b/server/routes/client-quotes.ts
@@ -1,10 +1,14 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
-import { query } from '../db/index.ts';
+import { withTransaction } from '../db/index.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
+import * as clientQuotesRepo from '../repositories/clientQuotesRepo.ts';
+import * as productsRepo from '../repositories/productsRepo.ts';
+import * as supplierQuotesRepo from '../repositories/supplierQuotesRepo.ts';
 import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
 import { logAudit } from '../utils/audit.ts';
-import { isPastLocalDate, normalizeNullableDateOnly } from '../utils/date.ts';
+import { isPastLocalDate } from '../utils/date.ts';
 import { isUniqueViolation } from '../utils/db-errors.ts';
+import { generateItemId } from '../utils/order-ids.ts';
 import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import { normalizeUnitType, type UnitType } from '../utils/unit-type.ts';
 import {
@@ -35,7 +39,6 @@ type IncomingQuoteItem = {
 type QuoteItemSnapshot = {
   productCost: number;
   productMolPercentage: number | null;
-  // Supplier quote snapshot fields
   supplierQuoteId: string | null;
   supplierQuoteItemId: string | null;
   supplierQuoteSupplierName: string | null;
@@ -144,90 +147,6 @@ const calculateQuoteTotals = (
   return { total, subtotal };
 };
 
-const getProductSnapshots = async (productIds: string[]) => {
-  const uniqueIds = Array.from(new Set(productIds.filter(Boolean)));
-  if (uniqueIds.length === 0) return new Map<string, QuoteItemSnapshot>();
-
-  const result = await query(
-    `SELECT
-        id,
-        costo,
-        mol_percentage as "molPercentage"
-     FROM products
-     WHERE id = ANY($1)`,
-    [uniqueIds],
-  );
-
-  const snapshots = new Map<string, QuoteItemSnapshot>();
-  result.rows.forEach((row) => {
-    snapshots.set(row.id, {
-      productCost: Number(row.costo ?? 0),
-      productMolPercentage:
-        row.molPercentage === undefined || row.molPercentage === null
-          ? null
-          : Number(row.molPercentage),
-      supplierQuoteId: null,
-      supplierQuoteItemId: null,
-      supplierQuoteSupplierName: null,
-      supplierQuoteUnitPrice: null,
-    });
-  });
-  return snapshots;
-};
-
-// New function to get supplier quote item snapshots
-const getSupplierQuoteItemSnapshots = async (supplierQuoteItemIds: string[]) => {
-  const uniqueIds = Array.from(new Set(supplierQuoteItemIds.filter(Boolean)));
-  if (uniqueIds.length === 0) {
-    return new Map<
-      string,
-      {
-        supplierQuoteId: string;
-        supplierName: string;
-        productId: string | null;
-        unitPrice: number;
-        netCost: number;
-      }
-    >();
-  }
-
-  const result = await query(
-    `SELECT
-        sqi.id as "itemId",
-        sq.id as "quoteId",
-        sq.supplier_name as "supplierName",
-        sqi.product_id as "productId",
-        sqi.unit_price as "unitPrice"
-     FROM supplier_quote_items sqi
-     JOIN supplier_quotes sq ON sq.id = sqi.quote_id
-     WHERE sqi.id = ANY($1) AND sq.status = 'accepted'`,
-    [uniqueIds],
-  );
-
-  const snapshots = new Map<
-    string,
-    {
-      supplierQuoteId: string;
-      supplierName: string;
-      productId: string | null;
-      unitPrice: number;
-      netCost: number;
-    }
-  >();
-  result.rows.forEach((row) => {
-    const netCost = Number(row.unitPrice ?? 0);
-
-    snapshots.set(row.itemId, {
-      supplierQuoteId: row.quoteId,
-      supplierName: row.supplierName,
-      productId: normalizeNullableString(row.productId),
-      unitPrice: Number(row.unitPrice ?? 0),
-      netCost,
-    });
-  });
-  return snapshots;
-};
-
 const resolveQuoteItemSnapshots = async (
   items: IncomingQuoteItem[],
   existingItemsById?: Map<string, IncomingQuoteItem & QuoteItemSnapshot>,
@@ -246,7 +165,7 @@ const resolveQuoteItemSnapshots = async (
     );
   });
 
-  const supplierQuoteSnapshots = await getSupplierQuoteItemSnapshots(
+  const supplierQuoteSnapshots = await supplierQuotesRepo.getQuoteItemSnapshots(
     itemsNeedingRecalc
       .map((item) => normalizeNullableString(item.supplierQuoteItemId))
       .filter((id): id is string => id !== null),
@@ -263,7 +182,7 @@ const resolveQuoteItemSnapshots = async (
       productIds.add(supplierQuoteSnapshot.productId);
     }
   }
-  const productSnapshots = await getProductSnapshots(Array.from(productIds));
+  const productSnapshots = await productsRepo.getSnapshots(Array.from(productIds));
 
   const resolvedItems: ResolvedQuoteItem[] = [];
   for (const item of items) {
@@ -294,7 +213,6 @@ const resolveQuoteItemSnapshots = async (
       }
     }
 
-    // Supplier quote snapshot fields
     let supplierQuoteId: string | null = null;
     let supplierQuoteSupplierName: string | null = null;
     let supplierQuoteUnitPrice: number | null = null;
@@ -369,7 +287,6 @@ const quoteItemSchema = {
     unitPrice: { type: 'number' },
     productCost: { type: 'number' },
     productMolPercentage: { type: ['number', 'null'] },
-    // Supplier quote fields
     supplierQuoteId: { type: ['string', 'null'] },
     supplierQuoteItemId: { type: ['string', 'null'] },
     supplierQuoteSupplierName: { type: ['string', 'null'] },
@@ -474,66 +391,27 @@ const quoteUpdateBodySchema = {
   },
 } as const;
 
-const toFiniteNumber = (value: unknown, fieldName: string) => {
-  const parsedValue = Number(value);
-  if (!Number.isFinite(parsedValue)) {
-    throw new TypeError(`Invalid numeric value for ${fieldName}`);
-  }
-  return parsedValue;
-};
+const generateQuoteItemId = () => generateItemId('qi-');
 
-const toNullableFiniteNumber = (value: unknown, fieldName: string) => {
-  if (value === undefined || value === null) return null;
-  return toFiniteNumber(value, fieldName);
-};
-
-const toNullableString = (value: unknown) => {
-  if (value === undefined || value === null) return null;
-  return String(value);
-};
-
-const normalizeQuoteItemRow = (row: Record<string, unknown>) => ({
-  id: String(row.id),
-  quoteId: String(row.quoteId),
-  productId: toNullableString(row.productId) || '',
-  productName: String(row.productName),
-  quantity: toFiniteNumber(row.quantity, 'quoteItem.quantity'),
-  unitPrice: toFiniteNumber(row.unitPrice, 'quoteItem.unitPrice'),
-  productCost: toFiniteNumber(row.productCost, 'quoteItem.productCost'),
-  productMolPercentage: toNullableFiniteNumber(
-    row.productMolPercentage,
-    'quoteItem.productMolPercentage',
-  ),
-  // Supplier quote fields
-  supplierQuoteId: toNullableString(row.supplierQuoteId),
-  supplierQuoteItemId: toNullableString(row.supplierQuoteItemId),
-  supplierQuoteSupplierName: toNullableString(row.supplierQuoteSupplierName),
-  supplierQuoteUnitPrice: toNullableFiniteNumber(
-    row.supplierQuoteUnitPrice,
-    'quoteItem.supplierQuoteUnitPrice',
-  ),
-  discount: toFiniteNumber(row.discount, 'quoteItem.discount'),
-  note: toNullableString(row.note),
-  unitType: normalizeUnitType(row.unitType),
-});
-
-const normalizeQuoteRow = (row: Record<string, unknown>) => ({
-  id: String(row.id),
-  linkedOfferId: toNullableString(row.linkedOfferId),
-  clientId: String(row.clientId),
-  clientName: String(row.clientName),
-  paymentTerms: toNullableString(row.paymentTerms),
-  discount: toFiniteNumber(row.discount, 'quote.discount'),
-  discountType: row.discountType === 'currency' ? 'currency' : 'percentage',
-  status: String(row.status),
-  expirationDate: normalizeNullableDateOnly(row.expirationDate, 'quote.expirationDate'),
-  notes: toNullableString(row.notes),
-  createdAt: toFiniteNumber(row.createdAt, 'quote.createdAt'),
-  updatedAt: toFiniteNumber(row.updatedAt, 'quote.updatedAt'),
-});
+const buildItemsForInsert = (items: ResolvedQuoteItem[]): clientQuotesRepo.NewClientQuoteItem[] =>
+  items.map((item) => ({
+    id: generateQuoteItemId(),
+    productId: item.productId || null,
+    productName: item.productName,
+    quantity: item.quantity,
+    unitPrice: item.unitPrice,
+    productCost: item.productCost ?? 0,
+    productMolPercentage: item.productMolPercentage ?? null,
+    discount: item.discount || 0,
+    note: item.note || null,
+    supplierQuoteId: item.supplierQuoteId ?? null,
+    supplierQuoteItemId: item.supplierQuoteItemId ?? null,
+    supplierQuoteSupplierName: item.supplierQuoteSupplierName ?? null,
+    supplierQuoteUnitPrice: item.supplierQuoteUnitPrice ?? null,
+    unitType: item.unitType ?? 'hours',
+  }));
 
 export default async function (fastify: FastifyInstance, _opts: unknown) {
-  // All quote routes require authentication
   fastify.addHook('onRequest', authenticateToken);
 
   const isQuoteExpired = (status: string, expirationDate: string | null | undefined) => {
@@ -560,78 +438,23 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       },
     },
     async (_request: FastifyRequest, _reply: FastifyReply) => {
-      // Get all quotes
-      const quotesResult = await query(
-        `SELECT
-                id,
-                (
-                  SELECT co.id
-                  FROM customer_offers co
-                  WHERE co.linked_quote_id = quotes.id
-                  LIMIT 1
-                ) as "linkedOfferId",
-                client_id as "clientId",
-                client_name as "clientName",
-                payment_terms as "paymentTerms",
-                discount,
-                discount_type as "discountType",
-                status,
-                expiration_date as "expirationDate",
-                notes,
-                EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt",
-                EXTRACT(EPOCH FROM updated_at) * 1000 as "updatedAt"
-            FROM quotes
-            ORDER BY created_at DESC`,
-        [],
-      );
+      const [quotes, items] = await Promise.all([
+        clientQuotesRepo.listAll(),
+        clientQuotesRepo.listAllItems(),
+      ]);
 
-      // Get all quote items
-      const itemsResult = await query(
-        `SELECT
-                id,
-                quote_id as "quoteId",
-                product_id as "productId",
-                product_name as "productName",
-                quantity,
-                unit_price as "unitPrice",
-                product_cost as "productCost",
-                product_mol_percentage as "productMolPercentage",
-                supplier_quote_id as "supplierQuoteId",
-                supplier_quote_item_id as "supplierQuoteItemId",
-                supplier_quote_supplier_name as "supplierQuoteSupplierName",
-                supplier_quote_unit_price as "supplierQuoteUnitPrice",
-                discount,
-                note,
-                unit_type as "unitType"
-            FROM quote_items
-            ORDER BY created_at ASC`,
-        [],
-      );
+      const itemsByQuote = new Map<string, clientQuotesRepo.ClientQuoteItem[]>();
+      for (const item of items) {
+        const list = itemsByQuote.get(item.quoteId);
+        if (list) list.push(item);
+        else itemsByQuote.set(item.quoteId, [item]);
+      }
 
-      const normalizedQuoteItems = itemsResult.rows.map((item) =>
-        normalizeQuoteItemRow(item as Record<string, unknown>),
-      );
-      const normalizedQuotes = quotesResult.rows.map((quote) =>
-        normalizeQuoteRow(quote as Record<string, unknown>),
-      );
-
-      // Group items by quote
-      const itemsByQuote: Record<string, ReturnType<typeof normalizeQuoteItemRow>[]> = {};
-      normalizedQuoteItems.forEach((item) => {
-        if (!itemsByQuote[item.quoteId]) {
-          itemsByQuote[item.quoteId] = [];
-        }
-        itemsByQuote[item.quoteId].push(item);
-      });
-
-      // Attach items to quotes
-      const quotes = normalizedQuotes.map((quote) => ({
+      return quotes.map((quote) => ({
         ...quote,
-        items: itemsByQuote[quote.id] || [],
+        items: itemsByQuote.get(quote.id) ?? [],
         isExpired: isQuoteExpired(quote.status, quote.expirationDate),
       }));
-
-      return quotes;
     },
   );
 
@@ -677,12 +500,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
 
       const nextIdResult = requireNonEmptyString(nextId, 'id');
       if (!nextIdResult.ok) return badRequest(reply, nextIdResult.message);
-      const existingQuote = await query('SELECT id FROM quotes WHERE id = $1', [
-        nextIdResult.value,
-      ]);
-      if (existingQuote.rows.length > 0) {
-        return reply.code(409).send({ error: 'Quote ID already exists' });
-      }
 
       const clientIdResult = requireNonEmptyString(clientId, 'clientId');
       if (!clientIdResult.ok) return badRequest(reply, clientIdResult.message);
@@ -719,87 +536,29 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       }
 
       try {
-        const quoteResult = await query(
-          `INSERT INTO quotes (id, client_id, client_name, payment_terms, discount, discount_type, status, expiration_date, notes)
-                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-                 RETURNING
-                    id,
-                    null::varchar as "linkedOfferId",
-                    client_id as "clientId",
-                    client_name as "clientName",
-                    payment_terms as "paymentTerms",
-                    discount,
-                    discount_type as "discountType",
-                    status,
-                    expiration_date as "expirationDate",
-                    notes,
-                    EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt",
-                    EXTRACT(EPOCH FROM updated_at) * 1000 as "updatedAt"`,
-          [
-            nextIdResult.value,
-            clientIdResult.value,
-            clientNameResult.value,
-            paymentTerms || 'immediate',
-            discountValue,
-            discountTypeValue,
-            status || 'draft',
-            expirationDateResult.value,
-            notes,
-          ],
-        );
-
-        // Insert quote items
-        const createdItems: ReturnType<typeof normalizeQuoteItemRow>[] = [];
-        for (const item of resolvedItems) {
-          const itemId = 'qi-' + Date.now() + '-' + Math.random().toString(36).substring(2, 11);
-          const itemResult = await query(
-            `INSERT INTO quote_items (
-              id, quote_id, product_id, product_name,
-              quantity, unit_price, product_cost, product_mol_percentage,
-              discount, note,
-              supplier_quote_id, supplier_quote_item_id, supplier_quote_supplier_name,
-              supplier_quote_unit_price,
-              unit_type
-            )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
-            RETURNING
-              id,
-              quote_id as "quoteId",
-              product_id as "productId",
-              product_name as "productName",
-              quantity,
-              unit_price as "unitPrice",
-              product_cost as "productCost",
-              product_mol_percentage as "productMolPercentage",
-              discount,
-              note,
-              supplier_quote_id as "supplierQuoteId",
-              supplier_quote_item_id as "supplierQuoteItemId",
-              supplier_quote_supplier_name as "supplierQuoteSupplierName",
-              supplier_quote_unit_price as "supplierQuoteUnitPrice",
-              unit_type as "unitType"`,
-            [
-              itemId,
-              nextIdResult.value,
-              item.productId || null,
-              item.productName,
-              item.quantity,
-              item.unitPrice,
-              item.productCost,
-              item.productMolPercentage ?? null,
-              item.discount || 0,
-              item.note || null,
-              item.supplierQuoteId ?? null,
-              item.supplierQuoteItemId ?? null,
-              item.supplierQuoteSupplierName ?? null,
-              item.supplierQuoteUnitPrice ?? null,
-              item.unitType || 'hours',
-            ],
+        const { quote, createdItems } = await withTransaction(async (tx) => {
+          const created = await clientQuotesRepo.create(
+            {
+              id: nextIdResult.value,
+              clientId: clientIdResult.value,
+              clientName: clientNameResult.value,
+              paymentTerms:
+                typeof paymentTerms === 'string' && paymentTerms ? paymentTerms : 'immediate',
+              discount: discountValue,
+              discountType: discountTypeValue,
+              status: typeof status === 'string' && status ? status : 'draft',
+              expirationDate: expirationDateResult.value,
+              notes: (notes as string | null | undefined) ?? null,
+            },
+            tx,
           );
-          createdItems.push(normalizeQuoteItemRow(itemResult.rows[0] as Record<string, unknown>));
-        }
-
-        const normalizedQuote = normalizeQuoteRow(quoteResult.rows[0] as Record<string, unknown>);
+          const items = await clientQuotesRepo.replaceItems(
+            created.id,
+            buildItemsForInsert(resolvedItems),
+            tx,
+          );
+          return { quote: created, createdItems: items };
+        });
 
         await logAudit({
           request,
@@ -812,9 +571,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           },
         });
         return reply.code(201).send({
-          ...normalizedQuote,
+          ...quote,
           items: createdItems,
-          isExpired: isQuoteExpired(normalizedQuote.status, normalizedQuote.expirationDate),
+          isExpired: isQuoteExpired(quote.status, quote.expirationDate),
         });
       } catch (err) {
         if (
@@ -823,8 +582,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         ) {
           return reply.code(409).send({ error: 'Quote ID already exists' });
         }
-        console.error('CRITICAL ERROR creating quote:', err);
-        // Return the specific error message to the frontend for debugging
+        request.log.error({ err }, 'CRITICAL ERROR creating quote');
         return reply.code(500).send({ error: `Internal Server Error: ${(err as Error).message}` });
       }
     },
@@ -889,26 +647,18 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         notes === undefined &&
         isExpiredOverride === undefined;
 
-      const linkedOfferResult = await query(
-        'SELECT id FROM customer_offers WHERE linked_quote_id = $1 LIMIT 1',
-        [idResult.value],
-      );
-      if (linkedOfferResult.rows.length > 0 && !isIdOnlyUpdate) {
+      const linkedOfferId = await clientQuotesRepo.findLinkedOfferId(idResult.value);
+      if (linkedOfferId && !isIdOnlyUpdate) {
         return reply.code(409).send({ error: 'Quotes become read-only once an offer exists' });
       }
 
-      const currentStatusResult = await query(
-        'SELECT status, discount, discount_type FROM quotes WHERE id = $1',
-        [idResult.value],
-      );
-      if (currentStatusResult.rows.length === 0) {
+      const current = await clientQuotesRepo.findCurrentForUpdate(idResult.value);
+      if (!current) {
         return reply.code(404).send({ error: 'Quote not found' });
       }
-      const currentStatus = currentStatusResult.rows[0].status;
-      const existingDiscountRaw = parseFloat(currentStatusResult.rows[0].discount || 0);
-      const existingDiscount = Number.isFinite(existingDiscountRaw) ? existingDiscountRaw : 0;
-      const existingDiscountType: 'percentage' | 'currency' =
-        currentStatusResult.rows[0].discount_type === 'currency' ? 'currency' : 'percentage';
+      const currentStatus = current.status;
+      const existingDiscount = current.discount;
+      const existingDiscountType = current.discountType;
       const hasNonStatusOrIdUpdates =
         clientId !== undefined ||
         clientName !== undefined ||
@@ -928,12 +678,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         const nextIdResult = requireNonEmptyString(nextId, 'id');
         if (!nextIdResult.ok) return badRequest(reply, nextIdResult.message);
         nextIdValue = nextIdResult.value;
-
-        const existingQuote = await query('SELECT id FROM quotes WHERE id = $1 AND id <> $2', [
-          nextIdValue,
-          idResult.value,
-        ]);
-        if (existingQuote.rows.length > 0) {
+        if (await clientQuotesRepo.findIdConflict(nextIdValue, idResult.value)) {
           return reply.code(409).send({ error: 'Quote ID already exists' });
         }
       }
@@ -966,39 +711,27 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         discountValue = discountResult.value;
       }
 
-      const discountTypeValue =
-        discountType === 'currency'
-          ? 'currency'
-          : discountType !== undefined
-            ? 'percentage'
-            : undefined;
+      const discountTypeValue: 'currency' | 'percentage' | undefined =
+        discountType === undefined
+          ? undefined
+          : discountType === 'currency'
+            ? 'currency'
+            : 'percentage';
 
       const effectiveDiscount = discountValue ?? existingDiscount;
       const isRestore = status === 'quoted' && isExpiredOverride === false;
 
       if (isRestore) {
-        const nonDraftSalesResult = await query(
-          'SELECT id FROM sales WHERE linked_quote_id = $1 AND status <> $2 LIMIT 1',
-          [idResult.value, 'draft'],
-        );
-        if (nonDraftSalesResult.rows.length > 0) {
+        if (await clientQuotesRepo.findNonDraftLinkedSale(idResult.value)) {
           return reply.code(409).send({
             error: 'Restore is only possible when linked sale orders are in draft status',
           });
         }
-
-        await query('DELETE FROM sales WHERE linked_quote_id = $1 AND status = $2 RETURNING id', [
-          idResult.value,
-          'draft',
-        ]);
+        await clientQuotesRepo.deleteDraftSalesForQuote(idResult.value);
       }
 
       if (status === 'quoted') {
-        const linkedSaleResult = await query(
-          'SELECT id FROM sales WHERE linked_quote_id = $1 LIMIT 1',
-          [idResult.value],
-        );
-        if (linkedSaleResult.rows.length > 0) {
+        if (await clientQuotesRepo.findAnyLinkedSale(idResult.value)) {
           return reply.code(409).send({ error: 'Cannot revert quote with existing sale orders' });
         }
       }
@@ -1012,46 +745,25 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         if (!itemsResult.ok) return badRequest(reply, itemsResult.message);
         const incomingItems = itemsResult.items;
 
-        const existingItemsResult = await query(
-          `SELECT
-              id,
-              product_id as "productId",
-              product_cost as "productCost",
-              product_mol_percentage as "productMolPercentage",
-              supplier_quote_id as "supplierQuoteId",
-              supplier_quote_item_id as "supplierQuoteItemId",
-              supplier_quote_supplier_name as "supplierQuoteSupplierName",
-               supplier_quote_unit_price as "supplierQuoteUnitPrice",
-               unit_type as "unitType"
-           FROM quote_items
-           WHERE quote_id = $1`,
-
-          [idResult.value],
-        );
+        const existingSnapshots = await clientQuotesRepo.findItemSnapshotsForQuote(idResult.value);
         const existingItemsById = new Map<string, IncomingQuoteItem & QuoteItemSnapshot>();
-        existingItemsResult.rows.forEach((item) => {
-          existingItemsById.set(item.id, {
-            id: item.id,
-            productId: normalizeNullableString(item.productId),
+        for (const snap of existingSnapshots) {
+          existingItemsById.set(snap.id, {
+            id: snap.id,
+            productId: snap.productId,
             productName: '',
             quantity: 0,
             unitPrice: 0,
             discount: 0,
-            productCost: Number(item.productCost ?? 0),
-            productMolPercentage:
-              item.productMolPercentage === undefined || item.productMolPercentage === null
-                ? null
-                : Number(item.productMolPercentage),
-            supplierQuoteId: normalizeNullableString(item.supplierQuoteId),
-            supplierQuoteItemId: normalizeNullableString(item.supplierQuoteItemId),
-            supplierQuoteSupplierName: normalizeNullableString(item.supplierQuoteSupplierName),
-            supplierQuoteUnitPrice:
-              item.supplierQuoteUnitPrice === undefined || item.supplierQuoteUnitPrice === null
-                ? null
-                : Number(item.supplierQuoteUnitPrice),
-            unitType: normalizeUnitType(item.unitType),
+            productCost: snap.productCost,
+            productMolPercentage: snap.productMolPercentage,
+            supplierQuoteId: snap.supplierQuoteId,
+            supplierQuoteItemId: snap.supplierQuoteItemId,
+            supplierQuoteSupplierName: snap.supplierQuoteSupplierName,
+            supplierQuoteUnitPrice: snap.supplierQuoteUnitPrice,
+            unitType: snap.unitType,
           });
-        });
+        }
 
         try {
           normalizedItems = await resolveQuoteItemSnapshots(incomingItems, existingItemsById);
@@ -1069,23 +781,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           return badRequest(reply, 'Total must be greater than 0');
         }
       } else if (discount !== undefined) {
-        const itemsResult = await query(
-          `SELECT
-                    quantity,
-                    unit_price as "unitPrice",
-                    discount
-                FROM quote_items
-                WHERE quote_id = $1`,
-          [idResult.value],
-        );
-        const itemsForTotal = itemsResult.rows.map((row) => ({
-          quantity: parseFloat(row.quantity),
-          unitPrice: parseFloat(row.unitPrice),
-          discount: parseFloat(row.discount || 0),
-        }));
+        const itemTotals = await clientQuotesRepo.findItemTotals(idResult.value);
         const effectiveDiscountType = discountTypeValue ?? existingDiscountType;
         const totals = calculateQuoteTotals(
-          itemsForTotal,
+          itemTotals,
           effectiveDiscount as number,
           effectiveDiscountType,
         );
@@ -1094,48 +793,37 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         }
       }
 
-      // Update quote
-      let quoteResult: Awaited<ReturnType<typeof query>>;
+      let result: {
+        quote: clientQuotesRepo.ClientQuote | null;
+        items: clientQuotesRepo.ClientQuoteItem[];
+      };
       try {
-        quoteResult = await query(
-          `UPDATE quotes
-             SET id = COALESCE($1, id),
-                 client_id = COALESCE($2, client_id),
-                 client_name = COALESCE($3, client_name),
-                 payment_terms = COALESCE($4, payment_terms),
-                 discount = COALESCE($5, discount),
-                 discount_type = COALESCE($6, discount_type),
-                 status = COALESCE($7, status),
-                 expiration_date = COALESCE($8, expiration_date),
-                 notes = COALESCE($9, notes),
-                 updated_at = CURRENT_TIMESTAMP
-             WHERE id = $10
-             RETURNING
-                id,
-                null::varchar as "linkedOfferId",
-                client_id as "clientId",
-                client_name as "clientName",
-                payment_terms as "paymentTerms",
-                discount,
-                discount_type as "discountType",
-                status,
-                expiration_date as "expirationDate",
-                notes,
-                EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt",
-                EXTRACT(EPOCH FROM updated_at) * 1000 as "updatedAt"`,
-          [
-            nextIdValue,
-            clientIdValue,
-            clientNameValue,
-            paymentTerms,
-            discountValue,
-            discountTypeValue,
-            status,
-            expirationDateValue,
-            notes,
+        result = await withTransaction(async (tx) => {
+          const quote = await clientQuotesRepo.update(
             idResult.value,
-          ],
-        );
+            {
+              id: nextIdValue ?? null,
+              clientId: (clientIdValue as string | null | undefined) ?? null,
+              clientName: (clientNameValue as string | null | undefined) ?? null,
+              paymentTerms: (paymentTerms as string | null | undefined) ?? null,
+              discount: (discountValue as number | null | undefined) ?? null,
+              discountType: discountTypeValue ?? null,
+              status: (status as string | null | undefined) ?? null,
+              expirationDate: (expirationDateValue as string | null | undefined) ?? null,
+              notes: (notes as string | null | undefined) ?? null,
+            },
+            tx,
+          );
+          if (!quote) return { quote: null, items: [] };
+          const items = normalizedItems
+            ? await clientQuotesRepo.replaceItems(
+                quote.id,
+                buildItemsForInsert(normalizedItems),
+                tx,
+              )
+            : await clientQuotesRepo.findItemsForQuote(quote.id, tx);
+          return { quote, items };
+        });
       } catch (err) {
         if (
           isUniqueViolation(err) &&
@@ -1146,102 +834,16 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         throw err;
       }
 
-      if (quoteResult.rows.length === 0) {
+      const updatedQuote = result.quote;
+      const updatedItems = result.items;
+      if (!updatedQuote) {
         return reply.code(404).send({ error: 'Quote not found' });
       }
 
-      const updatedQuoteId = String(quoteResult.rows[0].id);
+      const updatedQuoteId = updatedQuote.id;
 
-      // If items are provided, update them
-      let updatedItems: ReturnType<typeof normalizeQuoteItemRow>[] = [];
-      if (normalizedItems) {
-        // Delete existing items
-        await query('DELETE FROM quote_items WHERE quote_id = $1', [updatedQuoteId]);
-
-        // Insert new items
-        for (const item of normalizedItems) {
-          const itemId = 'qi-' + Date.now() + '-' + Math.random().toString(36).substring(2, 11);
-          const itemResult = await query(
-            `INSERT INTO quote_items (
-              id, quote_id, product_id, product_name,
-              quantity, unit_price, product_cost, product_mol_percentage,
-              discount, note,
-              supplier_quote_id, supplier_quote_item_id, supplier_quote_supplier_name,
-              supplier_quote_unit_price,
-              unit_type
-            )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
-            RETURNING
-              id,
-              quote_id as "quoteId",
-              product_id as "productId",
-              product_name as "productName",
-              quantity,
-              unit_price as "unitPrice",
-              product_cost as "productCost",
-              product_mol_percentage as "productMolPercentage",
-              discount,
-              note,
-              supplier_quote_id as "supplierQuoteId",
-              supplier_quote_item_id as "supplierQuoteItemId",
-              supplier_quote_supplier_name as "supplierQuoteSupplierName",
-              supplier_quote_unit_price as "supplierQuoteUnitPrice",
-              unit_type as "unitType"`,
-            [
-              itemId,
-              updatedQuoteId,
-              item.productId || null,
-              item.productName,
-              item.quantity,
-              item.unitPrice,
-              item.productCost,
-              item.productMolPercentage ?? null,
-              item.discount || 0,
-              item.note || null,
-              item.supplierQuoteId ?? null,
-              item.supplierQuoteItemId ?? null,
-              item.supplierQuoteSupplierName ?? null,
-              item.supplierQuoteUnitPrice ?? null,
-              item.unitType || 'hours',
-            ],
-          );
-          updatedItems.push(normalizeQuoteItemRow(itemResult.rows[0] as Record<string, unknown>));
-        }
-      } else {
-        // Fetch existing items
-        const itemsResult = await query(
-          `SELECT
-                    id,
-                    quote_id as "quoteId",
-                    product_id as "productId",
-                    product_name as "productName",
-                    quantity,
-                    unit_price as "unitPrice",
-                    product_cost as "productCost",
-                    product_mol_percentage as "productMolPercentage",
-                    supplier_quote_id as "supplierQuoteId",
-                    supplier_quote_item_id as "supplierQuoteItemId",
-                    supplier_quote_supplier_name as "supplierQuoteSupplierName",
-                    supplier_quote_unit_price as "supplierQuoteUnitPrice",
-                    discount,
-                    note,
-                    unit_type as "unitType"
-                FROM quote_items
-                WHERE quote_id = $1`,
-          [updatedQuoteId],
-        );
-        updatedItems = itemsResult.rows.map((item) =>
-          normalizeQuoteItemRow(item as Record<string, unknown>),
-        );
-      }
-
-      const normalizedQuote = normalizeQuoteRow(quoteResult.rows[0] as Record<string, unknown>);
-      const nextStatus = typeof status === 'string' ? status : normalizedQuote.status;
+      const nextStatus = typeof status === 'string' ? status : updatedQuote.status;
       const didStatusChange = status !== undefined && currentStatus !== nextStatus;
-
-      // Invalidate client cache if quote status affects sent quotes totals
-      if (didStatusChange && (currentStatus === 'sent' || nextStatus === 'sent')) {
-      }
 
       await logAudit({
         request,
@@ -1250,18 +852,18 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         entityId: updatedQuoteId,
         details: {
           targetLabel: updatedQuoteId,
-          secondaryLabel: normalizedQuote.clientName,
+          secondaryLabel: updatedQuote.clientName,
           fromValue: didStatusChange ? String(currentStatus) : undefined,
           toValue: didStatusChange ? String(nextStatus) : undefined,
         },
       });
       return {
-        ...normalizedQuote,
+        ...updatedQuote,
         items: updatedItems,
         isExpired:
           typeof isExpiredOverride === 'boolean'
             ? isExpiredOverride
-            : isQuoteExpired(normalizedQuote.status, normalizedQuote.expirationDate),
+            : isQuoteExpired(updatedQuote.status, updatedQuote.expirationDate),
       };
     },
   );
@@ -1286,29 +888,21 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
 
-      const linkedOfferResult = await query(
-        'SELECT id FROM customer_offers WHERE linked_quote_id = $1 LIMIT 1',
-        [idResult.value],
-      );
-      if (linkedOfferResult.rows.length > 0) {
+      if (await clientQuotesRepo.findLinkedOfferId(idResult.value)) {
         return reply
           .code(409)
           .send({ error: 'Cannot delete a quote once an offer has been created from it' });
       }
 
-      const statusResult = await query(
-        'SELECT status, client_name as "clientName" FROM quotes WHERE id = $1',
-        [idResult.value],
-      );
-      if (statusResult.rows.length === 0) {
+      const status = await clientQuotesRepo.findStatusAndClientName(idResult.value);
+      if (!status) {
         return reply.code(404).send({ error: 'Quote not found' });
       }
-      if (statusResult.rows[0].status === 'confirmed') {
+      if (status.status === 'confirmed') {
         return reply.code(409).send({ error: 'Cannot delete a confirmed quote' });
       }
 
-      // Items will be deleted automatically via CASCADE
-      await query('DELETE FROM quotes WHERE id = $1 RETURNING id', [idResult.value]);
+      await clientQuotesRepo.deleteById(idResult.value);
 
       await logAudit({
         request,
@@ -1317,7 +911,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         entityId: idResult.value,
         details: {
           targetLabel: idResult.value,
-          secondaryLabel: String(statusResult.rows[0].clientName ?? ''),
+          secondaryLabel: status.clientName ?? '',
         },
       });
       return reply.code(204).send();

--- a/server/routes/clients-orders.ts
+++ b/server/routes/clients-orders.ts
@@ -1,6 +1,8 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
-import { query, withTransaction } from '../db/index.ts';
+import { withTransaction } from '../db/index.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
+import * as clientsOrdersRepo from '../repositories/clientsOrdersRepo.ts';
+import * as supplierQuotesRepo from '../repositories/supplierQuotesRepo.ts';
 import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
 import { logAudit } from '../utils/audit.ts';
 import { isUniqueViolation } from '../utils/db-errors.ts';
@@ -10,7 +12,7 @@ import {
   generateSupplierOrderId,
 } from '../utils/order-ids.ts';
 import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
-import { normalizeUnitType } from '../utils/unit-type.ts';
+import { normalizeUnitType, type UnitType } from '../utils/unit-type.ts';
 import {
   badRequest,
   optionalLocalizedNonNegativeNumber,
@@ -142,72 +144,155 @@ const clientOrderUpdateBodySchema = {
   },
 } as const;
 
-const toFiniteNumber = (value: unknown, fieldName: string) => {
-  const parsedValue = Number(value);
-  if (!Number.isFinite(parsedValue)) {
-    throw new TypeError(`Invalid numeric value for ${fieldName}`);
+type NormalizedOrderItem = {
+  id?: string;
+  productId: string | null;
+  productName: string;
+  quantity: number;
+  unitPrice: number;
+  productCost: number;
+  productMolPercentage: number | null;
+  supplierQuoteId: string | null;
+  supplierQuoteItemId: string | null;
+  supplierQuoteSupplierName: string | null;
+  supplierQuoteUnitPrice: number | null;
+  supplierSaleId: string | null;
+  supplierSaleItemId: string | null;
+  supplierSaleSupplierName: string | null;
+  unitType: UnitType;
+  note: string | null;
+  discount: number;
+};
+
+const normalizeIncomingItems = (
+  items: unknown[],
+  reply: FastifyReply,
+): NormalizedOrderItem[] | null => {
+  const normalized: NormalizedOrderItem[] = [];
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i] as Record<string, unknown>;
+    const productNameResult = requireNonEmptyString(item.productName, `items[${i}].productName`);
+    if (!productNameResult.ok) {
+      badRequest(reply, productNameResult.message);
+      return null;
+    }
+    const quantityResult = parseLocalizedPositiveNumber(item.quantity, `items[${i}].quantity`);
+    if (!quantityResult.ok) {
+      badRequest(reply, quantityResult.message);
+      return null;
+    }
+    const unitPriceResult = parseLocalizedNonNegativeNumber(
+      item.unitPrice,
+      `items[${i}].unitPrice`,
+    );
+    if (!unitPriceResult.ok) {
+      badRequest(reply, unitPriceResult.message);
+      return null;
+    }
+    const itemDiscountResult = optionalLocalizedNonNegativeNumber(
+      item.discount,
+      `items[${i}].discount`,
+    );
+    if (!itemDiscountResult.ok) {
+      badRequest(reply, itemDiscountResult.message);
+      return null;
+    }
+    const toNullableString = (value: unknown) =>
+      value === null || value === undefined ? null : String(value);
+    const toNullableNumber = (value: unknown) =>
+      value === null || value === undefined ? null : Number(value);
+    normalized.push({
+      id: typeof item.id === 'string' ? item.id : undefined,
+      productId: toNullableString(item.productId),
+      productName: productNameResult.value,
+      quantity: quantityResult.value,
+      unitPrice: unitPriceResult.value,
+      productCost: Number(item.productCost ?? 0),
+      productMolPercentage: toNullableNumber(item.productMolPercentage),
+      supplierQuoteId: toNullableString(item.supplierQuoteId),
+      supplierQuoteItemId: toNullableString(item.supplierQuoteItemId),
+      supplierQuoteSupplierName: toNullableString(item.supplierQuoteSupplierName),
+      supplierQuoteUnitPrice: toNullableNumber(item.supplierQuoteUnitPrice),
+      supplierSaleId: toNullableString(item.supplierSaleId),
+      supplierSaleItemId: toNullableString(item.supplierSaleItemId),
+      supplierSaleSupplierName: toNullableString(item.supplierSaleSupplierName),
+      unitType: normalizeUnitType(item.unitType),
+      note: toNullableString(item.note),
+      discount: itemDiscountResult.value || 0,
+    });
   }
-  return parsedValue;
+  return normalized;
 };
 
-const toNullableFiniteNumber = (value: unknown, fieldName: string) => {
-  if (value === undefined || value === null) return null;
-  return toFiniteNumber(value, fieldName);
+const buildItemsForInsert = (
+  items: NormalizedOrderItem[],
+): clientsOrdersRepo.NewClientOrderItem[] =>
+  items.map((item) => ({
+    id: generateItemId('si-'),
+    productId: item.productId,
+    productName: item.productName,
+    quantity: item.quantity,
+    unitPrice: item.unitPrice,
+    productCost: item.productCost,
+    productMolPercentage: item.productMolPercentage,
+    discount: item.discount,
+    note: item.note,
+    supplierQuoteId: item.supplierQuoteId,
+    supplierQuoteItemId: item.supplierQuoteItemId,
+    supplierQuoteSupplierName: item.supplierQuoteSupplierName,
+    supplierQuoteUnitPrice: item.supplierQuoteUnitPrice,
+    supplierSaleId: item.supplierSaleId,
+    supplierSaleItemId: item.supplierSaleItemId,
+    supplierSaleSupplierName: item.supplierSaleSupplierName,
+    unitType: item.unitType,
+  }));
+
+const normalizeNotesValue = (value: unknown) => String(value ?? '');
+
+const normalizeItemsForComparison = (itemsToNormalize: Array<Record<string, unknown>>) =>
+  itemsToNormalize
+    .map((item) => {
+      const normalized = {
+        id: item.id ? String(item.id) : '',
+        productId: item.productId ? String(item.productId) : '',
+        productName: item.productName ? String(item.productName) : '',
+        quantity: Number(item.quantity),
+        unitPrice: Number(item.unitPrice),
+        discount: item.discount !== undefined && item.discount !== null ? Number(item.discount) : 0,
+      };
+      const sortKey =
+        normalized.id ||
+        `${normalized.productId}|${normalized.productName}|${normalized.quantity}|${normalized.unitPrice}|${normalized.discount}`;
+      return { ...normalized, sortKey };
+    })
+    .sort((a, b) => a.sortKey.localeCompare(b.sortKey));
+
+const itemsMatch = (
+  leftItems: Array<Record<string, unknown>>,
+  rightItems: Array<Record<string, unknown>>,
+) => {
+  if (leftItems.length !== rightItems.length) return false;
+  for (let i = 0; i < leftItems.length; i++) {
+    const leftItem = leftItems[i];
+    const rightItem = rightItems[i];
+    if (
+      leftItem.id !== rightItem.id ||
+      leftItem.productId !== rightItem.productId ||
+      leftItem.productName !== rightItem.productName ||
+      leftItem.quantity !== rightItem.quantity ||
+      leftItem.unitPrice !== rightItem.unitPrice ||
+      leftItem.discount !== rightItem.discount
+    ) {
+      return false;
+    }
+  }
+  return true;
 };
-
-const toNullableString = (value: unknown) => {
-  if (value === undefined || value === null) return null;
-  return String(value);
-};
-
-const normalizeClientOrderItemRow = (row: Record<string, unknown>) => ({
-  id: String(row.id),
-  orderId: String(row.orderId),
-  productId: toNullableString(row.productId),
-  productName: String(row.productName),
-  quantity: toFiniteNumber(row.quantity, 'clientOrderItem.quantity'),
-  unitPrice: toFiniteNumber(row.unitPrice, 'clientOrderItem.unitPrice'),
-  productCost: toFiniteNumber(row.productCost, 'clientOrderItem.productCost'),
-  productMolPercentage: toNullableFiniteNumber(
-    row.productMolPercentage,
-    'clientOrderItem.productMolPercentage',
-  ),
-  supplierQuoteId: toNullableString(row.supplierQuoteId),
-  supplierQuoteItemId: toNullableString(row.supplierQuoteItemId),
-  supplierQuoteSupplierName: toNullableString(row.supplierQuoteSupplierName),
-  supplierQuoteUnitPrice: toNullableFiniteNumber(
-    row.supplierQuoteUnitPrice,
-    'clientOrderItem.supplierQuoteUnitPrice',
-  ),
-  supplierSaleId: toNullableString(row.supplierSaleId),
-  supplierSaleItemId: toNullableString(row.supplierSaleItemId),
-  supplierSaleSupplierName: toNullableString(row.supplierSaleSupplierName),
-  unitType: normalizeUnitType(row.unitType),
-  note: toNullableString(row.note),
-  discount: toFiniteNumber(row.discount, 'clientOrderItem.discount'),
-});
-
-const normalizeClientOrderRow = (row: Record<string, unknown>) => ({
-  id: String(row.id),
-  linkedQuoteId: toNullableString(row.linkedQuoteId),
-  linkedOfferId: toNullableString(row.linkedOfferId),
-  clientId: String(row.clientId),
-  clientName: String(row.clientName),
-  paymentTerms: toNullableString(row.paymentTerms),
-  discount: toFiniteNumber(row.discount, 'clientOrder.discount'),
-  discountType: row.discountType === 'currency' ? 'currency' : 'percentage',
-  status: String(row.status),
-  notes: toNullableString(row.notes),
-  createdAt: toFiniteNumber(row.createdAt, 'clientOrder.createdAt'),
-  updatedAt: toFiniteNumber(row.updatedAt, 'clientOrder.updatedAt'),
-});
 
 export default async function (fastify: FastifyInstance, _opts: unknown) {
-  // All clients_orders routes require authentication
   fastify.addHook('onRequest', authenticateToken);
   // API path is clients-orders for backward compatibility; data is stored in sales/sale_items.
 
-  // GET / - List all clients_orders with their items
   fastify.get(
     '/',
     {
@@ -225,73 +310,21 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       },
     },
     async (_request: FastifyRequest, _reply: FastifyReply) => {
-      // Get all clients_orders
-      const clients_ordersResult = await query(
-        `SELECT
-                id,
-                linked_quote_id as "linkedQuoteId",
-                linked_offer_id as "linkedOfferId",
-                client_id as "clientId",
-                client_name as "clientName",
-                payment_terms as "paymentTerms",
-                discount,
-                discount_type as "discountType",
-                status,
-                notes,
-                EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt",
-                EXTRACT(EPOCH FROM updated_at) * 1000 as "updatedAt"
-            FROM sales
-            ORDER BY created_at DESC`,
-      );
+      const [orders, items] = await Promise.all([
+        clientsOrdersRepo.listAll(),
+        clientsOrdersRepo.listAllItems(),
+      ]);
 
-      // Get all order items
-      const itemsResult = await query(
-        `SELECT
-                id,
-                sale_id as "orderId",
-                product_id as "productId",
-                product_name as "productName",
-                quantity,
-                unit_price as "unitPrice",
-                product_cost as "productCost",
-                product_mol_percentage as "productMolPercentage",
-                supplier_quote_id as "supplierQuoteId",
-                supplier_quote_item_id as "supplierQuoteItemId",
-                supplier_quote_supplier_name as "supplierQuoteSupplierName",
-                supplier_quote_unit_price as "supplierQuoteUnitPrice",
-                supplier_sale_id as "supplierSaleId",
-                supplier_sale_item_id as "supplierSaleItemId",
-                supplier_sale_supplier_name as "supplierSaleSupplierName",
-                unit_type as "unitType",
-                note,
-                discount
-            FROM sale_items
-            ORDER BY created_at ASC`,
-      );
-
-      const normalizedOrders = clients_ordersResult.rows.map((order) =>
-        normalizeClientOrderRow(order as Record<string, unknown>),
-      );
-      const normalizedItems = itemsResult.rows.map((item) =>
-        normalizeClientOrderItemRow(item as Record<string, unknown>),
-      );
-
-      // Group items by order
-      const itemsByOrder: Record<string, ReturnType<typeof normalizeClientOrderItemRow>[]> = {};
-      normalizedItems.forEach((item) => {
-        if (!itemsByOrder[item.orderId]) {
-          itemsByOrder[item.orderId] = [];
-        }
-        itemsByOrder[item.orderId].push(item);
-      });
-
-      // Attach items to clients_orders
-      const clients_orders = normalizedOrders.map((order) => ({
+      const itemsByOrder = new Map<string, clientsOrdersRepo.ClientOrderItem[]>();
+      for (const item of items) {
+        const list = itemsByOrder.get(item.orderId);
+        if (list) list.push(item);
+        else itemsByOrder.set(item.orderId, [item]);
+      }
+      return orders.map((order) => ({
         ...order,
-        items: itemsByOrder[order.id] || [],
+        items: itemsByOrder.get(order.id) ?? [],
       }));
-
-      return clients_orders;
     },
   );
 
@@ -354,40 +387,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         return badRequest(reply, 'Items must be a non-empty array');
       }
 
-      const normalizedItems = [];
-      for (let i = 0; i < items.length; i++) {
-        const item = items[i];
-        const productNameResult = requireNonEmptyString(
-          item.productName,
-          `items[${i}].productName`,
-        );
-        if (!productNameResult.ok) return badRequest(reply, productNameResult.message);
-        const quantityResult = parseLocalizedPositiveNumber(item.quantity, `items[${i}].quantity`);
-        if (!quantityResult.ok) return badRequest(reply, quantityResult.message);
-        const unitPriceResult = parseLocalizedNonNegativeNumber(
-          item.unitPrice,
-          `items[${i}].unitPrice`,
-        );
-        if (!unitPriceResult.ok) return badRequest(reply, unitPriceResult.message);
-        const itemDiscountResult = optionalLocalizedNonNegativeNumber(
-          item.discount,
-          `items[${i}].discount`,
-        );
-        if (!itemDiscountResult.ok) return badRequest(reply, itemDiscountResult.message);
-        normalizedItems.push({
-          ...item,
-          productName: productNameResult.value,
-          quantity: quantityResult.value,
-          unitPrice: unitPriceResult.value,
-          productCost: Number(item.productCost ?? 0),
-          productMolPercentage:
-            item.productMolPercentage === undefined || item.productMolPercentage === null
-              ? null
-              : Number(item.productMolPercentage),
-          unitType: normalizeUnitType(item.unitType),
-          discount: itemDiscountResult.value || 0,
-        });
-      }
+      const normalizedItems = normalizeIncomingItems(items, reply);
+      if (!normalizedItems) return;
 
       const discountResult = optionalLocalizedNonNegativeNumber(discount, 'discount');
       if (!discountResult.ok) return badRequest(reply, discountResult.message);
@@ -395,70 +396,61 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
 
       let linkedQuoteIdValue = linkedQuoteIdResult.value;
       if (linkedOfferIdResult.value) {
-        const offerResult = await query(
-          'SELECT id, linked_quote_id as "linkedQuoteId", status FROM customer_offers WHERE id = $1',
-          [linkedOfferIdResult.value],
-        );
-        if (offerResult.rows.length === 0) {
+        const offer = await clientsOrdersRepo.findOfferDetails(linkedOfferIdResult.value);
+        if (!offer) {
           return reply.code(404).send({ error: 'Source offer not found' });
         }
-        if (offerResult.rows[0].status !== 'accepted') {
+        if (offer.status !== 'accepted') {
           return reply
             .code(409)
             .send({ error: 'Sale orders can only be created from accepted offers' });
         }
 
-        const existingOrderResult = await query(
-          'SELECT id FROM sales WHERE linked_offer_id = $1 LIMIT 1',
-          [linkedOfferIdResult.value],
-        );
-        if (existingOrderResult.rows.length > 0) {
+        if (await clientsOrdersRepo.findExistingForOffer(linkedOfferIdResult.value)) {
           return reply.code(409).send({ error: 'A sale order already exists for this offer' });
         }
 
         if (
           linkedQuoteIdResult.value !== null &&
-          linkedQuoteIdResult.value !== offerResult.rows[0].linkedQuoteId
+          linkedQuoteIdResult.value !== offer.linkedQuoteId
         ) {
           return reply.code(409).send({ error: 'linkedQuoteId must match the source offer quote' });
         }
 
-        linkedQuoteIdValue = offerResult.rows[0].linkedQuoteId || null;
+        linkedQuoteIdValue = offer.linkedQuoteId || null;
       }
 
       const orderId = nextIdResult.value || (await generateClientOrderId());
 
-      let orderResult: Awaited<ReturnType<typeof query>>;
+      let createdOrder: clientsOrdersRepo.ClientOrder;
+      let insertedItems: clientsOrdersRepo.ClientOrderItem[];
       try {
-        orderResult = await query(
-          `INSERT INTO sales (id, linked_quote_id, linked_offer_id, client_id, client_name, payment_terms, discount, discount_type, status, notes)
-               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-               RETURNING
-                  id,
-                  linked_quote_id as "linkedQuoteId",
-                  linked_offer_id as "linkedOfferId",
-                  client_id as "clientId",
-                  client_name as "clientName",
-                  payment_terms as "paymentTerms",
-                  discount,
-                  discount_type as "discountType",
-                  status,
-                  notes,
-                  EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt",
-                  EXTRACT(EPOCH FROM updated_at) * 1000 as "updatedAt"`,
-          [
+        const result = await withTransaction(async (tx) => {
+          const order = await clientsOrdersRepo.create(
+            {
+              id: orderId,
+              linkedQuoteId: linkedQuoteIdValue,
+              linkedOfferId: linkedOfferIdResult.value || null,
+              clientId: clientIdResult.value,
+              clientName: clientNameResult.value,
+              paymentTerms:
+                typeof paymentTerms === 'string' && paymentTerms ? paymentTerms : 'immediate',
+              discount: discountResult.value || 0,
+              discountType: discountTypeValue,
+              status: typeof status === 'string' && status ? status : 'draft',
+              notes: (notes as string | null | undefined) ?? null,
+            },
+            tx,
+          );
+          const items = await clientsOrdersRepo.insertItems(
             orderId,
-            linkedQuoteIdValue,
-            linkedOfferIdResult.value || null,
-            clientIdResult.value,
-            clientNameResult.value,
-            paymentTerms || 'immediate',
-            discountResult.value || 0,
-            discountTypeValue,
-            status || 'draft',
-            notes,
-          ],
-        );
+            buildItemsForInsert(normalizedItems),
+            tx,
+          );
+          return { order, items };
+        });
+        createdOrder = result.order;
+        insertedItems = result.items;
       } catch (error) {
         if (isUniqueViolation(error)) {
           if (error.constraint === 'sales_pkey' || error.detail?.includes('(id)')) {
@@ -474,54 +466,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         throw error;
       }
 
-      // Insert order items
-      for (const item of normalizedItems) {
-        const itemId = 'si-' + Date.now() + '-' + Math.random().toString(36).substring(2, 11);
-        const _itemResult = await query(
-          `INSERT INTO sale_items (id, sale_id, product_id, product_name, quantity, unit_price, product_cost, product_mol_percentage, discount, note, supplier_quote_id, supplier_quote_item_id, supplier_quote_supplier_name, supplier_quote_unit_price, supplier_sale_id, supplier_sale_item_id, supplier_sale_supplier_name, unit_type)
-                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
-                 RETURNING
-                    id,
-                    sale_id as "orderId",
-                    product_id as "productId",
-                    product_name as "productName",
-                    quantity,
-                    unit_price as "unitPrice",
-                    product_cost as "productCost",
-                    product_mol_percentage as "productMolPercentage",
-                    supplier_quote_id as "supplierQuoteId",
-                    supplier_quote_item_id as "supplierQuoteItemId",
-                    supplier_quote_supplier_name as "supplierQuoteSupplierName",
-                    supplier_quote_unit_price as "supplierQuoteUnitPrice",
-                    supplier_sale_id as "supplierSaleId",
-                    supplier_sale_item_id as "supplierSaleItemId",
-                    supplier_sale_supplier_name as "supplierSaleSupplierName",
-                    unit_type as "unitType",
-                    discount,
-                    note`,
-          [
-            itemId,
-            orderId,
-            item.productId,
-            item.productName,
-            item.quantity,
-            item.unitPrice,
-            item.productCost,
-            item.productMolPercentage ?? null,
-            item.discount || 0,
-            item.note || null,
-            item.supplierQuoteId ?? null,
-            item.supplierQuoteItemId ?? null,
-            item.supplierQuoteSupplierName ?? null,
-            item.supplierQuoteUnitPrice ?? null,
-            item.supplierSaleId ?? null,
-            item.supplierSaleItemId ?? null,
-            item.supplierSaleSupplierName ?? null,
-            item.unitType || 'hours',
-          ],
-        );
-      }
-
       const supplierQuoteIds = [
         ...new Set(
           normalizedItems
@@ -531,103 +475,71 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       ];
 
       const supplierOrderWarnings: string[] = [];
+      let didAutoCreate = false;
 
       for (const sqId of supplierQuoteIds) {
         try {
-          const [sqResult, existingSupplierOrder, sqItems] = await Promise.all([
-            query(
-              `SELECT id, supplier_id as "supplierId", supplier_name as "supplierName",
-                      payment_terms as "paymentTerms", notes, status
-               FROM supplier_quotes WHERE id = $1`,
-              [sqId],
-            ),
-            query('SELECT id FROM supplier_sales WHERE linked_quote_id = $1 LIMIT 1', [sqId]),
-            query(
-              `SELECT id, product_id as "productId", product_name as "productName",
-                      quantity, unit_price as "unitPrice", note
-               FROM supplier_quote_items WHERE quote_id = $1`,
-              [sqId],
-            ),
+          const [supplierQuote, existingSupplierOrderId, supplierItems] = await Promise.all([
+            supplierQuotesRepo.findById(sqId),
+            supplierQuotesRepo.findLinkedOrderId(sqId),
+            supplierQuotesRepo.findItemsForQuote(sqId),
           ]);
 
-          if (sqResult.rows.length === 0 || sqResult.rows[0].status !== 'accepted') continue;
-          if (existingSupplierOrder.rows.length > 0) continue;
-
-          const sq = sqResult.rows[0];
-          const items = sqItems.rows;
+          if (!supplierQuote || supplierQuote.status !== 'accepted') continue;
+          if (existingSupplierOrderId) continue;
 
           await withTransaction(async (tx) => {
             const supplierOrderId = await generateSupplierOrderId(tx);
-            await tx.query(
-              `INSERT INTO supplier_sales
-                (id, linked_quote_id, supplier_id, supplier_name, payment_terms, status, notes)
-               VALUES ($1, $2, $3, $4, $5, 'draft', $6)`,
-              [
-                supplierOrderId,
-                sqId,
-                sq.supplierId,
-                sq.supplierName,
-                sq.paymentTerms || 'immediate',
-                sq.notes,
-              ],
+            await clientsOrdersRepo.createSupplierOrder(
+              {
+                id: supplierOrderId,
+                linkedQuoteId: sqId,
+                supplierId: supplierQuote.supplierId,
+                supplierName: supplierQuote.supplierName,
+                paymentTerms: supplierQuote.paymentTerms || 'immediate',
+                notes: supplierQuote.notes,
+              },
+              tx,
             );
 
             const insertedSupplierItemIds: { quoteItemId: string; saleItemId: string }[] = [];
+            const supplierItemRecords = supplierItems.map((item) => {
+              const saleItemId = generateItemId('ssi-');
+              insertedSupplierItemIds.push({ quoteItemId: item.id, saleItemId });
+              return {
+                id: saleItemId,
+                productId: item.productId,
+                productName: item.productName,
+                quantity: item.quantity,
+                unitPrice: item.unitPrice,
+                note: item.note,
+              };
+            });
 
-            if (items.length > 0) {
-              const placeholders = items
-                .map(
-                  (_, i) =>
-                    `($${i * 7 + 1}, $${i * 7 + 2}, $${i * 7 + 3}, $${i * 7 + 4}, $${i * 7 + 5}, $${i * 7 + 6}, $${i * 7 + 7})`,
-                )
-                .join(', ');
-              const params = items.flatMap((item) => {
-                const saleItemId = generateItemId('ssi-');
-                insertedSupplierItemIds.push({ quoteItemId: item.id, saleItemId });
-                return [
-                  saleItemId,
-                  supplierOrderId,
-                  item.productId,
-                  item.productName,
-                  item.quantity,
-                  item.unitPrice,
-                  item.note,
-                ];
-              });
-              await tx.query(
-                `INSERT INTO supplier_sale_items (id, sale_id, product_id, product_name, quantity, unit_price, note)
-                 VALUES ${placeholders}`,
-                params,
-              );
-            }
-
-            await tx.query(
-              `UPDATE sale_items
-                 SET supplier_sale_id = $1,
-                     supplier_sale_supplier_name = $2
-               WHERE sale_id = $3 AND supplier_quote_id = $4`,
-              [supplierOrderId, sq.supplierName, orderId, sqId],
+            await clientsOrdersRepo.bulkInsertSupplierOrderItems(
+              supplierOrderId,
+              supplierItemRecords,
+              tx,
             );
 
-            // Map each supplier_sale_item back to its sale_item via quote_item_id.
-            // Safe because each supplier quote item maps 1:1 to a sale item within
-            // (sale_id, supplier_quote_id) — duplicates prevented by business logic.
-            if (insertedSupplierItemIds.length > 0) {
-              const valuesPlaceholders = insertedSupplierItemIds
-                .map((_, i) => `($${i * 2 + 3}, $${i * 2 + 4})`)
-                .join(', ');
-              const mappingParams = insertedSupplierItemIds.flatMap(
-                ({ quoteItemId, saleItemId }) => [quoteItemId, saleItemId],
-              );
-              await tx.query(
-                `UPDATE sale_items si
-                   SET supplier_sale_item_id = v.sale_item_id
-                 FROM (VALUES ${valuesPlaceholders}) v(quote_item_id, sale_item_id)
-                 WHERE si.sale_id = $1 AND si.supplier_quote_id = $2
-                   AND si.supplier_quote_item_id = v.quote_item_id`,
-                [orderId, sqId, ...mappingParams],
-              );
-            }
+            await clientsOrdersRepo.linkSaleItemsToSupplierOrder(
+              {
+                orderId,
+                supplierQuoteId: sqId,
+                supplierOrderId,
+                supplierName: supplierQuote.supplierName,
+              },
+              tx,
+            );
+
+            await clientsOrdersRepo.mapSaleItemsToSupplierItems(
+              {
+                orderId,
+                supplierQuoteId: sqId,
+                mappings: insertedSupplierItemIds,
+              },
+              tx,
+            );
 
             await logAudit({
               request,
@@ -636,42 +548,20 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
               entityId: supplierOrderId,
               details: {
                 targetLabel: supplierOrderId,
-                secondaryLabel: `${sq.supplierName} (from client order ${orderId}, supplier quote ${sqId})`,
+                secondaryLabel: `${supplierQuote.supplierName} (from client order ${orderId}, supplier quote ${sqId})`,
               },
             });
           });
+          didAutoCreate = true;
         } catch (err) {
           request.log.error({ err, supplierQuoteId: sqId }, 'Failed to auto-create supplier order');
           supplierOrderWarnings.push(`Failed to auto-create supplier order for quote ${sqId}`);
         }
       }
 
-      // Re-fetch items to pick up supplier_sale_* fields set during auto-creation
-      const refreshedItems = await query(
-        `SELECT
-                id,
-                sale_id as "orderId",
-                product_id as "productId",
-                product_name as "productName",
-                quantity,
-                unit_price as "unitPrice",
-                product_cost as "productCost",
-                product_mol_percentage as "productMolPercentage",
-                supplier_quote_id as "supplierQuoteId",
-                supplier_quote_item_id as "supplierQuoteItemId",
-                supplier_quote_supplier_name as "supplierQuoteSupplierName",
-                supplier_quote_unit_price as "supplierQuoteUnitPrice",
-                supplier_sale_id as "supplierSaleId",
-                supplier_sale_item_id as "supplierSaleItemId",
-                supplier_sale_supplier_name as "supplierSaleSupplierName",
-                unit_type as "unitType",
-                note,
-                discount
-            FROM sale_items
-            WHERE sale_id = $1
-            ORDER BY created_at ASC`,
-        [orderId],
-      );
+      const refreshedItems = didAutoCreate
+        ? await clientsOrdersRepo.findItemsForOrder(orderId)
+        : insertedItems;
 
       await logAudit({
         request,
@@ -684,10 +574,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         },
       });
       return reply.code(201).send({
-        ...normalizeClientOrderRow(orderResult.rows[0] as Record<string, unknown>),
-        items: refreshedItems.rows.map((item) =>
-          normalizeClientOrderItemRow(item as Record<string, unknown>),
-        ),
+        ...createdOrder,
+        items: refreshedItems,
         ...(supplierOrderWarnings.length > 0 ? { warnings: supplierOrderWarnings } : {}),
       });
     },
@@ -737,192 +625,68 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
 
-      let nextIdValue = nextId;
+      let nextIdValue: string | null = null;
       if (nextId !== undefined) {
         const nextIdResult = optionalNonEmptyString(nextId, 'id');
         if (!nextIdResult.ok) return badRequest(reply, nextIdResult.message);
         nextIdValue = nextIdResult.value;
         if (nextIdResult.value) {
-          const existingIdResult = await query('SELECT id FROM sales WHERE id = $1 AND id <> $2', [
-            nextIdResult.value,
-            idResult.value,
-          ]);
-          if (existingIdResult.rows.length > 0) {
+          if (await clientsOrdersRepo.findIdConflict(nextIdResult.value, idResult.value)) {
             return reply.code(409).send({ error: 'Order ID already exists' });
           }
         }
       }
 
-      let clientIdValue = clientId;
+      let clientIdValue: string | null | undefined = clientId as string | null | undefined;
       if (clientId !== undefined) {
         const clientIdResult = optionalNonEmptyString(clientId, 'clientId');
         if (!clientIdResult.ok) return badRequest(reply, clientIdResult.message);
         clientIdValue = clientIdResult.value;
       }
 
-      let clientNameValue = clientName;
+      let clientNameValue: string | null | undefined = clientName as string | null | undefined;
       if (clientName !== undefined) {
         const clientNameResult = optionalNonEmptyString(clientName, 'clientName');
         if (!clientNameResult.ok) return badRequest(reply, clientNameResult.message);
         clientNameValue = clientNameResult.value;
       }
 
-      let discountValue = discount;
+      let discountValue: number | null | undefined = discount as number | null | undefined;
       if (discount !== undefined) {
         const discountResult = optionalLocalizedNonNegativeNumber(discount, 'discount');
         if (!discountResult.ok) return badRequest(reply, discountResult.message);
         discountValue = discountResult.value;
       }
 
-      const discountTypeValue =
-        discountType !== undefined
-          ? discountType === 'currency'
-            ? 'currency'
-            : 'percentage'
-          : undefined;
+      let discountTypeValue: 'currency' | 'percentage' | undefined;
+      if (discountType !== undefined) {
+        discountTypeValue = discountType === 'currency' ? 'currency' : 'percentage';
+      }
 
-      let linkedOfferIdValue = linkedOfferId;
+      let linkedOfferIdValue: string | null | undefined = linkedOfferId as
+        | string
+        | null
+        | undefined;
       if (linkedOfferId !== undefined) {
         const linkedOfferIdResult = optionalNonEmptyString(linkedOfferId, 'linkedOfferId');
         if (!linkedOfferIdResult.ok) return badRequest(reply, linkedOfferIdResult.message);
         linkedOfferIdValue = linkedOfferIdResult.value;
       }
 
-      const normalizeNotesValue = (value: unknown) => String(value ?? '');
-      const normalizeItemsForUpdate = (itemsToNormalize: unknown[]) => {
-        if (!Array.isArray(itemsToNormalize) || itemsToNormalize.length === 0) {
-          badRequest(reply, 'Items must be a non-empty array');
-          return null;
-        }
-
-        const normalizedItems: Record<string, unknown>[] = [];
-        for (let i = 0; i < itemsToNormalize.length; i++) {
-          const item = itemsToNormalize[i] as Record<string, unknown>;
-          const productNameResult = requireNonEmptyString(
-            item.productName,
-            `items[${i}].productName`,
-          );
-          if (!productNameResult.ok) {
-            badRequest(reply, productNameResult.message);
-            return null;
-          }
-          const quantityResult = parseLocalizedPositiveNumber(
-            item.quantity,
-            `items[${i}].quantity`,
-          );
-          if (!quantityResult.ok) {
-            badRequest(reply, quantityResult.message);
-            return null;
-          }
-          const unitPriceResult = parseLocalizedNonNegativeNumber(
-            item.unitPrice,
-            `items[${i}].unitPrice`,
-          );
-          if (!unitPriceResult.ok) {
-            badRequest(reply, unitPriceResult.message);
-            return null;
-          }
-          const itemDiscountResult = optionalLocalizedNonNegativeNumber(
-            item.discount,
-            `items[${i}].discount`,
-          );
-          if (!itemDiscountResult.ok) {
-            badRequest(reply, itemDiscountResult.message);
-            return null;
-          }
-          normalizedItems.push({
-            ...item,
-            productName: productNameResult.value,
-            quantity: quantityResult.value,
-            unitPrice: unitPriceResult.value,
-            productCost: Number(item.productCost ?? 0),
-            productMolPercentage:
-              item.productMolPercentage === undefined || item.productMolPercentage === null
-                ? null
-                : Number(item.productMolPercentage),
-            unitType: normalizeUnitType(item.unitType),
-            discount: itemDiscountResult.value || 0,
-          });
-        }
-
-        return normalizedItems;
-      };
-
-      const normalizeItemsForComparison = (itemsToNormalize: Record<string, unknown>[]) => {
-        return itemsToNormalize
-          .map((item) => {
-            const normalized = {
-              id: item.id ? String(item.id) : '',
-              productId: item.productId ? String(item.productId) : '',
-              productName: item.productName ? String(item.productName) : '',
-              quantity: Number(item.quantity),
-              unitPrice: Number(item.unitPrice),
-              discount:
-                item.discount !== undefined && item.discount !== null ? Number(item.discount) : 0,
-            };
-            const sortKey =
-              normalized.id ||
-              `${normalized.productId}|${normalized.productName}|${normalized.quantity}|${normalized.unitPrice}|${normalized.discount}`;
-            return { ...normalized, sortKey };
-          })
-          .sort((a, b) => a.sortKey.localeCompare(b.sortKey));
-      };
-
-      const itemsMatch = (
-        leftItems: Record<string, unknown>[],
-        rightItems: Record<string, unknown>[],
-      ) => {
-        if (leftItems.length !== rightItems.length) {
-          return false;
-        }
-        for (let i = 0; i < leftItems.length; i++) {
-          const leftItem = leftItems[i];
-          const rightItem = rightItems[i];
-          if (
-            leftItem.id !== rightItem.id ||
-            leftItem.productId !== rightItem.productId ||
-            leftItem.productName !== rightItem.productName ||
-            leftItem.quantity !== rightItem.quantity ||
-            leftItem.unitPrice !== rightItem.unitPrice ||
-            leftItem.discount !== rightItem.discount
-          ) {
-            return false;
-          }
-        }
-        return true;
-      };
-
-      let normalizedItems: Record<string, unknown>[] | null = null;
+      let normalizedItems: NormalizedOrderItem[] | null = null;
       if (items !== undefined) {
-        normalizedItems = normalizeItemsForUpdate(items as unknown[]);
+        if (!Array.isArray(items) || items.length === 0) {
+          return badRequest(reply, 'Items must be a non-empty array');
+        }
+        normalizedItems = normalizeIncomingItems(items, reply);
         if (!normalizedItems) return;
       }
 
-      const existingOrderResult = await query(
-        `SELECT
-                    id,
-                    linked_quote_id as "linkedQuoteId",
-                    linked_offer_id as "linkedOfferId",
-                    client_id as "clientId",
-                    client_name as "clientName",
-                    payment_terms as "paymentTerms",
-                    discount,
-                    status,
-                    notes
-                FROM sales
-                WHERE id = $1`,
-        [idResult.value],
-      );
-
-      if (existingOrderResult.rows.length === 0) {
+      const existingOrder = await clientsOrdersRepo.findForUpdate(idResult.value);
+      if (!existingOrder) {
         return reply.code(404).send({ error: 'Order not found' });
       }
 
-      const existingOrder = existingOrderResult.rows[0];
-      let existingItems: Record<string, unknown>[] | null = null;
-
-      // Check if order is read-only (non-draft status)
-      // Status changes are always allowed, but other field changes are blocked for non-draft clients_orders
       const hasLockedFieldUpdates =
         linkedOfferId !== undefined ||
         clientIdValue !== undefined ||
@@ -943,6 +707,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const isSourceLinkedOrder = Boolean(
         existingOrder.linkedQuoteId || existingOrder.linkedOfferId,
       );
+
+      let existingItems: clientsOrdersRepo.ClientOrderItem[] | null = null;
 
       if (isSourceLinkedOrder) {
         const lockedFields: string[] = [];
@@ -987,37 +753,12 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         }
 
         if (items !== undefined) {
-          const itemsResult = await query(
-            `SELECT
-                            id,
-                            sale_id as "orderId",
-                            product_id as "productId",
-                            product_name as "productName",
-                            quantity,
-                            unit_price as "unitPrice",
-                            product_cost as "productCost",
-                            product_mol_percentage as "productMolPercentage",
-                            supplier_quote_id as "supplierQuoteId",
-                            supplier_quote_item_id as "supplierQuoteItemId",
-                            supplier_quote_supplier_name as "supplierQuoteSupplierName",
-                            supplier_quote_unit_price as "supplierQuoteUnitPrice",
-                    supplier_sale_id as "supplierSaleId",
-                    supplier_sale_item_id as "supplierSaleItemId",
-                    supplier_sale_supplier_name as "supplierSaleSupplierName",
-                            unit_type as "unitType",
-                            discount,
-                            note
-                        FROM sale_items
-                        WHERE sale_id = $1`,
-            [idResult.value],
-          );
-          existingItems = itemsResult.rows;
-
+          existingItems = await clientsOrdersRepo.findItemsForOrder(idResult.value);
           const normalizedExistingItems = normalizeItemsForComparison(
-            existingItems as Record<string, unknown>[],
+            existingItems as unknown as Array<Record<string, unknown>>,
           );
           const normalizedIncomingItems = normalizeItemsForComparison(
-            (normalizedItems ?? []) as Record<string, unknown>[],
+            (normalizedItems ?? []) as unknown as Array<Record<string, unknown>>,
           );
           if (!itemsMatch(normalizedExistingItems, normalizedIncomingItems)) {
             lockedFields.push('items');
@@ -1040,82 +781,69 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           });
         }
 
-        const offerResult = await query(
-          'SELECT id, linked_quote_id as "linkedQuoteId", status FROM customer_offers WHERE id = $1',
-          [linkedOfferIdValue],
-        );
-        if (offerResult.rows.length === 0) {
+        const offer = await clientsOrdersRepo.findOfferDetails(linkedOfferIdValue);
+        if (!offer) {
           return reply.code(404).send({ error: 'Source offer not found' });
         }
-        if (offerResult.rows[0].status !== 'accepted') {
+        if (offer.status !== 'accepted') {
           return reply
             .code(409)
             .send({ error: 'Sale orders can only be created from accepted offers' });
         }
-        if (
-          existingOrder.linkedQuoteId &&
-          existingOrder.linkedQuoteId !== offerResult.rows[0].linkedQuoteId
-        ) {
+        if (existingOrder.linkedQuoteId && existingOrder.linkedQuoteId !== offer.linkedQuoteId) {
           return reply.code(409).send({
             error: 'The selected offer does not match the order quote link',
           });
         }
 
-        const existingLinkedOrderResult = await query(
-          'SELECT id FROM sales WHERE linked_offer_id = $1 AND id <> $2 LIMIT 1',
-          [linkedOfferIdValue, idResult.value],
-        );
-        if (existingLinkedOrderResult.rows.length > 0) {
+        if (await clientsOrdersRepo.findExistingForOffer(linkedOfferIdValue, idResult.value)) {
           return reply.code(409).send({ error: 'A sale order already exists for this offer' });
         }
 
-        linkedQuoteIdValue = offerResult.rows[0].linkedQuoteId || null;
+        linkedQuoteIdValue = offer.linkedQuoteId || null;
       }
 
-      // Update order
-      let orderResult: Awaited<ReturnType<typeof query>>;
+      const willReplaceItems = !isSourceLinkedOrder && items !== undefined;
+      if (willReplaceItems && !normalizedItems) return;
+
+      let result: {
+        order: clientsOrdersRepo.ClientOrder | null;
+        items: clientsOrdersRepo.ClientOrderItem[];
+      };
       try {
-        orderResult = await query(
-          `UPDATE sales
-               SET id = COALESCE($1, id),
-                   linked_offer_id = COALESCE($2, linked_offer_id),
-                   linked_quote_id = COALESCE($3, linked_quote_id),
-                   client_id = COALESCE($4, client_id),
-                   client_name = COALESCE($5, client_name),
-                   payment_terms = COALESCE($6, payment_terms),
-                   discount = COALESCE($7, discount),
-                   discount_type = COALESCE($8, discount_type),
-                   status = COALESCE($9, status),
-                   notes = COALESCE($10, notes),
-                   updated_at = CURRENT_TIMESTAMP
-               WHERE id = $11
-               RETURNING
-                  id,
-                  linked_quote_id as "linkedQuoteId",
-                  linked_offer_id as "linkedOfferId",
-                  client_id as "clientId",
-                  client_name as "clientName",
-                  payment_terms as "paymentTerms",
-                  discount,
-                  discount_type as "discountType",
-                  status,
-                  notes,
-                  EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt",
-                  EXTRACT(EPOCH FROM updated_at) * 1000 as "updatedAt"`,
-          [
-            nextIdValue,
-            linkedOfferIdValue,
-            linkedQuoteIdValue,
-            clientIdValue,
-            clientNameValue,
-            paymentTerms,
-            discountValue,
-            discountTypeValue,
-            status,
-            notes,
+        result = await withTransaction(async (tx) => {
+          const order = await clientsOrdersRepo.update(
             idResult.value,
-          ],
-        );
+            {
+              id: nextIdValue,
+              linkedOfferId: (linkedOfferIdValue as string | null | undefined) ?? null,
+              linkedQuoteId: linkedQuoteIdValue,
+              clientId: (clientIdValue as string | null | undefined) ?? null,
+              clientName: (clientNameValue as string | null | undefined) ?? null,
+              paymentTerms: (paymentTerms as string | null | undefined) ?? null,
+              discount: (discountValue as number | null | undefined) ?? null,
+              discountType: discountTypeValue ?? null,
+              status: (status as string | null | undefined) ?? null,
+              notes: (notes as string | null | undefined) ?? null,
+            },
+            tx,
+          );
+          if (!order) return { order: null, items: [] };
+
+          let nextItems: clientsOrdersRepo.ClientOrderItem[];
+          if (isSourceLinkedOrder) {
+            nextItems = existingItems ?? (await clientsOrdersRepo.findItemsForOrder(order.id, tx));
+          } else if (willReplaceItems && normalizedItems) {
+            nextItems = await clientsOrdersRepo.replaceItems(
+              order.id,
+              buildItemsForInsert(normalizedItems),
+              tx,
+            );
+          } else {
+            nextItems = await clientsOrdersRepo.findItemsForOrder(order.id, tx);
+          }
+          return { order, items: nextItems };
+        });
       } catch (error) {
         if (isUniqueViolation(error)) {
           if (error.constraint === 'sales_pkey' || error.detail?.includes('(id)')) {
@@ -1131,138 +859,15 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         throw error;
       }
 
-      if (orderResult.rows.length === 0) {
+      const updatedOrder = result.order;
+      const updatedItems = result.items;
+      if (!updatedOrder) {
         return reply.code(404).send({ error: 'Order not found' });
       }
 
-      const updatedOrderId = String(orderResult.rows[0].id);
+      const updatedOrderId = updatedOrder.id;
 
-      // If items are provided, update them
-      let updatedItems: ReturnType<typeof normalizeClientOrderItemRow>[] = [];
-      if (isSourceLinkedOrder) {
-        if (existingItems) {
-          updatedItems = existingItems.map((item) =>
-            normalizeClientOrderItemRow(item as Record<string, unknown>),
-          );
-        } else {
-          const itemsResult = await query(
-            `SELECT
-                        id,
-                        sale_id as "orderId",
-                        product_id as "productId",
-                        product_name as "productName",
-                        quantity,
-                        unit_price as "unitPrice",
-                        product_cost as "productCost",
-                        product_mol_percentage as "productMolPercentage",
-                        supplier_quote_id as "supplierQuoteId",
-                        supplier_quote_item_id as "supplierQuoteItemId",
-                        supplier_quote_supplier_name as "supplierQuoteSupplierName",
-                        supplier_quote_unit_price as "supplierQuoteUnitPrice",
-                    supplier_sale_id as "supplierSaleId",
-                    supplier_sale_item_id as "supplierSaleItemId",
-                    supplier_sale_supplier_name as "supplierSaleSupplierName",
-                        unit_type as "unitType",
-                        discount,
-                         note
-                     FROM sale_items
-                     WHERE sale_id = $1`,
-            [updatedOrderId],
-          );
-          updatedItems = itemsResult.rows.map((item) =>
-            normalizeClientOrderItemRow(item as Record<string, unknown>),
-          );
-        }
-      } else if (items !== undefined) {
-        if (!normalizedItems) return;
-        // Delete existing items
-        await query('DELETE FROM sale_items WHERE sale_id = $1', [updatedOrderId]);
-
-        // Insert new items
-        for (const item of normalizedItems) {
-          const itemId = 'si-' + Date.now() + '-' + Math.random().toString(36).substring(2, 11);
-          const itemResult = await query(
-            `INSERT INTO sale_items (id, sale_id, product_id, product_name, quantity, unit_price, product_cost, product_mol_percentage, discount, note, supplier_quote_id, supplier_quote_item_id, supplier_quote_supplier_name, supplier_quote_unit_price, supplier_sale_id, supplier_sale_item_id, supplier_sale_supplier_name, unit_type)
-                     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
-                     RETURNING
-                        id,
-                        sale_id as "orderId",
-                        product_id as "productId",
-                        product_name as "productName",
-                        quantity,
-                        unit_price as "unitPrice",
-                        product_cost as "productCost",
-                        product_mol_percentage as "productMolPercentage",
-                        supplier_quote_id as "supplierQuoteId",
-                        supplier_quote_item_id as "supplierQuoteItemId",
-                        supplier_quote_supplier_name as "supplierQuoteSupplierName",
-                        supplier_quote_unit_price as "supplierQuoteUnitPrice",
-                    supplier_sale_id as "supplierSaleId",
-                    supplier_sale_item_id as "supplierSaleItemId",
-                    supplier_sale_supplier_name as "supplierSaleSupplierName",
-                        unit_type as "unitType",
-                        discount,
-                         note`,
-            [
-              itemId,
-              updatedOrderId,
-              item.productId,
-              item.productName,
-              item.quantity,
-              item.unitPrice,
-              item.productCost,
-              item.productMolPercentage ?? null,
-              item.discount || 0,
-              item.note || null,
-              item.supplierQuoteId ?? null,
-              item.supplierQuoteItemId ?? null,
-              item.supplierQuoteSupplierName ?? null,
-              item.supplierQuoteUnitPrice ?? null,
-              item.supplierSaleId ?? null,
-              item.supplierSaleItemId ?? null,
-              item.supplierSaleSupplierName ?? null,
-              item.unitType || 'hours',
-            ],
-          );
-          updatedItems.push(
-            normalizeClientOrderItemRow(itemResult.rows[0] as Record<string, unknown>),
-          );
-        }
-      } else {
-        // Fetch existing items
-        const itemsResult = await query(
-          `SELECT
-                    id,
-                    sale_id as "orderId",
-                    product_id as "productId",
-                    product_name as "productName",
-                    quantity,
-                    unit_price as "unitPrice",
-                    product_cost as "productCost",
-                    product_mol_percentage as "productMolPercentage",
-                    supplier_quote_id as "supplierQuoteId",
-                    supplier_quote_item_id as "supplierQuoteItemId",
-                    supplier_quote_supplier_name as "supplierQuoteSupplierName",
-                    supplier_quote_unit_price as "supplierQuoteUnitPrice",
-                    supplier_sale_id as "supplierSaleId",
-                    supplier_sale_item_id as "supplierSaleItemId",
-                    supplier_sale_supplier_name as "supplierSaleSupplierName",
-                    unit_type as "unitType",
-                    discount,
-                    note
-                FROM sale_items
-                WHERE sale_id = $1`,
-          [updatedOrderId],
-        );
-        updatedItems = itemsResult.rows.map((item) =>
-          normalizeClientOrderItemRow(item as Record<string, unknown>),
-        );
-      }
-
-      const nextStatus =
-        typeof status === 'string'
-          ? status
-          : String(orderResult.rows[0].status ?? existingOrder.status);
+      const nextStatus = typeof status === 'string' ? status : updatedOrder.status;
       const didStatusChange = status !== undefined && existingOrder.status !== nextStatus;
 
       await logAudit({
@@ -1272,15 +877,12 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         entityId: updatedOrderId,
         details: {
           targetLabel: updatedOrderId,
-          secondaryLabel: String(orderResult.rows[0].clientName ?? ''),
-          fromValue: didStatusChange ? String(existingOrder.status) : undefined,
+          secondaryLabel: updatedOrder.clientName,
+          fromValue: didStatusChange ? existingOrder.status : undefined,
           toValue: didStatusChange ? nextStatus : undefined,
         },
       });
-      return {
-        ...normalizeClientOrderRow(orderResult.rows[0] as Record<string, unknown>),
-        items: updatedItems,
-      };
+      return { ...updatedOrder, items: updatedItems };
     },
   );
 
@@ -1304,17 +906,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
 
-      // Check if order exists and is in draft status
-      const orderResult = await query(
-        'SELECT id, status, client_name as "clientName" FROM sales WHERE id = $1',
-        [idResult.value],
-      );
-
-      if (orderResult.rows.length === 0) {
+      const order = await clientsOrdersRepo.findStatusAndClientName(idResult.value);
+      if (!order) {
         return reply.code(404).send({ error: 'Order not found' });
       }
-
-      const order = orderResult.rows[0];
       if (order.status !== 'draft') {
         return reply.code(409).send({
           error: 'Only draft clients_orders can be deleted',
@@ -1322,8 +917,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         });
       }
 
-      // Items will be deleted automatically via CASCADE
-      await query('DELETE FROM sales WHERE id = $1', [idResult.value]);
+      await clientsOrdersRepo.deleteById(idResult.value);
 
       await logAudit({
         request,
@@ -1332,7 +926,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         entityId: idResult.value,
         details: {
           targetLabel: idResult.value,
-          secondaryLabel: String(order.clientName ?? ''),
+          secondaryLabel: order.clientName ?? '',
         },
       });
       return reply.code(204).send();

--- a/server/routes/clients-orders.ts
+++ b/server/routes/clients-orders.ts
@@ -804,7 +804,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       }
 
       const willReplaceItems = !isSourceLinkedOrder && items !== undefined;
-      if (willReplaceItems && !normalizedItems) return;
 
       let result: {
         order: clientsOrdersRepo.ClientOrder | null;

--- a/server/routes/clients.ts
+++ b/server/routes/clients.ts
@@ -1,6 +1,8 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
-import { query } from '../db/index.ts';
+import { withTransaction } from '../db/index.ts';
 import { authenticateToken, requireAnyPermission, requirePermission } from '../middleware/auth.ts';
+import * as clientProfileOptionsRepo from '../repositories/clientProfileOptionsRepo.ts';
+import * as clientsRepo from '../repositories/clientsRepo.ts';
 import {
   messageResponseSchema,
   standardErrorResponses,
@@ -21,14 +23,9 @@ import {
   validateClientIdentifier,
 } from '../utils/validation.ts';
 
-const PROFILE_OPTION_CATEGORIES = [
-  'sector',
-  'numberOfEmployees',
-  'revenue',
-  'officeCountRange',
-] as const;
-
-type ProfileOptionCategory = (typeof PROFILE_OPTION_CATEGORIES)[number];
+const PROFILE_OPTION_CATEGORIES = clientProfileOptionsRepo.PROFILE_OPTION_CATEGORIES;
+type ProfileOptionCategory = clientProfileOptionsRepo.ProfileOptionCategory;
+const PROFILE_OPTION_CATEGORY_SET = new Set<string>(PROFILE_OPTION_CATEGORIES);
 
 type ClientContactInput = {
   fullName: unknown;
@@ -37,14 +34,7 @@ type ClientContactInput = {
   phone?: unknown;
 };
 
-type ClientContact = {
-  fullName: string;
-  role?: string;
-  email?: string;
-  phone?: string;
-};
-
-const PROFILE_OPTION_CATEGORY_SET = new Set<string>(PROFILE_OPTION_CATEGORIES);
+type ClientContact = clientsRepo.ClientContact;
 
 const idParamSchema = {
   type: 'object',
@@ -194,18 +184,6 @@ const clientUpdateBodySchema = {
   },
 } as const;
 
-const toNumber = (v: unknown): number | undefined => {
-  if (v === null || v === undefined) return undefined;
-  const n = Number(v);
-  return Number.isFinite(n) ? n : undefined;
-};
-
-const toOptionalTrimmedString = (
-  value: unknown,
-  fieldName: string,
-): { ok: true; value: string | null } | { ok: false; message: string } =>
-  optionalNonEmptyString(value, fieldName);
-
 const isValidProfileOptionCategory = (value: unknown): value is ProfileOptionCategory =>
   typeof value === 'string' && PROFILE_OPTION_CATEGORY_SET.has(value);
 
@@ -272,126 +250,6 @@ const parseContacts = (
   return { ok: true, value: normalized };
 };
 
-const parseContactsFromDb = (value: unknown): ClientContact[] => {
-  if (!Array.isArray(value)) return [];
-
-  const contacts: ClientContact[] = [];
-  for (const raw of value) {
-    if (!raw || typeof raw !== 'object') continue;
-    const item = raw as Record<string, unknown>;
-    const fullName =
-      typeof item.fullName === 'string'
-        ? item.fullName.trim()
-        : typeof item.name === 'string'
-          ? item.name.trim()
-          : '';
-    if (!fullName) continue;
-
-    const role = typeof item.role === 'string' ? item.role.trim() : '';
-    const email = typeof item.email === 'string' ? item.email.trim() : '';
-    const phone = typeof item.phone === 'string' ? item.phone.trim() : '';
-
-    contacts.push({
-      fullName,
-      role: role || undefined,
-      email: email || undefined,
-      phone: phone || undefined,
-    });
-  }
-
-  return contacts;
-};
-
-const formatAddress = ({
-  civicNumber,
-  line,
-  cap,
-  state,
-  province,
-  country,
-}: {
-  civicNumber: string | null;
-  line: string | null;
-  cap: string | null;
-  state: string | null;
-  province: string | null;
-  country: string | null;
-}) => {
-  const street = [line, civicNumber].filter(Boolean).join(' ').trim();
-  const locality = [cap, state].filter(Boolean).join(' ').trim();
-  const provinceChunk = province ? `(${province})` : '';
-  return [street, [locality, provinceChunk].filter(Boolean).join(' ').trim(), country]
-    .filter((chunk) => chunk && chunk.trim().length > 0)
-    .join(', ');
-};
-
-const getPrimaryContact = (contacts: ClientContact[]) => contacts[0] ?? null;
-
-const mapClientRow = (c: Record<string, unknown>) => {
-  const fiscalCode = (c.fiscal_code as string | null) || null;
-  const createdAt = c.created_at ? new Date(c.created_at as string).getTime() : undefined;
-  const contacts = parseContactsFromDb(c.contacts);
-  const primaryContact = getPrimaryContact(contacts);
-
-  const addressCountry = (c.address_country as string | null) || null;
-  const addressState = (c.address_state as string | null) || null;
-  const addressCap = (c.address_cap as string | null) || null;
-  const addressProvince = (c.address_province as string | null) || null;
-  const addressCivicNumber = (c.address_civic_number as string | null) || null;
-  const addressLine = (c.address_line as string | null) || null;
-
-  const computedAddress = formatAddress({
-    civicNumber: addressCivicNumber,
-    line: addressLine,
-    cap: addressCap,
-    state: addressState,
-    province: addressProvince,
-    country: addressCountry,
-  });
-
-  return {
-    id: c.id,
-    name: c.name,
-    description: c.description,
-    isDisabled: c.is_disabled,
-    type: c.type,
-    contacts,
-    contactName: (c.contact_name as string | null) || primaryContact?.fullName || null,
-    clientCode: c.client_code,
-    email: (c.email as string | null) || primaryContact?.email || null,
-    phone: (c.phone as string | null) || primaryContact?.phone || null,
-    address: (c.address as string | null) || computedAddress || null,
-    addressCountry,
-    addressState,
-    addressCap,
-    addressProvince,
-    addressCivicNumber,
-    addressLine,
-    atecoCode: c.ateco_code,
-    website: c.website,
-    sector: c.sector,
-    numberOfEmployees: c.number_of_employees,
-    revenue: c.revenue,
-    fiscalCode,
-    officeCountRange: c.office_count_range,
-    totalSentQuotes: toNumber(c.total_sent_quotes),
-    totalAcceptedOrders: toNumber(c.total_accepted_orders),
-    vatNumber: fiscalCode,
-    taxCode: fiscalCode,
-    createdAt,
-  };
-};
-
-const mapProfileOptionRow = (row: Record<string, unknown>) => ({
-  id: String(row.id),
-  category: String(row.category),
-  value: String(row.value),
-  sortOrder: Number(row.sort_order ?? 0),
-  usageCount: Number(row.usage_count ?? 0),
-  createdAt: row.created_at ? new Date(String(row.created_at)).getTime() : null,
-  updatedAt: row.updated_at ? new Date(String(row.updated_at)).getTime() : null,
-});
-
 const resolveFiscalCode = ({
   vatNumber,
   fiscalCode,
@@ -403,27 +261,12 @@ const resolveFiscalCode = ({
 }) => vatNumber || fiscalCode || taxCode || null;
 
 const buildPrimaryFieldsFromContacts = (contacts: ClientContact[]) => {
-  const primary = getPrimaryContact(contacts);
+  const primary = contacts[0] ?? null;
   return {
     contactName: primary?.fullName ?? null,
     email: primary?.email ?? null,
     phone: primary?.phone ?? null,
   };
-};
-
-const getUsageCountExpression = (category: ProfileOptionCategory) => {
-  switch (category) {
-    case 'sector':
-      return '(SELECT COUNT(*) FROM clients c WHERE c.sector = o.value)';
-    case 'numberOfEmployees':
-      return '(SELECT COUNT(*) FROM clients c WHERE c.number_of_employees = o.value)';
-    case 'revenue':
-      return '(SELECT COUNT(*) FROM clients c WHERE c.revenue = o.value)';
-    case 'officeCountRange':
-      return '(SELECT COUNT(*) FROM clients c WHERE c.office_count_range = o.value)';
-    default:
-      return '0';
-  }
 };
 
 export default async function (fastify: FastifyInstance, _opts: unknown) {
@@ -465,67 +308,21 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const canViewAllClients = hasPermission(request, 'crm.clients_all.view');
       const canViewClientDetails = hasPermission(request, 'crm.clients.view');
 
-      let queryText = `
-        SELECT c.*,
-          COALESCE(sq.total_sent_quotes, 0) as total_sent_quotes,
-          COALESCE(so.total_accepted_orders, 0) as total_accepted_orders
-        FROM clients c
-        LEFT JOIN (
-          SELECT q.client_id,
-            SUM(
-              (SELECT COALESCE(SUM(qi.quantity * qi.unit_price * (1 - COALESCE(qi.discount, 0) / 100.0)), 0)
-               FROM quote_items qi WHERE qi.quote_id = q.id)
-              * (1 - COALESCE(q.discount, 0) / 100.0)
-            ) as total_sent_quotes
-          FROM quotes q
-          WHERE q.status = 'sent'
-          GROUP BY q.client_id
-        ) sq ON sq.client_id = c.id
-        LEFT JOIN (
-          SELECT s.client_id,
-            SUM(
-              (SELECT COALESCE(SUM(si.quantity * si.unit_price * (1 - COALESCE(si.discount, 0) / 100.0)), 0)
-               FROM sale_items si WHERE si.sale_id = s.id)
-              * (1 - COALESCE(s.discount, 0) / 100.0)
-            ) as total_accepted_orders
-          FROM sales s
-          WHERE s.status = 'confirmed'
-          GROUP BY s.client_id
-        ) so ON so.client_id = c.id
-        ORDER BY c.name
-      `;
+      const clients = await clientsRepo.list(
+        canViewAllClients
+          ? { canViewAllClients: true }
+          : { canViewAllClients: false, userId: request.user.id },
+      );
 
-      const queryParams: (string | null)[] = [];
-
-      if (!canViewAllClients) {
-        queryText = `
-          SELECT c.id, c.name, c.description, c.is_disabled, c.type,
-            c.contacts, c.contact_name, c.client_code, c.email, c.phone, c.address,
-            c.address_country, c.address_state, c.address_cap, c.address_province,
-            c.address_civic_number, c.address_line,
-            c.ateco_code, c.website, c.sector, c.number_of_employees,
-            c.revenue, c.fiscal_code, c.office_count_range, c.created_at,
-            NULL::numeric as total_sent_quotes,
-            NULL::numeric as total_accepted_orders
-          FROM clients c
-          INNER JOIN user_clients uc ON c.id = uc.client_id
-          WHERE uc.user_id = $1
-          ORDER BY c.name
-        `;
-        queryParams.push(request.user.id);
-      }
-
-      const result = await query(queryText, queryParams);
-      return result.rows.map((row) => {
+      return clients.map((client) => {
         if (!canViewClientDetails) {
           return {
-            id: row.id,
-            name: row.name,
+            id: client.id,
+            name: client.name,
             description: null,
           };
         }
-
-        return mapClientRow(row);
+        return client;
       });
     },
   );
@@ -597,22 +394,22 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       });
       if (!resolvedFiscalCode) return badRequest(reply, 'Fiscal code is required');
 
-      const addressResult = toOptionalTrimmedString(address, 'address');
+      const addressResult = optionalNonEmptyString(address, 'address');
       if (!addressResult.ok) return badRequest(reply, addressResult.message);
-      const addressCountryResult = toOptionalTrimmedString(addressCountry, 'addressCountry');
+      const addressCountryResult = optionalNonEmptyString(addressCountry, 'addressCountry');
       if (!addressCountryResult.ok) return badRequest(reply, addressCountryResult.message);
-      const addressStateResult = toOptionalTrimmedString(addressState, 'addressState');
+      const addressStateResult = optionalNonEmptyString(addressState, 'addressState');
       if (!addressStateResult.ok) return badRequest(reply, addressStateResult.message);
-      const addressCapResult = toOptionalTrimmedString(addressCap, 'addressCap');
+      const addressCapResult = optionalNonEmptyString(addressCap, 'addressCap');
       if (!addressCapResult.ok) return badRequest(reply, addressCapResult.message);
-      const addressProvinceResult = toOptionalTrimmedString(addressProvince, 'addressProvince');
+      const addressProvinceResult = optionalNonEmptyString(addressProvince, 'addressProvince');
       if (!addressProvinceResult.ok) return badRequest(reply, addressProvinceResult.message);
-      const addressCivicNumberResult = toOptionalTrimmedString(
+      const addressCivicNumberResult = optionalNonEmptyString(
         addressCivicNumber,
         'addressCivicNumber',
       );
       if (!addressCivicNumberResult.ok) return badRequest(reply, addressCivicNumberResult.message);
-      const addressLineResult = toOptionalTrimmedString(addressLine, 'addressLine');
+      const addressLineResult = optionalNonEmptyString(addressLine, 'addressLine');
       if (!addressLineResult.ok) return badRequest(reply, addressLineResult.message);
 
       const descriptionResult = optionalNonEmptyString(description, 'description');
@@ -649,21 +446,17 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const explicitPhoneResult = optionalNonEmptyString(phone, 'phone');
       if (!explicitPhoneResult.ok) return badRequest(reply, explicitPhoneResult.message);
 
-      const existingFiscalCode = await query(
-        'SELECT id FROM clients WHERE LOWER(fiscal_code) = LOWER($1)',
-        [resolvedFiscalCode],
-      );
-      if (existingFiscalCode.rows.length > 0) {
+      const [fiscalCodeConflict, clientCodeConflict] = await Promise.all([
+        clientsRepo.findByFiscalCode(resolvedFiscalCode, null),
+        clientCodeResult.value
+          ? clientsRepo.findByClientCode(clientCodeResult.value, null)
+          : Promise.resolve(false),
+      ]);
+      if (fiscalCodeConflict) {
         return badRequest(reply, 'Fiscal code already exists');
       }
-
-      if (clientCodeResult.value) {
-        const existingCode = await query('SELECT id FROM clients WHERE client_code = $1', [
-          clientCodeResult.value,
-        ]);
-        if (existingCode.rows.length > 0) {
-          return badRequest(reply, 'Client ID already exists');
-        }
+      if (clientCodeConflict) {
+        return badRequest(reply, 'Client ID already exists');
       }
 
       const id = 'c-' + Date.now();
@@ -671,52 +464,31 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const primaryFromContacts = buildPrimaryFieldsFromContacts(contactsValue);
 
       try {
-        const created = await query(
-          `
-            INSERT INTO clients (
-                id, name, is_disabled, type, contacts, contact_name, client_code,
-                email, phone, address, address_country, address_state, address_cap,
-                address_province, address_civic_number, address_line,
-                description, ateco_code, website, sector,
-                number_of_employees, revenue, fiscal_code, office_count_range
-            ) VALUES (
-                $1, $2, $3, $4, $5::jsonb, $6, $7,
-                $8, $9, $10, $11, $12, $13,
-                $14, $15, $16,
-                $17, $18, $19, $20,
-                $21, $22, $23, $24
-            )
-            RETURNING *
-          `,
-          [
-            id,
-            nameResult.value,
-            false,
-            type || 'company',
-            JSON.stringify(contactsValue),
-            explicitContactNameResult.value ?? primaryFromContacts.contactName,
-            clientCodeResult.value,
-            explicitEmailResult.value ?? primaryFromContacts.email,
-            explicitPhoneResult.value ?? primaryFromContacts.phone,
-            addressResult.value,
-            addressCountryResult.value,
-            addressStateResult.value,
-            addressCapResult.value,
-            addressProvinceResult.value,
-            addressCivicNumberResult.value,
-            addressLineResult.value,
-            descriptionResult.value,
-            atecoCodeResult.value,
-            websiteResult.value,
-            sectorResult.value,
-            numberOfEmployeesResult.value,
-            revenueResult.value,
-            resolvedFiscalCode,
-            officeCountRangeResult.value,
-          ],
-        );
-
-        const c = created.rows[0];
+        const client = await clientsRepo.create({
+          id,
+          name: nameResult.value,
+          type: typeof type === 'string' && type ? type : 'company',
+          contacts: contactsValue,
+          contactName: explicitContactNameResult.value ?? primaryFromContacts.contactName,
+          clientCode: clientCodeResult.value,
+          email: explicitEmailResult.value ?? primaryFromContacts.email,
+          phone: explicitPhoneResult.value ?? primaryFromContacts.phone,
+          address: addressResult.value,
+          addressCountry: addressCountryResult.value,
+          addressState: addressStateResult.value,
+          addressCap: addressCapResult.value,
+          addressProvince: addressProvinceResult.value,
+          addressCivicNumber: addressCivicNumberResult.value,
+          addressLine: addressLineResult.value,
+          description: descriptionResult.value,
+          atecoCode: atecoCodeResult.value,
+          website: websiteResult.value,
+          sector: sectorResult.value,
+          numberOfEmployees: numberOfEmployeesResult.value,
+          revenue: revenueResult.value,
+          fiscalCode: resolvedFiscalCode,
+          officeCountRange: officeCountRangeResult.value,
+        });
 
         if (request.user?.id) {
           await assignClientToUser(request.user.id, id);
@@ -728,11 +500,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           entityType: 'client',
           entityId: id,
           details: {
-            targetLabel: c.name as string,
-            secondaryLabel: (c.client_code as string | null) ?? undefined,
+            targetLabel: client.name,
+            secondaryLabel: client.clientCode ?? undefined,
           },
         });
-        return reply.code(201).send(mapClientRow(c));
+        return reply.code(201).send(client);
       } catch (err) {
         if (isUniqueViolation(err)) {
           if (err.constraint === 'idx_clients_fiscal_code_unique') {
@@ -910,36 +682,26 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       );
       if (!officeCountRangeResult.ok) return badRequest(reply, officeCountRangeResult.message);
 
-      if (resolvedFiscalCode) {
-        const existingFiscalCode = await query(
-          'SELECT id FROM clients WHERE LOWER(fiscal_code) = LOWER($1) AND id <> $2',
-          [resolvedFiscalCode, idResult.value],
-        );
-        if (existingFiscalCode.rows.length > 0) {
-          return badRequest(reply, 'Fiscal code already exists');
-        }
+      const [fiscalCodeConflict, clientCodeConflict, current] = await Promise.all([
+        resolvedFiscalCode
+          ? clientsRepo.findByFiscalCode(resolvedFiscalCode, idResult.value)
+          : Promise.resolve(false),
+        clientCodeValue
+          ? clientsRepo.findByClientCode(clientCodeValue, idResult.value)
+          : Promise.resolve(false),
+        clientsRepo.findContactsForUpdate(idResult.value),
+      ]);
+      if (fiscalCodeConflict) {
+        return badRequest(reply, 'Fiscal code already exists');
       }
-
-      if (clientCodeValue) {
-        const existingCode = await query(
-          'SELECT id FROM clients WHERE client_code = $1 AND id <> $2',
-          [clientCodeValue, idResult.value],
-        );
-        if (existingCode.rows.length > 0) {
-          return badRequest(reply, 'Client ID already exists');
-        }
+      if (clientCodeConflict) {
+        return badRequest(reply, 'Client ID already exists');
       }
-
-      const currentResult = await query(
-        'SELECT contacts, contact_name, email, phone FROM clients WHERE id = $1',
-        [idResult.value],
-      );
-      if (currentResult.rows.length === 0) {
+      if (!current) {
         return reply.code(404).send({ error: 'Client not found' });
       }
 
-      const currentContacts = parseContactsFromDb(currentResult.rows[0].contacts);
-      const effectiveContacts = hasContacts ? contactsResult.value : currentContacts;
+      const effectiveContacts = hasContacts ? contactsResult.value : current.contacts;
       const primaryFromContacts = buildPrimaryFieldsFromContacts(effectiveContacts);
 
       const finalContactName = hasContactName
@@ -962,71 +724,43 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const shouldUpdatePhone = hasPhone || hasContacts;
 
       try {
-        const result = await query(
-          `
-            UPDATE clients SET
-                name = COALESCE($1, name),
-                is_disabled = COALESCE($2, is_disabled),
-                type = COALESCE($3, type),
-                contacts = COALESCE($4::jsonb, contacts),
-                contact_name = CASE WHEN $25 THEN $5 ELSE contact_name END,
-                client_code = COALESCE($6, client_code),
-                email = CASE WHEN $26 THEN $7 ELSE email END,
-                phone = CASE WHEN $27 THEN $8 ELSE phone END,
-                address = COALESCE($9, address),
-                address_country = COALESCE($10, address_country),
-                address_state = COALESCE($11, address_state),
-                address_cap = COALESCE($12, address_cap),
-                address_province = COALESCE($13, address_province),
-                address_civic_number = COALESCE($14, address_civic_number),
-                address_line = COALESCE($15, address_line),
-                description = COALESCE($16, description),
-                ateco_code = COALESCE($17, ateco_code),
-                website = COALESCE($18, website),
-                sector = CASE WHEN $28 THEN $19 ELSE sector END,
-                number_of_employees = CASE WHEN $29 THEN $20 ELSE number_of_employees END,
-                revenue = CASE WHEN $30 THEN $21 ELSE revenue END,
-                fiscal_code = COALESCE($22, fiscal_code),
-                office_count_range = CASE WHEN $31 THEN $23 ELSE office_count_range END
-            WHERE id = $24
-            RETURNING *
-          `,
-          [
-            hasName ? nameValue : null,
-            hasIsDisabled ? body.isDisabled : null,
-            hasType ? body.type : null,
-            hasContacts ? JSON.stringify(effectiveContacts) : null,
-            finalContactName,
-            hasClientCode ? clientCodeValue : null,
-            finalEmail,
-            finalPhone,
-            hasAddress ? addressResult.value : null,
-            hasAddressCountry ? addressCountryResult.value : null,
-            hasAddressState ? addressStateResult.value : null,
-            hasAddressCap ? addressCapResult.value : null,
-            hasAddressProvince ? addressProvinceResult.value : null,
-            hasAddressCivicNumber ? addressCivicNumberResult.value : null,
-            hasAddressLine ? addressLineResult.value : null,
-            hasDescription ? descriptionResult.value : null,
-            hasAtecoCode ? atecoCodeResult.value : null,
-            hasWebsite ? websiteResult.value : null,
-            hasSector ? sectorResult.value : null,
-            hasNumberOfEmployees ? numberOfEmployeesResult.value : null,
-            hasRevenue ? revenueResult.value : null,
-            hasFiscalUpdate ? resolvedFiscalCode : null,
-            hasOfficeCountRange ? officeCountRangeResult.value : null,
-            idResult.value,
-            shouldUpdateContactName,
-            shouldUpdateEmail,
-            shouldUpdatePhone,
-            hasSector,
-            hasNumberOfEmployees,
-            hasRevenue,
-            hasOfficeCountRange,
-          ],
-        );
+        const client = await clientsRepo.update(idResult.value, {
+          name: hasName ? nameValue : null,
+          isDisabled: hasIsDisabled ? (body.isDisabled as boolean | null) : null,
+          type: hasType ? (body.type as string | null) : null,
+          contacts: hasContacts ? effectiveContacts : null,
+          clientCode: hasClientCode ? clientCodeValue : null,
+          address: hasAddress ? addressResult.value : null,
+          addressCountry: hasAddressCountry ? addressCountryResult.value : null,
+          addressState: hasAddressState ? addressStateResult.value : null,
+          addressCap: hasAddressCap ? addressCapResult.value : null,
+          addressProvince: hasAddressProvince ? addressProvinceResult.value : null,
+          addressCivicNumber: hasAddressCivicNumber ? addressCivicNumberResult.value : null,
+          addressLine: hasAddressLine ? addressLineResult.value : null,
+          description: hasDescription ? descriptionResult.value : null,
+          atecoCode: hasAtecoCode ? atecoCodeResult.value : null,
+          website: hasWebsite ? websiteResult.value : null,
+          fiscalCode: hasFiscalUpdate ? resolvedFiscalCode : null,
+          contactName: finalContactName,
+          contactNameProvided: shouldUpdateContactName,
+          email: finalEmail,
+          emailProvided: shouldUpdateEmail,
+          phone: finalPhone,
+          phoneProvided: shouldUpdatePhone,
+          sector: hasSector ? sectorResult.value : null,
+          sectorProvided: hasSector,
+          numberOfEmployees: hasNumberOfEmployees ? numberOfEmployeesResult.value : null,
+          numberOfEmployeesProvided: hasNumberOfEmployees,
+          revenue: hasRevenue ? revenueResult.value : null,
+          revenueProvided: hasRevenue,
+          officeCountRange: hasOfficeCountRange ? officeCountRangeResult.value : null,
+          officeCountRangeProvided: hasOfficeCountRange,
+        });
 
-        const c = result.rows[0];
+        if (!client) {
+          return reply.code(404).send({ error: 'Client not found' });
+        }
+
         const changedFields = [
           hasName ? 'name' : null,
           hasIsDisabled ? 'isDisabled' : null,
@@ -1064,11 +798,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           entityType: 'client',
           entityId: idResult.value,
           details: {
-            targetLabel: c.name as string,
-            secondaryLabel: (c.client_code as string | null) ?? undefined,
+            targetLabel: client.name,
+            secondaryLabel: client.clientCode ?? undefined,
           },
         });
-        return mapClientRow(c);
+        return client;
       } catch (err) {
         if (isUniqueViolation(err)) {
           if (err.constraint === 'idx_clients_fiscal_code_unique') {
@@ -1106,11 +840,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
 
-      const result = await query(
-        'DELETE FROM clients WHERE id = $1 RETURNING id, name, client_code',
-        [idResult.value],
-      );
-      if (result.rows.length === 0) {
+      const deleted = await clientsRepo.deleteById(idResult.value);
+      if (!deleted) {
         return reply.code(404).send({ error: 'Client not found' });
       }
 
@@ -1120,8 +851,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         entityType: 'client',
         entityId: idResult.value,
         details: {
-          targetLabel: result.rows[0].name as string,
-          secondaryLabel: (result.rows[0].client_code as string | null) ?? undefined,
+          targetLabel: deleted.name,
+          secondaryLabel: deleted.clientCode ?? undefined,
         },
       });
       return { message: 'Client deleted' };
@@ -1152,23 +883,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       );
       if (!categoryResult.ok) return badRequest(reply, categoryResult.message);
 
-      const usageCountExpr = getUsageCountExpression(categoryResult.value);
-      const result = await query(
-        `SELECT
-           o.id,
-           o.category,
-           o.value,
-           o.sort_order,
-           o.created_at,
-           o.updated_at,
-           ${usageCountExpr} as usage_count
-         FROM client_profile_options o
-         WHERE o.category = $1
-         ORDER BY o.sort_order ASC, o.value ASC`,
-        [categoryResult.value],
-      );
-
-      return result.rows.map(mapProfileOptionRow);
+      return clientProfileOptionsRepo.listByCategory(categoryResult.value);
     },
   );
 
@@ -1199,27 +914,26 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       if (!valueResult.ok) return badRequest(reply, valueResult.message);
 
       const sortOrderValue = Number.isFinite(Number(sortOrder)) ? Number(sortOrder) : null;
-      const existing = await query(
-        'SELECT id FROM client_profile_options WHERE category = $1 AND LOWER(value) = LOWER($2)',
-        [categoryResult.value, valueResult.value],
-      );
-      if (existing.rows.length > 0) {
+
+      const [valueExists, nextSortOrder] = await Promise.all([
+        clientProfileOptionsRepo.findByCategoryAndValue(
+          categoryResult.value,
+          valueResult.value,
+          null,
+        ),
+        clientProfileOptionsRepo.getNextSortOrder(categoryResult.value),
+      ]);
+      if (valueExists) {
         return badRequest(reply, 'Option with this value already exists for this category');
       }
-
-      const computedSortOrderResult = await query(
-        'SELECT COALESCE(MAX(sort_order), 0) + 1 as next_sort_order FROM client_profile_options WHERE category = $1',
-        [categoryResult.value],
-      );
-      const nextSortOrder = Number(computedSortOrderResult.rows[0]?.next_sort_order ?? 1);
       const id = generatePrefixedId('cpo');
 
-      const insertResult = await query(
-        `INSERT INTO client_profile_options (id, category, value, sort_order)
-         VALUES ($1, $2, $3, $4)
-         RETURNING id, category, value, sort_order, created_at, updated_at`,
-        [id, categoryResult.value, valueResult.value, sortOrderValue ?? nextSortOrder],
-      );
+      const option = await clientProfileOptionsRepo.create({
+        id,
+        category: categoryResult.value,
+        value: valueResult.value,
+        sortOrder: sortOrderValue ?? nextSortOrder,
+      });
 
       await logAudit({
         request,
@@ -1232,7 +946,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         },
       });
 
-      return reply.code(201).send(mapProfileOptionRow({ ...insertResult.rows[0], usage_count: 0 }));
+      return reply.code(201).send(option);
     },
   );
 
@@ -1270,66 +984,41 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const valueResult = requireNonEmptyString(value, 'value');
       if (!valueResult.ok) return badRequest(reply, valueResult.message);
 
-      const existingResult = await query(
-        'SELECT id, value FROM client_profile_options WHERE id = $1 AND category = $2',
-        [idResult.value, categoryResult.value],
+      const existing = await clientProfileOptionsRepo.findByCategoryAndId(
+        categoryResult.value,
+        idResult.value,
       );
-      if (existingResult.rows.length === 0) {
+      if (!existing) {
         return reply.code(404).send({ error: 'Profile option not found' });
       }
 
-      const duplicateResult = await query(
-        `SELECT id
-         FROM client_profile_options
-         WHERE category = $1 AND LOWER(value) = LOWER($2) AND id <> $3`,
-        [categoryResult.value, valueResult.value, idResult.value],
-      );
-      if (duplicateResult.rows.length > 0) {
+      if (
+        await clientProfileOptionsRepo.findByCategoryAndValue(
+          categoryResult.value,
+          valueResult.value,
+          idResult.value,
+        )
+      ) {
         return badRequest(reply, 'Option with this value already exists for this category');
       }
 
       const sortOrderValue = Number.isFinite(Number(sortOrder)) ? Number(sortOrder) : null;
-      await query(
-        `UPDATE client_profile_options
-         SET value = $1,
-             sort_order = COALESCE($2, sort_order),
-             updated_at = CURRENT_TIMESTAMP
-         WHERE id = $3 AND category = $4`,
-        [valueResult.value, sortOrderValue, idResult.value, categoryResult.value],
+      const updated = await withTransaction((tx) =>
+        clientProfileOptionsRepo.update(
+          categoryResult.value,
+          idResult.value,
+          {
+            value: valueResult.value,
+            sortOrder: sortOrderValue,
+            previousValue: existing.value,
+          },
+          tx,
+        ),
       );
 
-      const valueFieldByCategory: Record<ProfileOptionCategory, string> = {
-        sector: 'sector',
-        numberOfEmployees: 'number_of_employees',
-        revenue: 'revenue',
-        officeCountRange: 'office_count_range',
-      };
-
-      const previousValue = String(existingResult.rows[0].value);
-      if (previousValue !== valueResult.value) {
-        const fieldName = valueFieldByCategory[categoryResult.value];
-        await query(
-          `UPDATE clients
-           SET ${fieldName} = $1
-           WHERE ${fieldName} = $2`,
-          [valueResult.value, previousValue],
-        );
+      if (!updated) {
+        return reply.code(404).send({ error: 'Profile option not found' });
       }
-
-      const usageCountExpr = getUsageCountExpression(categoryResult.value);
-      const updatedResult = await query(
-        `SELECT
-           o.id,
-           o.category,
-           o.value,
-           o.sort_order,
-           o.created_at,
-           o.updated_at,
-           ${usageCountExpr} as usage_count
-         FROM client_profile_options o
-         WHERE o.id = $1`,
-        [idResult.value],
-      );
 
       await logAudit({
         request,
@@ -1342,7 +1031,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         },
       });
 
-      return mapProfileOptionRow(updatedResult.rows[0]);
+      return updated;
     },
   );
 
@@ -1375,29 +1064,25 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const idResult = requireNonEmptyString(params.id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
 
-      const existingResult = await query(
-        'SELECT id, category, value FROM client_profile_options WHERE id = $1 AND category = $2',
-        [idResult.value, categoryResult.value],
+      const existing = await clientProfileOptionsRepo.findByCategoryAndId(
+        categoryResult.value,
+        idResult.value,
       );
-      if (existingResult.rows.length === 0) {
+      if (!existing) {
         return reply.code(404).send({ error: 'Profile option not found' });
       }
 
-      const usageCountExpr = getUsageCountExpression(categoryResult.value);
-      const usageResult = await query(
-        `SELECT ${usageCountExpr} as usage_count
-         FROM client_profile_options o
-         WHERE o.id = $1`,
-        [idResult.value],
+      const usageCount = await clientProfileOptionsRepo.getUsageCount(
+        categoryResult.value,
+        idResult.value,
       );
-      const usageCount = Number(usageResult.rows[0]?.usage_count ?? 0);
       if (usageCount > 0) {
         return reply.code(409).send({
-          error: `Cannot delete option "${existingResult.rows[0].value}" because it is used by ${usageCount} client(s)`,
+          error: `Cannot delete option "${existing.value}" because it is used by ${usageCount} client(s)`,
         });
       }
 
-      await query('DELETE FROM client_profile_options WHERE id = $1', [idResult.value]);
+      await clientProfileOptionsRepo.deleteById(idResult.value);
 
       await logAudit({
         request,
@@ -1405,7 +1090,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         entityType: 'client_profile_option',
         entityId: idResult.value,
         details: {
-          targetLabel: String(existingResult.rows[0].value),
+          targetLabel: existing.value,
           secondaryLabel: categoryResult.value,
         },
       });

--- a/server/routes/invoices.ts
+++ b/server/routes/invoices.ts
@@ -1,10 +1,11 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
-import { query } from '../db/index.ts';
+import { withTransaction } from '../db/index.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
+import * as invoicesRepo from '../repositories/invoicesRepo.ts';
 import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
 import { logAudit } from '../utils/audit.ts';
-import { normalizeNullableDateOnly } from '../utils/date.ts';
 import { isForeignKeyViolation, isUniqueViolation } from '../utils/db-errors.ts';
+import { generateItemId } from '../utils/order-ids.ts';
 import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
@@ -134,43 +135,22 @@ const invoiceUpdateBodySchema = {
   },
 } as const;
 
-const toRequiredDateOnly = (value: unknown, fieldName: string) => {
-  const normalizedDate = normalizeNullableDateOnly(value, fieldName);
-  if (!normalizedDate) {
-    throw new TypeError(`Invalid date value for ${fieldName}`);
-  }
-  return normalizedDate;
+type NormalizedInvoiceItemInput = {
+  productId: string | null;
+  description: string;
+  unitOfMeasure: 'unit' | 'hours';
+  quantity: number;
+  unitPrice: number;
+  discount: number;
 };
 
-const generateInvoiceId = async (issueDate: string) => {
-  const year = issueDate.split('-')[0];
-  const result = await query(
-    `SELECT COALESCE(MAX(CAST(split_part(id, '-', 3) AS INTEGER)), 0) as "maxSequence"
-     FROM invoices
-     WHERE id ~ $1`,
-    [`^INV-${year}-[0-9]+$`],
-  );
-  const nextSequence = Number(result.rows[0]?.maxSequence ?? 0) + 1;
-  return `INV-${year}-${String(nextSequence).padStart(4, '0')}`;
-};
+const generateInvoiceItemId = () => generateItemId('inv-item-');
 
-const formatInvoiceItem = (item: Record<string, unknown>) => ({
-  ...item,
-  unitOfMeasure: item.unitOfMeasure === 'hours' ? 'hours' : 'unit',
-  quantity: parseFloat(String(item.quantity ?? 0)),
-  unitPrice: parseFloat(String(item.unitPrice ?? 0)),
-  discount: parseFloat(String(item.discount ?? 0)),
-});
-
-const getInvoiceClientId = async (invoiceId: string) => {
-  const result = await query(`SELECT client_id as "clientId" FROM invoices WHERE id = $1`, [
-    invoiceId,
-  ]);
-  return (result.rows[0]?.clientId as string | undefined) ?? null;
-};
-
-const validateAndNormalizeItems = async (items: unknown[], reply: FastifyReply) => {
-  const normalizedItems = [];
+const validateAndNormalizeItems = async (
+  items: unknown[],
+  reply: FastifyReply,
+): Promise<NormalizedInvoiceItemInput[] | null> => {
+  const normalizedItems: NormalizedInvoiceItemInput[] = [];
 
   for (let i = 0; i < items.length; i++) {
     const item = items[i] as Record<string, unknown>;
@@ -221,10 +201,9 @@ const validateAndNormalizeItems = async (items: unknown[], reply: FastifyReply) 
     }
 
     normalizedItems.push({
-      ...item,
-      productId: productIdResult.value,
+      productId: productIdResult.value || null,
       description: descriptionResult.value,
-      unitOfMeasure: unitOfMeasureResult.value,
+      unitOfMeasure: unitOfMeasureResult.value as 'unit' | 'hours',
       quantity: quantityResult.value,
       unitPrice: unitPriceResult.value,
       discount: discountResult.value || 0,
@@ -234,18 +213,16 @@ const validateAndNormalizeItems = async (items: unknown[], reply: FastifyReply) 
   return normalizedItems;
 };
 
-const formatInvoiceResponse = (
-  invoice: Record<string, unknown>,
-  items: Record<string, unknown>[],
-) => ({
-  ...invoice,
-  issueDate: toRequiredDateOnly(invoice.issueDate, 'invoice.issueDate'),
-  dueDate: toRequiredDateOnly(invoice.dueDate, 'invoice.dueDate'),
-  subtotal: parseFloat(String(invoice.subtotal ?? 0)),
-  total: parseFloat(String(invoice.total ?? 0)),
-  amountPaid: parseFloat(String(invoice.amountPaid ?? 0)),
-  items: items.map(formatInvoiceItem),
-});
+const buildItemsForInsert = (items: NormalizedInvoiceItemInput[]): invoicesRepo.NewInvoiceItem[] =>
+  items.map((item) => ({
+    id: generateInvoiceItemId(),
+    productId: item.productId,
+    description: item.description,
+    unitOfMeasure: item.unitOfMeasure,
+    quantity: item.quantity,
+    unitPrice: item.unitPrice,
+    discount: item.discount,
+  }));
 
 export default async function (fastify: FastifyInstance, _opts: unknown) {
   // All invoices routes require authentication
@@ -269,59 +246,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       },
     },
     async (_request: FastifyRequest, _reply: FastifyReply) => {
-      // Get all invoices
-      const invoicesResult = await query(
-        `SELECT 
-                id, 
-                linked_sale_id as "linkedSaleId",
-                client_id as "clientId", 
-                client_name as "clientName", 
-                issue_date as "issueDate",
-                due_date as "dueDate",
-                status, 
-                subtotal,
-                total,
-                amount_paid as "amountPaid",
-                notes,
-                EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt",
-                EXTRACT(EPOCH FROM updated_at) * 1000 as "updatedAt"
-            FROM invoices 
-            ORDER BY created_at DESC`,
-      );
-
-      // Get all invoice items
-      const itemsResult = await query(
-        `SELECT 
-                id,
-                invoice_id as "invoiceId",
-                product_id as "productId",
-                description,
-                unit_of_measure as "unitOfMeasure",
-                quantity,
-                unit_price as "unitPrice",
-                discount
-            FROM invoice_items
-            ORDER BY created_at ASC`,
-      );
-
-      // Group items by invoice
-      const itemsByInvoice: Record<string, unknown[]> = {};
-      itemsResult.rows.forEach((item: { invoiceId: string }) => {
-        if (!itemsByInvoice[item.invoiceId]) {
-          itemsByInvoice[item.invoiceId] = [];
-        }
-        itemsByInvoice[item.invoiceId].push(item);
-      });
-
-      // Attach items to invoices
-      const invoices = invoicesResult.rows.map((invoice) =>
-        formatInvoiceResponse(
-          invoice as Record<string, unknown>,
-          (itemsByInvoice[invoice.id] || []) as Record<string, unknown>[],
-        ),
-      );
-
-      return invoices;
+      return invoicesRepo.listAllWithItems();
     },
   );
 
@@ -402,44 +327,35 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
 
       const nextIdResult = optionalNonEmptyString(nextId, 'id');
       if (!nextIdResult.ok) return badRequest(reply, nextIdResult.message);
-      const invoiceId = nextIdResult.value || (await generateInvoiceId(issueDateResult.value));
+      const issueDateYear = issueDateResult.value.split('-')[0];
+      const invoiceId = nextIdResult.value || (await invoicesRepo.generateNextId(issueDateYear));
 
-      let invoiceResult: Awaited<ReturnType<typeof query>>;
+      let result: { invoice: invoicesRepo.Invoice; items: invoicesRepo.InvoiceItem[] };
       try {
-        invoiceResult = await query(
-          `INSERT INTO invoices (
-                      id, linked_sale_id, client_id, client_name, issue_date, due_date, 
-                      status, subtotal, total, amount_paid, notes
-                  ) 
-                  VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) 
-                  RETURNING 
-                      id, 
-                      linked_sale_id as "linkedSaleId",
-                      client_id as "clientId", 
-                      client_name as "clientName", 
-                      issue_date as "issueDate",
-                      due_date as "dueDate",
-                      status, 
-                      subtotal,
-                      total,
-                      amount_paid as "amountPaid",
-                      notes,
-                      EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt",
-                      EXTRACT(EPOCH FROM updated_at) * 1000 as "updatedAt"`,
-          [
-            invoiceId,
-            linkedSaleId || null,
-            clientIdResult.value,
-            clientNameResult.value,
-            issueDateResult.value,
-            dueDateResult.value,
-            status || 'draft',
-            subtotalResult.value || 0,
-            totalResult.value || 0,
-            amountPaidResult.value || 0,
-            notes,
-          ],
-        );
+        result = await withTransaction(async (tx) => {
+          const invoice = await invoicesRepo.create(
+            {
+              id: invoiceId,
+              linkedSaleId: (linkedSaleId as string | null | undefined) || null,
+              clientId: clientIdResult.value,
+              clientName: clientNameResult.value,
+              issueDate: issueDateResult.value,
+              dueDate: dueDateResult.value,
+              status: (status as string) || 'draft',
+              subtotal: subtotalResult.value || 0,
+              total: totalResult.value || 0,
+              amountPaid: amountPaidResult.value || 0,
+              notes: (notes as string | null | undefined) ?? null,
+            },
+            tx,
+          );
+          const items = await invoicesRepo.replaceItems(
+            invoice.id,
+            buildItemsForInsert(normalizedItems),
+            tx,
+          );
+          return { invoice, items };
+        });
       } catch (error) {
         if (
           isUniqueViolation(error) &&
@@ -450,52 +366,20 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         throw error;
       }
 
-      // Insert invoice items
-      const createdItems = [];
-      for (const item of normalizedItems) {
-        const itemId = 'inv-item-' + Date.now() + '-' + Math.random().toString(36).substring(2, 11);
-        const itemResult = await query(
-          `INSERT INTO invoice_items (
-                        id, invoice_id, product_id, description, unit_of_measure, quantity, unit_price, discount
-                    ) 
-                    VALUES ($1, $2, $3, $4, $5, $6, $7, $8) 
-                    RETURNING 
-                        id,
-                        invoice_id as "invoiceId",
-                        product_id as "productId",
-                        description,
-                        unit_of_measure as "unitOfMeasure",
-                        quantity,
-                        unit_price as "unitPrice",
-                        discount`,
-          [
-            itemId,
-            invoiceId,
-            item.productId || null,
-            item.description,
-            item.unitOfMeasure,
-            item.quantity,
-            item.unitPrice,
-            item.discount || 0,
-          ],
-        );
-        createdItems.push(itemResult.rows[0]);
-      }
+      const invoice = result.invoice;
+      const createdItems = result.items;
 
       await logAudit({
         request,
         action: 'invoice.created',
         entityType: 'invoice',
-        entityId: invoiceId,
+        entityId: invoice.id,
         details: {
-          targetLabel: invoiceId,
+          targetLabel: invoice.id,
           secondaryLabel: clientNameResult.value,
         },
       });
-      const invoice = invoiceResult.rows[0];
-      return reply
-        .code(201)
-        .send(formatInvoiceResponse(invoice as Record<string, unknown>, createdItems));
+      return reply.code(201).send({ ...invoice, items: createdItems });
     },
   );
 
@@ -545,53 +429,46 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
 
-      const existingClientId = items ? await getInvoiceClientId(idResult.value) : null;
+      const existingClientId = items ? await invoicesRepo.findClientId(idResult.value) : null;
       if (items && !existingClientId) {
         return reply.code(404).send({ error: 'Invoice not found' });
       }
 
-      let clientIdValue = clientId;
+      const patch: invoicesRepo.InvoiceUpdate = {};
+
       if (clientId !== undefined) {
         const clientIdResult = optionalNonEmptyString(clientId, 'clientId');
         if (!clientIdResult.ok) return badRequest(reply, clientIdResult.message);
-        clientIdValue = clientIdResult.value;
+        if (clientIdResult.value) patch.clientId = clientIdResult.value;
       }
 
-      let clientNameValue = clientName;
       if (clientName !== undefined) {
         const clientNameResult = optionalNonEmptyString(clientName, 'clientName');
         if (!clientNameResult.ok) return badRequest(reply, clientNameResult.message);
-        clientNameValue = clientNameResult.value;
+        if (clientNameResult.value) patch.clientName = clientNameResult.value;
       }
 
-      let nextIdValue = nextId;
       if (nextId !== undefined) {
         const nextIdResult = optionalNonEmptyString(nextId, 'id');
         if (!nextIdResult.ok) return badRequest(reply, nextIdResult.message);
-        nextIdValue = nextIdResult.value;
         if (nextIdResult.value) {
-          const existingIdResult = await query(
-            'SELECT id FROM invoices WHERE id = $1 AND id <> $2',
-            [nextIdResult.value, idResult.value],
-          );
-          if (existingIdResult.rows.length > 0) {
+          if (await invoicesRepo.findIdConflict(nextIdResult.value, idResult.value)) {
             return reply.code(409).send({ error: 'Invoice ID already exists' });
           }
+          patch.id = nextIdResult.value;
         }
       }
 
-      let issueDateValue = issueDate;
       if (issueDate !== undefined) {
         const issueDateResult = optionalDateString(issueDate, 'issueDate');
         if (!issueDateResult.ok) return badRequest(reply, issueDateResult.message);
-        issueDateValue = issueDateResult.value;
+        if (issueDateResult.value) patch.issueDate = issueDateResult.value;
       }
 
-      let dueDateValue = dueDate;
       if (dueDate !== undefined) {
         const dueDateResult = optionalDateString(dueDate, 'dueDate');
         if (!dueDateResult.ok) return badRequest(reply, dueDateResult.message);
-        dueDateValue = dueDateResult.value;
+        if (dueDateResult.value) patch.dueDate = dueDateResult.value;
       }
 
       if (issueDate && dueDate) {
@@ -600,72 +477,59 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         }
       }
 
-      let subtotalValue = subtotal;
       if (subtotal !== undefined) {
         const subtotalResult = optionalLocalizedNonNegativeNumber(subtotal, 'subtotal');
         if (!subtotalResult.ok) return badRequest(reply, subtotalResult.message);
-        subtotalValue = subtotalResult.value;
+        if (subtotalResult.value !== null && subtotalResult.value !== undefined) {
+          patch.subtotal = subtotalResult.value;
+        }
       }
 
-      let totalValue = total;
       if (total !== undefined) {
         const totalResult = optionalLocalizedNonNegativeNumber(total, 'total');
         if (!totalResult.ok) return badRequest(reply, totalResult.message);
-        totalValue = totalResult.value;
+        if (totalResult.value !== null && totalResult.value !== undefined) {
+          patch.total = totalResult.value;
+        }
       }
 
-      let amountPaidValue = amountPaid;
       if (amountPaid !== undefined) {
         const amountPaidResult = optionalLocalizedNonNegativeNumber(amountPaid, 'amountPaid');
         if (!amountPaidResult.ok) return badRequest(reply, amountPaidResult.message);
-        amountPaidValue = amountPaidResult.value;
+        if (amountPaidResult.value !== null && amountPaidResult.value !== undefined) {
+          patch.amountPaid = amountPaidResult.value;
+        }
       }
 
-      // Update invoice
-      let invoiceResult: Awaited<ReturnType<typeof query>>;
+      if (status !== undefined) patch.status = status as string;
+      if (notes !== undefined) patch.notes = notes as string | null;
+
+      let normalizedItemsForUpdate: NormalizedInvoiceItemInput[] | null = null;
+      if (items) {
+        if (!Array.isArray(items) || items.length === 0) {
+          return badRequest(reply, 'Items must be a non-empty array');
+        }
+        normalizedItemsForUpdate = await validateAndNormalizeItems(items, reply);
+        if (!normalizedItemsForUpdate) return;
+      }
+
+      let result: {
+        invoice: invoicesRepo.Invoice | null;
+        items: invoicesRepo.InvoiceItem[];
+      };
       try {
-        invoiceResult = await query(
-          `UPDATE invoices 
-                  SET id = COALESCE($1, id),
-                      client_id = COALESCE($2, client_id),
-                      client_name = COALESCE($3, client_name),
-                      issue_date = COALESCE($4, issue_date),
-                      due_date = COALESCE($5, due_date),
-                      status = COALESCE($6, status),
-                      subtotal = COALESCE($7, subtotal),
-                      total = COALESCE($8, total),
-                      amount_paid = COALESCE($9, amount_paid),
-                      notes = COALESCE($10, notes),
-                      updated_at = CURRENT_TIMESTAMP
-                  WHERE id = $11 
-                  RETURNING 
-                      id, 
-                      linked_sale_id as "linkedSaleId",
-                      client_id as "clientId", 
-                      client_name as "clientName", 
-                      issue_date as "issueDate",
-                      due_date as "dueDate",
-                      status, 
-                      subtotal,
-                      total,
-                      amount_paid as "amountPaid",
-                      notes,
-                      EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt",
-                      EXTRACT(EPOCH FROM updated_at) * 1000 as "updatedAt"`,
-          [
-            nextIdValue,
-            clientIdValue,
-            clientNameValue,
-            issueDateValue,
-            dueDateValue,
-            status,
-            subtotalValue,
-            totalValue,
-            amountPaidValue,
-            notes,
-            idResult.value,
-          ],
-        );
+        result = await withTransaction(async (tx) => {
+          const updated = await invoicesRepo.update(idResult.value, patch, tx);
+          if (!updated) return { invoice: null, items: [] };
+          const itemsOut = normalizedItemsForUpdate
+            ? await invoicesRepo.replaceItems(
+                updated.id,
+                buildItemsForInsert(normalizedItemsForUpdate),
+                tx,
+              )
+            : await invoicesRepo.findItemsForInvoice(updated.id, tx);
+          return { invoice: updated, items: itemsOut };
+        });
       } catch (error) {
         if (
           isUniqueViolation(error) &&
@@ -676,88 +540,23 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         throw error;
       }
 
-      if (invoiceResult.rows.length === 0) {
+      const invoice = result.invoice;
+      const updatedItems = result.items;
+      if (!invoice) {
         return reply.code(404).send({ error: 'Invoice not found' });
       }
 
-      const updatedInvoiceId = String(invoiceResult.rows[0].id);
-
-      // If items are provided, update them
-      let updatedItems = [];
-      if (items) {
-        if (!Array.isArray(items) || items.length === 0) {
-          return badRequest(reply, 'Items must be a non-empty array');
-        }
-        const normalizedItems = await validateAndNormalizeItems(items, reply);
-        if (!normalizedItems) return;
-        // Delete existing items
-        await query('DELETE FROM invoice_items WHERE invoice_id = $1', [updatedInvoiceId]);
-
-        // Insert new items
-        for (const item of normalizedItems) {
-          const itemId =
-            'inv-item-' + Date.now() + '-' + Math.random().toString(36).substring(2, 11);
-          const itemResult = await query(
-            `INSERT INTO invoice_items (
-                            id, invoice_id, product_id, description, unit_of_measure, quantity, unit_price, discount
-                        ) 
-                        VALUES ($1, $2, $3, $4, $5, $6, $7, $8) 
-                        RETURNING 
-                            id,
-                            invoice_id as "invoiceId",
-                            product_id as "productId",
-                            description,
-                            unit_of_measure as "unitOfMeasure",
-                            quantity,
-                            unit_price as "unitPrice",
-                            discount`,
-            [
-              itemId,
-              updatedInvoiceId,
-              item.productId || null,
-              item.description,
-              item.unitOfMeasure,
-              item.quantity,
-              item.unitPrice,
-              item.discount || 0,
-            ],
-          );
-          updatedItems.push(itemResult.rows[0]);
-        }
-      } else {
-        // Fetch existing items
-        const itemsResult = await query(
-          `SELECT 
-                        id,
-                        invoice_id as "invoiceId",
-                        product_id as "productId",
-                        description,
-                        unit_of_measure as "unitOfMeasure",
-                        quantity,
-                        unit_price as "unitPrice",
-                        discount
-                    FROM invoice_items
-                    WHERE invoice_id = $1`,
-          [updatedInvoiceId],
-        );
-        updatedItems = itemsResult.rows;
-      }
-
-      const invoice = invoiceResult.rows[0];
       await logAudit({
         request,
         action: 'invoice.updated',
         entityType: 'invoice',
-        entityId: updatedInvoiceId,
+        entityId: invoice.id,
         details: {
-          targetLabel: updatedInvoiceId,
-          secondaryLabel: String(invoice.clientName),
+          targetLabel: invoice.id,
+          secondaryLabel: invoice.clientName,
         },
       });
-      return formatInvoiceResponse(
-        invoice as Record<string, unknown>,
-        updatedItems as Record<string, unknown>[],
-      );
+      return { ...invoice, items: updatedItems };
     },
   );
 
@@ -783,12 +582,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
 
       // Invoice items will be deleted automatically via CASCADE
       try {
-        const result = await query(
-          'DELETE FROM invoices WHERE id = $1 RETURNING id, client_name as "clientName"',
-          [idResult.value],
-        );
+        const result = await invoicesRepo.deleteById(idResult.value);
 
-        if (result.rows.length === 0) {
+        if (!result) {
           return reply.code(404).send({ error: 'Invoice not found' });
         }
 
@@ -799,12 +595,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           entityId: idResult.value,
           details: {
             targetLabel: idResult.value,
-            secondaryLabel: String(result.rows[0].clientName ?? ''),
+            secondaryLabel: result.clientName ?? '',
           },
         });
         return reply.code(204).send();
       } catch (err) {
-        console.error('DELETE INVOICE ERROR:', err);
         if (isForeignKeyViolation(err)) {
           return reply.code(409).send({
             error: 'Cannot delete invoice because it is referenced by other records',

--- a/server/routes/invoices.ts
+++ b/server/routes/invoices.ts
@@ -349,7 +349,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
             },
             tx,
           );
-          const items = await invoicesRepo.replaceItems(
+          const items = await invoicesRepo.insertItems(
             invoice.id,
             buildItemsForInsert(normalizedItems),
             tx,
@@ -429,11 +429,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
 
-      const existingClientId = items ? await invoicesRepo.findClientId(idResult.value) : null;
-      if (items && !existingClientId) {
-        return reply.code(404).send({ error: 'Invoice not found' });
-      }
-
       const patch: invoicesRepo.InvoiceUpdate = {};
 
       if (clientId !== undefined) {
@@ -459,20 +454,38 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         }
       }
 
+      let nextIssueDate: string | undefined;
       if (issueDate !== undefined) {
         const issueDateResult = optionalDateString(issueDate, 'issueDate');
         if (!issueDateResult.ok) return badRequest(reply, issueDateResult.message);
-        if (issueDateResult.value) patch.issueDate = issueDateResult.value;
+        if (issueDateResult.value) {
+          patch.issueDate = issueDateResult.value;
+          nextIssueDate = issueDateResult.value;
+        }
       }
 
+      let nextDueDate: string | undefined;
       if (dueDate !== undefined) {
         const dueDateResult = optionalDateString(dueDate, 'dueDate');
         if (!dueDateResult.ok) return badRequest(reply, dueDateResult.message);
-        if (dueDateResult.value) patch.dueDate = dueDateResult.value;
+        if (dueDateResult.value) {
+          patch.dueDate = dueDateResult.value;
+          nextDueDate = dueDateResult.value;
+        }
       }
 
-      if (issueDate && dueDate) {
-        if ((dueDate as string) < (issueDate as string)) {
+      if (nextIssueDate !== undefined || nextDueDate !== undefined) {
+        let effectiveIssueDate = nextIssueDate;
+        let effectiveDueDate = nextDueDate;
+        if (effectiveIssueDate === undefined || effectiveDueDate === undefined) {
+          const persisted = await invoicesRepo.findDates(idResult.value);
+          if (!persisted) {
+            return reply.code(404).send({ error: 'Invoice not found' });
+          }
+          effectiveIssueDate = effectiveIssueDate ?? persisted.issueDate;
+          effectiveDueDate = effectiveDueDate ?? persisted.dueDate;
+        }
+        if (effectiveDueDate < effectiveIssueDate) {
           return badRequest(reply, 'dueDate must be on or after issueDate');
         }
       }

--- a/server/test/db/buildBulkInsertPlaceholders.test.ts
+++ b/server/test/db/buildBulkInsertPlaceholders.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'bun:test';
+import { buildBulkInsertPlaceholders } from '../../db/index.ts';
+
+describe('buildBulkInsertPlaceholders', () => {
+  test('single row defaults to $1..$N', () => {
+    expect(buildBulkInsertPlaceholders(1, 3)).toBe('($1, $2, $3)');
+  });
+
+  test('multiple rows continue numbering across rows', () => {
+    expect(buildBulkInsertPlaceholders(2, 3)).toBe('($1, $2, $3), ($4, $5, $6)');
+  });
+
+  test('startIndex shifts the starting placeholder', () => {
+    // Used by mapSaleItemsToSupplierItems where $1, $2 are reserved for parent ids.
+    expect(buildBulkInsertPlaceholders(2, 2, 3)).toBe('($3, $4), ($5, $6)');
+  });
+
+  test('startIndex with single row', () => {
+    expect(buildBulkInsertPlaceholders(1, 4, 5)).toBe('($5, $6, $7, $8)');
+  });
+
+  test('zero rows produces an empty string', () => {
+    expect(buildBulkInsertPlaceholders(0, 5)).toBe('');
+    expect(buildBulkInsertPlaceholders(0, 5, 7)).toBe('');
+  });
+});

--- a/server/test/repositories/clientOffersRepo.test.ts
+++ b/server/test/repositories/clientOffersRepo.test.ts
@@ -1,0 +1,240 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import * as clientOffersRepo from '../../repositories/clientOffersRepo.ts';
+import { type FakeExecutor, makeFakeExecutor } from '../helpers/fakeExecutor.ts';
+
+let exec: FakeExecutor;
+
+beforeEach(() => {
+  exec = makeFakeExecutor();
+});
+
+const offerRow = {
+  id: 'co-1',
+  linkedQuoteId: 'cq-1',
+  clientId: 'c-1',
+  clientName: 'Acme',
+  paymentTerms: 'net30',
+  discount: '5',
+  discountType: 'percentage',
+  status: 'draft',
+  expirationDate: new Date('2026-06-01T00:00:00Z'),
+  notes: null,
+  createdAt: 1735689600000,
+  updatedAt: 1735689700000,
+};
+
+const itemRow = {
+  id: 'coi-1',
+  offerId: 'co-1',
+  productId: 'p-1',
+  productName: 'Widget',
+  quantity: '2',
+  unitPrice: '10',
+  productCost: '5',
+  productMolPercentage: null,
+  supplierQuoteId: null,
+  supplierQuoteItemId: null,
+  supplierQuoteSupplierName: null,
+  supplierQuoteUnitPrice: null,
+  unitType: 'unit',
+  note: null,
+  discount: '0',
+};
+
+describe('listAll', () => {
+  test('orders by created_at DESC and maps types', async () => {
+    exec.enqueue({ rows: [offerRow] });
+    const result = await clientOffersRepo.listAll(exec);
+    expect(exec.calls[0].sql).toContain('FROM customer_offers');
+    expect(exec.calls[0].sql).toContain('ORDER BY created_at DESC');
+    expect(result[0].discount).toBe(5);
+    expect(result[0].expirationDate).toBe('2026-06-01');
+  });
+});
+
+describe('listAllItems', () => {
+  test('orders items by created_at ASC', async () => {
+    exec.enqueue({ rows: [itemRow] });
+    const result = await clientOffersRepo.listAllItems(exec);
+    expect(exec.calls[0].sql).toContain('ORDER BY created_at ASC');
+    expect(result[0].quantity).toBe(2);
+    expect(result[0].unitPrice).toBe(10);
+    expect(result[0].unitType).toBe('unit');
+  });
+});
+
+describe('existsById / findIdConflict', () => {
+  test('existsById returns true on match', async () => {
+    exec.enqueue({ rows: [{ id: 'co-1' }] });
+    expect(await clientOffersRepo.existsById('co-1', exec)).toBe(true);
+  });
+
+  test('findIdConflict excludes self via id <> $2', async () => {
+    exec.enqueue({ rows: [] });
+    await clientOffersRepo.findIdConflict('new', 'cur', exec);
+    expect(exec.calls[0].sql).toContain('id <> $2');
+    expect(exec.calls[0].params).toEqual(['new', 'cur']);
+  });
+});
+
+describe('findForUpdate', () => {
+  test('returns existing offer fields needed for permission checks', async () => {
+    exec.enqueue({
+      rows: [
+        {
+          id: 'co-1',
+          linkedQuoteId: 'cq-1',
+          clientId: 'c-1',
+          clientName: 'Acme',
+          status: 'draft',
+        },
+      ],
+    });
+    const result = await clientOffersRepo.findForUpdate('co-1', exec);
+    expect(result?.linkedQuoteId).toBe('cq-1');
+    expect(result?.status).toBe('draft');
+  });
+
+  test('returns null when not found', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await clientOffersRepo.findForUpdate('co-x', exec)).toBeNull();
+  });
+});
+
+describe('findExistingForQuote', () => {
+  test('returns offer id when one exists for the quote', async () => {
+    exec.enqueue({ rows: [{ id: 'co-1' }] });
+    expect(await clientOffersRepo.findExistingForQuote('cq-1', exec)).toBe('co-1');
+  });
+
+  test('returns null when none exists', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await clientOffersRepo.findExistingForQuote('cq-1', exec)).toBeNull();
+  });
+});
+
+describe('findLinkedSaleId', () => {
+  test('queries sales.linked_offer_id and returns sale id', async () => {
+    exec.enqueue({ rows: [{ id: 's-1' }] });
+    const result = await clientOffersRepo.findLinkedSaleId('co-1', exec);
+    expect(exec.calls[0].sql).toContain('FROM sales WHERE linked_offer_id = $1');
+    expect(result).toBe('s-1');
+  });
+});
+
+describe('create', () => {
+  test('inserts 10 fields and returns mapped offer', async () => {
+    exec.enqueue({ rows: [offerRow] });
+    const result = await clientOffersRepo.create(
+      {
+        id: 'co-1',
+        linkedQuoteId: 'cq-1',
+        clientId: 'c-1',
+        clientName: 'Acme',
+        paymentTerms: 'net30',
+        discount: 5,
+        discountType: 'percentage',
+        status: 'draft',
+        expirationDate: '2026-06-01',
+        notes: null,
+      },
+      exec,
+    );
+    expect(exec.calls[0].sql).toContain('INSERT INTO customer_offers');
+    expect(exec.calls[0].params).toHaveLength(10);
+    expect(result.id).toBe('co-1');
+  });
+});
+
+describe('update', () => {
+  test('passes 10 params and uses COALESCE preservation', async () => {
+    exec.enqueue({ rows: [offerRow] });
+    await clientOffersRepo.update('co-1', { status: 'accepted' }, exec);
+    expect(exec.calls[0].sql).toContain('UPDATE customer_offers');
+    expect(exec.calls[0].sql).toContain('updated_at = CURRENT_TIMESTAMP');
+    expect(exec.calls[0].params).toHaveLength(10);
+    expect(exec.calls[0].params[6]).toBe('accepted'); // status
+    expect(exec.calls[0].params[9]).toBe('co-1'); // where id
+  });
+
+  test('returns null when no row updated', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await clientOffersRepo.update('co-x', { status: 'accepted' }, exec)).toBeNull();
+  });
+});
+
+describe('replaceItems', () => {
+  test('issues DELETE then a single multi-row INSERT and preserves order', async () => {
+    exec.enqueue({ rows: [] });
+    exec.enqueue({
+      rows: [
+        { ...itemRow, id: 'a' },
+        { ...itemRow, id: 'b' },
+      ],
+    });
+    const items: clientOffersRepo.NewClientOfferItem[] = [
+      {
+        id: 'a',
+        productId: 'p-1',
+        productName: 'A',
+        quantity: 1,
+        unitPrice: 5,
+        productCost: 2,
+        productMolPercentage: null,
+        discount: 0,
+        note: null,
+        supplierQuoteId: null,
+        supplierQuoteItemId: null,
+        supplierQuoteSupplierName: null,
+        supplierQuoteUnitPrice: null,
+        unitType: 'unit',
+      },
+      {
+        id: 'b',
+        productId: null,
+        productName: 'B',
+        quantity: 2,
+        unitPrice: 6,
+        productCost: 3,
+        productMolPercentage: null,
+        discount: 1,
+        note: null,
+        supplierQuoteId: null,
+        supplierQuoteItemId: null,
+        supplierQuoteSupplierName: null,
+        supplierQuoteUnitPrice: null,
+        unitType: 'hours',
+      },
+    ];
+    const result = await clientOffersRepo.replaceItems('co-1', items, exec);
+    expect(exec.calls).toHaveLength(2);
+    expect(exec.calls[0].sql).toContain('DELETE FROM customer_offer_items');
+    expect(exec.calls[1].sql).toContain('INSERT INTO customer_offer_items');
+    expect(exec.calls[1].sql).toContain(
+      'VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15), ($16',
+    );
+    expect(exec.calls[1].params[0]).toBe('a');
+    expect(exec.calls[1].params[15]).toBe('b'); // 15 fields per row, second row starts at $16 = index 15
+    expect(result.map((i) => i.id)).toEqual(['a', 'b']);
+  });
+
+  test('with empty items skips the INSERT', async () => {
+    exec.enqueue({ rows: [] });
+    const result = await clientOffersRepo.replaceItems('co-1', [], exec);
+    expect(exec.calls).toHaveLength(1);
+    expect(exec.calls[0].sql).toContain('DELETE');
+    expect(result).toEqual([]);
+  });
+});
+
+describe('deleteById', () => {
+  test('returns true when row deleted', async () => {
+    exec.enqueue({ rows: [], rowCount: 1 });
+    expect(await clientOffersRepo.deleteById('co-1', exec)).toBe(true);
+  });
+
+  test('returns false when no row matched', async () => {
+    exec.enqueue({ rows: [], rowCount: 0 });
+    expect(await clientOffersRepo.deleteById('co-x', exec)).toBe(false);
+  });
+});

--- a/server/test/repositories/clientProfileOptionsRepo.test.ts
+++ b/server/test/repositories/clientProfileOptionsRepo.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import * as repo from '../../repositories/clientProfileOptionsRepo.ts';
+import { type FakeExecutor, makeFakeExecutor } from '../helpers/fakeExecutor.ts';
+
+let exec: FakeExecutor;
+
+beforeEach(() => {
+  exec = makeFakeExecutor();
+});
+
+const optionRow = {
+  id: 'cpo-1',
+  category: 'sector',
+  value: 'tech',
+  sort_order: 1,
+  usage_count: 3,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: null,
+};
+
+describe('listByCategory', () => {
+  test('embeds the correct usage-count subquery for sector', async () => {
+    exec.enqueue({ rows: [optionRow] });
+    const result = await repo.listByCategory('sector', exec);
+    expect(exec.calls[0].sql).toContain('clients c WHERE c.sector = o.value');
+    expect(exec.calls[0].sql).toContain('ORDER BY o.sort_order ASC, o.value ASC');
+    expect(exec.calls[0].params).toEqual(['sector']);
+    expect(result[0].usageCount).toBe(3);
+  });
+
+  test('embeds number_of_employees column when category=numberOfEmployees', async () => {
+    exec.enqueue({ rows: [] });
+    await repo.listByCategory('numberOfEmployees', exec);
+    expect(exec.calls[0].sql).toContain('c.number_of_employees = o.value');
+  });
+
+  test('embeds office_count_range column when category=officeCountRange', async () => {
+    exec.enqueue({ rows: [] });
+    await repo.listByCategory('officeCountRange', exec);
+    expect(exec.calls[0].sql).toContain('c.office_count_range = o.value');
+  });
+});
+
+describe('findByCategoryAndId', () => {
+  test('returns row when found', async () => {
+    exec.enqueue({ rows: [{ id: 'cpo-1', value: 'tech' }] });
+    const result = await repo.findByCategoryAndId('sector', 'cpo-1', exec);
+    expect(result).toEqual({ id: 'cpo-1', value: 'tech' });
+    expect(exec.calls[0].params).toEqual(['cpo-1', 'sector']);
+  });
+
+  test('returns null when not found', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await repo.findByCategoryAndId('sector', 'missing', exec)).toBeNull();
+  });
+});
+
+describe('findByCategoryAndValue', () => {
+  test('omits id <> $3 when excludeId is null', async () => {
+    exec.enqueue({ rows: [] });
+    await repo.findByCategoryAndValue('sector', 'tech', null, exec);
+    expect(exec.calls[0].sql).not.toContain('id <> $3');
+    expect(exec.calls[0].params).toEqual(['sector', 'tech']);
+  });
+
+  test('includes id <> $3 when excludeId provided', async () => {
+    exec.enqueue({ rows: [{ id: 'cpo-2' }] });
+    const result = await repo.findByCategoryAndValue('sector', 'tech', 'cpo-1', exec);
+    expect(exec.calls[0].sql).toContain('id <> $3');
+    expect(exec.calls[0].params).toEqual(['sector', 'tech', 'cpo-1']);
+    expect(result).toBe(true);
+  });
+});
+
+describe('getNextSortOrder', () => {
+  test('returns 1 when table is empty', async () => {
+    exec.enqueue({ rows: [{ next_sort_order: 1 }] });
+    expect(await repo.getNextSortOrder('sector', exec)).toBe(1);
+  });
+
+  test('returns max+1 when rows exist', async () => {
+    exec.enqueue({ rows: [{ next_sort_order: '5' }] });
+    expect(await repo.getNextSortOrder('sector', exec)).toBe(5);
+  });
+});
+
+describe('create', () => {
+  test('inserts and returns mapped row with usage_count=0', async () => {
+    exec.enqueue({
+      rows: [
+        {
+          id: 'cpo-new',
+          category: 'sector',
+          value: 'finance',
+          sort_order: 2,
+          created_at: '2026-04-01T00:00:00Z',
+          updated_at: null,
+        },
+      ],
+    });
+    const result = await repo.create(
+      { id: 'cpo-new', category: 'sector', value: 'finance', sortOrder: 2 },
+      exec,
+    );
+    expect(exec.calls[0].sql).toContain('INSERT INTO client_profile_options');
+    expect(exec.calls[0].params).toEqual(['cpo-new', 'sector', 'finance', 2]);
+    expect(result.usageCount).toBe(0);
+    expect(result.value).toBe('finance');
+  });
+});
+
+describe('update', () => {
+  test('updates option only when value did not change (no cascade)', async () => {
+    exec.enqueue({ rows: [], rowCount: 1 }); // UPDATE option
+    exec.enqueue({ rows: [optionRow] }); // SELECT updated
+    const result = await repo.update(
+      'sector',
+      'cpo-1',
+      { value: 'tech', sortOrder: null, previousValue: 'tech' },
+      exec,
+    );
+    // Only 2 calls (UPDATE option, SELECT) — no cascade UPDATE
+    expect(exec.calls).toHaveLength(2);
+    expect(exec.calls[0].sql).toContain('UPDATE client_profile_options');
+    expect(exec.calls[1].sql).toContain('SELECT');
+    expect(result?.value).toBe('tech');
+  });
+
+  test('cascades to clients table via internal allowlist when value changes (sector)', async () => {
+    exec.enqueue({ rows: [], rowCount: 1 }); // UPDATE option
+    exec.enqueue({ rows: [], rowCount: 5 }); // cascade UPDATE clients
+    exec.enqueue({ rows: [{ ...optionRow, value: 'finance' }] });
+    await repo.update(
+      'sector',
+      'cpo-1',
+      { value: 'finance', sortOrder: null, previousValue: 'tech' },
+      exec,
+    );
+    expect(exec.calls).toHaveLength(3);
+    expect(exec.calls[1].sql).toContain('UPDATE clients SET sector = $1 WHERE sector = $2');
+    expect(exec.calls[1].params).toEqual(['finance', 'tech']);
+  });
+
+  test('cascade for officeCountRange uses office_count_range column', async () => {
+    exec.enqueue({ rows: [], rowCount: 1 });
+    exec.enqueue({ rows: [], rowCount: 1 });
+    exec.enqueue({ rows: [{ ...optionRow, category: 'officeCountRange', value: '2-5' }] });
+    await repo.update(
+      'officeCountRange',
+      'cpo-2',
+      { value: '2-5', sortOrder: null, previousValue: '1' },
+      exec,
+    );
+    expect(exec.calls[1].sql).toContain(
+      'UPDATE clients SET office_count_range = $1 WHERE office_count_range = $2',
+    );
+  });
+
+  test('returns null when SELECT returns no rows', async () => {
+    exec.enqueue({ rows: [] });
+    exec.enqueue({ rows: [] });
+    const result = await repo.update(
+      'sector',
+      'cpo-x',
+      { value: 'tech', sortOrder: null, previousValue: 'tech' },
+      exec,
+    );
+    expect(result).toBeNull();
+  });
+});
+
+describe('getUsageCount', () => {
+  test('returns 0 when no rows match', async () => {
+    exec.enqueue({ rows: [{ usage_count: '0' }] });
+    expect(await repo.getUsageCount('sector', 'cpo-1', exec)).toBe(0);
+  });
+
+  test('parses count as a JS number', async () => {
+    exec.enqueue({ rows: [{ usage_count: '7' }] });
+    expect(await repo.getUsageCount('sector', 'cpo-1', exec)).toBe(7);
+  });
+});
+
+describe('deleteById', () => {
+  test('returns true when row deleted', async () => {
+    exec.enqueue({ rows: [], rowCount: 1 });
+    expect(await repo.deleteById('cpo-1', exec)).toBe(true);
+  });
+
+  test('returns false when no row matched', async () => {
+    exec.enqueue({ rows: [], rowCount: 0 });
+    expect(await repo.deleteById('cpo-x', exec)).toBe(false);
+  });
+});

--- a/server/test/repositories/clientProfileOptionsRepo.test.ts
+++ b/server/test/repositories/clientProfileOptionsRepo.test.ts
@@ -122,7 +122,8 @@ describe('update', () => {
     // Only 2 calls (UPDATE option, SELECT) — no cascade UPDATE
     expect(exec.calls).toHaveLength(2);
     expect(exec.calls[0].sql).toContain('UPDATE client_profile_options');
-    expect(exec.calls[1].sql).toContain('SELECT');
+    expect(exec.calls[1].sql).toContain('o.id = $1 AND o.category = $2');
+    expect(exec.calls[1].params).toEqual(['cpo-1', 'sector']);
     expect(result?.value).toBe('tech');
   });
 
@@ -156,16 +157,17 @@ describe('update', () => {
     );
   });
 
-  test('returns null when SELECT returns no rows', async () => {
-    exec.enqueue({ rows: [] });
-    exec.enqueue({ rows: [] });
+  test('returns null and skips cascade/select when option UPDATE matched no rows', async () => {
+    exec.enqueue({ rows: [], rowCount: 0 }); // UPDATE option matched nothing (e.g., concurrent delete)
     const result = await repo.update(
       'sector',
       'cpo-x',
-      { value: 'tech', sortOrder: null, previousValue: 'tech' },
+      { value: 'finance', sortOrder: null, previousValue: 'tech' },
       exec,
     );
     expect(result).toBeNull();
+    // Cascade UPDATE clients and final SELECT both skipped
+    expect(exec.calls).toHaveLength(1);
   });
 });
 

--- a/server/test/repositories/clientQuotesRepo.test.ts
+++ b/server/test/repositories/clientQuotesRepo.test.ts
@@ -1,0 +1,276 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import * as clientQuotesRepo from '../../repositories/clientQuotesRepo.ts';
+import { type FakeExecutor, makeFakeExecutor } from '../helpers/fakeExecutor.ts';
+
+let exec: FakeExecutor;
+
+beforeEach(() => {
+  exec = makeFakeExecutor();
+});
+
+const quoteRow = {
+  id: 'cq-1',
+  linkedOfferId: null,
+  clientId: 'c-1',
+  clientName: 'Acme',
+  paymentTerms: 'net30',
+  discount: '10',
+  discountType: 'percentage',
+  status: 'draft',
+  expirationDate: new Date('2026-06-01T00:00:00Z'),
+  notes: null,
+  createdAt: 1735689600000,
+  updatedAt: 1735689700000,
+};
+
+const itemRow = {
+  id: 'qi-1',
+  quoteId: 'cq-1',
+  productId: 'p-1',
+  productName: 'Widget',
+  quantity: '2',
+  unitPrice: '10',
+  productCost: '5',
+  productMolPercentage: '20',
+  supplierQuoteId: null,
+  supplierQuoteItemId: null,
+  supplierQuoteSupplierName: null,
+  supplierQuoteUnitPrice: null,
+  discount: '0',
+  note: null,
+  unitType: 'unit',
+};
+
+describe('listAll', () => {
+  test('embeds the linkedOfferId correlated subquery and orders DESC', async () => {
+    exec.enqueue({ rows: [{ ...quoteRow, linkedOfferId: 'co-1' }] });
+    const result = await clientQuotesRepo.listAll(exec);
+    expect(exec.calls[0].sql).toContain('FROM customer_offers co');
+    expect(exec.calls[0].sql).toContain('co.linked_quote_id = quotes.id');
+    expect(exec.calls[0].sql).toContain('ORDER BY created_at DESC');
+    expect(result[0].linkedOfferId).toBe('co-1');
+  });
+});
+
+describe('listAllItems', () => {
+  test('returns mapped items in created_at ASC order', async () => {
+    exec.enqueue({ rows: [itemRow] });
+    const result = await clientQuotesRepo.listAllItems(exec);
+    expect(exec.calls[0].sql).toContain('ORDER BY created_at ASC');
+    expect(result[0].quantity).toBe(2);
+    expect(result[0].productCost).toBe(5);
+    expect(result[0].productMolPercentage).toBe(20);
+  });
+
+  test('null productMolPercentage stays null in output', async () => {
+    exec.enqueue({ rows: [{ ...itemRow, productMolPercentage: null }] });
+    const result = await clientQuotesRepo.listAllItems(exec);
+    expect(result[0].productMolPercentage).toBeNull();
+  });
+});
+
+describe('existsById / findIdConflict', () => {
+  test('existsById returns true on match', async () => {
+    exec.enqueue({ rows: [{ id: 'cq-1' }] });
+    expect(await clientQuotesRepo.existsById('cq-1', exec)).toBe(true);
+  });
+
+  test('findIdConflict excludes self via id <> $2', async () => {
+    exec.enqueue({ rows: [] });
+    await clientQuotesRepo.findIdConflict('new', 'cur', exec);
+    expect(exec.calls[0].sql).toContain('id <> $2');
+  });
+});
+
+describe('findCurrentForUpdate', () => {
+  test('returns parsed status and discount fields', async () => {
+    exec.enqueue({
+      rows: [{ status: 'sent', discount: '15.5', discount_type: 'currency' }],
+    });
+    const result = await clientQuotesRepo.findCurrentForUpdate('cq-1', exec);
+    expect(result).toEqual({ status: 'sent', discount: 15.5, discountType: 'currency' });
+  });
+
+  test('defaults discountType to percentage when null', async () => {
+    exec.enqueue({ rows: [{ status: 'draft', discount: 0, discount_type: null }] });
+    const result = await clientQuotesRepo.findCurrentForUpdate('cq-1', exec);
+    expect(result?.discountType).toBe('percentage');
+  });
+
+  test('returns null when not found', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await clientQuotesRepo.findCurrentForUpdate('cq-x', exec)).toBeNull();
+  });
+});
+
+describe('linked-sale guards', () => {
+  test('findLinkedOfferId returns id from customer_offers', async () => {
+    exec.enqueue({ rows: [{ id: 'co-1' }] });
+    expect(await clientQuotesRepo.findLinkedOfferId('cq-1', exec)).toBe('co-1');
+    expect(exec.calls[0].sql).toContain('FROM customer_offers WHERE linked_quote_id = $1');
+  });
+
+  test('findNonDraftLinkedSale uses status <> "draft"', async () => {
+    exec.enqueue({ rows: [{ id: 's-1' }] });
+    await clientQuotesRepo.findNonDraftLinkedSale('cq-1', exec);
+    expect(exec.calls[0].sql).toContain('status <> $2');
+    expect(exec.calls[0].params).toEqual(['cq-1', 'draft']);
+  });
+
+  test('deleteDraftSalesForQuote scopes the delete to draft sales', async () => {
+    exec.enqueue({ rows: [], rowCount: 2 });
+    await clientQuotesRepo.deleteDraftSalesForQuote('cq-1', exec);
+    expect(exec.calls[0].sql).toContain('DELETE FROM sales');
+    expect(exec.calls[0].sql).toContain('linked_quote_id = $1 AND status = $2');
+    expect(exec.calls[0].params).toEqual(['cq-1', 'draft']);
+  });
+});
+
+describe('findItemSnapshotsForQuote', () => {
+  test('maps snapshot row fields with parsed numbers and unitType normalization', async () => {
+    exec.enqueue({
+      rows: [
+        {
+          id: 'qi-1',
+          productId: 'p-1',
+          productCost: '5',
+          productMolPercentage: '20',
+          supplierQuoteId: null,
+          supplierQuoteItemId: null,
+          supplierQuoteSupplierName: null,
+          supplierQuoteUnitPrice: null,
+          unitType: null,
+        },
+      ],
+    });
+    const result = await clientQuotesRepo.findItemSnapshotsForQuote('cq-1', exec);
+    expect(result[0]).toEqual({
+      id: 'qi-1',
+      productId: 'p-1',
+      productCost: 5,
+      productMolPercentage: 20,
+      supplierQuoteId: null,
+      supplierQuoteItemId: null,
+      supplierQuoteSupplierName: null,
+      supplierQuoteUnitPrice: null,
+      unitType: 'hours', // null normalized to "hours" by normalizeUnitType
+    });
+  });
+});
+
+describe('findItemTotals', () => {
+  test('returns parsed numeric totals', async () => {
+    exec.enqueue({
+      rows: [
+        { quantity: '2', unitPrice: '10', discount: '5' },
+        { quantity: 1, unitPrice: 20, discount: null },
+      ],
+    });
+    const result = await clientQuotesRepo.findItemTotals('cq-1', exec);
+    expect(result).toEqual([
+      { quantity: 2, unitPrice: 10, discount: 5 },
+      { quantity: 1, unitPrice: 20, discount: 0 },
+    ]);
+  });
+});
+
+describe('create', () => {
+  test('inserts 9 fields and returns mapped quote', async () => {
+    exec.enqueue({ rows: [quoteRow] });
+    const result = await clientQuotesRepo.create(
+      {
+        id: 'cq-1',
+        clientId: 'c-1',
+        clientName: 'Acme',
+        paymentTerms: 'net30',
+        discount: 10,
+        discountType: 'percentage',
+        status: 'draft',
+        expirationDate: '2026-06-01',
+        notes: null,
+      },
+      exec,
+    );
+    expect(exec.calls[0].sql).toContain('INSERT INTO quotes');
+    expect(exec.calls[0].params).toHaveLength(9);
+    expect(result.id).toBe('cq-1');
+    expect(result.discount).toBe(10);
+  });
+});
+
+describe('update', () => {
+  test('passes 10 params and uses COALESCE preservation', async () => {
+    exec.enqueue({ rows: [quoteRow] });
+    await clientQuotesRepo.update('cq-1', { status: 'accepted' }, exec);
+    expect(exec.calls[0].sql).toContain('UPDATE quotes');
+    expect(exec.calls[0].params).toHaveLength(10);
+    expect(exec.calls[0].params[6]).toBe('accepted');
+    expect(exec.calls[0].params[9]).toBe('cq-1');
+  });
+
+  test('returns null when no row updated', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await clientQuotesRepo.update('cq-x', { status: 'accepted' }, exec)).toBeNull();
+  });
+});
+
+describe('replaceItems', () => {
+  test('issues DELETE then bulk INSERT with 15 fields per row', async () => {
+    exec.enqueue({ rows: [] });
+    exec.enqueue({
+      rows: [
+        { ...itemRow, id: 'a' },
+        { ...itemRow, id: 'b' },
+      ],
+    });
+    const items: clientQuotesRepo.NewClientQuoteItem[] = [
+      {
+        id: 'a',
+        productId: 'p-1',
+        productName: 'A',
+        quantity: 1,
+        unitPrice: 5,
+        productCost: 2,
+        productMolPercentage: null,
+        discount: 0,
+        note: null,
+        supplierQuoteId: null,
+        supplierQuoteItemId: null,
+        supplierQuoteSupplierName: null,
+        supplierQuoteUnitPrice: null,
+        unitType: 'unit',
+      },
+      {
+        id: 'b',
+        productId: null,
+        productName: 'B',
+        quantity: 2,
+        unitPrice: 6,
+        productCost: 3,
+        productMolPercentage: 25,
+        discount: 1,
+        note: 'note-b',
+        supplierQuoteId: 'sq-1',
+        supplierQuoteItemId: 'sqi-1',
+        supplierQuoteSupplierName: 'Vendor',
+        supplierQuoteUnitPrice: 4,
+        unitType: 'hours',
+      },
+    ];
+    const result = await clientQuotesRepo.replaceItems('cq-1', items, exec);
+    expect(exec.calls).toHaveLength(2);
+    expect(exec.calls[0].sql).toContain('DELETE FROM quote_items');
+    expect(exec.calls[1].sql).toContain('INSERT INTO quote_items');
+    expect(exec.calls[1].params).toHaveLength(30); // 2 * 15
+    expect(exec.calls[1].params[0]).toBe('a');
+    expect(exec.calls[1].params[15]).toBe('b');
+    expect(result.map((i) => i.id)).toEqual(['a', 'b']);
+  });
+
+  test('with empty items skips the INSERT', async () => {
+    exec.enqueue({ rows: [] });
+    const result = await clientQuotesRepo.replaceItems('cq-1', [], exec);
+    expect(exec.calls).toHaveLength(1);
+    expect(result).toEqual([]);
+  });
+});

--- a/server/test/repositories/clientsOrdersRepo.test.ts
+++ b/server/test/repositories/clientsOrdersRepo.test.ts
@@ -1,0 +1,277 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import * as repo from '../../repositories/clientsOrdersRepo.ts';
+import { type FakeExecutor, makeFakeExecutor } from '../helpers/fakeExecutor.ts';
+
+let exec: FakeExecutor;
+
+beforeEach(() => {
+  exec = makeFakeExecutor();
+});
+
+const orderRow = {
+  id: 'co-1',
+  linkedQuoteId: null,
+  linkedOfferId: null,
+  clientId: 'c-1',
+  clientName: 'Acme',
+  paymentTerms: 'net30',
+  discount: '0',
+  discountType: 'percentage',
+  status: 'draft',
+  notes: null,
+  createdAt: 1735689600000,
+  updatedAt: 1735689700000,
+};
+
+const itemRow = {
+  id: 'si-1',
+  orderId: 'co-1',
+  productId: 'p-1',
+  productName: 'Widget',
+  quantity: '2',
+  unitPrice: '10',
+  productCost: '5',
+  productMolPercentage: null,
+  supplierQuoteId: null,
+  supplierQuoteItemId: null,
+  supplierQuoteSupplierName: null,
+  supplierQuoteUnitPrice: null,
+  supplierSaleId: null,
+  supplierSaleItemId: null,
+  supplierSaleSupplierName: null,
+  unitType: 'unit',
+  note: null,
+  discount: '0',
+};
+
+describe('listAll', () => {
+  test('orders by created_at DESC', async () => {
+    exec.enqueue({ rows: [orderRow] });
+    const result = await repo.listAll(exec);
+    expect(exec.calls[0].sql).toContain('FROM sales');
+    expect(exec.calls[0].sql).toContain('ORDER BY created_at DESC');
+    expect(result[0].id).toBe('co-1');
+  });
+});
+
+describe('findOfferDetails', () => {
+  test('returns offer with linkedQuoteId and status', async () => {
+    exec.enqueue({
+      rows: [{ id: 'co-1', linkedQuoteId: 'cq-1', status: 'accepted' }],
+    });
+    const result = await repo.findOfferDetails('co-1', exec);
+    expect(result).toEqual({ id: 'co-1', linkedQuoteId: 'cq-1', status: 'accepted' });
+  });
+
+  test('returns null when not found', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await repo.findOfferDetails('missing', exec)).toBeNull();
+  });
+});
+
+describe('findExistingForOffer', () => {
+  test('omits id <> $2 when no excludeOrderId', async () => {
+    exec.enqueue({ rows: [] });
+    await repo.findExistingForOffer('co-1', null, exec);
+    expect(exec.calls[0].sql).not.toContain('id <> $2');
+    expect(exec.calls[0].params).toEqual(['co-1']);
+  });
+
+  test('includes id <> $2 when excludeOrderId provided', async () => {
+    exec.enqueue({ rows: [{ id: 's-2' }] });
+    const result = await repo.findExistingForOffer('co-1', 's-1', exec);
+    expect(exec.calls[0].sql).toContain('id <> $2');
+    expect(result).toBe('s-2');
+  });
+});
+
+describe('create / update', () => {
+  test('create inserts 10 params', async () => {
+    exec.enqueue({ rows: [orderRow] });
+    await repo.create(
+      {
+        id: 'co-1',
+        linkedQuoteId: null,
+        linkedOfferId: null,
+        clientId: 'c-1',
+        clientName: 'Acme',
+        paymentTerms: 'net30',
+        discount: 0,
+        discountType: 'percentage',
+        status: 'draft',
+        notes: null,
+      },
+      exec,
+    );
+    expect(exec.calls[0].sql).toContain('INSERT INTO sales');
+    expect(exec.calls[0].params).toHaveLength(10);
+  });
+
+  test('update passes 11 params with id at the end', async () => {
+    exec.enqueue({ rows: [orderRow] });
+    await repo.update('co-1', { status: 'confirmed' }, exec);
+    expect(exec.calls[0].params).toHaveLength(11);
+    expect(exec.calls[0].params[10]).toBe('co-1');
+  });
+
+  test('update returns null when no row matches', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await repo.update('co-x', { status: 'confirmed' }, exec)).toBeNull();
+  });
+});
+
+describe('insertItems / replaceItems', () => {
+  const sampleItem: repo.NewClientOrderItem = {
+    id: 'si-1',
+    productId: 'p-1',
+    productName: 'A',
+    quantity: 1,
+    unitPrice: 5,
+    productCost: 2,
+    productMolPercentage: null,
+    discount: 0,
+    note: null,
+    supplierQuoteId: null,
+    supplierQuoteItemId: null,
+    supplierQuoteSupplierName: null,
+    supplierQuoteUnitPrice: null,
+    supplierSaleId: null,
+    supplierSaleItemId: null,
+    supplierSaleSupplierName: null,
+    unitType: 'unit',
+  };
+
+  test('insertItems issues a single bulk INSERT with 18 fields per row', async () => {
+    exec.enqueue({ rows: [itemRow] });
+    await repo.insertItems('co-1', [sampleItem], exec);
+    expect(exec.calls).toHaveLength(1);
+    expect(exec.calls[0].sql).toContain('INSERT INTO sale_items');
+    expect(exec.calls[0].params).toHaveLength(18);
+  });
+
+  test('insertItems with empty array skips INSERT', async () => {
+    expect(await repo.insertItems('co-1', [], exec)).toEqual([]);
+    expect(exec.calls).toHaveLength(0);
+  });
+
+  test('replaceItems issues DELETE then INSERT', async () => {
+    exec.enqueue({ rows: [] }); // DELETE
+    exec.enqueue({ rows: [itemRow] }); // INSERT
+    await repo.replaceItems('co-1', [sampleItem], exec);
+    expect(exec.calls).toHaveLength(2);
+    expect(exec.calls[0].sql).toContain('DELETE FROM sale_items');
+    expect(exec.calls[1].sql).toContain('INSERT INTO sale_items');
+  });
+});
+
+describe('supplier-order auto-creation flow (transaction injection)', () => {
+  test('createSupplierOrder uses passed exec for the INSERT', async () => {
+    exec.enqueue({ rows: [] });
+    await repo.createSupplierOrder(
+      {
+        id: 'so-1',
+        linkedQuoteId: 'sq-1',
+        supplierId: 'sup-1',
+        supplierName: 'Vendor',
+        paymentTerms: 'immediate',
+        notes: null,
+      },
+      exec,
+    );
+    expect(exec.calls[0].sql).toContain('INSERT INTO supplier_sales');
+    expect(exec.calls[0].sql).toContain("'draft'");
+    expect(exec.calls[0].params).toEqual(['so-1', 'sq-1', 'sup-1', 'Vendor', 'immediate', null]);
+  });
+
+  test('bulkInsertSupplierOrderItems builds 7-field placeholders per row', async () => {
+    exec.enqueue({ rows: [] });
+    await repo.bulkInsertSupplierOrderItems(
+      'so-1',
+      [
+        {
+          id: 'ssi-a',
+          productId: 'p-1',
+          productName: 'A',
+          quantity: 1,
+          unitPrice: 5,
+          note: null,
+        },
+        {
+          id: 'ssi-b',
+          productId: 'p-2',
+          productName: 'B',
+          quantity: 2,
+          unitPrice: 6,
+          note: 'n',
+        },
+      ],
+      exec,
+    );
+    expect(exec.calls[0].sql).toContain('INSERT INTO supplier_sale_items');
+    expect(exec.calls[0].sql).toContain('($1, $2, $3, $4, $5, $6, $7), ($8');
+    expect(exec.calls[0].params).toHaveLength(14);
+    expect(exec.calls[0].params[0]).toBe('ssi-a');
+    expect(exec.calls[0].params[7]).toBe('ssi-b');
+  });
+
+  test('bulkInsertSupplierOrderItems is a no-op for empty items', async () => {
+    await repo.bulkInsertSupplierOrderItems('so-1', [], exec);
+    expect(exec.calls).toHaveLength(0);
+  });
+
+  test('linkSaleItemsToSupplierOrder sets supplier_sale_id and name on matching sale_items', async () => {
+    exec.enqueue({ rows: [], rowCount: 2 });
+    await repo.linkSaleItemsToSupplierOrder(
+      {
+        orderId: 'co-1',
+        supplierQuoteId: 'sq-1',
+        supplierOrderId: 'so-1',
+        supplierName: 'Vendor',
+      },
+      exec,
+    );
+    expect(exec.calls[0].sql).toContain('UPDATE sale_items');
+    expect(exec.calls[0].sql).toContain('supplier_sale_id = $1');
+    expect(exec.calls[0].sql).toContain('supplier_sale_supplier_name = $2');
+    expect(exec.calls[0].params).toEqual(['so-1', 'Vendor', 'co-1', 'sq-1']);
+  });
+
+  test('mapSaleItemsToSupplierItems uses VALUES(...) join with $1/$2 anchors', async () => {
+    exec.enqueue({ rows: [], rowCount: 2 });
+    await repo.mapSaleItemsToSupplierItems(
+      {
+        orderId: 'co-1',
+        supplierQuoteId: 'sq-1',
+        mappings: [
+          { quoteItemId: 'sqi-a', saleItemId: 'ssi-a' },
+          { quoteItemId: 'sqi-b', saleItemId: 'ssi-b' },
+        ],
+      },
+      exec,
+    );
+    expect(exec.calls[0].sql).toContain(
+      'FROM (VALUES ($3, $4), ($5, $6)) v(quote_item_id, sale_item_id)',
+    );
+    expect(exec.calls[0].params).toEqual(['co-1', 'sq-1', 'sqi-a', 'ssi-a', 'sqi-b', 'ssi-b']);
+  });
+
+  test('mapSaleItemsToSupplierItems is a no-op for empty mappings', async () => {
+    await repo.mapSaleItemsToSupplierItems(
+      { orderId: 'co-1', supplierQuoteId: 'sq-1', mappings: [] },
+      exec,
+    );
+    expect(exec.calls).toHaveLength(0);
+  });
+});
+
+describe('deleteById', () => {
+  test('returns true when row deleted', async () => {
+    exec.enqueue({ rows: [], rowCount: 1 });
+    expect(await repo.deleteById('co-1', exec)).toBe(true);
+  });
+
+  test('returns false when no row matched', async () => {
+    exec.enqueue({ rows: [], rowCount: 0 });
+    expect(await repo.deleteById('co-x', exec)).toBe(false);
+  });
+});

--- a/server/test/repositories/clientsRepo.test.ts
+++ b/server/test/repositories/clientsRepo.test.ts
@@ -1,0 +1,338 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import * as clientsRepo from '../../repositories/clientsRepo.ts';
+import { type FakeExecutor, makeFakeExecutor } from '../helpers/fakeExecutor.ts';
+
+let exec: FakeExecutor;
+
+beforeEach(() => {
+  exec = makeFakeExecutor();
+});
+
+const baseRow = {
+  id: 'c-1',
+  name: 'Acme',
+  description: 'desc',
+  is_disabled: false,
+  type: 'company',
+  contacts: [{ fullName: 'Alice', email: 'a@x.com', phone: '555', role: 'CEO' }],
+  contact_name: null,
+  client_code: 'AC-1',
+  email: null,
+  phone: null,
+  address: null,
+  address_country: 'IT',
+  address_state: null,
+  address_cap: '00100',
+  address_province: 'RM',
+  address_civic_number: '10',
+  address_line: 'Via Roma',
+  ateco_code: '12.34',
+  website: 'https://acme.test',
+  sector: 'tech',
+  number_of_employees: '10-50',
+  revenue: '1M-5M',
+  fiscal_code: 'IT12345',
+  office_count_range: '1',
+  total_sent_quotes: '500',
+  total_accepted_orders: '1500.5',
+  created_at: '2026-01-15T00:00:00Z',
+};
+
+describe('mapClientRow', () => {
+  test('parses contacts JSONB and falls back to primary contact for primary fields', () => {
+    const result = clientsRepo.mapClientRow(baseRow);
+    expect(result.contacts).toEqual([
+      { fullName: 'Alice', role: 'CEO', email: 'a@x.com', phone: '555' },
+    ]);
+    expect(result.contactName).toBe('Alice');
+    expect(result.email).toBe('a@x.com');
+    expect(result.phone).toBe('555');
+  });
+
+  test('uses explicit contact_name/email/phone when set, ignoring primary contact', () => {
+    const result = clientsRepo.mapClientRow({
+      ...baseRow,
+      contact_name: 'Bob',
+      email: 'b@x.com',
+      phone: '999',
+    });
+    expect(result.contactName).toBe('Bob');
+    expect(result.email).toBe('b@x.com');
+    expect(result.phone).toBe('999');
+  });
+
+  test('computes formatted address when no explicit address provided', () => {
+    const result = clientsRepo.mapClientRow(baseRow);
+    expect(result.address).toContain('Via Roma');
+    expect(result.address).toContain('00100');
+    expect(result.address).toContain('IT');
+  });
+
+  test('parses numeric totals from string DB output', () => {
+    const result = clientsRepo.mapClientRow(baseRow);
+    expect(result.totalSentQuotes).toBe(500);
+    expect(result.totalAcceptedOrders).toBe(1500.5);
+  });
+
+  test('returns undefined totals when fields are NULL', () => {
+    const result = clientsRepo.mapClientRow({
+      ...baseRow,
+      total_sent_quotes: null,
+      total_accepted_orders: null,
+    });
+    expect(result.totalSentQuotes).toBeUndefined();
+    expect(result.totalAcceptedOrders).toBeUndefined();
+  });
+
+  test('mirrors fiscalCode into vatNumber and taxCode', () => {
+    const result = clientsRepo.mapClientRow(baseRow);
+    expect(result.vatNumber).toBe('IT12345');
+    expect(result.taxCode).toBe('IT12345');
+  });
+});
+
+describe('list', () => {
+  test('runs the privileged query with no params when canViewAllClients=true', async () => {
+    exec.enqueue({ rows: [baseRow] });
+    const result = await clientsRepo.list({ canViewAllClients: true }, exec);
+    expect(exec.calls[0].sql).toContain('LEFT JOIN');
+    expect(exec.calls[0].sql).toContain('total_sent_quotes');
+    expect(exec.calls[0].params).toEqual([]);
+    expect(result[0].id).toBe('c-1');
+  });
+
+  test('runs the restricted query with userId param when canViewAllClients=false', async () => {
+    exec.enqueue({ rows: [{ ...baseRow, total_sent_quotes: null, total_accepted_orders: null }] });
+    const result = await clientsRepo.list({ canViewAllClients: false, userId: 'u-1' }, exec);
+    expect(exec.calls[0].sql).toContain('INNER JOIN user_clients');
+    expect(exec.calls[0].sql).toContain('WHERE uc.user_id = $1');
+    expect(exec.calls[0].params).toEqual(['u-1']);
+    expect(result[0].totalSentQuotes).toBeUndefined();
+  });
+});
+
+describe('findContactsForUpdate', () => {
+  test('returns parsed contacts when client exists', async () => {
+    exec.enqueue({ rows: [{ contacts: [{ fullName: 'A' }] }] });
+    const result = await clientsRepo.findContactsForUpdate('c-1', exec);
+    expect(result).toEqual({ contacts: [{ fullName: 'A' }] });
+  });
+
+  test('returns null when client not found', async () => {
+    exec.enqueue({ rows: [] });
+    const result = await clientsRepo.findContactsForUpdate('c-x', exec);
+    expect(result).toBeNull();
+  });
+});
+
+describe('findByFiscalCode', () => {
+  test('queries with LOWER for case-insensitive match without exclude', async () => {
+    exec.enqueue({ rows: [{ id: 'c-1' }] });
+    const result = await clientsRepo.findByFiscalCode('IT123', null, exec);
+    expect(exec.calls[0].sql).toContain('LOWER(fiscal_code) = LOWER($1)');
+    expect(exec.calls[0].sql).not.toContain('id <>');
+    expect(exec.calls[0].params).toEqual(['IT123']);
+    expect(result).toBe(true);
+  });
+
+  test('adds id <> $2 clause when excludeId provided', async () => {
+    exec.enqueue({ rows: [] });
+    await clientsRepo.findByFiscalCode('IT123', 'c-1', exec);
+    expect(exec.calls[0].sql).toContain('id <> $2');
+    expect(exec.calls[0].params).toEqual(['IT123', 'c-1']);
+  });
+});
+
+describe('findByClientCode', () => {
+  test('respects excludeId parameter', async () => {
+    exec.enqueue({ rows: [] });
+    await clientsRepo.findByClientCode('AC-1', 'c-1', exec);
+    expect(exec.calls[0].sql).toContain('client_code = $1');
+    expect(exec.calls[0].sql).toContain('id <> $2');
+    expect(exec.calls[0].params).toEqual(['AC-1', 'c-1']);
+  });
+});
+
+describe('create', () => {
+  test('inserts 24 fields with stringified contacts JSON', async () => {
+    exec.enqueue({ rows: [baseRow] });
+    await clientsRepo.create(
+      {
+        id: 'c-1',
+        name: 'Acme',
+        type: 'company',
+        contacts: [{ fullName: 'Alice' }],
+        contactName: 'Alice',
+        clientCode: 'AC-1',
+        email: 'a@x.com',
+        phone: null,
+        address: null,
+        addressCountry: 'IT',
+        addressState: null,
+        addressCap: null,
+        addressProvince: null,
+        addressCivicNumber: null,
+        addressLine: null,
+        description: null,
+        atecoCode: null,
+        website: null,
+        sector: null,
+        numberOfEmployees: null,
+        revenue: null,
+        fiscalCode: 'IT12345',
+        officeCountRange: null,
+      },
+      exec,
+    );
+    expect(exec.calls[0].sql).toContain('INSERT INTO clients');
+    expect(exec.calls[0].params).toHaveLength(24);
+    expect(exec.calls[0].params[0]).toBe('c-1');
+    expect(exec.calls[0].params[2]).toBe(false); // is_disabled
+    expect(exec.calls[0].params[4]).toBe('[{"fullName":"Alice"}]'); // contacts JSON
+  });
+});
+
+describe('update', () => {
+  test('passes 31 params including 7 boolean CASE WHEN flags', async () => {
+    exec.enqueue({ rows: [baseRow] });
+    await clientsRepo.update(
+      'c-1',
+      {
+        name: 'New',
+        isDisabled: null,
+        type: null,
+        contacts: null,
+        clientCode: null,
+        address: null,
+        addressCountry: null,
+        addressState: null,
+        addressCap: null,
+        addressProvince: null,
+        addressCivicNumber: null,
+        addressLine: null,
+        description: null,
+        atecoCode: null,
+        website: null,
+        fiscalCode: null,
+        contactName: 'X',
+        contactNameProvided: true,
+        email: null,
+        emailProvided: false,
+        phone: null,
+        phoneProvided: false,
+        sector: 'tech',
+        sectorProvided: true,
+        numberOfEmployees: null,
+        numberOfEmployeesProvided: false,
+        revenue: null,
+        revenueProvided: false,
+        officeCountRange: null,
+        officeCountRangeProvided: false,
+      },
+      exec,
+    );
+    expect(exec.calls[0].sql).toContain('CASE WHEN $25');
+    expect(exec.calls[0].sql).toContain('CASE WHEN $28');
+    expect(exec.calls[0].params).toHaveLength(31);
+    expect(exec.calls[0].params[0]).toBe('New'); // name
+    expect(exec.calls[0].params[23]).toBe('c-1'); // where id
+    expect(exec.calls[0].params[24]).toBe(true); // contactNameProvided
+    expect(exec.calls[0].params[25]).toBe(false); // emailProvided
+    expect(exec.calls[0].params[27]).toBe(true); // sectorProvided
+  });
+
+  test('JSON-stringifies contacts when present, passes null otherwise', async () => {
+    exec.enqueue({ rows: [baseRow] });
+    const baseUpdate: clientsRepo.ClientUpdate = {
+      name: null,
+      isDisabled: null,
+      type: null,
+      contacts: [{ fullName: 'A' }],
+      clientCode: null,
+      address: null,
+      addressCountry: null,
+      addressState: null,
+      addressCap: null,
+      addressProvince: null,
+      addressCivicNumber: null,
+      addressLine: null,
+      description: null,
+      atecoCode: null,
+      website: null,
+      fiscalCode: null,
+      contactName: null,
+      contactNameProvided: false,
+      email: null,
+      emailProvided: false,
+      phone: null,
+      phoneProvided: false,
+      sector: null,
+      sectorProvided: false,
+      numberOfEmployees: null,
+      numberOfEmployeesProvided: false,
+      revenue: null,
+      revenueProvided: false,
+      officeCountRange: null,
+      officeCountRangeProvided: false,
+    };
+    await clientsRepo.update('c-1', baseUpdate, exec);
+    expect(exec.calls[0].params[3]).toBe('[{"fullName":"A"}]');
+  });
+
+  test('returns null when no row was updated', async () => {
+    exec.enqueue({ rows: [] });
+    const result = await clientsRepo.update(
+      'c-x',
+      {
+        name: null,
+        isDisabled: null,
+        type: null,
+        contacts: null,
+        clientCode: null,
+        address: null,
+        addressCountry: null,
+        addressState: null,
+        addressCap: null,
+        addressProvince: null,
+        addressCivicNumber: null,
+        addressLine: null,
+        description: null,
+        atecoCode: null,
+        website: null,
+        fiscalCode: null,
+        contactName: null,
+        contactNameProvided: false,
+        email: null,
+        emailProvided: false,
+        phone: null,
+        phoneProvided: false,
+        sector: null,
+        sectorProvided: false,
+        numberOfEmployees: null,
+        numberOfEmployeesProvided: false,
+        revenue: null,
+        revenueProvided: false,
+        officeCountRange: null,
+        officeCountRangeProvided: false,
+      },
+      exec,
+    );
+    expect(result).toBeNull();
+  });
+});
+
+describe('deleteById', () => {
+  test('returns id, name, clientCode when row deleted', async () => {
+    exec.enqueue({ rows: [{ id: 'c-1', name: 'Acme', client_code: 'AC-1' }] });
+    expect(await clientsRepo.deleteById('c-1', exec)).toEqual({
+      id: 'c-1',
+      name: 'Acme',
+      clientCode: 'AC-1',
+    });
+  });
+
+  test('returns null when no row deleted', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await clientsRepo.deleteById('c-x', exec)).toBeNull();
+  });
+});

--- a/server/test/repositories/invoicesRepo.test.ts
+++ b/server/test/repositories/invoicesRepo.test.ts
@@ -134,6 +134,11 @@ describe('findDates', () => {
     exec.enqueue({ rows: [] });
     expect(await invoicesRepo.findDates('INV-X', exec)).toBeNull();
   });
+
+  test('throws if a column comes back null (schema invariant: NOT NULL)', async () => {
+    exec.enqueue({ rows: [{ issueDate: '2026-04-01', dueDate: null }] });
+    await expect(invoicesRepo.findDates('INV-1', exec)).rejects.toThrow(/dueDate/);
+  });
 });
 
 describe('findIdConflict', () => {

--- a/server/test/repositories/invoicesRepo.test.ts
+++ b/server/test/repositories/invoicesRepo.test.ts
@@ -1,0 +1,269 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import * as invoicesRepo from '../../repositories/invoicesRepo.ts';
+import { type FakeExecutor, makeFakeExecutor } from '../helpers/fakeExecutor.ts';
+
+let exec: FakeExecutor;
+
+beforeEach(() => {
+  exec = makeFakeExecutor();
+});
+
+const rawInvoiceRow = {
+  id: 'INV-2026-0001',
+  linkedSaleId: null,
+  clientId: 'c-1',
+  clientName: 'Acme',
+  issueDate: new Date('2026-04-01T00:00:00Z'),
+  dueDate: new Date('2026-04-30T00:00:00Z'),
+  status: 'draft',
+  subtotal: '100',
+  total: '110',
+  amountPaid: '0',
+  notes: null,
+  createdAt: 1735689600000,
+  updatedAt: 1735689700000,
+};
+
+const rawItemRow = {
+  id: 'inv-item-1',
+  invoiceId: 'INV-2026-0001',
+  productId: null,
+  description: 'Widget',
+  unitOfMeasure: 'unit',
+  quantity: '2',
+  unitPrice: '50',
+  discount: '0',
+};
+
+describe('generateNextId', () => {
+  test('returns INV-{year}-0001 when no rows exist', async () => {
+    exec.enqueue({ rows: [{ maxSequence: 0 }] });
+    const id = await invoicesRepo.generateNextId('2026', exec);
+    expect(id).toBe('INV-2026-0001');
+    expect(exec.calls[0].params).toEqual(['^INV-2026-[0-9]+$']);
+  });
+
+  test('zero-pads to 4 digits and increments existing max', async () => {
+    exec.enqueue({ rows: [{ maxSequence: '7' }] });
+    const id = await invoicesRepo.generateNextId('2026', exec);
+    expect(id).toBe('INV-2026-0008');
+  });
+
+  test('handles missing maxSequence row', async () => {
+    exec.enqueue({ rows: [] });
+    const id = await invoicesRepo.generateNextId('2026', exec);
+    expect(id).toBe('INV-2026-0001');
+  });
+});
+
+describe('listAll', () => {
+  test('orders by created_at DESC and maps types', async () => {
+    exec.enqueue({ rows: [rawInvoiceRow] });
+    const result = await invoicesRepo.listAll(exec);
+    expect(exec.calls[0].sql).toContain('ORDER BY created_at DESC');
+    expect(result[0].issueDate).toBe('2026-04-01');
+    expect(result[0].dueDate).toBe('2026-04-30');
+    expect(result[0].subtotal).toBe(100);
+    expect(result[0].total).toBe(110);
+    expect(result[0].amountPaid).toBe(0);
+  });
+});
+
+describe('listAllItems', () => {
+  test('orders by created_at ASC and coerces unitOfMeasure', async () => {
+    exec.enqueue({ rows: [rawItemRow, { ...rawItemRow, unitOfMeasure: 'hours' }] });
+    const result = await invoicesRepo.listAllItems(exec);
+    expect(exec.calls[0].sql).toContain('ORDER BY created_at ASC');
+    expect(result[0].unitOfMeasure).toBe('unit');
+    expect(result[1].unitOfMeasure).toBe('hours');
+    expect(result[0].quantity).toBe(2);
+    expect(result[0].unitPrice).toBe(50);
+  });
+
+  test('falls back to unit when unitOfMeasure is unknown', async () => {
+    exec.enqueue({ rows: [{ ...rawItemRow, unitOfMeasure: null }] });
+    const result = await invoicesRepo.listAllItems(exec);
+    expect(result[0].unitOfMeasure).toBe('unit');
+  });
+});
+
+describe('listAllWithItems', () => {
+  test('groups items by invoiceId and preserves invoice order', async () => {
+    exec.enqueue({
+      rows: [
+        { ...rawInvoiceRow, id: 'INV-1' },
+        { ...rawInvoiceRow, id: 'INV-2' },
+      ],
+    });
+    exec.enqueue({
+      rows: [
+        { ...rawItemRow, id: 'i-a', invoiceId: 'INV-2' },
+        { ...rawItemRow, id: 'i-b', invoiceId: 'INV-1' },
+        { ...rawItemRow, id: 'i-c', invoiceId: 'INV-1' },
+      ],
+    });
+    const result = await invoicesRepo.listAllWithItems(exec);
+    expect(result.map((i) => i.id)).toEqual(['INV-1', 'INV-2']);
+    expect(result[0].items.map((i) => i.id)).toEqual(['i-b', 'i-c']);
+    expect(result[1].items.map((i) => i.id)).toEqual(['i-a']);
+  });
+
+  test('returns empty items array when no items exist', async () => {
+    exec.enqueue({ rows: [rawInvoiceRow] });
+    exec.enqueue({ rows: [] });
+    const result = await invoicesRepo.listAllWithItems(exec);
+    expect(result[0].items).toEqual([]);
+  });
+});
+
+describe('findClientId', () => {
+  test('returns clientId when found', async () => {
+    exec.enqueue({ rows: [{ clientId: 'c-1' }] });
+    expect(await invoicesRepo.findClientId('INV-1', exec)).toBe('c-1');
+  });
+
+  test('returns null when not found', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await invoicesRepo.findClientId('INV-X', exec)).toBeNull();
+  });
+});
+
+describe('findIdConflict', () => {
+  test('excludes self via id <> $2', async () => {
+    exec.enqueue({ rows: [] });
+    await invoicesRepo.findIdConflict('new-id', 'cur-id', exec);
+    expect(exec.calls[0].sql).toContain('id <> $2');
+    expect(exec.calls[0].params).toEqual(['new-id', 'cur-id']);
+  });
+
+  test('returns true when conflicting row exists', async () => {
+    exec.enqueue({ rows: [{ id: 'new-id' }] });
+    expect(await invoicesRepo.findIdConflict('new-id', 'cur-id', exec)).toBe(true);
+  });
+});
+
+describe('create', () => {
+  test('inserts all 11 fields and returns mapped invoice', async () => {
+    exec.enqueue({ rows: [rawInvoiceRow] });
+    const result = await invoicesRepo.create(
+      {
+        id: 'INV-2026-0001',
+        linkedSaleId: null,
+        clientId: 'c-1',
+        clientName: 'Acme',
+        issueDate: '2026-04-01',
+        dueDate: '2026-04-30',
+        status: 'draft',
+        subtotal: 100,
+        total: 110,
+        amountPaid: 0,
+        notes: null,
+      },
+      exec,
+    );
+    expect(exec.calls[0].sql).toContain('INSERT INTO invoices');
+    expect(exec.calls[0].params).toHaveLength(11);
+    expect(result.id).toBe('INV-2026-0001');
+    expect(result.subtotal).toBe(100);
+  });
+});
+
+describe('update', () => {
+  test('passes patch fields with null fallback for COALESCE preservation', async () => {
+    exec.enqueue({ rows: [rawInvoiceRow] });
+    await invoicesRepo.update('INV-2026-0001', { status: 'sent', total: 200 }, exec);
+    expect(exec.calls[0].sql).toContain('UPDATE invoices SET');
+    expect(exec.calls[0].sql).toContain('status = COALESCE($6, status)');
+    expect(exec.calls[0].sql).toContain('updated_at = CURRENT_TIMESTAMP');
+    const params = exec.calls[0].params;
+    expect(params[5]).toBe('sent'); // status
+    expect(params[7]).toBe(200); // total
+    expect(params[0]).toBeNull(); // id (not in patch)
+    expect(params[10]).toBe('INV-2026-0001'); // where clause
+  });
+
+  test('returns null when no row updated', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await invoicesRepo.update('INV-X', { status: 'sent' }, exec)).toBeNull();
+  });
+
+  test('preserves notes=null as no-change via COALESCE', async () => {
+    exec.enqueue({ rows: [rawInvoiceRow] });
+    await invoicesRepo.update('INV-1', {}, exec);
+    expect(exec.calls[0].params[9]).toBeNull();
+  });
+});
+
+describe('replaceItems', () => {
+  test('issues DELETE then a single multi-row INSERT and preserves order', async () => {
+    exec.enqueue({ rows: [] });
+    exec.enqueue({
+      rows: [
+        { ...rawItemRow, id: 'a' },
+        { ...rawItemRow, id: 'b' },
+      ],
+    });
+    const items = [
+      {
+        id: 'a',
+        productId: null,
+        description: 'A',
+        unitOfMeasure: 'unit' as const,
+        quantity: 1,
+        unitPrice: 5,
+        discount: 0,
+      },
+      {
+        id: 'b',
+        productId: null,
+        description: 'B',
+        unitOfMeasure: 'hours' as const,
+        quantity: 2,
+        unitPrice: 6,
+        discount: 1,
+      },
+    ];
+    const result = await invoicesRepo.replaceItems('INV-1', items, exec);
+    expect(exec.calls).toHaveLength(2);
+    expect(exec.calls[0].sql).toContain('DELETE FROM invoice_items');
+    expect(exec.calls[0].params).toEqual(['INV-1']);
+    expect(exec.calls[1].sql).toContain('INSERT INTO invoice_items');
+    expect(exec.calls[1].sql).toContain('VALUES ($1, $2, $3, $4, $5, $6, $7, $8), ($9');
+    expect(exec.calls[1].params[0]).toBe('a');
+    expect(exec.calls[1].params[8]).toBe('b');
+    expect(result.map((i) => i.id)).toEqual(['a', 'b']);
+  });
+
+  test('with empty items, deletes existing and skips INSERT', async () => {
+    exec.enqueue({ rows: [] });
+    const result = await invoicesRepo.replaceItems('INV-1', [], exec);
+    expect(exec.calls).toHaveLength(1);
+    expect(exec.calls[0].sql).toContain('DELETE');
+    expect(result).toEqual([]);
+  });
+});
+
+describe('deleteById', () => {
+  test('returns id and clientName when deleted', async () => {
+    exec.enqueue({ rows: [{ id: 'INV-1', clientName: 'Acme' }] });
+    expect(await invoicesRepo.deleteById('INV-1', exec)).toEqual({
+      id: 'INV-1',
+      clientName: 'Acme',
+    });
+  });
+
+  test('returns null when no row deleted', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await invoicesRepo.deleteById('INV-X', exec)).toBeNull();
+  });
+});
+
+describe('findItemsForInvoice', () => {
+  test('filters by invoice_id and maps rows', async () => {
+    exec.enqueue({ rows: [rawItemRow] });
+    const result = await invoicesRepo.findItemsForInvoice('INV-1', exec);
+    expect(exec.calls[0].sql).toContain('WHERE invoice_id = $1');
+    expect(exec.calls[0].params).toEqual(['INV-1']);
+    expect(result[0].id).toBe('inv-item-1');
+  });
+});

--- a/server/test/repositories/invoicesRepo.test.ts
+++ b/server/test/repositories/invoicesRepo.test.ts
@@ -116,15 +116,23 @@ describe('listAllWithItems', () => {
   });
 });
 
-describe('findClientId', () => {
-  test('returns clientId when found', async () => {
-    exec.enqueue({ rows: [{ clientId: 'c-1' }] });
-    expect(await invoicesRepo.findClientId('INV-1', exec)).toBe('c-1');
+describe('findDates', () => {
+  test('returns normalized issueDate/dueDate when found', async () => {
+    exec.enqueue({
+      rows: [
+        {
+          issueDate: '2026-04-01T00:00:00Z',
+          dueDate: new Date('2026-04-30T00:00:00Z'),
+        },
+      ],
+    });
+    const result = await invoicesRepo.findDates('INV-1', exec);
+    expect(result).toEqual({ issueDate: '2026-04-01', dueDate: '2026-04-30' });
   });
 
   test('returns null when not found', async () => {
     exec.enqueue({ rows: [] });
-    expect(await invoicesRepo.findClientId('INV-X', exec)).toBeNull();
+    expect(await invoicesRepo.findDates('INV-X', exec)).toBeNull();
   });
 });
 

--- a/server/test/repositories/productsRepo.test.ts
+++ b/server/test/repositories/productsRepo.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import * as productsRepo from '../../repositories/productsRepo.ts';
+import { type FakeExecutor, makeFakeExecutor } from '../helpers/fakeExecutor.ts';
+
+let exec: FakeExecutor;
+
+beforeEach(() => {
+  exec = makeFakeExecutor();
+});
+
+describe('getSnapshots', () => {
+  test('returns empty Map when given no ids without issuing a query', async () => {
+    const result = await productsRepo.getSnapshots([], exec);
+    expect(result.size).toBe(0);
+    expect(exec.calls).toHaveLength(0);
+  });
+
+  test('deduplicates ids and passes a unique-set array to ANY($1)', async () => {
+    exec.enqueue({ rows: [] });
+    await productsRepo.getSnapshots(['p-1', 'p-1', 'p-2'], exec);
+    expect(exec.calls[0].sql).toContain('id = ANY($1)');
+    expect(exec.calls[0].params).toEqual([['p-1', 'p-2']]);
+  });
+
+  test('maps cost as number and preserves null molPercentage', async () => {
+    exec.enqueue({
+      rows: [
+        { id: 'p-1', costo: '10.5', molPercentage: '20' },
+        { id: 'p-2', costo: '5', molPercentage: null },
+      ],
+    });
+    const result = await productsRepo.getSnapshots(['p-1', 'p-2'], exec);
+    expect(result.get('p-1')).toEqual({ productCost: 10.5, productMolPercentage: 20 });
+    expect(result.get('p-2')).toEqual({ productCost: 5, productMolPercentage: null });
+  });
+
+  test('coerces empty/falsy ids out before deduplication', async () => {
+    exec.enqueue({ rows: [] });
+    await productsRepo.getSnapshots(['', 'p-1', ''], exec);
+    expect(exec.calls[0].params).toEqual([['p-1']]);
+  });
+});

--- a/server/test/repositories/supplierQuotesRepo.test.ts
+++ b/server/test/repositories/supplierQuotesRepo.test.ts
@@ -157,6 +157,49 @@ describe('replaceItems', () => {
   });
 });
 
+describe('getQuoteItemSnapshots', () => {
+  test('returns empty Map when given no ids without issuing a query', async () => {
+    const result = await supplierQuotesRepo.getQuoteItemSnapshots([], exec);
+    expect(result.size).toBe(0);
+    expect(exec.calls).toHaveLength(0);
+  });
+
+  test('deduplicates ids and filters falsy values', async () => {
+    exec.enqueue({ rows: [] });
+    await supplierQuotesRepo.getQuoteItemSnapshots(['', 'a', 'a', 'b'], exec);
+    expect(exec.calls[0].params).toEqual([['a', 'b']]);
+  });
+
+  test('joins on supplier_quotes filtered to status=accepted', async () => {
+    exec.enqueue({ rows: [] });
+    await supplierQuotesRepo.getQuoteItemSnapshots(['a'], exec);
+    expect(exec.calls[0].sql).toContain('JOIN supplier_quotes sq ON sq.id = sqi.quote_id');
+    expect(exec.calls[0].sql).toContain("sq.status = 'accepted'");
+  });
+
+  test('maps row fields into snapshot shape with netCost mirroring unitPrice', async () => {
+    exec.enqueue({
+      rows: [
+        {
+          itemId: 'sqi-1',
+          quoteId: 'sq-1',
+          supplierName: 'Acme',
+          productId: 'p-1',
+          unitPrice: '12.5',
+        },
+      ],
+    });
+    const result = await supplierQuotesRepo.getQuoteItemSnapshots(['sqi-1'], exec);
+    expect(result.get('sqi-1')).toEqual({
+      supplierQuoteId: 'sq-1',
+      supplierName: 'Acme',
+      productId: 'p-1',
+      unitPrice: 12.5,
+      netCost: 12.5,
+    });
+  });
+});
+
 describe('deleteById', () => {
   test('returns supplierName when row deleted', async () => {
     exec.enqueue({ rows: [{ supplier_name: 'Acme' }] });

--- a/server/test/utils/parse.test.ts
+++ b/server/test/utils/parse.test.ts
@@ -30,6 +30,7 @@ describe('parseNullableDbNumber', () => {
 
   test('returns null for non-finite input rather than coercing to 0', () => {
     expect(parseNullableDbNumber('abc')).toBeNull();
+    expect(parseNullableDbNumber('')).toBeNull();
     expect(parseNullableDbNumber(Number.NaN)).toBeNull();
     expect(parseNullableDbNumber(Number.POSITIVE_INFINITY)).toBeNull();
   });

--- a/server/test/utils/parse.test.ts
+++ b/server/test/utils/parse.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'bun:test';
+import { parseDbNumber, parseNullableDbNumber } from '../../utils/parse.ts';
+
+describe('parseDbNumber', () => {
+  test('parses string numerics', () => {
+    expect(parseDbNumber('10.5', 0)).toBe(10.5);
+  });
+
+  test('returns fallback for null/undefined', () => {
+    expect(parseDbNumber(null, 0)).toBe(0);
+    expect(parseDbNumber(undefined, 0)).toBe(0);
+  });
+
+  test('returns fallback for non-finite values', () => {
+    expect(parseDbNumber('abc', 0)).toBe(0);
+    expect(parseDbNumber(Number.NaN, 0)).toBe(0);
+  });
+});
+
+describe('parseNullableDbNumber', () => {
+  test('returns null for null/undefined', () => {
+    expect(parseNullableDbNumber(null)).toBeNull();
+    expect(parseNullableDbNumber(undefined)).toBeNull();
+  });
+
+  test('parses string and number numerics', () => {
+    expect(parseNullableDbNumber('10.5')).toBe(10.5);
+    expect(parseNullableDbNumber(7)).toBe(7);
+  });
+
+  test('returns null for non-finite input rather than coercing to 0', () => {
+    expect(parseNullableDbNumber('abc')).toBeNull();
+    expect(parseNullableDbNumber(Number.NaN)).toBeNull();
+    expect(parseNullableDbNumber(Number.POSITIVE_INFINITY)).toBeNull();
+  });
+});

--- a/server/utils/date.ts
+++ b/server/utils/date.ts
@@ -19,6 +19,12 @@ export const normalizeNullableDateOnly = (value: unknown, fieldName: string) => 
   throw new TypeError(`Invalid date value for ${fieldName}`);
 };
 
+export const requireDateOnly = (value: unknown, fieldName: string): string => {
+  const normalized = normalizeNullableDateOnly(value, fieldName);
+  if (!normalized) throw new TypeError(`Invalid date value for ${fieldName}`);
+  return normalized;
+};
+
 export const todayLocalDateOnly = (now: Date = new Date()) => formatLocalDateOnly(now);
 
 export const isPastLocalDate = (dateOnly: string, now: Date = new Date()) =>

--- a/server/utils/parse.ts
+++ b/server/utils/parse.ts
@@ -9,5 +9,6 @@ export const parseDbNumber = <T extends number | undefined>(
 
 export const parseNullableDbNumber = (value: string | number | null | undefined): number | null => {
   if (value === null || value === undefined) return null;
-  return parseDbNumber(value, 0);
+  const n = typeof value === 'string' ? Number.parseFloat(value) : value;
+  return Number.isFinite(n) ? n : null;
 };

--- a/server/utils/parse.ts
+++ b/server/utils/parse.ts
@@ -6,3 +6,8 @@ export const parseDbNumber = <T extends number | undefined>(
   const n = typeof value === 'string' ? Number.parseFloat(value) : value;
   return Number.isFinite(n) ? n : fallback;
 };
+
+export const parseNullableDbNumber = (value: string | number | null | undefined): number | null => {
+  if (value === null || value === undefined) return null;
+  return parseDbNumber(value, 0);
+};


### PR DESCRIPTION
## Summary

- Continues the SQL extraction pattern from [#137](https://github.com/xBounceIT/praetor/pull/137) (suppliers) and [#136](https://github.com/xBounceIT/praetor/pull/136) (shared SQL helper). Moves inline SQL out of `clients`, `client-offers`, `client-quotes`, `clients-orders`, and `invoices` route handlers into 7 new per-domain repos, following the `notificationsRepo` reference pattern. Net: **-2.4k inserts of route code, +5.1k of focused repo + test code**.
- Wraps `create+replaceItems` / `update+replaceItems` sequences in `withTransaction` for the four routes, preventing orphaned parent rows when item insertion fails. Same treatment for `clientProfileOptionsRepo.update` (option row + cascade UPDATE + usage-count read).
- Adds two small shared helpers that replace ~80 lines of duplicated boilerplate across 7 repos: `parseNullableDbNumber` (utils/parse.ts) and `buildBulkInsertPlaceholders` (db/index.ts).

## Why

This is the next slice of the incremental "SQL belongs in `/server/repositories/`" migration documented in CLAUDE.md. Lifting client-side SQL out of routes:
- Lets the `withTransaction` plumbing thread cleanly through repo calls (e.g., the supplier-order auto-creation flow on client-order creation now passes a single `tx` through 4 repo functions).
- Enables fakes-based repo tests (no DB required) — added for all 7 new repos, 378 repo tests pass total.
- Surfaces correctness fixes: previously, `create + replaceItems` ran on two separate pool connections, so a failed items insert left an orphan parent row. Now atomic.

## What changed

**New repos (+ matching tests):**
- `clientsRepo` (incl. `clientProfileOptionsRepo`), `clientOffersRepo`, `clientQuotesRepo`, `clientsOrdersRepo`, `invoicesRepo`, `productsRepo`

**Routes migrated:**
- `routes/clients.ts`, `routes/client-offers.ts`, `routes/client-quotes.ts`, `routes/clients-orders.ts`, `routes/invoices.ts` — all inline SQL removed; routes now contain only validation/auth/orchestration.

**Shared helpers:**
- `parseNullableDbNumber(value)` — collapses the `=== null || === undefined ? null : parseDbNumber(...)` ladder used in every item-mapper.
- `buildBulkInsertPlaceholders(rowCount, fieldsPerRow)` — replaces the manual `Array.from({length}, (_, n) => ...)` builder used in 7 `replaceItems` functions.

**Correctness / efficiency tightening:**
- Atomicity: `create+replaceItems` and `update+replaceItems` now run in a single transaction across offers/quotes/orders/invoices.
- Drops redundant `existsById` pre-checks before INSERTs that already catch unique-violation errors.
- Parallelises independent reads with `Promise.all`: clients POST/PUT (fiscalCode/clientCode/contacts checks), profile-options POST (existence check + sort-order lookup).
- Skips the post-loop `findItemsForOrder` refetch in clients-orders POST when no supplier auto-create ran (uses the rows returned by `insertItems` directly).
- Auto-creation flow's `didAutoCreate` flag is now set after the transaction commits, not inside the callback (a rolled-back tx no longer triggers a wasted refetch).

## Reviewer notes

- `mapClientRow` is intentionally kept exported in `clientsRepo` because the existing client-mapper tests treat it as a focused unit (the mapping is non-trivial — JSONB contacts parsing, address composition, fallback chains).
- `clientsRepo.list` privileged path keeps the heavy correlated-subquery JOIN verbatim from the original SQL — separate optimisation, intentionally out of scope here.
- The supplier auto-create loop in `clients-orders` POST still runs sequentially per supplier-quote (each iteration is its own transaction). Parallelising would change audit ordering; deferred.

## Test plan

- [x] `bun test test/repositories` — 378 pass (covers all repos via fakes; no DB).
- [x] `tsc -p server/tsconfig.json` — clean.
- [x] `biome check` on touched files — clean.
- [ ] Manual smoke test in the running app: create/update/delete a client; create a quote → accept → create an offer; create a sale order from an offer (verifies supplier auto-creation flow); create/update an invoice; CRUD on client profile options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)