### PR TITLE
docs: include Drizzle ORM in tech stack

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 - Client-side helpers: `services/` (API + Gemini integration), `utils/`, shared types in `types.ts` and `constants.tsx`.
 - Static assets: `public/`, translations in `locales/`.
 - Backend API (Fastify + TS) is in `server/`.
-- API entry/build: `server/index.ts`, app wiring in `server/app.ts`, routes in `server/routes/`, DB schema/seed in `server/db/`.
+- API entry/build: `server/index.ts`, app wiring in `server/app.ts`, routes in `server/routes/`, Drizzle schema in `server/db/schema/` and migrations in `server/db/migrations/`.
 - Generated docs are committed under `docs/` (`docs/frontend/`, `docs/api/openapi.json`).
 
 ## Build, Test, and Development Commands

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Praetor is an AI-enhanced ERP application for time tracking, project management, CRM, and financial operations. React 19 + Vite frontend with Fastify + PostgreSQL backend.
+Praetor is an AI-enhanced ERP application for time tracking, project management, CRM, and financial operations. React 19 + Vite frontend with Fastify + PostgreSQL (Drizzle ORM) backend.
 
 ## Development Commands
 
@@ -39,8 +39,7 @@ bun run start        # Run compiled server
 - Server returns new token in `x-auth-token` header on each request
 
 ### Database
-- Direct PostgreSQL via `pg` driver (no ORM)
-- Raw SQL queries with parameterized inputs
+- PostgreSQL accessed via Drizzle ORM (`server/db/schema/`); migration is incremental, so some repositories still use the raw `pg` driver with parameterized SQL
 - Snake_case in DB → camelCase in API responses
 
 ### Database migrations

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Praetor is a modern, AI-enhanced ERP application inspired by the simplicity of t
 
 - **Frontend**: React 19, TypeScript
 - **Backend**: Fastify (API)
+- **Database**: PostgreSQL with Drizzle ORM
 - **Styling**: Tailwind CSS
 - **Charts**: Recharts
 - **AI Integration**: Gemini/OpenRouter via server-side provider calls (AI Reporting).


### PR DESCRIPTION
## What

Updates the three top-level documentation files (`README.md`, `CLAUDE.md`, `AGENTS.md`) to reflect that Drizzle ORM is now part of the stack.

- **README.md** — adds `**Database**: PostgreSQL with Drizzle ORM` to the Tech Stack list.
- **CLAUDE.md** — mentions Drizzle ORM in the project overview, and rewrites the `### Database` section to describe the incremental Drizzle migration honestly (some repositories still use the raw `pg` driver during Phase 3).
- **AGENTS.md** — replaces the generic `DB schema/seed in server/db/` with the more specific `Drizzle schema in server/db/schema/ and migrations in server/db/migrations/`.

## Why

Drizzle ORM is already a real production dependency (`drizzle-orm`, `drizzle-kit` in `server/package.json`), with 15 modeled tables under `server/db/schema/`, four active Drizzle migrations, and several repositories already converted (most recently `auditLogsRepo` in 1562aa06).

Despite that, the canonical docs were stale — and worse, internally contradictory:

- `CLAUDE.md:42` claimed *"Direct PostgreSQL via `pg` driver (no ORM)"* while `CLAUDE.md:46-48` immediately below documented the Drizzle Kit migration workflow.
- `README.md`'s Tech Stack omitted the database/ORM entirely.
- `AGENTS.md` pointed contributors at the generic `server/db/` folder instead of the Drizzle subdirectories where new schema work actually lives.

The detailed `server/db/README.md` is already accurate and is intentionally untouched.

## Reviewer notes

- Documentation-only change; no application code or tooling touched.
- The wording deliberately acknowledges the partial-migration state rather than claiming full Drizzle adoption — repositories not yet converted still use the raw `pg` driver, and that's worth signaling to contributors picking up new work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)