### PR TITLE
refactor(server): extract product/user route SQL into per-domain repos

### DIFF
--- a/server/repositories/productsRepo.ts
+++ b/server/repositories/productsRepo.ts
@@ -1,6 +1,22 @@
 import pool, { type QueryExecutor } from '../db/index.ts';
 import { parseDbNumber, parseNullableDbNumber } from '../utils/parse.ts';
 
+// Transaction-item tables that hold a `product_id` foreign key. Used in linked-products
+// existence checks when renaming/deleting categories, subcategories, and types.
+const TRANSACTION_ITEM_TABLES = [
+  'quote_items',
+  'customer_offer_items',
+  'sale_items',
+  'invoice_items',
+  'supplier_quote_items',
+  'supplier_sale_items',
+  'supplier_invoice_items',
+] as const;
+
+const PRODUCT_LINKED_EXISTS_CLAUSE = TRANSACTION_ITEM_TABLES.map(
+  (t) => `SELECT 1 FROM ${t} WHERE product_id = pr.id`,
+).join(' UNION ALL ');
+
 export type ProductSnapshot = {
   productCost: number;
   productMolPercentage: number | null;
@@ -36,4 +52,836 @@ export const getSnapshots = async (
     });
   }
   return snapshots;
+};
+
+// ===========================================================================
+// Product CRUD endpoints
+// ===========================================================================
+
+export type CostUnit = 'unit' | 'hours';
+
+export type ProductRow = {
+  id: string;
+  name: string;
+  productCode: string;
+  createdAt: number | null;
+  description: string | null;
+  costo: number;
+  molPercentage: number;
+  costUnit: CostUnit;
+  category: string | null;
+  subcategory: string | null;
+  type: string;
+  supplierId: string | null;
+  supplierName?: string | null;
+  isDisabled: boolean;
+};
+
+export type ProductCore = {
+  type: string;
+  supplierId: string | null;
+  category: string | null;
+};
+
+export type NewProduct = {
+  id: string;
+  name: string;
+  productCode: string;
+  description: string | null;
+  costo: number;
+  molPercentage: number;
+  costUnit: CostUnit;
+  category: string | null;
+  subcategory: string | null;
+  type: string;
+  supplierId: string | null;
+};
+
+export type ProductUpdateFields = Partial<{
+  name: string;
+  productCode: string;
+  description: string | null;
+  costo: number;
+  molPercentage: number;
+  type: string;
+  category: string | null;
+  subcategory: string | null;
+  supplierId: string | null;
+  costUnit: CostUnit;
+  isDisabled: boolean;
+}>;
+
+const toEpochMs = (v: unknown): number | null =>
+  v === null || v === undefined ? null : new Date(v as string | Date).getTime();
+
+const mapProductRow = (row: Record<string, unknown>): ProductRow => ({
+  ...(row as Omit<ProductRow, 'createdAt' | 'costo' | 'molPercentage'>),
+  costo: parseDbNumber(row.costo as string | number | null | undefined, 0),
+  molPercentage: parseDbNumber(row.molPercentage as string | number | null | undefined, 0),
+  createdAt: toEpochMs(row.createdAt),
+});
+
+const PRODUCT_LIST_COLUMNS = `
+  p.id,
+  p.name,
+  p.product_code as "productCode",
+  p.created_at as "createdAt",
+  p.description,
+  p.costo,
+  p.mol_percentage as "molPercentage",
+  p.cost_unit as "costUnit",
+  p.category,
+  p.subcategory,
+  p.type,
+  p.supplier_id as "supplierId",
+  s.name as "supplierName",
+  p.is_disabled as "isDisabled"
+`;
+
+const PRODUCT_DETAIL_COLUMNS = `
+  id,
+  name,
+  product_code as "productCode",
+  created_at as "createdAt",
+  description,
+  costo,
+  mol_percentage as "molPercentage",
+  cost_unit as "costUnit",
+  category,
+  subcategory,
+  type,
+  is_disabled as "isDisabled",
+  supplier_id as "supplierId"
+`;
+
+const PRODUCT_INSERT_RETURNING = `
+  id,
+  name,
+  product_code as "productCode",
+  created_at as "createdAt",
+  description,
+  costo,
+  mol_percentage as "molPercentage",
+  cost_unit as "costUnit",
+  category,
+  subcategory,
+  type,
+  supplier_id as "supplierId"
+`;
+
+export const listAllProducts = async (exec: QueryExecutor = pool): Promise<ProductRow[]> => {
+  const { rows } = await exec.query(
+    `SELECT ${PRODUCT_LIST_COLUMNS}
+       FROM products p
+       LEFT JOIN suppliers s ON p.supplier_id = s.id
+      ORDER BY p.name ASC`,
+  );
+  return rows.map(mapProductRow);
+};
+
+export const findProductById = async (
+  id: string,
+  exec: QueryExecutor = pool,
+): Promise<ProductRow | null> => {
+  const { rows } = await exec.query(
+    `SELECT ${PRODUCT_DETAIL_COLUMNS}
+       FROM products
+      WHERE id = $1`,
+    [id],
+  );
+  return rows[0] ? mapProductRow(rows[0]) : null;
+};
+
+export const findProductCoreById = async (
+  id: string,
+  exec: QueryExecutor = pool,
+): Promise<ProductCore | null> => {
+  const { rows } = await exec.query<{
+    type: string;
+    supplierId: string | null;
+    category: string | null;
+  }>(
+    `SELECT type, supplier_id AS "supplierId", category
+       FROM products
+      WHERE id = $1`,
+    [id],
+  );
+  return rows[0] ?? null;
+};
+
+export const existsProductByName = async (
+  name: string,
+  excludeId: string | null,
+  exec: QueryExecutor = pool,
+): Promise<boolean> => {
+  const { rows } = excludeId
+    ? await exec.query(`SELECT id FROM products WHERE LOWER(name) = LOWER($1) AND id != $2`, [
+        name,
+        excludeId,
+      ])
+    : await exec.query(`SELECT id FROM products WHERE LOWER(name) = LOWER($1)`, [name]);
+  return rows.length > 0;
+};
+
+export const existsProductByCode = async (
+  code: string,
+  excludeId: string | null,
+  exec: QueryExecutor = pool,
+): Promise<boolean> => {
+  const { rows } = excludeId
+    ? await exec.query(`SELECT id FROM products WHERE product_code = $1 AND id != $2`, [
+        code,
+        excludeId,
+      ])
+    : await exec.query(`SELECT id FROM products WHERE product_code = $1`, [code]);
+  return rows.length > 0;
+};
+
+export const insertProduct = async (
+  product: NewProduct,
+  exec: QueryExecutor = pool,
+): Promise<ProductRow> => {
+  const { rows } = await exec.query(
+    `INSERT INTO products (id, name, product_code, description, costo, mol_percentage, cost_unit, category, subcategory, type, supplier_id)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+     RETURNING ${PRODUCT_INSERT_RETURNING}`,
+    [
+      product.id,
+      product.name,
+      product.productCode,
+      product.description,
+      product.costo,
+      product.molPercentage,
+      product.costUnit,
+      product.category,
+      product.subcategory,
+      product.type,
+      product.supplierId,
+    ],
+  );
+  return mapProductRow(rows[0]);
+};
+
+export const updateProductDynamic = async (
+  id: string,
+  fields: ProductUpdateFields,
+  exec: QueryExecutor = pool,
+): Promise<ProductRow | null> => {
+  const sets: string[] = [];
+  const params: unknown[] = [];
+  let idx = 1;
+
+  const push = (column: string, value: unknown) => {
+    sets.push(`${column} = $${idx++}`);
+    params.push(value);
+  };
+
+  if (fields.name !== undefined) push('name', fields.name);
+  if (fields.productCode !== undefined) push('product_code', fields.productCode);
+  if (fields.description !== undefined) push('description', fields.description);
+  if (fields.costo !== undefined) push('costo', fields.costo);
+  if (fields.molPercentage !== undefined) push('mol_percentage', fields.molPercentage);
+  if (fields.type !== undefined) push('type', fields.type);
+  if (fields.category !== undefined) push('category', fields.category);
+  if (fields.subcategory !== undefined) push('subcategory', fields.subcategory);
+  if (fields.supplierId !== undefined) push('supplier_id', fields.supplierId);
+  if (fields.costUnit !== undefined) push('cost_unit', fields.costUnit);
+  if (fields.isDisabled !== undefined) push('is_disabled', fields.isDisabled);
+
+  if (sets.length === 0) return null;
+
+  params.push(id);
+  const { rows } = await exec.query(
+    `UPDATE products
+        SET ${sets.join(', ')}
+      WHERE id = $${idx}
+   RETURNING ${PRODUCT_DETAIL_COLUMNS}`,
+    params,
+  );
+  return rows[0] ? mapProductRow(rows[0]) : null;
+};
+
+export const deleteProductById = async (
+  id: string,
+  exec: QueryExecutor = pool,
+): Promise<{ name: string; productCode: string } | null> => {
+  const { rows } = await exec.query<{ name: string; productCode: string }>(
+    `DELETE FROM products
+      WHERE id = $1
+   RETURNING name, product_code as "productCode"`,
+    [id],
+  );
+  return rows[0] ?? null;
+};
+
+// ===========================================================================
+// Product types (user-managed)
+// ===========================================================================
+
+export type ProductTypeRow = {
+  id: string;
+  name: string;
+  costUnit: CostUnit;
+  createdAt: number | null;
+  updatedAt: number | null;
+  productCount: number;
+  categoryCount: number;
+};
+
+export type ProductTypeCore = {
+  id: string;
+  name: string;
+  costUnit: CostUnit;
+};
+
+const mapProductTypeRow = (row: Record<string, unknown>): ProductTypeRow => ({
+  id: row.id as string,
+  name: row.name as string,
+  costUnit: row.costUnit as CostUnit,
+  createdAt: toEpochMs(row.createdAt),
+  updatedAt: toEpochMs(row.updatedAt),
+  productCount: parseDbNumber(row.productCount as string | number | null | undefined, 0),
+  categoryCount: parseDbNumber(row.categoryCount as string | number | null | undefined, 0),
+});
+
+export const listAllProductTypesWithCounts = async (
+  exec: QueryExecutor = pool,
+): Promise<ProductTypeRow[]> => {
+  const { rows } = await exec.query(
+    `SELECT
+        t.id,
+        t.name,
+        t.cost_unit as "costUnit",
+        t.created_at as "createdAt",
+        t.updated_at as "updatedAt",
+        COALESCE(p.count, 0) as "productCount",
+        COALESCE(c.count, 0) as "categoryCount"
+       FROM product_types t
+       LEFT JOIN (
+         SELECT type, COUNT(*) as count FROM products GROUP BY type
+       ) p ON t.name = p.type
+       LEFT JOIN (
+         SELECT type, COUNT(*) as count FROM internal_product_categories GROUP BY type
+       ) c ON t.name = c.type
+       ORDER BY t.name ASC`,
+  );
+  return rows.map(mapProductTypeRow);
+};
+
+export const findProductTypeByName = async (
+  name: string,
+  exec: QueryExecutor = pool,
+): Promise<{ costUnit: CostUnit } | null> => {
+  const { rows } = await exec.query<{ costUnit: CostUnit }>(
+    `SELECT cost_unit AS "costUnit" FROM product_types WHERE name = $1`,
+    [name],
+  );
+  return rows[0] ?? null;
+};
+
+// Returns the cost_unit registered for `typeName`, falling back to the historical defaults
+// for service/consulting types when the registered row is missing.
+export const getCostUnitForType = async (
+  typeName: string,
+  exec: QueryExecutor = pool,
+): Promise<CostUnit> => {
+  const found = await findProductTypeByName(typeName, exec);
+  if (found) return found.costUnit;
+  return typeName === 'service' || typeName === 'consulting' ? 'hours' : 'unit';
+};
+
+export const existsProductTypeByName = async (
+  name: string,
+  excludeId: string | null,
+  exec: QueryExecutor = pool,
+): Promise<boolean> => {
+  const { rows } = excludeId
+    ? await exec.query(`SELECT id FROM product_types WHERE LOWER(name) = LOWER($1) AND id != $2`, [
+        name,
+        excludeId,
+      ])
+    : await exec.query(`SELECT id FROM product_types WHERE LOWER(name) = LOWER($1)`, [name]);
+  return rows.length > 0;
+};
+
+export const findProductTypeById = async (
+  id: string,
+  exec: QueryExecutor = pool,
+): Promise<{ id: string; name: string; costUnit: CostUnit } | null> => {
+  const { rows } = await exec.query<{ id: string; name: string; costUnit: CostUnit }>(
+    `SELECT id, name, cost_unit AS "costUnit" FROM product_types WHERE id = $1`,
+    [id],
+  );
+  return rows[0] ?? null;
+};
+
+export const insertProductType = async (
+  id: string,
+  name: string,
+  costUnit: CostUnit,
+  exec: QueryExecutor = pool,
+): Promise<ProductTypeRow> => {
+  const { rows } = await exec.query(
+    `INSERT INTO product_types (id, name, cost_unit)
+     VALUES ($1, $2, $3)
+     RETURNING id, name, cost_unit as "costUnit",
+               created_at as "createdAt", updated_at as "updatedAt"`,
+    [id, name, costUnit],
+  );
+  return mapProductTypeRow({ ...rows[0], productCount: 0, categoryCount: 0 });
+};
+
+export const updateProductTypeFields = async (
+  id: string,
+  name: string,
+  costUnit: CostUnit,
+  exec: QueryExecutor = pool,
+): Promise<ProductTypeRow | null> => {
+  const { rows } = await exec.query(
+    `UPDATE product_types
+        SET name = $1, cost_unit = $2, updated_at = CURRENT_TIMESTAMP
+      WHERE id = $3
+   RETURNING id, name, cost_unit as "costUnit",
+             created_at as "createdAt", updated_at as "updatedAt"`,
+    [name, costUnit, id],
+  );
+  return rows[0] ? mapProductTypeRow({ ...rows[0], productCount: 0, categoryCount: 0 }) : null;
+};
+
+export const propagateProductTypeName = async (
+  oldName: string,
+  newName: string,
+  exec: QueryExecutor = pool,
+): Promise<void> => {
+  await exec.query(`UPDATE products SET type = $1 WHERE type = $2`, [newName, oldName]);
+  await exec.query(`UPDATE internal_product_categories SET type = $1 WHERE type = $2`, [
+    newName,
+    oldName,
+  ]);
+};
+
+export const propagateProductTypeCostUnit = async (
+  typeName: string,
+  costUnit: CostUnit,
+  exec: QueryExecutor = pool,
+): Promise<void> => {
+  await exec.query(`UPDATE products SET cost_unit = $1 WHERE type = $2 AND supplier_id IS NULL`, [
+    costUnit,
+    typeName,
+  ]);
+  await exec.query(`UPDATE internal_product_categories SET cost_unit = $1 WHERE type = $2`, [
+    costUnit,
+    typeName,
+  ]);
+};
+
+export const countProductsForType = async (
+  typeName: string,
+  exec: QueryExecutor = pool,
+): Promise<number> => {
+  const { rows } = await exec.query<{ count: string }>(
+    `SELECT COUNT(*) as count FROM products WHERE type = $1`,
+    [typeName],
+  );
+  return parseDbNumber(rows[0]?.count, 0);
+};
+
+export const countCategoriesForType = async (
+  typeName: string,
+  exec: QueryExecutor = pool,
+): Promise<number> => {
+  const { rows } = await exec.query<{ count: string }>(
+    `SELECT COUNT(*) as count FROM internal_product_categories WHERE type = $1`,
+    [typeName],
+  );
+  return parseDbNumber(rows[0]?.count, 0);
+};
+
+export const deleteProductTypeById = async (
+  id: string,
+  exec: QueryExecutor = pool,
+): Promise<boolean> => {
+  const { rowCount } = await exec.query(`DELETE FROM product_types WHERE id = $1`, [id]);
+  return (rowCount ?? 0) > 0;
+};
+
+// ===========================================================================
+// Internal product categories
+// ===========================================================================
+
+export type InternalCategoryRow = {
+  id: string;
+  name: string;
+  type: string;
+  costUnit: CostUnit;
+  createdAt: number | null;
+  updatedAt: number | null;
+  productCount: number;
+  hasLinkedProducts: boolean;
+};
+
+const mapInternalCategoryRow = (row: Record<string, unknown>): InternalCategoryRow => ({
+  id: row.id as string,
+  name: row.name as string,
+  type: row.type as string,
+  costUnit: row.costUnit as CostUnit,
+  createdAt: toEpochMs(row.createdAt),
+  updatedAt: toEpochMs(row.updatedAt),
+  productCount: parseDbNumber(row.productCount as string | number | null | undefined, 0),
+  hasLinkedProducts: !!row.hasLinkedProducts,
+});
+
+export const listInternalCategoriesByType = async (
+  type: string,
+  exec: QueryExecutor = pool,
+): Promise<InternalCategoryRow[]> => {
+  const { rows } = await exec.query(
+    `SELECT c.id, c.name, c.type,
+            c.cost_unit as "costUnit",
+            c.created_at as "createdAt", c.updated_at as "updatedAt",
+            COALESCE(p.count, 0) as "productCount",
+            COALESCE(lp.has_linked, false) as "hasLinkedProducts"
+       FROM internal_product_categories c
+       LEFT JOIN (
+         SELECT category, COUNT(*) as count
+           FROM products
+          WHERE type = $1 AND supplier_id IS NULL
+          GROUP BY category
+       ) p ON c.name = p.category
+       LEFT JOIN (
+         SELECT pr.category, true as has_linked
+           FROM products pr
+          WHERE pr.type = $1
+            AND pr.supplier_id IS NULL
+            AND EXISTS (${PRODUCT_LINKED_EXISTS_CLAUSE})
+          GROUP BY pr.category
+       ) lp ON c.name = lp.category
+      WHERE c.type = $1
+      ORDER BY c.name ASC`,
+    [type],
+  );
+  return rows.map(mapInternalCategoryRow);
+};
+
+export const findInternalCategoryById = async (
+  id: string,
+  exec: QueryExecutor = pool,
+): Promise<{ id: string; name: string; type: string } | null> => {
+  const { rows } = await exec.query<{ id: string; name: string; type: string }>(
+    `SELECT id, name, type FROM internal_product_categories WHERE id = $1`,
+    [id],
+  );
+  return rows[0] ?? null;
+};
+
+export const findCategoryIdByNameAndType = async (
+  name: string,
+  type: string,
+  exec: QueryExecutor = pool,
+): Promise<string | null> => {
+  const { rows } = await exec.query<{ id: string }>(
+    `SELECT id FROM internal_product_categories WHERE name = $1 AND type = $2`,
+    [name, type],
+  );
+  return rows[0]?.id ?? null;
+};
+
+export const existsInternalCategoryByNameType = async (
+  name: string,
+  type: string,
+  excludeId: string | null,
+  exec: QueryExecutor = pool,
+): Promise<boolean> => {
+  const { rows } = excludeId
+    ? await exec.query(
+        `SELECT id FROM internal_product_categories
+          WHERE LOWER(name) = LOWER($1) AND type = $2 AND id != $3`,
+        [name, type, excludeId],
+      )
+    : await exec.query(
+        `SELECT id FROM internal_product_categories
+          WHERE LOWER(name) = LOWER($1) AND type = $2`,
+        [name, type],
+      );
+  return rows.length > 0;
+};
+
+export const insertInternalCategory = async (
+  id: string,
+  name: string,
+  type: string,
+  costUnit: CostUnit,
+  exec: QueryExecutor = pool,
+): Promise<InternalCategoryRow> => {
+  const { rows } = await exec.query(
+    `INSERT INTO internal_product_categories (id, name, type, cost_unit)
+     VALUES ($1, $2, $3, $4)
+     RETURNING id, name, type, cost_unit as "costUnit",
+               created_at as "createdAt", updated_at as "updatedAt"`,
+    [id, name, type, costUnit],
+  );
+  return mapInternalCategoryRow({
+    ...rows[0],
+    productCount: 0,
+    hasLinkedProducts: false,
+  });
+};
+
+export const updateInternalCategoryFields = async (
+  id: string,
+  name: string,
+  costUnit: CostUnit,
+  exec: QueryExecutor = pool,
+): Promise<InternalCategoryRow | null> => {
+  const { rows } = await exec.query(
+    `UPDATE internal_product_categories
+        SET name = $1, cost_unit = $2, updated_at = CURRENT_TIMESTAMP
+      WHERE id = $3
+   RETURNING id, name, type, cost_unit as "costUnit",
+             created_at as "createdAt", updated_at as "updatedAt"`,
+    [name, costUnit, id],
+  );
+  return rows[0]
+    ? mapInternalCategoryRow({ ...rows[0], productCount: 0, hasLinkedProducts: false })
+    : null;
+};
+
+export const propagateCategoryNameToProducts = async (
+  oldName: string,
+  newName: string,
+  type: string,
+  costUnit: CostUnit,
+  exec: QueryExecutor = pool,
+): Promise<void> => {
+  await exec.query(
+    `UPDATE products
+        SET category = $1, cost_unit = $2
+      WHERE category = $3 AND type = $4 AND supplier_id IS NULL`,
+    [newName, costUnit, oldName, type],
+  );
+};
+
+export const clearProductsCategoryByName = async (
+  name: string,
+  type: string,
+  exec: QueryExecutor = pool,
+): Promise<void> => {
+  await exec.query(
+    `UPDATE products
+        SET category = NULL, subcategory = NULL
+      WHERE category = $1 AND type = $2 AND supplier_id IS NULL`,
+    [name, type],
+  );
+};
+
+export const deleteInternalCategoryById = async (
+  id: string,
+  exec: QueryExecutor = pool,
+): Promise<boolean> => {
+  const { rowCount } = await exec.query(`DELETE FROM internal_product_categories WHERE id = $1`, [
+    id,
+  ]);
+  return (rowCount ?? 0) > 0;
+};
+
+export const countProductsForCategory = async (
+  name: string,
+  type: string,
+  exec: QueryExecutor = pool,
+): Promise<number> => {
+  const { rows } = await exec.query<{ count: string }>(
+    `SELECT COUNT(*) as count
+       FROM products
+      WHERE category = $1 AND type = $2 AND supplier_id IS NULL`,
+    [name, type],
+  );
+  return parseDbNumber(rows[0]?.count, 0);
+};
+
+// ===========================================================================
+// Internal product subcategories
+// ===========================================================================
+
+export type SubcategoryRow = {
+  name: string;
+  productCount: number;
+  hasLinkedProducts: boolean;
+};
+
+export const listInternalSubcategoriesByType = async (
+  categoryId: string,
+  exec: QueryExecutor = pool,
+): Promise<SubcategoryRow[]> => {
+  const { rows } = await exec.query<{
+    name: string;
+    productCount: string | number;
+    hasLinkedProducts: boolean;
+  }>(
+    `SELECT s.name,
+            COALESCE(p.count, 0) as "productCount",
+            COALESCE(lp.has_linked, false) as "hasLinkedProducts"
+       FROM internal_product_subcategories s
+       LEFT JOIN (
+         SELECT pr.subcategory, COUNT(*) as count
+           FROM products pr
+           JOIN internal_product_categories c
+             ON c.name = pr.category AND c.type = pr.type
+          WHERE c.id = $1 AND pr.supplier_id IS NULL
+          GROUP BY pr.subcategory
+       ) p ON s.name = p.subcategory
+       LEFT JOIN (
+         SELECT pr.subcategory, true as has_linked
+           FROM products pr
+           JOIN internal_product_categories c
+             ON c.name = pr.category AND c.type = pr.type
+          WHERE c.id = $1
+            AND pr.supplier_id IS NULL
+            AND EXISTS (${PRODUCT_LINKED_EXISTS_CLAUSE})
+          GROUP BY pr.subcategory
+       ) lp ON s.name = lp.subcategory
+      WHERE s.category_id = $1
+      ORDER BY s.name ASC`,
+    [categoryId],
+  );
+  return rows.map((row) => ({
+    name: row.name,
+    productCount: parseDbNumber(row.productCount, 0),
+    hasLinkedProducts: !!row.hasLinkedProducts,
+  }));
+};
+
+export const existsInternalSubcategoryByNameInCategory = async (
+  name: string,
+  categoryId: string,
+  exec: QueryExecutor = pool,
+): Promise<boolean> => {
+  const { rows } = await exec.query(
+    `SELECT 1 FROM internal_product_subcategories
+      WHERE category_id = $1 AND LOWER(name) = LOWER($2)
+      LIMIT 1`,
+    [categoryId, name],
+  );
+  return rows.length > 0;
+};
+
+export const insertInternalSubcategory = async (
+  id: string,
+  categoryId: string,
+  name: string,
+  exec: QueryExecutor = pool,
+): Promise<{ name: string }> => {
+  const { rows } = await exec.query<{ name: string }>(
+    `INSERT INTO internal_product_subcategories (id, category_id, name)
+     VALUES ($1, $2, $3)
+     RETURNING name`,
+    [id, categoryId, name],
+  );
+  return rows[0];
+};
+
+export const updateInternalSubcategoryName = async (
+  categoryId: string,
+  oldName: string,
+  newName: string,
+  exec: QueryExecutor = pool,
+): Promise<{ id: string } | null> => {
+  const { rows } = await exec.query<{ id: string }>(
+    `UPDATE internal_product_subcategories
+        SET name = $1, updated_at = CURRENT_TIMESTAMP
+      WHERE category_id = $2 AND name = $3
+   RETURNING id`,
+    [newName, categoryId, oldName],
+  );
+  return rows[0] ?? null;
+};
+
+export const propagateSubcategoryNameToProducts = async (
+  oldName: string,
+  newName: string,
+  type: string,
+  category: string,
+  exec: QueryExecutor = pool,
+): Promise<number> => {
+  const { rows } = await exec.query<{ id: string }>(
+    `UPDATE products
+        SET subcategory = $1
+      WHERE type = $2
+        AND category = $3
+        AND supplier_id IS NULL
+        AND subcategory = $4
+   RETURNING id`,
+    [newName, type, category, oldName],
+  );
+  return rows.length;
+};
+
+export const clearProductsSubcategoryByName = async (
+  name: string,
+  type: string,
+  category: string,
+  exec: QueryExecutor = pool,
+): Promise<void> => {
+  await exec.query(
+    `UPDATE products
+        SET subcategory = NULL
+      WHERE type = $1
+        AND category = $2
+        AND supplier_id IS NULL
+        AND subcategory = $3`,
+    [type, category, name],
+  );
+};
+
+export const deleteInternalSubcategoryByCategoryAndName = async (
+  categoryId: string,
+  name: string,
+  exec: QueryExecutor = pool,
+): Promise<{ id: string } | null> => {
+  const { rows } = await exec.query<{ id: string }>(
+    `DELETE FROM internal_product_subcategories
+      WHERE category_id = $1 AND name = $2
+   RETURNING id`,
+    [categoryId, name],
+  );
+  return rows[0] ?? null;
+};
+
+// ===========================================================================
+// Cross-domain link checks
+// ===========================================================================
+
+const TRANSACTION_LINK_COUNT_SUBQUERIES = TRANSACTION_ITEM_TABLES.map(
+  (t) => `SELECT COUNT(*)::bigint AS c FROM ${t} WHERE product_id = ANY($1)`,
+).join(' UNION ALL ');
+
+export const checkProductsLinkedToTransactions = async (
+  category: string,
+  type: string,
+  subcategory: string | undefined,
+  exec: QueryExecutor = pool,
+): Promise<{ linked: boolean; count: number }> => {
+  const subcategoryCondition = subcategory !== undefined ? `AND subcategory = $3` : '';
+  const params = subcategory !== undefined ? [category, type, subcategory] : [category, type];
+
+  const productResult = await exec.query<{ id: string }>(
+    `SELECT id FROM products
+       WHERE category = $1
+         AND type = $2
+         AND supplier_id IS NULL
+         ${subcategoryCondition}`,
+    params,
+  );
+
+  if (productResult.rows.length === 0) {
+    return { linked: false, count: 0 };
+  }
+
+  const productIds = productResult.rows.map((r) => r.id);
+  const linkResult = await exec.query<{ total: string }>(
+    `SELECT SUM(c)::bigint AS total FROM (${TRANSACTION_LINK_COUNT_SUBQUERIES}) sub`,
+    [productIds],
+  );
+  const totalLinks = parseDbNumber(linkResult.rows[0]?.total, 0);
+
+  return { linked: totalLinks > 0, count: totalLinks };
 };

--- a/server/repositories/suppliersRepo.ts
+++ b/server/repositories/suppliersRepo.ts
@@ -68,6 +68,16 @@ export const findById = async (
   return rows[0] ? mapRow(rows[0]) : null;
 };
 
+export const findNameById = async (
+  id: string,
+  exec: QueryExecutor = pool,
+): Promise<string | null> => {
+  const { rows } = await exec.query<{ name: string }>(`SELECT name FROM suppliers WHERE id = $1`, [
+    id,
+  ]);
+  return rows[0]?.name ?? null;
+};
+
 export type NewSupplier = {
   id: string;
   name: string;

--- a/server/repositories/usersRepo.ts
+++ b/server/repositories/usersRepo.ts
@@ -232,6 +232,9 @@ const mapUpdatedUserRow = (row: UpdatedUserRowDb): UpdatedUserRow => ({
   employeeType: (row.employeeType as EmployeeType | null) ?? 'app_user',
 });
 
+// SAFE: TOP_MANAGER_ROLE_ID and ADMIN_ROLE_ID are compile-time string constants from
+// utils/permissions.ts. Never interpolate dynamic / user-supplied values into this fragment —
+// pass them as bind parameters instead.
 const USER_LIST_FLAG_COLUMNS = `
   EXISTS (
     SELECT 1

--- a/server/repositories/usersRepo.ts
+++ b/server/repositories/usersRepo.ts
@@ -1,5 +1,9 @@
-import pool, { type QueryExecutor } from '../db/index.ts';
+import pool, { buildBulkInsertPlaceholders, type QueryExecutor } from '../db/index.ts';
 import { parseDbNumber } from '../utils/parse.ts';
+import { ADMIN_ROLE_ID, TOP_MANAGER_ROLE_ID } from '../utils/permissions.ts';
+import type { AssignmentSource } from '../utils/top-manager-assignments.ts';
+
+export type EmployeeType = 'app_user' | 'internal' | 'external';
 
 export type AuthUser = {
   id: string;
@@ -107,5 +111,487 @@ export const createUser = async (user: NewUser, exec: QueryExecutor = pool): Pro
     `INSERT INTO users (id, name, username, password_hash, role, avatar_initials)
      VALUES ($1, $2, $3, $4, $5, $6)`,
     [user.id, user.name, user.username, user.passwordHash, user.role, user.avatarInitials],
+  );
+};
+
+// ===========================================================================
+// User-management endpoints (full CRUD, role replacement, assignments)
+// ===========================================================================
+
+export type UserListRow = {
+  id: string;
+  name: string;
+  username: string;
+  email: string;
+  role: string;
+  avatarInitials: string;
+  costPerHour: number;
+  isDisabled: boolean;
+  employeeType: EmployeeType;
+  hasTopManagerRole: boolean;
+  isAdminOnly: boolean;
+};
+
+export type UserCore = {
+  id: string;
+  name: string;
+  username: string;
+  role: string;
+  employeeType: EmployeeType;
+};
+
+export type UpdatedUserRow = {
+  id: string;
+  name: string;
+  username: string;
+  role: string;
+  avatarInitials: string;
+  costPerHour: number;
+  isDisabled: boolean;
+  employeeType: EmployeeType;
+};
+
+export type UserUpdateFields = {
+  name?: string;
+  isDisabled?: boolean;
+  costPerHour?: number | null;
+  role?: string;
+};
+
+export type UserAssignments = {
+  clientIds: string[];
+  projectIds: string[];
+  taskIds: string[];
+};
+
+export type ManagerScopeOptions = {
+  canViewManagedUsers: boolean;
+  canViewInternal: boolean;
+  canViewExternal: boolean;
+};
+
+export type NewFullUser = {
+  id: string;
+  name: string;
+  username: string;
+  passwordHash: string;
+  role: string;
+  avatarInitials: string;
+  costPerHour: number;
+  isDisabled: boolean;
+  employeeType: EmployeeType;
+};
+
+type UserListRowDb = {
+  id: string;
+  name: string;
+  username: string;
+  email: string | null;
+  role: string;
+  avatarInitials: string | null;
+  costPerHour: string | number | null;
+  isDisabled: boolean | null;
+  employeeType: string | null;
+  hasTopManagerRole: boolean | null;
+  isAdminOnly: boolean | null;
+};
+
+const mapUserListRow = (row: UserListRowDb): UserListRow => ({
+  id: row.id,
+  name: row.name,
+  username: row.username,
+  email: row.email ?? '',
+  role: row.role,
+  avatarInitials: row.avatarInitials ?? '',
+  costPerHour: parseDbNumber(row.costPerHour, 0),
+  isDisabled: !!row.isDisabled,
+  employeeType: (row.employeeType as EmployeeType | null) ?? 'app_user',
+  hasTopManagerRole: !!row.hasTopManagerRole,
+  isAdminOnly: !!row.isAdminOnly,
+});
+
+type UpdatedUserRowDb = {
+  id: string;
+  name: string;
+  username: string;
+  role: string;
+  avatarInitials: string | null;
+  costPerHour: string | number | null;
+  isDisabled: boolean | null;
+  employeeType: string | null;
+};
+
+const mapUpdatedUserRow = (row: UpdatedUserRowDb): UpdatedUserRow => ({
+  id: row.id,
+  name: row.name,
+  username: row.username,
+  role: row.role,
+  avatarInitials: row.avatarInitials ?? '',
+  costPerHour: parseDbNumber(row.costPerHour, 0),
+  isDisabled: !!row.isDisabled,
+  employeeType: (row.employeeType as EmployeeType | null) ?? 'app_user',
+});
+
+const USER_LIST_FLAG_COLUMNS = `
+  EXISTS (
+    SELECT 1
+    FROM user_roles ur
+    WHERE ur.user_id = u.id AND ur.role_id = '${TOP_MANAGER_ROLE_ID}'
+  ) AS "hasTopManagerRole",
+  (
+    u.role = '${ADMIN_ROLE_ID}'
+    AND NOT EXISTS (
+      SELECT 1
+      FROM user_roles ur_admin_only
+      WHERE ur_admin_only.user_id = u.id AND ur_admin_only.role_id <> '${ADMIN_ROLE_ID}'
+    )
+  ) AS "isAdminOnly"
+`;
+
+export const listAllForAdmin = async (exec: QueryExecutor = pool): Promise<UserListRow[]> => {
+  const { rows } = await exec.query<UserListRowDb>(
+    `SELECT u.id,
+            u.name,
+            u.username,
+            COALESCE(s.email, '') AS email,
+            u.role,
+            u.avatar_initials AS "avatarInitials",
+            u.cost_per_hour AS "costPerHour",
+            u.is_disabled AS "isDisabled",
+            u.employee_type AS "employeeType",
+            ${USER_LIST_FLAG_COLUMNS}
+       FROM users u
+       LEFT JOIN settings s ON s.user_id = u.id
+       ORDER BY u.name`,
+  );
+  return rows.map(mapUserListRow);
+};
+
+export const listScopedForManager = async (
+  viewerId: string,
+  options: ManagerScopeOptions,
+  exec: QueryExecutor = pool,
+): Promise<UserListRow[]> => {
+  const conditions: string[] = ['u.id = $1'];
+  if (options.canViewManagedUsers) conditions.push('wum.user_id = $1');
+  if (options.canViewInternal) conditions.push("u.employee_type = 'internal'");
+  if (options.canViewExternal) conditions.push("u.employee_type = 'external'");
+
+  const { rows } = await exec.query<UserListRowDb>(
+    `SELECT DISTINCT u.id,
+                     u.name,
+                     u.username,
+                     COALESCE(s.email, '') AS email,
+                     u.role,
+                     u.avatar_initials AS "avatarInitials",
+                     u.cost_per_hour AS "costPerHour",
+                     u.is_disabled AS "isDisabled",
+                     u.employee_type AS "employeeType",
+                     ${USER_LIST_FLAG_COLUMNS}
+       FROM users u
+       LEFT JOIN settings s ON s.user_id = u.id
+       LEFT JOIN user_work_units uw ON u.id = uw.user_id
+       LEFT JOIN work_unit_managers wum ON uw.work_unit_id = wum.work_unit_id
+       WHERE (${conditions.join(' OR ')})
+         AND NOT EXISTS (
+           SELECT 1 FROM user_roles ur_tm
+           WHERE ur_tm.user_id = u.id AND ur_tm.role_id = '${TOP_MANAGER_ROLE_ID}'
+         )
+       ORDER BY u.name`,
+    [viewerId],
+  );
+  return rows.map(mapUserListRow);
+};
+
+export const findById = async (
+  id: string,
+  exec: QueryExecutor = pool,
+): Promise<UserListRow | null> => {
+  const { rows } = await exec.query<UserListRowDb>(
+    `SELECT u.id,
+            u.name,
+            u.username,
+            COALESCE(s.email, '') AS email,
+            u.role,
+            u.avatar_initials AS "avatarInitials",
+            u.cost_per_hour AS "costPerHour",
+            u.is_disabled AS "isDisabled",
+            u.employee_type AS "employeeType",
+            ${USER_LIST_FLAG_COLUMNS}
+       FROM users u
+       LEFT JOIN settings s ON s.user_id = u.id
+      WHERE u.id = $1`,
+    [id],
+  );
+  return rows[0] ? mapUserListRow(rows[0]) : null;
+};
+
+export const findCoreById = async (
+  id: string,
+  exec: QueryExecutor = pool,
+): Promise<UserCore | null> => {
+  const { rows } = await exec.query<{
+    id: string;
+    name: string;
+    username: string;
+    role: string;
+    employeeType: string | null;
+  }>(
+    `SELECT id, name, username, role, employee_type AS "employeeType"
+       FROM users
+      WHERE id = $1`,
+    [id],
+  );
+  if (!rows[0]) return null;
+  return {
+    id: rows[0].id,
+    name: rows[0].name,
+    username: rows[0].username,
+    role: rows[0].role,
+    employeeType: (rows[0].employeeType as EmployeeType | null) ?? 'app_user',
+  };
+};
+
+export const existsByUsername = async (
+  username: string,
+  exec: QueryExecutor = pool,
+): Promise<boolean> => {
+  const { rows } = await exec.query(`SELECT id FROM users WHERE username = $1`, [username]);
+  return rows.length > 0;
+};
+
+export const insertUser = async (user: NewFullUser, exec: QueryExecutor = pool): Promise<void> => {
+  await exec.query(
+    `INSERT INTO users (id, name, username, password_hash, role, avatar_initials, cost_per_hour, is_disabled, employee_type)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+    [
+      user.id,
+      user.name,
+      user.username,
+      user.passwordHash,
+      user.role,
+      user.avatarInitials,
+      user.costPerHour,
+      user.isDisabled,
+      user.employeeType,
+    ],
+  );
+};
+
+export const deleteById = async (id: string, exec: QueryExecutor = pool): Promise<boolean> => {
+  const { rowCount } = await exec.query(`DELETE FROM users WHERE id = $1 RETURNING id`, [id]);
+  return (rowCount ?? 0) > 0;
+};
+
+export const updateUserDynamic = async (
+  id: string,
+  fields: UserUpdateFields,
+  exec: QueryExecutor = pool,
+): Promise<UpdatedUserRow | null> => {
+  const sets: string[] = [];
+  const params: unknown[] = [];
+  let idx = 1;
+
+  if (fields.name !== undefined) {
+    sets.push(`name = $${idx++}`);
+    params.push(fields.name);
+  }
+  if (fields.isDisabled !== undefined) {
+    sets.push(`is_disabled = $${idx++}`);
+    params.push(fields.isDisabled);
+  }
+  if (fields.costPerHour !== undefined) {
+    sets.push(`cost_per_hour = $${idx++}`);
+    params.push(fields.costPerHour);
+  }
+  if (fields.role !== undefined) {
+    sets.push(`role = $${idx++}`);
+    params.push(fields.role);
+  }
+
+  if (sets.length === 0) return null;
+
+  params.push(id);
+  const { rows } = await exec.query<UpdatedUserRowDb>(
+    `UPDATE users SET ${sets.join(', ')}
+       WHERE id = $${idx}
+   RETURNING id, name, username, role,
+             avatar_initials AS "avatarInitials",
+             cost_per_hour AS "costPerHour",
+             is_disabled AS "isDisabled",
+             employee_type AS "employeeType"`,
+    params,
+  );
+  return rows[0] ? mapUpdatedUserRow(rows[0]) : null;
+};
+
+export const addUserRole = async (
+  userId: string,
+  roleId: string,
+  exec: QueryExecutor = pool,
+): Promise<void> => {
+  await exec.query(
+    `INSERT INTO user_roles (user_id, role_id) VALUES ($1, $2) ON CONFLICT DO NOTHING`,
+    [userId, roleId],
+  );
+};
+
+export const clearUserRoles = async (userId: string, exec: QueryExecutor = pool): Promise<void> => {
+  await exec.query(`DELETE FROM user_roles WHERE user_id = $1`, [userId]);
+};
+
+export const replaceUserRoles = async (
+  userId: string,
+  roleIds: string[],
+  exec: QueryExecutor = pool,
+): Promise<void> => {
+  await exec.query(`DELETE FROM user_roles WHERE user_id = $1`, [userId]);
+  if (roleIds.length === 0) return;
+
+  const params: unknown[] = [];
+  for (const roleId of roleIds) params.push(userId, roleId);
+  const placeholders = buildBulkInsertPlaceholders(roleIds.length, 2);
+  await exec.query(
+    `INSERT INTO user_roles (user_id, role_id) VALUES ${placeholders} ON CONFLICT DO NOTHING`,
+    params,
+  );
+};
+
+export const setPrimaryRole = async (
+  userId: string,
+  roleId: string,
+  exec: QueryExecutor = pool,
+): Promise<void> => {
+  await exec.query(`UPDATE users SET role = $1 WHERE id = $2`, [roleId, userId]);
+};
+
+export const getUserRoleIds = async (
+  userId: string,
+  exec: QueryExecutor = pool,
+): Promise<string[]> => {
+  const { rows } = await exec.query<{ roleId: string }>(
+    `SELECT role_id AS "roleId" FROM user_roles WHERE user_id = $1`,
+    [userId],
+  );
+  return rows.map((r) => r.roleId);
+};
+
+export const canManageUser = async (
+  targetUserId: string,
+  managerUserId: string,
+  exec: QueryExecutor = pool,
+): Promise<boolean> => {
+  const { rows } = await exec.query(
+    `SELECT 1
+       FROM user_work_units uw
+       JOIN work_unit_managers wum ON uw.work_unit_id = wum.work_unit_id
+      WHERE uw.user_id = $1 AND wum.user_id = $2
+      LIMIT 1`,
+    [targetUserId, managerUserId],
+  );
+  return rows.length > 0;
+};
+
+export const getAssignments = async (
+  userId: string,
+  exec: QueryExecutor = pool,
+): Promise<UserAssignments> => {
+  const [clientsRes, projectsRes, tasksRes] = await Promise.all([
+    exec.query<{ clientId: string }>(
+      `SELECT client_id AS "clientId" FROM user_clients WHERE user_id = $1`,
+      [userId],
+    ),
+    exec.query<{ projectId: string }>(
+      `SELECT project_id AS "projectId" FROM user_projects WHERE user_id = $1`,
+      [userId],
+    ),
+    exec.query<{ taskId: string }>(
+      `SELECT task_id AS "taskId" FROM user_tasks WHERE user_id = $1`,
+      [userId],
+    ),
+  ]);
+  return {
+    clientIds: clientsRes.rows.map((r) => r.clientId),
+    projectIds: projectsRes.rows.map((r) => r.projectId),
+    taskIds: tasksRes.rows.map((r) => r.taskId),
+  };
+};
+
+type AssignmentTable = {
+  table: 'user_clients' | 'user_projects' | 'user_tasks';
+  column: 'client_id' | 'project_id' | 'task_id';
+};
+
+const ASSIGNMENT_TABLES = {
+  clients: { table: 'user_clients', column: 'client_id' },
+  projects: { table: 'user_projects', column: 'project_id' },
+  tasks: { table: 'user_tasks', column: 'task_id' },
+} as const satisfies Record<'clients' | 'projects' | 'tasks', AssignmentTable>;
+
+const replaceAssignments = async (
+  spec: AssignmentTable,
+  userId: string,
+  ids: string[],
+  source: AssignmentSource,
+  exec: QueryExecutor,
+): Promise<void> => {
+  await exec.query(`DELETE FROM ${spec.table} WHERE user_id = $1`, [userId]);
+  if (ids.length === 0) return;
+
+  const params: unknown[] = [];
+  for (const id of ids) params.push(userId, id, source);
+  const placeholders = buildBulkInsertPlaceholders(ids.length, 3);
+  await exec.query(
+    `INSERT INTO ${spec.table} (user_id, ${spec.column}, assignment_source)
+     VALUES ${placeholders}
+     ON CONFLICT DO NOTHING`,
+    params,
+  );
+};
+
+export const replaceUserClients = (
+  userId: string,
+  clientIds: string[],
+  source: AssignmentSource,
+  exec: QueryExecutor = pool,
+): Promise<void> => replaceAssignments(ASSIGNMENT_TABLES.clients, userId, clientIds, source, exec);
+
+export const replaceUserProjects = (
+  userId: string,
+  projectIds: string[],
+  source: AssignmentSource,
+  exec: QueryExecutor = pool,
+): Promise<void> =>
+  replaceAssignments(ASSIGNMENT_TABLES.projects, userId, projectIds, source, exec);
+
+export const replaceUserTasks = (
+  userId: string,
+  taskIds: string[],
+  source: AssignmentSource,
+  exec: QueryExecutor = pool,
+): Promise<void> => replaceAssignments(ASSIGNMENT_TABLES.tasks, userId, taskIds, source, exec);
+
+export const clearProjectCascadeAssignments = async (
+  userId: string,
+  exec: QueryExecutor = pool,
+): Promise<void> => {
+  await exec.query(
+    `DELETE FROM user_clients WHERE user_id = $1 AND assignment_source = 'project_cascade'`,
+    [userId],
+  );
+};
+
+export const applyProjectCascadeToClients = async (
+  userId: string,
+  exec: QueryExecutor = pool,
+): Promise<void> => {
+  await exec.query(
+    `INSERT INTO user_clients (user_id, client_id, assignment_source)
+     SELECT $1, p.client_id, 'project_cascade'
+       FROM user_projects up
+       JOIN projects p ON up.project_id = p.id
+      WHERE up.user_id = $1
+     ON CONFLICT (user_id, client_id) DO NOTHING`,
+    [userId],
   );
 };

--- a/server/routes/products.ts
+++ b/server/routes/products.ts
@@ -1,6 +1,8 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
-import { query, withTransaction } from '../db/index.ts';
+import { withTransaction } from '../db/index.ts';
 import { authenticateToken, requireAnyPermission } from '../middleware/auth.ts';
+import * as productsRepo from '../repositories/productsRepo.ts';
+import * as suppliersRepo from '../repositories/suppliersRepo.ts';
 import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
 import { logAudit } from '../utils/audit.ts';
 import { generatePrefixedId } from '../utils/order-ids.ts';
@@ -42,13 +44,6 @@ const productSchema = {
   required: ['id', 'name', 'productCode', 'costo', 'molPercentage', 'costUnit', 'type'],
 } as const;
 
-function mapProductRow(row: Record<string, unknown>) {
-  return {
-    ...row,
-    createdAt: row.createdAt ? new Date(row.createdAt as string).getTime() : null,
-  };
-}
-
 const productCreateBodySchema = {
   type: 'object',
   properties: {
@@ -83,42 +78,26 @@ const productUpdateBodySchema = {
   },
 } as const;
 
-const getCostUnitForType = async (typeName: string): Promise<'unit' | 'hours'> => {
-  const result = await query('SELECT cost_unit FROM product_types WHERE name = $1', [typeName]);
-  if (result.rows.length > 0) {
-    return result.rows[0].cost_unit;
-  }
-  // Default fallback for backward compatibility or orphaned types
-  return typeName === 'service' || typeName === 'consulting' ? 'hours' : 'unit';
-};
-
-// Helper to validate that a type exists in product_types table
+// Validates `typeName` is a non-empty string that matches a registered product_type row.
+// Returns the row's costUnit so callers don't need a follow-up lookup.
 const requireValidType = async (
   typeName: unknown,
-): Promise<{ ok: true; value: string } | { ok: false; message: string }> => {
-  if (typeName === undefined || typeName === null || typeName === '') {
-    return { ok: false, message: 'type is required' };
-  }
-  if (typeof typeName !== 'string') {
-    return { ok: false, message: 'type must be a string' };
-  }
-  const trimmed = typeName.trim();
-  if (trimmed.length === 0) {
-    return { ok: false, message: 'type is required' };
-  }
-  // Check if type exists in product_types
-  const result = await query('SELECT 1 FROM product_types WHERE name = $1', [trimmed]);
-  if (result.rows.length === 0) {
+): Promise<
+  { ok: true; value: string; costUnit: productsRepo.CostUnit } | { ok: false; message: string }
+> => {
+  const r = requireNonEmptyString(typeName, 'type');
+  if (!r.ok) return r;
+  const found = await productsRepo.findProductTypeByName(r.value);
+  if (!found) {
     return {
       ok: false,
-      message: `Invalid type "${trimmed}". Type must be a registered product type.`,
+      message: `Invalid type "${r.value}". Type must be a registered product type.`,
     };
   }
-  return { ok: true, value: trimmed };
+  return { ok: true, value: r.value, costUnit: found.costUnit };
 };
 
 export default async function (fastify: FastifyInstance, _opts: unknown) {
-  // All product routes require authentication
   fastify.addHook('onRequest', authenticateToken);
 
   // GET / - List all products
@@ -145,13 +124,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       },
     },
     async (_request: FastifyRequest, _reply: FastifyReply) => {
-      const result = await query(
-        `SELECT p.id, p.name, p.product_code as "productCode", p.created_at as "createdAt", p.description, p.costo, p.mol_percentage as "molPercentage", p.cost_unit as "costUnit", p.category, p.subcategory, p.type, p.supplier_id as "supplierId", s.name as "supplierName", p.is_disabled as "isDisabled"
-         FROM products p 
-         LEFT JOIN suppliers s ON p.supplier_id = s.id 
-         ORDER BY p.name ASC`,
-      );
-      return result.rows.map(mapProductRow);
+      return await productsRepo.listAllProducts();
     },
   );
 
@@ -198,19 +171,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const nameResult = requireNonEmptyString(name, 'name');
       if (!nameResult.ok) return badRequest(reply, nameResult.message);
 
-      // check name uniqueness
-      const existingName = await query('SELECT id FROM products WHERE LOWER(name) = LOWER($1)', [
-        nameResult.value,
-      ]);
-      if (existingName.rows.length > 0) {
-        return badRequest(reply, 'Product name must be unique');
-      }
-
-      // Validate product code
       const productCodeResult = requireNonEmptyString(productCode, 'productCode');
       if (!productCodeResult.ok) return badRequest(reply, productCodeResult.message);
 
-      // Check product code format (alphanumeric, underscores, hyphens only)
       if (!/^[a-zA-Z0-9_-]+$/.test(productCodeResult.value)) {
         return badRequest(
           reply,
@@ -218,13 +181,12 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         );
       }
 
-      // Check product code uniqueness
-      const existingCode = await query('SELECT id FROM products WHERE product_code = $1', [
-        productCodeResult.value,
+      const [nameTaken, codeTaken] = await Promise.all([
+        productsRepo.existsProductByName(nameResult.value, null),
+        productsRepo.existsProductByCode(productCodeResult.value, null),
       ]);
-      if (existingCode.rows.length > 0) {
-        return badRequest(reply, 'Product code must be unique');
-      }
+      if (nameTaken) return badRequest(reply, 'Product name must be unique');
+      if (codeTaken) return badRequest(reply, 'Product code must be unique');
 
       if (costo === undefined || costo === null || costo === '') {
         return badRequest(reply, 'costo is required');
@@ -244,50 +206,34 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       if (type === undefined || type === null || type === '') {
         return badRequest(reply, 'type is required');
       }
-      // Validate type exists in product_types table
       const typeResult = await requireValidType(type);
       if (!typeResult.ok) return badRequest(reply, typeResult.message);
 
       // Internal products always derive their unit from type.
       // External products keep their explicitly configured unit.
-      let expectedCostUnit: string;
+      let expectedCostUnit: productsRepo.CostUnit = typeResult.costUnit;
       if (supplierId) {
-        const costUnitResult = validateEnum(costUnit, ['unit', 'hours'], 'costUnit');
-        expectedCostUnit = costUnitResult.ok
-          ? costUnitResult.value
-          : await getCostUnitForType(typeResult.value);
-      } else {
-        expectedCostUnit = await getCostUnitForType(typeResult.value);
+        const costUnitResult = validateEnum(costUnit, ['unit', 'hours'] as const, 'costUnit');
+        if (costUnitResult.ok) expectedCostUnit = costUnitResult.value;
       }
 
-      const id = 'p-' + Date.now();
-      const result = await query(
-        `INSERT INTO products (id, name, product_code, description, costo, mol_percentage, cost_unit, category, subcategory, type, supplier_id) 
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) 
-             RETURNING id, name, product_code as "productCode", created_at as "createdAt", description, costo, mol_percentage as "molPercentage", cost_unit as "costUnit", category, subcategory, type, supplier_id as "supplierId"`,
-        [
-          id,
-          nameResult.value,
-          productCodeResult.value,
-          description || null,
-          costoResult.value,
-          molPercentageResult.value,
-          expectedCostUnit,
-          category,
-          subcategory,
-          typeResult.value,
-          supplierId || null,
-        ],
-      );
+      const id = `p-${Date.now()}`;
+      const created = await productsRepo.insertProduct({
+        id,
+        name: nameResult.value,
+        productCode: productCodeResult.value,
+        description: (description as string | null) || null,
+        costo: costoResult.value,
+        molPercentage: molPercentageResult.value,
+        costUnit: expectedCostUnit,
+        category: (category as string | null) || null,
+        subcategory: (subcategory as string | null) || null,
+        type: typeResult.value,
+        supplierId: (supplierId as string | null) || null,
+      });
 
-      // If supplier was assigned, fetch supplier name
       if (supplierId) {
-        const supplierResult = await query('SELECT name FROM suppliers WHERE id = $1', [
-          supplierId,
-        ]);
-        if (supplierResult.rows.length > 0) {
-          result.rows[0].supplierName = supplierResult.rows[0].name;
-        }
+        created.supplierName = await suppliersRepo.findNameById(supplierId as string);
       }
 
       await logAudit({
@@ -296,11 +242,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         entityType: 'product',
         entityId: id,
         details: {
-          targetLabel: result.rows[0].name as string,
-          secondaryLabel: result.rows[0].productCode as string,
+          targetLabel: created.name,
+          secondaryLabel: created.productCode,
         },
       });
-      return reply.code(201).send(mapProductRow(result.rows[0]));
+      return reply.code(201).send(created);
     },
   );
 
@@ -338,67 +284,53 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
 
-      const fields: string[] = [];
-      const values: unknown[] = [];
-      let paramIndex = 1;
+      const fields: productsRepo.ProductUpdateFields = {};
 
-      // Name
+      let validatedName: string | null = null;
       if (body.name !== undefined) {
-        const nameResult = requireNonEmptyString(body.name, 'name'); // name cannot be empty for update if provided
+        const nameResult = requireNonEmptyString(body.name, 'name');
         if (!nameResult.ok) return badRequest(reply, nameResult.message);
-
-        // check name uniqueness (exclude current product)
-        const existingName = await query(
-          'SELECT id FROM products WHERE LOWER(name) = LOWER($1) AND id != $2',
-          [nameResult.value, idResult.value],
-        );
-        if (existingName.rows.length > 0) {
-          return badRequest(reply, 'Product name must be unique');
-        }
-        fields.push(`name = $${paramIndex++}`);
-        values.push(nameResult.value);
+        validatedName = nameResult.value;
       }
 
-      // Product Code
+      let validatedProductCode: string | null = null;
       if (body.productCode !== undefined) {
         const productCodeResult = requireNonEmptyString(body.productCode, 'productCode');
         if (!productCodeResult.ok) return badRequest(reply, productCodeResult.message);
 
-        // Check product code format (alphanumeric, underscores, hyphens only)
         if (!/^[a-zA-Z0-9_-]+$/.test(productCodeResult.value)) {
           return badRequest(
             reply,
             'Product code can only contain letters, numbers, underscores, and hyphens',
           );
         }
-
-        // Check product code uniqueness (exclude current product)
-        const existingCode = await query(
-          'SELECT id FROM products WHERE product_code = $1 AND id != $2',
-          [productCodeResult.value, idResult.value],
-        );
-        if (existingCode.rows.length > 0) {
-          return badRequest(reply, 'Product code must be unique');
-        }
-        fields.push(`product_code = $${paramIndex++}`);
-        values.push(productCodeResult.value);
+        validatedProductCode = productCodeResult.value;
       }
 
-      // Description (nullable)
+      const [nameTaken, codeTaken] = await Promise.all([
+        validatedName !== null
+          ? productsRepo.existsProductByName(validatedName, idResult.value)
+          : Promise.resolve(false),
+        validatedProductCode !== null
+          ? productsRepo.existsProductByCode(validatedProductCode, idResult.value)
+          : Promise.resolve(false),
+      ]);
+      if (nameTaken) return badRequest(reply, 'Product name must be unique');
+      if (codeTaken) return badRequest(reply, 'Product code must be unique');
+
+      if (validatedName !== null) fields.name = validatedName;
+      if (validatedProductCode !== null) fields.productCode = validatedProductCode;
+
       if (body.description !== undefined) {
-        fields.push(`description = $${paramIndex++}`);
-        values.push(body.description || null);
+        fields.description = (body.description as string | null) || null;
       }
 
-      // Costo
       if (body.costo !== undefined) {
         const costoResult = parseLocalizedNonNegativeNumber(body.costo, 'costo');
         if (!costoResult.ok) return badRequest(reply, costoResult.message);
-        fields.push(`costo = $${paramIndex++}`);
-        values.push(costoResult.value);
+        fields.costo = costoResult.value;
       }
 
-      // Mol Percentage
       if (body.molPercentage !== undefined) {
         const molPercentageResult = parseLocalizedNonNegativeNumber(
           body.molPercentage,
@@ -408,127 +340,83 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         if (molPercentageResult.value <= 0 || molPercentageResult.value >= 100) {
           return badRequest(reply, 'molPercentage must be greater than 0 and less than 100');
         }
-        fields.push(`mol_percentage = $${paramIndex++}`);
-        values.push(molPercentageResult.value);
+        fields.molPercentage = molPercentageResult.value;
       }
 
-      // Get current product info to determine if internal or external
-      const currentProductQuery = await query(
-        'SELECT type, supplier_id, category FROM products WHERE id = $1',
-        [idResult.value],
-      );
-      const currentProduct = currentProductQuery.rows[0] || {
-        type: null,
-        supplier_id: null,
-        category: null,
-      };
+      // currentProduct is only needed when we have to recompute cost_unit or default
+      // supplier-related fields. For pure name/productCode/description/costo/molPercentage/
+      // isDisabled updates, the row's existence is implicitly checked by updateProductDynamic.
+      const needsCurrentProduct =
+        body.type !== undefined ||
+        body.category !== undefined ||
+        body.supplierId !== undefined ||
+        body.costUnit !== undefined;
 
-      // Type - when type changes, handle costUnit appropriately
-      let updatedType = currentProduct.type;
-      const updatedSupplierId =
-        body.supplierId !== undefined
-          ? body.supplierId
-            ? body.supplierId
-            : null
-          : currentProduct.supplier_id;
+      let updatedType: string | null = null;
+      let typeCostUnit: productsRepo.CostUnit | null = null;
+      let updatedSupplierId: string | null = null;
+
+      if (needsCurrentProduct) {
+        const currentProduct = await productsRepo.findProductCoreById(idResult.value);
+        if (!currentProduct) {
+          return reply.code(404).send({ error: 'Product not found' });
+        }
+        updatedType = currentProduct.type;
+        updatedSupplierId = currentProduct.supplierId;
+      }
+
+      if (body.supplierId !== undefined) {
+        updatedSupplierId = body.supplierId ? (body.supplierId as string) : null;
+        fields.supplierId = updatedSupplierId;
+      }
 
       if (body.type !== undefined) {
         const typeResult = await requireValidType(body.type);
         if (!typeResult.ok) return badRequest(reply, typeResult.message);
-        fields.push(`type = $${paramIndex++}`);
-        values.push(typeResult.value);
+        fields.type = typeResult.value;
         updatedType = typeResult.value;
+        typeCostUnit = typeResult.costUnit;
       }
 
-      // Category update
       if (body.category !== undefined) {
-        fields.push(`category = $${paramIndex++}`);
-        values.push(body.category || null);
+        fields.category = (body.category as string | null) || null;
       }
 
-      // Subcategory update
       if (body.subcategory !== undefined) {
-        fields.push(`subcategory = $${paramIndex++}`);
-        values.push(body.subcategory || null);
+        fields.subcategory = (body.subcategory as string | null) || null;
       }
 
-      // Supplier update (nullable)
-      if (body.supplierId !== undefined) {
-        fields.push(`supplier_id = $${paramIndex++}`);
-        values.push(body.supplierId ? body.supplierId : null);
-      }
-
-      // Internal products always derive their unit from type.
-      // External products keep an explicitly configurable unit.
+      // Internal products always derive their unit from type. External products keep
+      // an explicitly configurable unit.
       const isExternal = updatedSupplierId !== null;
       const costUnitRelevantFieldsChanged =
         body.type !== undefined || body.category !== undefined || body.supplierId !== undefined;
-      let costUnitToSet: string | null = null;
 
-      if (!isExternal && costUnitRelevantFieldsChanged) {
-        costUnitToSet = await getCostUnitForType(updatedType);
-        fields.push(`cost_unit = $${paramIndex++}`);
-        values.push(costUnitToSet);
+      if (!isExternal && costUnitRelevantFieldsChanged && updatedType) {
+        fields.costUnit = typeCostUnit ?? (await productsRepo.getCostUnitForType(updatedType));
       } else if (isExternal && body.costUnit !== undefined) {
-        // External product: accept costUnit from request body
-        const costUnitResult = validateEnum(body.costUnit, ['unit', 'hours'], 'costUnit');
+        const costUnitResult = validateEnum(body.costUnit, ['unit', 'hours'] as const, 'costUnit');
         if (!costUnitResult.ok) return badRequest(reply, costUnitResult.message);
-        fields.push(`cost_unit = $${paramIndex++}`);
-        values.push(costUnitResult.value);
+        fields.costUnit = costUnitResult.value;
       }
 
-      // Is Disabled
       if (body.isDisabled !== undefined) {
-        fields.push(`is_disabled = $${paramIndex++}`);
-        values.push(parseBoolean(body.isDisabled));
+        fields.isDisabled = parseBoolean(body.isDisabled);
       }
 
-      if (fields.length === 0) {
-        // No updates
-        const result = await query(
-          `SELECT id, name, product_code as "productCode", created_at as "createdAt", description, costo, mol_percentage as "molPercentage", cost_unit as "costUnit", category, subcategory, type, is_disabled as "isDisabled", supplier_id as "supplierId"
-                 FROM products WHERE id = $1`,
-          [idResult.value],
-        );
-        if (result.rows.length === 0) return reply.code(404).send({ error: 'Product not found' });
+      const product =
+        Object.keys(fields).length === 0
+          ? await productsRepo.findProductById(idResult.value)
+          : await productsRepo.updateProductDynamic(idResult.value, fields);
 
-        // Populate supplier name if needed
-        if (result.rows[0].supplierId) {
-          const supplierResult = await query('SELECT name FROM suppliers WHERE id = $1', [
-            result.rows[0].supplierId,
-          ]);
-          if (supplierResult.rows.length > 0) {
-            result.rows[0].supplierName = supplierResult.rows[0].name;
-          }
-        }
-        return mapProductRow(result.rows[0]);
-      }
-
-      values.push(idResult.value); // Add ID as last parameter
-      const queryText = `
-            UPDATE products 
-            SET ${fields.join(', ')}
-            WHERE id = $${paramIndex}
-            RETURNING id, name, product_code as "productCode", created_at as "createdAt", description, costo, mol_percentage as "molPercentage", cost_unit as "costUnit", category, subcategory, type, is_disabled as "isDisabled", supplier_id as "supplierId"
-        `;
-
-      const result = await query(queryText, values);
-
-      if (result.rows.length === 0) {
+      if (!product) {
         return reply.code(404).send({ error: 'Product not found' });
       }
 
-      // If supplier was assigned, fetch supplier name
-      if (result.rows[0].supplierId) {
-        const supplierResult = await query('SELECT name FROM suppliers WHERE id = $1', [
-          result.rows[0].supplierId,
-        ]);
-        if (supplierResult.rows.length > 0) {
-          result.rows[0].supplierName = supplierResult.rows[0].name;
-        }
+      if (product.supplierId) {
+        product.supplierName = await suppliersRepo.findNameById(product.supplierId);
       }
 
-      const isDisabledChanged = body.isDisabled !== undefined;
       const changedFields = [
         body.name !== undefined ? 'name' : null,
         body.productCode !== undefined ? 'productCode' : null,
@@ -539,11 +427,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         body.subcategory !== undefined ? 'subcategory' : null,
         body.type !== undefined ? 'type' : null,
         body.costUnit !== undefined ? 'costUnit' : null,
-        isDisabledChanged ? 'isDisabled' : null,
+        body.isDisabled !== undefined ? 'isDisabled' : null,
         body.supplierId !== undefined ? 'supplierId' : null,
       ].filter((field): field is string => field !== null);
 
-      // Determine specific action based on what changed
       let action = 'product.updated';
       if (changedFields.length === 1 && changedFields[0] === 'isDisabled') {
         action = body.isDisabled ? 'product.disabled' : 'product.enabled';
@@ -555,11 +442,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         entityType: 'product',
         entityId: idResult.value,
         details: {
-          targetLabel: result.rows[0].name as string,
-          secondaryLabel: result.rows[0].productCode as string,
+          targetLabel: product.name,
+          secondaryLabel: product.productCode,
         },
       });
-      return mapProductRow(result.rows[0]);
+      return product;
     },
   );
 
@@ -583,12 +470,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
 
-      const result = await query(
-        'DELETE FROM products WHERE id = $1 RETURNING id, name, product_code as "productCode"',
-        [idResult.value],
-      );
+      const deleted = await productsRepo.deleteProductById(idResult.value);
 
-      if (result.rows.length === 0) {
+      if (!deleted) {
         return reply.code(404).send({ error: 'Product not found' });
       }
 
@@ -598,19 +482,14 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         entityType: 'product',
         entityId: idResult.value,
         details: {
-          targetLabel: result.rows[0].name as string,
-          secondaryLabel: result.rows[0].productCode as string,
+          targetLabel: deleted.name,
+          secondaryLabel: deleted.productCode,
         },
       });
       return reply.code(204).send();
     },
   );
 
-  // ============================================
-  // Internal Product Categories Endpoints
-  // ============================================
-
-  // Category schema
   const categorySchema = {
     type: 'object',
     properties: {
@@ -626,7 +505,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
     required: ['id', 'name', 'type', 'costUnit', 'hasLinkedProducts'],
   } as const;
 
-  // Subcategory schema
   const subcategorySchema = {
     type: 'object',
     properties: {
@@ -636,54 +514,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
     },
     required: ['name', 'productCount', 'hasLinkedProducts'],
   } as const;
-
-  // Helper: Check if internal products by category/subcategory are linked to offers/orders
-  async function checkProductsLinkedToTransactions(
-    category: string,
-    type: string,
-    subcategory?: string,
-  ): Promise<{ linked: boolean; count: number }> {
-    const subcategoryCondition = subcategory !== undefined ? `AND subcategory = $3` : '';
-    const params = subcategory !== undefined ? [category, type, subcategory] : [category, type];
-
-    // Find all matching internal product IDs
-    const productResult = await query(
-      `SELECT id FROM products 
-       WHERE category = $1 
-         AND type = $2 
-         AND supplier_id IS NULL
-         ${subcategoryCondition}`,
-      params,
-    );
-
-    if (productResult.rows.length === 0) {
-      return { linked: false, count: 0 };
-    }
-
-    const productIds = productResult.rows.map((r) => r.id);
-
-    // Check all tables that reference products
-    const tables = [
-      { name: 'quote_items', column: 'product_id' },
-      { name: 'customer_offer_items', column: 'product_id' },
-      { name: 'sale_items', column: 'product_id' },
-      { name: 'invoice_items', column: 'product_id' },
-      { name: 'supplier_quote_items', column: 'product_id' },
-      { name: 'supplier_sale_items', column: 'product_id' },
-      { name: 'supplier_invoice_items', column: 'product_id' },
-    ];
-
-    let totalLinks = 0;
-    for (const table of tables) {
-      const checkResult = await query(
-        `SELECT COUNT(*) as count FROM ${table.name} WHERE ${table.column} = ANY($1)`,
-        [productIds],
-      );
-      totalLinks += parseInt(checkResult.rows[0].count, 10);
-    }
-
-    return { linked: totalLinks > 0, count: totalLinks };
-  }
 
   // GET /internal-categories - List internal product categories by type
   fastify.get(
@@ -712,52 +542,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const typeResult = await requireValidType(type);
       if (!typeResult.ok) return badRequest(reply, typeResult.message);
 
-      const result = await query(
-        `SELECT c.id, c.name, c.type,
-                c.cost_unit as "costUnit",
-                c.created_at as "createdAt", c.updated_at as "updatedAt",
-                COALESCE(p.count, 0) as "productCount",
-                COALESCE(lp.has_linked, false) as "hasLinkedProducts"
-         FROM internal_product_categories c
-         LEFT JOIN (
-           SELECT category, COUNT(*) as count
-           FROM products
-           WHERE type = $1 AND supplier_id IS NULL
-           GROUP BY category
-         ) p ON c.name = p.category
-         LEFT JOIN (
-           SELECT pr.category, true as has_linked
-           FROM products pr
-           WHERE pr.type = $1 
-             AND pr.supplier_id IS NULL
-             AND EXISTS (
-               SELECT 1 FROM quote_items qi WHERE qi.product_id = pr.id
-               UNION ALL
-               SELECT 1 FROM customer_offer_items coi WHERE coi.product_id = pr.id
-               UNION ALL
-               SELECT 1 FROM sale_items si WHERE si.product_id = pr.id
-               UNION ALL
-               SELECT 1 FROM invoice_items ii WHERE ii.product_id = pr.id
-               UNION ALL
-               SELECT 1 FROM supplier_quote_items sqi WHERE sqi.product_id = pr.id
-               UNION ALL
-               SELECT 1 FROM supplier_sale_items ssi WHERE ssi.product_id = pr.id
-               UNION ALL
-               SELECT 1 FROM supplier_invoice_items sii WHERE sii.product_id = pr.id
-             )
-           GROUP BY pr.category
-         ) lp ON c.name = lp.category
-         WHERE c.type = $1
-         ORDER BY c.name ASC`,
-        [typeResult.value],
-      );
-
-      // Convert timestamps to numbers for JSON serialization
-      return result.rows.map((row) => ({
-        ...row,
-        createdAt: row.createdAt ? new Date(row.createdAt).getTime() : null,
-        updatedAt: row.updatedAt ? new Date(row.updatedAt).getTime() : null,
-      }));
+      return await productsRepo.listInternalCategoriesByType(typeResult.value);
     },
   );
 
@@ -795,23 +580,22 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const typeResult = await requireValidType(type);
       if (!typeResult.ok) return badRequest(reply, typeResult.message);
 
-      // Check uniqueness within type
-      const existingResult = await query(
-        'SELECT id FROM internal_product_categories WHERE LOWER(name) = LOWER($1) AND type = $2',
-        [nameResult.value, typeResult.value],
-      );
-      if (existingResult.rows.length > 0) {
+      if (
+        await productsRepo.existsInternalCategoryByNameType(
+          nameResult.value,
+          typeResult.value,
+          null,
+        )
+      ) {
         return badRequest(reply, 'Category with this name already exists for this type');
       }
 
       const id = generatePrefixedId('ipc');
-      const costUnit = await getCostUnitForType(typeResult.value);
-      const result = await query(
-        `INSERT INTO internal_product_categories (id, name, type, cost_unit) 
-         VALUES ($1, $2, $3, $4)
-         RETURNING id, name, type, cost_unit as "costUnit", 
-                   created_at as "createdAt", updated_at as "updatedAt"`,
-        [id, nameResult.value, typeResult.value, costUnit],
+      const created = await productsRepo.insertInternalCategory(
+        id,
+        nameResult.value,
+        typeResult.value,
+        typeResult.costUnit,
       );
 
       await logAudit({
@@ -825,13 +609,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         },
       });
 
-      return reply.code(201).send({
-        ...result.rows[0],
-        createdAt: result.rows[0].createdAt ? new Date(result.rows[0].createdAt).getTime() : null,
-        updatedAt: result.rows[0].updatedAt ? new Date(result.rows[0].updatedAt).getTime() : null,
-        productCount: 0,
-        hasLinkedProducts: false,
-      });
+      return reply.code(201).send(created);
     },
   );
 
@@ -863,38 +641,29 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
 
-      // Get current category
-      const currentResult = await query(
-        'SELECT id, name, type FROM internal_product_categories WHERE id = $1',
-        [idResult.value],
-      );
-      if (currentResult.rows.length === 0) {
+      const current = await productsRepo.findInternalCategoryById(idResult.value);
+      if (!current) {
         return reply.code(404).send({ error: 'Category not found' });
       }
-      const current = currentResult.rows[0];
 
       let newName = current.name;
-      const expectedCostUnit = await getCostUnitForType(current.type);
-
-      // Validate name update
       if (body.name !== undefined) {
         const nameResult = requireNonEmptyString(body.name, 'name');
         if (!nameResult.ok) return badRequest(reply, nameResult.message);
         newName = nameResult.value;
       }
 
-      // Check uniqueness if name is changing
-      if (newName !== current.name) {
-        const existingResult = await query(
-          'SELECT id FROM internal_product_categories WHERE LOWER(name) = LOWER($1) AND type = $2 AND id != $3',
-          [newName, current.type, idResult.value],
-        );
-        if (existingResult.rows.length > 0) {
+      const isRename = newName !== current.name;
+      let expectedCostUnit: productsRepo.CostUnit;
+      if (isRename) {
+        const [costUnit, nameTaken, linkedCheck] = await Promise.all([
+          productsRepo.getCostUnitForType(current.type),
+          productsRepo.existsInternalCategoryByNameType(newName, current.type, idResult.value),
+          productsRepo.checkProductsLinkedToTransactions(current.name, current.type, undefined),
+        ]);
+        if (nameTaken) {
           return badRequest(reply, 'Category with this name already exists for this type');
         }
-
-        // Check for linked transactions BEFORE any updates
-        const linkedCheck = await checkProductsLinkedToTransactions(current.name, current.type);
         if (linkedCheck.linked) {
           return reply.code(409).send({
             error: 'Cannot rename category',
@@ -902,28 +671,33 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
             linkedCount: linkedCheck.count,
           });
         }
+        expectedCostUnit = costUnit;
+      } else {
+        expectedCostUnit = await productsRepo.getCostUnitForType(current.type);
       }
 
-      // Update category and products atomically
-      const updateResult = await withTransaction(async (tx) => {
-        const result = await tx.query(
-          `UPDATE internal_product_categories
-           SET name = $1, cost_unit = $2, updated_at = CURRENT_TIMESTAMP
-           WHERE id = $3
-           RETURNING id, name, type, cost_unit as "costUnit",
-                      created_at as "createdAt", updated_at as "updatedAt"`,
-          [newName, expectedCostUnit, idResult.value],
+      const updated = await withTransaction(async (tx) => {
+        const row = await productsRepo.updateInternalCategoryFields(
+          idResult.value,
+          newName,
+          expectedCostUnit,
+          tx,
         );
-
-        if (newName !== current.name) {
-          await tx.query(
-            'UPDATE products SET category = $1, cost_unit = $2 WHERE category = $3 AND type = $4 AND supplier_id IS NULL',
-            [newName, expectedCostUnit, current.name, current.type],
+        if (isRename) {
+          await productsRepo.propagateCategoryNameToProducts(
+            current.name,
+            newName,
+            current.type,
+            expectedCostUnit,
+            tx,
           );
         }
-
-        return result;
+        return row;
       });
+
+      if (!updated) {
+        return reply.code(404).send({ error: 'Category not found' });
+      }
 
       await logAudit({
         request,
@@ -936,21 +710,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         },
       });
 
-      // Get updated product count
-      const countResult = await query(
-        'SELECT COUNT(*) as count FROM products WHERE category = $1 AND type = $2 AND supplier_id IS NULL',
-        [newName, current.type],
-      );
+      const productCount = await productsRepo.countProductsForCategory(newName, current.type);
 
       return {
-        ...updateResult.rows[0],
-        createdAt: updateResult.rows[0].createdAt
-          ? new Date(updateResult.rows[0].createdAt).getTime()
-          : null,
-        updatedAt: updateResult.rows[0].updatedAt
-          ? new Date(updateResult.rows[0].updatedAt).getTime()
-          : null,
-        productCount: parseInt(countResult.rows[0].count, 10),
+        ...updated,
+        productCount,
         hasLinkedProducts: false, // Rename only succeeds if no products were linked
       };
     },
@@ -977,32 +741,25 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
 
-      // Get category details before deletion
-      const categoryResult = await query(
-        'SELECT name, type FROM internal_product_categories WHERE id = $1',
-        [idResult.value],
-      );
-      if (categoryResult.rows.length === 0) {
+      const category = await productsRepo.findInternalCategoryById(idResult.value);
+      if (!category) {
         return reply.code(404).send({ error: 'Category not found' });
       }
-      const { name, type } = categoryResult.rows[0];
+      const { name, type } = category;
 
-      // Check if any products are linked to transactions
-      const linkedCheck = await checkProductsLinkedToTransactions(name, type);
+      const linkedCheck = await productsRepo.checkProductsLinkedToTransactions(
+        name,
+        type,
+        undefined,
+      );
       if (linkedCheck.linked) {
         return reply.code(409).send({
           error: `Cannot delete category "${name}" because ${linkedCheck.count} product(s) are linked to offers, orders, or invoices`,
         });
       }
 
-      // Clear category and subcategory from all internal products in this category
-      await query(
-        'UPDATE products SET category = NULL, subcategory = NULL WHERE category = $1 AND type = $2 AND supplier_id IS NULL',
-        [name, type],
-      );
-
-      // Delete the category
-      await query('DELETE FROM internal_product_categories WHERE id = $1', [idResult.value]);
+      await productsRepo.clearProductsCategoryByName(name, type);
+      await productsRepo.deleteInternalCategoryById(idResult.value);
 
       await logAudit({
         request,
@@ -1018,10 +775,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       return reply.code(204).send();
     },
   );
-
-  // ============================================
-  // Internal Product Subcategories Endpoints
-  // ============================================
 
   // GET /internal-subcategories - List internal subcategories by type and category
   fastify.get(
@@ -1054,57 +807,15 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const categoryResult = requireNonEmptyString(category, 'category');
       if (!categoryResult.ok) return badRequest(reply, categoryResult.message);
 
-      // First, get the category id
-      const categoryIdResult = await query(
-        'SELECT id FROM internal_product_categories WHERE name = $1 AND type = $2',
-        [categoryResult.value, typeResult.value],
+      const categoryId = await productsRepo.findCategoryIdByNameAndType(
+        categoryResult.value,
+        typeResult.value,
       );
-      if (categoryIdResult.rows.length === 0) {
+      if (!categoryId) {
         return reply.code(404).send({ error: 'Category not found' });
       }
-      const categoryId = categoryIdResult.rows[0].id;
 
-      // Then get subcategories with product counts and linked status
-      const result = await query(
-        `SELECT s.name, 
-                COALESCE(p.count, 0) as "productCount",
-                COALESCE(lp.has_linked, false) as "hasLinkedProducts"
-         FROM internal_product_subcategories s
-         LEFT JOIN (
-           SELECT subcategory, COUNT(*) as count
-           FROM products
-           WHERE type = $1 AND category = $2 AND supplier_id IS NULL
-           GROUP BY subcategory
-         ) p ON s.name = p.subcategory
-         LEFT JOIN (
-           SELECT pr.subcategory, true as has_linked
-           FROM products pr
-           WHERE pr.type = $1 
-             AND pr.category = $2
-             AND pr.supplier_id IS NULL
-             AND EXISTS (
-               SELECT 1 FROM quote_items qi WHERE qi.product_id = pr.id
-               UNION ALL
-               SELECT 1 FROM customer_offer_items coi WHERE coi.product_id = pr.id
-               UNION ALL
-               SELECT 1 FROM sale_items si WHERE si.product_id = pr.id
-               UNION ALL
-               SELECT 1 FROM invoice_items ii WHERE ii.product_id = pr.id
-               UNION ALL
-               SELECT 1 FROM supplier_quote_items sqi WHERE sqi.product_id = pr.id
-               UNION ALL
-               SELECT 1 FROM supplier_sale_items ssi WHERE ssi.product_id = pr.id
-               UNION ALL
-               SELECT 1 FROM supplier_invoice_items sii WHERE sii.product_id = pr.id
-             )
-           GROUP BY pr.subcategory
-         ) lp ON s.name = lp.subcategory
-         WHERE s.category_id = $3
-         ORDER BY s.name ASC`,
-        [typeResult.value, categoryResult.value, categoryId],
-      );
-
-      return result.rows;
+      return await productsRepo.listInternalSubcategoriesByType(categoryId);
     },
   );
 
@@ -1147,33 +858,25 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const categoryResult = requireNonEmptyString(category, 'category');
       if (!categoryResult.ok) return badRequest(reply, categoryResult.message);
 
-      // Get category id
-      const categoryIdResult = await query(
-        'SELECT id FROM internal_product_categories WHERE name = $1 AND type = $2',
-        [categoryResult.value, typeResult.value],
+      const categoryId = await productsRepo.findCategoryIdByNameAndType(
+        categoryResult.value,
+        typeResult.value,
       );
-      if (categoryIdResult.rows.length === 0) {
+      if (!categoryId) {
         return reply.code(404).send({ error: 'Category not found' });
       }
-      const categoryId = categoryIdResult.rows[0].id;
 
-      // Check if this subcategory already exists for this category
-      const existingResult = await query(
-        'SELECT 1 FROM internal_product_subcategories WHERE category_id = $1 AND LOWER(name) = LOWER($2) LIMIT 1',
-        [categoryId, nameResult.value],
-      );
-
-      if (existingResult.rows.length > 0) {
+      if (
+        await productsRepo.existsInternalSubcategoryByNameInCategory(nameResult.value, categoryId)
+      ) {
         return badRequest(reply, 'Subcategory with this name already exists for this category');
       }
 
-      // Create the subcategory
       const id = generatePrefixedId('ips');
-      const result = await query(
-        `INSERT INTO internal_product_subcategories (id, category_id, name)
-         VALUES ($1, $2, $3)
-         RETURNING name`,
-        [id, categoryId, nameResult.value],
+      const created = await productsRepo.insertInternalSubcategory(
+        id,
+        categoryId,
+        nameResult.value,
       );
 
       await logAudit({
@@ -1188,7 +891,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       });
 
       return reply.code(201).send({
-        name: result.rows[0].name,
+        name: created.name,
         productCount: 0,
         hasLinkedProducts: false,
       });
@@ -1241,29 +944,27 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const categoryResult = requireNonEmptyString(body.category, 'category');
       if (!categoryResult.ok) return badRequest(reply, categoryResult.message);
 
-      // Get category id
-      const categoryIdResult = await query(
-        'SELECT id FROM internal_product_categories WHERE name = $1 AND type = $2',
-        [categoryResult.value, typeResult.value],
+      const categoryId = await productsRepo.findCategoryIdByNameAndType(
+        categoryResult.value,
+        typeResult.value,
       );
-      if (categoryIdResult.rows.length === 0) {
+      if (!categoryId) {
         return reply.code(404).send({ error: 'Category not found' });
       }
-      const categoryId = categoryIdResult.rows[0].id;
 
-      // Check if target subcategory already exists
       if (oldNameResult.value.toLowerCase() !== newNameResult.value.toLowerCase()) {
-        const existingResult = await query(
-          'SELECT 1 FROM internal_product_subcategories WHERE category_id = $1 AND LOWER(name) = LOWER($2) LIMIT 1',
-          [categoryId, newNameResult.value],
-        );
-        if (existingResult.rows.length > 0) {
+        if (
+          await productsRepo.existsInternalSubcategoryByNameInCategory(
+            newNameResult.value,
+            categoryId,
+          )
+        ) {
           return badRequest(reply, 'Subcategory with this name already exists for this category');
         }
       }
 
-      // Check for linked transactions BEFORE any updates
-      const linkedCheck = await checkProductsLinkedToTransactions(
+      // Block rename when products are already linked — preserves historical references.
+      const linkedCheck = await productsRepo.checkProductsLinkedToTransactions(
         categoryResult.value,
         typeResult.value,
         oldNameResult.value,
@@ -1276,55 +977,33 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         });
       }
 
-      // Update subcategory and products atomically
-      let subId: string;
-      let productCount: number;
-      try {
-        const result = await withTransaction(async (tx) => {
-          const subResult = await tx.query(
-            `UPDATE internal_product_subcategories
-             SET name = $1, updated_at = CURRENT_TIMESTAMP
-             WHERE category_id = $2 AND name = $3
-             RETURNING id`,
-            [newNameResult.value, categoryId, oldNameResult.value],
-          );
-          if (subResult.rows.length === 0) {
-            const err = new Error('Subcategory not found') as Error & { statusCode?: number };
-            err.statusCode = 404;
-            throw err;
-          }
+      const result = await withTransaction(async (tx) => {
+        const sub = await productsRepo.updateInternalSubcategoryName(
+          categoryId,
+          oldNameResult.value,
+          newNameResult.value,
+          tx,
+        );
+        if (!sub) return null;
+        const updatedCount = await productsRepo.propagateSubcategoryNameToProducts(
+          oldNameResult.value,
+          newNameResult.value,
+          typeResult.value,
+          categoryResult.value,
+          tx,
+        );
+        return { subId: sub.id, productCount: updatedCount };
+      });
 
-          const updateResult = await tx.query(
-            `UPDATE products
-             SET subcategory = $1
-             WHERE type = $2
-               AND category = $3
-               AND supplier_id IS NULL
-               AND subcategory = $4
-             RETURNING id`,
-            [newNameResult.value, typeResult.value, categoryResult.value, oldNameResult.value],
-          );
-
-          return { subId: subResult.rows[0].id as string, productCount: updateResult.rows.length };
-        });
-        subId = result.subId;
-        productCount = result.productCount;
-      } catch (err: unknown) {
-        if (
-          err instanceof Error &&
-          'statusCode' in err &&
-          (err as Error & { statusCode?: number }).statusCode === 404
-        ) {
-          return reply.code(404).send({ error: err.message });
-        }
-        throw err;
+      if (!result) {
+        return reply.code(404).send({ error: 'Subcategory not found' });
       }
 
       await logAudit({
         request,
         action: 'internal_subcategory.renamed',
         entityType: 'internal_product_subcategory',
-        entityId: subId,
+        entityId: result.subId,
         details: {
           targetLabel: newNameResult.value,
           secondaryLabel: `From: ${oldNameResult.value}`,
@@ -1333,7 +1012,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
 
       return {
         name: newNameResult.value,
-        productCount,
+        productCount: result.productCount,
         hasLinkedProducts: false, // Rename only succeeds if no products were linked to transactions
       };
     },
@@ -1381,18 +1060,15 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const categoryResult = requireNonEmptyString(category, 'category');
       if (!categoryResult.ok) return badRequest(reply, categoryResult.message);
 
-      // Get category id
-      const categoryIdResult = await query(
-        'SELECT id FROM internal_product_categories WHERE name = $1 AND type = $2',
-        [categoryResult.value, typeResult.value],
+      const categoryId = await productsRepo.findCategoryIdByNameAndType(
+        categoryResult.value,
+        typeResult.value,
       );
-      if (categoryIdResult.rows.length === 0) {
+      if (!categoryId) {
         return reply.code(404).send({ error: 'Category not found' });
       }
-      const categoryId = categoryIdResult.rows[0].id;
 
-      // Check if products with this subcategory are linked to transactions
-      const linkedCheck = await checkProductsLinkedToTransactions(
+      const linkedCheck = await productsRepo.checkProductsLinkedToTransactions(
         categoryResult.value,
         typeResult.value,
         nameResult.value,
@@ -1403,25 +1079,17 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         });
       }
 
-      // Clear subcategory from all matching products
-      await query(
-        `UPDATE products 
-         SET subcategory = NULL
-         WHERE type = $1 
-           AND category = $2 
-           AND supplier_id IS NULL
-           AND subcategory = $3`,
-        [typeResult.value, categoryResult.value, nameResult.value],
+      await productsRepo.clearProductsSubcategoryByName(
+        nameResult.value,
+        typeResult.value,
+        categoryResult.value,
       );
 
-      // Delete the subcategory from the table
-      const subResult = await query(
-        `DELETE FROM internal_product_subcategories 
-         WHERE category_id = $1 AND name = $2
-         RETURNING id`,
-        [categoryId, nameResult.value],
+      const subDeleted = await productsRepo.deleteInternalSubcategoryByCategoryAndName(
+        categoryId,
+        nameResult.value,
       );
-      if (subResult.rows.length === 0) {
+      if (!subDeleted) {
         return reply.code(404).send({ error: 'Subcategory not found' });
       }
 
@@ -1429,7 +1097,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         request,
         action: 'internal_subcategory.deleted',
         entityType: 'internal_product_subcategory',
-        entityId: subResult.rows[0].id,
+        entityId: subDeleted.id,
         details: {
           targetLabel: nameResult.value,
           secondaryLabel: categoryResult.value,
@@ -1440,11 +1108,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
     },
   );
 
-  // ============================================
-  // Product Types Endpoints (User-Managed)
-  // ============================================
-
-  // Product Type schema
   const productTypeSchema = {
     type: 'object',
     properties: {
@@ -1474,30 +1137,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       },
     },
     async (_request: FastifyRequest, _reply: FastifyReply) => {
-      const result = await query(
-        `SELECT 
-          t.id,
-          t.name,
-          t.cost_unit as "costUnit",
-          t.created_at as "createdAt",
-          t.updated_at as "updatedAt",
-          COALESCE(p.count, 0) as "productCount",
-          COALESCE(c.count, 0) as "categoryCount"
-         FROM product_types t
-         LEFT JOIN (
-           SELECT type, COUNT(*) as count FROM products GROUP BY type
-         ) p ON t.name = p.type
-         LEFT JOIN (
-           SELECT type, COUNT(*) as count FROM internal_product_categories GROUP BY type
-         ) c ON t.name = c.type
-         ORDER BY t.name ASC`,
-      );
-
-      return result.rows.map((row) => ({
-        ...row,
-        createdAt: row.createdAt ? new Date(row.createdAt).getTime() : null,
-        updatedAt: row.updatedAt ? new Date(row.updatedAt).getTime() : null,
-      }));
+      return await productsRepo.listAllProductTypesWithCounts();
     },
   );
 
@@ -1532,26 +1172,18 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const nameResult = requireNonEmptyString(name, 'name');
       if (!nameResult.ok) return badRequest(reply, nameResult.message);
 
-      // Validate costUnit
-      const costUnitResult = validateEnum(costUnit, ['unit', 'hours'], 'costUnit');
+      const costUnitResult = validateEnum(costUnit, ['unit', 'hours'] as const, 'costUnit');
       if (!costUnitResult.ok) return badRequest(reply, costUnitResult.message);
 
-      // Check uniqueness (case-insensitive)
-      const existingResult = await query(
-        'SELECT id FROM product_types WHERE LOWER(name) = LOWER($1)',
-        [nameResult.value],
-      );
-      if (existingResult.rows.length > 0) {
+      if (await productsRepo.existsProductTypeByName(nameResult.value, null)) {
         return badRequest(reply, 'Product type with this name already exists');
       }
 
       const id = generatePrefixedId('pt');
-      const result = await query(
-        `INSERT INTO product_types (id, name, cost_unit)
-         VALUES ($1, $2, $3)
-         RETURNING id, name, cost_unit as "costUnit",
-                   created_at as "createdAt", updated_at as "updatedAt"`,
-        [id, nameResult.value, costUnitResult.value],
+      const created = await productsRepo.insertProductType(
+        id,
+        nameResult.value,
+        costUnitResult.value,
       );
 
       await logAudit({
@@ -1565,13 +1197,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         },
       });
 
-      return reply.code(201).send({
-        ...result.rows[0],
-        createdAt: result.rows[0].createdAt ? new Date(result.rows[0].createdAt).getTime() : null,
-        updatedAt: result.rows[0].updatedAt ? new Date(result.rows[0].updatedAt).getTime() : null,
-        productCount: 0,
-        categoryCount: 0,
-      });
+      return reply.code(201).send(created);
     },
   );
 
@@ -1604,75 +1230,45 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
 
-      // Get current type
-      const currentResult = await query(
-        'SELECT id, name, cost_unit FROM product_types WHERE id = $1',
-        [idResult.value],
-      );
-      if (currentResult.rows.length === 0) {
+      const current = await productsRepo.findProductTypeById(idResult.value);
+      if (!current) {
         return reply.code(404).send({ error: 'Product type not found' });
       }
-      const current = currentResult.rows[0];
 
       let newName = current.name;
-      let newCostUnit = current.cost_unit;
+      let newCostUnit = current.costUnit;
 
-      // Validate and update name if provided
       if (body.name !== undefined) {
         const nameResult = requireNonEmptyString(body.name, 'name');
         if (!nameResult.ok) return badRequest(reply, nameResult.message);
         newName = nameResult.value;
       }
 
-      // Validate and update costUnit if provided
       if (body.costUnit !== undefined) {
-        const costUnitResult = validateEnum(body.costUnit, ['unit', 'hours'], 'costUnit');
+        const costUnitResult = validateEnum(body.costUnit, ['unit', 'hours'] as const, 'costUnit');
         if (!costUnitResult.ok) return badRequest(reply, costUnitResult.message);
         newCostUnit = costUnitResult.value;
       }
 
-      // Check uniqueness if name is changing (case-insensitive)
       if (newName !== current.name) {
-        const existingResult = await query(
-          'SELECT id FROM product_types WHERE LOWER(name) = LOWER($1) AND id != $2',
-          [newName, idResult.value],
-        );
-        if (existingResult.rows.length > 0) {
+        if (await productsRepo.existsProductTypeByName(newName, idResult.value)) {
           return badRequest(reply, 'Product type with this name already exists');
         }
       }
 
-      // Perform all mutations atomically
-      const updateResult = await withTransaction(async (tx) => {
+      const updated = await withTransaction(async (tx) => {
         if (newName !== current.name) {
-          await tx.query('UPDATE products SET type = $1 WHERE type = $2', [newName, current.name]);
-          await tx.query('UPDATE internal_product_categories SET type = $1 WHERE type = $2', [
-            newName,
-            current.name,
-          ]);
+          await productsRepo.propagateProductTypeName(current.name, newName, tx);
         }
-
-        if (newCostUnit !== current.cost_unit) {
-          await tx.query(
-            'UPDATE products SET cost_unit = $1 WHERE type = $2 AND supplier_id IS NULL',
-            [newCostUnit, newName],
-          );
-          await tx.query('UPDATE internal_product_categories SET cost_unit = $1 WHERE type = $2', [
-            newCostUnit,
-            newName,
-          ]);
+        if (newCostUnit !== current.costUnit) {
+          await productsRepo.propagateProductTypeCostUnit(newName, newCostUnit, tx);
         }
-
-        const result = await tx.query(
-          `UPDATE product_types
-           SET name = $1, cost_unit = $2, updated_at = CURRENT_TIMESTAMP
-           WHERE id = $3
-           RETURNING id, name, cost_unit as "costUnit",
-                     created_at as "createdAt", updated_at as "updatedAt"`,
-          [newName, newCostUnit, idResult.value],
-        );
-        return result;
+        return await productsRepo.updateProductTypeFields(idResult.value, newName, newCostUnit, tx);
       });
+
+      if (!updated) {
+        return reply.code(404).send({ error: 'Product type not found' });
+      }
 
       await logAudit({
         request,
@@ -1685,26 +1281,15 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         },
       });
 
-      // Get updated counts
-      const productCountResult = await query(
-        'SELECT COUNT(*) as count FROM products WHERE type = $1',
-        [newName],
-      );
-      const categoryCountResult = await query(
-        'SELECT COUNT(*) as count FROM internal_product_categories WHERE type = $1',
-        [newName],
-      );
+      const [productCount, categoryCount] = await Promise.all([
+        productsRepo.countProductsForType(newName),
+        productsRepo.countCategoriesForType(newName),
+      ]);
 
       return {
-        ...updateResult.rows[0],
-        createdAt: updateResult.rows[0].createdAt
-          ? new Date(updateResult.rows[0].createdAt).getTime()
-          : null,
-        updatedAt: updateResult.rows[0].updatedAt
-          ? new Date(updateResult.rows[0].updatedAt).getTime()
-          : null,
-        productCount: parseInt(productCountResult.rows[0].count, 10),
-        categoryCount: parseInt(categoryCountResult.rows[0].count, 10),
+        ...updated,
+        productCount,
+        categoryCount,
       };
     },
   );
@@ -1730,43 +1315,29 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
 
-      // Get type details before deletion
-      const typeResult = await query('SELECT name FROM product_types WHERE id = $1', [
-        idResult.value,
-      ]);
-      if (typeResult.rows.length === 0) {
+      const type = await productsRepo.findProductTypeById(idResult.value);
+      if (!type) {
         return reply.code(404).send({ error: 'Product type not found' });
       }
-      const { name } = typeResult.rows[0];
+      const { name } = type;
 
-      // Check if any products use this type
-      const productCountResult = await query(
-        'SELECT COUNT(*) as count FROM products WHERE type = $1',
-        [name],
-      );
-      const productCount = parseInt(productCountResult.rows[0].count, 10);
+      const [productCount, categoryCount] = await Promise.all([
+        productsRepo.countProductsForType(name),
+        productsRepo.countCategoriesForType(name),
+      ]);
 
       if (productCount > 0) {
         return reply.code(409).send({
           error: `Cannot delete type "${name}" because ${productCount} product(s) are using it`,
         });
       }
-
-      // Check if any categories use this type
-      const categoryCountResult = await query(
-        'SELECT COUNT(*) as count FROM internal_product_categories WHERE type = $1',
-        [name],
-      );
-      const categoryCount = parseInt(categoryCountResult.rows[0].count, 10);
-
       if (categoryCount > 0) {
         return reply.code(409).send({
           error: `Cannot delete type "${name}" because ${categoryCount} category(s) are using it`,
         });
       }
 
-      // Delete the type
-      await query('DELETE FROM product_types WHERE id = $1', [idResult.value]);
+      await productsRepo.deleteProductTypeById(idResult.value);
 
       await logAudit({
         request,

--- a/server/routes/users.ts
+++ b/server/routes/users.ts
@@ -576,15 +576,17 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         }
       }
 
-      const settingsUpsert =
-        fields.name !== undefined || validatedEmail !== undefined
-          ? settingsRepo.upsertForUser(idResult.value, {
-              fullName: fields.name ?? null,
-              email: validatedEmail ?? null,
-              language: null,
-            })
-          : Promise.resolve();
-      const [, fullUser] = await Promise.all([settingsUpsert, usersRepo.findById(idResult.value)]);
+      // Settings upsert must complete before findById — findById LEFT JOINs settings to
+      // populate `email`, and parallel reads on different pool connections can observe the
+      // pre-update row under read-committed isolation, returning stale email in the response.
+      if (fields.name !== undefined || validatedEmail !== undefined) {
+        await settingsRepo.upsertForUser(idResult.value, {
+          fullName: fields.name ?? null,
+          email: validatedEmail ?? null,
+          language: null,
+        });
+      }
+      const fullUser = await usersRepo.findById(idResult.value);
       if (!fullUser) {
         return reply.code(404).send({ error: 'User not found' });
       }

--- a/server/routes/users.ts
+++ b/server/routes/users.ts
@@ -1,8 +1,11 @@
 import bcrypt from 'bcryptjs';
 import { randomUUID } from 'crypto';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
-import { query, withTransaction } from '../db/index.ts';
+import { withTransaction } from '../db/index.ts';
 import { authenticateToken, requireAnyPermission, requirePermission } from '../middleware/auth.ts';
+import * as rolesRepo from '../repositories/rolesRepo.ts';
+import * as settingsRepo from '../repositories/settingsRepo.ts';
+import * as usersRepo from '../repositories/usersRepo.ts';
 import {
   messageResponseSchema,
   standardErrorResponses,
@@ -14,6 +17,7 @@ import { isUniqueViolation } from '../utils/db-errors.ts';
 import { computeAvatarInitials } from '../utils/initials.ts';
 import { generatePrefixedId } from '../utils/order-ids.ts';
 import {
+  ADMIN_ROLE_ID,
   requestHasPermission as hasPermission,
   TOP_MANAGER_ROLE_ID,
 } from '../utils/permissions.ts';
@@ -29,7 +33,6 @@ import {
   optionalArrayOfStrings,
   optionalEmail,
   optionalLocalizedNonNegativeNumber,
-  optionalNonEmptyString,
   requireNonEmptyString,
   validateEnum,
 } from '../utils/validation.ts';
@@ -41,8 +44,6 @@ const idParamSchema = {
   },
   required: ['id'],
 } as const;
-
-const ADMIN_ROLE_ID = 'admin';
 
 const userSchema = {
   type: 'object',
@@ -140,38 +141,36 @@ const canViewUserEmails = (request: FastifyRequest) =>
   hasPermission(request, 'administration.user_management_all.view') ||
   hasPermission(request, 'administration.user_management.view');
 
-type UserRow = {
-  id: string;
-  name: string;
-  username: string;
-  email?: string | null;
-  role: string;
-  avatar_initials: string | null;
-  cost_per_hour: string | number | null;
-  is_disabled: boolean | null;
-  employee_type: string | null;
-  has_top_manager_role?: boolean | null;
-  is_admin_only?: boolean | null;
+const canViewAllUsers = (request: FastifyRequest) =>
+  hasPermission(request, 'administration.user_management_all.view') ||
+  hasPermission(request, 'hr.work_units_all.view');
+
+const CREATE_PERM_BY_EMPLOYEE_TYPE: Record<usersRepo.EmployeeType, string> = {
+  app_user: 'administration.user_management.create',
+  internal: 'hr.internal.create',
+  external: 'hr.external.create',
 };
 
-const mapUserResponse = (
-  user: UserRow,
+const UPDATE_PERM_BY_EMPLOYEE_TYPE: Record<usersRepo.EmployeeType, string> = {
+  app_user: 'administration.user_management.update',
+  internal: 'hr.internal.update',
+  external: 'hr.external.update',
+};
+
+const DELETE_PERM_BY_EMPLOYEE_TYPE: Record<usersRepo.EmployeeType, string> = {
+  app_user: 'administration.user_management.delete',
+  internal: 'hr.internal.delete',
+  external: 'hr.external.delete',
+};
+
+const maskUserResponse = (
+  user: usersRepo.UserListRow,
   canViewCosts: boolean,
   canRevealUserEmails: boolean,
-  hasTopManagerRole = Boolean(user.has_top_manager_role),
-  isAdminOnly = Boolean(user.is_admin_only),
 ) => ({
-  id: user.id,
-  name: user.name,
-  username: user.username,
-  email: canRevealUserEmails ? (user.email ?? '') : '',
-  role: user.role,
-  avatarInitials: user.avatar_initials ?? '',
-  costPerHour: canViewCosts ? parseFloat(String(user.cost_per_hour || 0)) : 0,
-  isDisabled: !!user.is_disabled,
-  employeeType: user.employee_type || 'app_user',
-  hasTopManagerRole,
-  isAdminOnly,
+  ...user,
+  email: canRevealUserEmails ? user.email : '',
+  costPerHour: canViewCosts ? user.costPerHour : 0,
 });
 
 export default async function (fastify: FastifyInstance, _opts: unknown) {
@@ -205,9 +204,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
     async (request: FastifyRequest, reply: FastifyReply) => {
       if (!assertAuthenticated(request, reply)) return;
 
-      const canViewAllUsers =
-        hasPermission(request, 'administration.user_management_all.view') ||
-        hasPermission(request, 'hr.work_units_all.view');
       const canViewUserManagement = hasPermission(request, 'administration.user_management.view');
       const canViewManagedUsers =
         hasPermission(request, 'timesheets.tracker.view') ||
@@ -219,87 +215,15 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const canViewCosts = hasPermission(request, 'hr.costs.view');
       const canRevealUserEmails = canViewUserEmails(request);
 
-      let result: Awaited<ReturnType<typeof query>>;
-      if (canViewAllUsers) {
-        result = await query(
-          `SELECT u.id,
-                  u.name,
-                  u.username,
-                  COALESCE(s.email, '') AS email,
-                  u.role,
-                  u.avatar_initials,
-                  u.cost_per_hour,
-                  u.is_disabled,
-                  u.employee_type,
-                  EXISTS (
-                    SELECT 1
-                    FROM user_roles ur
-                    WHERE ur.user_id = u.id AND ur.role_id = $1
-                  ) AS has_top_manager_role,
-                  (
-                    u.role = $2
-                    AND NOT EXISTS (
-                      SELECT 1
-                      FROM user_roles ur_admin_only
-                      WHERE ur_admin_only.user_id = u.id AND ur_admin_only.role_id <> $2
-                    )
-                  ) AS is_admin_only
-             FROM users u
-             LEFT JOIN settings s ON s.user_id = u.id
-             ORDER BY u.name`,
-          [TOP_MANAGER_ROLE_ID, ADMIN_ROLE_ID],
-        );
-      } else {
-        const conditions: string[] = ['u.id = $1'];
-        if (canViewManagedUsers) {
-          conditions.push('wum.user_id = $1');
-        }
-        if (canViewInternal) {
-          conditions.push("u.employee_type = 'internal'");
-        }
-        if (canViewExternal) {
-          conditions.push("u.employee_type = 'external'");
-        }
+      const users = canViewAllUsers(request)
+        ? await usersRepo.listAllForAdmin()
+        : await usersRepo.listScopedForManager(request.user.id, {
+            canViewManagedUsers,
+            canViewInternal,
+            canViewExternal,
+          });
 
-        result = await query(
-          `SELECT DISTINCT u.id,
-                           u.name,
-                           u.username,
-                           COALESCE(s.email, '') AS email,
-                           u.role,
-                           u.avatar_initials,
-                           u.cost_per_hour,
-                           u.is_disabled,
-                           u.employee_type,
-                           EXISTS (
-                             SELECT 1
-                             FROM user_roles ur
-                             WHERE ur.user_id = u.id AND ur.role_id = $2
-                           ) AS has_top_manager_role,
-                           (
-                             u.role = $3
-                             AND NOT EXISTS (
-                               SELECT 1
-                               FROM user_roles ur_admin_only
-                               WHERE ur_admin_only.user_id = u.id
-                                 AND ur_admin_only.role_id <> $3
-                             )
-                           ) AS is_admin_only
-             FROM users u
-             LEFT JOIN settings s ON s.user_id = u.id
-             LEFT JOIN user_work_units uw ON u.id = uw.user_id
-             LEFT JOIN work_unit_managers wum ON uw.work_unit_id = wum.work_unit_id
-             WHERE (${conditions.join(' OR ')})
-               AND NOT EXISTS (SELECT 1 FROM user_roles ur_tm WHERE ur_tm.user_id = u.id AND ur_tm.role_id = $2)
-             ORDER BY u.name`,
-          [request.user.id, TOP_MANAGER_ROLE_ID, ADMIN_ROLE_ID],
-        );
-      }
-
-      const value = result.rows.map((u) =>
-        mapUserResponse(u as UserRow, canViewCosts, canRevealUserEmails),
-      );
-      return value;
+      return users.map((u) => maskUserResponse(u, canViewCosts, canRevealUserEmails));
     },
   );
 
@@ -336,28 +260,16 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         employeeType?: string;
       };
 
-      // Validate employee type if provided
-      const employeeTypeResult: { ok: true; value: string } | { ok: false; message: string } =
-        employeeType
-          ? validateEnum(employeeType, ['app_user', 'internal', 'external'], 'employeeType')
-          : { ok: true, value: 'app_user' };
+      const employeeTypeResult:
+        | { ok: true; value: usersRepo.EmployeeType }
+        | { ok: false; message: string } = employeeType
+        ? validateEnum(employeeType, ['app_user', 'internal', 'external'] as const, 'employeeType')
+        : { ok: true, value: 'app_user' };
       if (!employeeTypeResult.ok) return badRequest(reply, employeeTypeResult.message);
 
       const effectiveEmployeeType = employeeTypeResult.value;
 
-      const canCreateAppUser = hasPermission(request, 'administration.user_management.create');
-      const canCreateInternal = hasPermission(request, 'hr.internal.create');
-      const canCreateExternal = hasPermission(request, 'hr.external.create');
-
-      if (effectiveEmployeeType === 'app_user' && !canCreateAppUser) {
-        return reply.code(403).send({ error: 'Insufficient permissions' });
-      }
-
-      if (effectiveEmployeeType === 'internal' && !canCreateInternal) {
-        return reply.code(403).send({ error: 'Insufficient permissions' });
-      }
-
-      if (effectiveEmployeeType === 'external' && !canCreateExternal) {
+      if (!hasPermission(request, CREATE_PERM_BY_EMPLOYEE_TYPE[effectiveEmployeeType])) {
         return reply.code(403).send({ error: 'Insufficient permissions' });
       }
 
@@ -375,12 +287,12 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       let roleValue: string;
 
       if (effectiveEmployeeType === 'internal' || effectiveEmployeeType === 'external') {
-        // Internal/external employees: generate dummy username, placeholder password, user role
+        // Internal/external employees never log in: generated username, random unguessable
+        // password, default user role kept only for FK consistency.
         usernameValue = generatePrefixedId('emp');
-        passwordHash = await bcrypt.hash(randomUUID(), 12); // Random unguessable password
-        roleValue = 'user'; // Internal/external employees have user role but cannot login
+        passwordHash = await bcrypt.hash(randomUUID(), 12);
+        roleValue = 'user';
       } else {
-        // App users: require username, password, and role
         const usernameResult = requireNonEmptyString(username, 'username');
         if (!usernameResult.ok) return badRequest(reply, usernameResult.message);
         usernameValue = usernameResult.value;
@@ -393,55 +305,38 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         if (!roleResult.ok) return badRequest(reply, roleResult.message);
         roleValue = roleResult.value;
 
-        const roleCheck = await query('SELECT id FROM roles WHERE id = $1', [roleValue]);
-        if (roleCheck.rows.length === 0) {
-          return badRequest(reply, 'Invalid role');
-        }
-
-        // Check username uniqueness for app users
-        const existingUser = await query('SELECT id FROM users WHERE username = $1', [
-          usernameValue,
+        const [roleExists, usernameTaken] = await Promise.all([
+          rolesRepo.findById(roleValue),
+          usersRepo.existsByUsername(usernameValue),
         ]);
-        if (existingUser.rows.length > 0) {
-          return badRequest(reply, 'Username already exists');
-        }
+        if (!roleExists) return badRequest(reply, 'Invalid role');
+        if (usernameTaken) return badRequest(reply, 'Username already exists');
       }
 
       const avatarInitials = computeAvatarInitials(nameResult.value);
       const id = generatePrefixedId('u');
 
       try {
-        await query(
-          `INSERT INTO users (id, name, username, password_hash, role, avatar_initials, cost_per_hour, is_disabled, employee_type)
-           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
-          [
-            id,
-            nameResult.value,
-            usernameValue,
-            passwordHash,
-            roleValue,
-            avatarInitials,
-            costPerHourResult.value || 0,
-            false,
-            effectiveEmployeeType,
-          ],
-        );
+        await usersRepo.insertUser({
+          id,
+          name: nameResult.value,
+          username: usernameValue,
+          passwordHash,
+          role: roleValue,
+          avatarInitials,
+          costPerHour: costPerHourResult.value || 0,
+          isDisabled: false,
+          employeeType: effectiveEmployeeType,
+        });
 
-        // Keep user_roles in sync with users.role (primary/default role)
-        await query(
-          'INSERT INTO user_roles (user_id, role_id) VALUES ($1, $2) ON CONFLICT DO NOTHING',
-          [id, roleValue],
-        );
+        // Keep user_roles in sync with users.role (primary/default role).
+        await usersRepo.addUserRole(id, roleValue);
 
-        await query(
-          `INSERT INTO settings (user_id, full_name, email)
-           VALUES ($1, $2, $3)
-           ON CONFLICT (user_id) DO UPDATE SET
-             full_name = EXCLUDED.full_name,
-             email = EXCLUDED.email,
-             updated_at = CURRENT_TIMESTAMP`,
-          [id, nameResult.value, emailResult.value || ''],
-        );
+        await settingsRepo.upsertForUser(id, {
+          fullName: nameResult.value,
+          email: emailResult.value || '',
+          language: null,
+        });
 
         if (roleValue === TOP_MANAGER_ROLE_ID) {
           await syncTopManagerAssignmentsForUser(id);
@@ -508,38 +403,18 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         return badRequest(reply, 'Cannot delete your own account');
       }
 
-      // Check the user's employee type
-      const userCheck = await query(
-        'SELECT name, username, employee_type FROM users WHERE id = $1',
-        [id],
-      );
-      if (userCheck.rows.length === 0) {
+      const user = await usersRepo.findCoreById(id);
+      if (!user) {
         return reply.code(404).send({ error: 'User not found' });
       }
 
-      const employeeType = userCheck.rows[0].employee_type || 'app_user';
-
-      if (employeeType === 'app_user') {
-        if (!hasPermission(request, 'administration.user_management.delete')) {
-          return reply.code(403).send({ error: 'Insufficient permissions' });
-        }
+      if (!hasPermission(request, DELETE_PERM_BY_EMPLOYEE_TYPE[user.employeeType])) {
+        return reply.code(403).send({ error: 'Insufficient permissions' });
       }
 
-      if (employeeType === 'internal') {
-        if (!hasPermission(request, 'hr.internal.delete')) {
-          return reply.code(403).send({ error: 'Insufficient permissions' });
-        }
-      }
+      const deleted = await usersRepo.deleteById(id);
 
-      if (employeeType === 'external') {
-        if (!hasPermission(request, 'hr.external.delete')) {
-          return reply.code(403).send({ error: 'Insufficient permissions' });
-        }
-      }
-
-      const result = await query('DELETE FROM users WHERE id = $1 RETURNING id', [id]);
-
-      if (result.rows.length === 0) {
+      if (!deleted) {
         return reply.code(404).send({ error: 'User not found' });
       }
 
@@ -549,8 +424,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         entityType: 'user',
         entityId: id,
         details: {
-          targetLabel: userCheck.rows[0].name as string,
-          secondaryLabel: userCheck.rows[0].username as string,
+          targetLabel: user.name,
+          secondaryLabel: user.username,
         },
       });
       return { message: 'User deleted' };
@@ -592,67 +467,48 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
 
+      const fields: usersRepo.UserUpdateFields = {};
+
       if (name !== undefined) {
-        const nameResult = optionalNonEmptyString(name, 'name');
+        const nameResult = requireNonEmptyString(name, 'name');
         if (!nameResult.ok) return badRequest(reply, nameResult.message);
+        fields.name = nameResult.value;
       }
 
-      if (costPerHour !== undefined) {
+      if (costPerHour !== undefined && hasPermission(request, 'hr.costs.update')) {
         const costPerHourResult = optionalLocalizedNonNegativeNumber(costPerHour, 'costPerHour');
         if (!costPerHourResult.ok) return badRequest(reply, costPerHourResult.message);
+        fields.costPerHour = costPerHourResult.value;
       }
 
+      let validatedEmail: string | null | undefined;
       if (email !== undefined) {
         const emailResult = optionalEmail(email, 'email');
         if (!emailResult.ok) return badRequest(reply, emailResult.message);
+        validatedEmail = emailResult.value;
       }
 
-      const targetUserResult = await query(
-        'SELECT id, name, username, role, employee_type FROM users WHERE id = $1',
-        [idResult.value],
-      );
-      if (targetUserResult.rows.length === 0) {
+      const targetUser = await usersRepo.findCoreById(idResult.value);
+      if (!targetUser) {
         return reply.code(404).send({ error: 'User not found' });
       }
 
-      const targetEmployeeType = targetUserResult.rows[0].employee_type || 'app_user';
-      const currentRole = targetUserResult.rows[0].role as string;
-      const currentName = targetUserResult.rows[0].name as string;
-      const currentUsername = targetUserResult.rows[0].username as string;
+      const targetEmployeeType = targetUser.employeeType;
+      const currentRole = targetUser.role;
+      const currentName = targetUser.name;
+      const currentUsername = targetUser.username;
 
-      if (targetEmployeeType === 'app_user') {
-        if (!hasPermission(request, 'administration.user_management.update')) {
-          return reply.code(403).send({ error: 'Insufficient permissions' });
-        }
-
-        if (
-          !hasPermission(request, 'administration.user_management_all.view') &&
-          idResult.value !== request.user?.id
-        ) {
-          const managedCheck = await query(
-            `SELECT 1
-               FROM user_work_units uw
-               JOIN work_unit_managers wum ON uw.work_unit_id = wum.work_unit_id
-               WHERE uw.user_id = $1 AND wum.user_id = $2
-               LIMIT 1`,
-            [idResult.value, request.user?.id],
-          );
-          if (managedCheck.rows.length === 0) {
-            return reply.code(403).send({ error: 'Insufficient permissions' });
-          }
-        }
+      if (!hasPermission(request, UPDATE_PERM_BY_EMPLOYEE_TYPE[targetEmployeeType])) {
+        return reply.code(403).send({ error: 'Insufficient permissions' });
       }
 
-      if (targetEmployeeType === 'internal') {
-        if (!hasPermission(request, 'hr.internal.update')) {
-          return reply.code(403).send({ error: 'Insufficient permissions' });
-        }
-      }
-
-      if (targetEmployeeType === 'external') {
-        if (!hasPermission(request, 'hr.external.update')) {
-          return reply.code(403).send({ error: 'Insufficient permissions' });
-        }
+      if (
+        targetEmployeeType === 'app_user' &&
+        !hasPermission(request, 'administration.user_management_all.view') &&
+        idResult.value !== request.user?.id &&
+        !(await usersRepo.canManageUser(idResult.value, request.user?.id ?? ''))
+      ) {
+        return reply.code(403).send({ error: 'Insufficient permissions' });
       }
 
       let roleValue: string | null = null;
@@ -664,86 +520,41 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         if (!roleResult.ok) return badRequest(reply, roleResult.message);
         roleValue = roleResult.value;
 
-        const roleCheck = await query('SELECT id FROM roles WHERE id = $1', [roleValue]);
-        if (roleCheck.rows.length === 0) {
+        const roleExists = await rolesRepo.findById(roleValue);
+        if (!roleExists) {
           return badRequest(reply, 'Invalid role');
         }
+        fields.role = roleValue;
       }
 
       if (idResult.value === request.user?.id && isDisabled === true) {
         return badRequest(reply, 'Cannot disable your own account');
       }
 
-      const updates: string[] = [];
-      const values: Array<string | boolean | number | null> = [];
-      let paramIdx = 1;
+      if (isDisabled !== undefined) fields.isDisabled = isDisabled;
 
-      if (name !== undefined) {
-        updates.push(`name = $${paramIdx++}`);
-        values.push((requireNonEmptyString(name, 'name') as { ok: true; value: string }).value);
-      }
+      const hasFieldUpdates = Object.keys(fields).length > 0;
 
-      if (isDisabled !== undefined) {
-        updates.push(`is_disabled = $${paramIdx++}`);
-        values.push(isDisabled);
-      }
-
-      if (costPerHour !== undefined && hasPermission(request, 'hr.costs.update')) {
-        updates.push(`cost_per_hour = $${paramIdx++}`);
-        values.push(
-          (
-            optionalLocalizedNonNegativeNumber(costPerHour, 'costPerHour') as {
-              ok: true;
-              value: number | null;
-            }
-          ).value,
-        );
-      }
-
-      if (role !== undefined) {
-        updates.push(`role = $${paramIdx++}`);
-        values.push(roleValue);
-      }
-
-      if (updates.length === 0 && email === undefined) {
+      if (!hasFieldUpdates && email === undefined) {
         return badRequest(reply, 'No fields to update');
       }
 
-      let result: Awaited<ReturnType<typeof query>>;
-      if (updates.length === 0) {
-        result = await query(
-          `SELECT id, name, username, role, avatar_initials, cost_per_hour, is_disabled, employee_type
-             FROM users
-            WHERE id = $1`,
-          [idResult.value],
-        );
-      } else if (role !== undefined) {
-        values.push(idResult.value);
-        result = await withTransaction(async (tx) => {
-          const updatedResult = await tx.query(
-            `UPDATE users SET ${updates.join(', ')} WHERE id = $${paramIdx} RETURNING id, name, username, role, avatar_initials, cost_per_hour, is_disabled, employee_type`,
-            values,
-          );
-
-          await tx.query('DELETE FROM user_roles WHERE user_id = $1', [idResult.value]);
-          await tx.query(
-            'INSERT INTO user_roles (user_id, role_id) VALUES ($1, $2) ON CONFLICT DO NOTHING',
-            [idResult.value, roleValue],
-          );
-          return updatedResult;
+      if (hasFieldUpdates) {
+        const updatedRow = await withTransaction(async (tx) => {
+          const row = await usersRepo.updateUserDynamic(idResult.value, fields, tx);
+          if (row && roleValue !== null) {
+            await usersRepo.clearUserRoles(idResult.value, tx);
+            await usersRepo.addUserRole(idResult.value, roleValue, tx);
+          }
+          return row;
         });
 
-        await syncTopManagerAssignmentsForUser(idResult.value);
-      } else {
-        values.push(idResult.value);
-        result = await query(
-          `UPDATE users SET ${updates.join(', ')} WHERE id = $${paramIdx} RETURNING id, name, username, role, avatar_initials, cost_per_hour, is_disabled, employee_type`,
-          values,
-        );
-      }
-
-      if (result.rows.length === 0) {
-        return reply.code(404).send({ error: 'User not found' });
+        if (!updatedRow) {
+          return reply.code(404).send({ error: 'User not found' });
+        }
+        if (roleValue !== null) {
+          await syncTopManagerAssignmentsForUser(idResult.value);
+        }
       }
 
       const changedFields = [
@@ -756,7 +567,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         role !== undefined ? 'role' : null,
       ].filter((field): field is string => field !== null);
 
-      // Determine specific action based on what changed
       let action = 'user.updated';
       if (changedFields.length === 1) {
         if (changedFields[0] === 'isDisabled') {
@@ -766,48 +576,19 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         }
       }
 
-      if (name !== undefined || email !== undefined) {
-        const emailResult = optionalEmail(email, 'email') as { ok: true; value: string | null };
-        await query(
-          `INSERT INTO settings (user_id, full_name, email)
-           VALUES ($1, $2, $3)
-           ON CONFLICT (user_id) DO UPDATE SET
-             full_name = CASE WHEN $4 THEN EXCLUDED.full_name ELSE settings.full_name END,
-             email = CASE WHEN $5 THEN EXCLUDED.email ELSE settings.email END,
-             updated_at = CURRENT_TIMESTAMP`,
-          [
-            idResult.value,
-            name ?? null,
-            emailResult.value,
-            name !== undefined,
-            email !== undefined,
-          ],
-        );
+      const settingsUpsert =
+        fields.name !== undefined || validatedEmail !== undefined
+          ? settingsRepo.upsertForUser(idResult.value, {
+              fullName: fields.name ?? null,
+              email: validatedEmail ?? null,
+              language: null,
+            })
+          : Promise.resolve();
+      const [, fullUser] = await Promise.all([settingsUpsert, usersRepo.findById(idResult.value)]);
+      if (!fullUser) {
+        return reply.code(404).send({ error: 'User not found' });
       }
 
-      const responseResult = await query(
-        `SELECT u.id, u.name, u.username, COALESCE(s.email, '') AS email, u.role,
-                u.avatar_initials, u.cost_per_hour, u.is_disabled, u.employee_type,
-                EXISTS (
-                  SELECT 1
-                  FROM user_roles ur
-                  WHERE ur.user_id = u.id AND ur.role_id = $2
-                ) AS has_top_manager_role,
-                (
-                  u.role = $3
-                  AND NOT EXISTS (
-                    SELECT 1
-                    FROM user_roles ur_admin_only
-                    WHERE ur_admin_only.user_id = u.id AND ur_admin_only.role_id <> $3
-                  )
-                ) AS is_admin_only
-           FROM users u
-           LEFT JOIN settings s ON s.user_id = u.id
-          WHERE u.id = $1`,
-        [idResult.value, TOP_MANAGER_ROLE_ID, ADMIN_ROLE_ID],
-      );
-
-      const u = responseResult.rows[0] as UserRow;
       const canRevealUserEmails = canViewUserEmails(request);
 
       await logAudit({
@@ -816,14 +597,18 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         entityType: 'user',
         entityId: idResult.value,
         details: {
-          targetLabel: (u.name as string) || currentName,
-          secondaryLabel: (u.username as string) || currentUsername,
+          targetLabel: fullUser.name || currentName,
+          secondaryLabel: fullUser.username || currentUsername,
           changedFields: changedFields.length > 0 ? changedFields : undefined,
           fromValue: role !== undefined ? currentRole : undefined,
-          toValue: role !== undefined ? String(u.role) : undefined,
+          toValue: role !== undefined ? fullUser.role : undefined,
         },
       });
-      return mapUserResponse(u, hasPermission(request, 'hr.costs.view'), canRevealUserEmails);
+      return maskUserResponse(
+        fullUser,
+        hasPermission(request, 'hr.costs.view'),
+        canRevealUserEmails,
+      );
     },
   );
 
@@ -847,19 +632,15 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
 
-      const userResult = await query('SELECT id, role FROM users WHERE id = $1', [idResult.value]);
-      if (userResult.rows.length === 0) return reply.code(404).send({ error: 'User not found' });
-
-      const primaryRoleId = userResult.rows[0].role as string;
-      const roleRows = await query('SELECT role_id FROM user_roles WHERE user_id = $1', [
-        idResult.value,
+      const [user, assignedRoleIds] = await Promise.all([
+        usersRepo.findCoreById(idResult.value),
+        usersRepo.getUserRoleIds(idResult.value),
       ]);
+      if (!user) return reply.code(404).send({ error: 'User not found' });
+
+      const primaryRoleId = user.role;
       const roleIds = Array.from(
-        new Set(
-          roleRows.rows
-            .map((r) => r.role_id as string)
-            .concat(primaryRoleId ? [primaryRoleId] : []),
-        ),
+        new Set(assignedRoleIds.concat(primaryRoleId ? [primaryRoleId] : [])),
       );
 
       return { roleIds, primaryRoleId };
@@ -907,30 +688,16 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         return badRequest(reply, 'primaryRoleId must be included in roleIds');
       }
 
-      const userExists = await query('SELECT name, username FROM users WHERE id = $1', [
-        idResult.value,
-      ]);
-      if (userExists.rows.length === 0) return reply.code(404).send({ error: 'User not found' });
+      const user = await usersRepo.findCoreById(idResult.value);
+      if (!user) return reply.code(404).send({ error: 'User not found' });
 
-      const roleCheck = await query('SELECT id FROM roles WHERE id = ANY($1::varchar[])', [
-        roleIdsResult.value,
-      ]);
-      const found = new Set(roleCheck.rows.map((r) => r.id as string));
+      const found = await rolesRepo.findExistingIds(roleIdsResult.value);
       const missing = roleIdsResult.value.filter((rid) => !found.has(rid));
       if (missing.length > 0) return badRequest(reply, `Invalid role(s): ${missing.join(', ')}`);
 
       await withTransaction(async (tx) => {
-        await tx.query('DELETE FROM user_roles WHERE user_id = $1', [idResult.value]);
-        for (const rid of roleIdsResult.value) {
-          await tx.query(
-            'INSERT INTO user_roles (user_id, role_id) VALUES ($1, $2) ON CONFLICT DO NOTHING',
-            [idResult.value, rid],
-          );
-        }
-        await tx.query('UPDATE users SET role = $1 WHERE id = $2', [
-          primaryRoleIdResult.value,
-          idResult.value,
-        ]);
+        await usersRepo.replaceUserRoles(idResult.value, roleIdsResult.value, tx);
+        await usersRepo.setPrimaryRole(idResult.value, primaryRoleIdResult.value, tx);
       });
 
       await syncTopManagerAssignmentsForUser(idResult.value);
@@ -940,8 +707,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         entityType: 'user',
         entityId: idResult.value,
         details: {
-          targetLabel: userExists.rows[0].name as string,
-          secondaryLabel: userExists.rows[0].username as string,
+          targetLabel: user.name,
+          secondaryLabel: user.username,
           counts: getAuditCounts({ roles: roleIdsResult.value.length }),
           toValue: primaryRoleIdResult.value,
         },
@@ -970,9 +737,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
 
-      const canViewAllUsers =
-        hasPermission(request, 'administration.user_management_all.view') ||
-        hasPermission(request, 'hr.work_units_all.view');
       const canViewAssignments =
         request.user?.id === id ||
         hasPermission(request, 'administration.user_management.view') ||
@@ -984,35 +748,13 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         return reply.code(403).send({ error: 'Insufficient permissions' });
       }
 
-      if (request.user?.id !== id && !canViewAllUsers) {
-        const managedCheck = await query(
-          `SELECT 1
-             FROM user_work_units uw
-             JOIN work_unit_managers wum ON uw.work_unit_id = wum.work_unit_id
-             WHERE uw.user_id = $1 AND wum.user_id = $2
-             LIMIT 1`,
-          [idResult.value, request.user?.id],
-        );
-        if (managedCheck.rows.length === 0) {
+      if (request.user?.id !== id && !canViewAllUsers(request)) {
+        if (!(await usersRepo.canManageUser(idResult.value, request.user?.id ?? ''))) {
           return reply.code(403).send({ error: 'Insufficient permissions' });
         }
       }
 
-      const clientsRes = await query('SELECT client_id FROM user_clients WHERE user_id = $1', [
-        idResult.value,
-      ]);
-      const projectsRes = await query('SELECT project_id FROM user_projects WHERE user_id = $1', [
-        idResult.value,
-      ]);
-      const tasksRes = await query('SELECT task_id FROM user_tasks WHERE user_id = $1', [
-        idResult.value,
-      ]);
-
-      return {
-        clientIds: clientsRes.rows.map((r) => r.client_id),
-        projectIds: projectsRes.rows.map((r) => r.project_id),
-        taskIds: tasksRes.rows.map((r) => r.task_id),
-      };
+      return await usersRepo.getAssignments(idResult.value);
     },
   );
 
@@ -1042,20 +784,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
 
-      const canViewAllUsers =
-        hasPermission(request, 'administration.user_management_all.view') ||
-        hasPermission(request, 'hr.work_units_all.view');
-
-      if (!canViewAllUsers && idResult.value !== request.user?.id) {
-        const managedCheck = await query(
-          `SELECT 1
-             FROM user_work_units uw
-             JOIN work_unit_managers wum ON uw.work_unit_id = wum.work_unit_id
-             WHERE uw.user_id = $1 AND wum.user_id = $2
-             LIMIT 1`,
-          [idResult.value, request.user?.id],
-        );
-        if (managedCheck.rows.length === 0) {
+      if (!canViewAllUsers(request) && idResult.value !== request.user?.id) {
+        if (!(await usersRepo.canManageUser(idResult.value, request.user?.id ?? ''))) {
           return reply.code(403).send({ error: 'Insufficient permissions' });
         }
       }
@@ -1069,67 +799,55 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const taskIdsResult = optionalArrayOfStrings(taskIds, 'taskIds');
       if (!taskIdsResult.ok) return badRequest(reply, taskIdsResult.message);
 
-      const targetUser = await query('SELECT name, username FROM users WHERE id = $1', [
-        idResult.value,
+      const [targetUser, isTopManager] = await Promise.all([
+        usersRepo.findCoreById(idResult.value),
+        userHasTopManagerRole(idResult.value),
       ]);
-      if (targetUser.rows.length === 0) return reply.code(404).send({ error: 'User not found' });
+      if (!targetUser) return reply.code(404).send({ error: 'User not found' });
 
-      if (await userHasTopManagerRole(idResult.value)) {
+      if (isTopManager) {
         return reply.code(409).send({
           error: 'Top Manager assignments are managed automatically and cannot be edited manually',
         });
       }
 
+      const resolvedClientIds = (clientIdsResult as { ok: true; value: string[] | null }).value;
+      const resolvedProjectIds = (projectIdsResult as { ok: true; value: string[] | null }).value;
+      const resolvedTaskIds = (taskIdsResult as { ok: true; value: string[] | null }).value;
+
       await withTransaction(async (tx) => {
         if (clientIds) {
-          await tx.query('DELETE FROM user_clients WHERE user_id = $1', [idResult.value]);
-          for (const clientId of (clientIdsResult as { ok: true; value: string[] | null }).value ||
-            []) {
-            await tx.query(
-              'INSERT INTO user_clients (user_id, client_id, assignment_source) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING',
-              [idResult.value, clientId, MANUAL_ASSIGNMENT_SOURCE],
-            );
-          }
-        }
-
-        if (projectIds) {
-          await tx.query('DELETE FROM user_projects WHERE user_id = $1', [idResult.value]);
-          for (const projectId of (projectIdsResult as { ok: true; value: string[] | null })
-            .value || []) {
-            await tx.query(
-              'INSERT INTO user_projects (user_id, project_id, assignment_source) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING',
-              [idResult.value, projectId, MANUAL_ASSIGNMENT_SOURCE],
-            );
-          }
-        }
-
-        if (taskIds) {
-          await tx.query('DELETE FROM user_tasks WHERE user_id = $1', [idResult.value]);
-          for (const taskId of (taskIdsResult as { ok: true; value: string[] | null }).value ||
-            []) {
-            await tx.query(
-              'INSERT INTO user_tasks (user_id, task_id, assignment_source) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING',
-              [idResult.value, taskId, MANUAL_ASSIGNMENT_SOURCE],
-            );
-          }
-        }
-
-        if (projectIds || clientIds) {
-          await tx.query(
-            `DELETE FROM user_clients WHERE user_id = $1 AND assignment_source = 'project_cascade'`,
-            [idResult.value],
+          await usersRepo.replaceUserClients(
+            idResult.value,
+            resolvedClientIds ?? [],
+            MANUAL_ASSIGNMENT_SOURCE,
+            tx,
           );
         }
 
-        await tx.query(
-          `INSERT INTO user_clients (user_id, client_id, assignment_source)
-           SELECT $1, p.client_id, 'project_cascade'
-           FROM user_projects up
-           JOIN projects p ON up.project_id = p.id
-           WHERE up.user_id = $1
-           ON CONFLICT (user_id, client_id) DO NOTHING`,
-          [idResult.value],
-        );
+        if (projectIds) {
+          await usersRepo.replaceUserProjects(
+            idResult.value,
+            resolvedProjectIds ?? [],
+            MANUAL_ASSIGNMENT_SOURCE,
+            tx,
+          );
+        }
+
+        if (taskIds) {
+          await usersRepo.replaceUserTasks(
+            idResult.value,
+            resolvedTaskIds ?? [],
+            MANUAL_ASSIGNMENT_SOURCE,
+            tx,
+          );
+        }
+
+        if (projectIds || clientIds) {
+          await usersRepo.clearProjectCascadeAssignments(idResult.value, tx);
+        }
+
+        await usersRepo.applyProjectCascadeToClients(idResult.value, tx);
       });
 
       await logAudit({
@@ -1138,18 +856,12 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         entityType: 'user',
         entityId: idResult.value,
         details: {
-          targetLabel: targetUser.rows[0].name as string,
-          secondaryLabel: targetUser.rows[0].username as string,
+          targetLabel: targetUser.name,
+          secondaryLabel: targetUser.username,
           counts: getAuditCounts({
-            clients: clientIds
-              ? ((clientIdsResult as { ok: true; value: string[] | null }).value?.length ?? 0)
-              : undefined,
-            projects: projectIds
-              ? ((projectIdsResult as { ok: true; value: string[] | null }).value?.length ?? 0)
-              : undefined,
-            tasks: taskIds
-              ? ((taskIdsResult as { ok: true; value: string[] | null }).value?.length ?? 0)
-              : undefined,
+            clients: clientIds ? (resolvedClientIds?.length ?? 0) : undefined,
+            projects: projectIds ? (resolvedProjectIds?.length ?? 0) : undefined,
+            tasks: taskIds ? (resolvedTaskIds?.length ?? 0) : undefined,
           }),
         },
       });

--- a/server/test/repositories/productsRepo.test.ts
+++ b/server/test/repositories/productsRepo.test.ts
@@ -40,3 +40,671 @@ describe('getSnapshots', () => {
     expect(exec.calls[0].params).toEqual([['p-1']]);
   });
 });
+
+// ===========================================================================
+// Product CRUD
+// ===========================================================================
+
+const sampleProductRow = {
+  id: 'p-1',
+  name: 'Widget',
+  productCode: 'WGT-001',
+  createdAt: '2024-01-15T10:00:00Z',
+  description: 'A widget',
+  costo: 12.5,
+  molPercentage: 30,
+  costUnit: 'unit',
+  category: 'cat-a',
+  subcategory: 'sub-a',
+  type: 'good',
+  supplierId: null,
+  supplierName: null,
+  isDisabled: false,
+};
+
+describe('listAllProducts', () => {
+  test('joins suppliers and converts createdAt to epoch ms', async () => {
+    exec.enqueue({ rows: [sampleProductRow] });
+    const result = await productsRepo.listAllProducts(exec);
+    expect(exec.calls[0].sql).toContain('LEFT JOIN suppliers');
+    expect(result[0].createdAt).toBe(new Date('2024-01-15T10:00:00Z').getTime());
+    expect(result[0].name).toBe('Widget');
+  });
+
+  test('returns null createdAt when row.createdAt is null', async () => {
+    exec.enqueue({ rows: [{ ...sampleProductRow, createdAt: null }] });
+    const [row] = await productsRepo.listAllProducts(exec);
+    expect(row.createdAt).toBeNull();
+  });
+});
+
+describe('findProductById / findProductCoreById', () => {
+  test('findProductById returns mapped row when present', async () => {
+    exec.enqueue({ rows: [sampleProductRow] });
+    const result = await productsRepo.findProductById('p-1', exec);
+    expect(result?.id).toBe('p-1');
+    expect(exec.calls[0].params).toEqual(['p-1']);
+  });
+
+  test('findProductById returns null when no row', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await productsRepo.findProductById('p-1', exec)).toBeNull();
+  });
+
+  test('findProductCoreById returns just type/supplierId/category', async () => {
+    exec.enqueue({
+      rows: [{ type: 'service', supplierId: 's-1', category: 'cat-a' }],
+    });
+    const result = await productsRepo.findProductCoreById('p-1', exec);
+    expect(result).toEqual({ type: 'service', supplierId: 's-1', category: 'cat-a' });
+  });
+});
+
+describe('existsProductByName / existsProductByCode', () => {
+  test('existsProductByName uses LOWER() for case-insensitive matching', async () => {
+    exec.enqueue({ rows: [] });
+    await productsRepo.existsProductByName('Widget', null, exec);
+    expect(exec.calls[0].sql).toContain('LOWER(name) = LOWER($1)');
+    expect(exec.calls[0].params).toEqual(['Widget']);
+  });
+
+  test('existsProductByName with excludeId adds the AND id != $2 clause', async () => {
+    exec.enqueue({ rows: [] });
+    await productsRepo.existsProductByName('Widget', 'p-2', exec);
+    expect(exec.calls[0].sql).toContain('id != $2');
+    expect(exec.calls[0].params).toEqual(['Widget', 'p-2']);
+  });
+
+  test('existsProductByCode without excludeId queries by exact match', async () => {
+    exec.enqueue({ rows: [] });
+    await productsRepo.existsProductByCode('WGT-001', null, exec);
+    expect(exec.calls[0].sql).toContain('product_code = $1');
+    expect(exec.calls[0].params).toEqual(['WGT-001']);
+  });
+
+  test.each([
+    [[{ id: 'p-1' }], true],
+    [[], false],
+  ] as const)('existsProductByCode returns %s for rows %j', async (rows, expected) => {
+    exec.enqueue({ rows: [...rows] });
+    expect(await productsRepo.existsProductByCode('WGT-001', null, exec)).toBe(expected);
+  });
+});
+
+describe('insertProduct', () => {
+  test('passes all 11 columns in declared order and maps the returned row', async () => {
+    exec.enqueue({
+      rows: [
+        {
+          id: 'p-1',
+          name: 'Widget',
+          productCode: 'WGT-001',
+          createdAt: '2024-01-15T10:00:00Z',
+          description: null,
+          costo: 12.5,
+          molPercentage: 30,
+          costUnit: 'unit',
+          category: null,
+          subcategory: null,
+          type: 'good',
+          supplierId: null,
+        },
+      ],
+      rowCount: 1,
+    });
+    await productsRepo.insertProduct(
+      {
+        id: 'p-1',
+        name: 'Widget',
+        productCode: 'WGT-001',
+        description: null,
+        costo: 12.5,
+        molPercentage: 30,
+        costUnit: 'unit',
+        category: null,
+        subcategory: null,
+        type: 'good',
+        supplierId: null,
+      },
+      exec,
+    );
+    expect(exec.calls[0].params).toEqual([
+      'p-1',
+      'Widget',
+      'WGT-001',
+      null,
+      12.5,
+      30,
+      'unit',
+      null,
+      null,
+      'good',
+      null,
+    ]);
+  });
+});
+
+describe('updateProductDynamic', () => {
+  test('returns null without issuing a query when fields is empty', async () => {
+    const result = await productsRepo.updateProductDynamic('p-1', {}, exec);
+    expect(result).toBeNull();
+    expect(exec.calls.length).toBe(0);
+  });
+
+  test('builds SET only for the provided fields and appends id last', async () => {
+    exec.enqueue({ rows: [sampleProductRow], rowCount: 1 });
+    await productsRepo.updateProductDynamic(
+      'p-1',
+      { name: 'New Name', costo: 99, isDisabled: true },
+      exec,
+    );
+    const sql = exec.calls[0].sql;
+    expect(sql).toContain('name = $1');
+    expect(sql).toContain('costo = $2');
+    expect(sql).toContain('is_disabled = $3');
+    expect(sql).toContain('WHERE id = $4');
+    expect(exec.calls[0].params).toEqual(['New Name', 99, true, 'p-1']);
+  });
+
+  test('uses snake_case column names for camelCase keys', async () => {
+    exec.enqueue({ rows: [sampleProductRow], rowCount: 1 });
+    await productsRepo.updateProductDynamic(
+      'p-1',
+      { productCode: 'X-1', molPercentage: 10, supplierId: 's-2', costUnit: 'hours' },
+      exec,
+    );
+    const sql = exec.calls[0].sql;
+    expect(sql).toContain('product_code = $1');
+    expect(sql).toContain('mol_percentage = $2');
+    expect(sql).toContain('supplier_id = $3');
+    expect(sql).toContain('cost_unit = $4');
+  });
+
+  test('returns null when UPDATE finds no row', async () => {
+    exec.enqueue({ rows: [], rowCount: 0 });
+    const result = await productsRepo.updateProductDynamic('p-1', { name: 'X' }, exec);
+    expect(result).toBeNull();
+  });
+});
+
+describe('deleteProductById', () => {
+  test('returns the {name, productCode} from RETURNING', async () => {
+    exec.enqueue({ rows: [{ name: 'Widget', productCode: 'WGT-001' }], rowCount: 1 });
+    const result = await productsRepo.deleteProductById('p-1', exec);
+    expect(result).toEqual({ name: 'Widget', productCode: 'WGT-001' });
+  });
+
+  test('returns null when no row was deleted', async () => {
+    exec.enqueue({ rows: [], rowCount: 0 });
+    expect(await productsRepo.deleteProductById('p-1', exec)).toBeNull();
+  });
+});
+
+// ===========================================================================
+// Product types
+// ===========================================================================
+
+describe('listAllProductTypesWithCounts', () => {
+  test('parses string counts from pg into numbers', async () => {
+    exec.enqueue({
+      rows: [
+        {
+          id: 'pt-1',
+          name: 'good',
+          costUnit: 'unit',
+          createdAt: '2024-01-01T00:00:00Z',
+          updatedAt: '2024-01-02T00:00:00Z',
+          productCount: '5',
+          categoryCount: '3',
+        },
+      ],
+    });
+    const [row] = await productsRepo.listAllProductTypesWithCounts(exec);
+    expect(row.productCount).toBe(5);
+    expect(row.categoryCount).toBe(3);
+    expect(row.createdAt).toBe(new Date('2024-01-01T00:00:00Z').getTime());
+  });
+});
+
+describe('findProductTypeByName', () => {
+  test('findProductTypeByName returns {costUnit} or null', async () => {
+    exec.enqueue({ rows: [{ costUnit: 'hours' }] });
+    expect(await productsRepo.findProductTypeByName('service', exec)).toEqual({
+      costUnit: 'hours',
+    });
+    exec.enqueue({ rows: [] });
+    expect(await productsRepo.findProductTypeByName('missing', exec)).toBeNull();
+  });
+});
+
+describe('existsProductTypeByName', () => {
+  test('without excludeId checks LOWER() match', async () => {
+    exec.enqueue({ rows: [] });
+    await productsRepo.existsProductTypeByName('Service', null, exec);
+    expect(exec.calls[0].sql).toContain('LOWER(name) = LOWER($1)');
+    expect(exec.calls[0].params).toEqual(['Service']);
+  });
+
+  test('with excludeId excludes the given id', async () => {
+    exec.enqueue({ rows: [] });
+    await productsRepo.existsProductTypeByName('Service', 'pt-1', exec);
+    expect(exec.calls[0].sql).toContain('id != $2');
+    expect(exec.calls[0].params).toEqual(['Service', 'pt-1']);
+  });
+});
+
+describe('findProductTypeById / insertProductType / updateProductTypeFields', () => {
+  test('findProductTypeById returns the mapped row or null', async () => {
+    exec.enqueue({ rows: [{ id: 'pt-1', name: 'good', costUnit: 'unit' }] });
+    const result = await productsRepo.findProductTypeById('pt-1', exec);
+    expect(result).toEqual({ id: 'pt-1', name: 'good', costUnit: 'unit' });
+
+    exec.enqueue({ rows: [] });
+    expect(await productsRepo.findProductTypeById('pt-99', exec)).toBeNull();
+  });
+
+  test('insertProductType passes [id, name, costUnit] and zero counts', async () => {
+    exec.enqueue({
+      rows: [
+        {
+          id: 'pt-1',
+          name: 'good',
+          costUnit: 'unit',
+          createdAt: '2024-01-01T00:00:00Z',
+          updatedAt: '2024-01-01T00:00:00Z',
+        },
+      ],
+      rowCount: 1,
+    });
+    const result = await productsRepo.insertProductType('pt-1', 'good', 'unit', exec);
+    expect(exec.calls[0].params).toEqual(['pt-1', 'good', 'unit']);
+    expect(result.productCount).toBe(0);
+    expect(result.categoryCount).toBe(0);
+  });
+
+  test('updateProductTypeFields passes [name, costUnit, id]', async () => {
+    exec.enqueue({
+      rows: [
+        {
+          id: 'pt-1',
+          name: 'service',
+          costUnit: 'hours',
+          createdAt: '2024-01-01T00:00:00Z',
+          updatedAt: '2024-01-02T00:00:00Z',
+        },
+      ],
+      rowCount: 1,
+    });
+    await productsRepo.updateProductTypeFields('pt-1', 'service', 'hours', exec);
+    expect(exec.calls[0].params).toEqual(['service', 'hours', 'pt-1']);
+  });
+
+  test('updateProductTypeFields returns null when no row updated', async () => {
+    exec.enqueue({ rows: [], rowCount: 0 });
+    expect(await productsRepo.updateProductTypeFields('pt-99', 'x', 'unit', exec)).toBeNull();
+  });
+});
+
+describe('product type propagations', () => {
+  test('propagateProductTypeName updates both products.type and internal_product_categories.type', async () => {
+    exec.enqueue({ rows: [], rowCount: 5 });
+    exec.enqueue({ rows: [], rowCount: 3 });
+    await productsRepo.propagateProductTypeName('old', 'new', exec);
+    expect(exec.calls).toHaveLength(2);
+    expect(exec.calls[0].sql).toContain('UPDATE products SET type = $1 WHERE type = $2');
+    expect(exec.calls[0].params).toEqual(['new', 'old']);
+    expect(exec.calls[1].sql).toContain('UPDATE internal_product_categories SET type');
+    expect(exec.calls[1].params).toEqual(['new', 'old']);
+  });
+
+  test('propagateProductTypeCostUnit updates products (internal only) and categories', async () => {
+    exec.enqueue({ rows: [], rowCount: 4 });
+    exec.enqueue({ rows: [], rowCount: 2 });
+    await productsRepo.propagateProductTypeCostUnit('good', 'hours', exec);
+    expect(exec.calls).toHaveLength(2);
+    expect(exec.calls[0].sql).toContain('supplier_id IS NULL');
+    expect(exec.calls[0].params).toEqual(['hours', 'good']);
+    expect(exec.calls[1].sql).toContain('UPDATE internal_product_categories SET cost_unit');
+    expect(exec.calls[1].params).toEqual(['hours', 'good']);
+  });
+});
+
+describe('countProductsForType / countCategoriesForType', () => {
+  test.each([
+    ['7', 7],
+    ['0', 0],
+  ] as const)('countProductsForType parses "%s" to %s', async (count, expected) => {
+    exec.enqueue({ rows: [{ count }] });
+    expect(await productsRepo.countProductsForType('good', exec)).toBe(expected);
+    expect(exec.calls[0].params).toEqual(['good']);
+  });
+
+  test('countProductsForType returns 0 when no row', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await productsRepo.countProductsForType('good', exec)).toBe(0);
+  });
+
+  test('countCategoriesForType filters by type and parses count', async () => {
+    exec.enqueue({ rows: [{ count: '4' }] });
+    expect(await productsRepo.countCategoriesForType('good', exec)).toBe(4);
+    expect(exec.calls[0].sql).toContain('FROM internal_product_categories WHERE type = $1');
+  });
+});
+
+describe('deleteProductTypeById', () => {
+  test.each([
+    [1, true],
+    [0, false],
+  ] as const)('returns %s when rowCount is %s', async (rowCount, expected) => {
+    exec.enqueue({ rows: [], rowCount });
+    expect(await productsRepo.deleteProductTypeById('pt-1', exec)).toBe(expected);
+  });
+});
+
+// ===========================================================================
+// Internal categories
+// ===========================================================================
+
+const sampleCategoryRow = {
+  id: 'ipc-1',
+  name: 'Mechanical',
+  type: 'good',
+  costUnit: 'unit',
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-02T00:00:00Z',
+  productCount: '3',
+  hasLinkedProducts: true,
+};
+
+describe('listInternalCategoriesByType', () => {
+  test('passes type as $1 and parses productCount + hasLinkedProducts', async () => {
+    exec.enqueue({ rows: [sampleCategoryRow] });
+    const [row] = await productsRepo.listInternalCategoriesByType('good', exec);
+    expect(exec.calls[0].params).toEqual(['good']);
+    expect(row.productCount).toBe(3);
+    expect(row.hasLinkedProducts).toBe(true);
+    expect(row.createdAt).toBe(new Date('2024-01-01T00:00:00Z').getTime());
+  });
+});
+
+describe('findInternalCategoryById / findCategoryIdByNameAndType', () => {
+  test('findInternalCategoryById returns {id, name, type} or null', async () => {
+    exec.enqueue({ rows: [{ id: 'ipc-1', name: 'Mechanical', type: 'good' }] });
+    expect(await productsRepo.findInternalCategoryById('ipc-1', exec)).toEqual({
+      id: 'ipc-1',
+      name: 'Mechanical',
+      type: 'good',
+    });
+
+    exec.enqueue({ rows: [] });
+    expect(await productsRepo.findInternalCategoryById('ipc-99', exec)).toBeNull();
+  });
+
+  test('findCategoryIdByNameAndType returns the id string or null', async () => {
+    exec.enqueue({ rows: [{ id: 'ipc-1' }] });
+    expect(await productsRepo.findCategoryIdByNameAndType('Mechanical', 'good', exec)).toBe(
+      'ipc-1',
+    );
+
+    exec.enqueue({ rows: [] });
+    expect(await productsRepo.findCategoryIdByNameAndType('Missing', 'good', exec)).toBeNull();
+  });
+});
+
+describe('existsInternalCategoryByNameType', () => {
+  test('without excludeId compares LOWER name + type', async () => {
+    exec.enqueue({ rows: [] });
+    await productsRepo.existsInternalCategoryByNameType('Mechanical', 'good', null, exec);
+    expect(exec.calls[0].sql).toContain('LOWER(name) = LOWER($1) AND type = $2');
+    expect(exec.calls[0].params).toEqual(['Mechanical', 'good']);
+  });
+
+  test('with excludeId adds AND id != $3', async () => {
+    exec.enqueue({ rows: [] });
+    await productsRepo.existsInternalCategoryByNameType('Mechanical', 'good', 'ipc-1', exec);
+    expect(exec.calls[0].sql).toContain('id != $3');
+    expect(exec.calls[0].params).toEqual(['Mechanical', 'good', 'ipc-1']);
+  });
+});
+
+describe('insertInternalCategory / updateInternalCategoryFields', () => {
+  test('insertInternalCategory passes [id, name, type, costUnit] and starts with zero counts', async () => {
+    exec.enqueue({
+      rows: [
+        {
+          id: 'ipc-1',
+          name: 'Mechanical',
+          type: 'good',
+          costUnit: 'unit',
+          createdAt: '2024-01-01T00:00:00Z',
+          updatedAt: '2024-01-01T00:00:00Z',
+        },
+      ],
+      rowCount: 1,
+    });
+    const result = await productsRepo.insertInternalCategory(
+      'ipc-1',
+      'Mechanical',
+      'good',
+      'unit',
+      exec,
+    );
+    expect(exec.calls[0].params).toEqual(['ipc-1', 'Mechanical', 'good', 'unit']);
+    expect(result.productCount).toBe(0);
+    expect(result.hasLinkedProducts).toBe(false);
+  });
+
+  test('updateInternalCategoryFields passes [name, costUnit, id]', async () => {
+    exec.enqueue({
+      rows: [
+        {
+          id: 'ipc-1',
+          name: 'Renamed',
+          type: 'good',
+          costUnit: 'unit',
+          createdAt: '2024-01-01T00:00:00Z',
+          updatedAt: '2024-01-02T00:00:00Z',
+        },
+      ],
+      rowCount: 1,
+    });
+    await productsRepo.updateInternalCategoryFields('ipc-1', 'Renamed', 'unit', exec);
+    expect(exec.calls[0].params).toEqual(['Renamed', 'unit', 'ipc-1']);
+  });
+
+  test('updateInternalCategoryFields returns null when no row updated', async () => {
+    exec.enqueue({ rows: [], rowCount: 0 });
+    expect(await productsRepo.updateInternalCategoryFields('ipc-99', 'x', 'unit', exec)).toBeNull();
+  });
+});
+
+describe('propagateCategoryNameToProducts / clearProductsCategoryByName', () => {
+  test('propagateCategoryNameToProducts only touches internal products', async () => {
+    exec.enqueue({ rows: [], rowCount: 4 });
+    await productsRepo.propagateCategoryNameToProducts('oldCat', 'newCat', 'good', 'unit', exec);
+    expect(exec.calls[0].sql).toContain('supplier_id IS NULL');
+    expect(exec.calls[0].params).toEqual(['newCat', 'unit', 'oldCat', 'good']);
+  });
+
+  test('clearProductsCategoryByName clears category and subcategory', async () => {
+    exec.enqueue({ rows: [], rowCount: 2 });
+    await productsRepo.clearProductsCategoryByName('cat-a', 'good', exec);
+    expect(exec.calls[0].sql).toContain('SET category = NULL, subcategory = NULL');
+    expect(exec.calls[0].params).toEqual(['cat-a', 'good']);
+  });
+});
+
+describe('deleteInternalCategoryById / countProductsForCategory', () => {
+  test.each([
+    [1, true],
+    [0, false],
+  ] as const)('deleteInternalCategoryById returns %s when rowCount is %s', async (rowCount, expected) => {
+    exec.enqueue({ rows: [], rowCount });
+    expect(await productsRepo.deleteInternalCategoryById('ipc-1', exec)).toBe(expected);
+  });
+
+  test('countProductsForCategory parses count and filters supplier_id IS NULL', async () => {
+    exec.enqueue({ rows: [{ count: '6' }] });
+    expect(await productsRepo.countProductsForCategory('cat-a', 'good', exec)).toBe(6);
+    expect(exec.calls[0].sql).toContain('supplier_id IS NULL');
+    expect(exec.calls[0].params).toEqual(['cat-a', 'good']);
+  });
+});
+
+// ===========================================================================
+// Internal subcategories
+// ===========================================================================
+
+describe('listInternalSubcategoriesByType', () => {
+  test('passes [categoryId] and parses productCount', async () => {
+    exec.enqueue({
+      rows: [{ name: 'sub-a', productCount: '2', hasLinkedProducts: false }],
+    });
+    const [row] = await productsRepo.listInternalSubcategoriesByType('ipc-1', exec);
+    expect(exec.calls[0].params).toEqual(['ipc-1']);
+    expect(row).toEqual({ name: 'sub-a', productCount: 2, hasLinkedProducts: false });
+  });
+});
+
+describe('existsInternalSubcategoryByNameInCategory', () => {
+  test('passes [categoryId, name] and case-insensitive matches', async () => {
+    exec.enqueue({ rows: [] });
+    await productsRepo.existsInternalSubcategoryByNameInCategory('Sub-A', 'ipc-1', exec);
+    expect(exec.calls[0].sql).toContain('LOWER(name) = LOWER($2)');
+    expect(exec.calls[0].params).toEqual(['ipc-1', 'Sub-A']);
+  });
+
+  test.each([
+    [[{ '?column?': 1 }], true],
+    [[], false],
+  ] as const)('returns %s when query returns %j rows', async (rows, expected) => {
+    exec.enqueue({ rows: [...rows] });
+    expect(
+      await productsRepo.existsInternalSubcategoryByNameInCategory('sub-a', 'ipc-1', exec),
+    ).toBe(expected);
+  });
+});
+
+describe('insertInternalSubcategory / updateInternalSubcategoryName', () => {
+  test('insertInternalSubcategory passes [id, categoryId, name] and returns the row', async () => {
+    exec.enqueue({ rows: [{ name: 'sub-a' }], rowCount: 1 });
+    const result = await productsRepo.insertInternalSubcategory('ips-1', 'ipc-1', 'sub-a', exec);
+    expect(exec.calls[0].params).toEqual(['ips-1', 'ipc-1', 'sub-a']);
+    expect(result).toEqual({ name: 'sub-a' });
+  });
+
+  test('updateInternalSubcategoryName passes [newName, categoryId, oldName]', async () => {
+    exec.enqueue({ rows: [{ id: 'ips-1' }], rowCount: 1 });
+    const result = await productsRepo.updateInternalSubcategoryName('ipc-1', 'old', 'new', exec);
+    expect(exec.calls[0].params).toEqual(['new', 'ipc-1', 'old']);
+    expect(result).toEqual({ id: 'ips-1' });
+  });
+
+  test('updateInternalSubcategoryName returns null when no row matched', async () => {
+    exec.enqueue({ rows: [], rowCount: 0 });
+    expect(
+      await productsRepo.updateInternalSubcategoryName('ipc-1', 'old', 'new', exec),
+    ).toBeNull();
+  });
+});
+
+describe('propagateSubcategoryNameToProducts / clearProductsSubcategoryByName / deleteInternalSubcategoryByCategoryAndName', () => {
+  test('propagateSubcategoryNameToProducts returns the affected row count', async () => {
+    exec.enqueue({ rows: [{ id: 'p-1' }, { id: 'p-2' }], rowCount: 2 });
+    const count = await productsRepo.propagateSubcategoryNameToProducts(
+      'old',
+      'new',
+      'good',
+      'cat-a',
+      exec,
+    );
+    expect(count).toBe(2);
+    expect(exec.calls[0].sql).toContain('supplier_id IS NULL');
+    expect(exec.calls[0].params).toEqual(['new', 'good', 'cat-a', 'old']);
+  });
+
+  test('clearProductsSubcategoryByName sets subcategory to NULL', async () => {
+    exec.enqueue({ rows: [], rowCount: 1 });
+    await productsRepo.clearProductsSubcategoryByName('sub-a', 'good', 'cat-a', exec);
+    expect(exec.calls[0].sql).toContain('SET subcategory = NULL');
+    expect(exec.calls[0].params).toEqual(['good', 'cat-a', 'sub-a']);
+  });
+
+  test('deleteInternalSubcategoryByCategoryAndName returns {id} or null', async () => {
+    exec.enqueue({ rows: [{ id: 'ips-1' }], rowCount: 1 });
+    expect(
+      await productsRepo.deleteInternalSubcategoryByCategoryAndName('ipc-1', 'sub-a', exec),
+    ).toEqual({ id: 'ips-1' });
+
+    exec.enqueue({ rows: [], rowCount: 0 });
+    expect(
+      await productsRepo.deleteInternalSubcategoryByCategoryAndName('ipc-1', 'sub-a', exec),
+    ).toBeNull();
+  });
+});
+
+// ===========================================================================
+// Cross-domain link checks
+// ===========================================================================
+
+describe('checkProductsLinkedToTransactions', () => {
+  test('returns {linked: false, count: 0} when no products match category+type', async () => {
+    exec.enqueue({ rows: [] });
+    const result = await productsRepo.checkProductsLinkedToTransactions(
+      'cat-a',
+      'good',
+      undefined,
+      exec,
+    );
+    expect(result).toEqual({ linked: false, count: 0 });
+    expect(exec.calls).toHaveLength(1);
+  });
+
+  test('without subcategory, the product-id query has only $1 and $2 params', async () => {
+    exec.enqueue({ rows: [] });
+    await productsRepo.checkProductsLinkedToTransactions('cat-a', 'good', undefined, exec);
+    expect(exec.calls[0].params).toEqual(['cat-a', 'good']);
+    expect(exec.calls[0].sql).not.toContain('subcategory');
+  });
+
+  test('with subcategory, adds AND subcategory = $3', async () => {
+    exec.enqueue({ rows: [] });
+    await productsRepo.checkProductsLinkedToTransactions('cat-a', 'good', 'sub-a', exec);
+    expect(exec.calls[0].sql).toContain('AND subcategory = $3');
+    expect(exec.calls[0].params).toEqual(['cat-a', 'good', 'sub-a']);
+  });
+
+  test('runs a single UNION-ALL count query that references all 7 transaction tables', async () => {
+    exec.enqueue({ rows: [{ id: 'p-1' }, { id: 'p-2' }] });
+    exec.enqueue({ rows: [{ total: '5' }] });
+    const result = await productsRepo.checkProductsLinkedToTransactions(
+      'cat-a',
+      'good',
+      undefined,
+      exec,
+    );
+    expect(exec.calls).toHaveLength(2); // 1 product fetch + 1 aggregated count
+    expect(result).toEqual({ linked: true, count: 5 });
+    const linkSql = exec.calls[1].sql;
+    expect(linkSql).toContain('quote_items');
+    expect(linkSql).toContain('customer_offer_items');
+    expect(linkSql).toContain('sale_items');
+    expect(linkSql).toContain('invoice_items');
+    expect(linkSql).toContain('supplier_quote_items');
+    expect(linkSql).toContain('supplier_sale_items');
+    expect(linkSql).toContain('supplier_invoice_items');
+    expect(exec.calls[1].params).toEqual([['p-1', 'p-2']]);
+  });
+
+  test('returns {linked: false, count: 0} when products match but no links', async () => {
+    exec.enqueue({ rows: [{ id: 'p-1' }] });
+    exec.enqueue({ rows: [{ total: '0' }] });
+    const result = await productsRepo.checkProductsLinkedToTransactions(
+      'cat-a',
+      'good',
+      undefined,
+      exec,
+    );
+    expect(result).toEqual({ linked: false, count: 0 });
+  });
+});

--- a/server/test/repositories/usersRepo.test.ts
+++ b/server/test/repositories/usersRepo.test.ts
@@ -170,3 +170,396 @@ describe('createUser', () => {
     ]);
   });
 });
+
+// ===========================================================================
+// User-management endpoint coverage
+// ===========================================================================
+
+const sampleListRow = {
+  id: 'user-1',
+  name: 'Alice',
+  username: 'alice',
+  email: 'alice@example.com',
+  role: 'manager',
+  avatarInitials: 'AL',
+  costPerHour: '42.5',
+  isDisabled: false,
+  employeeType: 'app_user',
+  hasTopManagerRole: false,
+  isAdminOnly: false,
+};
+
+describe('listAllForAdmin', () => {
+  test('takes no params and maps rows', async () => {
+    exec.enqueue({ rows: [sampleListRow] });
+    const result = await usersRepo.listAllForAdmin(exec);
+    expect(exec.calls[0].params).toEqual([]);
+    expect(result).toEqual([
+      {
+        id: 'user-1',
+        name: 'Alice',
+        username: 'alice',
+        email: 'alice@example.com',
+        role: 'manager',
+        avatarInitials: 'AL',
+        costPerHour: 42.5,
+        isDisabled: false,
+        employeeType: 'app_user',
+        hasTopManagerRole: false,
+        isAdminOnly: false,
+      },
+    ]);
+  });
+
+  test('coerces null email and avatarInitials to empty string', async () => {
+    exec.enqueue({
+      rows: [{ ...sampleListRow, email: null, avatarInitials: null, employeeType: null }],
+    });
+    const [user] = await usersRepo.listAllForAdmin(exec);
+    expect(user.email).toBe('');
+    expect(user.avatarInitials).toBe('');
+    expect(user.employeeType).toBe('app_user');
+  });
+});
+
+describe('listScopedForManager', () => {
+  test('always includes the self condition; OR-joins enabled scope conditions', async () => {
+    exec.enqueue({ rows: [] });
+    await usersRepo.listScopedForManager(
+      'viewer-1',
+      { canViewManagedUsers: true, canViewInternal: true, canViewExternal: false },
+      exec,
+    );
+    const sql = exec.calls[0].sql;
+    expect(sql).toContain('u.id = $1');
+    expect(sql).toContain('wum.user_id = $1');
+    expect(sql).toContain("u.employee_type = 'internal'");
+    expect(sql).not.toContain("u.employee_type = 'external'");
+    expect(exec.calls[0].params).toEqual(['viewer-1']);
+  });
+
+  test('hides top managers from results via NOT EXISTS', async () => {
+    exec.enqueue({ rows: [] });
+    await usersRepo.listScopedForManager(
+      'viewer-1',
+      { canViewManagedUsers: false, canViewInternal: false, canViewExternal: false },
+      exec,
+    );
+    expect(exec.calls[0].sql).toContain('NOT EXISTS');
+    expect(exec.calls[0].sql).toContain("role_id = 'top_manager'");
+  });
+});
+
+describe('findById', () => {
+  test('passes id as $1', async () => {
+    exec.enqueue({ rows: [sampleListRow] });
+    const result = await usersRepo.findById('user-1', exec);
+    expect(exec.calls[0].params).toEqual(['user-1']);
+    expect(result?.id).toBe('user-1');
+  });
+
+  test('returns null when no row exists', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await usersRepo.findById('user-1', exec)).toBeNull();
+  });
+});
+
+describe('findCoreById', () => {
+  test('returns the mapped core user when the row exists', async () => {
+    exec.enqueue({
+      rows: [
+        {
+          id: 'user-1',
+          name: 'Alice',
+          username: 'alice',
+          role: 'manager',
+          employeeType: 'internal',
+        },
+      ],
+    });
+    const result = await usersRepo.findCoreById('user-1', exec);
+    expect(result).toEqual({
+      id: 'user-1',
+      name: 'Alice',
+      username: 'alice',
+      role: 'manager',
+      employeeType: 'internal',
+    });
+    expect(exec.calls[0].params).toEqual(['user-1']);
+  });
+
+  test('defaults employeeType to app_user when null', async () => {
+    exec.enqueue({
+      rows: [
+        {
+          id: 'user-1',
+          name: 'Alice',
+          username: 'alice',
+          role: 'manager',
+          employeeType: null,
+        },
+      ],
+    });
+    const result = await usersRepo.findCoreById('user-1', exec);
+    expect(result?.employeeType).toBe('app_user');
+  });
+
+  test('returns null when no row exists', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await usersRepo.findCoreById('user-1', exec)).toBeNull();
+  });
+});
+
+describe('existsByUsername', () => {
+  test.each([
+    [[{ id: 'u1' }], true],
+    [[], false],
+  ] as const)('returns %s when query returns %j rows', async (rows, expected) => {
+    exec.enqueue({ rows: [...rows] });
+    expect(await usersRepo.existsByUsername('alice', exec)).toBe(expected);
+    expect(exec.calls[0].params).toEqual(['alice']);
+  });
+});
+
+describe('insertUser', () => {
+  test('passes all 9 columns in declared order', async () => {
+    exec.enqueue({ rows: [], rowCount: 1 });
+    await usersRepo.insertUser(
+      {
+        id: 'user-1',
+        name: 'Alice',
+        username: 'alice',
+        passwordHash: '$2b$10$x',
+        role: 'user',
+        avatarInitials: 'AL',
+        costPerHour: 42,
+        isDisabled: false,
+        employeeType: 'internal',
+      },
+      exec,
+    );
+    expect(exec.calls[0].params).toEqual([
+      'user-1',
+      'Alice',
+      'alice',
+      '$2b$10$x',
+      'user',
+      'AL',
+      42,
+      false,
+      'internal',
+    ]);
+  });
+});
+
+describe('deleteById', () => {
+  test.each([
+    [1, true],
+    [0, false],
+    [null, false],
+  ] as const)('returns %s when rowCount is %s', async (rowCount, expected) => {
+    exec.enqueue({ rows: [], rowCount });
+    expect(await usersRepo.deleteById('user-1', exec)).toBe(expected);
+  });
+
+  test('passes the id and uses RETURNING', async () => {
+    exec.enqueue({ rows: [{ id: 'user-1' }], rowCount: 1 });
+    await usersRepo.deleteById('user-1', exec);
+    expect(exec.calls[0].params).toEqual(['user-1']);
+    expect(exec.calls[0].sql).toContain('RETURNING id');
+  });
+});
+
+describe('updateUserDynamic', () => {
+  test('returns null without issuing a query when no fields are provided', async () => {
+    const result = await usersRepo.updateUserDynamic('user-1', {}, exec);
+    expect(result).toBeNull();
+    expect(exec.calls.length).toBe(0);
+  });
+
+  test('builds a SET clause containing only the provided fields', async () => {
+    exec.enqueue({
+      rows: [
+        {
+          id: 'user-1',
+          name: 'Alice',
+          username: 'alice',
+          role: 'user',
+          avatarInitials: 'AL',
+          costPerHour: 50,
+          isDisabled: true,
+          employeeType: 'app_user',
+        },
+      ],
+      rowCount: 1,
+    });
+    await usersRepo.updateUserDynamic(
+      'user-1',
+      { name: 'Alice', isDisabled: true, costPerHour: 50, role: 'user' },
+      exec,
+    );
+    const sql = exec.calls[0].sql;
+    expect(sql).toContain('name = $1');
+    expect(sql).toContain('is_disabled = $2');
+    expect(sql).toContain('cost_per_hour = $3');
+    expect(sql).toContain('role = $4');
+    expect(sql).toContain('WHERE id = $5');
+    expect(exec.calls[0].params).toEqual(['Alice', true, 50, 'user', 'user-1']);
+  });
+
+  test('returns null when no row was updated', async () => {
+    exec.enqueue({ rows: [], rowCount: 0 });
+    const result = await usersRepo.updateUserDynamic('user-1', { name: 'Alice' }, exec);
+    expect(result).toBeNull();
+  });
+
+  test('parses cost_per_hour from string into number on the returned row', async () => {
+    exec.enqueue({
+      rows: [
+        {
+          id: 'user-1',
+          name: 'Alice',
+          username: 'alice',
+          role: 'user',
+          avatarInitials: 'AL',
+          costPerHour: '17.25',
+          isDisabled: false,
+          employeeType: 'app_user',
+        },
+      ],
+      rowCount: 1,
+    });
+    const result = await usersRepo.updateUserDynamic('user-1', { name: 'Alice' }, exec);
+    expect(result?.costPerHour).toBe(17.25);
+  });
+});
+
+describe('addUserRole / clearUserRoles / setPrimaryRole', () => {
+  test('addUserRole inserts ON CONFLICT DO NOTHING', async () => {
+    exec.enqueue({ rows: [], rowCount: 1 });
+    await usersRepo.addUserRole('user-1', 'manager', exec);
+    expect(exec.calls[0].sql).toContain('ON CONFLICT DO NOTHING');
+    expect(exec.calls[0].params).toEqual(['user-1', 'manager']);
+  });
+
+  test('clearUserRoles deletes all rows for the user', async () => {
+    exec.enqueue({ rows: [], rowCount: 3 });
+    await usersRepo.clearUserRoles('user-1', exec);
+    expect(exec.calls[0].sql).toContain('DELETE FROM user_roles');
+    expect(exec.calls[0].params).toEqual(['user-1']);
+  });
+
+  test('setPrimaryRole passes [roleId, userId] in that order', async () => {
+    exec.enqueue({ rows: [], rowCount: 1 });
+    await usersRepo.setPrimaryRole('user-1', 'manager', exec);
+    expect(exec.calls[0].params).toEqual(['manager', 'user-1']);
+  });
+});
+
+describe('getUserRoleIds', () => {
+  test('returns the role ids in the order returned by the query', async () => {
+    exec.enqueue({ rows: [{ roleId: 'manager' }, { roleId: 'user' }] });
+    const result = await usersRepo.getUserRoleIds('user-1', exec);
+    expect(result).toEqual(['manager', 'user']);
+    expect(exec.calls[0].params).toEqual(['user-1']);
+  });
+
+  test('returns an empty array when no roles are assigned', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await usersRepo.getUserRoleIds('user-1', exec)).toEqual([]);
+  });
+});
+
+describe('canManageUser', () => {
+  test.each([
+    [[{ '?column?': 1 }], true],
+    [[], false],
+  ] as const)('returns %s when query returns %j rows', async (rows, expected) => {
+    exec.enqueue({ rows: [...rows] });
+    expect(await usersRepo.canManageUser('target-1', 'manager-1', exec)).toBe(expected);
+    expect(exec.calls[0].params).toEqual(['target-1', 'manager-1']);
+  });
+});
+
+describe('getAssignments', () => {
+  test('returns clientIds, projectIds, taskIds from the three parallel queries', async () => {
+    exec.enqueue({ rows: [{ clientId: 'c1' }, { clientId: 'c2' }] });
+    exec.enqueue({ rows: [{ projectId: 'p1' }] });
+    exec.enqueue({ rows: [{ taskId: 't1' }, { taskId: 't2' }] });
+    const result = await usersRepo.getAssignments('user-1', exec);
+    expect(result).toEqual({
+      clientIds: ['c1', 'c2'],
+      projectIds: ['p1'],
+      taskIds: ['t1', 't2'],
+    });
+    expect(exec.calls).toHaveLength(3);
+    for (const call of exec.calls) {
+      expect(call.params).toEqual(['user-1']);
+    }
+  });
+});
+
+describe('replaceUserClients', () => {
+  test('issues DELETE then a single bulk INSERT for the id list', async () => {
+    exec.enqueue({ rows: [], rowCount: 5 }); // DELETE
+    exec.enqueue({ rows: [], rowCount: 2 }); // INSERT
+    await usersRepo.replaceUserClients('user-1', ['c1', 'c2'], 'manual', exec);
+    expect(exec.calls).toHaveLength(2);
+    expect(exec.calls[0].sql).toContain('DELETE FROM user_clients');
+    expect(exec.calls[0].params).toEqual(['user-1']);
+    expect(exec.calls[1].sql).toContain('INSERT INTO user_clients');
+    expect(exec.calls[1].sql).toContain('ON CONFLICT DO NOTHING');
+    expect(exec.calls[1].params).toEqual(['user-1', 'c1', 'manual', 'user-1', 'c2', 'manual']);
+  });
+
+  test('only issues the DELETE when the id list is empty', async () => {
+    exec.enqueue({ rows: [], rowCount: 0 });
+    await usersRepo.replaceUserClients('user-1', [], 'manual', exec);
+    expect(exec.calls).toHaveLength(1);
+    expect(exec.calls[0].sql).toContain('DELETE');
+  });
+});
+
+describe('replaceUserProjects', () => {
+  test('issues DELETE then a single bulk INSERT into user_projects', async () => {
+    exec.enqueue({ rows: [] });
+    exec.enqueue({ rows: [] });
+    await usersRepo.replaceUserProjects('user-1', ['p1', 'p2'], 'manual', exec);
+    expect(exec.calls).toHaveLength(2);
+    expect(exec.calls[0].sql).toContain('DELETE FROM user_projects');
+    expect(exec.calls[1].sql).toContain('INSERT INTO user_projects');
+    expect(exec.calls[1].params).toEqual(['user-1', 'p1', 'manual', 'user-1', 'p2', 'manual']);
+  });
+});
+
+describe('replaceUserTasks', () => {
+  test('issues DELETE then a single bulk INSERT into user_tasks', async () => {
+    exec.enqueue({ rows: [] });
+    exec.enqueue({ rows: [] });
+    await usersRepo.replaceUserTasks('user-1', ['t1'], 'manual', exec);
+    expect(exec.calls).toHaveLength(2);
+    expect(exec.calls[0].sql).toContain('DELETE FROM user_tasks');
+    expect(exec.calls[1].sql).toContain('INSERT INTO user_tasks');
+    expect(exec.calls[1].params).toEqual(['user-1', 't1', 'manual']);
+  });
+});
+
+describe('clearProjectCascadeAssignments', () => {
+  test('only deletes rows whose assignment_source is project_cascade', async () => {
+    exec.enqueue({ rows: [], rowCount: 0 });
+    await usersRepo.clearProjectCascadeAssignments('user-1', exec);
+    expect(exec.calls[0].sql).toContain("assignment_source = 'project_cascade'");
+    expect(exec.calls[0].params).toEqual(['user-1']);
+  });
+});
+
+describe('applyProjectCascadeToClients', () => {
+  test('inserts derived rows from user_projects join projects with project_cascade source', async () => {
+    exec.enqueue({ rows: [], rowCount: 0 });
+    await usersRepo.applyProjectCascadeToClients('user-1', exec);
+    expect(exec.calls[0].sql).toContain("'project_cascade'");
+    expect(exec.calls[0].sql).toContain('JOIN projects');
+    expect(exec.calls[0].sql).toContain('ON CONFLICT (user_id, client_id) DO NOTHING');
+    expect(exec.calls[0].params).toEqual(['user-1']);
+  });
+});

--- a/server/test/repositories/usersRepo.test.ts
+++ b/server/test/repositories/usersRepo.test.ts
@@ -456,6 +456,27 @@ describe('addUserRole / clearUserRoles / setPrimaryRole', () => {
   });
 });
 
+describe('replaceUserRoles', () => {
+  test('issues DELETE then a single bulk INSERT for the id list', async () => {
+    exec.enqueue({ rows: [], rowCount: 3 }); // DELETE
+    exec.enqueue({ rows: [], rowCount: 2 }); // INSERT
+    await usersRepo.replaceUserRoles('user-1', ['manager', 'user'], exec);
+    expect(exec.calls).toHaveLength(2);
+    expect(exec.calls[0].sql).toContain('DELETE FROM user_roles');
+    expect(exec.calls[0].params).toEqual(['user-1']);
+    expect(exec.calls[1].sql).toContain('INSERT INTO user_roles');
+    expect(exec.calls[1].sql).toContain('ON CONFLICT DO NOTHING');
+    expect(exec.calls[1].params).toEqual(['user-1', 'manager', 'user-1', 'user']);
+  });
+
+  test('only issues the DELETE when the id list is empty', async () => {
+    exec.enqueue({ rows: [], rowCount: 0 });
+    await usersRepo.replaceUserRoles('user-1', [], exec);
+    expect(exec.calls).toHaveLength(1);
+    expect(exec.calls[0].sql).toContain('DELETE FROM user_roles');
+  });
+});
+
 describe('getUserRoleIds', () => {
   test('returns the role ids in the order returned by the query', async () => {
     exec.enqueue({ rows: [{ roleId: 'manager' }, { roleId: 'user' }] });

--- a/server/utils/permissions.ts
+++ b/server/utils/permissions.ts
@@ -16,6 +16,7 @@ export type PermissionDefinition = {
 };
 
 export const TOP_MANAGER_ROLE_ID = 'top_manager';
+export const ADMIN_ROLE_ID = 'admin';
 
 export const PERMISSION_DEFINITIONS: PermissionDefinition[] = [
   // Timesheets


### PR DESCRIPTION
## Summary

- Moves inline SQL out of `server/routes/products.ts` and `server/routes/users.ts` into per-domain `productsRepo` / `usersRepo` functions, mirroring the existing `notificationsRepo` / `clientsRepo` pattern. Each repo function takes an optional `QueryExecutor` so it works both standalone and inside `withTransaction`.
- Adds repo-level unit tests (`server/test/repositories/productsRepo.test.ts` and `usersRepo.test.ts`) covering the new functions against a fake executor — no DB required.
- Folds in the quality / efficiency follow-ups from two `/simplify` passes.

## Notable cleanups

- `requireValidType` now returns the registered `costUnit`, eliminating redundant `findProductTypeByName` lookups on product create, product update, and internal-category create.
- New `replaceUserRoles` bulk-inserts roles in a single query (mirrors `replaceAssignments`) — used by `PUT /users/:id/roles` to collapse the per-role insert loop.
- `PUT /users/:id` parallelizes `settingsRepo.upsertForUser` + final `usersRepo.findById`.
- `PUT /products/:id` skips `findProductCoreById` on simple edits (name/code/description/costo/molPercentage/isDisabled) and parallelizes the name + code uniqueness checks.
- Permission lookup tables (`CREATE_PERM_BY_EMPLOYEE_TYPE` / `UPDATE_*` / `DELETE_*`) collapse the per-employee-type permission branches in users.ts create/update/delete handlers.
- `ADMIN_ROLE_ID` moves from `usersRepo` to `utils/permissions.ts` next to `TOP_MANAGER_ROLE_ID`.
- `parseDbNumber` replaces hand-rolled count coercion across the new repo functions.
- `as const` on `validateEnum` allowed-values arrays drops the `as EmployeeType` / `as CostUnit` casts at the call sites.
- Stripped narration-only comments from the route files.

## Files changed

- `server/repositories/productsRepo.ts` — product / type / category / subcategory CRUD + cross-domain link checks
- `server/repositories/usersRepo.ts` — full user CRUD, role replacement, assignments
- `server/repositories/suppliersRepo.ts` — added `findNameById`
- `server/utils/permissions.ts` — added `ADMIN_ROLE_ID`
- `server/routes/products.ts`, `server/routes/users.ts` — slimmed down to call repo functions; route handlers retain validation, permission checks, audit logging
- `server/test/repositories/productsRepo.test.ts`, `usersRepo.test.ts` — new repo tests

## Test plan

- [x] `bunx tsc --noEmit` (server) — clean
- [x] `bun test test` — 495 passing, 0 failing (988 expects)
- [ ] Smoke-test the user-management UI (list, create, update, delete, role replacement, assignments) on a deploy
- [ ] Smoke-test the product/category/subcategory/type CRUD on a deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)