### PR TITLE
ci: add PR workflow with stack deploy + log error checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,18 +90,28 @@ jobs:
       - name: Start stack and wait for healthchecks
         run: docker compose up -d --wait --wait-timeout 60
 
-      - name: Wait for backend /api/health (via Caddy proxy)
+      - name: Wait for backend startup signal
         run: |
           for i in $(seq 1 30); do
-            code=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:3000/api/health || echo 000)
-            echo "[health] attempt $i/30 code=$code"
-            if [ "$code" = 200 ]; then
+            if docker compose logs --no-color --no-log-prefix backend 2>/dev/null | grep -q 'Praetor API server running'; then
+              echo "Backend ready after ~$((i*2))s"
               exit 0
             fi
             sleep 2
           done
-          echo "Health endpoint did not return 200 within 60s"
-          docker compose ps
+          echo "Backend did not log 'Praetor API server running' within 60s"
+          docker compose logs backend
+          exit 1
+
+      - name: Probe /api/health via Caddy proxy
+        run: |
+          for i in 1 2 3; do
+            if curl -fsS http://localhost:3000/api/health; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "/api/health failed via Caddy proxy after backend became ready"
           docker compose logs
           exit 1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Probe frontend SPA shell
         run: |
           response=$(mktemp)
-          code=$(curl -s -o "$response" -w '%{http_code}' http://localhost:3000/)
+          code=$(curl -s -o "$response" -w '%{http_code}' http://localhost:3000/ || echo 000)
           if [ "$code" != 200 ]; then
             echo "Frontend SPA returned $code"
             head -c 500 "$response"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,191 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  lint:
+    name: Lint & Typecheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.12
+
+      - name: Install root dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Install server dependencies
+        run: bun install --frozen-lockfile
+        working-directory: server
+
+      - name: Lint and typecheck
+        run: bun run lint
+
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.12
+
+      - name: Install root dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Install server dependencies
+        run: bun install --frozen-lockfile
+        working-directory: server
+
+      - name: Run repository tests
+        run: bun test server/test
+
+  build:
+    name: Frontend Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.12
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build frontend
+        run: bun run build
+
+  docker-stack:
+    name: Docker Stack Deploy & Health
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Prepare environment file
+        run: cp .env.example .env
+
+      - name: Build images
+        run: docker compose build
+
+      - name: Start stack and wait for healthchecks
+        run: docker compose up -d --wait --wait-timeout 60
+
+      - name: Wait for backend /api/health (via Caddy proxy)
+        run: |
+          for i in $(seq 1 30); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:3000/api/health || echo 000)
+            echo "[health] attempt $i/30 code=$code"
+            if [ "$code" = 200 ]; then
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Health endpoint did not return 200 within 60s"
+          docker compose ps
+          docker compose logs
+          exit 1
+
+      - name: Probe frontend SPA shell
+        run: |
+          response=$(mktemp)
+          code=$(curl -s -o "$response" -w '%{http_code}' http://localhost:3000/)
+          if [ "$code" != 200 ]; then
+            echo "Frontend SPA returned $code"
+            head -c 500 "$response"
+            exit 1
+          fi
+          if ! grep -qiE '<(!doctype html|html)' "$response"; then
+            echo "Frontend response did not look like HTML"
+            head -c 500 "$response"
+            exit 1
+          fi
+
+      - name: Verify all defined services are running
+        run: |
+          expected=$(docker compose config --services | sort | paste -sd, -)
+          running=$(docker compose ps --status running --services | sort | paste -sd, -)
+          echo "running:  $running"
+          echo "expected: $expected"
+          if [ "$running" != "$expected" ]; then
+            docker compose ps
+            exit 1
+          fi
+
+      - name: Capture container logs
+        if: always()
+        run: |
+          mkdir -p logs
+          docker compose logs --no-color --no-log-prefix postgres > logs/postgres.log 2>&1 || true
+          docker compose logs --no-color --no-log-prefix backend > logs/backend.log 2>&1 || true
+          docker compose logs --no-color --no-log-prefix frontend > logs/frontend.log 2>&1 || true
+          perl -i -pe 's/\e\[[\d;]*[A-Za-z]//g' logs/postgres.log logs/backend.log logs/frontend.log
+
+      - name: Dump container logs to console
+        if: always()
+        run: |
+          for svc in postgres backend frontend; do
+            echo "===== $svc ====="
+            cat "logs/$svc.log"
+          done
+
+      - name: Upload stack logs as artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-stack-logs
+          path: logs/
+          retention-days: 7
+
+      - name: Scan postgres logs for FATAL/PANIC
+        run: |
+          if grep -nE '\b(FATAL|PANIC):' logs/postgres.log; then
+            echo "::error::Postgres logged FATAL or PANIC"
+            exit 1
+          fi
+
+      - name: Scan backend logs for error/fatal entries
+        run: |
+          if grep -nE '^\[[^]]+\] (ERROR|FATAL)\b' logs/backend.log; then
+            echo "::error::Backend pretty logs contain ERROR or FATAL"
+            exit 1
+          fi
+          if grep -nE '"level":(50|60)\b' logs/backend.log; then
+            echo "::error::Backend JSON logs contain error/fatal level"
+            exit 1
+          fi
+          if grep -nF 'Failed to start server' logs/backend.log; then
+            echo "::error::Backend logged 'Failed to start server'"
+            exit 1
+          fi
+
+      - name: Scan frontend (Caddy) logs for error/fatal entries
+        run: |
+          if grep -nE '"level":"(error|fatal)"' logs/frontend.log; then
+            echo "::error::Caddy JSON logs contain error/fatal level"
+            exit 1
+          fi
+          if grep -niwE 'panic' logs/frontend.log; then
+            echo "::error::Caddy logs contain 'panic'"
+            exit 1
+          fi
+
+      - name: Tear down stack
+        if: always()
+        run: docker compose down -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint & Typecheck


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` so every PR to `main` runs lint+typecheck, repository tests, a frontend build sanity check, and a full docker-compose stack deploy with per-container log error scanning.
- Until now the only workflow was `create-release.yml` (tag-driven GHCR publish); PRs had no automated quality or stack-boot gate.
- All four jobs run in parallel; no changes to the existing release workflow or to any application/infrastructure files.

## What the docker-stack job does
1. `docker compose build` then `docker compose up -d --wait --wait-timeout 60` so compose itself blocks on the postgres healthcheck.
2. Polls `http://localhost:3000/api/health` (through Caddy, which proves backend + proxy + DB are all up) for up to 60s.
3. Probes the SPA shell at `http://localhost:3000/` and asserts the response is HTML.
4. Verifies all services declared in `docker-compose.yml` are in the `running` state — the expected list is derived from `docker compose config --services` so adding a service later doesn't silently bypass the check.
5. Captures each service's logs, ANSI-strips them, dumps them inline, and uploads as a 7-day artifact.
6. Scans each container's logs for service-specific error patterns:
   - **postgres**: `FATAL:` / `PANIC:`
   - **backend**: pino-pretty `[time] ERROR/FATAL`, JSON `"level":50/60`, or literal `Failed to start server`
   - **frontend (Caddy)**: JSON `"level":"error"/"fatal"` or `panic`
7. `docker compose down -v` in an `if: always()` step.

The backend's WARN-level `"PostgreSQL not ready; retrying"` (during startup ordering) and the default-secret security warnings are deliberately **not** matched — both are expected when the workflow runs with `.env.example` defaults.

## Notable design choices
- **Build from source on each PR** (not pull from GHCR) so the PR's actual code is what's tested.
- **`docker compose up --wait`** instead of a hand-rolled postgres healthcheck poll loop — fewer lines, leverages compose's own retry/timeout logic.
- **No GHA build cache** in this PR — adding it cleanly requires either a compose override file or per-service buildx invocations with image-tag wrangling. Worth a follow-up optimization PR.
- **No composite action** for the bun install pattern — the duplication is three short blocks across three jobs in this single workflow; extracting it would create a `.github/actions/...` directory for marginal gain.

## Test plan
- [ ] Open this PR and confirm the workflow triggers and all four jobs report status.
- [ ] Verify the docker-stack job builds, brings up the stack, hits `/api/health`, and turns green on a known-good main.
- [ ] Negative test: temporarily add a `logger.error(...)` line at backend startup, push, and confirm the backend log-scan step fails with the line cited.
- [ ] Negative test: temporarily make postgres fail (e.g. invalid POSTGRES_USER) and confirm `--wait-timeout` trips and the postgres log-scan or the start step fails with logs visible.
- [ ] Confirm the uploaded `docker-stack-logs` artifact contains `postgres.log`, `backend.log`, `frontend.log` with ANSI codes stripped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)