### PR TITLE
refactor(db): convert generalSettingsRepo to drizzle

### DIFF
--- a/server/db/migrations/0003_add_general_settings_table.sql
+++ b/server/db/migrations/0003_add_general_settings_table.sql
@@ -1,0 +1,51 @@
+-- First-time-modeling migration for the `general_settings` single-row config table (see
+-- db/README.md). The table already exists in dev/prod from schema.sql; CREATE TABLE,
+-- ADD CONSTRAINT, and INSERT are all guarded so this is a no-op on existing DBs while
+-- bootstrapping a fresh DB cleanly. Same overall pattern as 0002_add_config_tables.sql.
+--
+--   * CREATE TABLE IF NOT EXISTS — table-creation guard.
+--   * pg_constraint guard around ADD CONSTRAINT — re-adds the CHECK (id = 1) singleton
+--     invariant from schema.sql on fresh DBs without colliding with the auto-named
+--     constraint that already exists on dev/prod (matched by `contype = 'c'` rather than
+--     by name because Postgres's auto-generated name for an inline column CHECK isn't
+--     guaranteed across versions).
+--
+--     Note vs. 0002: `general_settings` has *additional* CHECKs in schema.sql beyond the
+--     singleton (`start_of_week IN ('Monday','Sunday')`, `ai_provider IN (...)`). On every
+--     realistic DB state — fresh from schema.sql or pre-seeded prod — all three CHECKs are
+--     present together, so the "any CHECK exists" proxy still correctly treats the singleton
+--     as already-present and skips. A future migration that drops one CHECK while leaving
+--     others would defeat this guard and need explicit handling.
+--
+--   * INSERT … ON CONFLICT DO NOTHING — seeds the singleton id=1 row so the first PUT to
+--     /general-settings succeeds; idempotent on existing DBs that already have the row
+--     from schema.sql:717.
+
+CREATE TABLE IF NOT EXISTS "general_settings" (
+	"id" integer PRIMARY KEY DEFAULT 1 NOT NULL,
+	"currency" varchar(10) DEFAULT '€',
+	"daily_limit" numeric(4, 2) DEFAULT '8.00',
+	"start_of_week" varchar(10) DEFAULT 'Monday',
+	"treat_saturday_as_holiday" boolean DEFAULT true,
+	"enable_ai_reporting" boolean DEFAULT false,
+	"gemini_api_key" varchar(255),
+	"ai_provider" varchar(20) DEFAULT 'gemini',
+	"openrouter_api_key" varchar(255),
+	"gemini_model_id" varchar(255),
+	"openrouter_model_id" varchar(255),
+	"allow_weekend_selection" boolean DEFAULT true,
+	"default_location" varchar(20) DEFAULT 'remote',
+	"updated_at" timestamp DEFAULT CURRENT_TIMESTAMP
+);
+--> statement-breakpoint
+DO $$ BEGIN
+	IF NOT EXISTS (
+		SELECT 1 FROM pg_constraint c
+		JOIN pg_class t ON c.conrelid = t.oid
+		JOIN pg_namespace n ON t.relnamespace = n.oid
+		WHERE t.relname = 'general_settings' AND n.nspname = 'public' AND c.contype = 'c'
+	) THEN
+		ALTER TABLE "general_settings" ADD CONSTRAINT "general_settings_id_check" CHECK ("id" = 1);
+	END IF;
+END $$;--> statement-breakpoint
+INSERT INTO "general_settings" ("id") VALUES (1) ON CONFLICT ("id") DO NOTHING;

--- a/server/db/migrations/0003_add_general_settings_table.sql
+++ b/server/db/migrations/0003_add_general_settings_table.sql
@@ -1,21 +1,28 @@
 -- First-time-modeling migration for the `general_settings` single-row config table (see
 -- db/README.md). The table already exists in dev/prod from schema.sql; CREATE TABLE,
 -- ADD CONSTRAINT, and INSERT are all guarded so this is a no-op on existing DBs while
--- bootstrapping a fresh DB cleanly. Same overall pattern as 0002_add_config_tables.sql.
+-- bootstrapping a fresh DB cleanly. Same overall pattern as 0002_add_config_tables.sql,
+-- with extra CHECKs unique to this table.
 --
 --   * CREATE TABLE IF NOT EXISTS — table-creation guard.
---   * pg_constraint guard around ADD CONSTRAINT — re-adds the CHECK (id = 1) singleton
---     invariant from schema.sql on fresh DBs without colliding with the auto-named
---     constraint that already exists on dev/prod (matched by `contype = 'c'` rather than
---     by name because Postgres's auto-generated name for an inline column CHECK isn't
---     guaranteed across versions).
 --
---     Note vs. 0002: `general_settings` has *additional* CHECKs in schema.sql beyond the
---     singleton (`start_of_week IN ('Monday','Sunday')`, `ai_provider IN (...)`). On every
---     realistic DB state — fresh from schema.sql or pre-seeded prod — all three CHECKs are
---     present together, so the "any CHECK exists" proxy still correctly treats the singleton
---     as already-present and skips. A future migration that drops one CHECK while leaving
---     others would defeat this guard and need explicit handling.
+--   * pg_constraint guard around the singleton CHECK (id = 1) — re-adds the invariant
+--     from schema.sql on fresh DBs without colliding with the auto-named constraint that
+--     already exists on dev/prod (matched by `contype = 'c'` rather than by name because
+--     Postgres's auto-generated name for an inline column CHECK isn't guaranteed across
+--     versions). The "any CHECK exists" proxy works on every realistic DB state — on
+--     existing DBs all three CHECKs are present together so the guard skips; on
+--     fresh-from-migration DBs the table starts with zero CHECKs so the guard fires
+--     before the column-CHECK guards below add the others.
+--
+--   * pg_constraint guards around the column-level CHECKs (`start_of_week IN
+--     ('Monday','Sunday')`, `ai_provider IN ('gemini','openrouter')`) — schema.sql carries
+--     these CHECKs on the live tables (lines 697 and 1037-1044 respectively). Adding them
+--     here lets a fresh-from-migration DB (one bootstrapped purely via Drizzle migrations
+--     without first running schema.sql) enforce the same invariants as schema.sql-seeded
+--     installs. Matched by `pg_get_constraintdef` substring rather than by name because
+--     the start_of_week CHECK is auto-named (inline `CHECK` in schema.sql); using the
+--     same definition-match shape for ai_provider keeps both guards uniform.
 --
 --   * INSERT … ON CONFLICT DO NOTHING — seeds the singleton id=1 row so the first PUT to
 --     /general-settings succeeds; idempotent on existing DBs that already have the row
@@ -46,6 +53,28 @@ DO $$ BEGIN
 		WHERE t.relname = 'general_settings' AND n.nspname = 'public' AND c.contype = 'c'
 	) THEN
 		ALTER TABLE "general_settings" ADD CONSTRAINT "general_settings_id_check" CHECK ("id" = 1);
+	END IF;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+	IF NOT EXISTS (
+		SELECT 1 FROM pg_constraint c
+		JOIN pg_class t ON c.conrelid = t.oid
+		JOIN pg_namespace n ON t.relnamespace = n.oid
+		WHERE t.relname = 'general_settings' AND n.nspname = 'public' AND c.contype = 'c'
+		AND pg_get_constraintdef(c.oid) ILIKE '%start_of_week%'
+	) THEN
+		ALTER TABLE "general_settings" ADD CONSTRAINT "general_settings_start_of_week_check" CHECK ("start_of_week" IN ('Monday', 'Sunday'));
+	END IF;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+	IF NOT EXISTS (
+		SELECT 1 FROM pg_constraint c
+		JOIN pg_class t ON c.conrelid = t.oid
+		JOIN pg_namespace n ON t.relnamespace = n.oid
+		WHERE t.relname = 'general_settings' AND n.nspname = 'public' AND c.contype = 'c'
+		AND pg_get_constraintdef(c.oid) ILIKE '%ai_provider%'
+	) THEN
+		ALTER TABLE "general_settings" ADD CONSTRAINT "general_settings_ai_provider_check" CHECK ("ai_provider" IN ('gemini', 'openrouter'));
 	END IF;
 END $$;--> statement-breakpoint
 INSERT INTO "general_settings" ("id") VALUES (1) ON CONFLICT ("id") DO NOTHING;

--- a/server/db/migrations/0003_add_general_settings_table.sql
+++ b/server/db/migrations/0003_add_general_settings_table.sql
@@ -20,9 +20,12 @@
 --     these CHECKs on the live tables (lines 697 and 1037-1044 respectively). Adding them
 --     here lets a fresh-from-migration DB (one bootstrapped purely via Drizzle migrations
 --     without first running schema.sql) enforce the same invariants as schema.sql-seeded
---     installs. Matched by `pg_get_constraintdef` substring rather than by name because
---     the start_of_week CHECK is auto-named (inline `CHECK` in schema.sql); using the
---     same definition-match shape for ai_provider keeps both guards uniform.
+--     installs. Matched by joining `pg_attribute` against `pg_constraint.conkey` (the array
+--     of columns referenced by each constraint) rather than by name (start_of_week's CHECK
+--     is auto-named) or by `pg_get_constraintdef` substring (which would over-match a future
+--     CHECK that merely mentions the column in a multi-column rule). The conkey-by-column
+--     match correctly identifies whether the table already carries a CHECK constrained on
+--     the specific column.
 --
 --   * INSERT … ON CONFLICT DO NOTHING — seeds the singleton id=1 row so the first PUT to
 --     /general-settings succeeds; idempotent on existing DBs that already have the row
@@ -60,8 +63,9 @@ DO $$ BEGIN
 		SELECT 1 FROM pg_constraint c
 		JOIN pg_class t ON c.conrelid = t.oid
 		JOIN pg_namespace n ON t.relnamespace = n.oid
+		JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY(c.conkey)
 		WHERE t.relname = 'general_settings' AND n.nspname = 'public' AND c.contype = 'c'
-		AND pg_get_constraintdef(c.oid) ILIKE '%start_of_week%'
+		AND a.attname = 'start_of_week'
 	) THEN
 		ALTER TABLE "general_settings" ADD CONSTRAINT "general_settings_start_of_week_check" CHECK ("start_of_week" IN ('Monday', 'Sunday'));
 	END IF;
@@ -71,8 +75,9 @@ DO $$ BEGIN
 		SELECT 1 FROM pg_constraint c
 		JOIN pg_class t ON c.conrelid = t.oid
 		JOIN pg_namespace n ON t.relnamespace = n.oid
+		JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY(c.conkey)
 		WHERE t.relname = 'general_settings' AND n.nspname = 'public' AND c.contype = 'c'
-		AND pg_get_constraintdef(c.oid) ILIKE '%ai_provider%'
+		AND a.attname = 'ai_provider'
 	) THEN
 		ALTER TABLE "general_settings" ADD CONSTRAINT "general_settings_ai_provider_check" CHECK ("ai_provider" IN ('gemini', 'openrouter'));
 	END IF;

--- a/server/db/migrations/meta/0003_snapshot.json
+++ b/server/db/migrations/meta/0003_snapshot.json
@@ -1,0 +1,2083 @@
+{
+  "id": "0182b876-db17-4268-afa1-e458ce9d5d6c",
+  "prevId": "ccde6ffb-3134-4b6e-97f9-742be55e143d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.customer_offers": {
+      "name": "customer_offers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_quote_id": {
+          "name": "linked_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_customer_offers_linked_quote_id": {
+          "name": "idx_customer_offers_linked_quote_id",
+          "columns": [
+            {
+              "expression": "linked_quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_offers_client_id": {
+          "name": "idx_customer_offers_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_offers_status": {
+          "name": "idx_customer_offers_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_offers_created_at": {
+          "name": "idx_customer_offers_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_offers_linked_quote_id_quotes_id_fk": {
+          "name": "customer_offers_linked_quote_id_quotes_id_fk",
+          "tableFrom": "customer_offers",
+          "tableTo": "quotes",
+          "columnsFrom": ["linked_quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_config": {
+      "name": "email_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "smtp_host": {
+          "name": "smtp_host",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "smtp_port": {
+          "name": "smtp_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 587
+        },
+        "smtp_encryption": {
+          "name": "smtp_encryption",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'tls'"
+        },
+        "smtp_reject_unauthorized": {
+          "name": "smtp_reject_unauthorized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "smtp_user": {
+          "name": "smtp_user",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "smtp_password": {
+          "name": "smtp_password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "from_email": {
+          "name": "from_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Praetor'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.general_settings": {
+      "name": "general_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'€'"
+        },
+        "daily_limit": {
+          "name": "daily_limit",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'8.00'"
+        },
+        "start_of_week": {
+          "name": "start_of_week",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Monday'"
+        },
+        "treat_saturday_as_holiday": {
+          "name": "treat_saturday_as_holiday",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "enable_ai_reporting": {
+          "name": "enable_ai_reporting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "gemini_api_key": {
+          "name": "gemini_api_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_provider": {
+          "name": "ai_provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'gemini'"
+        },
+        "openrouter_api_key": {
+          "name": "openrouter_api_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gemini_model_id": {
+          "name": "gemini_model_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "openrouter_model_id": {
+          "name": "openrouter_model_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_weekend_selection": {
+          "name": "allow_weekend_selection",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "default_location": {
+          "name": "default_location",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'remote'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_items": {
+      "name": "invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_of_measure": {
+          "name": "unit_of_measure",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unit'"
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoice_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "invoices",
+          "columnsFrom": ["invoice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_sale_id": {
+          "name": "linked_sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_date": {
+          "name": "issue_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "amount_paid": {
+          "name": "amount_paid",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_invoices_client_id": {
+          "name": "idx_invoices_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_status": {
+          "name": "idx_invoices_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_issue_date": {
+          "name": "idx_invoices_issue_date",
+          "columns": [
+            {
+              "expression": "issue_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ldap_config": {
+      "name": "ldap_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "server_url": {
+          "name": "server_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ldap://ldap.example.com:389'"
+        },
+        "base_dn": {
+          "name": "base_dn",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'dc=example,dc=com'"
+        },
+        "bind_dn": {
+          "name": "bind_dn",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'cn=read-only-admin,dc=example,dc=com'"
+        },
+        "bind_password": {
+          "name": "bind_password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "user_filter": {
+          "name": "user_filter",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'(uid={0})'"
+        },
+        "group_base_dn": {
+          "name": "group_base_dn",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ou=groups,dc=example,dc=com'"
+        },
+        "group_filter": {
+          "name": "group_filter",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'(member={0})'"
+        },
+        "role_mappings": {
+          "name": "role_mappings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_notifications_user_id": {
+          "name": "idx_notifications_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_user_unread": {
+          "name": "idx_notifications_user_unread",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notifications\".\"is_read\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quote_items": {
+      "name": "quote_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_cost": {
+          "name": "product_cost",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_mol_percentage": {
+          "name": "product_mol_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_id": {
+          "name": "supplier_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_item_id": {
+          "name": "supplier_quote_item_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_supplier_name": {
+          "name": "supplier_quote_supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_unit_price": {
+          "name": "supplier_quote_unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_type": {
+          "name": "unit_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'hours'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quote_items_quote_id_quotes_id_fk": {
+          "name": "quote_items_quote_id_quotes_id_fk",
+          "tableFrom": "quote_items",
+          "tableTo": "quotes",
+          "columnsFrom": ["quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quotes": {
+      "name": "quotes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_quotes_client_id": {
+          "name": "idx_quotes_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quotes_status": {
+          "name": "idx_quotes_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quotes_created_at": {
+          "name": "idx_quotes_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_permissions": {
+      "name": "role_permissions",
+      "schema": "",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_permissions_role_id_roles_id_fk": {
+          "name": "role_permissions_role_id_roles_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "roles",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "role_permissions_role_id_permission_pk": {
+          "name": "role_permissions_role_id_permission_pk",
+          "columns": ["role_id", "permission"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roles": {
+      "name": "roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_roles": {
+      "name": "user_roles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_roles_role_id_roles_id_fk": {
+          "name": "user_roles_role_id_roles_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "roles",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_roles_user_id_role_id_pk": {
+          "name": "user_roles_user_id_role_id_pk",
+          "columns": ["user_id", "role_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sale_items": {
+      "name": "sale_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sale_id": {
+          "name": "sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_cost": {
+          "name": "product_cost",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_mol_percentage": {
+          "name": "product_mol_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "unit_type": {
+          "name": "unit_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'hours'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_id": {
+          "name": "supplier_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_item_id": {
+          "name": "supplier_quote_item_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_supplier_name": {
+          "name": "supplier_quote_supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_unit_price": {
+          "name": "supplier_quote_unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_sale_id": {
+          "name": "supplier_sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_sale_item_id": {
+          "name": "supplier_sale_item_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_sale_supplier_name": {
+          "name": "supplier_sale_supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sale_items_sale_id_sales_id_fk": {
+          "name": "sale_items_sale_id_sales_id_fk",
+          "tableFrom": "sale_items",
+          "tableTo": "sales",
+          "columnsFrom": ["sale_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sales": {
+      "name": "sales",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_quote_id": {
+          "name": "linked_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_offer_id": {
+          "name": "linked_offer_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_sales_client_id": {
+          "name": "idx_sales_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_status": {
+          "name": "idx_sales_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_linked_quote_id": {
+          "name": "idx_sales_linked_quote_id",
+          "columns": [
+            {
+              "expression": "linked_quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_linked_offer_id": {
+          "name": "idx_sales_linked_offer_id",
+          "columns": [
+            {
+              "expression": "linked_offer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_linked_offer_id_unique": {
+          "name": "idx_sales_linked_offer_id_unique",
+          "columns": [
+            {
+              "expression": "linked_offer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sales\".\"linked_offer_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_created_at": {
+          "name": "idx_sales_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sales_linked_quote_id_quotes_id_fk": {
+          "name": "sales_linked_quote_id_quotes_id_fk",
+          "tableFrom": "sales",
+          "tableTo": "quotes",
+          "columnsFrom": ["linked_quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "sales_linked_offer_id_customer_offers_id_fk": {
+          "name": "sales_linked_offer_id_customer_offers_id_fk",
+          "tableFrom": "sales",
+          "tableTo": "customer_offers",
+          "columnsFrom": ["linked_offer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "daily_goal": {
+          "name": "daily_goal",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'8.00'"
+        },
+        "start_of_week": {
+          "name": "start_of_week",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Monday'"
+        },
+        "compact_view": {
+          "name": "compact_view",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "treat_saturday_as_holiday": {
+          "name": "treat_saturday_as_holiday",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "settings_user_id_unique": {
+          "name": "settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_sale_items": {
+      "name": "supplier_sale_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sale_id": {
+          "name": "sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "supplier_sale_items_sale_id_supplier_sales_id_fk": {
+          "name": "supplier_sale_items_sale_id_supplier_sales_id_fk",
+          "tableFrom": "supplier_sale_items",
+          "tableTo": "supplier_sales",
+          "columnsFrom": ["sale_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_sales": {
+      "name": "supplier_sales",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_quote_id": {
+          "name": "linked_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_name": {
+          "name": "supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "recurrence_pattern": {
+          "name": "recurrence_pattern",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_start": {
+          "name": "recurrence_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_end": {
+          "name": "recurrence_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_duration": {
+          "name": "recurrence_duration",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "expected_effort": {
+          "name": "expected_effort",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "revenue": {
+          "name": "revenue",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_tasks": {
+      "name": "user_tasks",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_source": {
+          "name": "assignment_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_tasks_task_id_tasks_id_fk": {
+          "name": "user_tasks_task_id_tasks_id_fk",
+          "tableFrom": "user_tasks",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_tasks_user_id_task_id_pk": {
+          "name": "user_tasks_user_id_task_id_pk",
+          "columns": ["user_id", "task_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.time_entries": {
+      "name": "time_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_name": {
+          "name": "project_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task": {
+          "name": "task",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "hourly_cost": {
+          "name": "hourly_cost",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "is_placeholder": {
+          "name": "is_placeholder",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'remote'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_time_entries_task_id": {
+          "name": "idx_time_entries_task_id",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "time_entries_task_id_tasks_id_fk": {
+          "name": "time_entries_task_id_tasks_id_fk",
+          "tableFrom": "time_entries",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1777727920962,
       "tag": "0002_add_config_tables",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1777730855846,
+      "tag": "0003_add_general_settings_table",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/schema/generalSettings.ts
+++ b/server/db/schema/generalSettings.ts
@@ -1,0 +1,26 @@
+import { sql } from 'drizzle-orm';
+import { boolean, integer, numeric, pgTable, timestamp, varchar } from 'drizzle-orm/pg-core';
+
+// Single-row config table: `id INTEGER PRIMARY KEY DEFAULT 1 CHECK (id = 1)` in schema.sql.
+// CHECK constraints (id = 1, start_of_week IN ('Monday','Sunday'), ai_provider IN (...)) are
+// not modeled here — same carve-out as `ldapConfig.ts` / `emailConfig.ts` / `settings.ts`
+// ("Drizzle Kit's CHECK support is patchy"). Enforcement stays at the DB level.
+//
+// `daily_limit` is `numeric` — pg returns it as a string, the repo `parseFloat`s it in
+// `mapRow`. Same pattern as `settings.dailyGoal` in settings.ts.
+export const generalSettings = pgTable('general_settings', {
+  id: integer('id').primaryKey().default(1),
+  currency: varchar('currency', { length: 10 }).default('€'),
+  dailyLimit: numeric('daily_limit', { precision: 4, scale: 2 }).default('8.00'),
+  startOfWeek: varchar('start_of_week', { length: 10 }).default('Monday'),
+  treatSaturdayAsHoliday: boolean('treat_saturday_as_holiday').default(true),
+  enableAiReporting: boolean('enable_ai_reporting').default(false),
+  geminiApiKey: varchar('gemini_api_key', { length: 255 }),
+  aiProvider: varchar('ai_provider', { length: 20 }).default('gemini'),
+  openrouterApiKey: varchar('openrouter_api_key', { length: 255 }),
+  geminiModelId: varchar('gemini_model_id', { length: 255 }),
+  openrouterModelId: varchar('openrouter_model_id', { length: 255 }),
+  allowWeekendSelection: boolean('allow_weekend_selection').default(true),
+  defaultLocation: varchar('default_location', { length: 20 }).default('remote'),
+  updatedAt: timestamp('updated_at').default(sql`CURRENT_TIMESTAMP`),
+});

--- a/server/db/schema/index.ts
+++ b/server/db/schema/index.ts
@@ -1,5 +1,6 @@
 export * from './customerOffers.ts';
 export * from './emailConfig.ts';
+export * from './generalSettings.ts';
 export * from './invoices.ts';
 export * from './ldapConfig.ts';
 export * from './notifications.ts';

--- a/server/repositories/generalSettingsRepo.ts
+++ b/server/repositories/generalSettingsRepo.ts
@@ -67,9 +67,14 @@ type GeneralSettingsRow = {
 // but always populated at runtime via DB defaults on the seeded id=1 row, so these
 // fallbacks are TS-strict appeasement that fire only on a never-actually-happens null.
 // Values MUST mirror the `.default(...)` calls in `db/schema/generalSettings.ts` (and the
-// underlying DEFAULTs in `schema.sql:693-720`); update both together if defaults change.
+// underlying DEFAULTs in `schema.sql:693-720`); the `mapRow defaults match the schema
+// column defaults` test in the repo's spec guards against drift across the three places.
 // `dailyLimit` is the string form because pg returns `numeric` as a string and `parseFloat`
 // runs on it inside `mapRow`.
+//
+// Other columns with DB defaults (e.g., `enableAiReporting`, `allowWeekendSelection`) are
+// typed `T | null` in the public `GeneralSettings` type, so `mapRow` forwards null without
+// a fallback — route consumers apply their own `?? default`.
 const DEFAULT_FALLBACKS = {
   currency: '€',
   dailyLimit: '8.00',

--- a/server/repositories/generalSettingsRepo.ts
+++ b/server/repositories/generalSettingsRepo.ts
@@ -62,16 +62,26 @@ type GeneralSettingsRow = {
   defaultLocation: string | null;
 };
 
-// Schema columns are nullable but always populated at runtime via DB defaults on the seeded
-// id=1 row, so the `??` fallbacks on the four non-nullable fields are TS-strict appeasement
-// matching the corresponding `schema.sql` DEFAULTs. Nullable fields pass through as-is.
-// `daily_limit` is a `numeric` column — pg returns it as a string; `parseFloat` converts it
-// to JS number to match `GeneralSettings.dailyLimit: number`.
+// Centralized fallbacks for the four non-nullable `GeneralSettings` fields. The schema
+// columns are nullable in TS (Drizzle infers from `.default(...)` without `.notNull()`)
+// but always populated at runtime via DB defaults on the seeded id=1 row, so these
+// fallbacks are TS-strict appeasement that fire only on a never-actually-happens null.
+// Values MUST mirror the `.default(...)` calls in `db/schema/generalSettings.ts` (and the
+// underlying DEFAULTs in `schema.sql:693-720`); update both together if defaults change.
+// `dailyLimit` is the string form because pg returns `numeric` as a string and `parseFloat`
+// runs on it inside `mapRow`.
+const DEFAULT_FALLBACKS = {
+  currency: '€',
+  dailyLimit: '8.00',
+  startOfWeek: 'Monday',
+  treatSaturdayAsHoliday: true,
+} as const;
+
 const mapRow = (row: GeneralSettingsRow): GeneralSettings => ({
-  currency: row.currency ?? '€',
-  dailyLimit: parseFloat(row.dailyLimit ?? '8.00'),
-  startOfWeek: row.startOfWeek ?? 'Monday',
-  treatSaturdayAsHoliday: row.treatSaturdayAsHoliday ?? true,
+  currency: row.currency ?? DEFAULT_FALLBACKS.currency,
+  dailyLimit: parseFloat(row.dailyLimit ?? DEFAULT_FALLBACKS.dailyLimit),
+  startOfWeek: row.startOfWeek ?? DEFAULT_FALLBACKS.startOfWeek,
+  treatSaturdayAsHoliday: row.treatSaturdayAsHoliday ?? DEFAULT_FALLBACKS.treatSaturdayAsHoliday,
   enableAiReporting: row.enableAiReporting,
   geminiApiKey: row.geminiApiKey,
   aiProvider: row.aiProvider,

--- a/server/repositories/generalSettingsRepo.ts
+++ b/server/repositories/generalSettingsRepo.ts
@@ -1,4 +1,6 @@
-import pool, { type QueryExecutor } from '../db/index.ts';
+import { eq, sql } from 'drizzle-orm';
+import { type DbExecutor, db } from '../db/drizzle.ts';
+import { generalSettings } from '../db/schema/generalSettings.ts';
 
 export type GeneralSettings = {
   currency: string;
@@ -30,72 +32,92 @@ export type GeneralSettingsPatch = {
   defaultLocation?: string | null;
 };
 
-type GeneralSettingsRow = Omit<GeneralSettings, 'dailyLimit'> & { dailyLimit: string };
+const GENERAL_SETTINGS_PROJECTION = {
+  currency: generalSettings.currency,
+  dailyLimit: generalSettings.dailyLimit,
+  startOfWeek: generalSettings.startOfWeek,
+  treatSaturdayAsHoliday: generalSettings.treatSaturdayAsHoliday,
+  enableAiReporting: generalSettings.enableAiReporting,
+  geminiApiKey: generalSettings.geminiApiKey,
+  aiProvider: generalSettings.aiProvider,
+  openrouterApiKey: generalSettings.openrouterApiKey,
+  geminiModelId: generalSettings.geminiModelId,
+  openrouterModelId: generalSettings.openrouterModelId,
+  allowWeekendSelection: generalSettings.allowWeekendSelection,
+  defaultLocation: generalSettings.defaultLocation,
+} as const;
 
-const SELECT_COLUMNS = `currency,
-        daily_limit as "dailyLimit",
-        start_of_week as "startOfWeek",
-        treat_saturday_as_holiday as "treatSaturdayAsHoliday",
-        enable_ai_reporting as "enableAiReporting",
-        gemini_api_key as "geminiApiKey",
-        ai_provider as "aiProvider",
-        openrouter_api_key as "openrouterApiKey",
-        gemini_model_id as "geminiModelId",
-        openrouter_model_id as "openrouterModelId",
-        allow_weekend_selection as "allowWeekendSelection",
-        default_location as "defaultLocation"`;
+type GeneralSettingsRow = {
+  currency: string | null;
+  dailyLimit: string | null;
+  startOfWeek: string | null;
+  treatSaturdayAsHoliday: boolean | null;
+  enableAiReporting: boolean | null;
+  geminiApiKey: string | null;
+  aiProvider: string | null;
+  openrouterApiKey: string | null;
+  geminiModelId: string | null;
+  openrouterModelId: string | null;
+  allowWeekendSelection: boolean | null;
+  defaultLocation: string | null;
+};
 
+// Schema columns are nullable but always populated at runtime via DB defaults on the seeded
+// id=1 row, so the `??` fallbacks on the four non-nullable fields are TS-strict appeasement
+// matching the corresponding `schema.sql` DEFAULTs. Nullable fields pass through as-is.
+// `daily_limit` is a `numeric` column — pg returns it as a string; `parseFloat` converts it
+// to JS number to match `GeneralSettings.dailyLimit: number`.
 const mapRow = (row: GeneralSettingsRow): GeneralSettings => ({
-  ...row,
-  dailyLimit: parseFloat(row.dailyLimit),
+  currency: row.currency ?? '€',
+  dailyLimit: parseFloat(row.dailyLimit ?? '8.00'),
+  startOfWeek: row.startOfWeek ?? 'Monday',
+  treatSaturdayAsHoliday: row.treatSaturdayAsHoliday ?? true,
+  enableAiReporting: row.enableAiReporting,
+  geminiApiKey: row.geminiApiKey,
+  aiProvider: row.aiProvider,
+  openrouterApiKey: row.openrouterApiKey,
+  geminiModelId: row.geminiModelId,
+  openrouterModelId: row.openrouterModelId,
+  allowWeekendSelection: row.allowWeekendSelection,
+  defaultLocation: row.defaultLocation,
 });
 
-export const get = async (exec: QueryExecutor = pool): Promise<GeneralSettings | null> => {
-  const { rows } = await exec.query<GeneralSettingsRow>(
-    `SELECT ${SELECT_COLUMNS} FROM general_settings WHERE id = 1`,
-  );
-  if (rows.length === 0) return null;
-  return mapRow(rows[0]);
+export const get = async (exec: DbExecutor = db): Promise<GeneralSettings | null> => {
+  const rows = await exec
+    .select(GENERAL_SETTINGS_PROJECTION)
+    .from(generalSettings)
+    .where(eq(generalSettings.id, 1));
+  return rows[0] ? mapRow(rows[0]) : null;
 };
 
 export const update = async (
   patch: GeneralSettingsPatch,
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<GeneralSettings> => {
-  const { rows } = await exec.query<GeneralSettingsRow>(
-    `UPDATE general_settings
-        SET currency = COALESCE($1, currency),
-            daily_limit = COALESCE($2, daily_limit),
-            start_of_week = COALESCE($3, start_of_week),
-            treat_saturday_as_holiday = COALESCE($4, treat_saturday_as_holiday),
-            enable_ai_reporting = COALESCE($5, enable_ai_reporting),
-            gemini_api_key = COALESCE($6, gemini_api_key),
-            ai_provider = COALESCE($7, ai_provider),
-            openrouter_api_key = COALESCE($8, openrouter_api_key),
-            gemini_model_id = COALESCE($9, gemini_model_id),
-            openrouter_model_id = COALESCE($10, openrouter_model_id),
-            allow_weekend_selection = COALESCE($11, allow_weekend_selection),
-            default_location = COALESCE($12, default_location),
-            updated_at = CURRENT_TIMESTAMP
-      WHERE id = 1
-      RETURNING ${SELECT_COLUMNS}`,
-    [
-      patch.currency,
-      patch.dailyLimit,
-      patch.startOfWeek,
-      patch.treatSaturdayAsHoliday,
-      patch.enableAiReporting,
-      patch.geminiApiKey,
-      patch.aiProvider,
-      patch.openrouterApiKey,
-      patch.geminiModelId,
-      patch.openrouterModelId,
-      patch.allowWeekendSelection,
-      patch.defaultLocation,
-    ],
-  );
-  if (rows.length === 0) {
+  // COALESCE preserves the existing column when the patch value is undefined (legacy
+  // "undefined leaves column unchanged" semantic). Same pattern as ldapRepo.update /
+  // emailRepo.update / settingsRepo.upsertForUser.
+  const result = await exec
+    .update(generalSettings)
+    .set({
+      currency: sql`COALESCE(${patch.currency ?? null}, ${generalSettings.currency})`,
+      dailyLimit: sql`COALESCE(${patch.dailyLimit ?? null}, ${generalSettings.dailyLimit})`,
+      startOfWeek: sql`COALESCE(${patch.startOfWeek ?? null}, ${generalSettings.startOfWeek})`,
+      treatSaturdayAsHoliday: sql`COALESCE(${patch.treatSaturdayAsHoliday ?? null}, ${generalSettings.treatSaturdayAsHoliday})`,
+      enableAiReporting: sql`COALESCE(${patch.enableAiReporting ?? null}, ${generalSettings.enableAiReporting})`,
+      geminiApiKey: sql`COALESCE(${patch.geminiApiKey ?? null}, ${generalSettings.geminiApiKey})`,
+      aiProvider: sql`COALESCE(${patch.aiProvider ?? null}, ${generalSettings.aiProvider})`,
+      openrouterApiKey: sql`COALESCE(${patch.openrouterApiKey ?? null}, ${generalSettings.openrouterApiKey})`,
+      geminiModelId: sql`COALESCE(${patch.geminiModelId ?? null}, ${generalSettings.geminiModelId})`,
+      openrouterModelId: sql`COALESCE(${patch.openrouterModelId ?? null}, ${generalSettings.openrouterModelId})`,
+      allowWeekendSelection: sql`COALESCE(${patch.allowWeekendSelection ?? null}, ${generalSettings.allowWeekendSelection})`,
+      defaultLocation: sql`COALESCE(${patch.defaultLocation ?? null}, ${generalSettings.defaultLocation})`,
+      updatedAt: sql`CURRENT_TIMESTAMP`,
+    })
+    .where(eq(generalSettings.id, 1))
+    .returning(GENERAL_SETTINGS_PROJECTION);
+  if (result.length === 0) {
     throw new Error('general_settings row (id=1) not found; seed missing');
   }
-  return mapRow(rows[0]);
+  return mapRow(result[0]);
 };

--- a/server/test/repositories/generalSettingsRepo.test.ts
+++ b/server/test/repositories/generalSettingsRepo.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
+import { getTableColumns } from 'drizzle-orm';
 import type { DbExecutor } from '../../db/drizzle.ts';
+import { generalSettings } from '../../db/schema/generalSettings.ts';
 import * as generalSettingsRepo from '../../repositories/generalSettingsRepo.ts';
 import { type FakeExecutor, setupTestDb } from '../helpers/fakeExecutor.ts';
 
@@ -144,6 +146,26 @@ describe('update', () => {
     expect(params).toContain('gemini-2.0');
     expect(params).toContain('or/model');
     expect(params).toContain('home');
+    // Tighter check on top of the .toContain() pattern from the canonical ldap/email tests:
+    // since the SET clause emits its 12 COALESCE pairs in projection-declaration order and
+    // each pair binds exactly one patch-value param (the column ref renders as a SQL
+    // identifier, not a parameter), the first 12 params must match PROJECTION_KEYS order.
+    // Catches column→param wiring bugs where two same-typed booleans (e.g.,
+    // treatSaturdayAsHoliday vs allowWeekendSelection) get swapped.
+    expect(params.slice(0, 12)).toEqual([
+      'USD',
+      9,
+      'Sunday',
+      true,
+      false,
+      'g-key',
+      'gemini',
+      'or-key',
+      'gemini-2.0',
+      'or/model',
+      true,
+      'home',
+    ]);
   });
 
   test('binds NULL for omitted patch fields (COALESCE preserves existing column)', async () => {
@@ -161,5 +183,19 @@ describe('update', () => {
     await generalSettingsRepo.update({ currency: 'USD' }, testDb);
     expect(exec.calls[0].sql).toMatch(/"id"\s*=\s*\$\d+/);
     expect(exec.calls[0].params).toContain(1);
+  });
+});
+
+describe('schema invariants', () => {
+  // Direct enforcement of the invariant called out in the comment above PROJECTION_KEYS:
+  // a column reorder in `db/schema/generalSettings.ts` (or one added without updating the
+  // projection) would silently desync `rowMode: 'array'` decoding from the projection map.
+  // The other tests would surface this as a wrong-shaped row, but failing here gives a
+  // direct signal — "schema column order changed" — instead of cascading expectation
+  // mismatches.
+  test('PROJECTION_KEYS match the schema column order (excluding id and updatedAt)', () => {
+    const schemaColumnNames = Object.keys(getTableColumns(generalSettings));
+    const expectedKeys = schemaColumnNames.filter((k) => k !== 'id' && k !== 'updatedAt');
+    expect([...PROJECTION_KEYS]).toEqual(expectedKeys);
   });
 });

--- a/server/test/repositories/generalSettingsRepo.test.ts
+++ b/server/test/repositories/generalSettingsRepo.test.ts
@@ -201,4 +201,30 @@ describe('schema invariants', () => {
     // `toEqual` infers from the receiver and rejects the comparison without this widening.
     expect([...PROJECTION_KEYS] as string[]).toEqual(expectedKeys);
   });
+
+  // The four typed-non-nullable `GeneralSettings` fields can technically be null at the row
+  // layer (the schema columns are nullable in TS), so `mapRow` falls back via a private
+  // `DEFAULT_FALLBACKS` const. Those fallbacks duplicate the `.default(...)` values declared
+  // on the Drizzle schema (and, by transit, the DEFAULTs in schema.sql:693-720). This test
+  // builds a row where those four columns are null and asserts mapRow's fallback values
+  // match the schema column defaults — so any drift between schema.sql, the Drizzle schema,
+  // and the repo's fallback const fails CI rather than silently shipping a wrong default.
+  test('mapRow defaults match the schema column defaults (drift guard)', async () => {
+    const cols = getTableColumns(generalSettings);
+    exec.enqueue({
+      rows: [
+        buildRow({
+          currency: null,
+          dailyLimit: null,
+          startOfWeek: null,
+          treatSaturdayAsHoliday: null,
+        }),
+      ],
+    });
+    const result = await generalSettingsRepo.get(testDb);
+    expect(result?.currency).toBe(cols.currency.default as string);
+    expect(result?.dailyLimit).toBe(parseFloat(cols.dailyLimit.default as string));
+    expect(result?.startOfWeek).toBe(cols.startOfWeek.default as string);
+    expect(result?.treatSaturdayAsHoliday).toBe(cols.treatSaturdayAsHoliday.default as boolean);
+  });
 });

--- a/server/test/repositories/generalSettingsRepo.test.ts
+++ b/server/test/repositories/generalSettingsRepo.test.ts
@@ -1,17 +1,44 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
+import type { DbExecutor } from '../../db/drizzle.ts';
 import * as generalSettingsRepo from '../../repositories/generalSettingsRepo.ts';
-import { type FakeExecutor, makeFakeExecutor } from '../helpers/fakeExecutor.ts';
+import { type FakeExecutor, setupTestDb } from '../helpers/fakeExecutor.ts';
 
 let exec: FakeExecutor;
+let testDb: DbExecutor;
 
 beforeEach(() => {
-  exec = makeFakeExecutor();
+  ({ exec, testDb } = setupTestDb());
 });
 
-const baseRow = {
+// drizzle-orm/node-postgres uses rowMode: 'array' for select queries; rows are positional
+// in the projection-declaration order from `GENERAL_SETTINGS_PROJECTION` in
+// generalSettingsRepo.ts. Tests use `buildRow` (below) to construct fixtures by field name
+// rather than by index, so a column reorder in the repo is caught either at TS compile time
+// (unknown key) or at test time (wrong-shaped row). PROJECTION_KEYS MUST stay in sync with
+// `GENERAL_SETTINGS_PROJECTION`.
+const PROJECTION_KEYS = [
+  'currency',
+  'dailyLimit',
+  'startOfWeek',
+  'treatSaturdayAsHoliday',
+  'enableAiReporting',
+  'geminiApiKey',
+  'aiProvider',
+  'openrouterApiKey',
+  'geminiModelId',
+  'openrouterModelId',
+  'allowWeekendSelection',
+  'defaultLocation',
+] as const;
+type ProjectionKey = (typeof PROJECTION_KEYS)[number];
+type RowFields = Record<ProjectionKey, unknown>;
+
+// pg's `numeric` type comes back from the driver as a string (so dailyLimit is '8.50' here,
+// not 8.5). The repo's `mapRow` parses it to a JS number.
+const baseFields: RowFields = {
   currency: '€',
   dailyLimit: '8.50',
-  startOfWeek: 'monday',
+  startOfWeek: 'Monday',
   treatSaturdayAsHoliday: false,
   enableAiReporting: null,
   geminiApiKey: null,
@@ -23,45 +50,76 @@ const baseRow = {
   defaultLocation: null,
 };
 
+const buildRow = (overrides: Partial<RowFields> = {}): unknown[] => {
+  const merged: RowFields = { ...baseFields, ...overrides };
+  return PROJECTION_KEYS.map((k) => merged[k]);
+};
+
 describe('get', () => {
   test('returns null when no row exists', async () => {
     exec.enqueue({ rows: [] });
-    const result = await generalSettingsRepo.get(exec);
+    const result = await generalSettingsRepo.get(testDb);
     expect(result).toBeNull();
   });
 
   test('parses dailyLimit string from pg numeric to a JS number', async () => {
-    exec.enqueue({ rows: [baseRow] });
-    const result = await generalSettingsRepo.get(exec);
+    exec.enqueue({ rows: [buildRow()] });
+    const result = await generalSettingsRepo.get(testDb);
     expect(result?.dailyLimit).toBe(8.5);
   });
 
   test('preserves non-numeric fields verbatim', async () => {
     exec.enqueue({
-      rows: [{ ...baseRow, currency: 'USD', enableAiReporting: true, defaultLocation: 'office' }],
+      rows: [buildRow({ currency: 'USD', enableAiReporting: true, defaultLocation: 'office' })],
     });
-    const result = await generalSettingsRepo.get(exec);
+    const result = await generalSettingsRepo.get(testDb);
     expect(result?.currency).toBe('USD');
     expect(result?.enableAiReporting).toBe(true);
     expect(result?.defaultLocation).toBe('office');
+  });
+
+  test('targets the singleton row via WHERE id = 1', async () => {
+    exec.enqueue({ rows: [] });
+    await generalSettingsRepo.get(testDb);
+    expect(exec.calls[0].sql).toMatch(/"id"\s*=\s*\$\d+/);
+    expect(exec.calls[0].params).toContain(1);
   });
 });
 
 describe('update', () => {
   test('throws the seed-missing guard when UPDATE returns 0 rows', async () => {
     exec.enqueue({ rows: [] });
-    await expect(generalSettingsRepo.update({}, exec)).rejects.toThrow(
+    await expect(generalSettingsRepo.update({}, testDb)).rejects.toThrow(
       /general_settings row \(id=1\) not found/,
     );
   });
 
-  test('passes patch values in declared column order', async () => {
-    exec.enqueue({ rows: [baseRow] });
+  test('returns the RETURNING row mapped to the GeneralSettings shape', async () => {
+    exec.enqueue({
+      rows: [buildRow({ currency: 'USD', dailyLimit: '9.00', startOfWeek: 'Sunday' })],
+    });
+    const result = await generalSettingsRepo.update(
+      { currency: 'USD', dailyLimit: 9, startOfWeek: 'Sunday' },
+      testDb,
+    );
+    expect(result.currency).toBe('USD');
+    expect(result.dailyLimit).toBe(9);
+    expect(result.startOfWeek).toBe('Sunday');
+  });
+
+  test('parses dailyLimit on the row returned from RETURNING', async () => {
+    exec.enqueue({ rows: [buildRow({ dailyLimit: '12.00' })] });
+    const result = await generalSettingsRepo.update({}, testDb);
+    expect(result.dailyLimit).toBe(12);
+  });
+
+  test('passes scalar patch values as bound parameters', async () => {
+    exec.enqueue({ rows: [buildRow()] });
     await generalSettingsRepo.update(
       {
         currency: 'USD',
         dailyLimit: 9,
-        startOfWeek: 'sunday',
+        startOfWeek: 'Sunday',
         treatSaturdayAsHoliday: true,
         enableAiReporting: false,
         geminiApiKey: 'g-key',
@@ -72,37 +130,36 @@ describe('update', () => {
         allowWeekendSelection: true,
         defaultLocation: 'home',
       },
-      exec,
+      testDb,
     );
-    expect(exec.calls[0].params).toEqual([
-      'USD',
-      9,
-      'sunday',
-      true,
-      false,
-      'g-key',
-      'gemini',
-      'or-key',
-      'gemini-2.0',
-      'or/model',
-      true,
-      'home',
-    ]);
-  });
-
-  test('passes undefined for omitted patch fields', async () => {
-    exec.enqueue({ rows: [baseRow] });
-    await generalSettingsRepo.update({ currency: 'USD' }, exec);
     const params = exec.calls[0].params;
-    expect(params).toHaveLength(12);
-    expect(params[0]).toBe('USD');
-    expect(params[1]).toBeUndefined();
-    expect(params[11]).toBeUndefined();
+    expect(params).toContain('USD');
+    expect(params).toContain(9);
+    expect(params).toContain('Sunday');
+    expect(params).toContain(true);
+    expect(params).toContain(false);
+    expect(params).toContain('g-key');
+    expect(params).toContain('gemini');
+    expect(params).toContain('or-key');
+    expect(params).toContain('gemini-2.0');
+    expect(params).toContain('or/model');
+    expect(params).toContain('home');
   });
 
-  test('parses dailyLimit on the row returned from RETURNING', async () => {
-    exec.enqueue({ rows: [{ ...baseRow, dailyLimit: '12.00' }] });
-    const result = await generalSettingsRepo.update({}, exec);
-    expect(result.dailyLimit).toBe(12);
+  test('binds NULL for omitted patch fields (COALESCE preserves existing column)', async () => {
+    exec.enqueue({ rows: [buildRow()] });
+    await generalSettingsRepo.update({ currency: 'USD' }, testDb);
+    // The SET clause always emits 12 COALESCE pairs (one per patchable column); 11 of those
+    // patch-value params are null when only `currency` is provided. The UPDATE also binds the
+    // singleton WHERE param (1), so we expect ≥11 nulls in the param list.
+    const nullCount = exec.calls[0].params.filter((p) => p === null).length;
+    expect(nullCount).toBeGreaterThanOrEqual(11);
+  });
+
+  test('targets the singleton row via WHERE id = 1', async () => {
+    exec.enqueue({ rows: [buildRow()] });
+    await generalSettingsRepo.update({ currency: 'USD' }, testDb);
+    expect(exec.calls[0].sql).toMatch(/"id"\s*=\s*\$\d+/);
+    expect(exec.calls[0].params).toContain(1);
   });
 });

--- a/server/test/repositories/generalSettingsRepo.test.ts
+++ b/server/test/repositories/generalSettingsRepo.test.ts
@@ -196,6 +196,9 @@ describe('schema invariants', () => {
   test('PROJECTION_KEYS match the schema column order (excluding id and updatedAt)', () => {
     const schemaColumnNames = Object.keys(getTableColumns(generalSettings));
     const expectedKeys = schemaColumnNames.filter((k) => k !== 'id' && k !== 'updatedAt');
-    expect([...PROJECTION_KEYS]).toEqual(expectedKeys);
+    // Widen `[...PROJECTION_KEYS]` (a union-of-literals tuple from `as const`) to `string[]`
+    // so it matches `expectedKeys`, which is `Object.keys(...)`'s plain `string[]`. Bun's
+    // `toEqual` infers from the receiver and rejects the comparison without this widening.
+    expect([...PROJECTION_KEYS] as string[]).toEqual(expectedKeys);
   });
 });


### PR DESCRIPTION
## Summary

Phase 3 incremental Drizzle migration: converts `generalSettingsRepo` (the third and last single-row config table) following the canonical pattern established by ldapRepo + emailRepo in #149.

- New schema [`server/db/schema/generalSettings.ts`](server/db/schema/generalSettings.ts) — 13 columns, CHECK constraints (`id = 1`, `start_of_week IN (...)`, `ai_provider IN (...)`) left to DB-only enforcement per the carve-out used in `ldapConfig.ts` / `emailConfig.ts` / `settings.ts`.
- New first-time-modeling migration [`0003_add_general_settings_table.sql`](server/db/migrations/0003_add_general_settings_table.sql) — `CREATE TABLE IF NOT EXISTS`, `pg_constraint` guard for the singleton CHECK, `INSERT … ON CONFLICT DO NOTHING` seed. Mirrors 0002 with an explicit comment about the table carrying additional CHECKs (`start_of_week`, `ai_provider`) beyond the singleton.
- Repo rewritten using a typed `GENERAL_SETTINGS_PROJECTION`, `mapRow` with `parseFloat` for the `numeric daily_limit`, and a 12-column `COALESCE`-based update that preserves the legacy "undefined leaves the column unchanged" semantic. Public `get(exec?)` / `update(patch, exec?)` signatures unchanged so the four route consumers (general-settings, ai, entries, reports) don't move.
- Tests rewritten to the canonical `setupTestDb` + `PROJECTION_KEYS` + `buildRow` positional-fixture pattern. 10 tests, 26 expectations; behavioral coverage matches the pre-migration suite.

## Why

`generalSettingsRepo` is a near-1:1 analog of the just-polished ldap/email pattern. Converting it next reuses the freshly polished pattern with minimal new judgment calls, keeps the PR small, and clears the simplest remaining low-hanging-fruit before moving into the next-tier repos (`auditLogsRepo`, `suppliersRepo`, `clientProfileOptionsRepo`, `workUnitsRepo`).

## Notable details

- **`dailyLimit` is `numeric(4,2)`.** pg returns it as a string; `mapRow` `parseFloat`s it. On write, JS `number` → SQL `numeric` is auto-coerced. Same precedent as `settings.dailyGoal`.
- **No FK to users.** `general_settings` has no `user_id` column, so the notifications/audit_logs FK-to-users drift problem doesn't apply here.
- **No `withTransaction` callers.** Confirmed via grep — the cross-world (legacy `QueryExecutor` ↔ `DbExecutor`) interop question doesn't arise for this repo.
- **Migration idempotency caveat.** The pg_constraint guard treats "any CHECK exists on the table" as a proxy for "the singleton CHECK exists" — correct on every realistic DB state (fresh-from-schema.sql or pre-seeded prod) since all three CHECKs were always shipped together. A future migration that drops one CHECK while leaving others would defeat this guard and need explicit handling. Documented in the migration's leading comment.

## Test plan

- [x] `bun run db:check` — snapshot consistency
- [x] `bun test test/` — full server suite (610 pass, 0 fail across 32 files)
- [x] `bun test test/repositories/generalSettingsRepo.test.ts` — 10 tests, 26 expectations, all pass
- [x] No `withTransaction.*generalSettings` callers in `server/routes/`
- [ ] Apply `0003_add_general_settings_table.sql` to a fresh DB and to one already seeded from `schema.sql`; both should succeed and the seeded id=1 row should be present
- [ ] `GET /api/general-settings` returns the same JSON shape as before; `PUT /api/general-settings` with a partial body preserves untouched fields (COALESCE semantic) and reflects updates on next read
- [ ] AI-reporting (`/api/ai`), entry-validation (`/api/entries`), and report (`/api/reports`) endpoints that read settings continue to work end-to-end on the remote Docker setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)