### PR TITLE
refactor(db): convert ldapRepo and emailRepo to drizzle

### DIFF
--- a/server/db/migrations/0002_add_config_tables.sql
+++ b/server/db/migrations/0002_add_config_tables.sql
@@ -1,7 +1,16 @@
 -- First-time-modeling migration for the single-row config tables (see db/README.md). Both
--- tables already exist in dev/prod from schema.sql, so the CREATE TABLE statements are
--- guarded with IF NOT EXISTS — no-op on existing DBs while still bootstrapping a fresh DB
--- cleanly. Same pattern as 0000_baseline_pre_drizzle and 0001_add_phase3_tables.
+-- tables already exist in dev/prod from schema.sql; CREATE TABLE / ALTER / INSERT are all
+-- guarded so this is a no-op on existing DBs while bootstrapping a fresh DB cleanly:
+--   * CREATE TABLE IF NOT EXISTS — table-creation guard.
+--   * pg_constraint guard around ADD CONSTRAINT — re-adds the CHECK (id = 1) singleton
+--     invariant from schema.sql on fresh DBs without colliding with the auto-named
+--     constraint that already exists on dev/prod (matched by `contype = 'c'` rather than by
+--     name because Postgres's auto-generated name for an inline column CHECK isn't
+--     guaranteed across versions).
+--   * INSERT … ON CONFLICT DO NOTHING — seeds the singleton id=1 row so the first PUT to
+--     /email/config and /ldap/config succeeds; idempotent on existing DBs that already
+--     have the row from schema.sql.
+-- Same overall pattern as 0000_baseline_pre_drizzle and 0001_add_phase3_tables.
 
 CREATE TABLE IF NOT EXISTS "email_config" (
 	"id" integer PRIMARY KEY DEFAULT 1 NOT NULL,
@@ -30,3 +39,26 @@ CREATE TABLE IF NOT EXISTS "ldap_config" (
 	"role_mappings" jsonb DEFAULT '[]'::jsonb,
 	"updated_at" timestamp DEFAULT CURRENT_TIMESTAMP
 );
+--> statement-breakpoint
+DO $$ BEGIN
+	IF NOT EXISTS (
+		SELECT 1 FROM pg_constraint c
+		JOIN pg_class t ON c.conrelid = t.oid
+		JOIN pg_namespace n ON t.relnamespace = n.oid
+		WHERE t.relname = 'email_config' AND n.nspname = 'public' AND c.contype = 'c'
+	) THEN
+		ALTER TABLE "email_config" ADD CONSTRAINT "email_config_id_check" CHECK ("id" = 1);
+	END IF;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+	IF NOT EXISTS (
+		SELECT 1 FROM pg_constraint c
+		JOIN pg_class t ON c.conrelid = t.oid
+		JOIN pg_namespace n ON t.relnamespace = n.oid
+		WHERE t.relname = 'ldap_config' AND n.nspname = 'public' AND c.contype = 'c'
+	) THEN
+		ALTER TABLE "ldap_config" ADD CONSTRAINT "ldap_config_id_check" CHECK ("id" = 1);
+	END IF;
+END $$;--> statement-breakpoint
+INSERT INTO "email_config" ("id") VALUES (1) ON CONFLICT ("id") DO NOTHING;--> statement-breakpoint
+INSERT INTO "ldap_config" ("id") VALUES (1) ON CONFLICT ("id") DO NOTHING;

--- a/server/db/migrations/0002_add_config_tables.sql
+++ b/server/db/migrations/0002_add_config_tables.sql
@@ -1,0 +1,32 @@
+-- First-time-modeling migration for the single-row config tables (see db/README.md). Both
+-- tables already exist in dev/prod from schema.sql, so the CREATE TABLE statements are
+-- guarded with IF NOT EXISTS — no-op on existing DBs while still bootstrapping a fresh DB
+-- cleanly. Same pattern as 0000_baseline_pre_drizzle and 0001_add_phase3_tables.
+
+CREATE TABLE IF NOT EXISTS "email_config" (
+	"id" integer PRIMARY KEY DEFAULT 1 NOT NULL,
+	"enabled" boolean DEFAULT false,
+	"smtp_host" varchar(255) DEFAULT '',
+	"smtp_port" integer DEFAULT 587,
+	"smtp_encryption" varchar(20) DEFAULT 'tls',
+	"smtp_reject_unauthorized" boolean DEFAULT true,
+	"smtp_user" varchar(255) DEFAULT '',
+	"smtp_password" varchar(255) DEFAULT '',
+	"from_email" varchar(255) DEFAULT '',
+	"from_name" varchar(255) DEFAULT 'Praetor',
+	"updated_at" timestamp DEFAULT CURRENT_TIMESTAMP
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "ldap_config" (
+	"id" integer PRIMARY KEY DEFAULT 1 NOT NULL,
+	"enabled" boolean DEFAULT false,
+	"server_url" varchar(500) DEFAULT 'ldap://ldap.example.com:389',
+	"base_dn" varchar(500) DEFAULT 'dc=example,dc=com',
+	"bind_dn" varchar(500) DEFAULT 'cn=read-only-admin,dc=example,dc=com',
+	"bind_password" varchar(255) DEFAULT '',
+	"user_filter" varchar(255) DEFAULT '(uid={0})',
+	"group_base_dn" varchar(500) DEFAULT 'ou=groups,dc=example,dc=com',
+	"group_filter" varchar(255) DEFAULT '(member={0})',
+	"role_mappings" jsonb DEFAULT '[]'::jsonb,
+	"updated_at" timestamp DEFAULT CURRENT_TIMESTAMP
+);

--- a/server/db/migrations/0002_add_config_tables.sql
+++ b/server/db/migrations/0002_add_config_tables.sql
@@ -6,7 +6,10 @@
 --     invariant from schema.sql on fresh DBs without colliding with the auto-named
 --     constraint that already exists on dev/prod (matched by `contype = 'c'` rather than by
 --     name because Postgres's auto-generated name for an inline column CHECK isn't
---     guaranteed across versions).
+--     guaranteed across versions). The guard treats "any CHECK constraint exists on the
+--     table" as a proxy for "the singleton CHECK exists" — correct for these tables, which
+--     only ever carry the singleton invariant. Adding any other CHECK to either table later
+--     would require revisiting this guard.
 --   * INSERT … ON CONFLICT DO NOTHING — seeds the singleton id=1 row so the first PUT to
 --     /email/config and /ldap/config succeeds; idempotent on existing DBs that already
 --     have the row from schema.sql.

--- a/server/db/migrations/meta/0002_snapshot.json
+++ b/server/db/migrations/meta/0002_snapshot.json
@@ -1,0 +1,1976 @@
+{
+  "id": "ccde6ffb-3134-4b6e-97f9-742be55e143d",
+  "prevId": "e80aab07-ebb7-41df-9bb8-d6955451cf4d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.customer_offers": {
+      "name": "customer_offers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_quote_id": {
+          "name": "linked_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_customer_offers_linked_quote_id": {
+          "name": "idx_customer_offers_linked_quote_id",
+          "columns": [
+            {
+              "expression": "linked_quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_offers_client_id": {
+          "name": "idx_customer_offers_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_offers_status": {
+          "name": "idx_customer_offers_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_offers_created_at": {
+          "name": "idx_customer_offers_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_offers_linked_quote_id_quotes_id_fk": {
+          "name": "customer_offers_linked_quote_id_quotes_id_fk",
+          "tableFrom": "customer_offers",
+          "tableTo": "quotes",
+          "columnsFrom": ["linked_quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_config": {
+      "name": "email_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "smtp_host": {
+          "name": "smtp_host",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "smtp_port": {
+          "name": "smtp_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 587
+        },
+        "smtp_encryption": {
+          "name": "smtp_encryption",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'tls'"
+        },
+        "smtp_reject_unauthorized": {
+          "name": "smtp_reject_unauthorized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "smtp_user": {
+          "name": "smtp_user",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "smtp_password": {
+          "name": "smtp_password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "from_email": {
+          "name": "from_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Praetor'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_items": {
+      "name": "invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_of_measure": {
+          "name": "unit_of_measure",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unit'"
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoice_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "invoices",
+          "columnsFrom": ["invoice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_sale_id": {
+          "name": "linked_sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_date": {
+          "name": "issue_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "amount_paid": {
+          "name": "amount_paid",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_invoices_client_id": {
+          "name": "idx_invoices_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_status": {
+          "name": "idx_invoices_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_issue_date": {
+          "name": "idx_invoices_issue_date",
+          "columns": [
+            {
+              "expression": "issue_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ldap_config": {
+      "name": "ldap_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "server_url": {
+          "name": "server_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ldap://ldap.example.com:389'"
+        },
+        "base_dn": {
+          "name": "base_dn",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'dc=example,dc=com'"
+        },
+        "bind_dn": {
+          "name": "bind_dn",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'cn=read-only-admin,dc=example,dc=com'"
+        },
+        "bind_password": {
+          "name": "bind_password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "user_filter": {
+          "name": "user_filter",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'(uid={0})'"
+        },
+        "group_base_dn": {
+          "name": "group_base_dn",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ou=groups,dc=example,dc=com'"
+        },
+        "group_filter": {
+          "name": "group_filter",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'(member={0})'"
+        },
+        "role_mappings": {
+          "name": "role_mappings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_notifications_user_id": {
+          "name": "idx_notifications_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_user_unread": {
+          "name": "idx_notifications_user_unread",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notifications\".\"is_read\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quote_items": {
+      "name": "quote_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_cost": {
+          "name": "product_cost",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_mol_percentage": {
+          "name": "product_mol_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_id": {
+          "name": "supplier_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_item_id": {
+          "name": "supplier_quote_item_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_supplier_name": {
+          "name": "supplier_quote_supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_unit_price": {
+          "name": "supplier_quote_unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_type": {
+          "name": "unit_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'hours'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quote_items_quote_id_quotes_id_fk": {
+          "name": "quote_items_quote_id_quotes_id_fk",
+          "tableFrom": "quote_items",
+          "tableTo": "quotes",
+          "columnsFrom": ["quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quotes": {
+      "name": "quotes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_quotes_client_id": {
+          "name": "idx_quotes_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quotes_status": {
+          "name": "idx_quotes_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quotes_created_at": {
+          "name": "idx_quotes_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_permissions": {
+      "name": "role_permissions",
+      "schema": "",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_permissions_role_id_roles_id_fk": {
+          "name": "role_permissions_role_id_roles_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "roles",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "role_permissions_role_id_permission_pk": {
+          "name": "role_permissions_role_id_permission_pk",
+          "columns": ["role_id", "permission"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roles": {
+      "name": "roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_roles": {
+      "name": "user_roles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_roles_role_id_roles_id_fk": {
+          "name": "user_roles_role_id_roles_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "roles",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_roles_user_id_role_id_pk": {
+          "name": "user_roles_user_id_role_id_pk",
+          "columns": ["user_id", "role_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sale_items": {
+      "name": "sale_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sale_id": {
+          "name": "sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_cost": {
+          "name": "product_cost",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_mol_percentage": {
+          "name": "product_mol_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "unit_type": {
+          "name": "unit_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'hours'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_id": {
+          "name": "supplier_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_item_id": {
+          "name": "supplier_quote_item_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_supplier_name": {
+          "name": "supplier_quote_supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_unit_price": {
+          "name": "supplier_quote_unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_sale_id": {
+          "name": "supplier_sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_sale_item_id": {
+          "name": "supplier_sale_item_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_sale_supplier_name": {
+          "name": "supplier_sale_supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sale_items_sale_id_sales_id_fk": {
+          "name": "sale_items_sale_id_sales_id_fk",
+          "tableFrom": "sale_items",
+          "tableTo": "sales",
+          "columnsFrom": ["sale_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sales": {
+      "name": "sales",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_quote_id": {
+          "name": "linked_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_offer_id": {
+          "name": "linked_offer_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_sales_client_id": {
+          "name": "idx_sales_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_status": {
+          "name": "idx_sales_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_linked_quote_id": {
+          "name": "idx_sales_linked_quote_id",
+          "columns": [
+            {
+              "expression": "linked_quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_linked_offer_id": {
+          "name": "idx_sales_linked_offer_id",
+          "columns": [
+            {
+              "expression": "linked_offer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_linked_offer_id_unique": {
+          "name": "idx_sales_linked_offer_id_unique",
+          "columns": [
+            {
+              "expression": "linked_offer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sales\".\"linked_offer_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_created_at": {
+          "name": "idx_sales_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sales_linked_quote_id_quotes_id_fk": {
+          "name": "sales_linked_quote_id_quotes_id_fk",
+          "tableFrom": "sales",
+          "tableTo": "quotes",
+          "columnsFrom": ["linked_quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "sales_linked_offer_id_customer_offers_id_fk": {
+          "name": "sales_linked_offer_id_customer_offers_id_fk",
+          "tableFrom": "sales",
+          "tableTo": "customer_offers",
+          "columnsFrom": ["linked_offer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "daily_goal": {
+          "name": "daily_goal",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'8.00'"
+        },
+        "start_of_week": {
+          "name": "start_of_week",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Monday'"
+        },
+        "compact_view": {
+          "name": "compact_view",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "treat_saturday_as_holiday": {
+          "name": "treat_saturday_as_holiday",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "settings_user_id_unique": {
+          "name": "settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_sale_items": {
+      "name": "supplier_sale_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sale_id": {
+          "name": "sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "supplier_sale_items_sale_id_supplier_sales_id_fk": {
+          "name": "supplier_sale_items_sale_id_supplier_sales_id_fk",
+          "tableFrom": "supplier_sale_items",
+          "tableTo": "supplier_sales",
+          "columnsFrom": ["sale_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_sales": {
+      "name": "supplier_sales",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_quote_id": {
+          "name": "linked_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_name": {
+          "name": "supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "recurrence_pattern": {
+          "name": "recurrence_pattern",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_start": {
+          "name": "recurrence_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_end": {
+          "name": "recurrence_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_duration": {
+          "name": "recurrence_duration",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "expected_effort": {
+          "name": "expected_effort",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "revenue": {
+          "name": "revenue",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_tasks": {
+      "name": "user_tasks",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_source": {
+          "name": "assignment_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_tasks_task_id_tasks_id_fk": {
+          "name": "user_tasks_task_id_tasks_id_fk",
+          "tableFrom": "user_tasks",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_tasks_user_id_task_id_pk": {
+          "name": "user_tasks_user_id_task_id_pk",
+          "columns": ["user_id", "task_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.time_entries": {
+      "name": "time_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_name": {
+          "name": "project_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task": {
+          "name": "task",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "hourly_cost": {
+          "name": "hourly_cost",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "is_placeholder": {
+          "name": "is_placeholder",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'remote'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_time_entries_task_id": {
+          "name": "idx_time_entries_task_id",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "time_entries_task_id_tasks_id_fk": {
+          "name": "time_entries_task_id_tasks_id_fk",
+          "tableFrom": "time_entries",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1777679280848,
       "tag": "0001_add_phase3_tables",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1777727920962,
+      "tag": "0002_add_config_tables",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/schema/emailConfig.ts
+++ b/server/db/schema/emailConfig.ts
@@ -1,0 +1,22 @@
+import { sql } from 'drizzle-orm';
+import { boolean, integer, pgTable, timestamp, varchar } from 'drizzle-orm/pg-core';
+
+// Single-row config table: `id INTEGER PRIMARY KEY DEFAULT 1 CHECK (id = 1)` in schema.sql.
+// CHECK not modeled — see `ldapConfig.ts` for the rationale.
+//
+// `smtp_encryption` has no CHECK in the legacy schema (older versions accepted any string,
+// see commit a1f1fcac). The repo normalizes the value at the boundary so consumers get a
+// typed `SmtpEncryption` union; the column itself stays a plain varchar.
+export const emailConfig = pgTable('email_config', {
+  id: integer('id').primaryKey().default(1),
+  enabled: boolean('enabled').default(false),
+  smtpHost: varchar('smtp_host', { length: 255 }).default(''),
+  smtpPort: integer('smtp_port').default(587),
+  smtpEncryption: varchar('smtp_encryption', { length: 20 }).default('tls'),
+  smtpRejectUnauthorized: boolean('smtp_reject_unauthorized').default(true),
+  smtpUser: varchar('smtp_user', { length: 255 }).default(''),
+  smtpPassword: varchar('smtp_password', { length: 255 }).default(''),
+  fromEmail: varchar('from_email', { length: 255 }).default(''),
+  fromName: varchar('from_name', { length: 255 }).default('Praetor'),
+  updatedAt: timestamp('updated_at').default(sql`CURRENT_TIMESTAMP`),
+});

--- a/server/db/schema/index.ts
+++ b/server/db/schema/index.ts
@@ -1,5 +1,7 @@
 export * from './customerOffers.ts';
+export * from './emailConfig.ts';
 export * from './invoices.ts';
+export * from './ldapConfig.ts';
 export * from './notifications.ts';
 export * from './quotes.ts';
 export * from './roles.ts';

--- a/server/db/schema/ldapConfig.ts
+++ b/server/db/schema/ldapConfig.ts
@@ -1,0 +1,25 @@
+import { sql } from 'drizzle-orm';
+import { boolean, integer, jsonb, pgTable, timestamp, varchar } from 'drizzle-orm/pg-core';
+
+// Single-row config table: `id INTEGER PRIMARY KEY DEFAULT 1 CHECK (id = 1)` in schema.sql.
+// The CHECK constraint isn't modeled here — same carve-out as `settings.ts` ("Drizzle Kit's
+// CHECK support is patchy"). Enforcement stays at the DB level.
+//
+// `role_mappings` uses a structural `$type<...>()` rather than importing the named
+// `LdapRoleMapping` from `ldapRepo.ts` — keeping schema → repo as a one-way dependency
+// (matches every other repo's convention of owning its domain types).
+export const ldapConfig = pgTable('ldap_config', {
+  id: integer('id').primaryKey().default(1),
+  enabled: boolean('enabled').default(false),
+  serverUrl: varchar('server_url', { length: 500 }).default('ldap://ldap.example.com:389'),
+  baseDn: varchar('base_dn', { length: 500 }).default('dc=example,dc=com'),
+  bindDn: varchar('bind_dn', { length: 500 }).default('cn=read-only-admin,dc=example,dc=com'),
+  bindPassword: varchar('bind_password', { length: 255 }).default(''),
+  userFilter: varchar('user_filter', { length: 255 }).default('(uid={0})'),
+  groupBaseDn: varchar('group_base_dn', { length: 500 }).default('ou=groups,dc=example,dc=com'),
+  groupFilter: varchar('group_filter', { length: 255 }).default('(member={0})'),
+  roleMappings: jsonb('role_mappings')
+    .$type<Array<{ ldapGroup: string; role: string }>>()
+    .default(sql`'[]'::jsonb`),
+  updatedAt: timestamp('updated_at').default(sql`CURRENT_TIMESTAMP`),
+});

--- a/server/repositories/emailRepo.ts
+++ b/server/repositories/emailRepo.ts
@@ -1,4 +1,6 @@
-import pool, { type QueryExecutor } from '../db/index.ts';
+import { eq, sql } from 'drizzle-orm';
+import { type DbExecutor, db } from '../db/drizzle.ts';
+import { emailConfig } from '../db/schema/emailConfig.ts';
 
 export const SMTP_ENCRYPTIONS = ['insecure', 'ssl', 'tls'] as const;
 export type SmtpEncryption = (typeof SMTP_ENCRYPTIONS)[number];
@@ -35,66 +37,79 @@ export const DEFAULT_CONFIG: EmailConfig = {
   fromName: 'Praetor',
 };
 
-// Older versions of email_config accepted any string for smtp_encryption (see commit a1f1fcac).
-// Normalize at the boundary so consumers can rely on the union type.
-type EmailConfigRow = Omit<EmailConfig, 'smtpEncryption'> & { smtpEncryption: string };
+const EMAIL_PROJECTION = {
+  enabled: emailConfig.enabled,
+  smtpHost: emailConfig.smtpHost,
+  smtpPort: emailConfig.smtpPort,
+  smtpEncryption: emailConfig.smtpEncryption,
+  smtpRejectUnauthorized: emailConfig.smtpRejectUnauthorized,
+  smtpUser: emailConfig.smtpUser,
+  smtpPassword: emailConfig.smtpPassword,
+  fromEmail: emailConfig.fromEmail,
+  fromName: emailConfig.fromName,
+} as const;
 
-const mapRow = (row: EmailConfigRow): EmailConfig => ({
-  ...row,
-  smtpEncryption: (SMTP_ENCRYPTIONS as readonly string[]).includes(row.smtpEncryption)
-    ? (row.smtpEncryption as SmtpEncryption)
-    : 'tls',
-});
+type EmailRow = {
+  enabled: boolean | null;
+  smtpHost: string | null;
+  smtpPort: number | null;
+  smtpEncryption: string | null;
+  smtpRejectUnauthorized: boolean | null;
+  smtpUser: string | null;
+  smtpPassword: string | null;
+  fromEmail: string | null;
+  fromName: string | null;
+};
 
-const SELECT_COLUMNS = `enabled,
-        smtp_host as "smtpHost",
-        smtp_port as "smtpPort",
-        smtp_encryption as "smtpEncryption",
-        smtp_reject_unauthorized as "smtpRejectUnauthorized",
-        smtp_user as "smtpUser",
-        smtp_password as "smtpPassword",
-        from_email as "fromEmail",
-        from_name as "fromName"`;
+// Older versions of email_config accepted any string for smtp_encryption (see commit a1f1fcac);
+// normalize at the boundary so consumers can rely on the union type. Other `?? <default>`
+// coercions are TS-strict appeasements for columns always populated at runtime via DB defaults.
+const mapRow = (row: EmailRow): EmailConfig => {
+  const encryption = row.smtpEncryption ?? '';
+  return {
+    enabled: row.enabled ?? false,
+    smtpHost: row.smtpHost ?? '',
+    smtpPort: row.smtpPort ?? 587,
+    smtpEncryption: (SMTP_ENCRYPTIONS as readonly string[]).includes(encryption)
+      ? (encryption as SmtpEncryption)
+      : 'tls',
+    smtpRejectUnauthorized: row.smtpRejectUnauthorized ?? true,
+    smtpUser: row.smtpUser ?? '',
+    smtpPassword: row.smtpPassword ?? '',
+    fromEmail: row.fromEmail ?? '',
+    fromName: row.fromName ?? 'Praetor',
+  };
+};
 
-export const get = async (exec: QueryExecutor = pool): Promise<EmailConfig | null> => {
-  const { rows } = await exec.query<EmailConfigRow>(
-    `SELECT ${SELECT_COLUMNS} FROM email_config WHERE id = 1`,
-  );
+export const get = async (exec: DbExecutor = db): Promise<EmailConfig | null> => {
+  const rows = await exec.select(EMAIL_PROJECTION).from(emailConfig).where(eq(emailConfig.id, 1));
   return rows[0] ? mapRow(rows[0]) : null;
 };
 
 export const update = async (
   patch: EmailConfigPatch,
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<EmailConfig> => {
-  const { rows } = await exec.query<EmailConfigRow>(
-    `UPDATE email_config
-        SET enabled = COALESCE($1, enabled),
-            smtp_host = COALESCE($2, smtp_host),
-            smtp_port = COALESCE($3, smtp_port),
-            smtp_encryption = COALESCE($4, smtp_encryption),
-            smtp_reject_unauthorized = COALESCE($5, smtp_reject_unauthorized),
-            smtp_user = COALESCE($6, smtp_user),
-            smtp_password = COALESCE($7, smtp_password),
-            from_email = COALESCE($8, from_email),
-            from_name = COALESCE($9, from_name),
-            updated_at = CURRENT_TIMESTAMP
-      WHERE id = 1
-      RETURNING ${SELECT_COLUMNS}`,
-    [
-      patch.enabled,
-      patch.smtpHost,
-      patch.smtpPort,
-      patch.smtpEncryption,
-      patch.smtpRejectUnauthorized,
-      patch.smtpUser,
-      patch.smtpPasswordCiphertext,
-      patch.fromEmail,
-      patch.fromName,
-    ],
-  );
-  if (rows.length === 0) {
+  // COALESCE preserves the existing column when the patch value is undefined (legacy
+  // "undefined leaves column unchanged" semantic). Same pattern as ldapRepo.update.
+  const result = await exec
+    .update(emailConfig)
+    .set({
+      enabled: sql`COALESCE(${patch.enabled ?? null}, ${emailConfig.enabled})`,
+      smtpHost: sql`COALESCE(${patch.smtpHost ?? null}, ${emailConfig.smtpHost})`,
+      smtpPort: sql`COALESCE(${patch.smtpPort ?? null}, ${emailConfig.smtpPort})`,
+      smtpEncryption: sql`COALESCE(${patch.smtpEncryption ?? null}, ${emailConfig.smtpEncryption})`,
+      smtpRejectUnauthorized: sql`COALESCE(${patch.smtpRejectUnauthorized ?? null}, ${emailConfig.smtpRejectUnauthorized})`,
+      smtpUser: sql`COALESCE(${patch.smtpUser ?? null}, ${emailConfig.smtpUser})`,
+      smtpPassword: sql`COALESCE(${patch.smtpPasswordCiphertext ?? null}, ${emailConfig.smtpPassword})`,
+      fromEmail: sql`COALESCE(${patch.fromEmail ?? null}, ${emailConfig.fromEmail})`,
+      fromName: sql`COALESCE(${patch.fromName ?? null}, ${emailConfig.fromName})`,
+      updatedAt: sql`CURRENT_TIMESTAMP`,
+    })
+    .where(eq(emailConfig.id, 1))
+    .returning(EMAIL_PROJECTION);
+  if (result.length === 0) {
     throw new Error('email_config row (id=1) not found; seed missing');
   }
-  return mapRow(rows[0]);
+  return mapRow(result[0]);
 };

--- a/server/repositories/ldapRepo.ts
+++ b/server/repositories/ldapRepo.ts
@@ -1,4 +1,6 @@
-import pool, { type QueryExecutor } from '../db/index.ts';
+import { eq, sql } from 'drizzle-orm';
+import { type DbExecutor, db } from '../db/drizzle.ts';
+import { ldapConfig } from '../db/schema/ldapConfig.ts';
 
 export type LdapRoleMapping = { ldapGroup: string; role: string };
 
@@ -28,56 +30,77 @@ export const DEFAULT_CONFIG: LdapConfig = {
   roleMappings: [],
 };
 
-const SELECT_COLUMNS = `enabled,
-        server_url as "serverUrl",
-        base_dn as "baseDn",
-        bind_dn as "bindDn",
-        bind_password as "bindPassword",
-        user_filter as "userFilter",
-        group_base_dn as "groupBaseDn",
-        group_filter as "groupFilter",
-        COALESCE(role_mappings, '[]'::jsonb) as "roleMappings"`;
+const LDAP_PROJECTION = {
+  enabled: ldapConfig.enabled,
+  serverUrl: ldapConfig.serverUrl,
+  baseDn: ldapConfig.baseDn,
+  bindDn: ldapConfig.bindDn,
+  bindPassword: ldapConfig.bindPassword,
+  userFilter: ldapConfig.userFilter,
+  groupBaseDn: ldapConfig.groupBaseDn,
+  groupFilter: ldapConfig.groupFilter,
+  roleMappings: ldapConfig.roleMappings,
+} as const;
 
-export const get = async (exec: QueryExecutor = pool): Promise<LdapConfig | null> => {
-  const { rows } = await exec.query<LdapConfig>(
-    `SELECT ${SELECT_COLUMNS} FROM ldap_config WHERE id = 1`,
-  );
-  if (rows.length === 0) return null;
-  return rows[0];
+type LdapRow = {
+  enabled: boolean | null;
+  serverUrl: string | null;
+  baseDn: string | null;
+  bindDn: string | null;
+  bindPassword: string | null;
+  userFilter: string | null;
+  groupBaseDn: string | null;
+  groupFilter: string | null;
+  roleMappings: LdapRoleMapping[] | null;
+};
+
+// Schema columns are nullable but always populated at runtime via DB defaults on the seeded
+// id=1 row, so `?? <default>` is a TS-strict appeasement matching the non-nullable `LdapConfig`.
+const mapRow = (row: LdapRow): LdapConfig => ({
+  enabled: row.enabled ?? false,
+  serverUrl: row.serverUrl ?? '',
+  baseDn: row.baseDn ?? '',
+  bindDn: row.bindDn ?? '',
+  bindPassword: row.bindPassword ?? '',
+  userFilter: row.userFilter ?? '',
+  groupBaseDn: row.groupBaseDn ?? '',
+  groupFilter: row.groupFilter ?? '',
+  roleMappings: row.roleMappings ?? [],
+});
+
+export const get = async (exec: DbExecutor = db): Promise<LdapConfig | null> => {
+  const rows = await exec.select(LDAP_PROJECTION).from(ldapConfig).where(eq(ldapConfig.id, 1));
+  return rows[0] ? mapRow(rows[0]) : null;
 };
 
 export const update = async (
   patch: LdapConfigPatch,
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<LdapConfig> => {
-  const { rows } = await exec.query<LdapConfig>(
-    `UPDATE ldap_config SET
-        enabled = COALESCE($1, enabled),
-        server_url = COALESCE($2, server_url),
-        base_dn = COALESCE($3, base_dn),
-        bind_dn = COALESCE($4, bind_dn),
-        bind_password = COALESCE($5, bind_password),
-        user_filter = COALESCE($6, user_filter),
-        group_base_dn = COALESCE($7, group_base_dn),
-        group_filter = COALESCE($8, group_filter),
-        role_mappings = COALESCE($9, role_mappings),
-        updated_at = CURRENT_TIMESTAMP
-      WHERE id = 1
-      RETURNING ${SELECT_COLUMNS}`,
-    [
-      patch.enabled,
-      patch.serverUrl,
-      patch.baseDn,
-      patch.bindDn,
-      patch.bindPassword,
-      patch.userFilter,
-      patch.groupBaseDn,
-      patch.groupFilter,
-      patch.roleMappings === undefined ? null : JSON.stringify(patch.roleMappings),
-    ],
-  );
-  if (rows.length === 0) {
+  // COALESCE preserves the existing column when the patch value is undefined (legacy
+  // "undefined leaves column unchanged" semantic). Same pattern as settingsRepo.upsertForUser.
+  // `role_mappings` needs the explicit `::jsonb` cast on the bound text param so COALESCE's
+  // both branches share the JSONB type.
+  const roleMappingsParam =
+    patch.roleMappings === undefined ? null : JSON.stringify(patch.roleMappings);
+  const result = await exec
+    .update(ldapConfig)
+    .set({
+      enabled: sql`COALESCE(${patch.enabled ?? null}, ${ldapConfig.enabled})`,
+      serverUrl: sql`COALESCE(${patch.serverUrl ?? null}, ${ldapConfig.serverUrl})`,
+      baseDn: sql`COALESCE(${patch.baseDn ?? null}, ${ldapConfig.baseDn})`,
+      bindDn: sql`COALESCE(${patch.bindDn ?? null}, ${ldapConfig.bindDn})`,
+      bindPassword: sql`COALESCE(${patch.bindPassword ?? null}, ${ldapConfig.bindPassword})`,
+      userFilter: sql`COALESCE(${patch.userFilter ?? null}, ${ldapConfig.userFilter})`,
+      groupBaseDn: sql`COALESCE(${patch.groupBaseDn ?? null}, ${ldapConfig.groupBaseDn})`,
+      groupFilter: sql`COALESCE(${patch.groupFilter ?? null}, ${ldapConfig.groupFilter})`,
+      roleMappings: sql`COALESCE(${roleMappingsParam}::jsonb, ${ldapConfig.roleMappings})`,
+      updatedAt: sql`CURRENT_TIMESTAMP`,
+    })
+    .where(eq(ldapConfig.id, 1))
+    .returning(LDAP_PROJECTION);
+  if (result.length === 0) {
     throw new Error('ldap_config row (id=1) not found; seed missing');
   }
-  return rows[0];
+  return mapRow(result[0]);
 };

--- a/server/repositories/ldapRepo.ts
+++ b/server/repositories/ldapRepo.ts
@@ -55,16 +55,21 @@ type LdapRow = {
 };
 
 // Schema columns are nullable but always populated at runtime via DB defaults on the seeded
-// id=1 row, so `?? <default>` is a TS-strict appeasement matching the non-nullable `LdapConfig`.
+// id=1 row, so the `??` fallbacks are a TS-strict appeasement matching the non-nullable
+// `LdapConfig`. Falling back to the corresponding `DEFAULT_CONFIG` value (rather than `''`)
+// keeps the read-with-null-column path consistent with the route's no-row fallback
+// (`(await ldapRepo.get()) ?? ldapRepo.DEFAULT_CONFIG`). `roleMappings` falls back to a
+// fresh `[]` rather than `DEFAULT_CONFIG.roleMappings` so the module-level default array
+// can't be aliased and mutated by callers.
 const mapRow = (row: LdapRow): LdapConfig => ({
-  enabled: row.enabled ?? false,
-  serverUrl: row.serverUrl ?? '',
-  baseDn: row.baseDn ?? '',
-  bindDn: row.bindDn ?? '',
-  bindPassword: row.bindPassword ?? '',
-  userFilter: row.userFilter ?? '',
-  groupBaseDn: row.groupBaseDn ?? '',
-  groupFilter: row.groupFilter ?? '',
+  enabled: row.enabled ?? DEFAULT_CONFIG.enabled,
+  serverUrl: row.serverUrl ?? DEFAULT_CONFIG.serverUrl,
+  baseDn: row.baseDn ?? DEFAULT_CONFIG.baseDn,
+  bindDn: row.bindDn ?? DEFAULT_CONFIG.bindDn,
+  bindPassword: row.bindPassword ?? DEFAULT_CONFIG.bindPassword,
+  userFilter: row.userFilter ?? DEFAULT_CONFIG.userFilter,
+  groupBaseDn: row.groupBaseDn ?? DEFAULT_CONFIG.groupBaseDn,
+  groupFilter: row.groupFilter ?? DEFAULT_CONFIG.groupFilter,
   roleMappings: row.roleMappings ?? [],
 });
 

--- a/server/test/repositories/emailRepo.test.ts
+++ b/server/test/repositories/emailRepo.test.ts
@@ -1,49 +1,45 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
+import type { DbExecutor } from '../../db/drizzle.ts';
 import * as emailRepo from '../../repositories/emailRepo.ts';
-import { type FakeExecutor, makeFakeExecutor } from '../helpers/fakeExecutor.ts';
+import { type FakeExecutor, setupTestDb } from '../helpers/fakeExecutor.ts';
 
 let exec: FakeExecutor;
+let testDb: DbExecutor;
 
 beforeEach(() => {
-  exec = makeFakeExecutor();
+  ({ exec, testDb } = setupTestDb());
 });
 
-const baseRow = {
-  enabled: false,
-  smtpHost: '',
-  smtpPort: 587,
-  smtpEncryption: 'tls',
-  smtpRejectUnauthorized: true,
-  smtpUser: '',
-  smtpPassword: '',
-  fromEmail: '',
-  fromName: 'Praetor',
-};
+// drizzle-orm/node-postgres uses rowMode: 'array' for select queries; rows are positional
+// in the projection-declaration order from `EMAIL_PROJECTION` in emailRepo.ts:
+// [enabled, smtpHost, smtpPort, smtpEncryption, smtpRejectUnauthorized,
+//  smtpUser, smtpPassword, fromEmail, fromName]
+const baseRow: unknown[] = [false, '', 587, 'tls', true, '', '', '', 'Praetor'];
 
 describe('get', () => {
   test('returns null when SELECT returns 0 rows', async () => {
     exec.enqueue({ rows: [] });
-    const result = await emailRepo.get(exec);
+    const result = await emailRepo.get(testDb);
     expect(result).toBeNull();
   });
 
-  test('returns the row verbatim when present', async () => {
+  test('returns the row mapped to EmailConfig when present', async () => {
     exec.enqueue({
       rows: [
-        {
-          ...baseRow,
-          enabled: true,
-          smtpHost: 'smtp.example.com',
-          smtpPort: 465,
-          smtpEncryption: 'ssl',
-          smtpUser: 'noreply@example.com',
-          smtpPassword: 'enc:ciphertext',
-          fromEmail: 'noreply@example.com',
-          fromName: 'Acme',
-        },
+        [
+          true,
+          'smtp.example.com',
+          465,
+          'ssl',
+          true,
+          'noreply@example.com',
+          'enc:ciphertext',
+          'noreply@example.com',
+          'Acme',
+        ],
       ],
     });
-    const result = await emailRepo.get(exec);
+    const result = await emailRepo.get(testDb);
     expect(result).toEqual({
       enabled: true,
       smtpHost: 'smtp.example.com',
@@ -58,19 +54,30 @@ describe('get', () => {
   });
 
   test('normalizes a legacy smtpEncryption value to tls', async () => {
-    exec.enqueue({ rows: [{ ...baseRow, smtpEncryption: 'starttls' }] });
-    const result = await emailRepo.get(exec);
+    const row = baseRow.slice();
+    row[3] = 'starttls';
+    exec.enqueue({ rows: [row] });
+    const result = await emailRepo.get(testDb);
     expect(result?.smtpEncryption).toBe('tls');
+  });
+
+  test('targets the singleton row via WHERE id = 1', async () => {
+    exec.enqueue({ rows: [] });
+    await emailRepo.get(testDb);
+    expect(exec.calls[0].sql).toMatch(/"id"\s*=\s*\$\d+/);
+    expect(exec.calls[0].params).toContain(1);
   });
 });
 
 describe('update', () => {
   test('throws the seed-missing guard when UPDATE returns 0 rows', async () => {
     exec.enqueue({ rows: [] });
-    await expect(emailRepo.update({}, exec)).rejects.toThrow(/email_config row \(id=1\) not found/);
+    await expect(emailRepo.update({}, testDb)).rejects.toThrow(
+      /email_config row \(id=1\) not found/,
+    );
   });
 
-  test('passes patch values in declared column order', async () => {
+  test('passes patch values as bound parameters', async () => {
     exec.enqueue({ rows: [baseRow] });
     await emailRepo.update(
       {
@@ -84,47 +91,60 @@ describe('update', () => {
         fromEmail: 'noreply@example.com',
         fromName: 'Acme',
       },
-      exec,
+      testDb,
     );
-    expect(exec.calls[0].params).toEqual([
-      true,
-      'smtp.example.com',
-      465,
-      'ssl',
-      false,
-      'noreply@example.com',
-      'enc:ciphertext',
-      'noreply@example.com',
-      'Acme',
-    ]);
-  });
-
-  test('passes undefined for omitted patch fields', async () => {
-    exec.enqueue({ rows: [baseRow] });
-    await emailRepo.update({ fromName: 'Acme' }, exec);
     const params = exec.calls[0].params;
-    expect(params).toHaveLength(9);
-    expect(params[8]).toBe('Acme');
-    expect(params[0]).toBeUndefined();
-    expect(params[6]).toBeUndefined();
+    expect(params).toContain(true);
+    expect(params).toContain('smtp.example.com');
+    expect(params).toContain(465);
+    expect(params).toContain('ssl');
+    expect(params).toContain(false);
+    expect(params).toContain('noreply@example.com');
+    expect(params).toContain('enc:ciphertext');
+    expect(params).toContain('Acme');
   });
 
-  test('passes the ciphertext through to $7 when set', async () => {
+  test('binds null for omitted patch fields (COALESCE preserves the existing column)', async () => {
     exec.enqueue({ rows: [baseRow] });
-    await emailRepo.update({ smtpPasswordCiphertext: 'enc:ciphertext' }, exec);
-    expect(exec.calls[0].params[6]).toBe('enc:ciphertext');
+    await emailRepo.update({ fromName: 'Acme' }, testDb);
+    const params = exec.calls[0].params;
+    // The COALESCE pattern binds NULL for every undefined patch field, plus the explicit
+    // value for the field that's set. Exact null-count is implementation detail; what matters
+    // is that the explicit value is bound and the SET clause covers every column.
+    expect(params).toContain('Acme');
+    expect(params.filter((p) => p === null).length).toBeGreaterThan(0);
+  });
+
+  test('binds the ciphertext (not the patch.smtpPassword field) when set', async () => {
+    exec.enqueue({ rows: [baseRow] });
+    await emailRepo.update({ smtpPasswordCiphertext: 'enc:ciphertext' }, testDb);
+    expect(exec.calls[0].params).toContain('enc:ciphertext');
+    // The patch type renames the password field; this test locks in that the renamed field
+    // is what reaches `email_config.smtp_password`.
+    expect(exec.calls[0].sql).toContain('"smtp_password"');
   });
 
   test('returns the row from RETURNING', async () => {
-    exec.enqueue({ rows: [{ ...baseRow, fromName: 'Acme' }] });
-    const result = await emailRepo.update({ fromName: 'Acme' }, exec);
+    const returned = baseRow.slice();
+    returned[8] = 'Acme';
+    exec.enqueue({ rows: [returned] });
+    const result = await emailRepo.update({ fromName: 'Acme' }, testDb);
     expect(result.fromName).toBe('Acme');
   });
 
   test('normalizes a legacy smtpEncryption from RETURNING to tls', async () => {
-    exec.enqueue({ rows: [{ ...baseRow, smtpEncryption: 'starttls' }] });
-    const result = await emailRepo.update({ fromName: 'Acme' }, exec);
+    const returned = baseRow.slice();
+    returned[3] = 'starttls';
+    exec.enqueue({ rows: [returned] });
+    const result = await emailRepo.update({ fromName: 'Acme' }, testDb);
     expect(result.smtpEncryption).toBe('tls');
+  });
+
+  test('targets the singleton row via WHERE id = 1', async () => {
+    exec.enqueue({ rows: [baseRow] });
+    await emailRepo.update({ fromName: 'Acme' }, testDb);
+    expect(exec.calls[0].sql).toMatch(/"id"\s*=\s*\$\d+/);
+    expect(exec.calls[0].params).toContain(1);
   });
 });
 

--- a/server/test/repositories/emailRepo.test.ts
+++ b/server/test/repositories/emailRepo.test.ts
@@ -11,10 +11,40 @@ beforeEach(() => {
 });
 
 // drizzle-orm/node-postgres uses rowMode: 'array' for select queries; rows are positional
-// in the projection-declaration order from `EMAIL_PROJECTION` in emailRepo.ts:
-// [enabled, smtpHost, smtpPort, smtpEncryption, smtpRejectUnauthorized,
-//  smtpUser, smtpPassword, fromEmail, fromName]
-const baseRow: unknown[] = [false, '', 587, 'tls', true, '', '', '', 'Praetor'];
+// in the projection-declaration order from `EMAIL_PROJECTION` in emailRepo.ts. Tests use
+// `buildRow` (below) to construct fixtures by field name rather than by index, so a column
+// reorder in the repo is caught either at TS compile time (unknown key) or at test time
+// (wrong-shaped row). PROJECTION_KEYS MUST stay in sync with `EMAIL_PROJECTION`.
+const PROJECTION_KEYS = [
+  'enabled',
+  'smtpHost',
+  'smtpPort',
+  'smtpEncryption',
+  'smtpRejectUnauthorized',
+  'smtpUser',
+  'smtpPassword',
+  'fromEmail',
+  'fromName',
+] as const;
+type ProjectionKey = (typeof PROJECTION_KEYS)[number];
+type RowFields = Record<ProjectionKey, unknown>;
+
+const baseFields: RowFields = {
+  enabled: false,
+  smtpHost: '',
+  smtpPort: 587,
+  smtpEncryption: 'tls',
+  smtpRejectUnauthorized: true,
+  smtpUser: '',
+  smtpPassword: '',
+  fromEmail: '',
+  fromName: 'Praetor',
+};
+
+const buildRow = (overrides: Partial<RowFields> = {}): unknown[] => {
+  const merged: RowFields = { ...baseFields, ...overrides };
+  return PROJECTION_KEYS.map((k) => merged[k]);
+};
 
 describe('get', () => {
   test('returns null when SELECT returns 0 rows', async () => {
@@ -26,17 +56,16 @@ describe('get', () => {
   test('returns the row mapped to EmailConfig when present', async () => {
     exec.enqueue({
       rows: [
-        [
-          true,
-          'smtp.example.com',
-          465,
-          'ssl',
-          true,
-          'noreply@example.com',
-          'enc:ciphertext',
-          'noreply@example.com',
-          'Acme',
-        ],
+        buildRow({
+          enabled: true,
+          smtpHost: 'smtp.example.com',
+          smtpPort: 465,
+          smtpEncryption: 'ssl',
+          smtpUser: 'noreply@example.com',
+          smtpPassword: 'enc:ciphertext',
+          fromEmail: 'noreply@example.com',
+          fromName: 'Acme',
+        }),
       ],
     });
     const result = await emailRepo.get(testDb);
@@ -54,9 +83,7 @@ describe('get', () => {
   });
 
   test('normalizes a legacy smtpEncryption value to tls', async () => {
-    const row = baseRow.slice();
-    row[3] = 'starttls';
-    exec.enqueue({ rows: [row] });
+    exec.enqueue({ rows: [buildRow({ smtpEncryption: 'starttls' })] });
     const result = await emailRepo.get(testDb);
     expect(result?.smtpEncryption).toBe('tls');
   });
@@ -78,7 +105,7 @@ describe('update', () => {
   });
 
   test('passes patch values as bound parameters', async () => {
-    exec.enqueue({ rows: [baseRow] });
+    exec.enqueue({ rows: [buildRow()] });
     await emailRepo.update(
       {
         enabled: true,
@@ -105,7 +132,7 @@ describe('update', () => {
   });
 
   test('binds null for omitted patch fields (COALESCE preserves the existing column)', async () => {
-    exec.enqueue({ rows: [baseRow] });
+    exec.enqueue({ rows: [buildRow()] });
     await emailRepo.update({ fromName: 'Acme' }, testDb);
     const params = exec.calls[0].params;
     // The COALESCE pattern binds NULL for every undefined patch field, plus the explicit
@@ -116,7 +143,7 @@ describe('update', () => {
   });
 
   test('binds the ciphertext (not the patch.smtpPassword field) when set', async () => {
-    exec.enqueue({ rows: [baseRow] });
+    exec.enqueue({ rows: [buildRow()] });
     await emailRepo.update({ smtpPasswordCiphertext: 'enc:ciphertext' }, testDb);
     expect(exec.calls[0].params).toContain('enc:ciphertext');
     // The patch type renames the password field; this test locks in that the renamed field
@@ -125,23 +152,19 @@ describe('update', () => {
   });
 
   test('returns the row from RETURNING', async () => {
-    const returned = baseRow.slice();
-    returned[8] = 'Acme';
-    exec.enqueue({ rows: [returned] });
+    exec.enqueue({ rows: [buildRow({ fromName: 'Acme' })] });
     const result = await emailRepo.update({ fromName: 'Acme' }, testDb);
     expect(result.fromName).toBe('Acme');
   });
 
   test('normalizes a legacy smtpEncryption from RETURNING to tls', async () => {
-    const returned = baseRow.slice();
-    returned[3] = 'starttls';
-    exec.enqueue({ rows: [returned] });
+    exec.enqueue({ rows: [buildRow({ smtpEncryption: 'starttls' })] });
     const result = await emailRepo.update({ fromName: 'Acme' }, testDb);
     expect(result.smtpEncryption).toBe('tls');
   });
 
   test('targets the singleton row via WHERE id = 1', async () => {
-    exec.enqueue({ rows: [baseRow] });
+    exec.enqueue({ rows: [buildRow()] });
     await emailRepo.update({ fromName: 'Acme' }, testDb);
     expect(exec.calls[0].sql).toMatch(/"id"\s*=\s*\$\d+/);
     expect(exec.calls[0].params).toContain(1);

--- a/server/test/repositories/ldapRepo.test.ts
+++ b/server/test/repositories/ldapRepo.test.ts
@@ -12,20 +12,40 @@ beforeEach(() => {
 });
 
 // drizzle-orm/node-postgres uses rowMode: 'array' for select queries; rows are positional
-// in the projection-declaration order from `LDAP_PROJECTION` in ldapRepo.ts:
-// [enabled, serverUrl, baseDn, bindDn, bindPassword, userFilter, groupBaseDn, groupFilter, roleMappings]
+// in the projection-declaration order from `LDAP_PROJECTION` in ldapRepo.ts. Tests use
+// `buildRow` (below) to construct fixtures by field name rather than by index, so a column
+// reorder in the repo is caught either at TS compile time (unknown key) or at test time
+// (wrong-shaped row). PROJECTION_KEYS MUST stay in sync with `LDAP_PROJECTION`.
+const PROJECTION_KEYS = [
+  'enabled',
+  'serverUrl',
+  'baseDn',
+  'bindDn',
+  'bindPassword',
+  'userFilter',
+  'groupBaseDn',
+  'groupFilter',
+  'roleMappings',
+] as const;
+type ProjectionKey = (typeof PROJECTION_KEYS)[number];
+type RowFields = Record<ProjectionKey, unknown>;
 
-const baseRow = [
-  false,
-  'ldap://example',
-  'dc=example',
-  'cn=admin',
-  '',
-  '(uid={0})',
-  'ou=groups',
-  '(member={0})',
-  [] as LdapRoleMapping[],
-];
+const baseFields: RowFields = {
+  enabled: false,
+  serverUrl: 'ldap://example',
+  baseDn: 'dc=example',
+  bindDn: 'cn=admin',
+  bindPassword: '',
+  userFilter: '(uid={0})',
+  groupBaseDn: 'ou=groups',
+  groupFilter: '(member={0})',
+  roleMappings: [] as LdapRoleMapping[],
+};
+
+const buildRow = (overrides: Partial<RowFields> = {}): unknown[] => {
+  const merged: RowFields = { ...baseFields, ...overrides };
+  return PROJECTION_KEYS.map((k) => merged[k]);
+};
 
 describe('get', () => {
   test('returns null when no row exists', async () => {
@@ -36,9 +56,7 @@ describe('get', () => {
 
   test('returns the row, including JSONB roleMappings as a JS array', async () => {
     const mappings: LdapRoleMapping[] = [{ ldapGroup: 'admins', role: 'admin' }];
-    const row = baseRow.slice();
-    row[8] = mappings;
-    exec.enqueue({ rows: [row] });
+    exec.enqueue({ rows: [buildRow({ roleMappings: mappings })] });
     const result = await ldapRepo.get(testDb);
     expect(result?.roleMappings).toEqual(mappings);
   });
@@ -59,11 +77,9 @@ describe('update', () => {
 
   test('returns the RETURNING row mapped to the LdapConfig shape', async () => {
     const mappings: LdapRoleMapping[] = [{ ldapGroup: 'g', role: 'r' }];
-    const returned = baseRow.slice();
-    returned[0] = true;
-    returned[1] = 'ldaps://x';
-    returned[8] = mappings;
-    exec.enqueue({ rows: [returned] });
+    exec.enqueue({
+      rows: [buildRow({ enabled: true, serverUrl: 'ldaps://x', roleMappings: mappings })],
+    });
     const result = await ldapRepo.update({ enabled: true, serverUrl: 'ldaps://x' }, testDb);
     expect(result.enabled).toBe(true);
     expect(result.serverUrl).toBe('ldaps://x');
@@ -71,20 +87,20 @@ describe('update', () => {
   });
 
   test('JSON-stringifies a non-empty roleMappings array as the bound parameter', async () => {
-    exec.enqueue({ rows: [baseRow] });
+    exec.enqueue({ rows: [buildRow()] });
     const mappings = [{ ldapGroup: 'g', role: 'r' }];
     await ldapRepo.update({ roleMappings: mappings }, testDb);
     expect(exec.calls[0].params).toContain(JSON.stringify(mappings));
   });
 
   test('binds JSON "[]" for an empty roleMappings array (set-to-empty case)', async () => {
-    exec.enqueue({ rows: [baseRow] });
+    exec.enqueue({ rows: [buildRow()] });
     await ldapRepo.update({ roleMappings: [] }, testDb);
     expect(exec.calls[0].params).toContain('[]');
   });
 
   test('binds NULL for roleMappings when patch.roleMappings is undefined (COALESCE preserves)', async () => {
-    exec.enqueue({ rows: [baseRow] });
+    exec.enqueue({ rows: [buildRow()] });
     await ldapRepo.update({ enabled: true }, testDb);
     // The SET clause always includes role_mappings via COALESCE($N::jsonb, role_mappings);
     // when patch is undefined, $N binds to null and COALESCE returns the existing column.
@@ -93,7 +109,7 @@ describe('update', () => {
   });
 
   test('passes scalar patch values as bound parameters', async () => {
-    exec.enqueue({ rows: [baseRow] });
+    exec.enqueue({ rows: [buildRow()] });
     await ldapRepo.update(
       {
         enabled: true,
@@ -119,7 +135,7 @@ describe('update', () => {
   });
 
   test('targets the singleton row via WHERE id = 1', async () => {
-    exec.enqueue({ rows: [baseRow] });
+    exec.enqueue({ rows: [buildRow()] });
     await ldapRepo.update({ enabled: true }, testDb);
     expect(exec.calls[0].sql).toMatch(/"id"\s*=\s*\$\d+/);
     expect(exec.calls[0].params).toContain(1);

--- a/server/test/repositories/ldapRepo.test.ts
+++ b/server/test/repositories/ldapRepo.test.ts
@@ -1,67 +1,98 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
+import type { DbExecutor } from '../../db/drizzle.ts';
 import type { LdapRoleMapping } from '../../repositories/ldapRepo.ts';
 import * as ldapRepo from '../../repositories/ldapRepo.ts';
-import { type FakeExecutor, makeFakeExecutor } from '../helpers/fakeExecutor.ts';
+import { type FakeExecutor, setupTestDb } from '../helpers/fakeExecutor.ts';
 
 let exec: FakeExecutor;
+let testDb: DbExecutor;
 
 beforeEach(() => {
-  exec = makeFakeExecutor();
+  ({ exec, testDb } = setupTestDb());
 });
 
-const baseRow = {
-  enabled: false,
-  serverUrl: 'ldap://example',
-  baseDn: 'dc=example',
-  bindDn: 'cn=admin',
-  bindPassword: '',
-  userFilter: '(uid={0})',
-  groupBaseDn: 'ou=groups',
-  groupFilter: '(member={0})',
-  roleMappings: [] as LdapRoleMapping[],
-};
+// drizzle-orm/node-postgres uses rowMode: 'array' for select queries; rows are positional
+// in the projection-declaration order from `LDAP_PROJECTION` in ldapRepo.ts:
+// [enabled, serverUrl, baseDn, bindDn, bindPassword, userFilter, groupBaseDn, groupFilter, roleMappings]
+
+const baseRow = [
+  false,
+  'ldap://example',
+  'dc=example',
+  'cn=admin',
+  '',
+  '(uid={0})',
+  'ou=groups',
+  '(member={0})',
+  [] as LdapRoleMapping[],
+];
 
 describe('get', () => {
   test('returns null when no row exists', async () => {
     exec.enqueue({ rows: [] });
-    const result = await ldapRepo.get(exec);
+    const result = await ldapRepo.get(testDb);
     expect(result).toBeNull();
   });
 
-  test('returns the row verbatim, including JSONB roleMappings as a JS array', async () => {
+  test('returns the row, including JSONB roleMappings as a JS array', async () => {
     const mappings: LdapRoleMapping[] = [{ ldapGroup: 'admins', role: 'admin' }];
-    exec.enqueue({ rows: [{ ...baseRow, roleMappings: mappings }] });
-    const result = await ldapRepo.get(exec);
+    const row = baseRow.slice();
+    row[8] = mappings;
+    exec.enqueue({ rows: [row] });
+    const result = await ldapRepo.get(testDb);
     expect(result?.roleMappings).toEqual(mappings);
+  });
+
+  test('targets the singleton row via WHERE id = 1', async () => {
+    exec.enqueue({ rows: [] });
+    await ldapRepo.get(testDb);
+    expect(exec.calls[0].sql).toMatch(/"id"\s*=\s*\$\d+/);
+    expect(exec.calls[0].params).toContain(1);
   });
 });
 
 describe('update', () => {
   test('throws the seed-missing guard when UPDATE returns 0 rows', async () => {
     exec.enqueue({ rows: [] });
-    await expect(ldapRepo.update({}, exec)).rejects.toThrow(/ldap_config row \(id=1\) not found/);
+    await expect(ldapRepo.update({}, testDb)).rejects.toThrow(/ldap_config row \(id=1\) not found/);
   });
 
-  test('JSON.stringifies a non-empty roleMappings array as $9', async () => {
+  test('returns the RETURNING row mapped to the LdapConfig shape', async () => {
+    const mappings: LdapRoleMapping[] = [{ ldapGroup: 'g', role: 'r' }];
+    const returned = baseRow.slice();
+    returned[0] = true;
+    returned[1] = 'ldaps://x';
+    returned[8] = mappings;
+    exec.enqueue({ rows: [returned] });
+    const result = await ldapRepo.update({ enabled: true, serverUrl: 'ldaps://x' }, testDb);
+    expect(result.enabled).toBe(true);
+    expect(result.serverUrl).toBe('ldaps://x');
+    expect(result.roleMappings).toEqual(mappings);
+  });
+
+  test('JSON-stringifies a non-empty roleMappings array as the bound parameter', async () => {
     exec.enqueue({ rows: [baseRow] });
     const mappings = [{ ldapGroup: 'g', role: 'r' }];
-    await ldapRepo.update({ roleMappings: mappings }, exec);
-    expect(exec.calls[0].params[8]).toBe(JSON.stringify(mappings));
+    await ldapRepo.update({ roleMappings: mappings }, testDb);
+    expect(exec.calls[0].params).toContain(JSON.stringify(mappings));
   });
 
-  test('serializes an empty roleMappings array via JSON.stringify (set-to-empty case)', async () => {
+  test('binds JSON "[]" for an empty roleMappings array (set-to-empty case)', async () => {
     exec.enqueue({ rows: [baseRow] });
-    await ldapRepo.update({ roleMappings: [] }, exec);
-    expect(exec.calls[0].params[8]).toBe(JSON.stringify([]));
+    await ldapRepo.update({ roleMappings: [] }, testDb);
+    expect(exec.calls[0].params).toContain('[]');
   });
 
-  test('passes null for roleMappings when omitted (leave-unchanged case)', async () => {
+  test('binds NULL for roleMappings when patch.roleMappings is undefined (COALESCE preserves)', async () => {
     exec.enqueue({ rows: [baseRow] });
-    await ldapRepo.update({ enabled: true }, exec);
-    expect(exec.calls[0].params[8]).toBeNull();
+    await ldapRepo.update({ enabled: true }, testDb);
+    // The SET clause always includes role_mappings via COALESCE($N::jsonb, role_mappings);
+    // when patch is undefined, $N binds to null and COALESCE returns the existing column.
+    expect(exec.calls[0].sql).toContain('::jsonb');
+    expect(exec.calls[0].params.filter((p) => p === null).length).toBeGreaterThanOrEqual(8);
   });
 
-  test('passes the other patch fields in $1..$8 order', async () => {
+  test('passes scalar patch values as bound parameters', async () => {
     exec.enqueue({ rows: [baseRow] });
     await ldapRepo.update(
       {
@@ -74,17 +105,39 @@ describe('update', () => {
         groupBaseDn: 'ou=g',
         groupFilter: '(uniqueMember={0})',
       },
-      exec,
+      testDb,
     );
-    expect(exec.calls[0].params.slice(0, 8)).toEqual([
-      true,
-      'ldaps://x',
-      'dc=y',
-      'cn=z',
-      'pw',
-      '(cn={0})',
-      'ou=g',
-      '(uniqueMember={0})',
-    ]);
+    const params = exec.calls[0].params;
+    expect(params).toContain(true);
+    expect(params).toContain('ldaps://x');
+    expect(params).toContain('dc=y');
+    expect(params).toContain('cn=z');
+    expect(params).toContain('pw');
+    expect(params).toContain('(cn={0})');
+    expect(params).toContain('ou=g');
+    expect(params).toContain('(uniqueMember={0})');
+  });
+
+  test('targets the singleton row via WHERE id = 1', async () => {
+    exec.enqueue({ rows: [baseRow] });
+    await ldapRepo.update({ enabled: true }, testDb);
+    expect(exec.calls[0].sql).toMatch(/"id"\s*=\s*\$\d+/);
+    expect(exec.calls[0].params).toContain(1);
+  });
+});
+
+describe('DEFAULT_CONFIG', () => {
+  test('matches the schema-default shape used as a fallback when seed is absent', () => {
+    expect(ldapRepo.DEFAULT_CONFIG).toEqual({
+      enabled: false,
+      serverUrl: 'ldap://ldap.example.com:389',
+      baseDn: 'dc=example,dc=com',
+      bindDn: 'cn=read-only-admin,dc=example,dc=com',
+      bindPassword: '',
+      userFilter: '(uid={0})',
+      groupBaseDn: 'ou=groups,dc=example,dc=com',
+      groupFilter: '(member={0})',
+      roleMappings: [],
+    });
   });
 });


### PR DESCRIPTION
## Summary

Continues Phase 3 of the Drizzle ORM adoption — converts `ldapRepo` and `emailRepo` from raw SQL (pg driver) to Drizzle. Bundled because both are single-row config tables with an identical `get` + `update` shape, so the conversion of one is the template for the other. Brings the converted-repo count to **10 of 28**.

## Changes

- **New schemas**: [`server/db/schema/ldapConfig.ts`](server/db/schema/ldapConfig.ts), [`server/db/schema/emailConfig.ts`](server/db/schema/emailConfig.ts), re-exported from [`server/db/schema/index.ts`](server/db/schema/index.ts).
- **New migration**: [`server/db/migrations/0002_add_config_tables.sql`](server/db/migrations/0002_add_config_tables.sql) — \"first-time-modeling\" pattern with \`CREATE TABLE IF NOT EXISTS\` guards, matching \`0000_baseline_pre_drizzle\` and \`0001_add_phase3_tables\`. No-op on existing dev/prod DBs (which already have the tables from \`schema.sql\`); records entries in \`__drizzle_migrations\` for tracking.
- **Repo rewrites**: [`ldapRepo.ts`](server/repositories/ldapRepo.ts) and [`emailRepo.ts`](server/repositories/emailRepo.ts) using Drizzle. Public API preserved exactly (function names, parameter shapes, return shapes, \`DEFAULT_CONFIG\`, \`SMTP_ENCRYPTIONS\`, error messages). No route changes needed.
- **Tests adapted**: switched from \`makeFakeExecutor\` to \`setupTestDb\` (positional-array rows in projection-declaration order, per Drizzle's \`rowMode: 'array'\`).

## Pattern notes

- **\`COALESCE(patch, column)\` semantic preserved**: the legacy \"undefined leaves column unchanged\" behavior is replicated via \`sql\`COALESCE(\${patch.x ?? null}, \${table.x})\`\` for every field — same pattern as \`settingsRepo.upsertForUser\`.
- **JSONB handling**: \`role_mappings\` in \`ldapRepo.update\` uses an explicit \`::jsonb\` cast on the bound text param so COALESCE's branches share a uniform JSONB type. Wire shape (JSON-stringified text) matches the legacy code.
- **\`LdapRoleMapping\` lives in the repo, not the schema** — matches the convention every other Drizzle-converted repo uses (each repo owns its domain types). The schema uses an inline structural \`\$type<...>()\` to avoid a schema → repo dependency.

## Test plan

- [x] \`bun test test/repositories\` — 586 / 586 pass
- [x] \`bun run build\` (server tsc) — clean
- [x] \`bun run db:check\` — drizzle snapshot consistent with migrations
- [x] \`biome check\` — clean
- [ ] **Reviewer to verify on a staging DB**: \`bun run db:migrate\` is a no-op on an existing DB with seeded \`ldap_config\`/\`email_config\` rows; \`SELECT * FROM ldap_config WHERE id = 1\` and \`SELECT * FROM email_config WHERE id = 1\` return unchanged values post-migration.
- [ ] **Manual smoke** in dev: hit the LDAP and email config endpoints; PATCH a single field and confirm the unset fields are preserved (the COALESCE semantic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)