### PR TITLE
refactor(db): convert entriesRepo + clientOffersRepo to drizzle (tier 2)

### DIFF
--- a/server/db/migrations/0005_claim_customer_offer_items.sql
+++ b/server/db/migrations/0005_claim_customer_offer_items.sql
@@ -1,0 +1,47 @@
+-- First-time-modeling migration for the customer_offer_items table (see db/README.md).
+-- All statements are guarded so this is a no-op on existing dev/prod DBs (which already
+-- have customer_offer_items + its FK + its CHECK constraint from schema.sql) while still
+-- bootstrapping a fresh DB cleanly.
+
+CREATE TABLE IF NOT EXISTS "customer_offer_items" (
+	"id" varchar(50) PRIMARY KEY NOT NULL,
+	"offer_id" varchar(100) NOT NULL,
+	"product_id" varchar(50),
+	"product_name" varchar(255) NOT NULL,
+	"quantity" numeric(10, 2) DEFAULT '1' NOT NULL,
+	"unit_price" numeric(15, 2) DEFAULT '0' NOT NULL,
+	"product_cost" numeric(15, 2) DEFAULT '0' NOT NULL,
+	"product_mol_percentage" numeric(5, 2),
+	"discount" numeric(5, 2) DEFAULT '0',
+	"note" text,
+	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP,
+	"unit_type" varchar(10) DEFAULT 'hours',
+	"supplier_quote_id" varchar(100),
+	"supplier_quote_item_id" varchar(50),
+	"supplier_quote_supplier_name" varchar(255),
+	"supplier_quote_unit_price" numeric(15, 2),
+	CONSTRAINT "chk_customer_offer_items_unit_type" CHECK ("customer_offer_items"."unit_type" IN ('hours', 'days', 'unit'))
+);
+--> statement-breakpoint
+-- Pre-existing DBs already have an FK from customer_offer_items.offer_id to
+-- customer_offers(id) under PG's default name `customer_offer_items_offer_id_fkey`
+-- (declared inline in schema.sql). Skip if any FK from this column to customer_offers
+-- exists, regardless of name, to avoid duplicating the constraint.
+DO $$
+BEGIN
+	IF NOT EXISTS (
+		SELECT 1
+		FROM pg_constraint c
+		JOIN pg_class t ON t.oid = c.conrelid
+		JOIN pg_class ft ON ft.oid = c.confrelid
+		JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = ANY(c.conkey)
+		WHERE c.contype = 'f'
+			AND t.relname = 'customer_offer_items'
+			AND ft.relname = 'customer_offers'
+			AND a.attname = 'offer_id'
+	) THEN
+		ALTER TABLE "customer_offer_items" ADD CONSTRAINT "customer_offer_items_offer_id_customer_offers_id_fk" FOREIGN KEY ("offer_id") REFERENCES "public"."customer_offers"("id") ON DELETE cascade ON UPDATE cascade;
+	END IF;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_customer_offer_items_offer_id" ON "customer_offer_items" USING btree ("offer_id");

--- a/server/db/migrations/meta/0005_snapshot.json
+++ b/server/db/migrations/meta/0005_snapshot.json
@@ -1,0 +1,2338 @@
+{
+  "id": "705f3023-3a68-4881-89e1-9aaea32eb728",
+  "prevId": "82bfba3f-1898-4c4d-a245-71207adf98cb",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user.login'"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_audit_logs_created_at": {
+          "name": "idx_audit_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_user_id": {
+          "name": "idx_audit_logs_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_action": {
+          "name": "idx_audit_logs_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_offers": {
+      "name": "customer_offers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_quote_id": {
+          "name": "linked_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_customer_offers_linked_quote_id": {
+          "name": "idx_customer_offers_linked_quote_id",
+          "columns": [
+            {
+              "expression": "linked_quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_offers_client_id": {
+          "name": "idx_customer_offers_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_offers_status": {
+          "name": "idx_customer_offers_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_offers_created_at": {
+          "name": "idx_customer_offers_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_offers_linked_quote_id_quotes_id_fk": {
+          "name": "customer_offers_linked_quote_id_quotes_id_fk",
+          "tableFrom": "customer_offers",
+          "tableTo": "quotes",
+          "columnsFrom": ["linked_quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_offer_items": {
+      "name": "customer_offer_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "offer_id": {
+          "name": "offer_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_cost": {
+          "name": "product_cost",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_mol_percentage": {
+          "name": "product_mol_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "unit_type": {
+          "name": "unit_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'hours'"
+        },
+        "supplier_quote_id": {
+          "name": "supplier_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_item_id": {
+          "name": "supplier_quote_item_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_supplier_name": {
+          "name": "supplier_quote_supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_unit_price": {
+          "name": "supplier_quote_unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_customer_offer_items_offer_id": {
+          "name": "idx_customer_offer_items_offer_id",
+          "columns": [
+            {
+              "expression": "offer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_offer_items_offer_id_customer_offers_id_fk": {
+          "name": "customer_offer_items_offer_id_customer_offers_id_fk",
+          "tableFrom": "customer_offer_items",
+          "tableTo": "customer_offers",
+          "columnsFrom": ["offer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_customer_offer_items_unit_type": {
+          "name": "chk_customer_offer_items_unit_type",
+          "value": "\"customer_offer_items\".\"unit_type\" IN ('hours', 'days', 'unit')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.email_config": {
+      "name": "email_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "smtp_host": {
+          "name": "smtp_host",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "smtp_port": {
+          "name": "smtp_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 587
+        },
+        "smtp_encryption": {
+          "name": "smtp_encryption",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'tls'"
+        },
+        "smtp_reject_unauthorized": {
+          "name": "smtp_reject_unauthorized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "smtp_user": {
+          "name": "smtp_user",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "smtp_password": {
+          "name": "smtp_password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "from_email": {
+          "name": "from_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Praetor'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.general_settings": {
+      "name": "general_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'€'"
+        },
+        "daily_limit": {
+          "name": "daily_limit",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'8.00'"
+        },
+        "start_of_week": {
+          "name": "start_of_week",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Monday'"
+        },
+        "treat_saturday_as_holiday": {
+          "name": "treat_saturday_as_holiday",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "enable_ai_reporting": {
+          "name": "enable_ai_reporting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "gemini_api_key": {
+          "name": "gemini_api_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_provider": {
+          "name": "ai_provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'gemini'"
+        },
+        "openrouter_api_key": {
+          "name": "openrouter_api_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gemini_model_id": {
+          "name": "gemini_model_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "openrouter_model_id": {
+          "name": "openrouter_model_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_weekend_selection": {
+          "name": "allow_weekend_selection",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "default_location": {
+          "name": "default_location",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'remote'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_items": {
+      "name": "invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_of_measure": {
+          "name": "unit_of_measure",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unit'"
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoice_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "invoices",
+          "columnsFrom": ["invoice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_sale_id": {
+          "name": "linked_sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_date": {
+          "name": "issue_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "amount_paid": {
+          "name": "amount_paid",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_invoices_client_id": {
+          "name": "idx_invoices_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_status": {
+          "name": "idx_invoices_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_issue_date": {
+          "name": "idx_invoices_issue_date",
+          "columns": [
+            {
+              "expression": "issue_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ldap_config": {
+      "name": "ldap_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "server_url": {
+          "name": "server_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ldap://ldap.example.com:389'"
+        },
+        "base_dn": {
+          "name": "base_dn",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'dc=example,dc=com'"
+        },
+        "bind_dn": {
+          "name": "bind_dn",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'cn=read-only-admin,dc=example,dc=com'"
+        },
+        "bind_password": {
+          "name": "bind_password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "user_filter": {
+          "name": "user_filter",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'(uid={0})'"
+        },
+        "group_base_dn": {
+          "name": "group_base_dn",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ou=groups,dc=example,dc=com'"
+        },
+        "group_filter": {
+          "name": "group_filter",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'(member={0})'"
+        },
+        "role_mappings": {
+          "name": "role_mappings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_notifications_user_id": {
+          "name": "idx_notifications_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_user_unread": {
+          "name": "idx_notifications_user_unread",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notifications\".\"is_read\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quote_items": {
+      "name": "quote_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_cost": {
+          "name": "product_cost",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_mol_percentage": {
+          "name": "product_mol_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_id": {
+          "name": "supplier_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_item_id": {
+          "name": "supplier_quote_item_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_supplier_name": {
+          "name": "supplier_quote_supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_unit_price": {
+          "name": "supplier_quote_unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_type": {
+          "name": "unit_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'hours'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quote_items_quote_id_quotes_id_fk": {
+          "name": "quote_items_quote_id_quotes_id_fk",
+          "tableFrom": "quote_items",
+          "tableTo": "quotes",
+          "columnsFrom": ["quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quotes": {
+      "name": "quotes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_quotes_client_id": {
+          "name": "idx_quotes_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quotes_status": {
+          "name": "idx_quotes_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quotes_created_at": {
+          "name": "idx_quotes_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_permissions": {
+      "name": "role_permissions",
+      "schema": "",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_permissions_role_id_roles_id_fk": {
+          "name": "role_permissions_role_id_roles_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "roles",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "role_permissions_role_id_permission_pk": {
+          "name": "role_permissions_role_id_permission_pk",
+          "columns": ["role_id", "permission"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roles": {
+      "name": "roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_roles": {
+      "name": "user_roles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_roles_role_id_roles_id_fk": {
+          "name": "user_roles_role_id_roles_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "roles",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_roles_user_id_role_id_pk": {
+          "name": "user_roles_user_id_role_id_pk",
+          "columns": ["user_id", "role_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sale_items": {
+      "name": "sale_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sale_id": {
+          "name": "sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_cost": {
+          "name": "product_cost",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_mol_percentage": {
+          "name": "product_mol_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "unit_type": {
+          "name": "unit_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'hours'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_id": {
+          "name": "supplier_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_item_id": {
+          "name": "supplier_quote_item_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_supplier_name": {
+          "name": "supplier_quote_supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_unit_price": {
+          "name": "supplier_quote_unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_sale_id": {
+          "name": "supplier_sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_sale_item_id": {
+          "name": "supplier_sale_item_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_sale_supplier_name": {
+          "name": "supplier_sale_supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sale_items_sale_id_sales_id_fk": {
+          "name": "sale_items_sale_id_sales_id_fk",
+          "tableFrom": "sale_items",
+          "tableTo": "sales",
+          "columnsFrom": ["sale_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sales": {
+      "name": "sales",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_quote_id": {
+          "name": "linked_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_offer_id": {
+          "name": "linked_offer_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_sales_client_id": {
+          "name": "idx_sales_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_status": {
+          "name": "idx_sales_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_linked_quote_id": {
+          "name": "idx_sales_linked_quote_id",
+          "columns": [
+            {
+              "expression": "linked_quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_linked_offer_id": {
+          "name": "idx_sales_linked_offer_id",
+          "columns": [
+            {
+              "expression": "linked_offer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_linked_offer_id_unique": {
+          "name": "idx_sales_linked_offer_id_unique",
+          "columns": [
+            {
+              "expression": "linked_offer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sales\".\"linked_offer_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_created_at": {
+          "name": "idx_sales_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sales_linked_quote_id_quotes_id_fk": {
+          "name": "sales_linked_quote_id_quotes_id_fk",
+          "tableFrom": "sales",
+          "tableTo": "quotes",
+          "columnsFrom": ["linked_quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "sales_linked_offer_id_customer_offers_id_fk": {
+          "name": "sales_linked_offer_id_customer_offers_id_fk",
+          "tableFrom": "sales",
+          "tableTo": "customer_offers",
+          "columnsFrom": ["linked_offer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "daily_goal": {
+          "name": "daily_goal",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'8.00'"
+        },
+        "start_of_week": {
+          "name": "start_of_week",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Monday'"
+        },
+        "compact_view": {
+          "name": "compact_view",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "treat_saturday_as_holiday": {
+          "name": "treat_saturday_as_holiday",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "settings_user_id_unique": {
+          "name": "settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_sale_items": {
+      "name": "supplier_sale_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sale_id": {
+          "name": "sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "supplier_sale_items_sale_id_supplier_sales_id_fk": {
+          "name": "supplier_sale_items_sale_id_supplier_sales_id_fk",
+          "tableFrom": "supplier_sale_items",
+          "tableTo": "supplier_sales",
+          "columnsFrom": ["sale_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_sales": {
+      "name": "supplier_sales",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_quote_id": {
+          "name": "linked_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_name": {
+          "name": "supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "recurrence_pattern": {
+          "name": "recurrence_pattern",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_start": {
+          "name": "recurrence_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_end": {
+          "name": "recurrence_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_duration": {
+          "name": "recurrence_duration",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "expected_effort": {
+          "name": "expected_effort",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "revenue": {
+          "name": "revenue",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_tasks": {
+      "name": "user_tasks",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_source": {
+          "name": "assignment_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_tasks_task_id_tasks_id_fk": {
+          "name": "user_tasks_task_id_tasks_id_fk",
+          "tableFrom": "user_tasks",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_tasks_user_id_task_id_pk": {
+          "name": "user_tasks_user_id_task_id_pk",
+          "columns": ["user_id", "task_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.time_entries": {
+      "name": "time_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_name": {
+          "name": "project_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task": {
+          "name": "task",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "hourly_cost": {
+          "name": "hourly_cost",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "is_placeholder": {
+          "name": "is_placeholder",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'remote'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_time_entries_task_id": {
+          "name": "idx_time_entries_task_id",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "time_entries_task_id_tasks_id_fk": {
+          "name": "time_entries_task_id_tasks_id_fk",
+          "tableFrom": "time_entries",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1777736290821,
       "tag": "0004_claim_audit_logs",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1777742281742,
+      "tag": "0005_claim_customer_offer_items",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/schema/customerOfferItems.ts
+++ b/server/db/schema/customerOfferItems.ts
@@ -1,0 +1,37 @@
+import { sql } from 'drizzle-orm';
+import { check, index, numeric, pgTable, text, timestamp, varchar } from 'drizzle-orm/pg-core';
+import { customerOffers } from './customerOffers.ts';
+
+// Final shape after the ALTER TABLEs in schema.sql added unit_type, the supplier_quote_*
+// columns, and the chk_customer_offer_items_unit_type CHECK constraint.
+// `product_id` runtime FK to `products(id)` (un-modeled — products is in Tier 5).
+export const customerOfferItems = pgTable(
+  'customer_offer_items',
+  {
+    id: varchar('id', { length: 50 }).primaryKey(),
+    offerId: varchar('offer_id', { length: 100 })
+      .notNull()
+      .references(() => customerOffers.id, { onDelete: 'cascade', onUpdate: 'cascade' }),
+    productId: varchar('product_id', { length: 50 }),
+    productName: varchar('product_name', { length: 255 }).notNull(),
+    quantity: numeric('quantity', { precision: 10, scale: 2 }).notNull().default('1'),
+    unitPrice: numeric('unit_price', { precision: 15, scale: 2 }).notNull().default('0'),
+    productCost: numeric('product_cost', { precision: 15, scale: 2 }).notNull().default('0'),
+    productMolPercentage: numeric('product_mol_percentage', { precision: 5, scale: 2 }),
+    discount: numeric('discount', { precision: 5, scale: 2 }).default('0'),
+    note: text('note'),
+    createdAt: timestamp('created_at').default(sql`CURRENT_TIMESTAMP`),
+    unitType: varchar('unit_type', { length: 10 }).default('hours'),
+    supplierQuoteId: varchar('supplier_quote_id', { length: 100 }),
+    supplierQuoteItemId: varchar('supplier_quote_item_id', { length: 50 }),
+    supplierQuoteSupplierName: varchar('supplier_quote_supplier_name', { length: 255 }),
+    supplierQuoteUnitPrice: numeric('supplier_quote_unit_price', { precision: 15, scale: 2 }),
+  },
+  (table) => [
+    index('idx_customer_offer_items_offer_id').on(table.offerId),
+    check(
+      'chk_customer_offer_items_unit_type',
+      sql`${table.unitType} IN ('hours', 'days', 'unit')`,
+    ),
+  ],
+);

--- a/server/db/schema/customerOfferItems.ts
+++ b/server/db/schema/customerOfferItems.ts
@@ -1,5 +1,6 @@
 import { sql } from 'drizzle-orm';
 import { check, index, numeric, pgTable, text, timestamp, varchar } from 'drizzle-orm/pg-core';
+import type { UnitType } from '../../utils/unit-type.ts';
 import { customerOffers } from './customerOffers.ts';
 
 // Final shape after the ALTER TABLEs in schema.sql added unit_type, the supplier_quote_*
@@ -21,7 +22,7 @@ export const customerOfferItems = pgTable(
     discount: numeric('discount', { precision: 5, scale: 2 }).default('0'),
     note: text('note'),
     createdAt: timestamp('created_at').default(sql`CURRENT_TIMESTAMP`),
-    unitType: varchar('unit_type', { length: 10 }).default('hours'),
+    unitType: varchar('unit_type', { length: 10 }).$type<UnitType>().default('hours'),
     supplierQuoteId: varchar('supplier_quote_id', { length: 100 }),
     supplierQuoteItemId: varchar('supplier_quote_item_id', { length: 50 }),
     supplierQuoteSupplierName: varchar('supplier_quote_supplier_name', { length: 255 }),

--- a/server/db/schema/index.ts
+++ b/server/db/schema/index.ts
@@ -1,4 +1,5 @@
 export * from './auditLogs.ts';
+export * from './customerOfferItems.ts';
 export * from './customerOffers.ts';
 export * from './emailConfig.ts';
 export * from './generalSettings.ts';

--- a/server/repositories/clientOffersRepo.ts
+++ b/server/repositories/clientOffersRepo.ts
@@ -1,4 +1,8 @@
-import pool, { buildBulkInsertPlaceholders, type QueryExecutor } from '../db/index.ts';
+import { and, asc, desc, eq, ne, sql } from 'drizzle-orm';
+import { type DbExecutor, db, executeRows } from '../db/drizzle.ts';
+import { customerOfferItems } from '../db/schema/customerOfferItems.ts';
+import { customerOffers } from '../db/schema/customerOffers.ts';
+import { sales } from '../db/schema/sales.ts';
 import { normalizeNullableDateOnly } from '../utils/date.ts';
 import { parseDbNumber, parseNullableDbNumber } from '../utils/parse.ts';
 import { normalizeUnitType, type UnitType } from '../utils/unit-type.ts';
@@ -36,6 +40,10 @@ export type ClientOfferItem = {
   discount: number;
 };
 
+// Snake-case-aliased shape returned by raw-SQL `executeRows` paths (`update`, `insertItems`).
+// The SELECT clauses below alias columns to camelCase via `AS "fooBar"`, so these row shapes
+// are camelCase as well — the difference vs. builder rows is that timestamp columns come back
+// as epoch-ms numbers (via `EXTRACT(EPOCH FROM ...) * 1000`) rather than `Date` objects.
 type ClientOfferRow = {
   id: string;
   linkedQuoteId: string;
@@ -69,7 +77,7 @@ type ClientOfferItemRow = {
   discount: string | number;
 };
 
-const OFFER_COLUMNS = `
+const OFFER_RETURNING_SQL = sql`
   id,
   linked_quote_id as "linkedQuoteId",
   client_id as "clientId",
@@ -84,7 +92,7 @@ const OFFER_COLUMNS = `
   EXTRACT(EPOCH FROM updated_at) * 1000 as "updatedAt"
 `;
 
-const ITEM_COLUMNS = `
+const ITEM_RETURNING_SQL = sql`
   id,
   offer_id as "offerId",
   product_id as "productId",
@@ -117,6 +125,21 @@ const mapOffer = (row: ClientOfferRow): ClientOffer => ({
   updatedAt: parseDbNumber(row.updatedAt, 0),
 });
 
+const mapBuilderOffer = (row: typeof customerOffers.$inferSelect): ClientOffer => ({
+  id: row.id,
+  linkedQuoteId: row.linkedQuoteId,
+  clientId: row.clientId,
+  clientName: row.clientName,
+  paymentTerms: row.paymentTerms,
+  discount: parseDbNumber(row.discount, 0),
+  discountType: row.discountType === 'currency' ? 'currency' : 'percentage',
+  status: row.status,
+  expirationDate: normalizeNullableDateOnly(row.expirationDate, 'offer.expirationDate'),
+  notes: row.notes,
+  createdAt: row.createdAt?.getTime() ?? 0,
+  updatedAt: row.updatedAt?.getTime() ?? 0,
+});
+
 const mapItem = (row: ClientOfferItemRow): ClientOfferItem => ({
   id: row.id,
   offerId: row.offerId,
@@ -135,37 +158,54 @@ const mapItem = (row: ClientOfferItemRow): ClientOfferItem => ({
   discount: parseDbNumber(row.discount, 0),
 });
 
-export const listAll = async (exec: QueryExecutor = pool): Promise<ClientOffer[]> => {
-  const { rows } = await exec.query<ClientOfferRow>(
-    `SELECT ${OFFER_COLUMNS} FROM customer_offers ORDER BY created_at DESC`,
-  );
-  return rows.map(mapOffer);
+const mapBuilderItem = (row: typeof customerOfferItems.$inferSelect): ClientOfferItem => ({
+  id: row.id,
+  offerId: row.offerId,
+  productId: row.productId,
+  productName: row.productName,
+  quantity: parseDbNumber(row.quantity, 0),
+  unitPrice: parseDbNumber(row.unitPrice, 0),
+  productCost: parseDbNumber(row.productCost, 0),
+  productMolPercentage: parseNullableDbNumber(row.productMolPercentage),
+  supplierQuoteId: row.supplierQuoteId,
+  supplierQuoteItemId: row.supplierQuoteItemId,
+  supplierQuoteSupplierName: row.supplierQuoteSupplierName,
+  supplierQuoteUnitPrice: parseNullableDbNumber(row.supplierQuoteUnitPrice),
+  unitType: normalizeUnitType(row.unitType),
+  note: row.note,
+  discount: parseDbNumber(row.discount, 0),
+});
+
+export const listAll = async (exec: DbExecutor = db): Promise<ClientOffer[]> => {
+  const rows = await exec.select().from(customerOffers).orderBy(desc(customerOffers.createdAt));
+  return rows.map(mapBuilderOffer);
 };
 
-export const listAllItems = async (exec: QueryExecutor = pool): Promise<ClientOfferItem[]> => {
-  const { rows } = await exec.query<ClientOfferItemRow>(
-    `SELECT ${ITEM_COLUMNS} FROM customer_offer_items ORDER BY created_at ASC`,
-  );
-  return rows.map(mapItem);
+export const listAllItems = async (exec: DbExecutor = db): Promise<ClientOfferItem[]> => {
+  const rows = await exec
+    .select()
+    .from(customerOfferItems)
+    .orderBy(asc(customerOfferItems.createdAt));
+  return rows.map(mapBuilderItem);
 };
 
-export const existsById = async (id: string, exec: QueryExecutor = pool): Promise<boolean> => {
-  const { rows } = await exec.query<{ id: string }>(
-    `SELECT id FROM customer_offers WHERE id = $1`,
-    [id],
-  );
+export const existsById = async (id: string, exec: DbExecutor = db): Promise<boolean> => {
+  const rows = await exec
+    .select({ id: customerOffers.id })
+    .from(customerOffers)
+    .where(eq(customerOffers.id, id));
   return rows.length > 0;
 };
 
 export const findIdConflict = async (
   newId: string,
   currentId: string,
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<boolean> => {
-  const { rows } = await exec.query<{ id: string }>(
-    `SELECT id FROM customer_offers WHERE id = $1 AND id <> $2`,
-    [newId, currentId],
-  );
+  const rows = await exec
+    .select({ id: customerOffers.id })
+    .from(customerOffers)
+    .where(and(eq(customerOffers.id, newId), ne(customerOffers.id, currentId)));
   return rows.length > 0;
 };
 
@@ -179,63 +219,65 @@ export type ExistingOffer = {
 
 export const findForUpdate = async (
   id: string,
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<ExistingOffer | null> => {
-  const { rows } = await exec.query<ExistingOffer>(
-    `SELECT id,
-            linked_quote_id as "linkedQuoteId",
-            client_id as "clientId",
-            client_name as "clientName",
-            status
-       FROM customer_offers
-      WHERE id = $1`,
-    [id],
-  );
+  const rows = await exec
+    .select({
+      id: customerOffers.id,
+      linkedQuoteId: customerOffers.linkedQuoteId,
+      clientId: customerOffers.clientId,
+      clientName: customerOffers.clientName,
+      status: customerOffers.status,
+    })
+    .from(customerOffers)
+    .where(eq(customerOffers.id, id));
   return rows[0] ?? null;
 };
 
 export const findStatusAndClientName = async (
   id: string,
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<{ status: string; clientName: string } | null> => {
-  const { rows } = await exec.query<{ status: string; clientName: string }>(
-    `SELECT status, client_name as "clientName" FROM customer_offers WHERE id = $1`,
-    [id],
-  );
+  const rows = await exec
+    .select({ status: customerOffers.status, clientName: customerOffers.clientName })
+    .from(customerOffers)
+    .where(eq(customerOffers.id, id));
   return rows[0] ?? null;
 };
 
 export const findExistingForQuote = async (
   quoteId: string,
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<string | null> => {
-  const { rows } = await exec.query<{ id: string }>(
-    `SELECT id FROM customer_offers WHERE linked_quote_id = $1 LIMIT 1`,
-    [quoteId],
-  );
+  const rows = await exec
+    .select({ id: customerOffers.id })
+    .from(customerOffers)
+    .where(eq(customerOffers.linkedQuoteId, quoteId))
+    .limit(1);
   return rows[0]?.id ?? null;
 };
 
 export const findLinkedSaleId = async (
   offerId: string,
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<string | null> => {
-  const { rows } = await exec.query<{ id: string }>(
-    `SELECT id FROM sales WHERE linked_offer_id = $1 LIMIT 1`,
-    [offerId],
-  );
+  const rows = await exec
+    .select({ id: sales.id })
+    .from(sales)
+    .where(eq(sales.linkedOfferId, offerId))
+    .limit(1);
   return rows[0]?.id ?? null;
 };
 
 export const findItemsForOffer = async (
   offerId: string,
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<ClientOfferItem[]> => {
-  const { rows } = await exec.query<ClientOfferItemRow>(
-    `SELECT ${ITEM_COLUMNS} FROM customer_offer_items WHERE offer_id = $1`,
-    [offerId],
-  );
-  return rows.map(mapItem);
+  const rows = await exec
+    .select()
+    .from(customerOfferItems)
+    .where(eq(customerOfferItems.offerId, offerId));
+  return rows.map(mapBuilderItem);
 };
 
 export type NewClientOffer = {
@@ -253,27 +295,26 @@ export type NewClientOffer = {
 
 export const create = async (
   input: NewClientOffer,
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<ClientOffer> => {
-  const { rows } = await exec.query<ClientOfferRow>(
-    `INSERT INTO customer_offers
-        (id, linked_quote_id, client_id, client_name, payment_terms, discount, discount_type, status, expiration_date, notes)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-     RETURNING ${OFFER_COLUMNS}`,
-    [
-      input.id,
-      input.linkedQuoteId,
-      input.clientId,
-      input.clientName,
-      input.paymentTerms,
-      input.discount,
-      input.discountType,
-      input.status,
-      input.expirationDate,
-      input.notes,
-    ],
-  );
-  return mapOffer(rows[0]);
+  const [row] = await exec
+    .insert(customerOffers)
+    .values({
+      id: input.id,
+      linkedQuoteId: input.linkedQuoteId,
+      clientId: input.clientId,
+      clientName: input.clientName,
+      paymentTerms: input.paymentTerms,
+      // numeric columns accept number or string at the wire level; the schema's TS
+      // type is `string` so cast through. The pg driver serializes both equivalently.
+      discount: input.discount as unknown as string,
+      discountType: input.discountType,
+      status: input.status,
+      expirationDate: input.expirationDate,
+      notes: input.notes,
+    })
+    .returning();
+  return mapBuilderOffer(row);
 };
 
 export type ClientOfferUpdate = {
@@ -291,34 +332,26 @@ export type ClientOfferUpdate = {
 export const update = async (
   id: string,
   patch: ClientOfferUpdate,
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<ClientOffer | null> => {
-  const { rows } = await exec.query<ClientOfferRow>(
-    `UPDATE customer_offers
-        SET id = COALESCE($1, id),
-            client_id = COALESCE($2, client_id),
-            client_name = COALESCE($3, client_name),
-            payment_terms = COALESCE($4, payment_terms),
-            discount = COALESCE($5, discount),
-            discount_type = COALESCE($6, discount_type),
-            status = COALESCE($7, status),
-            expiration_date = COALESCE($8, expiration_date),
-            notes = COALESCE($9, notes),
-            updated_at = CURRENT_TIMESTAMP
-      WHERE id = $10
-      RETURNING ${OFFER_COLUMNS}`,
-    [
-      patch.id ?? null,
-      patch.clientId ?? null,
-      patch.clientName ?? null,
-      patch.paymentTerms ?? null,
-      patch.discount ?? null,
-      patch.discountType ?? null,
-      patch.status ?? null,
-      patch.expirationDate ?? null,
-      patch.notes ?? null,
-      id,
-    ],
+  // The COALESCE pattern preserves the existing column when the patch field is null —
+  // matches the pre-Drizzle contract callers rely on (the client-offers route always
+  // passes a value, using `null` to mean "keep existing" for fields that weren't sent).
+  const rows = await executeRows<ClientOfferRow>(
+    exec,
+    sql`UPDATE customer_offers
+           SET id = COALESCE(${patch.id ?? null}, id),
+               client_id = COALESCE(${patch.clientId ?? null}, client_id),
+               client_name = COALESCE(${patch.clientName ?? null}, client_name),
+               payment_terms = COALESCE(${patch.paymentTerms ?? null}, payment_terms),
+               discount = COALESCE(${patch.discount ?? null}, discount),
+               discount_type = COALESCE(${patch.discountType ?? null}, discount_type),
+               status = COALESCE(${patch.status ?? null}, status),
+               expiration_date = COALESCE(${patch.expirationDate ?? null}, expiration_date),
+               notes = COALESCE(${patch.notes ?? null}, notes),
+               updated_at = CURRENT_TIMESTAMP
+         WHERE id = ${id}
+         RETURNING ${OFFER_RETURNING_SQL}`,
   );
   return rows[0] ? mapOffer(rows[0]) : null;
 };
@@ -343,36 +376,24 @@ export type NewClientOfferItem = {
 export const insertItems = async (
   offerId: string,
   items: NewClientOfferItem[],
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<ClientOfferItem[]> => {
   if (items.length === 0) return [];
-  const placeholders = buildBulkInsertPlaceholders(items.length, 15);
-  const params = items.flatMap((item) => [
-    item.id,
-    offerId,
-    item.productId,
-    item.productName,
-    item.quantity,
-    item.unitPrice,
-    item.productCost,
-    item.productMolPercentage,
-    item.discount,
-    item.note,
-    item.supplierQuoteId,
-    item.supplierQuoteItemId,
-    item.supplierQuoteSupplierName,
-    item.supplierQuoteUnitPrice,
-    item.unitType,
-  ]);
-  const { rows } = await exec.query<ClientOfferItemRow>(
-    `INSERT INTO customer_offer_items
-       (id, offer_id, product_id, product_name, quantity, unit_price, product_cost,
-        product_mol_percentage, discount, note,
-        supplier_quote_id, supplier_quote_item_id, supplier_quote_supplier_name,
-        supplier_quote_unit_price, unit_type)
-     VALUES ${placeholders}
-     RETURNING ${ITEM_COLUMNS}`,
-    params,
+  // Multi-row INSERT via `sql.join` of per-row tuples. Drizzle's tagged template handles
+  // parameter numbering; preserves the existing single-statement bulk insert.
+  const valuesTuples = items.map(
+    (item) =>
+      sql`(${item.id}, ${offerId}, ${item.productId}, ${item.productName}, ${item.quantity}, ${item.unitPrice}, ${item.productCost}, ${item.productMolPercentage}, ${item.discount}, ${item.note}, ${item.supplierQuoteId}, ${item.supplierQuoteItemId}, ${item.supplierQuoteSupplierName}, ${item.supplierQuoteUnitPrice}, ${item.unitType})`,
+  );
+  const rows = await executeRows<ClientOfferItemRow>(
+    exec,
+    sql`INSERT INTO customer_offer_items
+           (id, offer_id, product_id, product_name, quantity, unit_price, product_cost,
+            product_mol_percentage, discount, note,
+            supplier_quote_id, supplier_quote_item_id, supplier_quote_supplier_name,
+            supplier_quote_unit_price, unit_type)
+         VALUES ${sql.join(valuesTuples, sql`, `)}
+         RETURNING ${ITEM_RETURNING_SQL}`,
   );
   return rows.map(mapItem);
 };
@@ -380,13 +401,13 @@ export const insertItems = async (
 export const replaceItems = async (
   offerId: string,
   items: NewClientOfferItem[],
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<ClientOfferItem[]> => {
-  await exec.query(`DELETE FROM customer_offer_items WHERE offer_id = $1`, [offerId]);
+  await exec.delete(customerOfferItems).where(eq(customerOfferItems.offerId, offerId));
   return insertItems(offerId, items, exec);
 };
 
-export const deleteById = async (id: string, exec: QueryExecutor = pool): Promise<boolean> => {
-  const { rowCount } = await exec.query(`DELETE FROM customer_offers WHERE id = $1`, [id]);
-  return (rowCount ?? 0) > 0;
+export const deleteById = async (id: string, exec: DbExecutor = db): Promise<boolean> => {
+  const result = await exec.delete(customerOffers).where(eq(customerOffers.id, id));
+  return (result.rowCount ?? 0) > 0;
 };

--- a/server/repositories/clientOffersRepo.ts
+++ b/server/repositories/clientOffersRepo.ts
@@ -1,10 +1,10 @@
 import { and, asc, desc, eq, ne, sql } from 'drizzle-orm';
-import { type DbExecutor, db, executeRows } from '../db/drizzle.ts';
+import { type DbExecutor, db } from '../db/drizzle.ts';
 import { customerOfferItems } from '../db/schema/customerOfferItems.ts';
 import { customerOffers } from '../db/schema/customerOffers.ts';
 import { sales } from '../db/schema/sales.ts';
 import { normalizeNullableDateOnly } from '../utils/date.ts';
-import { parseDbNumber, parseNullableDbNumber } from '../utils/parse.ts';
+import { numericForDb, parseDbNumber, parseNullableDbNumber } from '../utils/parse.ts';
 import { normalizeUnitType, type UnitType } from '../utils/unit-type.ts';
 
 export type ClientOffer = {
@@ -40,92 +40,7 @@ export type ClientOfferItem = {
   discount: number;
 };
 
-// Snake-case-aliased shape returned by raw-SQL `executeRows` paths (`update`, `insertItems`).
-// The SELECT clauses below alias columns to camelCase via `AS "fooBar"`, so these row shapes
-// are camelCase as well — the difference vs. builder rows is that timestamp columns come back
-// as epoch-ms numbers (via `EXTRACT(EPOCH FROM ...) * 1000`) rather than `Date` objects.
-type ClientOfferRow = {
-  id: string;
-  linkedQuoteId: string;
-  clientId: string;
-  clientName: string;
-  paymentTerms: string | null;
-  discount: string | number;
-  discountType: string;
-  status: string;
-  expirationDate: string | Date | null;
-  notes: string | null;
-  createdAt: string | number;
-  updatedAt: string | number;
-};
-
-type ClientOfferItemRow = {
-  id: string;
-  offerId: string;
-  productId: string | null;
-  productName: string;
-  quantity: string | number;
-  unitPrice: string | number;
-  productCost: string | number;
-  productMolPercentage: string | number | null;
-  supplierQuoteId: string | null;
-  supplierQuoteItemId: string | null;
-  supplierQuoteSupplierName: string | null;
-  supplierQuoteUnitPrice: string | number | null;
-  unitType: string | null;
-  note: string | null;
-  discount: string | number;
-};
-
-const OFFER_RETURNING_SQL = sql`
-  id,
-  linked_quote_id as "linkedQuoteId",
-  client_id as "clientId",
-  client_name as "clientName",
-  payment_terms as "paymentTerms",
-  discount,
-  discount_type as "discountType",
-  status,
-  expiration_date as "expirationDate",
-  notes,
-  EXTRACT(EPOCH FROM created_at) * 1000 as "createdAt",
-  EXTRACT(EPOCH FROM updated_at) * 1000 as "updatedAt"
-`;
-
-const ITEM_RETURNING_SQL = sql`
-  id,
-  offer_id as "offerId",
-  product_id as "productId",
-  product_name as "productName",
-  quantity,
-  unit_price as "unitPrice",
-  product_cost as "productCost",
-  product_mol_percentage as "productMolPercentage",
-  supplier_quote_id as "supplierQuoteId",
-  supplier_quote_item_id as "supplierQuoteItemId",
-  supplier_quote_supplier_name as "supplierQuoteSupplierName",
-  supplier_quote_unit_price as "supplierQuoteUnitPrice",
-  unit_type as "unitType",
-  note,
-  discount
-`;
-
-const mapOffer = (row: ClientOfferRow): ClientOffer => ({
-  id: row.id,
-  linkedQuoteId: row.linkedQuoteId,
-  clientId: row.clientId,
-  clientName: row.clientName,
-  paymentTerms: row.paymentTerms,
-  discount: parseDbNumber(row.discount, 0),
-  discountType: row.discountType === 'currency' ? 'currency' : 'percentage',
-  status: row.status,
-  expirationDate: normalizeNullableDateOnly(row.expirationDate, 'offer.expirationDate'),
-  notes: row.notes,
-  createdAt: parseDbNumber(row.createdAt, 0),
-  updatedAt: parseDbNumber(row.updatedAt, 0),
-});
-
-const mapBuilderOffer = (row: typeof customerOffers.$inferSelect): ClientOffer => ({
+const mapOffer = (row: typeof customerOffers.$inferSelect): ClientOffer => ({
   id: row.id,
   linkedQuoteId: row.linkedQuoteId,
   clientId: row.clientId,
@@ -140,25 +55,7 @@ const mapBuilderOffer = (row: typeof customerOffers.$inferSelect): ClientOffer =
   updatedAt: row.updatedAt?.getTime() ?? 0,
 });
 
-const mapItem = (row: ClientOfferItemRow): ClientOfferItem => ({
-  id: row.id,
-  offerId: row.offerId,
-  productId: row.productId,
-  productName: row.productName,
-  quantity: parseDbNumber(row.quantity, 0),
-  unitPrice: parseDbNumber(row.unitPrice, 0),
-  productCost: parseDbNumber(row.productCost, 0),
-  productMolPercentage: parseNullableDbNumber(row.productMolPercentage),
-  supplierQuoteId: row.supplierQuoteId,
-  supplierQuoteItemId: row.supplierQuoteItemId,
-  supplierQuoteSupplierName: row.supplierQuoteSupplierName,
-  supplierQuoteUnitPrice: parseNullableDbNumber(row.supplierQuoteUnitPrice),
-  unitType: normalizeUnitType(row.unitType),
-  note: row.note,
-  discount: parseDbNumber(row.discount, 0),
-});
-
-const mapBuilderItem = (row: typeof customerOfferItems.$inferSelect): ClientOfferItem => ({
+const mapItem = (row: typeof customerOfferItems.$inferSelect): ClientOfferItem => ({
   id: row.id,
   offerId: row.offerId,
   productId: row.productId,
@@ -178,7 +75,7 @@ const mapBuilderItem = (row: typeof customerOfferItems.$inferSelect): ClientOffe
 
 export const listAll = async (exec: DbExecutor = db): Promise<ClientOffer[]> => {
   const rows = await exec.select().from(customerOffers).orderBy(desc(customerOffers.createdAt));
-  return rows.map(mapBuilderOffer);
+  return rows.map(mapOffer);
 };
 
 export const listAllItems = async (exec: DbExecutor = db): Promise<ClientOfferItem[]> => {
@@ -186,7 +83,7 @@ export const listAllItems = async (exec: DbExecutor = db): Promise<ClientOfferIt
     .select()
     .from(customerOfferItems)
     .orderBy(asc(customerOfferItems.createdAt));
-  return rows.map(mapBuilderItem);
+  return rows.map(mapItem);
 };
 
 export const existsById = async (id: string, exec: DbExecutor = db): Promise<boolean> => {
@@ -277,7 +174,7 @@ export const findItemsForOffer = async (
     .select()
     .from(customerOfferItems)
     .where(eq(customerOfferItems.offerId, offerId));
-  return rows.map(mapBuilderItem);
+  return rows.map(mapItem);
 };
 
 export type NewClientOffer = {
@@ -305,16 +202,14 @@ export const create = async (
       clientId: input.clientId,
       clientName: input.clientName,
       paymentTerms: input.paymentTerms,
-      // numeric columns accept number or string at the wire level; the schema's TS
-      // type is `string` so cast through. The pg driver serializes both equivalently.
-      discount: input.discount as unknown as string,
+      discount: numericForDb(input.discount),
       discountType: input.discountType,
       status: input.status,
       expirationDate: input.expirationDate,
       notes: input.notes,
     })
     .returning();
-  return mapBuilderOffer(row);
+  return mapOffer(row);
 };
 
 export type ClientOfferUpdate = {
@@ -329,31 +224,31 @@ export type ClientOfferUpdate = {
   notes?: string | null;
 };
 
+// COALESCE preserves the existing column when the patch field is null — the client-offers
+// route always passes a value, using `null` to mean "keep existing" for fields that weren't
+// sent in the request body.
 export const update = async (
   id: string,
   patch: ClientOfferUpdate,
   exec: DbExecutor = db,
 ): Promise<ClientOffer | null> => {
-  // The COALESCE pattern preserves the existing column when the patch field is null —
-  // matches the pre-Drizzle contract callers rely on (the client-offers route always
-  // passes a value, using `null` to mean "keep existing" for fields that weren't sent).
-  const rows = await executeRows<ClientOfferRow>(
-    exec,
-    sql`UPDATE customer_offers
-           SET id = COALESCE(${patch.id ?? null}, id),
-               client_id = COALESCE(${patch.clientId ?? null}, client_id),
-               client_name = COALESCE(${patch.clientName ?? null}, client_name),
-               payment_terms = COALESCE(${patch.paymentTerms ?? null}, payment_terms),
-               discount = COALESCE(${patch.discount ?? null}, discount),
-               discount_type = COALESCE(${patch.discountType ?? null}, discount_type),
-               status = COALESCE(${patch.status ?? null}, status),
-               expiration_date = COALESCE(${patch.expirationDate ?? null}, expiration_date),
-               notes = COALESCE(${patch.notes ?? null}, notes),
-               updated_at = CURRENT_TIMESTAMP
-         WHERE id = ${id}
-         RETURNING ${OFFER_RETURNING_SQL}`,
-  );
-  return rows[0] ? mapOffer(rows[0]) : null;
+  const [row] = await exec
+    .update(customerOffers)
+    .set({
+      id: sql`COALESCE(${patch.id ?? null}, ${customerOffers.id})`,
+      clientId: sql`COALESCE(${patch.clientId ?? null}, ${customerOffers.clientId})`,
+      clientName: sql`COALESCE(${patch.clientName ?? null}, ${customerOffers.clientName})`,
+      paymentTerms: sql`COALESCE(${patch.paymentTerms ?? null}, ${customerOffers.paymentTerms})`,
+      discount: sql`COALESCE(${numericForDb(patch.discount) ?? null}::numeric, ${customerOffers.discount})`,
+      discountType: sql`COALESCE(${patch.discountType ?? null}, ${customerOffers.discountType})`,
+      status: sql`COALESCE(${patch.status ?? null}, ${customerOffers.status})`,
+      expirationDate: sql`COALESCE(${patch.expirationDate ?? null}::date, ${customerOffers.expirationDate})`,
+      notes: sql`COALESCE(${patch.notes ?? null}, ${customerOffers.notes})`,
+      updatedAt: sql`CURRENT_TIMESTAMP`,
+    })
+    .where(eq(customerOffers.id, id))
+    .returning();
+  return row ? mapOffer(row) : null;
 };
 
 export type NewClientOfferItem = {
@@ -379,22 +274,28 @@ export const insertItems = async (
   exec: DbExecutor = db,
 ): Promise<ClientOfferItem[]> => {
   if (items.length === 0) return [];
-  // Multi-row INSERT via `sql.join` of per-row tuples. Drizzle's tagged template handles
-  // parameter numbering; preserves the existing single-statement bulk insert.
-  const valuesTuples = items.map(
-    (item) =>
-      sql`(${item.id}, ${offerId}, ${item.productId}, ${item.productName}, ${item.quantity}, ${item.unitPrice}, ${item.productCost}, ${item.productMolPercentage}, ${item.discount}, ${item.note}, ${item.supplierQuoteId}, ${item.supplierQuoteItemId}, ${item.supplierQuoteSupplierName}, ${item.supplierQuoteUnitPrice}, ${item.unitType})`,
-  );
-  const rows = await executeRows<ClientOfferItemRow>(
-    exec,
-    sql`INSERT INTO customer_offer_items
-           (id, offer_id, product_id, product_name, quantity, unit_price, product_cost,
-            product_mol_percentage, discount, note,
-            supplier_quote_id, supplier_quote_item_id, supplier_quote_supplier_name,
-            supplier_quote_unit_price, unit_type)
-         VALUES ${sql.join(valuesTuples, sql`, `)}
-         RETURNING ${ITEM_RETURNING_SQL}`,
-  );
+  const rows = await exec
+    .insert(customerOfferItems)
+    .values(
+      items.map((item) => ({
+        id: item.id,
+        offerId,
+        productId: item.productId,
+        productName: item.productName,
+        quantity: numericForDb(item.quantity),
+        unitPrice: numericForDb(item.unitPrice),
+        productCost: numericForDb(item.productCost),
+        productMolPercentage: numericForDb(item.productMolPercentage),
+        discount: numericForDb(item.discount),
+        note: item.note,
+        supplierQuoteId: item.supplierQuoteId,
+        supplierQuoteItemId: item.supplierQuoteItemId,
+        supplierQuoteSupplierName: item.supplierQuoteSupplierName,
+        supplierQuoteUnitPrice: numericForDb(item.supplierQuoteUnitPrice),
+        unitType: item.unitType,
+      })),
+    )
+    .returning();
   return rows.map(mapItem);
 };
 

--- a/server/repositories/clientOffersRepo.ts
+++ b/server/repositories/clientOffersRepo.ts
@@ -224,9 +224,6 @@ export type ClientOfferUpdate = {
   notes?: string | null;
 };
 
-// COALESCE preserves the existing column when the patch field is null — the client-offers
-// route always passes a value, using `null` to mean "keep existing" for fields that weren't
-// sent in the request body.
 export const update = async (
   id: string,
   patch: ClientOfferUpdate,

--- a/server/repositories/entriesRepo.ts
+++ b/server/repositories/entriesRepo.ts
@@ -1,7 +1,9 @@
-import pool, { type QueryExecutor } from '../db/index.ts';
+import { and, eq, gte, type SQL, sql } from 'drizzle-orm';
+import { type DbExecutor, db, executeRows } from '../db/drizzle.ts';
+import { timeEntries } from '../db/schema/timeEntries.ts';
 import { normalizeNullableDateOnly } from '../utils/date.ts';
 import { parseDbNumber } from '../utils/parse.ts';
-import { managedUserIdsSubquery } from './workUnitsRepo.ts';
+import { managedUserIdsSubquerySql } from './workUnitsRepo.ts';
 
 export type TimeEntry = {
   id: string;
@@ -21,6 +23,8 @@ export type TimeEntry = {
   createdAt: number;
 };
 
+// Snake-case row shape returned by raw-SQL `executeRows` paths. Carries the extra
+// `created_at_text` column that the cursor pagination needs (see `ENTRY_COLUMNS_SQL`).
 type TimeEntryRow = {
   id: string;
   user_id: string;
@@ -43,11 +47,11 @@ type TimeEntryRow = {
   created_at_text: string;
 };
 
-const ENTRY_COLUMNS = `id, user_id, date, client_id, client_name, project_id,
+const ENTRY_COLUMNS_SQL = sql`id, user_id, date, client_id, client_name, project_id,
   project_name, task, task_id, notes, duration, hourly_cost, is_placeholder, location, created_at,
   created_at::text AS created_at_text`;
 
-const mapRow = (row: TimeEntryRow): TimeEntry => {
+const mapRawRow = (row: TimeEntryRow): TimeEntry => {
   const date = normalizeNullableDateOnly(row.date, 'entry.date');
   if (!date) throw new TypeError('Invalid date value for entry.date');
   return {
@@ -66,6 +70,31 @@ const mapRow = (row: TimeEntryRow): TimeEntry => {
     isPlaceholder: !!row.is_placeholder,
     location: row.location || 'remote',
     createdAt: new Date(row.created_at).getTime(),
+  };
+};
+
+// Builder paths receive Drizzle's inferred camelCase row. Coercion is otherwise the
+// same as `mapRawRow`. Two mappers (rather than one) avoid synthesizing a missing
+// `created_at_text` for builder paths that never read it.
+const mapBuilderRow = (row: typeof timeEntries.$inferSelect): TimeEntry => {
+  const date = normalizeNullableDateOnly(row.date, 'entry.date');
+  if (!date) throw new TypeError('Invalid date value for entry.date');
+  return {
+    id: row.id,
+    userId: row.userId,
+    date,
+    clientId: row.clientId,
+    clientName: row.clientName,
+    projectId: row.projectId,
+    projectName: row.projectName,
+    task: row.task,
+    taskId: row.taskId,
+    notes: row.notes,
+    duration: parseDbNumber(row.duration, 0),
+    hourlyCost: parseDbNumber(row.hourlyCost, 0),
+    isPlaceholder: !!row.isPlaceholder,
+    location: row.location || 'remote',
+    createdAt: row.createdAt?.getTime() ?? 0,
   };
 };
 
@@ -89,11 +118,8 @@ const resolveLimit = (limit?: number): number => {
   return Math.min(Math.floor(limit), MAX_LIMIT);
 };
 
-const buildCursorClause = (cursor: EntriesCursor | undefined, startIdx: number) => {
-  if (!cursor) return { sql: '', params: [], nextIdx: startIdx };
-  const sql = `(created_at, id) < ($${startIdx}::timestamp, $${startIdx + 1})`;
-  return { sql, params: [cursor.createdAt, cursor.id], nextIdx: startIdx + 2 };
-};
+const cursorClause = (cursor: EntriesCursor | undefined): SQL | null =>
+  cursor ? sql`(created_at, id) < (${cursor.createdAt}::timestamp, ${cursor.id})` : null;
 
 export type ListEntriesResult = {
   entries: TimeEntry[];
@@ -101,7 +127,7 @@ export type ListEntriesResult = {
 };
 
 const buildResult = (rows: TimeEntryRow[], limit: number): ListEntriesResult => {
-  const entries = rows.map(mapRow);
+  const entries = rows.map(mapRawRow);
   const lastRow = rows[rows.length - 1];
   const nextCursor =
     entries.length === limit && lastRow
@@ -110,16 +136,21 @@ const buildResult = (rows: TimeEntryRow[], limit: number): ListEntriesResult => 
   return { entries, nextCursor };
 };
 
+const joinAnd = (clauses: Array<SQL | null>): SQL | null => {
+  const filtered = clauses.filter((c): c is SQL => c !== null);
+  if (filtered.length === 0) return null;
+  return sql.join(filtered, sql` AND `);
+};
+
 export const listAll = async (
   options: ListEntriesOptions = {},
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<ListEntriesResult> => {
   const limit = resolveLimit(options.limit);
-  const cursor = buildCursorClause(options.cursor, 1);
-  const where = cursor.sql ? `WHERE ${cursor.sql}` : '';
-  const { rows } = await exec.query<TimeEntryRow>(
-    `SELECT ${ENTRY_COLUMNS} FROM time_entries ${where} ORDER BY created_at DESC, id DESC LIMIT $${cursor.nextIdx}`,
-    [...cursor.params, limit],
+  const where = cursorClause(options.cursor);
+  const rows = await executeRows<TimeEntryRow>(
+    exec,
+    sql`SELECT ${ENTRY_COLUMNS_SQL} FROM time_entries${where ? sql` WHERE ${where}` : sql``} ORDER BY created_at DESC, id DESC LIMIT ${limit}`,
   );
   return buildResult(rows, limit);
 };
@@ -127,18 +158,13 @@ export const listAll = async (
 export const listForUser = async (
   userId: string,
   options: ListEntriesOptions = {},
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<ListEntriesResult> => {
   const limit = resolveLimit(options.limit);
-  const cursor = buildCursorClause(options.cursor, 2);
-  const cursorClause = cursor.sql ? ` AND ${cursor.sql}` : '';
-  const { rows } = await exec.query<TimeEntryRow>(
-    `SELECT ${ENTRY_COLUMNS}
-       FROM time_entries
-      WHERE user_id = $1${cursorClause}
-      ORDER BY created_at DESC, id DESC
-      LIMIT $${cursor.nextIdx}`,
-    [userId, ...cursor.params, limit],
+  const where = joinAnd([sql`user_id = ${userId}`, cursorClause(options.cursor)]);
+  const rows = await executeRows<TimeEntryRow>(
+    exec,
+    sql`SELECT ${ENTRY_COLUMNS_SQL} FROM time_entries WHERE ${where} ORDER BY created_at DESC, id DESC LIMIT ${limit}`,
   );
   return buildResult(rows, limit);
 };
@@ -146,18 +172,14 @@ export const listForUser = async (
 export const listForManagerView = async (
   managerId: string,
   options: ListEntriesOptions = {},
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<ListEntriesResult> => {
   const limit = resolveLimit(options.limit);
-  const cursor = buildCursorClause(options.cursor, 2);
-  const cursorClause = cursor.sql ? ` AND ${cursor.sql}` : '';
-  const { rows } = await exec.query<TimeEntryRow>(
-    `SELECT ${ENTRY_COLUMNS}
-       FROM time_entries
-      WHERE (user_id = $1 OR user_id IN (${managedUserIdsSubquery(1)}))${cursorClause}
-      ORDER BY created_at DESC, id DESC
-      LIMIT $${cursor.nextIdx}`,
-    [managerId, ...cursor.params, limit],
+  const managerScope = sql`(user_id = ${managerId} OR user_id IN (${managedUserIdsSubquerySql(managerId)}))`;
+  const where = joinAnd([managerScope, cursorClause(options.cursor)]);
+  const rows = await executeRows<TimeEntryRow>(
+    exec,
+    sql`SELECT ${ENTRY_COLUMNS_SQL} FROM time_entries WHERE ${where} ORDER BY created_at DESC, id DESC LIMIT ${limit}`,
   );
   return buildResult(rows, limit);
 };
@@ -182,12 +204,12 @@ export const decodeCursor = (raw: string): EntriesCursor | null => {
   }
 };
 
-export const findOwner = async (id: string, exec: QueryExecutor = pool): Promise<string | null> => {
-  const { rows } = await exec.query<{ user_id: string }>(
-    `SELECT user_id FROM time_entries WHERE id = $1`,
-    [id],
-  );
-  return rows[0]?.user_id ?? null;
+export const findOwner = async (id: string, exec: DbExecutor = db): Promise<string | null> => {
+  const rows = await exec
+    .select({ userId: timeEntries.userId })
+    .from(timeEntries)
+    .where(eq(timeEntries.id, id));
+  return rows[0]?.userId ?? null;
 };
 
 export type EntryContext = {
@@ -199,21 +221,18 @@ export type EntryContext = {
 
 export const findContext = async (
   id: string,
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<EntryContext | null> => {
-  const { rows } = await exec.query<{
-    user_id: string;
-    project_id: string;
-    task: string;
-    task_id: string | null;
-  }>(`SELECT user_id, project_id, task, task_id FROM time_entries WHERE id = $1`, [id]);
-  if (!rows[0]) return null;
-  return {
-    userId: rows[0].user_id,
-    projectId: rows[0].project_id,
-    task: rows[0].task,
-    taskId: rows[0].task_id,
-  };
+  const rows = await exec
+    .select({
+      userId: timeEntries.userId,
+      projectId: timeEntries.projectId,
+      task: timeEntries.task,
+      taskId: timeEntries.taskId,
+    })
+    .from(timeEntries)
+    .where(eq(timeEntries.id, id));
+  return rows[0] ?? null;
 };
 
 export type NewEntry = {
@@ -233,29 +252,29 @@ export type NewEntry = {
   location: string;
 };
 
-export const create = async (entry: NewEntry, exec: QueryExecutor = pool): Promise<TimeEntry> => {
-  const { rows } = await exec.query<TimeEntryRow>(
-    `INSERT INTO time_entries (id, user_id, date, client_id, client_name, project_id, project_name, task, task_id, notes, duration, hourly_cost, is_placeholder, location)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
-     RETURNING ${ENTRY_COLUMNS}`,
-    [
-      entry.id,
-      entry.userId,
-      entry.date,
-      entry.clientId,
-      entry.clientName,
-      entry.projectId,
-      entry.projectName,
-      entry.task,
-      entry.taskId,
-      entry.notes,
-      entry.duration,
-      entry.hourlyCost,
-      entry.isPlaceholder,
-      entry.location,
-    ],
-  );
-  return mapRow(rows[0]);
+export const create = async (entry: NewEntry, exec: DbExecutor = db): Promise<TimeEntry> => {
+  const [row] = await exec
+    .insert(timeEntries)
+    .values({
+      id: entry.id,
+      userId: entry.userId,
+      date: entry.date,
+      clientId: entry.clientId,
+      clientName: entry.clientName,
+      projectId: entry.projectId,
+      projectName: entry.projectName,
+      task: entry.task,
+      taskId: entry.taskId,
+      notes: entry.notes,
+      // numeric columns accept number or string at the wire level; the schema's TS
+      // type is `string` so cast through. The pg driver serializes both equivalently.
+      duration: entry.duration as unknown as string,
+      hourlyCost: entry.hourlyCost as unknown as string,
+      isPlaceholder: entry.isPlaceholder,
+      location: entry.location,
+    })
+    .returning();
+  return mapBuilderRow(row);
 };
 
 export type EntryUpdate = {
@@ -271,43 +290,30 @@ export type EntryUpdate = {
 export const update = async (
   id: string,
   patch: EntryUpdate,
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<TimeEntry | null> => {
-  const sets: string[] = [];
-  const params: unknown[] = [];
-  let idx = 1;
-  const fields: Array<[string, unknown]> = [
-    ['duration', patch.duration],
-    ['notes', patch.notes],
-    ['is_placeholder', patch.isPlaceholder],
-    ['location', patch.location],
-    ['task_id', patch.taskId],
-  ];
-  for (const [col, value] of fields) {
-    if (value !== undefined) {
-      sets.push(`${col} = $${idx++}`);
-      params.push(value);
-    }
+  const setValues: Partial<typeof timeEntries.$inferInsert> = {};
+  if (patch.duration !== undefined) setValues.duration = patch.duration as unknown as string;
+  if (patch.notes !== undefined) setValues.notes = patch.notes;
+  if (patch.isPlaceholder !== undefined) setValues.isPlaceholder = patch.isPlaceholder;
+  if (patch.location !== undefined) setValues.location = patch.location;
+  if (patch.taskId !== undefined) setValues.taskId = patch.taskId;
+
+  if (Object.keys(setValues).length === 0) {
+    const [row] = await exec.select().from(timeEntries).where(eq(timeEntries.id, id));
+    return row ? mapBuilderRow(row) : null;
   }
 
-  if (sets.length === 0) {
-    const { rows } = await exec.query<TimeEntryRow>(
-      `SELECT ${ENTRY_COLUMNS} FROM time_entries WHERE id = $1`,
-      [id],
-    );
-    return rows[0] ? mapRow(rows[0]) : null;
-  }
-
-  params.push(id);
-  const { rows } = await exec.query<TimeEntryRow>(
-    `UPDATE time_entries SET ${sets.join(', ')} WHERE id = $${idx} RETURNING ${ENTRY_COLUMNS}`,
-    params,
-  );
-  return rows[0] ? mapRow(rows[0]) : null;
+  const [row] = await exec
+    .update(timeEntries)
+    .set(setValues)
+    .where(eq(timeEntries.id, id))
+    .returning();
+  return row ? mapBuilderRow(row) : null;
 };
 
-export const deleteById = async (id: string, exec: QueryExecutor = pool): Promise<void> => {
-  await exec.query(`DELETE FROM time_entries WHERE id = $1`, [id]);
+export const deleteById = async (id: string, exec: DbExecutor = db): Promise<void> => {
+  await exec.delete(timeEntries).where(eq(timeEntries.id, id));
 };
 
 export type BulkDeleteFilters = {
@@ -322,27 +328,24 @@ export type BulkDeleteFilters = {
 
 export const bulkDelete = async (
   filters: BulkDeleteFilters,
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<number> => {
-  let sql = 'DELETE FROM time_entries WHERE project_id = $1 AND task = $2';
-  const params: unknown[] = [filters.projectId, filters.task];
-  let idx = 3;
-
+  const conditions: SQL[] = [
+    eq(timeEntries.projectId, filters.projectId),
+    eq(timeEntries.task, filters.task),
+  ];
   if (filters.restrictToManagerScopeOf) {
-    sql += ` AND (user_id = $${idx} OR user_id IN (${managedUserIdsSubquery(idx)}))`;
-    params.push(filters.restrictToManagerScopeOf);
-    idx++;
+    const managerId = filters.restrictToManagerScopeOf;
+    conditions.push(
+      sql`(user_id = ${managerId} OR user_id IN (${managedUserIdsSubquerySql(managerId)}))`,
+    );
   }
-
   if (filters.fromDate) {
-    sql += ` AND date >= $${idx++}`;
-    params.push(filters.fromDate);
+    conditions.push(gte(timeEntries.date, filters.fromDate));
   }
-
   if (filters.placeholderOnly === true) {
-    sql += ' AND is_placeholder = true';
+    conditions.push(eq(timeEntries.isPlaceholder, true));
   }
-
-  const result = await exec.query(sql, params);
+  const result = await exec.delete(timeEntries).where(and(...conditions));
   return result.rowCount ?? 0;
 };

--- a/server/repositories/entriesRepo.ts
+++ b/server/repositories/entriesRepo.ts
@@ -25,6 +25,8 @@ export type TimeEntry = {
 
 // Snake-case row shape returned by raw-SQL `executeRows` paths. Carries the extra
 // `created_at_text` column that the cursor pagination needs (see `ENTRY_COLUMNS_SQL`).
+// `created_at` is nullable in the schema (DEFAULT but no NOT NULL); `created_at::text`
+// is null too when the source column is.
 type TimeEntryRow = {
   id: string;
   user_id: string;
@@ -40,11 +42,11 @@ type TimeEntryRow = {
   hourly_cost: string | number | null;
   is_placeholder: boolean | null;
   location: string | null;
-  created_at: string | Date;
+  created_at: string | Date | null;
   // Microsecond-precision text rep of created_at — pg returns TIMESTAMP as a JS Date (ms-only),
   // which would lose precision in the cursor and skip rows at page boundaries. Using ::text keeps
   // the full Postgres precision for cursor round-trips.
-  created_at_text: string;
+  created_at_text: string | null;
 };
 
 const ENTRY_COLUMNS_SQL = sql`id, user_id, date, client_id, client_name, project_id,
@@ -69,7 +71,7 @@ const mapRawRow = (row: TimeEntryRow): TimeEntry => {
     hourlyCost: parseDbNumber(row.hourly_cost, 0),
     isPlaceholder: !!row.is_placeholder,
     location: row.location || 'remote',
-    createdAt: new Date(row.created_at).getTime(),
+    createdAt: row.created_at ? new Date(row.created_at).getTime() : 0,
   };
 };
 
@@ -129,8 +131,11 @@ export type ListEntriesResult = {
 const buildResult = (rows: TimeEntryRow[], limit: number): ListEntriesResult => {
   const entries = rows.map(mapRawRow);
   const lastRow = rows[rows.length - 1];
+  // `created_at` is nullable in the schema, so `created_at::text` can also be null on rows
+  // inserted before the DEFAULT was added. Skip the cursor in that case so we don't emit a
+  // malformed `{createdAt: null, id}` payload (`EntriesCursor.createdAt: string`).
   const nextCursor =
-    entries.length === limit && lastRow
+    entries.length === limit && lastRow && lastRow.created_at_text
       ? { createdAt: lastRow.created_at_text, id: lastRow.id }
       : null;
   return { entries, nextCursor };

--- a/server/repositories/entriesRepo.ts
+++ b/server/repositories/entriesRepo.ts
@@ -2,7 +2,7 @@ import { and, eq, gte, type SQL, sql } from 'drizzle-orm';
 import { type DbExecutor, db, executeRows } from '../db/drizzle.ts';
 import { timeEntries } from '../db/schema/timeEntries.ts';
 import { normalizeNullableDateOnly } from '../utils/date.ts';
-import { parseDbNumber } from '../utils/parse.ts';
+import { numericForDb, parseDbNumber } from '../utils/parse.ts';
 import { managedUserIdsSubquerySql } from './workUnitsRepo.ts';
 
 export type TimeEntry = {
@@ -266,10 +266,8 @@ export const create = async (entry: NewEntry, exec: DbExecutor = db): Promise<Ti
       task: entry.task,
       taskId: entry.taskId,
       notes: entry.notes,
-      // numeric columns accept number or string at the wire level; the schema's TS
-      // type is `string` so cast through. The pg driver serializes both equivalently.
-      duration: entry.duration as unknown as string,
-      hourlyCost: entry.hourlyCost as unknown as string,
+      duration: numericForDb(entry.duration),
+      hourlyCost: numericForDb(entry.hourlyCost),
       isPlaceholder: entry.isPlaceholder,
       location: entry.location,
     })
@@ -293,7 +291,7 @@ export const update = async (
   exec: DbExecutor = db,
 ): Promise<TimeEntry | null> => {
   const setValues: Partial<typeof timeEntries.$inferInsert> = {};
-  if (patch.duration !== undefined) setValues.duration = patch.duration as unknown as string;
+  if (patch.duration !== undefined) setValues.duration = numericForDb(patch.duration);
   if (patch.notes !== undefined) setValues.notes = patch.notes;
   if (patch.isPlaceholder !== undefined) setValues.isPlaceholder = patch.isPlaceholder;
   if (patch.location !== undefined) setValues.location = patch.location;

--- a/server/repositories/workUnitsRepo.ts
+++ b/server/repositories/workUnitsRepo.ts
@@ -1,3 +1,4 @@
+import { type SQL, sql } from 'drizzle-orm';
 import pool, { type QueryExecutor } from '../db/index.ts';
 
 export type Manager = { id: string; name: string };
@@ -204,11 +205,23 @@ export const isUserManagedBy = async (
   return rows.length > 0;
 };
 
+// Legacy `$N`-placeholder string — used by un-converted repos that still author raw `pg`
+// query strings. Remove when this repo is converted to Drizzle (Tier 3 of the conversion
+// roadmap), at which point `managedUserIdsSubquerySql` is the only call shape that remains.
 export const managedUserIdsSubquery = (paramIdx: number) =>
   `SELECT uwu.user_id
      FROM user_work_units uwu
      JOIN work_unit_managers wum ON uwu.work_unit_id = wum.work_unit_id
     WHERE wum.user_id = $${paramIdx}`;
+
+// Drizzle-flavored sibling of `managedUserIdsSubquery` for repos using `sql\`\`` templates.
+// Drizzle's tagged template handles parameter numbering automatically, so the caller
+// passes the actual managerId rather than a `$N` index.
+export const managedUserIdsSubquerySql = (managerId: string): SQL =>
+  sql`SELECT uwu.user_id
+        FROM user_work_units uwu
+        JOIN work_unit_managers wum ON uwu.work_unit_id = wum.work_unit_id
+       WHERE wum.user_id = ${managerId}`;
 
 export const listManagedUserIds = async (
   managerId: string,

--- a/server/repositories/workUnitsRepo.ts
+++ b/server/repositories/workUnitsRepo.ts
@@ -205,18 +205,8 @@ export const isUserManagedBy = async (
   return rows.length > 0;
 };
 
-// Legacy `$N`-placeholder string — used by un-converted repos that still author raw `pg`
-// query strings. Remove when this repo is converted to Drizzle (Tier 3 of the conversion
-// roadmap), at which point `managedUserIdsSubquerySql` is the only call shape that remains.
-export const managedUserIdsSubquery = (paramIdx: number) =>
-  `SELECT uwu.user_id
-     FROM user_work_units uwu
-     JOIN work_unit_managers wum ON uwu.work_unit_id = wum.work_unit_id
-    WHERE wum.user_id = $${paramIdx}`;
-
-// Drizzle-flavored sibling of `managedUserIdsSubquery` for repos using `sql\`\`` templates.
-// Drizzle's tagged template handles parameter numbering automatically, so the caller
-// passes the actual managerId rather than a `$N` index.
+// Drizzle SQL fragment for the "user_ids managed by `managerId`" subquery, for embedding in
+// other repos' `sql\`\`` templates (e.g. entriesRepo's manager-scope filters).
 export const managedUserIdsSubquerySql = (managerId: string): SQL =>
   sql`SELECT uwu.user_id
         FROM user_work_units uwu

--- a/server/routes/client-offers.ts
+++ b/server/routes/client-offers.ts
@@ -1,5 +1,5 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
-import { withTransaction } from '../db/index.ts';
+import { withDbTransaction } from '../db/drizzle.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
 import * as clientOffersRepo from '../repositories/clientOffersRepo.ts';
 import * as clientQuotesRepo from '../repositories/clientQuotesRepo.ts';
@@ -375,7 +375,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         items: clientOffersRepo.ClientOfferItem[];
       };
       try {
-        result = await withTransaction(async (tx) => {
+        result = await withDbTransaction(async (tx) => {
           const offer = await clientOffersRepo.create(
             {
               id: nextIdResult.value,
@@ -576,7 +576,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         items: clientOffersRepo.ClientOfferItem[];
       };
       try {
-        result = await withTransaction(async (tx) => {
+        result = await withDbTransaction(async (tx) => {
           const offer = await clientOffersRepo.update(
             idResult.value,
             {

--- a/server/test/repositories/clientOffersRepo.test.ts
+++ b/server/test/repositories/clientOffersRepo.test.ts
@@ -112,6 +112,37 @@ describe('findExistingForQuote', () => {
   });
 });
 
+describe('findStatusAndClientName', () => {
+  test('returns status + clientName when offer exists', async () => {
+    exec.enqueue({ rows: [['draft', 'Acme']] });
+    const result = await clientOffersRepo.findStatusAndClientName('co-1', testDb);
+    expect(exec.calls[0].params).toEqual(['co-1']);
+    expect(result).toEqual({ status: 'draft', clientName: 'Acme' });
+  });
+
+  test('returns null when not found', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await clientOffersRepo.findStatusAndClientName('co-x', testDb)).toBeNull();
+  });
+});
+
+describe('findItemsForOffer', () => {
+  test('queries by offer_id and maps rows', async () => {
+    exec.enqueue({ rows: [itemRow(), itemRow({ 0: 'coi-2', 4: '3' })] });
+    const result = await clientOffersRepo.findItemsForOffer('co-1', testDb);
+    expect(exec.calls[0].sql).toContain('from "customer_offer_items"');
+    expect(exec.calls[0].sql).toContain('"offer_id" = $1');
+    expect(exec.calls[0].params).toEqual(['co-1']);
+    expect(result.map((i) => i.id)).toEqual(['coi-1', 'coi-2']);
+    expect(result[1].quantity).toBe(3);
+  });
+
+  test('returns [] when no items for offer', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await clientOffersRepo.findItemsForOffer('co-x', testDb)).toEqual([]);
+  });
+});
+
 describe('findLinkedSaleId', () => {
   test('queries sales.linked_offer_id and returns sale id', async () => {
     exec.enqueue({ rows: [['s-1']] });
@@ -169,7 +200,8 @@ describe('update', () => {
   test('numericForDb stringifies discount before COALESCE', async () => {
     exec.enqueue({ rows: [offerRow()] });
     await clientOffersRepo.update('co-1', { discount: 12.5 }, testDb);
-    expect(exec.calls[0].params).toContain('12.5');
+    // Discount is the 5th COALESCE argument (id, clientId, clientName, paymentTerms, discount, ...).
+    expect(exec.calls[0].params[4]).toBe('12.5');
   });
 });
 

--- a/server/test/repositories/clientOffersRepo.test.ts
+++ b/server/test/repositories/clientOffersRepo.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
 import type { DbExecutor } from '../../db/drizzle.ts';
 import * as clientOffersRepo from '../../repositories/clientOffersRepo.ts';
-import { type FakeExecutor, setupTestDb } from '../helpers/fakeExecutor.ts';
+import { type FakeExecutor, makeRow, setupTestDb } from '../helpers/fakeExecutor.ts';
 
 let exec: FakeExecutor;
 let testDb: DbExecutor;
@@ -10,20 +10,16 @@ beforeEach(() => {
   ({ exec, testDb } = setupTestDb());
 });
 
-// Builder paths use rowMode: 'array' — fixture rows are positional in the schema's column
-// declaration order.
+// All paths are builder-based — fixture rows are positional arrays in schema column order:
 //
-// customerOffers columns (12): [id, linkedQuoteId, clientId, clientName, paymentTerms,
-//   discount, discountType, status, expirationDate, notes, createdAt, updatedAt]
+// customerOffers (12): [id, linkedQuoteId, clientId, clientName, paymentTerms, discount,
+//   discountType, status, expirationDate, notes, createdAt, updatedAt]
 //
-// customerOfferItems columns (16): [id, offerId, productId, productName, quantity, unitPrice,
+// customerOfferItems (16): [id, offerId, productId, productName, quantity, unitPrice,
 //   productCost, productMolPercentage, discount, note, createdAt, unitType, supplierQuoteId,
 //   supplierQuoteItemId, supplierQuoteSupplierName, supplierQuoteUnitPrice]
-//
-// Raw-SQL paths via `executeRows` (`update`, `insertItems`) return objects keyed by the
-// SELECT alias (camelCase via `as "fooBar"`), so those fixtures stay as objects.
 
-const offerBuilderRow: unknown[] = [
+const offerRow: unknown[] = [
   'co-1',
   'cq-1',
   'c-1',
@@ -38,7 +34,7 @@ const offerBuilderRow: unknown[] = [
   new Date('2026-01-01T00:01:40Z'),
 ];
 
-const itemBuilderRow: unknown[] = [
+const itemRow: unknown[] = [
   'coi-1',
   'co-1',
   'p-1',
@@ -57,42 +53,9 @@ const itemBuilderRow: unknown[] = [
   null,
 ];
 
-const offerRawRow = {
-  id: 'co-1',
-  linkedQuoteId: 'cq-1',
-  clientId: 'c-1',
-  clientName: 'Acme',
-  paymentTerms: 'net30',
-  discount: '5',
-  discountType: 'percentage',
-  status: 'draft',
-  expirationDate: new Date('2026-06-01T00:00:00Z'),
-  notes: null,
-  createdAt: 1735689600000,
-  updatedAt: 1735689700000,
-};
-
-const itemRawRow = {
-  id: 'coi-1',
-  offerId: 'co-1',
-  productId: 'p-1',
-  productName: 'Widget',
-  quantity: '2',
-  unitPrice: '10',
-  productCost: '5',
-  productMolPercentage: null,
-  supplierQuoteId: null,
-  supplierQuoteItemId: null,
-  supplierQuoteSupplierName: null,
-  supplierQuoteUnitPrice: null,
-  unitType: 'unit',
-  note: null,
-  discount: '0',
-};
-
 describe('listAll', () => {
   test('orders by created_at DESC and maps types', async () => {
-    exec.enqueue({ rows: [offerBuilderRow] });
+    exec.enqueue({ rows: [offerRow] });
     const result = await clientOffersRepo.listAll(testDb);
     expect(exec.calls[0].sql).toContain('from "customer_offers"');
     expect(exec.calls[0].sql).toContain('order by "customer_offers"."created_at" desc');
@@ -103,7 +66,7 @@ describe('listAll', () => {
 
 describe('listAllItems', () => {
   test('orders items by created_at ASC', async () => {
-    exec.enqueue({ rows: [itemBuilderRow] });
+    exec.enqueue({ rows: [itemRow] });
     const result = await clientOffersRepo.listAllItems(testDb);
     expect(exec.calls[0].sql).toContain('order by "customer_offer_items"."created_at" asc');
     expect(result[0].quantity).toBe(2);
@@ -164,7 +127,7 @@ describe('findLinkedSaleId', () => {
 
 describe('create', () => {
   test('inserts 10 fields and returns mapped offer', async () => {
-    exec.enqueue({ rows: [offerBuilderRow] });
+    exec.enqueue({ rows: [offerRow] });
     const result = await clientOffersRepo.create(
       {
         id: 'co-1',
@@ -182,21 +145,25 @@ describe('create', () => {
     );
     expect(exec.calls[0].sql).toContain('insert into "customer_offers"');
     expect(exec.calls[0].params).toHaveLength(10);
+    expect(exec.calls[0].params[5]).toBe('5'); // discount via numericForDb
     expect(result.id).toBe('co-1');
   });
 });
 
 describe('update', () => {
-  test('passes 10 params and uses COALESCE preservation (raw SQL)', async () => {
-    exec.enqueue({ rows: [offerRawRow] });
+  test('binds 9 patch values via COALESCE, WHERE id last', async () => {
+    exec.enqueue({ rows: [offerRow] });
     await clientOffersRepo.update('co-1', { status: 'accepted' }, testDb);
-    expect(exec.calls[0].sql).toContain('UPDATE customer_offers');
-    expect(exec.calls[0].sql).toContain('updated_at = CURRENT_TIMESTAMP');
-    expect(exec.calls[0].sql).toContain('COALESCE');
+    const sql = exec.calls[0].sql;
+    expect(sql).toContain('update "customer_offers"');
+    expect(sql).toContain('COALESCE');
+    expect(sql).toContain('CURRENT_TIMESTAMP');
+    expect(sql).toContain('"id" = $10');
+    // Drizzle's `sql\`COALESCE(${value}, ${col})\`` interpolates the column ref by name
+    // (not as a parameter), so each COALESCE adds exactly one param: 9 patch fields → $1..$9,
+    // then the WHERE id → $10. Only `status` has a non-null patch value here.
     expect(exec.calls[0].params).toHaveLength(10);
-    // Patch order in the COALESCE list: id, clientId, clientName, paymentTerms, discount,
-    // discountType, status, expirationDate, notes, then the WHERE id.
-    expect(exec.calls[0].params[6]).toBe('accepted'); // status
+    expect(exec.calls[0].params[6]).toBe('accepted'); // status (7th field, index 6)
     expect(exec.calls[0].params[9]).toBe('co-1'); // where id
   });
 
@@ -204,16 +171,68 @@ describe('update', () => {
     exec.enqueue({ rows: [] });
     expect(await clientOffersRepo.update('co-x', { status: 'accepted' }, testDb)).toBeNull();
   });
+
+  test('numericForDb stringifies discount before COALESCE', async () => {
+    exec.enqueue({ rows: [offerRow] });
+    await clientOffersRepo.update('co-1', { discount: 12.5 }, testDb);
+    expect(exec.calls[0].params).toContain('12.5');
+  });
+});
+
+describe('insertItems', () => {
+  test('binds 15 fields per row in column order, with numericForDb on numerics', async () => {
+    exec.enqueue({ rows: [itemRow] });
+    await clientOffersRepo.insertItems(
+      'co-1',
+      [
+        {
+          id: 'coi-1',
+          productId: 'p-1',
+          productName: 'Widget',
+          quantity: 2,
+          unitPrice: 10,
+          productCost: 5,
+          productMolPercentage: null,
+          discount: 0,
+          note: null,
+          supplierQuoteId: null,
+          supplierQuoteItemId: null,
+          supplierQuoteSupplierName: null,
+          supplierQuoteUnitPrice: null,
+          unitType: 'unit',
+        },
+      ],
+      testDb,
+    );
+    expect(exec.calls[0].sql).toContain('insert into "customer_offer_items"');
+    // Drizzle emits columns in schema declaration order (createdAt is skipped — column has
+    // a CURRENT_TIMESTAMP default and isn't in the values object), so unitType lands between
+    // note and supplierQuoteId, matching its schema position.
+    expect(exec.calls[0].params).toEqual([
+      'coi-1',
+      'co-1',
+      'p-1',
+      'Widget',
+      '2', // quantity via numericForDb
+      '10',
+      '5',
+      null, // productMolPercentage null passes through
+      '0',
+      null, // note
+      'unit', // unitType — schema position 11
+      null,
+      null,
+      null,
+      null,
+    ]);
+  });
 });
 
 describe('replaceItems', () => {
   test('issues DELETE then a single multi-row INSERT and preserves order', async () => {
     exec.enqueue({ rows: [] });
     exec.enqueue({
-      rows: [
-        { ...itemRawRow, id: 'a' },
-        { ...itemRawRow, id: 'b' },
-      ],
+      rows: [makeRow(itemRow, { 0: 'a' }), makeRow(itemRow, { 0: 'b' })],
     });
     const items: clientOffersRepo.NewClientOfferItem[] = [
       {
@@ -252,10 +271,7 @@ describe('replaceItems', () => {
     const result = await clientOffersRepo.replaceItems('co-1', items, testDb);
     expect(exec.calls).toHaveLength(2);
     expect(exec.calls[0].sql).toContain('delete from "customer_offer_items"');
-    expect(exec.calls[1].sql).toContain('INSERT INTO customer_offer_items');
-    expect(exec.calls[1].sql).toContain(
-      'VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15), ($16',
-    );
+    expect(exec.calls[1].sql).toContain('insert into "customer_offer_items"');
     expect(exec.calls[1].params[0]).toBe('a');
     expect(exec.calls[1].params[15]).toBe('b'); // 15 fields per row, second row starts at index 15
     expect(result.map((i) => i.id)).toEqual(['a', 'b']);
@@ -279,5 +295,76 @@ describe('deleteById', () => {
   test('returns false when no row matched', async () => {
     exec.enqueue({ rows: [], rowCount: 0 });
     expect(await clientOffersRepo.deleteById('co-x', testDb)).toBe(false);
+  });
+});
+
+describe('mapOffer (exercised via create return path)', () => {
+  const baseInput: clientOffersRepo.NewClientOffer = {
+    id: 'co-1',
+    linkedQuoteId: 'cq-1',
+    clientId: 'c-1',
+    clientName: 'Acme',
+    paymentTerms: 'net30',
+    discount: 5,
+    discountType: 'percentage',
+    status: 'draft',
+    expirationDate: '2026-06-01',
+    notes: null,
+  };
+
+  test('numeric-string discount is parsed to number', async () => {
+    exec.enqueue({ rows: [makeRow(offerRow, { 5: '12.5' })] });
+    const result = await clientOffersRepo.create(baseInput, testDb);
+    expect(result.discount).toBe(12.5);
+  });
+
+  test('unknown discountType falls back to percentage', async () => {
+    exec.enqueue({ rows: [makeRow(offerRow, { 6: 'mystery' })] });
+    const result = await clientOffersRepo.create(baseInput, testDb);
+    expect(result.discountType).toBe('percentage');
+  });
+
+  test('null createdAt/updatedAt fall back to 0', async () => {
+    exec.enqueue({ rows: [makeRow(offerRow, { 10: null, 11: null })] });
+    const result = await clientOffersRepo.create(baseInput, testDb);
+    expect(result.createdAt).toBe(0);
+    expect(result.updatedAt).toBe(0);
+  });
+});
+
+describe('mapItem (exercised via insertItems return path)', () => {
+  const baseItem: clientOffersRepo.NewClientOfferItem = {
+    id: 'coi-1',
+    productId: 'p-1',
+    productName: 'Widget',
+    quantity: 2,
+    unitPrice: 10,
+    productCost: 5,
+    productMolPercentage: null,
+    discount: 0,
+    note: null,
+    supplierQuoteId: null,
+    supplierQuoteItemId: null,
+    supplierQuoteSupplierName: null,
+    supplierQuoteUnitPrice: null,
+    unitType: 'unit',
+  };
+
+  test('null productMolPercentage stays null (not coerced to 0)', async () => {
+    exec.enqueue({ rows: [makeRow(itemRow, { 7: null })] });
+    const [result] = await clientOffersRepo.insertItems('co-1', [baseItem], testDb);
+    expect(result.productMolPercentage).toBeNull();
+  });
+
+  test('numeric-string productMolPercentage is parsed to number', async () => {
+    exec.enqueue({ rows: [makeRow(itemRow, { 7: '12.5' })] });
+    const [result] = await clientOffersRepo.insertItems('co-1', [baseItem], testDb);
+    expect(result.productMolPercentage).toBe(12.5);
+  });
+
+  test('null unitType normalizes to default "hours"', async () => {
+    exec.enqueue({ rows: [makeRow(itemRow, { 11: null })] });
+    const [result] = await clientOffersRepo.insertItems('co-1', [baseItem], testDb);
+    expect(result.unitType).toBe('hours');
   });
 });

--- a/server/test/repositories/clientOffersRepo.test.ts
+++ b/server/test/repositories/clientOffersRepo.test.ts
@@ -78,7 +78,7 @@ describe('existsById / findIdConflict', () => {
     expect(await clientOffersRepo.existsById('co-1', testDb)).toBe(true);
   });
 
-  test('findIdConflict pins the != predicate so the row being renamed is excluded', async () => {
+  test('findIdConflict excludes the current id via <> predicate', async () => {
     exec.enqueue({ rows: [] });
     await clientOffersRepo.findIdConflict('new', 'cur', testDb);
     expect(exec.calls[0].sql).toContain('"id" <> $2');

--- a/server/test/repositories/clientOffersRepo.test.ts
+++ b/server/test/repositories/clientOffersRepo.test.ts
@@ -10,16 +10,9 @@ beforeEach(() => {
   ({ exec, testDb } = setupTestDb());
 });
 
-// All paths are builder-based — fixture rows are positional arrays in schema column order:
-//
-// customerOffers (12): [id, linkedQuoteId, clientId, clientName, paymentTerms, discount,
-//   discountType, status, expirationDate, notes, createdAt, updatedAt]
-//
-// customerOfferItems (16): [id, offerId, productId, productName, quantity, unitPrice,
-//   productCost, productMolPercentage, discount, note, createdAt, unitType, supplierQuoteId,
-//   supplierQuoteItemId, supplierQuoteSupplierName, supplierQuoteUnitPrice]
-
-const offerRow: unknown[] = [
+// Builder fixtures match the column order in db/schema/customerOffers.ts and
+// db/schema/customerOfferItems.ts.
+const OFFER_BASE: readonly unknown[] = [
   'co-1',
   'cq-1',
   'c-1',
@@ -34,7 +27,9 @@ const offerRow: unknown[] = [
   new Date('2026-01-01T00:01:40Z'),
 ];
 
-const itemRow: unknown[] = [
+const offerRow = (overrides: Record<number, unknown> = {}) => makeRow(OFFER_BASE, overrides);
+
+const ITEM_BASE: readonly unknown[] = [
   'coi-1',
   'co-1',
   'p-1',
@@ -53,9 +48,11 @@ const itemRow: unknown[] = [
   null,
 ];
 
+const itemRow = (overrides: Record<number, unknown> = {}) => makeRow(ITEM_BASE, overrides);
+
 describe('listAll', () => {
   test('orders by created_at DESC and maps types', async () => {
-    exec.enqueue({ rows: [offerRow] });
+    exec.enqueue({ rows: [offerRow()] });
     const result = await clientOffersRepo.listAll(testDb);
     expect(exec.calls[0].sql).toContain('from "customer_offers"');
     expect(exec.calls[0].sql).toContain('order by "customer_offers"."created_at" desc');
@@ -66,7 +63,7 @@ describe('listAll', () => {
 
 describe('listAllItems', () => {
   test('orders items by created_at ASC', async () => {
-    exec.enqueue({ rows: [itemRow] });
+    exec.enqueue({ rows: [itemRow()] });
     const result = await clientOffersRepo.listAllItems(testDb);
     expect(exec.calls[0].sql).toContain('order by "customer_offer_items"."created_at" asc');
     expect(result[0].quantity).toBe(2);
@@ -81,7 +78,7 @@ describe('existsById / findIdConflict', () => {
     expect(await clientOffersRepo.existsById('co-1', testDb)).toBe(true);
   });
 
-  test('findIdConflict excludes self via != predicate', async () => {
+  test('findIdConflict pins the != predicate so the row being renamed is excluded', async () => {
     exec.enqueue({ rows: [] });
     await clientOffersRepo.findIdConflict('new', 'cur', testDb);
     expect(exec.calls[0].sql).toContain('"id" <> $2');
@@ -127,7 +124,7 @@ describe('findLinkedSaleId', () => {
 
 describe('create', () => {
   test('inserts 10 fields and returns mapped offer', async () => {
-    exec.enqueue({ rows: [offerRow] });
+    exec.enqueue({ rows: [offerRow()] });
     const result = await clientOffersRepo.create(
       {
         id: 'co-1',
@@ -152,18 +149,15 @@ describe('create', () => {
 
 describe('update', () => {
   test('binds 9 patch values via COALESCE, WHERE id last', async () => {
-    exec.enqueue({ rows: [offerRow] });
+    exec.enqueue({ rows: [offerRow()] });
     await clientOffersRepo.update('co-1', { status: 'accepted' }, testDb);
     const sql = exec.calls[0].sql;
     expect(sql).toContain('update "customer_offers"');
     expect(sql).toContain('COALESCE');
     expect(sql).toContain('CURRENT_TIMESTAMP');
     expect(sql).toContain('"id" = $10');
-    // Drizzle's `sql\`COALESCE(${value}, ${col})\`` interpolates the column ref by name
-    // (not as a parameter), so each COALESCE adds exactly one param: 9 patch fields → $1..$9,
-    // then the WHERE id → $10. Only `status` has a non-null patch value here.
     expect(exec.calls[0].params).toHaveLength(10);
-    expect(exec.calls[0].params[6]).toBe('accepted'); // status (7th field, index 6)
+    expect(exec.calls[0].params[6]).toBe('accepted'); // status
     expect(exec.calls[0].params[9]).toBe('co-1'); // where id
   });
 
@@ -173,7 +167,7 @@ describe('update', () => {
   });
 
   test('numericForDb stringifies discount before COALESCE', async () => {
-    exec.enqueue({ rows: [offerRow] });
+    exec.enqueue({ rows: [offerRow()] });
     await clientOffersRepo.update('co-1', { discount: 12.5 }, testDb);
     expect(exec.calls[0].params).toContain('12.5');
   });
@@ -181,7 +175,7 @@ describe('update', () => {
 
 describe('insertItems', () => {
   test('binds 15 fields per row in column order, with numericForDb on numerics', async () => {
-    exec.enqueue({ rows: [itemRow] });
+    exec.enqueue({ rows: [itemRow()] });
     await clientOffersRepo.insertItems(
       'co-1',
       [
@@ -205,21 +199,21 @@ describe('insertItems', () => {
       testDb,
     );
     expect(exec.calls[0].sql).toContain('insert into "customer_offer_items"');
-    // Drizzle emits columns in schema declaration order (createdAt is skipped — column has
-    // a CURRENT_TIMESTAMP default and isn't in the values object), so unitType lands between
-    // note and supplierQuoteId, matching its schema position.
+    // Drizzle emits columns in schema declaration order (createdAt is skipped — has
+    // CURRENT_TIMESTAMP default and isn't passed), so unitType lands between note and the
+    // supplier_quote_* group rather than at the end of the values list.
     expect(exec.calls[0].params).toEqual([
       'coi-1',
       'co-1',
       'p-1',
       'Widget',
-      '2', // quantity via numericForDb
+      '2',
       '10',
       '5',
-      null, // productMolPercentage null passes through
+      null,
       '0',
-      null, // note
-      'unit', // unitType — schema position 11
+      null,
+      'unit',
       null,
       null,
       null,
@@ -232,7 +226,7 @@ describe('replaceItems', () => {
   test('issues DELETE then a single multi-row INSERT and preserves order', async () => {
     exec.enqueue({ rows: [] });
     exec.enqueue({
-      rows: [makeRow(itemRow, { 0: 'a' }), makeRow(itemRow, { 0: 'b' })],
+      rows: [itemRow({ 0: 'a' }), itemRow({ 0: 'b' })],
     });
     const items: clientOffersRepo.NewClientOfferItem[] = [
       {
@@ -313,19 +307,19 @@ describe('mapOffer (exercised via create return path)', () => {
   };
 
   test('numeric-string discount is parsed to number', async () => {
-    exec.enqueue({ rows: [makeRow(offerRow, { 5: '12.5' })] });
+    exec.enqueue({ rows: [offerRow({ 5: '12.5' })] });
     const result = await clientOffersRepo.create(baseInput, testDb);
     expect(result.discount).toBe(12.5);
   });
 
   test('unknown discountType falls back to percentage', async () => {
-    exec.enqueue({ rows: [makeRow(offerRow, { 6: 'mystery' })] });
+    exec.enqueue({ rows: [offerRow({ 6: 'mystery' })] });
     const result = await clientOffersRepo.create(baseInput, testDb);
     expect(result.discountType).toBe('percentage');
   });
 
   test('null createdAt/updatedAt fall back to 0', async () => {
-    exec.enqueue({ rows: [makeRow(offerRow, { 10: null, 11: null })] });
+    exec.enqueue({ rows: [offerRow({ 10: null, 11: null })] });
     const result = await clientOffersRepo.create(baseInput, testDb);
     expect(result.createdAt).toBe(0);
     expect(result.updatedAt).toBe(0);
@@ -351,19 +345,19 @@ describe('mapItem (exercised via insertItems return path)', () => {
   };
 
   test('null productMolPercentage stays null (not coerced to 0)', async () => {
-    exec.enqueue({ rows: [makeRow(itemRow, { 7: null })] });
+    exec.enqueue({ rows: [itemRow({ 7: null })] });
     const [result] = await clientOffersRepo.insertItems('co-1', [baseItem], testDb);
     expect(result.productMolPercentage).toBeNull();
   });
 
   test('numeric-string productMolPercentage is parsed to number', async () => {
-    exec.enqueue({ rows: [makeRow(itemRow, { 7: '12.5' })] });
+    exec.enqueue({ rows: [itemRow({ 7: '12.5' })] });
     const [result] = await clientOffersRepo.insertItems('co-1', [baseItem], testDb);
     expect(result.productMolPercentage).toBe(12.5);
   });
 
   test('null unitType normalizes to default "hours"', async () => {
-    exec.enqueue({ rows: [makeRow(itemRow, { 11: null })] });
+    exec.enqueue({ rows: [itemRow({ 11: null })] });
     const [result] = await clientOffersRepo.insertItems('co-1', [baseItem], testDb);
     expect(result.unitType).toBe('hours');
   });

--- a/server/test/repositories/clientOffersRepo.test.ts
+++ b/server/test/repositories/clientOffersRepo.test.ts
@@ -1,14 +1,63 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
+import type { DbExecutor } from '../../db/drizzle.ts';
 import * as clientOffersRepo from '../../repositories/clientOffersRepo.ts';
-import { type FakeExecutor, makeFakeExecutor } from '../helpers/fakeExecutor.ts';
+import { type FakeExecutor, setupTestDb } from '../helpers/fakeExecutor.ts';
 
 let exec: FakeExecutor;
+let testDb: DbExecutor;
 
 beforeEach(() => {
-  exec = makeFakeExecutor();
+  ({ exec, testDb } = setupTestDb());
 });
 
-const offerRow = {
+// Builder paths use rowMode: 'array' — fixture rows are positional in the schema's column
+// declaration order.
+//
+// customerOffers columns (12): [id, linkedQuoteId, clientId, clientName, paymentTerms,
+//   discount, discountType, status, expirationDate, notes, createdAt, updatedAt]
+//
+// customerOfferItems columns (16): [id, offerId, productId, productName, quantity, unitPrice,
+//   productCost, productMolPercentage, discount, note, createdAt, unitType, supplierQuoteId,
+//   supplierQuoteItemId, supplierQuoteSupplierName, supplierQuoteUnitPrice]
+//
+// Raw-SQL paths via `executeRows` (`update`, `insertItems`) return objects keyed by the
+// SELECT alias (camelCase via `as "fooBar"`), so those fixtures stay as objects.
+
+const offerBuilderRow: unknown[] = [
+  'co-1',
+  'cq-1',
+  'c-1',
+  'Acme',
+  'net30',
+  '5',
+  'percentage',
+  'draft',
+  '2026-06-01',
+  null,
+  new Date('2026-01-01T00:00:00Z'),
+  new Date('2026-01-01T00:01:40Z'),
+];
+
+const itemBuilderRow: unknown[] = [
+  'coi-1',
+  'co-1',
+  'p-1',
+  'Widget',
+  '2',
+  '10',
+  '5',
+  null,
+  '0',
+  null,
+  new Date('2026-01-01T00:00:00Z'),
+  'unit',
+  null,
+  null,
+  null,
+  null,
+];
+
+const offerRawRow = {
   id: 'co-1',
   linkedQuoteId: 'cq-1',
   clientId: 'c-1',
@@ -23,7 +72,7 @@ const offerRow = {
   updatedAt: 1735689700000,
 };
 
-const itemRow = {
+const itemRawRow = {
   id: 'coi-1',
   offerId: 'co-1',
   productId: 'p-1',
@@ -43,10 +92,10 @@ const itemRow = {
 
 describe('listAll', () => {
   test('orders by created_at DESC and maps types', async () => {
-    exec.enqueue({ rows: [offerRow] });
-    const result = await clientOffersRepo.listAll(exec);
-    expect(exec.calls[0].sql).toContain('FROM customer_offers');
-    expect(exec.calls[0].sql).toContain('ORDER BY created_at DESC');
+    exec.enqueue({ rows: [offerBuilderRow] });
+    const result = await clientOffersRepo.listAll(testDb);
+    expect(exec.calls[0].sql).toContain('from "customer_offers"');
+    expect(exec.calls[0].sql).toContain('order by "customer_offers"."created_at" desc');
     expect(result[0].discount).toBe(5);
     expect(result[0].expirationDate).toBe('2026-06-01');
   });
@@ -54,9 +103,9 @@ describe('listAll', () => {
 
 describe('listAllItems', () => {
   test('orders items by created_at ASC', async () => {
-    exec.enqueue({ rows: [itemRow] });
-    const result = await clientOffersRepo.listAllItems(exec);
-    expect(exec.calls[0].sql).toContain('ORDER BY created_at ASC');
+    exec.enqueue({ rows: [itemBuilderRow] });
+    const result = await clientOffersRepo.listAllItems(testDb);
+    expect(exec.calls[0].sql).toContain('order by "customer_offer_items"."created_at" asc');
     expect(result[0].quantity).toBe(2);
     expect(result[0].unitPrice).toBe(10);
     expect(result[0].unitType).toBe('unit');
@@ -65,66 +114,57 @@ describe('listAllItems', () => {
 
 describe('existsById / findIdConflict', () => {
   test('existsById returns true on match', async () => {
-    exec.enqueue({ rows: [{ id: 'co-1' }] });
-    expect(await clientOffersRepo.existsById('co-1', exec)).toBe(true);
+    exec.enqueue({ rows: [['co-1']] });
+    expect(await clientOffersRepo.existsById('co-1', testDb)).toBe(true);
   });
 
-  test('findIdConflict excludes self via id <> $2', async () => {
+  test('findIdConflict excludes self via != predicate', async () => {
     exec.enqueue({ rows: [] });
-    await clientOffersRepo.findIdConflict('new', 'cur', exec);
-    expect(exec.calls[0].sql).toContain('id <> $2');
+    await clientOffersRepo.findIdConflict('new', 'cur', testDb);
+    expect(exec.calls[0].sql).toContain('"id" <> $2');
     expect(exec.calls[0].params).toEqual(['new', 'cur']);
   });
 });
 
 describe('findForUpdate', () => {
   test('returns existing offer fields needed for permission checks', async () => {
-    exec.enqueue({
-      rows: [
-        {
-          id: 'co-1',
-          linkedQuoteId: 'cq-1',
-          clientId: 'c-1',
-          clientName: 'Acme',
-          status: 'draft',
-        },
-      ],
-    });
-    const result = await clientOffersRepo.findForUpdate('co-1', exec);
+    exec.enqueue({ rows: [['co-1', 'cq-1', 'c-1', 'Acme', 'draft']] });
+    const result = await clientOffersRepo.findForUpdate('co-1', testDb);
     expect(result?.linkedQuoteId).toBe('cq-1');
     expect(result?.status).toBe('draft');
   });
 
   test('returns null when not found', async () => {
     exec.enqueue({ rows: [] });
-    expect(await clientOffersRepo.findForUpdate('co-x', exec)).toBeNull();
+    expect(await clientOffersRepo.findForUpdate('co-x', testDb)).toBeNull();
   });
 });
 
 describe('findExistingForQuote', () => {
   test('returns offer id when one exists for the quote', async () => {
-    exec.enqueue({ rows: [{ id: 'co-1' }] });
-    expect(await clientOffersRepo.findExistingForQuote('cq-1', exec)).toBe('co-1');
+    exec.enqueue({ rows: [['co-1']] });
+    expect(await clientOffersRepo.findExistingForQuote('cq-1', testDb)).toBe('co-1');
   });
 
   test('returns null when none exists', async () => {
     exec.enqueue({ rows: [] });
-    expect(await clientOffersRepo.findExistingForQuote('cq-1', exec)).toBeNull();
+    expect(await clientOffersRepo.findExistingForQuote('cq-1', testDb)).toBeNull();
   });
 });
 
 describe('findLinkedSaleId', () => {
   test('queries sales.linked_offer_id and returns sale id', async () => {
-    exec.enqueue({ rows: [{ id: 's-1' }] });
-    const result = await clientOffersRepo.findLinkedSaleId('co-1', exec);
-    expect(exec.calls[0].sql).toContain('FROM sales WHERE linked_offer_id = $1');
+    exec.enqueue({ rows: [['s-1']] });
+    const result = await clientOffersRepo.findLinkedSaleId('co-1', testDb);
+    expect(exec.calls[0].sql).toContain('from "sales"');
+    expect(exec.calls[0].sql).toContain('"linked_offer_id" = $1');
     expect(result).toBe('s-1');
   });
 });
 
 describe('create', () => {
   test('inserts 10 fields and returns mapped offer', async () => {
-    exec.enqueue({ rows: [offerRow] });
+    exec.enqueue({ rows: [offerBuilderRow] });
     const result = await clientOffersRepo.create(
       {
         id: 'co-1',
@@ -138,28 +178,31 @@ describe('create', () => {
         expirationDate: '2026-06-01',
         notes: null,
       },
-      exec,
+      testDb,
     );
-    expect(exec.calls[0].sql).toContain('INSERT INTO customer_offers');
+    expect(exec.calls[0].sql).toContain('insert into "customer_offers"');
     expect(exec.calls[0].params).toHaveLength(10);
     expect(result.id).toBe('co-1');
   });
 });
 
 describe('update', () => {
-  test('passes 10 params and uses COALESCE preservation', async () => {
-    exec.enqueue({ rows: [offerRow] });
-    await clientOffersRepo.update('co-1', { status: 'accepted' }, exec);
+  test('passes 10 params and uses COALESCE preservation (raw SQL)', async () => {
+    exec.enqueue({ rows: [offerRawRow] });
+    await clientOffersRepo.update('co-1', { status: 'accepted' }, testDb);
     expect(exec.calls[0].sql).toContain('UPDATE customer_offers');
     expect(exec.calls[0].sql).toContain('updated_at = CURRENT_TIMESTAMP');
+    expect(exec.calls[0].sql).toContain('COALESCE');
     expect(exec.calls[0].params).toHaveLength(10);
+    // Patch order in the COALESCE list: id, clientId, clientName, paymentTerms, discount,
+    // discountType, status, expirationDate, notes, then the WHERE id.
     expect(exec.calls[0].params[6]).toBe('accepted'); // status
     expect(exec.calls[0].params[9]).toBe('co-1'); // where id
   });
 
   test('returns null when no row updated', async () => {
     exec.enqueue({ rows: [] });
-    expect(await clientOffersRepo.update('co-x', { status: 'accepted' }, exec)).toBeNull();
+    expect(await clientOffersRepo.update('co-x', { status: 'accepted' }, testDb)).toBeNull();
   });
 });
 
@@ -168,8 +211,8 @@ describe('replaceItems', () => {
     exec.enqueue({ rows: [] });
     exec.enqueue({
       rows: [
-        { ...itemRow, id: 'a' },
-        { ...itemRow, id: 'b' },
+        { ...itemRawRow, id: 'a' },
+        { ...itemRawRow, id: 'b' },
       ],
     });
     const items: clientOffersRepo.NewClientOfferItem[] = [
@@ -206,23 +249,23 @@ describe('replaceItems', () => {
         unitType: 'hours',
       },
     ];
-    const result = await clientOffersRepo.replaceItems('co-1', items, exec);
+    const result = await clientOffersRepo.replaceItems('co-1', items, testDb);
     expect(exec.calls).toHaveLength(2);
-    expect(exec.calls[0].sql).toContain('DELETE FROM customer_offer_items');
+    expect(exec.calls[0].sql).toContain('delete from "customer_offer_items"');
     expect(exec.calls[1].sql).toContain('INSERT INTO customer_offer_items');
     expect(exec.calls[1].sql).toContain(
       'VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15), ($16',
     );
     expect(exec.calls[1].params[0]).toBe('a');
-    expect(exec.calls[1].params[15]).toBe('b'); // 15 fields per row, second row starts at $16 = index 15
+    expect(exec.calls[1].params[15]).toBe('b'); // 15 fields per row, second row starts at index 15
     expect(result.map((i) => i.id)).toEqual(['a', 'b']);
   });
 
   test('with empty items skips the INSERT', async () => {
     exec.enqueue({ rows: [] });
-    const result = await clientOffersRepo.replaceItems('co-1', [], exec);
+    const result = await clientOffersRepo.replaceItems('co-1', [], testDb);
     expect(exec.calls).toHaveLength(1);
-    expect(exec.calls[0].sql).toContain('DELETE');
+    expect(exec.calls[0].sql).toContain('delete from');
     expect(result).toEqual([]);
   });
 });
@@ -230,11 +273,11 @@ describe('replaceItems', () => {
 describe('deleteById', () => {
   test('returns true when row deleted', async () => {
     exec.enqueue({ rows: [], rowCount: 1 });
-    expect(await clientOffersRepo.deleteById('co-1', exec)).toBe(true);
+    expect(await clientOffersRepo.deleteById('co-1', testDb)).toBe(true);
   });
 
   test('returns false when no row matched', async () => {
     exec.enqueue({ rows: [], rowCount: 0 });
-    expect(await clientOffersRepo.deleteById('co-x', exec)).toBe(false);
+    expect(await clientOffersRepo.deleteById('co-x', testDb)).toBe(false);
   });
 });

--- a/server/test/repositories/entriesRepo.test.ts
+++ b/server/test/repositories/entriesRepo.test.ts
@@ -260,8 +260,8 @@ describe('create', () => {
       'Dev',
       't-1',
       'n',
-      1.5,
-      100,
+      '1.5',
+      '100',
       false,
       'remote',
     ]);
@@ -383,7 +383,7 @@ describe('update', () => {
     expect(result?.isPlaceholder).toBe(false);
     expect(exec.calls[0].sql).toContain('"duration" = $1');
     expect(exec.calls[0].sql).toContain('"id" = $2');
-    expect(exec.calls[0].params).toEqual([2, 'e-1']);
+    expect(exec.calls[0].params).toEqual(['2', 'e-1']);
   });
 
   test('builds SET list in schema column order from defined fields', async () => {
@@ -403,7 +403,7 @@ describe('update', () => {
     expect(sql).toContain('"is_placeholder" = $4');
     expect(sql).toContain('"location" = $5');
     expect(sql).toContain('"id" = $6');
-    expect(exec.calls[0].params).toEqual(['t-2', 'updated', 2, true, 'office', 'e-1']);
+    expect(exec.calls[0].params).toEqual(['t-2', 'updated', '2', true, 'office', 'e-1']);
   });
 
   test('passes taskId through when set, omitting other fields', async () => {

--- a/server/test/repositories/entriesRepo.test.ts
+++ b/server/test/repositories/entriesRepo.test.ts
@@ -189,6 +189,22 @@ describe('encodeCursor / decodeCursor', () => {
       id: 'e-2',
     });
   });
+
+  test('null created_at_text on the last row suppresses nextCursor', async () => {
+    exec.enqueue({
+      rows: [rawRow, { ...rawRow, id: 'e-2', created_at: null, created_at_text: null }],
+    });
+    const result = await entriesRepo.listAll({ limit: 2 }, testDb);
+    expect(result.nextCursor).toBeNull();
+  });
+});
+
+describe('mapRawRow (exercised via listAll return path)', () => {
+  test('null created_at falls back to 0 (matches mapBuilderRow)', async () => {
+    exec.enqueue({ rows: [{ ...rawRow, created_at: null, created_at_text: null }] });
+    const result = await entriesRepo.listAll({}, testDb);
+    expect(result.entries[0].createdAt).toBe(0);
+  });
 });
 
 describe('findOwner', () => {
@@ -358,7 +374,7 @@ describe('mapBuilderRow (exercised via create return path)', () => {
 
   test('throws TypeError when row.date is null', async () => {
     exec.enqueue({ rows: [entryRow({ 2: null })] });
-    expect(entriesRepo.create(newEntry, testDb)).rejects.toThrow(TypeError);
+    await expect(entriesRepo.create(newEntry, testDb)).rejects.toThrow(TypeError);
   });
 });
 

--- a/server/test/repositories/entriesRepo.test.ts
+++ b/server/test/repositories/entriesRepo.test.ts
@@ -195,6 +195,7 @@ describe('encodeCursor / decodeCursor', () => {
       rows: [rawRow, { ...rawRow, id: 'e-2', created_at: null, created_at_text: null }],
     });
     const result = await entriesRepo.listAll({ limit: 2 }, testDb);
+    expect(result.entries).toHaveLength(2);
     expect(result.nextCursor).toBeNull();
   });
 });

--- a/server/test/repositories/entriesRepo.test.ts
+++ b/server/test/repositories/entriesRepo.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
 import type { DbExecutor } from '../../db/drizzle.ts';
 import * as entriesRepo from '../../repositories/entriesRepo.ts';
-import { type FakeExecutor, setupTestDb } from '../helpers/fakeExecutor.ts';
+import { type FakeExecutor, makeRow, setupTestDb } from '../helpers/fakeExecutor.ts';
 
 let exec: FakeExecutor;
 let testDb: DbExecutor;
@@ -10,14 +10,10 @@ beforeEach(() => {
   ({ exec, testDb } = setupTestDb());
 });
 
-// Builder paths use rowMode: 'array' — fixture rows are positional in `timeEntries` schema
-// column order: [id, userId, date, clientId, clientName, projectId, projectName, task, taskId,
-// notes, duration, hourlyCost, isPlaceholder, location, createdAt].
-//
-// Raw-SQL paths via `executeRows` return objects keyed by SELECT column name (snake_case here,
-// since the SQL uses unaliased column names + `created_at::text AS created_at_text`).
-
-const builderRow: unknown[] = [
+// Builder fixtures match the column order in db/schema/timeEntries.ts. Raw-SQL fixtures
+// are objects keyed by SELECT column name (snake_case + an extra `created_at_text` for
+// cursor pagination — see ENTRY_COLUMNS_SQL).
+const ENTRY_BASE: readonly unknown[] = [
   'e-1',
   'u-1',
   '2026-04-30',
@@ -34,6 +30,8 @@ const builderRow: unknown[] = [
   'remote',
   new Date('2026-04-30T12:00:00Z'),
 ];
+
+const entryRow = (overrides: Record<number, unknown> = {}) => makeRow(ENTRY_BASE, overrides);
 
 const rawRow = {
   id: 'e-1',
@@ -229,7 +227,7 @@ describe('findContext', () => {
 
 describe('create', () => {
   test('passes 14 params in expected order and returns mapped row', async () => {
-    exec.enqueue({ rows: [builderRow] });
+    exec.enqueue({ rows: [entryRow()] });
     const result = await entriesRepo.create(
       {
         id: 'e-1',
@@ -273,9 +271,7 @@ describe('create', () => {
   });
 
   test('null taskId is passed through (task name has no matching task row)', async () => {
-    const rowWithNullTaskId = builderRow.slice();
-    rowWithNullTaskId[8] = null;
-    exec.enqueue({ rows: [rowWithNullTaskId] });
+    exec.enqueue({ rows: [entryRow({ 8: null })] });
     const result = await entriesRepo.create(
       {
         id: 'e-1',
@@ -317,64 +313,58 @@ const newEntry = {
   location: 'remote',
 };
 
-const overrideRow = (index: number, value: unknown): unknown[] => {
-  const row = builderRow.slice();
-  row[index] = value;
-  return row;
-};
-
 describe('mapBuilderRow (exercised via create return path)', () => {
   test('null duration falls back to 0', async () => {
-    exec.enqueue({ rows: [overrideRow(10, null)] });
+    exec.enqueue({ rows: [entryRow({ 10: null })] });
     const result = await entriesRepo.create(newEntry, testDb);
     expect(result.duration).toBe(0);
   });
 
   test('null hourly_cost falls back to 0', async () => {
-    exec.enqueue({ rows: [overrideRow(11, null)] });
+    exec.enqueue({ rows: [entryRow({ 11: null })] });
     const result = await entriesRepo.create(newEntry, testDb);
     expect(result.hourlyCost).toBe(0);
   });
 
   test('null is_placeholder coerces to false', async () => {
-    exec.enqueue({ rows: [overrideRow(12, null)] });
+    exec.enqueue({ rows: [entryRow({ 12: null })] });
     const result = await entriesRepo.create(newEntry, testDb);
     expect(result.isPlaceholder).toBe(false);
   });
 
   test('null location falls back to "remote"', async () => {
-    exec.enqueue({ rows: [overrideRow(13, null)] });
+    exec.enqueue({ rows: [entryRow({ 13: null })] });
     const result = await entriesRepo.create(newEntry, testDb);
     expect(result.location).toBe('remote');
   });
 
   test('empty location falls back to "remote"', async () => {
-    exec.enqueue({ rows: [overrideRow(13, '')] });
+    exec.enqueue({ rows: [entryRow({ 13: '' })] });
     const result = await entriesRepo.create(newEntry, testDb);
     expect(result.location).toBe('remote');
   });
 
   test('numeric-string duration is parsed to number', async () => {
-    exec.enqueue({ rows: [overrideRow(10, '2.75')] });
+    exec.enqueue({ rows: [entryRow({ 10: '2.75' })] });
     const result = await entriesRepo.create(newEntry, testDb);
     expect(result.duration).toBe(2.75);
   });
 
   test('null createdAt falls back to 0', async () => {
-    exec.enqueue({ rows: [overrideRow(14, null)] });
+    exec.enqueue({ rows: [entryRow({ 14: null })] });
     const result = await entriesRepo.create(newEntry, testDb);
     expect(result.createdAt).toBe(0);
   });
 
   test('throws TypeError when row.date is null', async () => {
-    exec.enqueue({ rows: [overrideRow(2, null)] });
+    exec.enqueue({ rows: [entryRow({ 2: null })] });
     expect(entriesRepo.create(newEntry, testDb)).rejects.toThrow(TypeError);
   });
 });
 
 describe('update', () => {
   test('only sets provided fields, id is the last param', async () => {
-    exec.enqueue({ rows: [builderRow] });
+    exec.enqueue({ rows: [entryRow()] });
     const result = await entriesRepo.update('e-1', { duration: 2 }, testDb);
     expect(result?.id).toBe('e-1');
     expect(result?.userId).toBe('u-1');
@@ -387,7 +377,7 @@ describe('update', () => {
   });
 
   test('builds SET list in schema column order from defined fields', async () => {
-    exec.enqueue({ rows: [builderRow] });
+    exec.enqueue({ rows: [entryRow()] });
     await entriesRepo.update(
       'e-1',
       { duration: 2, notes: 'updated', isPlaceholder: true, location: 'office', taskId: 't-2' },
@@ -407,7 +397,7 @@ describe('update', () => {
   });
 
   test('passes taskId through when set, omitting other fields', async () => {
-    exec.enqueue({ rows: [builderRow] });
+    exec.enqueue({ rows: [entryRow()] });
     await entriesRepo.update('e-1', { taskId: 't-2' }, testDb);
     expect(exec.calls[0].sql).toContain('"task_id" = $1');
     expect(exec.calls[0].sql).toContain('"id" = $2');
@@ -415,7 +405,7 @@ describe('update', () => {
   });
 
   test('omitting all fields falls back to a SELECT (no UPDATE issued)', async () => {
-    exec.enqueue({ rows: [builderRow] });
+    exec.enqueue({ rows: [entryRow()] });
     const result = await entriesRepo.update('e-1', {}, testDb);
     expect(exec.calls[0].sql).not.toContain('update');
     expect(exec.calls[0].sql).toContain('select');
@@ -434,7 +424,7 @@ describe('update', () => {
   });
 
   test('notes: null clears the column (distinct from undefined which is skipped)', async () => {
-    exec.enqueue({ rows: [overrideRow(9, null)] });
+    exec.enqueue({ rows: [entryRow({ 9: null })] });
     const result = await entriesRepo.update('e-1', { notes: null }, testDb);
     expect(exec.calls[0].sql).toContain('update');
     expect(exec.calls[0].sql).toContain('"notes" = $1');

--- a/server/test/repositories/entriesRepo.test.ts
+++ b/server/test/repositories/entriesRepo.test.ts
@@ -1,25 +1,71 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
+import type { DbExecutor } from '../../db/drizzle.ts';
 import * as entriesRepo from '../../repositories/entriesRepo.ts';
-import { type FakeExecutor, makeFakeExecutor } from '../helpers/fakeExecutor.ts';
+import { type FakeExecutor, setupTestDb } from '../helpers/fakeExecutor.ts';
 
 let exec: FakeExecutor;
+let testDb: DbExecutor;
 
 beforeEach(() => {
-  exec = makeFakeExecutor();
+  ({ exec, testDb } = setupTestDb());
 });
+
+// Builder paths use rowMode: 'array' — fixture rows are positional in `timeEntries` schema
+// column order: [id, userId, date, clientId, clientName, projectId, projectName, task, taskId,
+// notes, duration, hourlyCost, isPlaceholder, location, createdAt].
+//
+// Raw-SQL paths via `executeRows` return objects keyed by SELECT column name (snake_case here,
+// since the SQL uses unaliased column names + `created_at::text AS created_at_text`).
+
+const builderRow: unknown[] = [
+  'e-1',
+  'u-1',
+  '2026-04-30',
+  'c-1',
+  'Acme',
+  'p-1',
+  'Alpha',
+  'Dev',
+  't-1',
+  'n',
+  '1.5',
+  '100',
+  false,
+  'remote',
+  new Date('2026-04-30T12:00:00Z'),
+];
+
+const rawRow = {
+  id: 'e-1',
+  user_id: 'u-1',
+  date: '2026-04-30',
+  client_id: 'c-1',
+  client_name: 'Acme',
+  project_id: 'p-1',
+  project_name: 'Alpha',
+  task: 'Dev',
+  task_id: 't-1',
+  notes: 'n',
+  duration: '1.5',
+  hourly_cost: '100',
+  is_placeholder: false,
+  location: 'remote',
+  created_at: new Date('2026-04-30T12:00:00Z'),
+  created_at_text: '2026-04-30 12:00:00.000000',
+};
 
 describe('listAll', () => {
   test('passes default limit and no cursor', async () => {
     exec.enqueue({ rows: [] });
-    const result = await entriesRepo.listAll({}, exec);
+    const result = await entriesRepo.listAll({}, testDb);
     expect(exec.calls[0].params).toEqual([200]);
-    expect(exec.calls[0].sql).toContain('LIMIT $1');
+    expect(exec.calls[0].sql).not.toContain('WHERE');
     expect(result.nextCursor).toBeNull();
   });
 
   test('caps limit at 500', async () => {
     exec.enqueue({ rows: [] });
-    await entriesRepo.listAll({ limit: 9999 }, exec);
+    await entriesRepo.listAll({ limit: 9999 }, testDb);
     expect(exec.calls[0].params).toEqual([500]);
   });
 
@@ -27,10 +73,11 @@ describe('listAll', () => {
     exec.enqueue({ rows: [] });
     await entriesRepo.listAll(
       { limit: 50, cursor: { createdAt: '2026-04-30 12:00:00.123456', id: 'e-1' } },
-      exec,
+      testDb,
     );
     expect(exec.calls[0].params).toEqual(['2026-04-30 12:00:00.123456', 'e-1', 50]);
     expect(exec.calls[0].sql).toContain('::timestamp');
+    expect(exec.calls[0].sql).toContain('created_at_text');
     expect(exec.calls[0].sql).not.toContain('to_timestamp');
   });
 
@@ -42,7 +89,7 @@ describe('listAll', () => {
     ['fractional truncates via Math.floor', 1.7, 1],
   ])('resolveLimit treats %s (%p) as %p', async (_label, input, expected) => {
     exec.enqueue({ rows: [] });
-    await entriesRepo.listAll({ limit: input }, exec);
+    await entriesRepo.listAll({ limit: input }, testDb);
     expect(exec.calls[0].params).toEqual([expected]);
   });
 });
@@ -50,47 +97,50 @@ describe('listAll', () => {
 describe('listForUser', () => {
   test('passes userId as $1 and limit at the end', async () => {
     exec.enqueue({ rows: [] });
-    await entriesRepo.listForUser('u-1', {}, exec);
+    await entriesRepo.listForUser('u-1', {}, testDb);
     expect(exec.calls[0].params).toEqual(['u-1', 200]);
-    expect(exec.calls[0].sql).toContain('WHERE user_id = $1');
+    expect(exec.calls[0].sql).toContain('user_id = $1');
   });
 
-  test('with cursor: cursor params start at $2, limit lands at $4', async () => {
+  test('with cursor: cursor params follow userId, limit lands last', async () => {
     exec.enqueue({ rows: [] });
     await entriesRepo.listForUser(
       'u-1',
       { limit: 50, cursor: { createdAt: '2026-04-30 12:00:00.123456', id: 'e-9' } },
-      exec,
+      testDb,
     );
     expect(exec.calls[0].params).toEqual(['u-1', '2026-04-30 12:00:00.123456', 'e-9', 50]);
     const sql = exec.calls[0].sql;
-    expect(sql).toContain('WHERE user_id = $1');
+    expect(sql).toContain('user_id = $1');
     expect(sql).toContain('$2::timestamp');
     expect(sql).toContain('LIMIT $4');
   });
 });
 
 describe('listForManagerView', () => {
-  test('uses managerId for both own + managed subquery', async () => {
+  test('uses managerId for both own + managed subquery (Drizzle binds twice)', async () => {
     exec.enqueue({ rows: [] });
-    await entriesRepo.listForManagerView('mgr', {}, exec);
-    expect(exec.calls[0].params).toEqual(['mgr', 200]);
-    expect(exec.calls[0].sql).toContain('work_unit_managers');
-    expect(exec.calls[0].sql).toContain('user_id = $1');
-    expect(exec.calls[0].sql).toContain('wum.user_id = $1');
+    await entriesRepo.listForManagerView('mgr', {}, testDb);
+    // Drizzle's `sql\`\`` template doesn't dedupe interpolations — the managerId is bound
+    // once for `user_id = $1` and once for the subquery's `wum.user_id = $2`.
+    expect(exec.calls[0].params).toEqual(['mgr', 'mgr', 200]);
+    const sql = exec.calls[0].sql;
+    expect(sql).toContain('work_unit_managers');
+    expect(sql).toContain('user_id = $1');
+    expect(sql).toContain('wum.user_id = $2');
   });
 
-  test('with cursor: cursor params start at $2, limit lands at $4', async () => {
+  test('with cursor: cursor params follow the manager scope params', async () => {
     exec.enqueue({ rows: [] });
     await entriesRepo.listForManagerView(
       'mgr',
       { limit: 25, cursor: { createdAt: '2026-04-30 12:00:00.123456', id: 'e-9' } },
-      exec,
+      testDb,
     );
-    expect(exec.calls[0].params).toEqual(['mgr', '2026-04-30 12:00:00.123456', 'e-9', 25]);
+    expect(exec.calls[0].params).toEqual(['mgr', 'mgr', '2026-04-30 12:00:00.123456', 'e-9', 25]);
     const sql = exec.calls[0].sql;
-    expect(sql).toContain('$2::timestamp');
-    expect(sql).toContain('LIMIT $4');
+    expect(sql).toContain('$3::timestamp');
+    expect(sql).toContain('LIMIT $5');
   });
 });
 
@@ -132,53 +182,33 @@ describe('encodeCursor / decodeCursor', () => {
   });
 
   test('produces a nextCursor that preserves µs precision from created_at_text', async () => {
-    const row = {
-      id: 'e-2',
-      user_id: 'u-1',
-      date: '2026-04-30',
-      client_id: 'c-1',
-      client_name: 'Acme',
-      project_id: 'p-1',
-      project_name: 'Alpha',
-      task: 'Dev',
-      task_id: 't-1',
-      notes: null,
-      duration: 1,
-      hourly_cost: 100,
-      is_placeholder: false,
-      location: 'remote',
-      created_at: new Date('2026-04-30T12:00:00.123Z'),
-      created_at_text: '2026-04-30 12:00:00.123456',
-    };
     exec.enqueue({
-      rows: [row, { ...row, id: 'e-1', created_at_text: '2026-04-30 12:00:00.123100' }],
+      rows: [rawRow, { ...rawRow, id: 'e-2', created_at_text: '2026-04-30 12:00:00.123100' }],
     });
-    const result = await entriesRepo.listAll({ limit: 2 }, exec);
+    const result = await entriesRepo.listAll({ limit: 2 }, testDb);
     expect(result.nextCursor).toEqual({
       createdAt: '2026-04-30 12:00:00.123100',
-      id: 'e-1',
+      id: 'e-2',
     });
   });
 });
 
 describe('findOwner', () => {
   test('returns owner id when entry exists', async () => {
-    exec.enqueue({ rows: [{ user_id: 'u-1' }] });
-    expect(await entriesRepo.findOwner('e-1', exec)).toBe('u-1');
+    exec.enqueue({ rows: [['u-1']] });
+    expect(await entriesRepo.findOwner('e-1', testDb)).toBe('u-1');
   });
 
   test('returns null when entry not found', async () => {
     exec.enqueue({ rows: [] });
-    expect(await entriesRepo.findOwner('e-x', exec)).toBeNull();
+    expect(await entriesRepo.findOwner('e-x', testDb)).toBeNull();
   });
 });
 
 describe('findContext', () => {
   test('returns full context including taskId when present', async () => {
-    exec.enqueue({
-      rows: [{ user_id: 'u-1', project_id: 'p-1', task: 'Dev', task_id: 't-1' }],
-    });
-    expect(await entriesRepo.findContext('e-1', exec)).toEqual({
+    exec.enqueue({ rows: [['u-1', 'p-1', 'Dev', 't-1']] });
+    expect(await entriesRepo.findContext('e-1', testDb)).toEqual({
       userId: 'u-1',
       projectId: 'p-1',
       task: 'Dev',
@@ -187,39 +217,19 @@ describe('findContext', () => {
   });
 
   test('returns context with null taskId for orphaned entries', async () => {
-    exec.enqueue({
-      rows: [{ user_id: 'u-1', project_id: 'p-1', task: 'Dev', task_id: null }],
-    });
-    expect((await entriesRepo.findContext('e-1', exec))?.taskId).toBeNull();
+    exec.enqueue({ rows: [['u-1', 'p-1', 'Dev', null]] });
+    expect((await entriesRepo.findContext('e-1', testDb))?.taskId).toBeNull();
   });
 
   test('returns null when entry not found', async () => {
     exec.enqueue({ rows: [] });
-    expect(await entriesRepo.findContext('e-x', exec)).toBeNull();
+    expect(await entriesRepo.findContext('e-x', testDb)).toBeNull();
   });
 });
 
-const rawRow = {
-  id: 'e-1',
-  user_id: 'u-1',
-  date: '2026-04-30',
-  client_id: 'c-1',
-  client_name: 'Acme',
-  project_id: 'p-1',
-  project_name: 'Alpha',
-  task: 'Dev',
-  task_id: 't-1',
-  notes: 'n',
-  duration: '1.5',
-  hourly_cost: '100',
-  is_placeholder: false,
-  location: 'remote',
-  created_at: new Date('2026-04-30T12:00:00Z'),
-};
-
 describe('create', () => {
   test('passes 14 params in expected order and returns mapped row', async () => {
-    exec.enqueue({ rows: [rawRow] });
+    exec.enqueue({ rows: [builderRow] });
     const result = await entriesRepo.create(
       {
         id: 'e-1',
@@ -237,7 +247,7 @@ describe('create', () => {
         isPlaceholder: false,
         location: 'remote',
       },
-      exec,
+      testDb,
     );
     expect(exec.calls[0].params).toEqual([
       'e-1',
@@ -255,7 +265,7 @@ describe('create', () => {
       false,
       'remote',
     ]);
-    expect(exec.calls[0].sql).toContain('RETURNING');
+    expect(exec.calls[0].sql).toContain('returning');
     expect(result.duration).toBe(1.5);
     expect(result.hourlyCost).toBe(100);
     expect(result.userId).toBe('u-1');
@@ -263,7 +273,9 @@ describe('create', () => {
   });
 
   test('null taskId is passed through (task name has no matching task row)', async () => {
-    exec.enqueue({ rows: [{ ...rawRow, task_id: null }] });
+    const rowWithNullTaskId = builderRow.slice();
+    rowWithNullTaskId[8] = null;
+    exec.enqueue({ rows: [rowWithNullTaskId] });
     const result = await entriesRepo.create(
       {
         id: 'e-1',
@@ -281,7 +293,7 @@ describe('create', () => {
         isPlaceholder: false,
         location: 'remote',
       },
-      exec,
+      testDb,
     );
     expect(exec.calls[0].params[8]).toBeNull();
     expect(result.taskId).toBeNull();
@@ -305,124 +317,128 @@ const newEntry = {
   location: 'remote',
 };
 
-describe('mapRow (exercised via create return path)', () => {
+const overrideRow = (index: number, value: unknown): unknown[] => {
+  const row = builderRow.slice();
+  row[index] = value;
+  return row;
+};
+
+describe('mapBuilderRow (exercised via create return path)', () => {
   test('null duration falls back to 0', async () => {
-    exec.enqueue({ rows: [{ ...rawRow, duration: null }] });
-    const result = await entriesRepo.create(newEntry, exec);
+    exec.enqueue({ rows: [overrideRow(10, null)] });
+    const result = await entriesRepo.create(newEntry, testDb);
     expect(result.duration).toBe(0);
   });
 
   test('null hourly_cost falls back to 0', async () => {
-    exec.enqueue({ rows: [{ ...rawRow, hourly_cost: null }] });
-    const result = await entriesRepo.create(newEntry, exec);
+    exec.enqueue({ rows: [overrideRow(11, null)] });
+    const result = await entriesRepo.create(newEntry, testDb);
     expect(result.hourlyCost).toBe(0);
   });
 
   test('null is_placeholder coerces to false', async () => {
-    exec.enqueue({ rows: [{ ...rawRow, is_placeholder: null }] });
-    const result = await entriesRepo.create(newEntry, exec);
+    exec.enqueue({ rows: [overrideRow(12, null)] });
+    const result = await entriesRepo.create(newEntry, testDb);
     expect(result.isPlaceholder).toBe(false);
   });
 
   test('null location falls back to "remote"', async () => {
-    exec.enqueue({ rows: [{ ...rawRow, location: null }] });
-    const result = await entriesRepo.create(newEntry, exec);
+    exec.enqueue({ rows: [overrideRow(13, null)] });
+    const result = await entriesRepo.create(newEntry, testDb);
     expect(result.location).toBe('remote');
   });
 
   test('empty location falls back to "remote"', async () => {
-    exec.enqueue({ rows: [{ ...rawRow, location: '' }] });
-    const result = await entriesRepo.create(newEntry, exec);
+    exec.enqueue({ rows: [overrideRow(13, '')] });
+    const result = await entriesRepo.create(newEntry, testDb);
     expect(result.location).toBe('remote');
   });
 
   test('numeric-string duration is parsed to number', async () => {
-    exec.enqueue({ rows: [{ ...rawRow, duration: '2.75' }] });
-    const result = await entriesRepo.create(newEntry, exec);
+    exec.enqueue({ rows: [overrideRow(10, '2.75')] });
+    const result = await entriesRepo.create(newEntry, testDb);
     expect(result.duration).toBe(2.75);
   });
 
-  test('string created_at is converted to ms epoch', async () => {
-    exec.enqueue({ rows: [{ ...rawRow, created_at: '2026-04-30T12:00:00Z' }] });
-    const result = await entriesRepo.create(newEntry, exec);
-    expect(result.createdAt).toBe(new Date('2026-04-30T12:00:00Z').getTime());
+  test('null createdAt falls back to 0', async () => {
+    exec.enqueue({ rows: [overrideRow(14, null)] });
+    const result = await entriesRepo.create(newEntry, testDb);
+    expect(result.createdAt).toBe(0);
   });
 
   test('throws TypeError when row.date is null', async () => {
-    exec.enqueue({ rows: [{ ...rawRow, date: null }] });
-    await expect(entriesRepo.create(newEntry, exec)).rejects.toThrow(TypeError);
-  });
-
-  test('throws TypeError when row.date is an unsupported type', async () => {
-    exec.enqueue({ rows: [{ ...rawRow, date: 12345 }] });
-    await expect(entriesRepo.create(newEntry, exec)).rejects.toThrow(TypeError);
+    exec.enqueue({ rows: [overrideRow(2, null)] });
+    expect(entriesRepo.create(newEntry, testDb)).rejects.toThrow(TypeError);
   });
 });
 
 describe('update', () => {
   test('only sets provided fields, id is the last param', async () => {
-    exec.enqueue({ rows: [rawRow] });
-    const result = await entriesRepo.update('e-1', { duration: 2 }, exec);
+    exec.enqueue({ rows: [builderRow] });
+    const result = await entriesRepo.update('e-1', { duration: 2 }, testDb);
     expect(result?.id).toBe('e-1');
     expect(result?.userId).toBe('u-1');
     expect(result?.duration).toBe(1.5);
     expect(result?.hourlyCost).toBe(100);
     expect(result?.isPlaceholder).toBe(false);
-    expect(exec.calls[0].sql).toContain('SET duration = $1');
-    expect(exec.calls[0].sql).toContain('WHERE id = $2');
+    expect(exec.calls[0].sql).toContain('"duration" = $1');
+    expect(exec.calls[0].sql).toContain('"id" = $2');
     expect(exec.calls[0].params).toEqual([2, 'e-1']);
   });
 
-  test('builds SET list in column order from defined fields', async () => {
-    exec.enqueue({ rows: [rawRow] });
+  test('builds SET list in schema column order from defined fields', async () => {
+    exec.enqueue({ rows: [builderRow] });
     await entriesRepo.update(
       'e-1',
       { duration: 2, notes: 'updated', isPlaceholder: true, location: 'office', taskId: 't-2' },
-      exec,
+      testDb,
     );
+    // Drizzle emits SET columns in schema column declaration order regardless of how the
+    // `.set({...})` object is constructed: task_id (col 9) → notes (10) → duration (11) →
+    // is_placeholder (13) → location (14).
     const sql = exec.calls[0].sql;
-    expect(sql).toContain('duration = $1');
-    expect(sql).toContain('notes = $2');
-    expect(sql).toContain('is_placeholder = $3');
-    expect(sql).toContain('location = $4');
-    expect(sql).toContain('task_id = $5');
-    expect(sql).toContain('WHERE id = $6');
-    expect(exec.calls[0].params).toEqual([2, 'updated', true, 'office', 't-2', 'e-1']);
+    expect(sql).toContain('"task_id" = $1');
+    expect(sql).toContain('"notes" = $2');
+    expect(sql).toContain('"duration" = $3');
+    expect(sql).toContain('"is_placeholder" = $4');
+    expect(sql).toContain('"location" = $5');
+    expect(sql).toContain('"id" = $6');
+    expect(exec.calls[0].params).toEqual(['t-2', 'updated', 2, true, 'office', 'e-1']);
   });
 
   test('passes taskId through when set, omitting other fields', async () => {
-    exec.enqueue({ rows: [rawRow] });
-    await entriesRepo.update('e-1', { taskId: 't-2' }, exec);
-    expect(exec.calls[0].sql).toContain('SET task_id = $1');
-    expect(exec.calls[0].sql).toContain('WHERE id = $2');
+    exec.enqueue({ rows: [builderRow] });
+    await entriesRepo.update('e-1', { taskId: 't-2' }, testDb);
+    expect(exec.calls[0].sql).toContain('"task_id" = $1');
+    expect(exec.calls[0].sql).toContain('"id" = $2');
     expect(exec.calls[0].params).toEqual(['t-2', 'e-1']);
   });
 
   test('omitting all fields falls back to a SELECT (no UPDATE issued)', async () => {
-    exec.enqueue({ rows: [rawRow] });
-    const result = await entriesRepo.update('e-1', {}, exec);
-    expect(exec.calls[0].sql).not.toContain('UPDATE');
-    expect(exec.calls[0].sql).toContain('SELECT');
+    exec.enqueue({ rows: [builderRow] });
+    const result = await entriesRepo.update('e-1', {}, testDb);
+    expect(exec.calls[0].sql).not.toContain('update');
+    expect(exec.calls[0].sql).toContain('select');
     expect(exec.calls[0].params).toEqual(['e-1']);
     expect(result?.id).toBe('e-1');
   });
 
   test('returns null when no row matched (UPDATE path)', async () => {
     exec.enqueue({ rows: [] });
-    expect(await entriesRepo.update('e-x', { duration: 2 }, exec)).toBeNull();
+    expect(await entriesRepo.update('e-x', { duration: 2 }, testDb)).toBeNull();
   });
 
   test('returns null when no row matched (SELECT fallback path)', async () => {
     exec.enqueue({ rows: [] });
-    expect(await entriesRepo.update('e-x', {}, exec)).toBeNull();
+    expect(await entriesRepo.update('e-x', {}, testDb)).toBeNull();
   });
 
   test('notes: null clears the column (distinct from undefined which is skipped)', async () => {
-    exec.enqueue({ rows: [{ ...rawRow, notes: null }] });
-    const result = await entriesRepo.update('e-1', { notes: null }, exec);
-    expect(exec.calls[0].sql).toContain('UPDATE');
-    expect(exec.calls[0].sql).toContain('notes = $1');
-    expect(exec.calls[0].sql).toContain('WHERE id = $2');
+    exec.enqueue({ rows: [overrideRow(9, null)] });
+    const result = await entriesRepo.update('e-1', { notes: null }, testDb);
+    expect(exec.calls[0].sql).toContain('update');
+    expect(exec.calls[0].sql).toContain('"notes" = $1');
+    expect(exec.calls[0].sql).toContain('"id" = $2');
     expect(exec.calls[0].params).toEqual([null, 'e-1']);
     expect(result?.notes).toBeNull();
   });
@@ -431,50 +447,50 @@ describe('update', () => {
 describe('deleteById', () => {
   test('passes id as $1 against time_entries', async () => {
     exec.enqueue({ rows: [] });
-    await entriesRepo.deleteById('e-1', exec);
+    await entriesRepo.deleteById('e-1', testDb);
     expect(exec.calls[0].params).toEqual(['e-1']);
-    expect(exec.calls[0].sql).toContain('DELETE FROM time_entries');
-    expect(exec.calls[0].sql).toContain('WHERE id = $1');
+    expect(exec.calls[0].sql).toContain('delete from "time_entries"');
+    expect(exec.calls[0].sql).toContain('"id" = $1');
   });
 });
 
 describe('bulkDelete', () => {
   test('minimal filters: project + task only, returns row count', async () => {
     exec.enqueue({ rows: [], rowCount: 2 });
-    const result = await entriesRepo.bulkDelete({ projectId: 'p-1', task: 'Dev' }, exec);
+    const result = await entriesRepo.bulkDelete({ projectId: 'p-1', task: 'Dev' }, testDb);
     expect(result).toBe(2);
     expect(exec.calls[0].params).toEqual(['p-1', 'Dev']);
-    expect(exec.calls[0].sql).toContain('project_id = $1');
-    expect(exec.calls[0].sql).toContain('task = $2');
-    expect(exec.calls[0].sql).not.toContain('RETURNING');
-    expect(exec.calls[0].sql).not.toContain('user_id =');
-    expect(exec.calls[0].sql).not.toContain('date >=');
+    expect(exec.calls[0].sql).toContain('"project_id" = $1');
+    expect(exec.calls[0].sql).toContain('"task" = $2');
+    expect(exec.calls[0].sql).not.toContain('returning');
+    expect(exec.calls[0].sql).not.toContain('user_id');
+    expect(exec.calls[0].sql).not.toContain('"date"');
     expect(exec.calls[0].sql).not.toContain('is_placeholder');
   });
 
   test('returns 0 when rowCount is null', async () => {
     exec.enqueue({ rows: [], rowCount: null });
-    const result = await entriesRepo.bulkDelete({ projectId: 'p-1', task: 'Dev' }, exec);
+    const result = await entriesRepo.bulkDelete({ projectId: 'p-1', task: 'Dev' }, testDb);
     expect(result).toBe(0);
   });
 
-  test('manager-scope restriction adds the user_id subquery, reusing $3', async () => {
+  test('manager-scope restriction adds the user_id subquery (managerId bound twice)', async () => {
     exec.enqueue({ rows: [] });
     await entriesRepo.bulkDelete(
       { projectId: 'p-1', task: 'Dev', restrictToManagerScopeOf: 'mgr' },
-      exec,
+      testDb,
     );
-    expect(exec.calls[0].params).toEqual(['p-1', 'Dev', 'mgr']);
+    expect(exec.calls[0].params).toEqual(['p-1', 'Dev', 'mgr', 'mgr']);
     const sql = exec.calls[0].sql;
     expect(sql).toContain('user_id = $3');
-    expect(sql).toContain('wum.user_id = $3');
+    expect(sql).toContain('wum.user_id = $4');
   });
 
   test('fromDate appends date filter at the next index', async () => {
     exec.enqueue({ rows: [] });
-    await entriesRepo.bulkDelete({ projectId: 'p-1', task: 'Dev', fromDate: '2026-04-30' }, exec);
+    await entriesRepo.bulkDelete({ projectId: 'p-1', task: 'Dev', fromDate: '2026-04-30' }, testDb);
     expect(exec.calls[0].params).toEqual(['p-1', 'Dev', '2026-04-30']);
-    expect(exec.calls[0].sql).toContain('date >= $3');
+    expect(exec.calls[0].sql).toContain('"date" >= $3');
   });
 
   test('manager-scope + fromDate uses sequential indexes', async () => {
@@ -486,22 +502,22 @@ describe('bulkDelete', () => {
         restrictToManagerScopeOf: 'mgr',
         fromDate: '2026-04-30',
       },
-      exec,
+      testDb,
     );
-    expect(exec.calls[0].params).toEqual(['p-1', 'Dev', 'mgr', '2026-04-30']);
-    expect(exec.calls[0].sql).toContain('date >= $4');
+    expect(exec.calls[0].params).toEqual(['p-1', 'Dev', 'mgr', 'mgr', '2026-04-30']);
+    expect(exec.calls[0].sql).toContain('"date" >= $5');
   });
 
-  test('placeholderOnly is appended as a literal predicate (no param)', async () => {
+  test('placeholderOnly: true binds `is_placeholder = $N` with true', async () => {
     exec.enqueue({ rows: [] });
-    await entriesRepo.bulkDelete({ projectId: 'p-1', task: 'Dev', placeholderOnly: true }, exec);
-    expect(exec.calls[0].params).toEqual(['p-1', 'Dev']);
-    expect(exec.calls[0].sql).toContain('is_placeholder = true');
+    await entriesRepo.bulkDelete({ projectId: 'p-1', task: 'Dev', placeholderOnly: true }, testDb);
+    expect(exec.calls[0].params).toEqual(['p-1', 'Dev', true]);
+    expect(exec.calls[0].sql).toContain('"is_placeholder" = $3');
   });
 
   test('placeholderOnly: false does NOT add the predicate (gated on === true)', async () => {
     exec.enqueue({ rows: [] });
-    await entriesRepo.bulkDelete({ projectId: 'p-1', task: 'Dev', placeholderOnly: false }, exec);
+    await entriesRepo.bulkDelete({ projectId: 'p-1', task: 'Dev', placeholderOnly: false }, testDb);
     expect(exec.calls[0].params).toEqual(['p-1', 'Dev']);
     expect(exec.calls[0].sql).not.toContain('is_placeholder');
   });
@@ -516,16 +532,16 @@ describe('bulkDelete', () => {
         fromDate: '2026-04-30',
         placeholderOnly: true,
       },
-      exec,
+      testDb,
     );
     expect(result).toBe(5);
-    expect(exec.calls[0].params).toEqual(['p-1', 'Dev', 'mgr', '2026-04-30']);
+    expect(exec.calls[0].params).toEqual(['p-1', 'Dev', 'mgr', 'mgr', '2026-04-30', true]);
     const sql = exec.calls[0].sql;
-    expect(sql).toContain('project_id = $1');
-    expect(sql).toContain('task = $2');
+    expect(sql).toContain('"project_id" = $1');
+    expect(sql).toContain('"task" = $2');
     expect(sql).toContain('user_id = $3');
-    expect(sql).toContain('wum.user_id = $3');
-    expect(sql).toContain('date >= $4');
-    expect(sql).toContain('is_placeholder = true');
+    expect(sql).toContain('wum.user_id = $4');
+    expect(sql).toContain('"date" >= $5');
+    expect(sql).toContain('"is_placeholder" = $6');
   });
 });


### PR DESCRIPTION
## Summary

Tier 2 of the Drizzle Phase 3 conversion roadmap — the two next repos after `auditLogsRepo` (Tier 1, merged in #151). Two converted repositories, one new schema modeled, one route refactored to `withDbTransaction`.

- **`entriesRepo`** — cursor-paginated list functions stay on raw SQL via `executeRows` (microsecond-precision tuple compare via `created_at::text` can't be expressed by the Drizzle query builder); CRUD/lookups use the builder. Adds a Drizzle-flavored `managedUserIdsSubquerySql` to `workUnitsRepo` alongside the legacy `$N`-string helper (legacy stays until Tier 3 converts `workUnitsRepo` itself).

- **`clientOffersRepo`** — fully on the Drizzle builder. `update` uses the canonical `sql\`COALESCE(${value ?? null}, ${col})\`` pattern from `clientQuotesRepo`; `insertItems` uses `.insert().values(items.map(...)).returning()` with `numericForDb` per field. Single mappers consume `typeof customerOffers.$inferSelect` / `typeof customerOfferItems.$inferSelect` directly — no shadow row types.

- **`customer_offer_items` modeled for the first time** in `db/schema/customerOfferItems.ts` with the `chk_customer_offer_items_unit_type` CHECK and the offer-id FK declared. The `0005_claim_customer_offer_items.sql` migration is idempotent (`CREATE TABLE IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`, plus a `pg_constraint` guard for the FK that exists on pre-existing DBs under PG's default `_fkey` name vs Drizzle's generated `_fk` name).

- **`client-offers.ts`** — both `withTransaction` blocks switch to `withDbTransaction` (both repos in those blocks — `clientOffersRepo` and `clientQuotesRepo` — are now Drizzle-converted).

## Why

Continuation of the roadmap landed in commit `1562aa06` (and earlier — see `server/db/README.md`). 13/28 repositories now converted. The two repos here were chosen as the next tier because both have their underlying tables already modeled (or easily modelable for the items table), keeping each PR a focused conversion + minimal schema work.

## Notes for reviewers

- **Cursor pagination preservation in `entriesRepo`** — the microsecond-precision `(created_at, id) < ($N::timestamp, $N+1)` tuple compare and the `created_at::text AS created_at_text` column projection are load-bearing. The smoke check in the per-PR playbook is paginating across two rows whose `created_at` differs only in sub-millisecond digits.

- **Migration FK guard** — pre-existing DBs already have an FK from `customer_offer_items.offer_id` to `customer_offers(id)` under PG's default name `customer_offer_items_offer_id_fkey` (declared inline in `schema.sql`). The `DO $$ ... pg_constraint ... END $$` guard checks for any FK on `(offer_id, customer_offers)` regardless of constraint name, so the migration is idempotent on existing DBs and adds the FK on fresh ones.

- **`workUnitsRepo` dual API during Tier 2 → Tier 3 overlap** — the new `managedUserIdsSubquerySql` (Drizzle SQL fragment) and the legacy `managedUserIdsSubquery(paramIdx)` (raw `$N`-string) coexist until Tier 3 #5 converts `workUnitsRepo` itself.

- **Test pattern alignment** — both new test files use the established `setupTestDb()` + `defineRow`-style factory pattern from `clientQuotesRepo.test.ts` (e.g. `OFFER_BASE` + `offerRow(overrides)`).

## Test plan

- [x] `cd server && bun test test/` → 618/618 pass
- [x] `cd server && bun run db:check` → clean (snapshot consistent, no drift)
- [x] `cd server && bun run db:generate` → "No schema changes" (confirms `.\$type<UnitType>()` annotation is TS-only)
- [x] Root `tsc --noEmit` → clean
- [x] biome check → clean (lint-staged passes on every commit)
- [ ] Manual smoke (defer to merge prep): create offer with items → edit (exercises `replaceItems` in transaction) → delete (exercises CASCADE)
- [ ] Manual smoke: paginate `/api/entries` across sub-millisecond timestamps to verify cursor fidelity
- [ ] Manual smoke: bulk-delete entries via the manager-scope filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)