### PR TITLE
fix(db): reorder supplier_sales backfill to fix fresh-DB init

### DIFF
--- a/server/db/schema.sql
+++ b/server/db/schema.sql
@@ -1161,14 +1161,6 @@ ALTER TABLE sale_items ADD COLUMN IF NOT EXISTS supplier_sale_id VARCHAR(100);
 ALTER TABLE sale_items ADD COLUMN IF NOT EXISTS supplier_sale_item_id VARCHAR(50);
 ALTER TABLE sale_items ADD COLUMN IF NOT EXISTS supplier_sale_supplier_name VARCHAR(255);
 
--- Backfill: link existing sale_items to their auto-created supplier_sales via shared supplier_quote_id
-UPDATE sale_items si
-SET supplier_sale_id = ss.id,
-    supplier_sale_supplier_name = ss.supplier_name
-FROM supplier_sales ss
-WHERE ss.linked_quote_id = si.supplier_quote_id
-  AND si.supplier_sale_id IS NULL;
-
 CREATE INDEX IF NOT EXISTS idx_sale_items_sale_id ON sale_items(sale_id);
 CREATE INDEX IF NOT EXISTS idx_sale_items_supplier_sale_id ON sale_items(supplier_sale_id);
 
@@ -1471,6 +1463,14 @@ END $$;
 
 CREATE INDEX IF NOT EXISTS idx_supplier_sales_supplier_id ON supplier_sales(supplier_id);
 CREATE INDEX IF NOT EXISTS idx_supplier_sales_status ON supplier_sales(status);
+
+-- Backfill: link existing sale_items to their auto-created supplier_sales via shared supplier_quote_id
+UPDATE sale_items si
+SET supplier_sale_id = ss.id,
+    supplier_sale_supplier_name = ss.supplier_name
+FROM supplier_sales ss
+WHERE ss.linked_quote_id = si.supplier_quote_id
+  AND si.supplier_sale_id IS NULL;
 
 CREATE TABLE IF NOT EXISTS supplier_sale_items (
     id VARCHAR(50) PRIMARY KEY,


### PR DESCRIPTION
## Summary
- Fresh-DB init was aborting with `ERROR: relation "supplier_sales" does not exist` at line 1170 of `server/db/schema.sql`. The backfill `UPDATE sale_items ... FROM supplier_sales ss` lived inside the `sale_items` block, but `CREATE TABLE supplier_sales` doesn't run until ~93 lines later.
- Move the backfill to the end of the `supplier_sales` section — after the table, FK setup, legacy `supplier_offers → supplier_sales` migration, status normalization, and all indexes — and just before `supplier_sale_items` is created.
- The `UPDATE` is idempotent (`WHERE si.supplier_sale_id IS NULL`), so existing installs re-running `schema.sql` are unaffected. The bonus is that rows inserted by the legacy `supplier_offers` migration block are now also picked up by the same backfill, since it runs after that block.

Pure schema-ordering fix; no application-layer changes.

## Test plan
- [ ] `docker compose down -v && docker compose up -d praetor-postgres` — container reaches `database system is ready to accept connections` with no `relation "supplier_sales" does not exist` in the logs.
- [ ] Re-run `schema.sql` against an existing populated DB — completes without errors (idempotence check).
- [ ] On a freshly seeded DB, spot-check linkage:
      `SELECT si.id, si.supplier_quote_id, si.supplier_sale_id, ss.id FROM sale_items si LEFT JOIN supplier_sales ss ON ss.linked_quote_id = si.supplier_quote_id WHERE si.supplier_quote_id IS NOT NULL LIMIT 20;`
      — `si.supplier_sale_id` should equal `ss.id` whenever a matching `supplier_sales` row exists.
- [ ] `cd server && bun run dev` — backend starts without DB errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)