### PR TITLE
feat(db): convert notificationsRepo to Drizzle (Phase 1)

### DIFF
--- a/server/repositories/notificationsRepo.ts
+++ b/server/repositories/notificationsRepo.ts
@@ -2,10 +2,11 @@ import { and, count, desc, eq, sql } from 'drizzle-orm';
 import { type DbExecutor, db } from '../db/drizzle.ts';
 import { notifications } from '../db/schema/notifications.ts';
 
-// `is_read = false` is written as a SQL literal (not eq(..., false)) so PG can match
-// the predicate against the partial index `idx_notifications_user_unread WHERE is_read = false`.
-// A parameterized `is_read = $N` defeats the partial-index match under generic plans.
-const isUnread = sql`${notifications.isRead} = false`;
+// `is_read IS NOT TRUE` matches both `false` and NULL rows so list / count / markAll
+// agree on what "unread" means (mapRow coerces null → false). Drizzle's `eq(col, false)`
+// would parameterize the comparison and miss NULL; a SQL literal also avoids defeating
+// any partial index that may exist on `is_read = false`.
+const isUnread = sql`${notifications.isRead} is not true`;
 
 export type Notification = {
   id: string;

--- a/server/repositories/notificationsRepo.ts
+++ b/server/repositories/notificationsRepo.ts
@@ -6,7 +6,7 @@ import { notifications } from '../db/schema/notifications.ts';
 // agree on what "unread" means (mapRow coerces null → false). Drizzle's `eq(col, false)`
 // would parameterize the comparison and miss NULL; a SQL literal also avoids defeating
 // any partial index that may exist on `is_read = false`.
-const isUnread = sql`${notifications.isRead} is not true`;
+const isUnread = sql`${notifications.isRead} IS NOT TRUE`;
 
 export type Notification = {
   id: string;
@@ -27,7 +27,9 @@ const mapRow = (row: typeof notifications.$inferSelect): Notification => ({
   message: row.message ?? '',
   data: row.data,
   isRead: row.isRead ?? false,
-  createdAt: row.createdAt ? row.createdAt.getTime() : 0,
+  // `created_at` has DEFAULT CURRENT_TIMESTAMP, so the `?? 0` branch should not fire
+  // in practice; the schema permits NULL only because Phase 0 mirrored schema.sql.
+  createdAt: row.createdAt?.getTime() ?? 0,
 });
 
 export const listForUser = async (

--- a/server/repositories/notificationsRepo.ts
+++ b/server/repositories/notificationsRepo.ts
@@ -1,4 +1,11 @@
-import pool, { type QueryExecutor } from '../db/index.ts';
+import { and, count, desc, eq, sql } from 'drizzle-orm';
+import { type DbExecutor, db } from '../db/drizzle.ts';
+import { notifications } from '../db/schema/notifications.ts';
+
+// `is_read = false` is written as a SQL literal (not eq(..., false)) so PG can match
+// the predicate against the partial index `idx_notifications_user_unread WHERE is_read = false`.
+// A parameterized `is_read = $N` defeats the partial-index match under generic plans.
+const isUnread = sql`${notifications.isRead} = false`;
 
 export type Notification = {
   id: string;
@@ -11,69 +18,67 @@ export type Notification = {
   createdAt: number;
 };
 
+const mapRow = (row: typeof notifications.$inferSelect): Notification => ({
+  id: row.id,
+  userId: row.userId,
+  type: row.type,
+  title: row.title,
+  message: row.message ?? '',
+  data: row.data,
+  isRead: row.isRead ?? false,
+  createdAt: row.createdAt ? row.createdAt.getTime() : 0,
+});
+
 export const listForUser = async (
   userId: string,
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<Notification[]> => {
-  const { rows } = await exec.query<Notification>(
-    `SELECT
-        id,
-        user_id as "userId",
-        type,
-        title,
-        message,
-        data,
-        is_read as "isRead",
-        (EXTRACT(EPOCH FROM created_at) * 1000)::float8 as "createdAt"
-      FROM notifications
-      WHERE user_id = $1
-      ORDER BY created_at DESC
-      LIMIT 50`,
-    [userId],
-  );
-  return rows;
+  const rows = await exec
+    .select()
+    .from(notifications)
+    .where(eq(notifications.userId, userId))
+    .orderBy(desc(notifications.createdAt))
+    .limit(50);
+  return rows.map(mapRow);
 };
 
 export const countUnreadForUser = async (
   userId: string,
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<number> => {
-  const { rows } = await exec.query<{ count: string }>(
-    `SELECT COUNT(*) as count FROM notifications WHERE user_id = $1 AND is_read = FALSE`,
-    [userId],
-  );
-  return Number.parseInt(rows[0].count, 10);
+  const [result] = await exec
+    .select({ value: count() })
+    .from(notifications)
+    .where(and(eq(notifications.userId, userId), isUnread));
+  return result?.value ?? 0;
 };
 
 export const markReadForUser = async (
   id: string,
   userId: string,
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<boolean> => {
-  const { rowCount } = await exec.query(
-    `UPDATE notifications
-       SET is_read = TRUE
-     WHERE id = $1 AND user_id = $2`,
-    [id, userId],
-  );
-  return (rowCount ?? 0) > 0;
+  const result = await exec
+    .update(notifications)
+    .set({ isRead: true })
+    .where(and(eq(notifications.id, id), eq(notifications.userId, userId)));
+  return (result.rowCount ?? 0) > 0;
 };
 
-export const markAllReadForUser = async (
-  userId: string,
-  exec: QueryExecutor = pool,
-): Promise<void> => {
-  await exec.query(`UPDATE notifications SET is_read = TRUE WHERE user_id = $1`, [userId]);
+export const markAllReadForUser = async (userId: string, exec: DbExecutor = db): Promise<void> => {
+  await exec
+    .update(notifications)
+    .set({ isRead: true })
+    .where(and(eq(notifications.userId, userId), isUnread));
 };
 
 export const deleteForUser = async (
   id: string,
   userId: string,
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<boolean> => {
-  const { rowCount } = await exec.query(
-    `DELETE FROM notifications WHERE id = $1 AND user_id = $2`,
-    [id, userId],
-  );
-  return (rowCount ?? 0) > 0;
+  const result = await exec
+    .delete(notifications)
+    .where(and(eq(notifications.id, id), eq(notifications.userId, userId)));
+  return (result.rowCount ?? 0) > 0;
 };

--- a/server/repositories/notificationsRepo.ts
+++ b/server/repositories/notificationsRepo.ts
@@ -4,8 +4,9 @@ import { notifications } from '../db/schema/notifications.ts';
 
 // `is_read IS NOT TRUE` matches both `false` and NULL rows so list / count / markAll
 // agree on what "unread" means (mapRow coerces null → false). Drizzle's `eq(col, false)`
-// would parameterize the comparison and miss NULL; a SQL literal also avoids defeating
-// any partial index that may exist on `is_read = false`.
+// would parameterize the comparison and miss NULL. The partial index
+// `idx_notifications_user_unread` (predicate `is_read = false`) is not matched by this
+// predicate — the NULL-handling consistency is the tradeoff we want.
 const isUnread = sql`${notifications.isRead} IS NOT TRUE`;
 
 export type Notification = {
@@ -27,8 +28,9 @@ const mapRow = (row: typeof notifications.$inferSelect): Notification => ({
   message: row.message ?? '',
   data: row.data,
   isRead: row.isRead ?? false,
-  // `created_at` has DEFAULT CURRENT_TIMESTAMP, so the `?? 0` branch should not fire
-  // in practice; the schema permits NULL only because Phase 0 mirrored schema.sql.
+  // `created_at` is nullable in the schema (mirrors `schema.sql`) but has
+  // DEFAULT CURRENT_TIMESTAMP, so the runtime invariant is that it always has a value;
+  // `?? 0` is a TS-strict appeasement for the unreachable branch.
   createdAt: row.createdAt?.getTime() ?? 0,
 });
 

--- a/server/test/repositories/notificationsRepo.test.ts
+++ b/server/test/repositories/notificationsRepo.test.ts
@@ -9,9 +9,22 @@ import { type FakeExecutor, makeFakeExecutor } from '../helpers/fakeExecutor.ts'
 let exec: FakeExecutor;
 let testDb: DbExecutor;
 
+// Drizzle's node-postgres driver invokes `client.query(config, params)` where `config` is
+// a `{ text, rowMode, ... }` object — not a string. Translate both call shapes so the fake
+// records the SQL string (rather than the raw config object) and so future SQL-string
+// assertions or debugging are straightforward.
+const makePoolAdapter = (fake: FakeExecutor): Pool =>
+  ({
+    query(textOrConfig: string | { text: string; values?: unknown[] }, params?: unknown[]) {
+      const text = typeof textOrConfig === 'string' ? textOrConfig : textOrConfig.text;
+      const values = params ?? (typeof textOrConfig === 'string' ? undefined : textOrConfig.values);
+      return fake.query(text, values);
+    },
+  }) as unknown as Pool;
+
 beforeEach(() => {
   exec = makeFakeExecutor();
-  testDb = drizzle(exec as unknown as Pool, { schema });
+  testDb = drizzle(makePoolAdapter(exec), { schema });
 });
 
 // drizzle-orm/node-postgres uses rowMode: 'array' for select queries; rows are positional

--- a/server/test/repositories/notificationsRepo.test.ts
+++ b/server/test/repositories/notificationsRepo.test.ts
@@ -13,6 +13,10 @@ let testDb: DbExecutor;
 // a `{ text, rowMode, ... }` object — not a string. Translate both call shapes so the fake
 // records the SQL string (rather than the raw config object) and so future SQL-string
 // assertions or debugging are straightforward.
+//
+// Note: this adapter only implements `.query()`. Drizzle's `db.transaction(...)` calls
+// `.connect()` on the pool, which would fail here — this test pattern is for non-
+// transactional repos. Repos with transactional callers will need a different setup.
 const makePoolAdapter = (fake: FakeExecutor): Pool =>
   ({
     query(textOrConfig: string | { text: string; values?: unknown[] }, params?: unknown[]) {
@@ -55,6 +59,15 @@ describe('listForUser', () => {
         createdAt: 1700000000000,
       },
     ]);
+  });
+
+  test('passes JSONB data through unchanged', async () => {
+    const data = { actor: 'u9', refType: 'task', refId: 't1' };
+    exec.enqueue({
+      rows: [['n1', 'user-1', 'task', 't', 'm', data, false, new Date(1700000000000)]],
+    });
+    const [result] = await notificationsRepo.listForUser('user-1', testDb);
+    expect(result.data).toEqual(data);
   });
 
   test('coerces null message/isRead/createdAt to defaults', async () => {

--- a/server/test/repositories/notificationsRepo.test.ts
+++ b/server/test/repositories/notificationsRepo.test.ts
@@ -1,60 +1,83 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import type { Pool } from 'pg';
+import type { DbExecutor } from '../../db/drizzle.ts';
+import * as schema from '../../db/schema/index.ts';
 import * as notificationsRepo from '../../repositories/notificationsRepo.ts';
 import { type FakeExecutor, makeFakeExecutor } from '../helpers/fakeExecutor.ts';
 
 let exec: FakeExecutor;
+let testDb: DbExecutor;
 
 beforeEach(() => {
   exec = makeFakeExecutor();
+  testDb = drizzle(exec as unknown as Pool, { schema });
 });
 
+// drizzle-orm/node-postgres uses rowMode: 'array' for select queries; rows are positional
+// in the column-declaration order from db/schema/notifications.ts.
+
 describe('listForUser', () => {
-  test('passes userId as $1', async () => {
+  test('passes userId in the query params', async () => {
     exec.enqueue({ rows: [] });
-    await notificationsRepo.listForUser('user-1', exec);
-    expect(exec.calls[0].params).toEqual(['user-1']);
+    await notificationsRepo.listForUser('user-1', testDb);
+    expect(exec.calls[0].params).toContain('user-1');
   });
 
-  test('returns rows verbatim from the query', async () => {
-    const row = {
-      id: 'n1',
-      userId: 'user-1',
-      type: 'task',
-      title: 't',
-      message: 'm',
-      data: null,
-      isRead: false,
-      createdAt: 1700000000000,
-    };
-    exec.enqueue({ rows: [row] });
-    const result = await notificationsRepo.listForUser('user-1', exec);
-    expect(result).toEqual([row]);
+  test('maps a returned row to the Notification shape', async () => {
+    const createdAt = new Date(1700000000000);
+    exec.enqueue({
+      rows: [['n1', 'user-1', 'task', 't', 'm', null, false, createdAt]],
+    });
+    const result = await notificationsRepo.listForUser('user-1', testDb);
+    expect(result).toEqual([
+      {
+        id: 'n1',
+        userId: 'user-1',
+        type: 'task',
+        title: 't',
+        message: 'm',
+        data: null,
+        isRead: false,
+        createdAt: 1700000000000,
+      },
+    ]);
+  });
+
+  test('coerces null message/isRead/createdAt to defaults', async () => {
+    exec.enqueue({
+      rows: [['n1', 'user-1', 'task', 't', null, null, null, null]],
+    });
+    const [result] = await notificationsRepo.listForUser('user-1', testDb);
+    expect(result.message).toBe('');
+    expect(result.isRead).toBe(false);
+    expect(result.createdAt).toBe(0);
   });
 });
 
 describe('countUnreadForUser', () => {
-  test('parses the string count from pg into a JS number', async () => {
-    exec.enqueue({ rows: [{ count: '42' }] });
-    const result = await notificationsRepo.countUnreadForUser('user-1', exec);
+  test('returns the count value as a number', async () => {
+    exec.enqueue({ rows: [['42']] });
+    const result = await notificationsRepo.countUnreadForUser('user-1', testDb);
     expect(result).toBe(42);
   });
 
   test('returns 0 when no unread notifications exist', async () => {
-    exec.enqueue({ rows: [{ count: '0' }] });
-    const result = await notificationsRepo.countUnreadForUser('user-1', exec);
+    exec.enqueue({ rows: [['0']] });
+    const result = await notificationsRepo.countUnreadForUser('user-1', testDb);
     expect(result).toBe(0);
   });
 
-  test('passes userId as $1', async () => {
-    exec.enqueue({ rows: [{ count: '0' }] });
-    await notificationsRepo.countUnreadForUser('user-1', exec);
-    expect(exec.calls[0].params).toEqual(['user-1']);
+  test('passes userId in the query params', async () => {
+    exec.enqueue({ rows: [['0']] });
+    await notificationsRepo.countUnreadForUser('user-1', testDb);
+    expect(exec.calls[0].params).toContain('user-1');
   });
 });
 
 describe.each([
-  ['markReadForUser', () => notificationsRepo.markReadForUser('n1', 'user-1', exec)],
-  ['deleteForUser', () => notificationsRepo.deleteForUser('n1', 'user-1', exec)],
+  ['markReadForUser', () => notificationsRepo.markReadForUser('n1', 'user-1', testDb)],
+  ['deleteForUser', () => notificationsRepo.deleteForUser('n1', 'user-1', testDb)],
 ] as const)('%s', (_label, run) => {
   test.each([
     [1, true],
@@ -65,18 +88,19 @@ describe.each([
     expect(await run()).toBe(expected);
   });
 
-  test('passes [id, userId] as $1, $2', async () => {
+  test('passes id and userId in the query params', async () => {
     exec.enqueue({ rows: [], rowCount: 1 });
     await run();
-    expect(exec.calls[0].params).toEqual(['n1', 'user-1']);
+    expect(exec.calls[0].params).toContain('n1');
+    expect(exec.calls[0].params).toContain('user-1');
   });
 });
 
 describe('markAllReadForUser', () => {
-  test('passes userId as $1 and resolves to undefined', async () => {
+  test('passes userId in the query params and resolves to undefined', async () => {
     exec.enqueue({ rows: [] });
-    const result = await notificationsRepo.markAllReadForUser('user-1', exec);
+    const result = await notificationsRepo.markAllReadForUser('user-1', testDb);
     expect(result).toBeUndefined();
-    expect(exec.calls[0].params).toEqual(['user-1']);
+    expect(exec.calls[0].params).toContain('user-1');
   });
 });


### PR DESCRIPTION
## Summary

Phase 1 pilot of the Drizzle ORM adoption plan. Converts [`server/repositories/notificationsRepo.ts`](server/repositories/notificationsRepo.ts) — the smallest repo (5 functions, no transactional callers) — from raw `pg` SQL to Drizzle's query builder. Sets the canonical reference pattern that the remaining 27 repos will follow during Phase 3 conversions. Phase 0 scaffolded the Drizzle wrapper and schema; this PR is the first repo using them.

The `Notification` public type, route call sites, and route-layer behavior are unchanged. Routes call these functions without an `exec` arg, so the default shift from `pool` to `db` is invisible. API response shape stays effectively the same — see *Behavior notes* below for two small intentional differences.

## What changed

- **Repo functions** rewritten with Drizzle's `select` / `update` / `delete` builders. `exec` parameter type changes from `QueryExecutor = pool` to `DbExecutor = db`.
- **`mapRow`** helper (in-file) replaces the in-SQL `AS \"userId\"` aliases and `EXTRACT(EPOCH FROM created_at) * 1000` cast with a TS-side mapper that coerces nullable schema columns (`message`, `isRead`, `createdAt`) to the public shape.
- **`isUnread` SQL literal**: `WHERE is_read IS NOT TRUE` is emitted via a small `sql\`${notifications.isRead} IS NOT TRUE\`` constant, used by both `countUnreadForUser` and `markAllReadForUser`. Treats both `false` and NULL rows as unread, matching `mapRow`'s NULL → false coercion so list / count / markAll all agree on what \"unread\" means. Drizzle's `eq(col, false)` would parameterize the comparison and miss NULL rows.
- **`markAllReadForUser`** now skips already-`true` rows (via the `IS NOT TRUE` filter), so PG doesn't burn a write/lock per already-read row. Final state is identical to the pre-conversion behavior; NULL rows are still flipped to `true`.
- **Tests** wrap `FakeExecutor` in a small `makePoolAdapter` so the fake honestly handles Drizzle's `query(config, params)` call shape (where `config` is a `{ text, rowMode, ... }` object). Drizzle uses `rowMode: 'array'` for select queries, so enqueued rows are positional arrays in the column-declaration order from [`server/db/schema/notifications.ts`](server/db/schema/notifications.ts). Param assertions use `toContain` because Drizzle parameterizes `LIMIT`, `SET` values, and the like — exact param positioning isn't the repo's contract.

## Behavior notes

Two small intentional differences from the pre-conversion behavior:

- **`createdAt` precision**: `Date.getTime()` returns integer milliseconds; the previous `EXTRACT(EPOCH FROM created_at) * 1000)::float8` could carry sub-millisecond precision. Notification timestamps don't need µs precision. If a consumer ever needs it, the fix is one `sql<number>` projection in `listForUser` (~10 extra lines).
- **`countUnreadForUser` index choice**: the `IS NOT TRUE` predicate doesn't match the partial index `idx_notifications_user_unread WHERE is_read = false`, so PG falls back to `idx_notifications_user_id` and filters in-row. Accepted trade-off in favor of NULL-handling consistency. Reinstating the partial-index match would require either a `NOT NULL` migration on `is_read` (out of scope per Phase 0) or accepting the list/count NULL-handling inconsistency that surfaced in review.

## Reviewer notes

- This is the **canonical reference** for Phase 3. Worth scanning for patterns you'd want repeated (or not).
- `withTransaction` interop with Drizzle is **deliberately out of scope** — `notificationsRepo` has zero transactional callers. Cross-paradigm transaction support will be addressed when a Drizzle-converted repo first needs to share a transaction with a legacy repo. The test-side `makePoolAdapter` is also non-transactional; future repos with transactional callers will need a different setup.
- `result?.value ?? 0` in `countUnreadForUser` — both the `?.` and `?? 0` are TS-strict-required (destructure-of-empty-array nullability + `count()` return-type nullability), not redundant.

## Test plan

- [x] `bun test` (server) — 597 / 597 pass, no regressions outside the converted file.
- [x] `bun test test/repositories/notificationsRepo.test.ts` — 16 / 16 pass (5 happy-path, 1 JSONB pass-through, 1 null-coercion, plus the existing rowCount/param matrices).
- [x] `tsc --noEmit` (root) — clean.
- [ ] Smoke-test `GET /api/notifications`, `PUT /api/notifications/:id/read`, `PUT /api/notifications/read-all`, `DELETE /api/notifications/:id` against the dev server. Per [CLAUDE.md](CLAUDE.md) the app runs on remote Docker; this is a manual step.
- [ ] If a Postgres slow-query log is available, optionally run `EXPLAIN ANALYZE` on `countUnreadForUser`'s emitted SQL to confirm which index is hit and whether the `IS NOT TRUE` choice impacts users with very large notification histories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)