### PR TITLE
refactor(db): drizzle migration tier 6 — convert 4 reports repos

### DIFF
--- a/server/db/migrations/0017_claim_report_chat_tables.sql
+++ b/server/db/migrations/0017_claim_report_chat_tables.sql
@@ -1,0 +1,45 @@
+-- First-time-modeling migration for the report_chat_* tables (see db/README.md). All
+-- statements are guarded so this is a no-op on existing dev/prod DBs (which already have
+-- report_chat_sessions + report_chat_messages + their FKs and indexes from schema.sql)
+-- while still bootstrapping a fresh DB cleanly.
+
+CREATE TABLE IF NOT EXISTS "report_chat_messages" (
+	"id" varchar(50) PRIMARY KEY NOT NULL,
+	"session_id" varchar(50) NOT NULL,
+	"role" varchar(20) NOT NULL,
+	"content" text NOT NULL,
+	"thought_content" text,
+	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "report_chat_sessions" (
+	"id" varchar(50) PRIMARY KEY NOT NULL,
+	"user_id" varchar(50) NOT NULL,
+	"title" varchar(255) DEFAULT 'AI Reporting' NOT NULL,
+	"is_archived" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP,
+	"updated_at" timestamp DEFAULT CURRENT_TIMESTAMP
+);
+--> statement-breakpoint
+-- Pre-existing DBs already have FKs from schema.sql under PG's default names. Skip if any
+-- FK from this column to the parent table exists, regardless of name, to avoid duplicating.
+DO $$
+BEGIN
+	IF NOT EXISTS (
+		SELECT 1
+		FROM pg_constraint c
+		JOIN pg_class t ON t.oid = c.conrelid
+		JOIN pg_class ft ON ft.oid = c.confrelid
+		JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = ANY(c.conkey)
+		WHERE c.contype = 'f'
+			AND t.relname = 'report_chat_messages'
+			AND ft.relname = 'report_chat_sessions'
+			AND a.attname = 'session_id'
+	) THEN
+		ALTER TABLE "report_chat_messages" ADD CONSTRAINT "report_chat_messages_session_id_report_chat_sessions_id_fk" FOREIGN KEY ("session_id") REFERENCES "public"."report_chat_sessions"("id") ON DELETE cascade ON UPDATE no action;
+	END IF;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_report_chat_messages_session_created" ON "report_chat_messages" USING btree ("session_id","created_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_report_chat_sessions_user_updated" ON "report_chat_sessions" USING btree ("user_id","updated_at" DESC NULLS LAST);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_report_chat_sessions_user_archived" ON "report_chat_sessions" USING btree ("user_id","is_archived");

--- a/server/db/migrations/meta/0017_snapshot.json
+++ b/server/db/migrations/meta/0017_snapshot.json
@@ -1,0 +1,4178 @@
+{
+  "id": "093206bc-d2c3-4505-8829-6e8bf0e5eec7",
+  "prevId": "ca4a213e-be02-4993-a2c7-c175d428be99",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user.login'"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_audit_logs_created_at": {
+          "name": "idx_audit_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_user_id": {
+          "name": "idx_audit_logs_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_action": {
+          "name": "idx_audit_logs_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.client_profile_options": {
+      "name": "client_profile_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_client_profile_options_category_value_unique": {
+          "name": "idx_client_profile_options_category_value_unique",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "LOWER(\"value\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_client_profile_options_category_sort": {
+          "name": "idx_client_profile_options_category_sort",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_client_profile_options_category": {
+          "name": "chk_client_profile_options_category",
+          "value": "\"client_profile_options\".\"category\" IN ('sector', 'numberOfEmployees', 'revenue', 'officeCountRange')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'company'"
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_code": {
+          "name": "client_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ateco_code": {
+          "name": "ateco_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sector": {
+          "name": "sector",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_of_employees": {
+          "name": "number_of_employees",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revenue": {
+          "name": "revenue",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fiscal_code": {
+          "name": "fiscal_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "office_count_range": {
+          "name": "office_count_range",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "address_country": {
+          "name": "address_country",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_state": {
+          "name": "address_state",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_cap": {
+          "name": "address_cap",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_province": {
+          "name": "address_province",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_civic_number": {
+          "name": "address_civic_number",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line": {
+          "name": "address_line",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_clients_fiscal_code_unique": {
+          "name": "idx_clients_fiscal_code_unique",
+          "columns": [
+            {
+              "expression": "LOWER(\"fiscal_code\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"fiscal_code\" IS NOT NULL AND \"clients\".\"fiscal_code\" <> ''",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_clients_client_code_unique": {
+          "name": "idx_clients_client_code_unique",
+          "columns": [
+            {
+              "expression": "client_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"client_code\" IS NOT NULL AND \"clients\".\"client_code\" <> ''",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.customer_offer_items": {
+      "name": "customer_offer_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "offer_id": {
+          "name": "offer_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_cost": {
+          "name": "product_cost",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_mol_percentage": {
+          "name": "product_mol_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "unit_type": {
+          "name": "unit_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'hours'"
+        },
+        "supplier_quote_id": {
+          "name": "supplier_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_item_id": {
+          "name": "supplier_quote_item_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_supplier_name": {
+          "name": "supplier_quote_supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_unit_price": {
+          "name": "supplier_quote_unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_customer_offer_items_offer_id": {
+          "name": "idx_customer_offer_items_offer_id",
+          "columns": [
+            {
+              "expression": "offer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_offer_items_offer_id_customer_offers_id_fk": {
+          "name": "customer_offer_items_offer_id_customer_offers_id_fk",
+          "tableFrom": "customer_offer_items",
+          "tableTo": "customer_offers",
+          "columnsFrom": ["offer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_customer_offer_items_unit_type": {
+          "name": "chk_customer_offer_items_unit_type",
+          "value": "\"customer_offer_items\".\"unit_type\" IN ('hours', 'days', 'unit')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.customer_offers": {
+      "name": "customer_offers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_quote_id": {
+          "name": "linked_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_customer_offers_linked_quote_id": {
+          "name": "idx_customer_offers_linked_quote_id",
+          "columns": [
+            {
+              "expression": "linked_quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_offers_client_id": {
+          "name": "idx_customer_offers_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_offers_status": {
+          "name": "idx_customer_offers_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_offers_created_at": {
+          "name": "idx_customer_offers_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_offers_linked_quote_id_quotes_id_fk": {
+          "name": "customer_offers_linked_quote_id_quotes_id_fk",
+          "tableFrom": "customer_offers",
+          "tableTo": "quotes",
+          "columnsFrom": ["linked_quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_config": {
+      "name": "email_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "smtp_host": {
+          "name": "smtp_host",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "smtp_port": {
+          "name": "smtp_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 587
+        },
+        "smtp_encryption": {
+          "name": "smtp_encryption",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'tls'"
+        },
+        "smtp_reject_unauthorized": {
+          "name": "smtp_reject_unauthorized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "smtp_user": {
+          "name": "smtp_user",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "smtp_password": {
+          "name": "smtp_password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "from_email": {
+          "name": "from_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Praetor'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.general_settings": {
+      "name": "general_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'€'"
+        },
+        "daily_limit": {
+          "name": "daily_limit",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'8.00'"
+        },
+        "start_of_week": {
+          "name": "start_of_week",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Monday'"
+        },
+        "treat_saturday_as_holiday": {
+          "name": "treat_saturday_as_holiday",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "enable_ai_reporting": {
+          "name": "enable_ai_reporting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "gemini_api_key": {
+          "name": "gemini_api_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_provider": {
+          "name": "ai_provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'gemini'"
+        },
+        "openrouter_api_key": {
+          "name": "openrouter_api_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gemini_model_id": {
+          "name": "gemini_model_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "openrouter_model_id": {
+          "name": "openrouter_model_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_weekend_selection": {
+          "name": "allow_weekend_selection",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "default_location": {
+          "name": "default_location",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'remote'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoice_items": {
+      "name": "invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_of_measure": {
+          "name": "unit_of_measure",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unit'"
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoice_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "invoices",
+          "columnsFrom": ["invoice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_sale_id": {
+          "name": "linked_sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_date": {
+          "name": "issue_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "amount_paid": {
+          "name": "amount_paid",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_invoices_client_id": {
+          "name": "idx_invoices_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_status": {
+          "name": "idx_invoices_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_issue_date": {
+          "name": "idx_invoices_issue_date",
+          "columns": [
+            {
+              "expression": "issue_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ldap_config": {
+      "name": "ldap_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "server_url": {
+          "name": "server_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ldap://ldap.example.com:389'"
+        },
+        "base_dn": {
+          "name": "base_dn",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'dc=example,dc=com'"
+        },
+        "bind_dn": {
+          "name": "bind_dn",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'cn=read-only-admin,dc=example,dc=com'"
+        },
+        "bind_password": {
+          "name": "bind_password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "user_filter": {
+          "name": "user_filter",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'(uid={0})'"
+        },
+        "group_base_dn": {
+          "name": "group_base_dn",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ou=groups,dc=example,dc=com'"
+        },
+        "group_filter": {
+          "name": "group_filter",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'(member={0})'"
+        },
+        "role_mappings": {
+          "name": "role_mappings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_notifications_user_id": {
+          "name": "idx_notifications_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_user_unread": {
+          "name": "idx_notifications_user_unread",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notifications\".\"is_read\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.internal_product_categories": {
+      "name": "internal_product_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_unit": {
+          "name": "cost_unit",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unit'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_internal_product_categories_type": {
+          "name": "idx_internal_product_categories_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "internal_product_categories_name_type_key": {
+          "name": "internal_product_categories_name_type_key",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "internal_product_categories_cost_unit_check": {
+          "name": "internal_product_categories_cost_unit_check",
+          "value": "\"internal_product_categories\".\"cost_unit\" IN ('unit', 'hours')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.internal_product_subcategories": {
+      "name": "internal_product_subcategories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_internal_product_subcategories_category_id": {
+          "name": "idx_internal_product_subcategories_category_id",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "internal_product_subcategories_category_id_name_key": {
+          "name": "internal_product_subcategories_category_id_name_key",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "internal_product_subcategories_category_id_internal_product_categories_id_fk": {
+          "name": "internal_product_subcategories_category_id_internal_product_categories_id_fk",
+          "tableFrom": "internal_product_subcategories",
+          "tableTo": "internal_product_categories",
+          "columnsFrom": ["category_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_code": {
+          "name": "product_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "costo": {
+          "name": "costo",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "mol_percentage": {
+          "name": "mol_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "cost_unit": {
+          "name": "cost_unit",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unit'"
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'item'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subcategory": {
+          "name": "subcategory",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_products_name": {
+          "name": "idx_products_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_name_unique": {
+          "name": "idx_products_name_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_product_code_unique": {
+          "name": "idx_products_product_code_unique",
+          "columns": [
+            {
+              "expression": "product_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_supplier_id": {
+          "name": "idx_products_supplier_id",
+          "columns": [
+            {
+              "expression": "supplier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_type": {
+          "name": "idx_products_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "products_supplier_id_suppliers_id_fk": {
+          "name": "products_supplier_id_suppliers_id_fk",
+          "tableFrom": "products",
+          "tableTo": "suppliers",
+          "columnsFrom": ["supplier_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_types": {
+      "name": "product_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_unit": {
+          "name": "cost_unit",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unit'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_product_types_name": {
+          "name": "idx_product_types_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "product_types_name_unique": {
+          "name": "product_types_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "product_types_cost_unit_check": {
+          "name": "product_types_cost_unit_check",
+          "value": "\"product_types\".\"cost_unit\" IN ('unit', 'hours')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#3b82f6'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_projects_client_id": {
+          "name": "idx_projects_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quote_items": {
+      "name": "quote_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_cost": {
+          "name": "product_cost",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_mol_percentage": {
+          "name": "product_mol_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_id": {
+          "name": "supplier_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_item_id": {
+          "name": "supplier_quote_item_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_supplier_name": {
+          "name": "supplier_quote_supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_unit_price": {
+          "name": "supplier_quote_unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_type": {
+          "name": "unit_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'hours'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quote_items_quote_id_quotes_id_fk": {
+          "name": "quote_items_quote_id_quotes_id_fk",
+          "tableFrom": "quote_items",
+          "tableTo": "quotes",
+          "columnsFrom": ["quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quotes": {
+      "name": "quotes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_quotes_client_id": {
+          "name": "idx_quotes_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quotes_status": {
+          "name": "idx_quotes_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quotes_created_at": {
+          "name": "idx_quotes_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report_chat_messages": {
+      "name": "report_chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thought_content": {
+          "name": "thought_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_report_chat_messages_session_created": {
+          "name": "idx_report_chat_messages_session_created",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_chat_messages_session_id_report_chat_sessions_id_fk": {
+          "name": "report_chat_messages_session_id_report_chat_sessions_id_fk",
+          "tableFrom": "report_chat_messages",
+          "tableTo": "report_chat_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.report_chat_sessions": {
+      "name": "report_chat_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'AI Reporting'"
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_report_chat_sessions_user_updated": {
+          "name": "idx_report_chat_sessions_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_report_chat_sessions_user_archived": {
+          "name": "idx_report_chat_sessions_user_archived",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_permissions": {
+      "name": "role_permissions",
+      "schema": "",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_permissions_role_id_roles_id_fk": {
+          "name": "role_permissions_role_id_roles_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "roles",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "role_permissions_role_id_permission_pk": {
+          "name": "role_permissions_role_id_permission_pk",
+          "columns": ["role_id", "permission"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roles": {
+      "name": "roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_roles": {
+      "name": "user_roles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_roles_role_id_roles_id_fk": {
+          "name": "user_roles_role_id_roles_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "roles",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_roles_user_id_role_id_pk": {
+          "name": "user_roles_user_id_role_id_pk",
+          "columns": ["user_id", "role_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sale_items": {
+      "name": "sale_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sale_id": {
+          "name": "sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_cost": {
+          "name": "product_cost",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_mol_percentage": {
+          "name": "product_mol_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "unit_type": {
+          "name": "unit_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'hours'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_id": {
+          "name": "supplier_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_item_id": {
+          "name": "supplier_quote_item_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_supplier_name": {
+          "name": "supplier_quote_supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_unit_price": {
+          "name": "supplier_quote_unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_sale_id": {
+          "name": "supplier_sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_sale_item_id": {
+          "name": "supplier_sale_item_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_sale_supplier_name": {
+          "name": "supplier_sale_supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sale_items_sale_id_sales_id_fk": {
+          "name": "sale_items_sale_id_sales_id_fk",
+          "tableFrom": "sale_items",
+          "tableTo": "sales",
+          "columnsFrom": ["sale_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sales": {
+      "name": "sales",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_quote_id": {
+          "name": "linked_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_offer_id": {
+          "name": "linked_offer_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_sales_client_id": {
+          "name": "idx_sales_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_status": {
+          "name": "idx_sales_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_linked_quote_id": {
+          "name": "idx_sales_linked_quote_id",
+          "columns": [
+            {
+              "expression": "linked_quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_linked_offer_id": {
+          "name": "idx_sales_linked_offer_id",
+          "columns": [
+            {
+              "expression": "linked_offer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_linked_offer_id_unique": {
+          "name": "idx_sales_linked_offer_id_unique",
+          "columns": [
+            {
+              "expression": "linked_offer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sales\".\"linked_offer_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_created_at": {
+          "name": "idx_sales_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sales_linked_quote_id_quotes_id_fk": {
+          "name": "sales_linked_quote_id_quotes_id_fk",
+          "tableFrom": "sales",
+          "tableTo": "quotes",
+          "columnsFrom": ["linked_quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "sales_linked_offer_id_customer_offers_id_fk": {
+          "name": "sales_linked_offer_id_customer_offers_id_fk",
+          "tableFrom": "sales",
+          "tableTo": "customer_offers",
+          "columnsFrom": ["linked_offer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "daily_goal": {
+          "name": "daily_goal",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'8.00'"
+        },
+        "start_of_week": {
+          "name": "start_of_week",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Monday'"
+        },
+        "compact_view": {
+          "name": "compact_view",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "treat_saturday_as_holiday": {
+          "name": "treat_saturday_as_holiday",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "settings_user_id_unique": {
+          "name": "settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_invoice_items": {
+      "name": "supplier_invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_invoice_items_invoice_id": {
+          "name": "idx_supplier_invoice_items_invoice_id",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_invoice_items_invoice_id_supplier_invoices_id_fk": {
+          "name": "supplier_invoice_items_invoice_id_supplier_invoices_id_fk",
+          "tableFrom": "supplier_invoice_items",
+          "tableTo": "supplier_invoices",
+          "columnsFrom": ["invoice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_invoices": {
+      "name": "supplier_invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_sale_id": {
+          "name": "linked_sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_name": {
+          "name": "supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_date": {
+          "name": "issue_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "amount_paid": {
+          "name": "amount_paid",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_invoices_supplier_id": {
+          "name": "idx_supplier_invoices_supplier_id",
+          "columns": [
+            {
+              "expression": "supplier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_invoices_status": {
+          "name": "idx_supplier_invoices_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_invoices_issue_date": {
+          "name": "idx_supplier_invoices_issue_date",
+          "columns": [
+            {
+              "expression": "issue_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_invoices_linked_sale_id": {
+          "name": "idx_supplier_invoices_linked_sale_id",
+          "columns": [
+            {
+              "expression": "linked_sale_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_invoices_linked_sale_id_unique": {
+          "name": "idx_supplier_invoices_linked_sale_id_unique",
+          "columns": [
+            {
+              "expression": "linked_sale_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"supplier_invoices\".\"linked_sale_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_invoices_linked_sale_id_supplier_sales_id_fk": {
+          "name": "supplier_invoices_linked_sale_id_supplier_sales_id_fk",
+          "tableFrom": "supplier_invoices",
+          "tableTo": "supplier_sales",
+          "columnsFrom": ["linked_sale_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "supplier_invoices_supplier_id_suppliers_id_fk": {
+          "name": "supplier_invoices_supplier_id_suppliers_id_fk",
+          "tableFrom": "supplier_invoices",
+          "tableTo": "suppliers",
+          "columnsFrom": ["supplier_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "supplier_invoices_status_check": {
+          "name": "supplier_invoices_status_check",
+          "value": "\"supplier_invoices\".\"status\" IN ('draft', 'sent', 'paid', 'overdue', 'cancelled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier_quote_items": {
+      "name": "supplier_quote_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "unit_type": {
+          "name": "unit_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'hours'"
+        }
+      },
+      "indexes": {
+        "idx_supplier_quote_items_quote_id": {
+          "name": "idx_supplier_quote_items_quote_id",
+          "columns": [
+            {
+              "expression": "quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_quote_items_quote_id_supplier_quotes_id_fk": {
+          "name": "supplier_quote_items_quote_id_supplier_quotes_id_fk",
+          "tableFrom": "supplier_quote_items",
+          "tableTo": "supplier_quotes",
+          "columnsFrom": ["quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_supplier_quote_items_unit_type": {
+          "name": "chk_supplier_quote_items_unit_type",
+          "value": "\"supplier_quote_items\".\"unit_type\" IN ('hours', 'days', 'unit')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier_quotes": {
+      "name": "supplier_quotes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_name": {
+          "name": "supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_quotes_supplier_id": {
+          "name": "idx_supplier_quotes_supplier_id",
+          "columns": [
+            {
+              "expression": "supplier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_quotes_status": {
+          "name": "idx_supplier_quotes_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_quotes_created_at": {
+          "name": "idx_supplier_quotes_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_quotes_supplier_id_suppliers_id_fk": {
+          "name": "supplier_quotes_supplier_id_suppliers_id_fk",
+          "tableFrom": "supplier_quotes",
+          "tableTo": "suppliers",
+          "columnsFrom": ["supplier_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "supplier_quotes_status_check": {
+          "name": "supplier_quotes_status_check",
+          "value": "\"supplier_quotes\".\"status\" IN ('received', 'approved', 'rejected', 'draft', 'sent', 'accepted', 'denied')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier_sale_items": {
+      "name": "supplier_sale_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sale_id": {
+          "name": "sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "supplier_sale_items_sale_id_supplier_sales_id_fk": {
+          "name": "supplier_sale_items_sale_id_supplier_sales_id_fk",
+          "tableFrom": "supplier_sale_items",
+          "tableTo": "supplier_sales",
+          "columnsFrom": ["sale_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_sales": {
+      "name": "supplier_sales",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_quote_id": {
+          "name": "linked_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_name": {
+          "name": "supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.suppliers": {
+      "name": "suppliers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "supplier_code": {
+          "name": "supplier_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_code": {
+          "name": "tax_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_suppliers_name": {
+          "name": "idx_suppliers_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "recurrence_pattern": {
+          "name": "recurrence_pattern",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_start": {
+          "name": "recurrence_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_end": {
+          "name": "recurrence_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_duration": {
+          "name": "recurrence_duration",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "expected_effort": {
+          "name": "expected_effort",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "revenue": {
+          "name": "revenue",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_tasks": {
+      "name": "user_tasks",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_source": {
+          "name": "assignment_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_tasks_task_id_tasks_id_fk": {
+          "name": "user_tasks_task_id_tasks_id_fk",
+          "tableFrom": "user_tasks",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_tasks_user_id_task_id_pk": {
+          "name": "user_tasks_user_id_task_id_pk",
+          "columns": ["user_id", "task_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.time_entries": {
+      "name": "time_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_name": {
+          "name": "project_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task": {
+          "name": "task",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "hourly_cost": {
+          "name": "hourly_cost",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "is_placeholder": {
+          "name": "is_placeholder",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'remote'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_time_entries_task_id": {
+          "name": "idx_time_entries_task_id",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "time_entries_task_id_tasks_id_fk": {
+          "name": "time_entries_task_id_tasks_id_fk",
+          "tableFrom": "time_entries",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_initials": {
+          "name": "avatar_initials",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_per_hour": {
+          "name": "cost_per_hour",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "employee_type": {
+          "name": "employee_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'app_user'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": ["username"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_work_units": {
+      "name": "user_work_units",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "work_unit_id": {
+          "name": "work_unit_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_work_units_user_id_work_unit_id_pk": {
+          "name": "user_work_units_user_id_work_unit_id_pk",
+          "columns": ["user_id", "work_unit_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.work_unit_managers": {
+      "name": "work_unit_managers",
+      "schema": "",
+      "columns": {
+        "work_unit_id": {
+          "name": "work_unit_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "work_unit_managers_work_unit_id_user_id_pk": {
+          "name": "work_unit_managers_work_unit_id_user_id_pk",
+          "columns": ["work_unit_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.work_units": {
+      "name": "work_units",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1777810497762,
       "tag": "0016_claim_products_and_categories",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1777820744011,
+      "tag": "0017_claim_report_chat_tables",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/schema/index.ts
+++ b/server/db/schema/index.ts
@@ -14,6 +14,8 @@ export * from './products.ts';
 export * from './productTypes.ts';
 export * from './projects.ts';
 export * from './quotes.ts';
+export * from './reportChatMessages.ts';
+export * from './reportChatSessions.ts';
 export * from './roles.ts';
 export * from './sales.ts';
 export * from './settings.ts';

--- a/server/db/schema/reportChatMessages.ts
+++ b/server/db/schema/reportChatMessages.ts
@@ -1,0 +1,23 @@
+import { sql } from 'drizzle-orm';
+import { index, pgTable, text, timestamp, varchar } from 'drizzle-orm/pg-core';
+import { reportChatSessions } from './reportChatSessions.ts';
+
+// `role` carries a CHECK (role IN ('user', 'assistant')) constraint at the DB level
+// (defined in schema.sql). Drizzle's pg-core has no first-class CHECK helper — don't
+// broaden the role union without coordinating a CHECK update.
+export const reportChatMessages = pgTable(
+  'report_chat_messages',
+  {
+    id: varchar('id', { length: 50 }).primaryKey(),
+    sessionId: varchar('session_id', { length: 50 })
+      .notNull()
+      .references(() => reportChatSessions.id, { onDelete: 'cascade' }),
+    role: varchar('role', { length: 20 }).notNull(),
+    content: text('content').notNull(),
+    thoughtContent: text('thought_content'),
+    createdAt: timestamp('created_at').default(sql`CURRENT_TIMESTAMP`),
+  },
+  (table) => [
+    index('idx_report_chat_messages_session_created').on(table.sessionId, table.createdAt.asc()),
+  ],
+);

--- a/server/db/schema/reportChatSessions.ts
+++ b/server/db/schema/reportChatSessions.ts
@@ -1,0 +1,21 @@
+import { sql } from 'drizzle-orm';
+import { boolean, index, pgTable, timestamp, varchar } from 'drizzle-orm/pg-core';
+
+// `user_id` has a runtime FK to `users(id) ON DELETE CASCADE` (defined in schema.sql) —
+// same carve-out as `notifications.user_id`: the FK lives in schema.sql until a follow-up
+// tier claims it with a constraint-existence guard.
+export const reportChatSessions = pgTable(
+  'report_chat_sessions',
+  {
+    id: varchar('id', { length: 50 }).primaryKey(),
+    userId: varchar('user_id', { length: 50 }).notNull(),
+    title: varchar('title', { length: 255 }).notNull().default('AI Reporting'),
+    isArchived: boolean('is_archived').notNull().default(false),
+    createdAt: timestamp('created_at').default(sql`CURRENT_TIMESTAMP`),
+    updatedAt: timestamp('updated_at').default(sql`CURRENT_TIMESTAMP`),
+  },
+  (table) => [
+    index('idx_report_chat_sessions_user_updated').on(table.userId, table.updatedAt.desc()),
+    index('idx_report_chat_sessions_user_archived').on(table.userId, table.isArchived),
+  ],
+);

--- a/server/repositories/reportsAiChatRepo.ts
+++ b/server/repositories/reportsAiChatRepo.ts
@@ -1,8 +1,15 @@
-import pool, { type QueryExecutor } from '../db/index.ts';
+import { and, asc, desc, eq, gt, lt, lte, sql } from 'drizzle-orm';
+import { type DbExecutor, db } from '../db/drizzle.ts';
+import { reportChatMessages } from '../db/schema/reportChatMessages.ts';
+import { reportChatSessions } from '../db/schema/reportChatSessions.ts';
 
 export const DEFAULT_CHAT_TITLE = 'AI Reporting';
 export const RPT_CHAT_ID_PREFIX = 'rpt-chat';
 export const RPT_MSG_ID_PREFIX = 'rpt-msg';
+
+// Mirrors the DB-side CHECK (role IN ('user', 'assistant')) on report_chat_messages.role.
+export const CHAT_ROLE = { user: 'user', assistant: 'assistant' } as const;
+export type ChatRole = (typeof CHAT_ROLE)[keyof typeof CHAT_ROLE];
 
 export type ChatSessionSummary = {
   id: string;
@@ -32,148 +39,154 @@ export type ChatMessageRef = {
 
 export const listSessionsForUser = async (
   userId: string,
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<ChatSessionSummary[]> => {
-  const { rows } = await exec.query<ChatSessionSummary>(
-    `SELECT
-        id,
-        COALESCE(title, '') as title,
-        (EXTRACT(EPOCH FROM created_at) * 1000)::float8 as "createdAt",
-        (EXTRACT(EPOCH FROM updated_at) * 1000)::float8 as "updatedAt"
-       FROM report_chat_sessions
-      WHERE user_id = $1 AND is_archived = FALSE
-      ORDER BY updated_at DESC
-      LIMIT 50`,
-    [userId],
-  );
-  return rows;
+  const rows = await exec
+    .select({
+      id: reportChatSessions.id,
+      title: reportChatSessions.title,
+      createdAt: reportChatSessions.createdAt,
+      updatedAt: reportChatSessions.updatedAt,
+    })
+    .from(reportChatSessions)
+    .where(and(eq(reportChatSessions.userId, userId), eq(reportChatSessions.isArchived, false)))
+    .orderBy(desc(reportChatSessions.updatedAt))
+    .limit(50);
+  return rows.map((r) => ({
+    id: r.id,
+    title: r.title ?? '',
+    // `created_at`/`updated_at` are nullable in the schema but have DEFAULT
+    // CURRENT_TIMESTAMP — `?? 0` is a TS-strict appeasement for the unreachable branch.
+    createdAt: r.createdAt?.getTime() ?? 0,
+    updatedAt: r.updatedAt?.getTime() ?? 0,
+  }));
 };
 
 export const createSession = async (
   id: string,
   userId: string,
   title: string,
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<void> => {
-  await exec.query(
-    `INSERT INTO report_chat_sessions (id, user_id, title, is_archived, created_at, updated_at)
-     VALUES ($1, $2, $3, FALSE, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
-    [id, userId, title],
-  );
+  await exec.insert(reportChatSessions).values({
+    id,
+    userId,
+    title,
+    isArchived: false,
+  });
 };
 
 export const archiveSession = async (
   id: string,
   userId: string,
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<boolean> => {
-  const { rowCount } = await exec.query(
-    `UPDATE report_chat_sessions
-        SET is_archived = TRUE, updated_at = CURRENT_TIMESTAMP
-      WHERE id = $1 AND user_id = $2`,
-    [id, userId],
-  );
-  return (rowCount ?? 0) > 0;
+  const result = await exec
+    .update(reportChatSessions)
+    .set({ isArchived: true, updatedAt: sql`CURRENT_TIMESTAMP` })
+    .where(and(eq(reportChatSessions.id, id), eq(reportChatSessions.userId, userId)));
+  return (result.rowCount ?? 0) > 0;
 };
 
 export const sessionExistsForUser = async (
   id: string,
   userId: string,
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<boolean> => {
-  const { rowCount } = await exec.query(
-    `SELECT 1 FROM report_chat_sessions WHERE id = $1 AND user_id = $2 LIMIT 1`,
-    [id, userId],
-  );
-  return (rowCount ?? 0) > 0;
+  const result = await exec
+    .select({ exists: sql`1` })
+    .from(reportChatSessions)
+    .where(and(eq(reportChatSessions.id, id), eq(reportChatSessions.userId, userId)))
+    .limit(1);
+  return result.length > 0;
 };
 
 export const getActiveSessionForUser = async (
   id: string,
   userId: string,
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<{ title: string } | null> => {
-  const { rows } = await exec.query<{ title: string }>(
-    `SELECT COALESCE(title, '') as title
-       FROM report_chat_sessions
-      WHERE id = $1 AND user_id = $2 AND is_archived = FALSE
-      LIMIT 1`,
-    [id, userId],
-  );
-  return rows[0] ?? null;
+  const rows = await exec
+    .select({ title: reportChatSessions.title })
+    .from(reportChatSessions)
+    .where(
+      and(
+        eq(reportChatSessions.id, id),
+        eq(reportChatSessions.userId, userId),
+        eq(reportChatSessions.isArchived, false),
+      ),
+    )
+    .limit(1);
+  const row = rows[0];
+  if (!row) return null;
+  return { title: row.title ?? '' };
 };
 
 export const updateSessionTitleAndTouch = async (
   id: string,
   userId: string,
   candidateTitle: string,
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<void> => {
-  await exec.query(
-    `UPDATE report_chat_sessions
-        SET updated_at = CURRENT_TIMESTAMP,
-            title = CASE
-              WHEN BTRIM(title) = '' OR title = $4 THEN LEFT($2, 80)
-              ELSE title
-            END
-      WHERE id = $1 AND user_id = $3`,
-    [id, candidateTitle, userId, DEFAULT_CHAT_TITLE],
-  );
+  await exec
+    .update(reportChatSessions)
+    .set({
+      updatedAt: sql`CURRENT_TIMESTAMP`,
+      // Only overwrite the title when it's blank or still the default — preserves any
+      // user-edited title across re-sends.
+      title: sql`CASE
+        WHEN BTRIM(${reportChatSessions.title}) = '' OR ${reportChatSessions.title} = ${DEFAULT_CHAT_TITLE}
+        THEN LEFT(${candidateTitle}, 80)
+        ELSE ${reportChatSessions.title}
+      END`,
+    })
+    .where(and(eq(reportChatSessions.id, id), eq(reportChatSessions.userId, userId)));
 };
 
 export const touchSession = async (
   id: string,
   userId: string,
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<void> => {
-  await exec.query(
-    `UPDATE report_chat_sessions
-        SET updated_at = CURRENT_TIMESTAMP
-      WHERE id = $1 AND user_id = $2`,
-    [id, userId],
-  );
+  await exec
+    .update(reportChatSessions)
+    .set({ updatedAt: sql`CURRENT_TIMESTAMP` })
+    .where(and(eq(reportChatSessions.id, id), eq(reportChatSessions.userId, userId)));
 };
 
 export const listMessagesForSession = async (
   sessionId: string,
   options: { beforeMs: number | null; limit: number },
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<ChatMessage[]> => {
   const { beforeMs, limit } = options;
-  const { rows } =
+  const where =
     beforeMs == null
-      ? await exec.query<ChatMessage>(
-          `SELECT
-              id,
-              session_id as "sessionId",
-              COALESCE(role, '') as role,
-              COALESCE(content, '') as content,
-              thought_content as "thoughtContent",
-              (EXTRACT(EPOCH FROM created_at) * 1000)::float8 as "createdAt"
-            FROM report_chat_messages
-           WHERE session_id = $1
-           ORDER BY created_at DESC
-           LIMIT $2`,
-          [sessionId, limit],
-        )
-      : await exec.query<ChatMessage>(
-          `SELECT
-              id,
-              session_id as "sessionId",
-              COALESCE(role, '') as role,
-              COALESCE(content, '') as content,
-              thought_content as "thoughtContent",
-              (EXTRACT(EPOCH FROM created_at) * 1000)::float8 as "createdAt"
-            FROM report_chat_messages
-           WHERE session_id = $1
-             AND created_at < TO_TIMESTAMP($2 / 1000.0)
-           ORDER BY created_at DESC
-           LIMIT $3`,
-          [sessionId, beforeMs, limit],
+      ? eq(reportChatMessages.sessionId, sessionId)
+      : and(
+          eq(reportChatMessages.sessionId, sessionId),
+          lt(reportChatMessages.createdAt, sql`TO_TIMESTAMP(${beforeMs} / 1000.0)`),
         );
+  const rows = await exec
+    .select({
+      id: reportChatMessages.id,
+      sessionId: reportChatMessages.sessionId,
+      role: reportChatMessages.role,
+      content: reportChatMessages.content,
+      thoughtContent: reportChatMessages.thoughtContent,
+      createdAt: reportChatMessages.createdAt,
+    })
+    .from(reportChatMessages)
+    .where(where)
+    .orderBy(desc(reportChatMessages.createdAt))
+    .limit(limit);
   return rows.map((r) => ({
-    ...r,
-    thoughtContent: r.thoughtContent ? String(r.thoughtContent) : null,
+    id: r.id,
+    sessionId: r.sessionId,
+    role: r.role ?? '',
+    content: r.content ?? '',
+    thoughtContent: r.thoughtContent || null,
+    createdAt: r.createdAt?.getTime() ?? 0,
   }));
 };
 
@@ -182,43 +195,36 @@ export type RecentMessageOptions = { limit?: number; beforeOrAt?: Date };
 export const listRecentMessages = async (
   sessionId: string,
   options: RecentMessageOptions = {},
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<ConversationTurn[]> => {
   const limit = options.limit ?? 20;
-  if (options.beforeOrAt) {
-    const { rows } = await exec.query<ConversationTurn>(
-      `SELECT COALESCE(role, '') as role, COALESCE(content, '') as content
-         FROM report_chat_messages
-        WHERE session_id = $1
-          AND created_at <= $2
-        ORDER BY created_at DESC
-        LIMIT $3`,
-      [sessionId, options.beforeOrAt, limit],
-    );
-    return rows;
-  }
-  const { rows } = await exec.query<ConversationTurn>(
-    `SELECT COALESCE(role, '') as role, COALESCE(content, '') as content
-       FROM report_chat_messages
-      WHERE session_id = $1
-      ORDER BY created_at DESC
-      LIMIT $2`,
-    [sessionId, limit],
-  );
-  return rows;
+  const where = options.beforeOrAt
+    ? and(
+        eq(reportChatMessages.sessionId, sessionId),
+        lte(reportChatMessages.createdAt, options.beforeOrAt),
+      )
+    : eq(reportChatMessages.sessionId, sessionId);
+  const rows = await exec
+    .select({ role: reportChatMessages.role, content: reportChatMessages.content })
+    .from(reportChatMessages)
+    .where(where)
+    .orderBy(desc(reportChatMessages.createdAt))
+    .limit(limit);
+  return rows.map((r) => ({ role: r.role ?? '', content: r.content ?? '' }));
 };
 
 export const insertUserMessage = async (
   id: string,
   sessionId: string,
   content: string,
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<void> => {
-  await exec.query(
-    `INSERT INTO report_chat_messages (id, session_id, role, content, created_at)
-     VALUES ($1, $2, 'user', $3, CURRENT_TIMESTAMP)`,
-    [id, sessionId, content],
-  );
+  await exec.insert(reportChatMessages).values({
+    id,
+    sessionId,
+    role: CHAT_ROLE.user,
+    content,
+  });
 };
 
 export type InsertAssistantMessageInput = {
@@ -231,70 +237,82 @@ export type InsertAssistantMessageInput = {
 
 export const insertAssistantMessage = async (
   input: InsertAssistantMessageInput,
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<void> => {
-  await exec.query(
-    `INSERT INTO report_chat_messages (id, session_id, role, content, thought_content, created_at)
-     VALUES ($1, $2, 'assistant', $3, $4, COALESCE($5::timestamptz, CURRENT_TIMESTAMP))`,
-    [input.id, input.sessionId, input.content, input.thoughtContent, input.createdAt ?? null],
-  );
+  await exec.insert(reportChatMessages).values({
+    id: input.id,
+    sessionId: input.sessionId,
+    role: CHAT_ROLE.assistant,
+    content: input.content,
+    thoughtContent: input.thoughtContent,
+    ...(input.createdAt !== undefined ? { createdAt: new Date(input.createdAt) } : {}),
+  });
 };
 
 export const findUserMessage = async (
   messageId: string,
   sessionId: string,
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<ChatMessageRef | null> => {
-  const { rows } = await exec.query<ChatMessageRef>(
-    `SELECT id, created_at as "createdAt"
-       FROM report_chat_messages
-      WHERE id = $1 AND session_id = $2 AND role = 'user'
-      LIMIT 1`,
-    [messageId, sessionId],
-  );
-  return rows[0] ?? null;
+  const rows = await exec
+    .select({ id: reportChatMessages.id, createdAt: reportChatMessages.createdAt })
+    .from(reportChatMessages)
+    .where(
+      and(
+        eq(reportChatMessages.id, messageId),
+        eq(reportChatMessages.sessionId, sessionId),
+        eq(reportChatMessages.role, CHAT_ROLE.user),
+      ),
+    )
+    .limit(1);
+  const row = rows[0];
+  return row?.createdAt ? { id: row.id, createdAt: row.createdAt } : null;
 };
 
 export const findFirstAssistantAfter = async (
   sessionId: string,
   afterDate: Date,
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<ChatMessageRef | null> => {
-  const { rows } = await exec.query<ChatMessageRef>(
-    `SELECT id, created_at as "createdAt"
-       FROM report_chat_messages
-      WHERE session_id = $1 AND role = 'assistant'
-        AND created_at > $2
-      ORDER BY created_at ASC
-      LIMIT 1`,
-    [sessionId, afterDate],
-  );
-  return rows[0] ?? null;
+  const rows = await exec
+    .select({ id: reportChatMessages.id, createdAt: reportChatMessages.createdAt })
+    .from(reportChatMessages)
+    .where(
+      and(
+        eq(reportChatMessages.sessionId, sessionId),
+        eq(reportChatMessages.role, CHAT_ROLE.assistant),
+        gt(reportChatMessages.createdAt, afterDate),
+      ),
+    )
+    .orderBy(asc(reportChatMessages.createdAt))
+    .limit(1);
+  const row = rows[0];
+  return row?.createdAt ? { id: row.id, createdAt: row.createdAt } : null;
 };
 
-export const deleteMessage = async (id: string, exec: QueryExecutor = pool): Promise<void> => {
-  await exec.query(`DELETE FROM report_chat_messages WHERE id = $1`, [id]);
+export const deleteMessage = async (id: string, exec: DbExecutor = db): Promise<void> => {
+  await exec.delete(reportChatMessages).where(eq(reportChatMessages.id, id));
 };
 
 export const updateMessageContent = async (
   id: string,
   content: string,
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<void> => {
-  await exec.query(`UPDATE report_chat_messages SET content = $1 WHERE id = $2`, [content, id]);
+  await exec.update(reportChatMessages).set({ content }).where(eq(reportChatMessages.id, id));
 };
 
 export const getFirstUserMessageContent = async (
   sessionId: string,
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<string> => {
-  const { rows } = await exec.query<{ content: string }>(
-    `SELECT COALESCE(content, '') as content
-       FROM report_chat_messages
-      WHERE session_id = $1 AND role = 'user'
-      ORDER BY created_at ASC
-      LIMIT 1`,
-    [sessionId],
-  );
+  const rows = await exec
+    .select({ content: reportChatMessages.content })
+    .from(reportChatMessages)
+    .where(
+      and(eq(reportChatMessages.sessionId, sessionId), eq(reportChatMessages.role, CHAT_ROLE.user)),
+    )
+    .orderBy(asc(reportChatMessages.createdAt))
+    .limit(1);
   return rows[0]?.content ?? '';
 };

--- a/server/repositories/reportsAiChatRepo.ts
+++ b/server/repositories/reportsAiChatRepo.ts
@@ -54,7 +54,7 @@ export const listSessionsForUser = async (
     .limit(50);
   return rows.map((r) => ({
     id: r.id,
-    title: r.title ?? '',
+    title: r.title,
     // `created_at`/`updated_at` are nullable in the schema but have DEFAULT
     // CURRENT_TIMESTAMP — `?? 0` is a TS-strict appeasement for the unreachable branch.
     createdAt: r.createdAt?.getTime() ?? 0,
@@ -119,7 +119,7 @@ export const getActiveSessionForUser = async (
     .limit(1);
   const row = rows[0];
   if (!row) return null;
-  return { title: row.title ?? '' };
+  return { title: row.title };
 };
 
 export const updateSessionTitleAndTouch = async (
@@ -183,9 +183,11 @@ export const listMessagesForSession = async (
   return rows.map((r) => ({
     id: r.id,
     sessionId: r.sessionId,
-    role: r.role ?? '',
-    content: r.content ?? '',
+    role: r.role,
+    content: r.content,
     thoughtContent: r.thoughtContent || null,
+    // `created_at` is nullable in the schema but has DEFAULT CURRENT_TIMESTAMP —
+    // `?? 0` is a TS-strict appeasement for the unreachable branch.
     createdAt: r.createdAt?.getTime() ?? 0,
   }));
 };
@@ -210,7 +212,7 @@ export const listRecentMessages = async (
     .where(where)
     .orderBy(desc(reportChatMessages.createdAt))
     .limit(limit);
-  return rows.map((r) => ({ role: r.role ?? '', content: r.content ?? '' }));
+  return rows.map((r) => ({ role: r.role, content: r.content }));
 };
 
 export const insertUserMessage = async (

--- a/server/repositories/reportsCatalogRepo.ts
+++ b/server/repositories/reportsCatalogRepo.ts
@@ -1,5 +1,6 @@
-import pool, { type QueryExecutor } from '../db/index.ts';
-import { toDbNumber as toNumber, toDbText as toText } from '../utils/parse.ts';
+import { sql } from 'drizzle-orm';
+import { type DbExecutor, db, executeRows } from '../db/drizzle.ts';
+import { toDbNumber, toDbText } from '../utils/parse.ts';
 
 type SupplierRow = {
   id: string;
@@ -48,19 +49,21 @@ export type SuppliersSection = {
 
 export const getSuppliersSection = async (
   opts: SuppliersSectionOptions,
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<SuppliersSection> => {
   const { fromDate, toDate, canViewSupplierQuotes, canListProducts, itemsLimit } = opts;
 
-  const [summaryRes, listRes] = await Promise.all([
-    exec.query<{ count: string; disabled_count: string }>(
-      `SELECT
+  const [summaryRows, listRows] = await Promise.all([
+    executeRows<{ count: string; disabled_count: string }>(
+      exec,
+      sql`SELECT
           COUNT(*) as count,
           SUM(CASE WHEN is_disabled THEN 1 ELSE 0 END) as disabled_count
          FROM suppliers`,
     ),
-    exec.query<SupplierRow>(
-      `SELECT
+    executeRows<SupplierRow>(
+      exec,
+      sql`SELECT
           id,
           name,
           supplier_code,
@@ -71,19 +74,18 @@ export const getSuppliersSection = async (
           is_disabled
          FROM suppliers
         ORDER BY name ASC
-        LIMIT $1`,
-      [itemsLimit],
+        LIMIT ${itemsLimit}`,
     ),
   ]);
 
-  const items: SupplierInfo[] = listRes.rows.map((r) => ({
-    id: toText(r.id),
-    name: toText(r.name),
-    supplierCode: toText(r.supplier_code),
-    contactName: toText(r.contact_name),
-    email: toText(r.email),
-    phone: toText(r.phone),
-    address: toText(r.address),
+  const items: SupplierInfo[] = listRows.map((r) => ({
+    id: toDbText(r.id),
+    name: toDbText(r.name),
+    supplierCode: toDbText(r.supplier_code),
+    contactName: toDbText(r.contact_name),
+    email: toDbText(r.email),
+    phone: toDbText(r.phone),
+    address: toDbText(r.address),
     isDisabled: Boolean(r.is_disabled),
   }));
 
@@ -100,17 +102,18 @@ export const getSuppliersSection = async (
 
   if (supplierIds.length > 0) {
     const quoteStatsPromise = canViewSupplierQuotes
-      ? exec.query<{ supplier_id: string; quote_count: string; net_value: string }>(
-          `WITH per_quote AS (
+      ? executeRows<{ supplier_id: string; quote_count: string; net_value: string }>(
+          exec,
+          sql`WITH per_quote AS (
               SELECT
                 sq.id,
                 sq.supplier_id,
                 SUM(sqi.quantity * sqi.unit_price) as net_value
               FROM supplier_quotes sq
               JOIN supplier_quote_items sqi ON sqi.quote_id = sq.id
-             WHERE sq.created_at::date >= $1
-               AND sq.created_at::date <= $2
-               AND sq.supplier_id = ANY($3)
+             WHERE sq.created_at::date >= ${fromDate}
+               AND sq.created_at::date <= ${toDate}
+               AND sq.supplier_id = ANY(${sql.param(supplierIds)})
              GROUP BY sq.id
            )
           SELECT
@@ -119,51 +122,51 @@ export const getSuppliersSection = async (
             COALESCE(SUM(net_value), 0) as net_value
             FROM per_quote
            GROUP BY supplier_id`,
-          [fromDate, toDate, supplierIds],
         )
       : null;
 
     const productStatsPromise = canListProducts
-      ? exec.query<{ supplier_id: string; product_count: string }>(
-          `SELECT supplier_id, COUNT(*) as product_count
+      ? executeRows<{ supplier_id: string; product_count: string }>(
+          exec,
+          sql`SELECT supplier_id, COUNT(*) as product_count
              FROM products
-            WHERE supplier_id = ANY($1)
+            WHERE supplier_id = ANY(${sql.param(supplierIds)})
             GROUP BY supplier_id`,
-          [supplierIds],
         )
       : null;
 
-    const [quoteStats, productStats] = await Promise.all([quoteStatsPromise, productStatsPromise]);
+    const [quoteStatsRows, productStatsRows] = await Promise.all([
+      quoteStatsPromise,
+      productStatsPromise,
+    ]);
 
-    if (quoteStats) {
-      for (const row of quoteStats.rows) {
-        const target = activityBySupplier.get(toText(row.supplier_id));
+    if (quoteStatsRows) {
+      for (const row of quoteStatsRows) {
+        const target = activityBySupplier.get(toDbText(row.supplier_id));
         if (!target) continue;
-        target.quotesCount = toNumber(row.quote_count);
-        target.quotesNet = toNumber(row.net_value);
+        target.quotesCount = toDbNumber(row.quote_count);
+        target.quotesNet = toDbNumber(row.net_value);
       }
     }
 
-    if (productStats) {
-      for (const row of productStats.rows) {
-        const target = activityBySupplier.get(toText(row.supplier_id));
+    if (productStatsRows) {
+      for (const row of productStatsRows) {
+        const target = activityBySupplier.get(toDbText(row.supplier_id));
         if (!target) continue;
-        target.productsCount = toNumber(row.product_count);
+        target.productsCount = toDbNumber(row.product_count);
       }
     }
   }
 
-  const supplierCount = toNumber(summaryRes.rows[0]?.count);
-  const supplierDisabledCount = toNumber(summaryRes.rows[0]?.disabled_count);
+  const supplierCount = toDbNumber(summaryRows[0]?.count);
+  const supplierDisabledCount = toDbNumber(summaryRows[0]?.disabled_count);
 
   return {
     count: supplierCount,
     activeCount: Math.max(supplierCount - supplierDisabledCount, 0),
     disabledCount: supplierDisabledCount,
     items,
-    activitySummary: supplierIds
-      .map((id) => activityBySupplier.get(id))
-      .filter((a): a is SupplierActivity => a !== undefined),
+    activitySummary: Array.from(activityBySupplier.values()),
   };
 };
 
@@ -190,19 +193,20 @@ export type SupplierQuotesSection = {
 
 export const getSupplierQuotesSection = async (
   opts: SupplierQuotesSectionOptions,
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<SupplierQuotesSection> => {
   const { fromDate, toDate, topLimit } = opts;
 
   const [totals, byStatus, byMonth, topSuppliers, topQuotes] = await Promise.all([
-    exec.query<{ count: string; total_net: string; avg_net: string }>(
-      `WITH per_quote AS (
+    executeRows<{ count: string; total_net: string; avg_net: string }>(
+      exec,
+      sql`WITH per_quote AS (
           SELECT
             sq.id,
             SUM(sqi.quantity * sqi.unit_price) as net_value
             FROM supplier_quotes sq
             JOIN supplier_quote_items sqi ON sqi.quote_id = sq.id
-           WHERE sq.created_at::date >= $1 AND sq.created_at::date <= $2
+           WHERE sq.created_at::date >= ${fromDate} AND sq.created_at::date <= ${toDate}
            GROUP BY sq.id
          )
         SELECT
@@ -210,10 +214,10 @@ export const getSupplierQuotesSection = async (
           COALESCE(SUM(net_value), 0) as total_net,
           COALESCE(AVG(net_value), 0) as avg_net
           FROM per_quote`,
-      [fromDate, toDate],
     ),
-    exec.query<{ status: string; count: string; total_net: string }>(
-      `WITH per_quote AS (
+    executeRows<{ status: string; count: string; total_net: string }>(
+      exec,
+      sql`WITH per_quote AS (
           SELECT
             sq.id,
             sq.status,
@@ -222,24 +226,24 @@ export const getSupplierQuotesSection = async (
             SUM(sqi.quantity * sqi.unit_price) as net_value
             FROM supplier_quotes sq
             JOIN supplier_quote_items sqi ON sqi.quote_id = sq.id
-           WHERE sq.created_at::date >= $1 AND sq.created_at::date <= $2
+           WHERE sq.created_at::date >= ${fromDate} AND sq.created_at::date <= ${toDate}
            GROUP BY sq.id
          )
         SELECT status, COUNT(*) as count, COALESCE(SUM(net_value), 0) as total_net
           FROM per_quote
          GROUP BY status
          ORDER BY count DESC`,
-      [fromDate, toDate],
     ),
-    exec.query<{ label: string; count: string; total_net: string }>(
-      `WITH per_quote AS (
+    executeRows<{ label: string; count: string; total_net: string }>(
+      exec,
+      sql`WITH per_quote AS (
           SELECT
             sq.id,
             sq.created_at,
             SUM(sqi.quantity * sqi.unit_price) as net_value
             FROM supplier_quotes sq
             JOIN supplier_quote_items sqi ON sqi.quote_id = sq.id
-           WHERE sq.created_at::date >= $1 AND sq.created_at::date <= $2
+           WHERE sq.created_at::date >= ${fromDate} AND sq.created_at::date <= ${toDate}
            GROUP BY sq.id
          )
         SELECT
@@ -249,17 +253,17 @@ export const getSupplierQuotesSection = async (
           FROM per_quote
          GROUP BY DATE_TRUNC('month', created_at)
          ORDER BY label ASC`,
-      [fromDate, toDate],
     ),
-    exec.query<{ label: string; quote_count: string; value: string }>(
-      `WITH per_quote AS (
+    executeRows<{ label: string; quote_count: string; value: string }>(
+      exec,
+      sql`WITH per_quote AS (
           SELECT
             sq.id,
             sq.supplier_name,
             SUM(sqi.quantity * sqi.unit_price) as net_value
             FROM supplier_quotes sq
             JOIN supplier_quote_items sqi ON sqi.quote_id = sq.id
-           WHERE sq.created_at::date >= $1 AND sq.created_at::date <= $2
+           WHERE sq.created_at::date >= ${fromDate} AND sq.created_at::date <= ${toDate}
            GROUP BY sq.id
          )
         SELECT
@@ -269,17 +273,17 @@ export const getSupplierQuotesSection = async (
           FROM per_quote
          GROUP BY supplier_name
          ORDER BY value DESC
-         LIMIT $3`,
-      [fromDate, toDate, topLimit],
+         LIMIT ${topLimit}`,
     ),
-    exec.query<{
+    executeRows<{
       id: string;
       supplier_name: string;
       status: string;
       net_value: string;
       created_at: string;
     }>(
-      `WITH per_quote AS (
+      exec,
+      sql`WITH per_quote AS (
           SELECT
             sq.id,
             sq.supplier_name,
@@ -288,7 +292,7 @@ export const getSupplierQuotesSection = async (
             SUM(sqi.quantity * sqi.unit_price) as net_value
             FROM supplier_quotes sq
             JOIN supplier_quote_items sqi ON sqi.quote_id = sq.id
-           WHERE sq.created_at::date >= $1 AND sq.created_at::date <= $2
+           WHERE sq.created_at::date >= ${fromDate} AND sq.created_at::date <= ${toDate}
            GROUP BY sq.id
          )
         SELECT
@@ -299,39 +303,41 @@ export const getSupplierQuotesSection = async (
           EXTRACT(EPOCH FROM created_at) * 1000 as created_at
           FROM per_quote
          ORDER BY net_value DESC
-         LIMIT $3`,
-      [fromDate, toDate, topLimit],
+         LIMIT ${topLimit}`,
     ),
   ]);
 
   return {
     totals: {
-      count: toNumber(totals.rows[0]?.count),
-      totalNet: toNumber(totals.rows[0]?.total_net),
-      avgNet: toNumber(totals.rows[0]?.avg_net),
+      count: toDbNumber(totals[0]?.count),
+      totalNet: toDbNumber(totals[0]?.total_net),
+      avgNet: toDbNumber(totals[0]?.avg_net),
     },
-    byMonth: byMonth.rows.map((r) => ({
-      label: toText(r.label),
-      count: toNumber(r.count),
-      totalNet: toNumber(r.total_net),
+    byMonth: byMonth.map((r) => ({
+      label: toDbText(r.label),
+      count: toDbNumber(r.count),
+      totalNet: toDbNumber(r.total_net),
     })),
-    byStatus: byStatus.rows.map((r) => ({
-      status: toText(r.status),
-      count: toNumber(r.count),
-      totalNet: toNumber(r.total_net),
+    byStatus: byStatus.map((r) => ({
+      status: toDbText(r.status),
+      count: toDbNumber(r.count),
+      totalNet: toDbNumber(r.total_net),
     })),
-    topQuotesByNet: topQuotes.rows.map((r) => ({
-      id: toText(r.id),
-      supplierName: toText(r.supplier_name),
-      purchaseOrderNumber: toText(r.id),
-      status: toText(r.status),
-      netValue: toNumber(r.net_value),
-      createdAt: toNumber(r.created_at),
-    })),
-    topSuppliersByNet: topSuppliers.rows.map((r) => ({
-      label: toText(r.label),
-      value: toNumber(r.value),
-      quoteCount: toNumber(r.quote_count),
+    topQuotesByNet: topQuotes.map((r) => {
+      const id = toDbText(r.id);
+      return {
+        id,
+        supplierName: toDbText(r.supplier_name),
+        purchaseOrderNumber: id,
+        status: toDbText(r.status),
+        netValue: toDbNumber(r.net_value),
+        createdAt: toDbNumber(r.created_at),
+      };
+    }),
+    topSuppliersByNet: topSuppliers.map((r) => ({
+      label: toDbText(r.label),
+      value: toDbNumber(r.value),
+      quoteCount: toDbNumber(r.quote_count),
     })),
   };
 };
@@ -363,7 +369,7 @@ export type CatalogSection = {
 
 export const getCatalogSection = async (
   opts: CatalogSectionOptions,
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<CatalogSection> => {
   const { fromDate, toDate, topLimit } = opts;
 
@@ -376,64 +382,69 @@ export const getCatalogSection = async (
     topProductsByUsage,
     topProductsByRevenue,
   ] = await Promise.all([
-    exec.query<{ internal_count: string; external_count: string; disabled_count: string }>(
-      `SELECT
+    executeRows<{ internal_count: string; external_count: string; disabled_count: string }>(
+      exec,
+      sql`SELECT
           SUM(CASE WHEN supplier_id IS NULL THEN 1 ELSE 0 END) as internal_count,
           SUM(CASE WHEN supplier_id IS NOT NULL THEN 1 ELSE 0 END) as external_count,
           SUM(CASE WHEN is_disabled THEN 1 ELSE 0 END) as disabled_count
          FROM products`,
     ),
-    exec.query<{ label: string; value: string }>(
-      `SELECT COALESCE(NULLIF(type, ''), 'unknown') as label, COUNT(*) as value
+    executeRows<{ label: string; value: string }>(
+      exec,
+      sql`SELECT COALESCE(NULLIF(type, ''), 'unknown') as label, COUNT(*) as value
          FROM products
         GROUP BY COALESCE(NULLIF(type, ''), 'unknown')
         ORDER BY value DESC`,
     ),
-    exec.query<{ label: string; value: string }>(
-      `SELECT COALESCE(NULLIF(category, ''), 'uncategorized') as label, COUNT(*) as value
+    executeRows<{ label: string; value: string }>(
+      exec,
+      sql`SELECT COALESCE(NULLIF(category, ''), 'uncategorized') as label, COUNT(*) as value
          FROM products
         GROUP BY COALESCE(NULLIF(category, ''), 'uncategorized')
         ORDER BY value DESC`,
     ),
-    exec.query<{ label: string; value: string }>(
-      `SELECT COALESCE(NULLIF(subcategory, ''), 'none') as label, COUNT(*) as value
+    executeRows<{ label: string; value: string }>(
+      exec,
+      sql`SELECT COALESCE(NULLIF(subcategory, ''), 'none') as label, COUNT(*) as value
          FROM products
         GROUP BY COALESCE(NULLIF(subcategory, ''), 'none')
         ORDER BY value DESC`,
     ),
-    exec.query<{ label: string; value: string }>(
-      `SELECT COALESCE(s.name, 'Unknown') as label, COUNT(*) as value
+    executeRows<{ label: string; value: string }>(
+      exec,
+      sql`SELECT COALESCE(s.name, 'Unknown') as label, COUNT(*) as value
          FROM products p
          LEFT JOIN suppliers s ON s.id = p.supplier_id
         WHERE p.supplier_id IS NOT NULL
         GROUP BY COALESCE(s.name, 'Unknown')
         ORDER BY value DESC
-        LIMIT $1`,
-      [topLimit],
+        LIMIT ${topLimit}`,
     ),
-    exec.query<{
+    executeRows<{
       product_id: string;
       product_name: string;
       usage_count: string;
       quantity_total: string;
     }>(
-      `WITH usage_rows AS (
+      exec,
+      sql`WITH usage_rows AS (
           SELECT qi.product_id, qi.product_name, COUNT(*) as use_count, COALESCE(SUM(qi.quantity), 0) as quantity_total
             FROM quote_items qi
             JOIN quotes q ON q.id = qi.quote_id
-           WHERE q.created_at::date >= $1 AND q.created_at::date <= $2
+           WHERE q.created_at::date >= ${fromDate} AND q.created_at::date <= ${toDate}
            GROUP BY qi.product_id, qi.product_name
           UNION ALL
           SELECT si.product_id, si.product_name, COUNT(*) as use_count, COALESCE(SUM(si.quantity), 0) as quantity_total
             FROM sale_items si
             JOIN sales s ON s.id = si.sale_id
-           WHERE s.created_at::date >= $1 AND s.created_at::date <= $2
+           WHERE s.created_at::date >= ${fromDate} AND s.created_at::date <= ${toDate}
            GROUP BY si.product_id, si.product_name
           UNION ALL
           SELECT ii.product_id, ii.description as product_name, COUNT(*) as use_count, COALESCE(SUM(ii.quantity), 0) as quantity_total
             FROM invoice_items ii
             JOIN invoices i ON i.id = ii.invoice_id
-           WHERE i.issue_date >= $1 AND i.issue_date <= $2 AND ii.product_id IS NOT NULL
+           WHERE i.issue_date >= ${fromDate} AND i.issue_date <= ${toDate} AND ii.product_id IS NOT NULL
            GROUP BY ii.product_id, ii.description
          )
         SELECT
@@ -444,11 +455,11 @@ export const getCatalogSection = async (
           FROM usage_rows
          GROUP BY product_id, product_name
          ORDER BY usage_count DESC, quantity_total DESC
-         LIMIT $3`,
-      [fromDate, toDate, topLimit],
+         LIMIT ${topLimit}`,
     ),
-    exec.query<{ product_id: string; product_name: string; value: string }>(
-      `SELECT
+    executeRows<{ product_id: string; product_name: string; value: string }>(
+      exec,
+      sql`SELECT
           si.product_id,
           si.product_name,
           COALESCE(
@@ -462,43 +473,42 @@ export const getCatalogSection = async (
           ) as value
          FROM sale_items si
          JOIN sales s ON s.id = si.sale_id
-        WHERE s.created_at::date >= $1 AND s.created_at::date <= $2
+        WHERE s.created_at::date >= ${fromDate} AND s.created_at::date <= ${toDate}
         GROUP BY si.product_id, si.product_name
         ORDER BY value DESC
-        LIMIT $3`,
-      [fromDate, toDate, topLimit],
+        LIMIT ${topLimit}`,
     ),
   ]);
 
   return {
     productCounts: {
-      internal: toNumber(counts.rows[0]?.internal_count),
-      external: toNumber(counts.rows[0]?.external_count),
-      disabled: toNumber(counts.rows[0]?.disabled_count),
+      internal: toDbNumber(counts[0]?.internal_count),
+      external: toDbNumber(counts[0]?.external_count),
+      disabled: toDbNumber(counts[0]?.disabled_count),
     },
-    byType: byType.rows.map((r) => ({ label: toText(r.label), value: toNumber(r.value) })),
-    byCategory: byCategory.rows.map((r) => ({
-      label: toText(r.label),
-      value: toNumber(r.value),
+    byType: byType.map((r) => ({ label: toDbText(r.label), value: toDbNumber(r.value) })),
+    byCategory: byCategory.map((r) => ({
+      label: toDbText(r.label),
+      value: toDbNumber(r.value),
     })),
-    bySubcategory: bySubcategory.rows.map((r) => ({
-      label: toText(r.label),
-      value: toNumber(r.value),
+    bySubcategory: bySubcategory.map((r) => ({
+      label: toDbText(r.label),
+      value: toDbNumber(r.value),
     })),
-    productsBySupplierCount: productsBySupplier.rows.map((r) => ({
-      label: toText(r.label),
-      value: toNumber(r.value),
+    productsBySupplierCount: productsBySupplier.map((r) => ({
+      label: toDbText(r.label),
+      value: toDbNumber(r.value),
     })),
-    topProductsByUsage: topProductsByUsage.rows.map((r) => ({
-      productId: toText(r.product_id),
-      productName: toText(r.product_name),
-      usageCount: toNumber(r.usage_count),
-      quantity: toNumber(r.quantity_total),
+    topProductsByUsage: topProductsByUsage.map((r) => ({
+      productId: toDbText(r.product_id),
+      productName: toDbText(r.product_name),
+      usageCount: toDbNumber(r.usage_count),
+      quantity: toDbNumber(r.quantity_total),
     })),
-    topProductsByRevenue: topProductsByRevenue.rows.map((r) => ({
-      productId: toText(r.product_id),
-      productName: toText(r.product_name),
-      value: toNumber(r.value),
+    topProductsByRevenue: topProductsByRevenue.map((r) => ({
+      productId: toDbText(r.product_id),
+      productName: toDbText(r.product_name),
+      value: toDbNumber(r.value),
     })),
   };
 };

--- a/server/repositories/reportsClientsRepo.ts
+++ b/server/repositories/reportsClientsRepo.ts
@@ -1,5 +1,6 @@
-import pool, { type QueryExecutor } from '../db/index.ts';
-import { toDbNumber as toNumber, toDbText as toText } from '../utils/parse.ts';
+import { sql } from 'drizzle-orm';
+import { type DbExecutor, db, executeRows } from '../db/drizzle.ts';
+import { toDbNumber, toDbText } from '../utils/parse.ts';
 
 type ClientRow = {
   id: string;
@@ -59,7 +60,7 @@ export type ClientsSection = {
 
 export const getClientsSection = async (
   opts: ClientsSectionOptions,
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<ClientsSection> => {
   const {
     viewerId,
@@ -76,62 +77,62 @@ export const getClientsSection = async (
   } = opts;
 
   const countQuery = canViewAllClients
-    ? exec.query<{ count: string }>(`SELECT COUNT(*) as count FROM clients`)
-    : exec.query<{ count: string }>(
-        `SELECT COUNT(*) as count
-           FROM clients c
-           JOIN user_clients uc ON uc.client_id = c.id
-          WHERE uc.user_id = $1`,
-        [viewerId],
+    ? executeRows<{ count: string }>(exec, sql`SELECT COUNT(*) as count FROM clients`)
+    : executeRows<{ count: string }>(
+        exec,
+        sql`SELECT COUNT(*) as count
+              FROM clients c
+              JOIN user_clients uc ON uc.client_id = c.id
+             WHERE uc.user_id = ${viewerId}`,
       );
 
   const listQuery = canViewAllClients
-    ? exec.query<ClientRow>(
-        `SELECT
-            c.id,
-            c.name,
-            c.client_code,
-            c.type,
-            c.contact_name,
-            c.email,
-            c.phone,
-            c.address,
-            c.is_disabled
-           FROM clients c
-          ORDER BY c.name ASC
-          LIMIT $1`,
-        [itemsLimit],
+    ? executeRows<ClientRow>(
+        exec,
+        sql`SELECT
+              c.id,
+              c.name,
+              c.client_code,
+              c.type,
+              c.contact_name,
+              c.email,
+              c.phone,
+              c.address,
+              c.is_disabled
+             FROM clients c
+            ORDER BY c.name ASC
+            LIMIT ${itemsLimit}`,
       )
-    : exec.query<ClientRow>(
-        `SELECT DISTINCT
-            c.id,
-            c.name,
-            c.client_code,
-            c.type,
-            c.contact_name,
-            c.email,
-            c.phone,
-            c.address,
-            c.is_disabled
-           FROM clients c
-           JOIN user_clients uc ON uc.client_id = c.id
-          WHERE uc.user_id = $1
-          ORDER BY c.name ASC
-          LIMIT $2`,
-        [viewerId, itemsLimit],
+    : executeRows<ClientRow>(
+        exec,
+        sql`SELECT DISTINCT
+              c.id,
+              c.name,
+              c.client_code,
+              c.type,
+              c.contact_name,
+              c.email,
+              c.phone,
+              c.address,
+              c.is_disabled
+             FROM clients c
+             JOIN user_clients uc ON uc.client_id = c.id
+            WHERE uc.user_id = ${viewerId}
+            ORDER BY c.name ASC
+            LIMIT ${itemsLimit}`,
       );
 
-  const [countRes, listRes] = await Promise.all([countQuery, listQuery]);
+  const [countRows, listRows] = await Promise.all([countQuery, listQuery]);
 
-  const items: ClientInfo[] = listRes.rows.map((r) => ({
-    id: toText(r.id),
-    name: toText(r.name),
-    clientCode: toText(r.client_code),
-    type: toText(r.type),
-    contactName: toText(r.contact_name),
-    email: toText(r.email),
-    phone: toText(r.phone),
-    address: toText(r.address),
+  const items: ClientInfo[] = listRows.map((r) => ({
+    id: toDbText(r.id),
+    name: toDbText(r.name),
+    clientCode: toDbText(r.client_code),
+    type: toDbText(r.type),
+    contactName: toDbText(r.contact_name),
+    email: toDbText(r.email),
+    phone: toDbText(r.phone),
+    address: toDbText(r.address),
     isDisabled: Boolean(r.is_disabled),
   }));
 
@@ -154,8 +155,9 @@ export const getClientsSection = async (
 
   if (clientIds.length > 0) {
     const quotesPromise = canViewQuotes
-      ? exec.query<{ client_id: string; quote_count: string; net_value: string }>(
-          `WITH per_quote AS (
+      ? executeRows<{ client_id: string; quote_count: string; net_value: string }>(
+          exec,
+          sql`WITH per_quote AS (
                 SELECT
                   q.id,
                   q.client_id,
@@ -163,9 +165,9 @@ export const getClientsSection = async (
                     * (1 - COALESCE(q.discount, 0) / 100.0) as net_value
                 FROM quotes q
                 JOIN quote_items qi ON qi.quote_id = q.id
-               WHERE q.created_at::date >= $1
-                 AND q.created_at::date <= $2
-                 AND q.client_id = ANY($3)
+               WHERE q.created_at::date >= ${fromDate}
+                 AND q.created_at::date <= ${toDate}
+                 AND q.client_id = ANY(${sql.param(clientIds)})
                GROUP BY q.id
              )
              SELECT
@@ -174,13 +176,13 @@ export const getClientsSection = async (
                COALESCE(SUM(net_value), 0) as net_value
                FROM per_quote
                GROUP BY client_id`,
-          [fromDate, toDate, clientIds],
         )
       : null;
 
     const ordersPromise = canViewOrders
-      ? exec.query<{ client_id: string; order_count: string; net_value: string }>(
-          `WITH per_order AS (
+      ? executeRows<{ client_id: string; order_count: string; net_value: string }>(
+          exec,
+          sql`WITH per_order AS (
                 SELECT
                   s.id,
                   s.client_id,
@@ -188,9 +190,9 @@ export const getClientsSection = async (
                     * (1 - COALESCE(s.discount, 0) / 100.0) as net_value
                 FROM sales s
                 JOIN sale_items si ON si.sale_id = s.id
-               WHERE s.created_at::date >= $1
-                 AND s.created_at::date <= $2
-                 AND s.client_id = ANY($3)
+               WHERE s.created_at::date >= ${fromDate}
+                 AND s.created_at::date <= ${toDate}
+                 AND s.client_id = ANY(${sql.param(clientIds)})
                GROUP BY s.id
              )
              SELECT
@@ -199,104 +201,92 @@ export const getClientsSection = async (
                COALESCE(SUM(net_value), 0) as net_value
                FROM per_order
                GROUP BY client_id`,
-          [fromDate, toDate, clientIds],
         )
       : null;
 
     const invoicesPromise = canViewInvoices
-      ? exec.query<{
+      ? executeRows<{
           client_id: string;
           invoice_count: string;
           total_sum: string;
           outstanding_sum: string;
         }>(
-          `SELECT
+          exec,
+          sql`SELECT
                 client_id,
                 COUNT(*) as invoice_count,
                 COALESCE(SUM(total), 0) as total_sum,
                 COALESCE(SUM(GREATEST(total - amount_paid, 0)), 0) as outstanding_sum
                FROM invoices
-              WHERE issue_date >= $1
-                AND issue_date <= $2
-                AND client_id = ANY($3)
+              WHERE issue_date >= ${fromDate}
+                AND issue_date <= ${toDate}
+                AND client_id = ANY(${sql.param(clientIds)})
               GROUP BY client_id`,
-          [fromDate, toDate, clientIds],
         )
       : null;
 
+    const timesheetUserFilter = canViewAllTimesheets
+      ? sql``
+      : sql`AND te.user_id = ANY(${sql.param(allowedTimesheetUserIds || [])})`;
     const timesheetsPromise = canViewTimesheets
-      ? canViewAllTimesheets
-        ? exec.query<{ client_id: string; hours: string }>(
-            `SELECT
-                te.client_id,
-                COALESCE(SUM(te.duration), 0) as hours
-               FROM time_entries te
-              WHERE te.date >= $1
-                AND te.date <= $2
-                AND te.client_id = ANY($3)
-              GROUP BY te.client_id`,
-            [fromDate, toDate, clientIds],
-          )
-        : exec.query<{ client_id: string; hours: string }>(
-            `SELECT
-                te.client_id,
-                COALESCE(SUM(te.duration), 0) as hours
-               FROM time_entries te
-              WHERE te.date >= $1
-                AND te.date <= $2
-                AND te.user_id = ANY($3)
-                AND te.client_id = ANY($4)
-              GROUP BY te.client_id`,
-            [fromDate, toDate, allowedTimesheetUserIds || [], clientIds],
-          )
+      ? executeRows<{ client_id: string; hours: string }>(
+          exec,
+          sql`SELECT
+              te.client_id,
+              COALESCE(SUM(te.duration), 0) as hours
+             FROM time_entries te
+            WHERE te.date >= ${fromDate}
+              AND te.date <= ${toDate}
+              ${timesheetUserFilter}
+              AND te.client_id = ANY(${sql.param(clientIds)})
+            GROUP BY te.client_id`,
+        )
       : null;
 
-    const [quotesRes, ordersRes, invoicesRes, timesheetsRes] = await Promise.all([
+    const [quotesRows, ordersRows, invoicesRows, timesheetsRows] = await Promise.all([
       quotesPromise,
       ordersPromise,
       invoicesPromise,
       timesheetsPromise,
     ]);
 
-    if (quotesRes) {
-      for (const row of quotesRes.rows) {
-        const target = activityByClient.get(toText(row.client_id));
+    if (quotesRows) {
+      for (const row of quotesRows) {
+        const target = activityByClient.get(toDbText(row.client_id));
         if (!target) continue;
-        target.quotesCount = toNumber(row.quote_count);
-        target.quotesNet = toNumber(row.net_value);
+        target.quotesCount = toDbNumber(row.quote_count);
+        target.quotesNet = toDbNumber(row.net_value);
       }
     }
-    if (ordersRes) {
-      for (const row of ordersRes.rows) {
-        const target = activityByClient.get(toText(row.client_id));
+    if (ordersRows) {
+      for (const row of ordersRows) {
+        const target = activityByClient.get(toDbText(row.client_id));
         if (!target) continue;
-        target.ordersCount = toNumber(row.order_count);
-        target.ordersNet = toNumber(row.net_value);
+        target.ordersCount = toDbNumber(row.order_count);
+        target.ordersNet = toDbNumber(row.net_value);
       }
     }
-    if (invoicesRes) {
-      for (const row of invoicesRes.rows) {
-        const target = activityByClient.get(toText(row.client_id));
+    if (invoicesRows) {
+      for (const row of invoicesRows) {
+        const target = activityByClient.get(toDbText(row.client_id));
         if (!target) continue;
-        target.invoicesCount = toNumber(row.invoice_count);
-        target.invoicesTotal = toNumber(row.total_sum);
-        target.invoicesOutstanding = toNumber(row.outstanding_sum);
+        target.invoicesCount = toDbNumber(row.invoice_count);
+        target.invoicesTotal = toDbNumber(row.total_sum);
+        target.invoicesOutstanding = toDbNumber(row.outstanding_sum);
       }
     }
-    if (timesheetsRes) {
-      for (const row of timesheetsRes.rows) {
-        const target = activityByClient.get(toText(row.client_id));
+    if (timesheetsRows) {
+      for (const row of timesheetsRows) {
+        const target = activityByClient.get(toDbText(row.client_id));
         if (!target) continue;
-        target.timesheetHours = toNumber(row.hours);
+        target.timesheetHours = toDbNumber(row.hours);
       }
     }
   }
 
   return {
-    count: toNumber(countRes.rows[0]?.count),
+    count: toDbNumber(countRows[0]?.count),
     items,
-    activitySummary: clientIds
-      .map((id) => activityByClient.get(id))
-      .filter((a): a is ClientActivity => a !== undefined),
+    activitySummary: Array.from(activityByClient.values()),
   };
 };

--- a/server/repositories/reportsRevenueRepo.ts
+++ b/server/repositories/reportsRevenueRepo.ts
@@ -1,5 +1,6 @@
-import pool, { type QueryExecutor } from '../db/index.ts';
-import { toDbNumber as toNumber, toDbText as toText } from '../utils/parse.ts';
+import { sql } from 'drizzle-orm';
+import { type DbExecutor, db, executeRows } from '../db/drizzle.ts';
+import { toDbNumber, toDbText } from '../utils/parse.ts';
 
 export type RevenueDateRangeOptions = {
   fromDate: string;
@@ -24,20 +25,21 @@ export type QuotesSection = {
 
 export const getQuotesSection = async (
   opts: RevenueDateRangeOptions,
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<QuotesSection> => {
   const { fromDate, toDate, topLimit } = opts;
 
   const [totals, byStatus, byMonth, topQuotes, topClients] = await Promise.all([
-    exec.query<{ count: string; total_net: string; avg_net: string }>(
-      `WITH per_quote AS (
+    executeRows<{ count: string; total_net: string; avg_net: string }>(
+      exec,
+      sql`WITH per_quote AS (
           SELECT
             q.id,
             SUM(qi.quantity * qi.unit_price * (1 - COALESCE(qi.discount, 0) / 100.0))
               * (1 - COALESCE(q.discount, 0) / 100.0) as net_value
             FROM quotes q
             JOIN quote_items qi ON qi.quote_id = q.id
-           WHERE q.created_at::date >= $1 AND q.created_at::date <= $2
+           WHERE q.created_at::date >= ${fromDate} AND q.created_at::date <= ${toDate}
            GROUP BY q.id
          )
         SELECT
@@ -45,10 +47,10 @@ export const getQuotesSection = async (
           COALESCE(SUM(net_value), 0) as total_net,
           COALESCE(AVG(net_value), 0) as avg_net
           FROM per_quote`,
-      [fromDate, toDate],
     ),
-    exec.query<{ status: string; count: string; total_net: string }>(
-      `WITH per_quote AS (
+    executeRows<{ status: string; count: string; total_net: string }>(
+      exec,
+      sql`WITH per_quote AS (
           SELECT
             q.id,
             q.status,
@@ -57,17 +59,17 @@ export const getQuotesSection = async (
             (SUM(qi.quantity * qi.unit_price * (1 - COALESCE(qi.discount, 0) / 100.0)) * (1 - COALESCE(q.discount, 0) / 100.0)) as net_value
             FROM quotes q
             JOIN quote_items qi ON qi.quote_id = q.id
-           WHERE q.created_at::date >= $1 AND q.created_at::date <= $2
+           WHERE q.created_at::date >= ${fromDate} AND q.created_at::date <= ${toDate}
            GROUP BY q.id
          )
         SELECT status, COUNT(*) as count, COALESCE(SUM(net_value), 0) as total_net
           FROM per_quote
          GROUP BY status
          ORDER BY count DESC`,
-      [fromDate, toDate],
     ),
-    exec.query<{ label: string; count: string; total_net: string }>(
-      `WITH per_quote AS (
+    executeRows<{ label: string; count: string; total_net: string }>(
+      exec,
+      sql`WITH per_quote AS (
           SELECT
             q.id,
             q.created_at,
@@ -75,7 +77,7 @@ export const getQuotesSection = async (
               * (1 - COALESCE(q.discount, 0) / 100.0) as net_value
             FROM quotes q
             JOIN quote_items qi ON qi.quote_id = q.id
-           WHERE q.created_at::date >= $1 AND q.created_at::date <= $2
+           WHERE q.created_at::date >= ${fromDate} AND q.created_at::date <= ${toDate}
            GROUP BY q.id
          )
         SELECT
@@ -85,16 +87,16 @@ export const getQuotesSection = async (
           FROM per_quote
          GROUP BY DATE_TRUNC('month', created_at)
          ORDER BY label ASC`,
-      [fromDate, toDate],
     ),
-    exec.query<{
+    executeRows<{
       id: string;
       client_name: string;
       status: string;
       net_value: string;
       created_at: string;
     }>(
-      `WITH per_quote AS (
+      exec,
+      sql`WITH per_quote AS (
           SELECT
             q.id,
             q.client_name,
@@ -104,7 +106,7 @@ export const getQuotesSection = async (
               * (1 - COALESCE(q.discount, 0) / 100.0) as net_value
             FROM quotes q
             JOIN quote_items qi ON qi.quote_id = q.id
-           WHERE q.created_at::date >= $1 AND q.created_at::date <= $2
+           WHERE q.created_at::date >= ${fromDate} AND q.created_at::date <= ${toDate}
            GROUP BY q.id
          )
         SELECT
@@ -115,18 +117,18 @@ export const getQuotesSection = async (
           EXTRACT(EPOCH FROM created_at) * 1000 as created_at
           FROM per_quote
          ORDER BY net_value DESC
-         LIMIT $3`,
-      [fromDate, toDate, topLimit],
+         LIMIT ${topLimit}`,
     ),
-    exec.query<{ label: string; quote_count: string; value: string }>(
-      `WITH per_quote AS (
+    executeRows<{ label: string; quote_count: string; value: string }>(
+      exec,
+      sql`WITH per_quote AS (
           SELECT
             q.id,
             q.client_name,
             (SUM(qi.quantity * qi.unit_price * (1 - COALESCE(qi.discount, 0) / 100.0)) * (1 - COALESCE(q.discount, 0) / 100.0)) as net_value
             FROM quotes q
             JOIN quote_items qi ON qi.quote_id = q.id
-           WHERE q.created_at::date >= $1 AND q.created_at::date <= $2
+           WHERE q.created_at::date >= ${fromDate} AND q.created_at::date <= ${toDate}
            GROUP BY q.id
          )
         SELECT
@@ -136,39 +138,41 @@ export const getQuotesSection = async (
           FROM per_quote
          GROUP BY client_name
          ORDER BY value DESC
-         LIMIT $3`,
-      [fromDate, toDate, topLimit],
+         LIMIT ${topLimit}`,
     ),
   ]);
 
   return {
     totals: {
-      count: toNumber(totals.rows[0]?.count),
-      totalNet: toNumber(totals.rows[0]?.total_net),
-      avgNet: toNumber(totals.rows[0]?.avg_net),
+      count: toDbNumber(totals[0]?.count),
+      totalNet: toDbNumber(totals[0]?.total_net),
+      avgNet: toDbNumber(totals[0]?.avg_net),
     },
-    byMonth: byMonth.rows.map((r) => ({
-      label: toText(r.label),
-      count: toNumber(r.count),
-      totalNet: toNumber(r.total_net),
+    byMonth: byMonth.map((r) => ({
+      label: toDbText(r.label),
+      count: toDbNumber(r.count),
+      totalNet: toDbNumber(r.total_net),
     })),
-    byStatus: byStatus.rows.map((r) => ({
-      status: toText(r.status),
-      count: toNumber(r.count),
-      totalNet: toNumber(r.total_net),
+    byStatus: byStatus.map((r) => ({
+      status: toDbText(r.status),
+      count: toDbNumber(r.count),
+      totalNet: toDbNumber(r.total_net),
     })),
-    topQuotesByNet: topQuotes.rows.map((r) => ({
-      id: toText(r.id),
-      quoteCode: toText(r.id),
-      clientName: toText(r.client_name),
-      status: toText(r.status),
-      netValue: toNumber(r.net_value),
-      createdAt: toNumber(r.created_at),
-    })),
-    topClientsByNet: topClients.rows.map((r) => ({
-      label: toText(r.label),
-      value: toNumber(r.value),
-      quoteCount: toNumber(r.quote_count),
+    topQuotesByNet: topQuotes.map((r) => {
+      const id = toDbText(r.id);
+      return {
+        id,
+        quoteCode: id,
+        clientName: toDbText(r.client_name),
+        status: toDbText(r.status),
+        netValue: toDbNumber(r.net_value),
+        createdAt: toDbNumber(r.created_at),
+      };
+    }),
+    topClientsByNet: topClients.map((r) => ({
+      label: toDbText(r.label),
+      value: toDbNumber(r.value),
+      quoteCount: toDbNumber(r.quote_count),
     })),
   };
 };
@@ -189,20 +193,21 @@ export type OrdersSection = {
 
 export const getOrdersSection = async (
   opts: RevenueDateRangeOptions,
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<OrdersSection> => {
   const { fromDate, toDate, topLimit } = opts;
 
   const [totals, byStatus, byMonth, topOrders, topClients] = await Promise.all([
-    exec.query<{ count: string; total_net: string; avg_net: string }>(
-      `WITH per_order AS (
+    executeRows<{ count: string; total_net: string; avg_net: string }>(
+      exec,
+      sql`WITH per_order AS (
           SELECT
             s.id,
             SUM(si.quantity * si.unit_price * (1 - COALESCE(si.discount, 0) / 100.0))
               * (1 - COALESCE(s.discount, 0) / 100.0) as net_value
             FROM sales s
             JOIN sale_items si ON si.sale_id = s.id
-           WHERE s.created_at::date >= $1 AND s.created_at::date <= $2
+           WHERE s.created_at::date >= ${fromDate} AND s.created_at::date <= ${toDate}
            GROUP BY s.id
          )
         SELECT
@@ -210,10 +215,10 @@ export const getOrdersSection = async (
           COALESCE(SUM(net_value), 0) as total_net,
           COALESCE(AVG(net_value), 0) as avg_net
           FROM per_order`,
-      [fromDate, toDate],
     ),
-    exec.query<{ status: string; count: string; total_net: string }>(
-      `WITH per_order AS (
+    executeRows<{ status: string; count: string; total_net: string }>(
+      exec,
+      sql`WITH per_order AS (
           SELECT
             s.id,
             s.status,
@@ -222,17 +227,17 @@ export const getOrdersSection = async (
             (SUM(si.quantity * si.unit_price * (1 - COALESCE(si.discount, 0) / 100.0)) * (1 - COALESCE(s.discount, 0) / 100.0)) as net_value
             FROM sales s
             JOIN sale_items si ON si.sale_id = s.id
-           WHERE s.created_at::date >= $1 AND s.created_at::date <= $2
+           WHERE s.created_at::date >= ${fromDate} AND s.created_at::date <= ${toDate}
            GROUP BY s.id
          )
         SELECT status, COUNT(*) as count, COALESCE(SUM(net_value), 0) as total_net
           FROM per_order
          GROUP BY status
          ORDER BY count DESC`,
-      [fromDate, toDate],
     ),
-    exec.query<{ label: string; count: string; total_net: string }>(
-      `WITH per_order AS (
+    executeRows<{ label: string; count: string; total_net: string }>(
+      exec,
+      sql`WITH per_order AS (
           SELECT
             s.id,
             s.created_at,
@@ -240,7 +245,7 @@ export const getOrdersSection = async (
               * (1 - COALESCE(s.discount, 0) / 100.0) as net_value
             FROM sales s
             JOIN sale_items si ON si.sale_id = s.id
-           WHERE s.created_at::date >= $1 AND s.created_at::date <= $2
+           WHERE s.created_at::date >= ${fromDate} AND s.created_at::date <= ${toDate}
            GROUP BY s.id
          )
         SELECT
@@ -250,16 +255,16 @@ export const getOrdersSection = async (
           FROM per_order
          GROUP BY DATE_TRUNC('month', created_at)
          ORDER BY label ASC`,
-      [fromDate, toDate],
     ),
-    exec.query<{
+    executeRows<{
       id: string;
       client_name: string;
       status: string;
       net_value: string;
       created_at: string;
     }>(
-      `WITH per_order AS (
+      exec,
+      sql`WITH per_order AS (
           SELECT
             s.id,
             s.client_name,
@@ -269,7 +274,7 @@ export const getOrdersSection = async (
               * (1 - COALESCE(s.discount, 0) / 100.0) as net_value
             FROM sales s
             JOIN sale_items si ON si.sale_id = s.id
-           WHERE s.created_at::date >= $1 AND s.created_at::date <= $2
+           WHERE s.created_at::date >= ${fromDate} AND s.created_at::date <= ${toDate}
            GROUP BY s.id
          )
         SELECT
@@ -280,18 +285,18 @@ export const getOrdersSection = async (
           EXTRACT(EPOCH FROM created_at) * 1000 as created_at
           FROM per_order
          ORDER BY net_value DESC
-         LIMIT $3`,
-      [fromDate, toDate, topLimit],
+         LIMIT ${topLimit}`,
     ),
-    exec.query<{ label: string; order_count: string; value: string }>(
-      `WITH per_order AS (
+    executeRows<{ label: string; order_count: string; value: string }>(
+      exec,
+      sql`WITH per_order AS (
           SELECT
             s.id,
             s.client_name,
             (SUM(si.quantity * si.unit_price * (1 - COALESCE(si.discount, 0) / 100.0)) * (1 - COALESCE(s.discount, 0) / 100.0)) as net_value
             FROM sales s
             JOIN sale_items si ON si.sale_id = s.id
-           WHERE s.created_at::date >= $1 AND s.created_at::date <= $2
+           WHERE s.created_at::date >= ${fromDate} AND s.created_at::date <= ${toDate}
            GROUP BY s.id
          )
         SELECT
@@ -301,38 +306,37 @@ export const getOrdersSection = async (
           FROM per_order
          GROUP BY client_name
          ORDER BY value DESC
-         LIMIT $3`,
-      [fromDate, toDate, topLimit],
+         LIMIT ${topLimit}`,
     ),
   ]);
 
   return {
     totals: {
-      count: toNumber(totals.rows[0]?.count),
-      totalNet: toNumber(totals.rows[0]?.total_net),
-      avgNet: toNumber(totals.rows[0]?.avg_net),
+      count: toDbNumber(totals[0]?.count),
+      totalNet: toDbNumber(totals[0]?.total_net),
+      avgNet: toDbNumber(totals[0]?.avg_net),
     },
-    byMonth: byMonth.rows.map((r) => ({
-      label: toText(r.label),
-      count: toNumber(r.count),
-      totalNet: toNumber(r.total_net),
+    byMonth: byMonth.map((r) => ({
+      label: toDbText(r.label),
+      count: toDbNumber(r.count),
+      totalNet: toDbNumber(r.total_net),
     })),
-    byStatus: byStatus.rows.map((r) => ({
-      status: toText(r.status),
-      count: toNumber(r.count),
-      totalNet: toNumber(r.total_net),
+    byStatus: byStatus.map((r) => ({
+      status: toDbText(r.status),
+      count: toDbNumber(r.count),
+      totalNet: toDbNumber(r.total_net),
     })),
-    topOrdersByNet: topOrders.rows.map((r) => ({
-      id: toText(r.id),
-      clientName: toText(r.client_name),
-      status: toText(r.status),
-      netValue: toNumber(r.net_value),
-      createdAt: toNumber(r.created_at),
+    topOrdersByNet: topOrders.map((r) => ({
+      id: toDbText(r.id),
+      clientName: toDbText(r.client_name),
+      status: toDbText(r.status),
+      netValue: toDbNumber(r.net_value),
+      createdAt: toDbNumber(r.created_at),
     })),
-    topClientsByNet: topClients.rows.map((r) => ({
-      label: toText(r.label),
-      value: toNumber(r.value),
-      orderCount: toNumber(r.order_count),
+    topClientsByNet: topClients.map((r) => ({
+      label: toDbText(r.label),
+      value: toDbNumber(r.value),
+      orderCount: toDbNumber(r.order_count),
     })),
   };
 };
@@ -355,61 +359,62 @@ export type InvoicesSection = {
 
 export const getInvoicesSection = async (
   opts: RevenueDateRangeOptions,
-  exec: QueryExecutor = pool,
+  exec: DbExecutor = db,
 ): Promise<InvoicesSection> => {
   const { fromDate, toDate, topLimit } = opts;
 
   const [totals, byStatus, byMonth, aging, topInvoices, topClients] = await Promise.all([
-    exec.query<{
+    executeRows<{
       count: string;
       total_sum: string;
       outstanding_sum: string;
       paid_sum: string;
     }>(
-      `SELECT
+      exec,
+      sql`SELECT
           COUNT(*) as count,
           COALESCE(SUM(total), 0) as total_sum,
           COALESCE(SUM(GREATEST(total - amount_paid, 0)), 0) as outstanding_sum,
           COALESCE(SUM(amount_paid), 0) as paid_sum
          FROM invoices
-        WHERE issue_date >= $1 AND issue_date <= $2`,
-      [fromDate, toDate],
+        WHERE issue_date >= ${fromDate} AND issue_date <= ${toDate}`,
     ),
-    exec.query<{
+    executeRows<{
       status: string;
       count: string;
       total_sum: string;
       outstanding_sum: string;
     }>(
-      `SELECT status,
+      exec,
+      sql`SELECT status,
               COUNT(*) as count,
               COALESCE(SUM(total), 0) as total_sum,
               COALESCE(SUM(GREATEST(total - amount_paid, 0)), 0) as outstanding_sum
          FROM invoices
-        WHERE issue_date >= $1 AND issue_date <= $2
+        WHERE issue_date >= ${fromDate} AND issue_date <= ${toDate}
         GROUP BY status
         ORDER BY count DESC`,
-      [fromDate, toDate],
     ),
-    exec.query<{
+    executeRows<{
       label: string;
       count: string;
       total_sum: string;
       outstanding_sum: string;
     }>(
-      `SELECT
+      exec,
+      sql`SELECT
           TO_CHAR(DATE_TRUNC('month', issue_date), 'YYYY-MM') as label,
           COUNT(*) as count,
           COALESCE(SUM(total), 0) as total_sum,
           COALESCE(SUM(GREATEST(total - amount_paid, 0)), 0) as outstanding_sum
          FROM invoices
-        WHERE issue_date >= $1 AND issue_date <= $2
+        WHERE issue_date >= ${fromDate} AND issue_date <= ${toDate}
         GROUP BY DATE_TRUNC('month', issue_date)
         ORDER BY label ASC`,
-      [fromDate, toDate],
     ),
-    exec.query<{ bucket: string; count: string; outstanding_sum: string }>(
-      `SELECT
+    executeRows<{ bucket: string; count: string; outstanding_sum: string }>(
+      exec,
+      sql`SELECT
           CASE
             WHEN CURRENT_DATE - due_date <= 30 THEN '0-30'
             WHEN CURRENT_DATE - due_date <= 60 THEN '31-60'
@@ -419,82 +424,84 @@ export const getInvoicesSection = async (
           COUNT(*) as count,
           COALESCE(SUM(GREATEST(total - amount_paid, 0)), 0) as outstanding_sum
          FROM invoices
-        WHERE issue_date >= $1
-          AND issue_date <= $2
+        WHERE issue_date >= ${fromDate}
+          AND issue_date <= ${toDate}
           AND GREATEST(total - amount_paid, 0) > 0
         GROUP BY bucket
         ORDER BY bucket ASC`,
-      [fromDate, toDate],
     ),
-    exec.query<{
+    executeRows<{
       id: string;
       client_name: string;
       status: string;
       due_date: string;
       outstanding: string;
     }>(
-      `SELECT
+      exec,
+      sql`SELECT
           id,
           client_name,
           status,
           due_date,
           GREATEST(total - amount_paid, 0) as outstanding
          FROM invoices
-        WHERE issue_date >= $1 AND issue_date <= $2
+        WHERE issue_date >= ${fromDate} AND issue_date <= ${toDate}
         ORDER BY outstanding DESC
-        LIMIT $3`,
-      [fromDate, toDate, topLimit],
+        LIMIT ${topLimit}`,
     ),
-    exec.query<{ label: string; invoice_count: string; value: string }>(
-      `SELECT
+    executeRows<{ label: string; invoice_count: string; value: string }>(
+      exec,
+      sql`SELECT
           client_name as label,
           COUNT(*) as invoice_count,
           COALESCE(SUM(GREATEST(total - amount_paid, 0)), 0) as value
          FROM invoices
-        WHERE issue_date >= $1 AND issue_date <= $2
+        WHERE issue_date >= ${fromDate} AND issue_date <= ${toDate}
         GROUP BY client_name
         ORDER BY value DESC
-        LIMIT $3`,
-      [fromDate, toDate, topLimit],
+        LIMIT ${topLimit}`,
     ),
   ]);
 
   return {
     totals: {
-      count: toNumber(totals.rows[0]?.count),
-      total: toNumber(totals.rows[0]?.total_sum),
-      outstanding: toNumber(totals.rows[0]?.outstanding_sum),
-      paidAmount: toNumber(totals.rows[0]?.paid_sum),
+      count: toDbNumber(totals[0]?.count),
+      total: toDbNumber(totals[0]?.total_sum),
+      outstanding: toDbNumber(totals[0]?.outstanding_sum),
+      paidAmount: toDbNumber(totals[0]?.paid_sum),
     },
-    byMonth: byMonth.rows.map((r) => ({
-      label: toText(r.label),
-      count: toNumber(r.count),
-      total: toNumber(r.total_sum),
-      outstanding: toNumber(r.outstanding_sum),
+    byMonth: byMonth.map((r) => ({
+      label: toDbText(r.label),
+      count: toDbNumber(r.count),
+      total: toDbNumber(r.total_sum),
+      outstanding: toDbNumber(r.outstanding_sum),
     })),
-    aging: aging.rows.map((r) => ({
-      bucket: toText(r.bucket),
-      count: toNumber(r.count),
-      outstanding: toNumber(r.outstanding_sum),
+    aging: aging.map((r) => ({
+      bucket: toDbText(r.bucket),
+      count: toDbNumber(r.count),
+      outstanding: toDbNumber(r.outstanding_sum),
     })),
-    byStatus: byStatus.rows.map((r) => ({
-      status: toText(r.status),
-      count: toNumber(r.count),
-      total: toNumber(r.total_sum),
-      outstanding: toNumber(r.outstanding_sum),
+    byStatus: byStatus.map((r) => ({
+      status: toDbText(r.status),
+      count: toDbNumber(r.count),
+      total: toDbNumber(r.total_sum),
+      outstanding: toDbNumber(r.outstanding_sum),
     })),
-    topInvoicesByOutstanding: topInvoices.rows.map((r) => ({
-      id: toText(r.id),
-      invoiceNumber: toText(r.id),
-      clientName: toText(r.client_name),
-      status: toText(r.status),
-      dueDate: toText(r.due_date),
-      outstanding: toNumber(r.outstanding),
-    })),
-    topClientsByOutstanding: topClients.rows.map((r) => ({
-      label: toText(r.label),
-      value: toNumber(r.value),
-      invoiceCount: toNumber(r.invoice_count),
+    topInvoicesByOutstanding: topInvoices.map((r) => {
+      const id = toDbText(r.id);
+      return {
+        id,
+        invoiceNumber: id,
+        clientName: toDbText(r.client_name),
+        status: toDbText(r.status),
+        dueDate: toDbText(r.due_date),
+        outstanding: toDbNumber(r.outstanding),
+      };
+    }),
+    topClientsByOutstanding: topClients.map((r) => ({
+      label: toDbText(r.label),
+      value: toDbNumber(r.value),
+      invoiceCount: toDbNumber(r.invoice_count),
     })),
   };
 };

--- a/server/routes/reports.ts
+++ b/server/routes/reports.ts
@@ -1,9 +1,8 @@
 import { AsyncLocalStorage } from 'async_hooks';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
-import type { QueryResultRow } from 'pg';
 import type { DbExecutor } from '../db/drizzle.ts';
-import pool, { type QueryExecutor } from '../db/index.ts';
+import pool from '../db/index.ts';
 import * as schema from '../db/schema/index.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
 import * as generalSettingsRepo from '../repositories/generalSettingsRepo.ts';
@@ -42,26 +41,16 @@ const incrementDatasetCounter = () => {
   if (counter) counter.count += 1;
 };
 
-// Two parallel "counting" executors that share the same AsyncLocalStorage counter:
-//   - `datasetExec` (legacy `QueryExecutor`) for repos still on raw `pg`
-//   - `datasetDb` (Drizzle `DbExecutor`) for repos converted in Phase 3+
-// Each request handler enters `datasetQueryCounterStorage` once and any query through either
-// executor increments the same counter, so dataset query budgets stay consistent across the
-// mixed-mode period of the migration.
+// Counting Drizzle executor: every query through `datasetDb` increments the per-request
+// `datasetQueryCounterStorage` counter so dataset query budgets stay enforced.
 //
-// IMPORTANT: counting only happens when callers use these exact instances. If a future caller
+// IMPORTANT: counting only happens for queries on this exact instance. If a future caller
 // wraps a converted reports repo in `withDbTransaction(tx => repo.fn(opts, tx))`, the `tx`
-// argument is a fresh Drizzle transaction without the `logger` hook attached, so its queries
-// won't increment the counter. Today reporting is read-only and never transactional, but if
-// that changes the wrapping needs to move (e.g. a `withCountingTransaction` helper that
-// re-attaches the logger to the tx).
-const datasetExec: QueryExecutor = {
-  query: <T extends QueryResultRow = QueryResultRow>(text: string, params?: unknown[]) => {
-    incrementDatasetCounter();
-    return pool.query<T>(text, params);
-  },
-};
-
+// argument is a fresh Drizzle transaction without the `logger` hook attached, so its
+// queries won't increment the counter. Today reporting is read-only and never transactional,
+// but if that changes the wrapping needs to move (e.g. a `withCountingTransaction` helper
+// that re-attaches the logger to the tx).
+//
 // `schema` is required for the return type to satisfy `DbExecutor`
 // (`PgDatabase<…, typeof schema, …>`) — without it the inferred type is
 // `PgDatabase<…, Record<string, never>, …>` which isn't assignable. The query builder is
@@ -962,7 +951,7 @@ const buildBusinessDataset = async (
           allowedTimesheetUserIds,
           itemsLimit: listLimits.items,
         },
-        datasetExec,
+        datasetDb,
       );
     }
 
@@ -1042,7 +1031,7 @@ const buildBusinessDataset = async (
       includedSections.add('quotes');
       dataset.quotes = await reportsRevenueRepo.getQuotesSection(
         { fromDate, toDate, topLimit: listLimits.top },
-        datasetExec,
+        datasetDb,
       );
     }
 
@@ -1050,7 +1039,7 @@ const buildBusinessDataset = async (
       includedSections.add('orders');
       dataset.orders = await reportsRevenueRepo.getOrdersSection(
         { fromDate, toDate, topLimit: listLimits.top },
-        datasetExec,
+        datasetDb,
       );
     }
 
@@ -1058,7 +1047,7 @@ const buildBusinessDataset = async (
       includedSections.add('invoices');
       dataset.invoices = await reportsRevenueRepo.getInvoicesSection(
         { fromDate, toDate, topLimit: listLimits.top },
-        datasetExec,
+        datasetDb,
       );
     }
 
@@ -1074,7 +1063,7 @@ const buildBusinessDataset = async (
           canListProducts,
           itemsLimit: listLimits.items,
         },
-        datasetExec,
+        datasetDb,
       );
     }
 
@@ -1082,7 +1071,7 @@ const buildBusinessDataset = async (
       includedSections.add('supplierQuotes');
       dataset.supplierQuotes = await reportsCatalogRepo.getSupplierQuotesSection(
         { fromDate, toDate, topLimit: listLimits.top },
-        datasetExec,
+        datasetDb,
       );
     }
 
@@ -1090,7 +1079,7 @@ const buildBusinessDataset = async (
       includedSections.add('catalog');
       dataset.catalog = await reportsCatalogRepo.getCatalogSection(
         { fromDate, toDate, topLimit: listLimits.top },
-        datasetExec,
+        datasetDb,
       );
     }
 

--- a/server/test/helpers/fakeExecutor.ts
+++ b/server/test/helpers/fakeExecutor.ts
@@ -16,6 +16,7 @@ type ResponseFactory = (sql: string, params: unknown[]) => FakeResponse;
 export type FakeExecutor = QueryExecutor & {
   readonly calls: readonly FakeCall[];
   enqueue: (response: FakeResponse | ResponseFactory) => void;
+  enqueueEmptyN: (n: number) => void;
 };
 
 export const makeFakeExecutor = (): FakeExecutor => {
@@ -26,6 +27,9 @@ export const makeFakeExecutor = (): FakeExecutor => {
     calls,
     enqueue(response) {
       queue.push(response);
+    },
+    enqueueEmptyN(n) {
+      for (let i = 0; i < n; i++) queue.push({ rows: [] });
     },
     async query<T extends QueryResultRow = QueryResultRow>(
       text: string,

--- a/server/test/repositories/reportsAiChatRepo.test.ts
+++ b/server/test/repositories/reportsAiChatRepo.test.ts
@@ -27,7 +27,7 @@ describe('listSessionsForUser', () => {
     expect(exec.calls[0].params).toContain(50);
   });
 
-  test('returns rows with title fallback to "" and timestamps coerced to epoch ms', async () => {
+  test('returns rows with timestamps coerced to epoch ms', async () => {
     const created = new Date(1);
     const updated = new Date(2);
     exec.enqueue({ rows: [['s1', 'Hello', created, updated]] });
@@ -35,10 +35,10 @@ describe('listSessionsForUser', () => {
     expect(result).toEqual([{ id: 's1', title: 'Hello', createdAt: 1, updatedAt: 2 }]);
   });
 
-  test('null title coerces to ""; null timestamps coerce to 0', async () => {
-    exec.enqueue({ rows: [['s1', null, null, null]] });
+  test('null timestamps coerce to 0', async () => {
+    exec.enqueue({ rows: [['s1', 'Hello', null, null]] });
     const [result] = await repo.listSessionsForUser('user-1', testDb);
-    expect(result).toEqual({ id: 's1', title: '', createdAt: 0, updatedAt: 0 });
+    expect(result).toEqual({ id: 's1', title: 'Hello', createdAt: 0, updatedAt: 0 });
   });
 });
 
@@ -96,16 +96,10 @@ describe('getActiveSessionForUser', () => {
     expect(result).toBeNull();
   });
 
-  test('returns first row with title fallback to ""', async () => {
+  test('returns first row', async () => {
     exec.enqueue({ rows: [['Hello']] });
     const result = await repo.getActiveSessionForUser('s1', 'user-1', testDb);
     expect(result).toEqual({ title: 'Hello' });
-  });
-
-  test('null title coerces to ""', async () => {
-    exec.enqueue({ rows: [[null]] });
-    const result = await repo.getActiveSessionForUser('s1', 'user-1', testDb);
-    expect(result).toEqual({ title: '' });
   });
 
   test('filters on is_archived=false (bound as a param) and binds [id, userId]', async () => {
@@ -182,11 +176,9 @@ describe('listMessagesForSession', () => {
     expect(m.thoughtContent).toBeNull();
   });
 
-  test('null role/content coerce to ""', async () => {
-    exec.enqueue({ rows: [['m1', 's1', null, null, null, null]] });
+  test('null thoughtContent and null createdAt coerce safely', async () => {
+    exec.enqueue({ rows: [['m1', 's1', 'user', 'hi', null, null]] });
     const [m] = await repo.listMessagesForSession('s1', { beforeMs: null, limit: 1 }, testDb);
-    expect(m.role).toBe('');
-    expect(m.content).toBe('');
     expect(m.thoughtContent).toBeNull();
     expect(m.createdAt).toBe(0);
   });
@@ -213,12 +205,6 @@ describe('listRecentMessages', () => {
     await repo.listRecentMessages('s1', { beforeOrAt: cutoff, limit: 10 }, testDb);
     expect(exec.calls[0].params).toEqual(['s1', cutoff.toISOString(), 10]);
     expect(exec.calls[0].sql).toContain('<=');
-  });
-
-  test('null role/content coerce to ""', async () => {
-    exec.enqueue({ rows: [[null, null]] });
-    const [t] = await repo.listRecentMessages('s1', {}, testDb);
-    expect(t).toEqual({ role: '', content: '' });
   });
 });
 

--- a/server/test/repositories/reportsAiChatRepo.test.ts
+++ b/server/test/repositories/reportsAiChatRepo.test.ts
@@ -1,11 +1,13 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
+import type { DbExecutor } from '../../db/drizzle.ts';
 import * as repo from '../../repositories/reportsAiChatRepo.ts';
-import { type FakeExecutor, makeFakeExecutor } from '../helpers/fakeExecutor.ts';
+import { type FakeExecutor, setupTestDb } from '../helpers/fakeExecutor.ts';
 
 let exec: FakeExecutor;
+let testDb: DbExecutor;
 
 beforeEach(() => {
-  exec = makeFakeExecutor();
+  ({ exec, testDb } = setupTestDb());
 });
 
 describe('constants', () => {
@@ -17,29 +19,35 @@ describe('constants', () => {
 });
 
 describe('listSessionsForUser', () => {
-  test('passes userId as $1 and limits to 50', async () => {
+  test('binds userId, isArchived=false, and limit=50', async () => {
     exec.enqueue({ rows: [] });
-    await repo.listSessionsForUser('user-1', exec);
-    expect(exec.calls[0].params).toEqual(['user-1']);
-    expect(exec.calls[0].sql).toContain('LIMIT 50');
-    expect(exec.calls[0].sql).toContain('is_archived = FALSE');
+    await repo.listSessionsForUser('user-1', testDb);
+    expect(exec.calls[0].params).toContain('user-1');
+    expect(exec.calls[0].params).toContain(false);
+    expect(exec.calls[0].params).toContain(50);
   });
 
-  test('returns rows verbatim (SQL coerces title via COALESCE)', async () => {
-    const row = { id: 's1', title: 'Hello', createdAt: 1, updatedAt: 2 };
-    exec.enqueue({ rows: [row] });
-    const result = await repo.listSessionsForUser('user-1', exec);
-    expect(result).toEqual([row]);
+  test('returns rows with title fallback to "" and timestamps coerced to epoch ms', async () => {
+    const created = new Date(1);
+    const updated = new Date(2);
+    exec.enqueue({ rows: [['s1', 'Hello', created, updated]] });
+    const result = await repo.listSessionsForUser('user-1', testDb);
+    expect(result).toEqual([{ id: 's1', title: 'Hello', createdAt: 1, updatedAt: 2 }]);
+  });
+
+  test('null title coerces to ""; null timestamps coerce to 0', async () => {
+    exec.enqueue({ rows: [['s1', null, null, null]] });
+    const [result] = await repo.listSessionsForUser('user-1', testDb);
+    expect(result).toEqual({ id: 's1', title: '', createdAt: 0, updatedAt: 0 });
   });
 });
 
 describe('createSession', () => {
-  test('passes [id, userId, title] and inserts non-archived row', async () => {
+  test('inserts with [id, userId, title, isArchived=false]', async () => {
     exec.enqueue({ rows: [] });
-    await repo.createSession('s1', 'user-1', 'My Title', exec);
-    expect(exec.calls[0].params).toEqual(['s1', 'user-1', 'My Title']);
-    expect(exec.calls[0].sql).toContain('INSERT INTO report_chat_sessions');
-    expect(exec.calls[0].sql).toContain('FALSE, CURRENT_TIMESTAMP');
+    await repo.createSession('s1', 'user-1', 'My Title', testDb);
+    expect(exec.calls[0].sql).toContain('insert into "report_chat_sessions"');
+    expect(exec.calls[0].params).toEqual(['s1', 'user-1', 'My Title', false]);
   });
 });
 
@@ -50,102 +58,111 @@ describe('archiveSession', () => {
     [null, false],
   ] as const)('returns %s when rowCount is %s', async (rowCount, expected) => {
     exec.enqueue({ rows: [], rowCount });
-    expect(await repo.archiveSession('s1', 'user-1', exec)).toBe(expected);
+    expect(await repo.archiveSession('s1', 'user-1', testDb)).toBe(expected);
   });
 
-  test('passes [id, userId] and sets is_archived = TRUE', async () => {
+  test('binds isArchived=true followed by [id, userId] for the where clause', async () => {
     exec.enqueue({ rows: [], rowCount: 1 });
-    await repo.archiveSession('s1', 'user-1', exec);
-    expect(exec.calls[0].params).toEqual(['s1', 'user-1']);
-    expect(exec.calls[0].sql).toContain('SET is_archived = TRUE');
+    await repo.archiveSession('s1', 'user-1', testDb);
+    expect(exec.calls[0].sql).toContain('update "report_chat_sessions"');
+    expect(exec.calls[0].sql).toContain('"is_archived"');
+    expect(exec.calls[0].params).toEqual([true, 's1', 'user-1']);
   });
 });
 
 describe('sessionExistsForUser', () => {
-  test.each([
-    [1, true],
-    [0, false],
-  ] as const)('returns %s when rowCount is %s', async (rowCount, expected) => {
-    exec.enqueue({ rows: [], rowCount });
-    expect(await repo.sessionExistsForUser('s1', 'user-1', exec)).toBe(expected);
+  test('returns true when at least one row matches', async () => {
+    exec.enqueue({ rows: [[1]] });
+    expect(await repo.sessionExistsForUser('s1', 'user-1', testDb)).toBe(true);
+  });
+
+  test('returns false when no row matches', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await repo.sessionExistsForUser('s1', 'user-1', testDb)).toBe(false);
+  });
+
+  test('binds [id, userId] for the where clause', async () => {
+    exec.enqueue({ rows: [] });
+    await repo.sessionExistsForUser('s1', 'user-1', testDb);
+    expect(exec.calls[0].params).toContain('s1');
+    expect(exec.calls[0].params).toContain('user-1');
   });
 });
 
 describe('getActiveSessionForUser', () => {
   test('returns null when no row found', async () => {
     exec.enqueue({ rows: [] });
-    const result = await repo.getActiveSessionForUser('s1', 'user-1', exec);
+    const result = await repo.getActiveSessionForUser('s1', 'user-1', testDb);
     expect(result).toBeNull();
   });
 
-  test('returns first row when found', async () => {
-    exec.enqueue({ rows: [{ title: 'Hello' }] });
-    const result = await repo.getActiveSessionForUser('s1', 'user-1', exec);
+  test('returns first row with title fallback to ""', async () => {
+    exec.enqueue({ rows: [['Hello']] });
+    const result = await repo.getActiveSessionForUser('s1', 'user-1', testDb);
     expect(result).toEqual({ title: 'Hello' });
   });
 
-  test('filters on is_archived = FALSE', async () => {
+  test('null title coerces to ""', async () => {
+    exec.enqueue({ rows: [[null]] });
+    const result = await repo.getActiveSessionForUser('s1', 'user-1', testDb);
+    expect(result).toEqual({ title: '' });
+  });
+
+  test('filters on is_archived=false (bound as a param) and binds [id, userId]', async () => {
     exec.enqueue({ rows: [] });
-    await repo.getActiveSessionForUser('s1', 'user-1', exec);
-    expect(exec.calls[0].sql).toContain('is_archived = FALSE');
-    expect(exec.calls[0].params).toEqual(['s1', 'user-1']);
+    await repo.getActiveSessionForUser('s1', 'user-1', testDb);
+    expect(exec.calls[0].params).toContain('s1');
+    expect(exec.calls[0].params).toContain('user-1');
+    expect(exec.calls[0].params).toContain(false);
   });
 });
 
 describe('updateSessionTitleAndTouch', () => {
-  test('passes [id, candidateTitle, userId, DEFAULT_CHAT_TITLE]', async () => {
+  test('binds [DEFAULT_CHAT_TITLE, candidateTitle, id, userId] in source order', async () => {
     exec.enqueue({ rows: [] });
-    await repo.updateSessionTitleAndTouch('s1', 'user-1', 'New Title', exec);
-    expect(exec.calls[0].params).toEqual(['s1', 'New Title', 'user-1', repo.DEFAULT_CHAT_TITLE]);
+    await repo.updateSessionTitleAndTouch('s1', 'user-1', 'New Title', testDb);
+    expect(exec.calls[0].params).toEqual([repo.DEFAULT_CHAT_TITLE, 'New Title', 's1', 'user-1']);
   });
 
-  test('only overwrites title when blank or default — uses CASE clause', async () => {
+  test('only overwrites title when blank or default — keeps the CASE expression', async () => {
     exec.enqueue({ rows: [] });
-    await repo.updateSessionTitleAndTouch('s1', 'user-1', 'New', exec);
-    expect(exec.calls[0].sql).toContain("BTRIM(title) = '' OR title = $4");
-    expect(exec.calls[0].sql).toContain('LEFT($2, 80)');
+    await repo.updateSessionTitleAndTouch('s1', 'user-1', 'New', testDb);
+    expect(exec.calls[0].sql).toContain('CASE');
+    expect(exec.calls[0].sql).toContain('BTRIM');
+    expect(exec.calls[0].sql).toContain('LEFT(');
   });
 });
 
 describe('touchSession', () => {
-  test('updates only updated_at, scoped by user', async () => {
+  test('updates only updated_at, scoped by [id, userId]', async () => {
     exec.enqueue({ rows: [] });
-    await repo.touchSession('s1', 'user-1', exec);
+    await repo.touchSession('s1', 'user-1', testDb);
     expect(exec.calls[0].params).toEqual(['s1', 'user-1']);
-    expect(exec.calls[0].sql).toContain('SET updated_at = CURRENT_TIMESTAMP');
+    expect(exec.calls[0].sql).toContain('update "report_chat_sessions"');
+    expect(exec.calls[0].sql).toContain('"updated_at"');
     expect(exec.calls[0].sql).not.toContain('is_archived');
   });
 });
 
 describe('listMessagesForSession', () => {
-  test('without beforeMs uses 2-param query', async () => {
+  test('without beforeMs uses 2-param query (sessionId, limit)', async () => {
     exec.enqueue({ rows: [] });
-    await repo.listMessagesForSession('s1', { beforeMs: null, limit: 30 }, exec);
+    await repo.listMessagesForSession('s1', { beforeMs: null, limit: 30 }, testDb);
     expect(exec.calls[0].params).toEqual(['s1', 30]);
     expect(exec.calls[0].sql).not.toContain('TO_TIMESTAMP');
   });
 
   test('with beforeMs uses 3-param query and TO_TIMESTAMP filter', async () => {
     exec.enqueue({ rows: [] });
-    await repo.listMessagesForSession('s1', { beforeMs: 1700000000000, limit: 10 }, exec);
+    await repo.listMessagesForSession('s1', { beforeMs: 1700000000000, limit: 10 }, testDb);
     expect(exec.calls[0].params).toEqual(['s1', 1700000000000, 10]);
     expect(exec.calls[0].sql).toContain('TO_TIMESTAMP($2 / 1000.0)');
   });
 
-  test('maps row, coercing nulls and stringifying ids', async () => {
-    exec.enqueue({
-      rows: [
-        {
-          id: 'm1',
-          sessionId: 's1',
-          role: 'user',
-          content: 'hi',
-          thoughtContent: null,
-          createdAt: 1700000000000,
-        },
-      ],
-    });
-    const result = await repo.listMessagesForSession('s1', { beforeMs: null, limit: 10 }, exec);
+  test('maps positional row to ChatMessage shape, coercing nulls', async () => {
+    const created = new Date(1700000000000);
+    exec.enqueue({ rows: [['m1', 's1', 'user', 'hi', null, created]] });
+    const result = await repo.listMessagesForSession('s1', { beforeMs: null, limit: 10 }, testDb);
     expect(result).toEqual([
       {
         id: 'm1',
@@ -159,83 +176,72 @@ describe('listMessagesForSession', () => {
   });
 
   test('empty content/role pass through; empty thoughtContent maps to null', async () => {
-    exec.enqueue({
-      rows: [
-        {
-          id: 'm1',
-          sessionId: 's1',
-          role: '',
-          content: '',
-          thoughtContent: '',
-          createdAt: 0,
-        },
-      ],
-    });
-    const [m] = await repo.listMessagesForSession('s1', { beforeMs: null, limit: 1 }, exec);
+    exec.enqueue({ rows: [['m1', 's1', '', '', '', new Date(0)]] });
+    const [m] = await repo.listMessagesForSession('s1', { beforeMs: null, limit: 1 }, testDb);
     expect(m.content).toBe('');
     expect(m.thoughtContent).toBeNull();
   });
 
-  test('SQL COALESCEs role and content so the typed shape is accurate', async () => {
-    exec.enqueue({ rows: [] });
-    await repo.listMessagesForSession('s1', { beforeMs: null, limit: 1 }, exec);
-    expect(exec.calls[0].sql).toContain("COALESCE(role, '')");
-    expect(exec.calls[0].sql).toContain("COALESCE(content, '')");
+  test('null role/content coerce to ""', async () => {
+    exec.enqueue({ rows: [['m1', 's1', null, null, null, null]] });
+    const [m] = await repo.listMessagesForSession('s1', { beforeMs: null, limit: 1 }, testDb);
+    expect(m.role).toBe('');
+    expect(m.content).toBe('');
+    expect(m.thoughtContent).toBeNull();
+    expect(m.createdAt).toBe(0);
   });
 });
 
 describe('listRecentMessages', () => {
-  test('default limit is 20 and DESC order is preserved', async () => {
+  test('default limit is 20 and orders DESC', async () => {
     exec.enqueue({ rows: [] });
-    await repo.listRecentMessages('s1', {}, exec);
+    await repo.listRecentMessages('s1', {}, testDb);
     expect(exec.calls[0].params).toEqual(['s1', 20]);
-    expect(exec.calls[0].sql).toContain('ORDER BY created_at DESC');
+    expect(exec.calls[0].sql.toLowerCase()).toContain('order by');
+    expect(exec.calls[0].sql.toLowerCase()).toContain('desc');
   });
 
   test('custom limit is honored', async () => {
     exec.enqueue({ rows: [] });
-    await repo.listRecentMessages('s1', { limit: 5 }, exec);
+    await repo.listRecentMessages('s1', { limit: 5 }, testDb);
     expect(exec.calls[0].params).toEqual(['s1', 5]);
   });
 
   test('beforeOrAt filter switches to <= predicate with 3 params', async () => {
     exec.enqueue({ rows: [] });
     const cutoff = new Date('2026-01-01T00:00:00Z');
-    await repo.listRecentMessages('s1', { beforeOrAt: cutoff, limit: 10 }, exec);
-    expect(exec.calls[0].params).toEqual(['s1', cutoff, 10]);
-    expect(exec.calls[0].sql).toContain('created_at <= $2');
+    await repo.listRecentMessages('s1', { beforeOrAt: cutoff, limit: 10 }, testDb);
+    expect(exec.calls[0].params).toEqual(['s1', cutoff.toISOString(), 10]);
+    expect(exec.calls[0].sql).toContain('<=');
   });
 
-  test('SQL COALESCEs role and content so the typed shape is accurate', async () => {
-    exec.enqueue({ rows: [] });
-    await repo.listRecentMessages('s1', {}, exec);
-    expect(exec.calls[0].sql).toContain("COALESCE(role, '')");
-    expect(exec.calls[0].sql).toContain("COALESCE(content, '')");
+  test('null role/content coerce to ""', async () => {
+    exec.enqueue({ rows: [[null, null]] });
+    const [t] = await repo.listRecentMessages('s1', {}, testDb);
+    expect(t).toEqual({ role: '', content: '' });
   });
 });
 
 describe('insertUserMessage', () => {
-  test('writes role=user with [id, sessionId, content]', async () => {
+  test('writes role=user with [id, sessionId, role, content]', async () => {
     exec.enqueue({ rows: [] });
-    await repo.insertUserMessage('m1', 's1', 'hi', exec);
-    expect(exec.calls[0].params).toEqual(['m1', 's1', 'hi']);
-    expect(exec.calls[0].sql).toContain("'user'");
-    expect(exec.calls[0].sql).toContain('CURRENT_TIMESTAMP');
+    await repo.insertUserMessage('m1', 's1', 'hi', testDb);
+    expect(exec.calls[0].params).toEqual(['m1', 's1', 'user', 'hi']);
+    expect(exec.calls[0].sql).toContain('insert into "report_chat_messages"');
   });
 });
 
 describe('insertAssistantMessage', () => {
-  test('without createdAt: passes null as $5 so COALESCE falls through to CURRENT_TIMESTAMP', async () => {
+  test('without createdAt: column default supplies created_at; binds 5 params', async () => {
     exec.enqueue({ rows: [] });
     await repo.insertAssistantMessage(
       { id: 'm1', sessionId: 's1', content: 'ok', thoughtContent: null },
-      exec,
+      testDb,
     );
-    expect(exec.calls[0].params).toEqual(['m1', 's1', 'ok', null, null]);
-    expect(exec.calls[0].sql).toContain('COALESCE($5::timestamptz, CURRENT_TIMESTAMP)');
+    expect(exec.calls[0].params).toEqual(['m1', 's1', 'assistant', 'ok', null]);
   });
 
-  test('with explicit createdAt: passes it through as $5', async () => {
+  test('with explicit Date createdAt: binds it as the 6th param (ISO-serialized)', async () => {
     exec.enqueue({ rows: [] });
     const when = new Date('2026-05-01T12:00:00Z');
     await repo.insertAssistantMessage(
@@ -246,52 +252,85 @@ describe('insertAssistantMessage', () => {
         thoughtContent: 'thinking…',
         createdAt: when,
       },
-      exec,
+      testDb,
     );
-    expect(exec.calls[0].params).toEqual(['m1', 's1', 'ok', 'thinking…', when]);
+    expect(exec.calls[0].params).toEqual([
+      'm1',
+      's1',
+      'assistant',
+      'ok',
+      'thinking…',
+      when.toISOString(),
+    ]);
+  });
+
+  test('with string createdAt: coerced to Date in repo, then ISO-serialized by Drizzle', async () => {
+    exec.enqueue({ rows: [] });
+    const iso = '2026-05-01T12:00:00.000Z';
+    await repo.insertAssistantMessage(
+      {
+        id: 'm1',
+        sessionId: 's1',
+        content: 'ok',
+        thoughtContent: null,
+        createdAt: iso,
+      },
+      testDb,
+    );
+    const params = exec.calls[0].params;
+    expect(params[params.length - 1]).toBe(iso);
   });
 });
 
 describe('findUserMessage / findFirstAssistantAfter', () => {
   test('findUserMessage returns null when missing', async () => {
     exec.enqueue({ rows: [] });
-    expect(await repo.findUserMessage('m1', 's1', exec)).toBeNull();
+    expect(await repo.findUserMessage('m1', 's1', testDb)).toBeNull();
   });
 
-  test('findUserMessage maps created_at via SQL alias and returns first row', async () => {
+  test('findUserMessage returns first row as ChatMessageRef', async () => {
     const when = new Date('2026-05-01T12:00:00Z');
-    exec.enqueue({ rows: [{ id: 'm1', createdAt: when }] });
-    const result = await repo.findUserMessage('m1', 's1', exec);
+    exec.enqueue({ rows: [['m1', when]] });
+    const result = await repo.findUserMessage('m1', 's1', testDb);
     expect(result).toEqual({ id: 'm1', createdAt: when });
-    expect(exec.calls[0].sql).toContain("role = 'user'");
+  });
+
+  test('findUserMessage binds [messageId, sessionId, role=user]', async () => {
+    exec.enqueue({ rows: [] });
+    await repo.findUserMessage('m1', 's1', testDb);
+    expect(exec.calls[0].params).toContain('m1');
+    expect(exec.calls[0].params).toContain('s1');
+    expect(exec.calls[0].params).toContain('user');
   });
 
   test('findFirstAssistantAfter returns null when no later message', async () => {
     exec.enqueue({ rows: [] });
-    expect(await repo.findFirstAssistantAfter('s1', new Date('2026-05-01'), exec)).toBeNull();
+    expect(await repo.findFirstAssistantAfter('s1', new Date('2026-05-01'), testDb)).toBeNull();
   });
 
-  test('findFirstAssistantAfter passes [sessionId, afterDate] and orders ASC', async () => {
+  test('findFirstAssistantAfter binds [sessionId, role=assistant, afterDate] and orders ASC', async () => {
     exec.enqueue({ rows: [] });
     const when = new Date('2026-05-01T12:00:00Z');
-    await repo.findFirstAssistantAfter('s1', when, exec);
-    expect(exec.calls[0].params).toEqual(['s1', when]);
-    expect(exec.calls[0].sql).toContain('ORDER BY created_at ASC');
-    expect(exec.calls[0].sql).toContain("role = 'assistant'");
+    await repo.findFirstAssistantAfter('s1', when, testDb);
+    expect(exec.calls[0].params).toContain('s1');
+    expect(exec.calls[0].params).toContain('assistant');
+    expect(exec.calls[0].params).toContain(when.toISOString());
+    expect(exec.calls[0].sql.toLowerCase()).toContain('order by');
+    expect(exec.calls[0].sql.toLowerCase()).toContain('asc');
   });
 });
 
 describe('deleteMessage / updateMessageContent', () => {
-  test('deleteMessage passes id as $1', async () => {
+  test('deleteMessage targets report_chat_messages with [id]', async () => {
     exec.enqueue({ rows: [] });
-    await repo.deleteMessage('m1', exec);
+    await repo.deleteMessage('m1', testDb);
     expect(exec.calls[0].params).toEqual(['m1']);
-    expect(exec.calls[0].sql).toContain('DELETE FROM report_chat_messages');
+    expect(exec.calls[0].sql).toContain('delete from "report_chat_messages"');
   });
 
-  test('updateMessageContent passes [content, id] in that order', async () => {
+  test('updateMessageContent binds [content, id] (set first, then where)', async () => {
     exec.enqueue({ rows: [] });
-    await repo.updateMessageContent('m1', 'new', exec);
+    await repo.updateMessageContent('m1', 'new', testDb);
     expect(exec.calls[0].params).toEqual(['new', 'm1']);
   });
 });
@@ -299,19 +338,20 @@ describe('deleteMessage / updateMessageContent', () => {
 describe('getFirstUserMessageContent', () => {
   test('returns empty string when no user message', async () => {
     exec.enqueue({ rows: [] });
-    expect(await repo.getFirstUserMessageContent('s1', exec)).toBe('');
+    expect(await repo.getFirstUserMessageContent('s1', testDb)).toBe('');
   });
 
-  test('returns first user message content', async () => {
-    exec.enqueue({ rows: [{ content: 'first ask' }] });
-    expect(await repo.getFirstUserMessageContent('s1', exec)).toBe('first ask');
+  test('returns first user message content from positional row', async () => {
+    exec.enqueue({ rows: [['first ask']] });
+    expect(await repo.getFirstUserMessageContent('s1', testDb)).toBe('first ask');
   });
 
-  test('SQL filters role=user and orders ASC LIMIT 1', async () => {
+  test('binds [sessionId, role=user] and limits to 1 with ASC order', async () => {
     exec.enqueue({ rows: [] });
-    await repo.getFirstUserMessageContent('s1', exec);
-    expect(exec.calls[0].sql).toContain("role = 'user'");
-    expect(exec.calls[0].sql).toContain('ORDER BY created_at ASC');
-    expect(exec.calls[0].sql).toContain('LIMIT 1');
+    await repo.getFirstUserMessageContent('s1', testDb);
+    expect(exec.calls[0].params).toContain('s1');
+    expect(exec.calls[0].params).toContain('user');
+    expect(exec.calls[0].params).toContain(1); // limit
+    expect(exec.calls[0].sql.toLowerCase()).toContain('asc');
   });
 });

--- a/server/test/repositories/reportsCatalogRepo.test.ts
+++ b/server/test/repositories/reportsCatalogRepo.test.ts
@@ -1,23 +1,21 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
+import type { DbExecutor } from '../../db/drizzle.ts';
 import * as repo from '../../repositories/reportsCatalogRepo.ts';
-import { type FakeExecutor, makeFakeExecutor } from '../helpers/fakeExecutor.ts';
+import { type FakeExecutor, setupTestDb } from '../helpers/fakeExecutor.ts';
 
 let exec: FakeExecutor;
+let testDb: DbExecutor;
 
 beforeEach(() => {
-  exec = makeFakeExecutor();
+  ({ exec, testDb } = setupTestDb());
 });
 
 const FROM = '2026-01-01';
 const TO = '2026-01-31';
 
-const enqueueEmptyN = (n: number) => {
-  for (let i = 0; i < n; i++) exec.enqueue({ rows: [] });
-};
-
 describe('getSuppliersSection', () => {
   test('summary + list run in parallel; activity branches skipped when no suppliers', async () => {
-    enqueueEmptyN(2);
+    exec.enqueueEmptyN(2);
     await repo.getSuppliersSection(
       {
         fromDate: FROM,
@@ -26,7 +24,7 @@ describe('getSuppliersSection', () => {
         canListProducts: true,
         itemsLimit: 50,
       },
-      exec,
+      testDb,
     );
     expect(exec.calls).toHaveLength(2);
   });
@@ -42,7 +40,7 @@ describe('getSuppliersSection', () => {
         canListProducts: false,
         itemsLimit: 50,
       },
-      exec,
+      testDb,
     );
     expect(result).toMatchObject({ count: 10, activeCount: 7, disabledCount: 3 });
   });
@@ -73,7 +71,7 @@ describe('getSuppliersSection', () => {
         canListProducts: false,
         itemsLimit: 50,
       },
-      exec,
+      testDb,
     );
     expect(exec.calls).toHaveLength(3);
     expect(result.activitySummary).toEqual([
@@ -89,8 +87,8 @@ describe('getSuppliersSection', () => {
 
 describe('getSupplierQuotesSection', () => {
   test('dispatches 5 parallel queries on supplier_quotes', async () => {
-    enqueueEmptyN(5);
-    await repo.getSupplierQuotesSection({ fromDate: FROM, toDate: TO, topLimit: 10 }, exec);
+    exec.enqueueEmptyN(5);
+    await repo.getSupplierQuotesSection({ fromDate: FROM, toDate: TO, topLimit: 10 }, testDb);
     expect(exec.calls).toHaveLength(5);
     for (const call of exec.calls) {
       expect(call.sql).toContain('FROM supplier_quotes sq');
@@ -100,8 +98,8 @@ describe('getSupplierQuotesSection', () => {
   });
 
   test('LIMIT queries pass topLimit as $3 (parameterized, not interpolated)', async () => {
-    enqueueEmptyN(5);
-    await repo.getSupplierQuotesSection({ fromDate: FROM, toDate: TO, topLimit: 7 }, exec);
+    exec.enqueueEmptyN(5);
+    await repo.getSupplierQuotesSection({ fromDate: FROM, toDate: TO, topLimit: 7 }, testDb);
     const limited = exec.calls.filter((c) => /LIMIT \$\d+/.test(c.sql));
     expect(limited.length).toBeGreaterThan(0);
     for (const call of limited) {
@@ -111,9 +109,7 @@ describe('getSupplierQuotesSection', () => {
   });
 
   test('topQuotesByNet maps id into both id and purchaseOrderNumber', async () => {
-    enqueueEmptyN(2);
-    enqueueEmptyN(1);
-    enqueueEmptyN(1);
+    exec.enqueueEmptyN(4);
     exec.enqueue({
       rows: [
         {
@@ -127,7 +123,7 @@ describe('getSupplierQuotesSection', () => {
     });
     const result = await repo.getSupplierQuotesSection(
       { fromDate: FROM, toDate: TO, topLimit: 10 },
-      exec,
+      testDb,
     );
     expect(result.topQuotesByNet).toEqual([
       {
@@ -144,8 +140,8 @@ describe('getSupplierQuotesSection', () => {
 
 describe('getCatalogSection', () => {
   test('dispatches 7 parallel queries (counts + 4 breakdowns + 2 top lists)', async () => {
-    enqueueEmptyN(7);
-    await repo.getCatalogSection({ fromDate: FROM, toDate: TO, topLimit: 10 }, exec);
+    exec.enqueueEmptyN(7);
+    await repo.getCatalogSection({ fromDate: FROM, toDate: TO, topLimit: 10 }, testDb);
     expect(exec.calls).toHaveLength(7);
   });
 
@@ -153,24 +149,27 @@ describe('getCatalogSection', () => {
     exec.enqueue({
       rows: [{ internal_count: '5', external_count: '3', disabled_count: '1' }],
     });
-    enqueueEmptyN(6);
-    const result = await repo.getCatalogSection({ fromDate: FROM, toDate: TO, topLimit: 10 }, exec);
+    exec.enqueueEmptyN(6);
+    const result = await repo.getCatalogSection(
+      { fromDate: FROM, toDate: TO, topLimit: 10 },
+      testDb,
+    );
     expect(result.productCounts).toEqual({ internal: 5, external: 3, disabled: 1 });
   });
 
   test('productsBySupplier query has [topLimit] as the only param (LIMIT $1)', async () => {
-    enqueueEmptyN(7);
-    await repo.getCatalogSection({ fromDate: FROM, toDate: TO, topLimit: 12 }, exec);
+    exec.enqueueEmptyN(7);
+    await repo.getCatalogSection({ fromDate: FROM, toDate: TO, topLimit: 12 }, testDb);
     const productsBySupplierCall = exec.calls.find((c) => c.sql.includes('LEFT JOIN suppliers'));
     expect(productsBySupplierCall?.params).toEqual([12]);
     expect(productsBySupplierCall?.sql).toContain('LIMIT $1');
   });
 
-  test('top product queries use parameterized LIMIT $3 with [from, to, topLimit]', async () => {
-    enqueueEmptyN(7);
-    await repo.getCatalogSection({ fromDate: FROM, toDate: TO, topLimit: 8 }, exec);
+  test('top usage query binds [from, to] per UNION ALL leg + topLimit (7 params, LIMIT $7)', async () => {
+    exec.enqueueEmptyN(7);
+    await repo.getCatalogSection({ fromDate: FROM, toDate: TO, topLimit: 8 }, testDb);
     const usageCall = exec.calls.find((c) => c.sql.includes('WITH usage_rows'));
-    expect(usageCall?.params).toEqual([FROM, TO, 8]);
-    expect(usageCall?.sql).toContain('LIMIT $3');
+    expect(usageCall?.params).toEqual([FROM, TO, FROM, TO, FROM, TO, 8]);
+    expect(usageCall?.sql).toContain('LIMIT $7');
   });
 });

--- a/server/test/repositories/reportsClientsRepo.test.ts
+++ b/server/test/repositories/reportsClientsRepo.test.ts
@@ -1,11 +1,13 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
+import type { DbExecutor } from '../../db/drizzle.ts';
 import * as repo from '../../repositories/reportsClientsRepo.ts';
-import { type FakeExecutor, makeFakeExecutor } from '../helpers/fakeExecutor.ts';
+import { type FakeExecutor, setupTestDb } from '../helpers/fakeExecutor.ts';
 
 let exec: FakeExecutor;
+let testDb: DbExecutor;
 
 beforeEach(() => {
-  exec = makeFakeExecutor();
+  ({ exec, testDb } = setupTestDb());
 });
 
 const FROM = '2026-01-01';
@@ -24,29 +26,25 @@ const baseOpts = {
   itemsLimit: 50,
 };
 
-const enqueueEmptyN = (n: number) => {
-  for (let i = 0; i < n; i++) exec.enqueue({ rows: [] });
-};
-
 describe('getClientsSection', () => {
   test('admin viewer: count + list run in parallel; no activity queries when permissions disabled', async () => {
-    enqueueEmptyN(2);
+    exec.enqueueEmptyN(2);
     exec.enqueue({ rows: [{ count: '0' }] });
-    await repo.getClientsSection({ ...baseOpts }, exec);
+    await repo.getClientsSection({ ...baseOpts }, testDb);
     expect(exec.calls).toHaveLength(2);
     expect(exec.calls[0].sql).toContain('SELECT COUNT(*)');
     expect(exec.calls[1].sql).not.toContain('user_clients');
   });
 
   test('non-admin viewer joins user_clients with viewerId', async () => {
-    enqueueEmptyN(2);
-    await repo.getClientsSection({ ...baseOpts, canViewAllClients: false }, exec);
+    exec.enqueueEmptyN(2);
+    await repo.getClientsSection({ ...baseOpts, canViewAllClients: false }, testDb);
     expect(exec.calls[0].sql).toContain('JOIN user_clients');
     expect(exec.calls[0].params).toEqual(['u1']);
     expect(exec.calls[1].params).toEqual(['u1', 50]);
   });
 
-  test('client list maps row shape with toText/Boolean coercion', async () => {
+  test('client list maps row shape with toDbText/Boolean coercion', async () => {
     exec.enqueue({ rows: [{ count: '1' }] });
     exec.enqueue({
       rows: [
@@ -63,7 +61,7 @@ describe('getClientsSection', () => {
         },
       ],
     });
-    const result = await repo.getClientsSection({ ...baseOpts }, exec);
+    const result = await repo.getClientsSection({ ...baseOpts }, testDb);
     expect(result.count).toBe(1);
     expect(result.items).toEqual([
       {
@@ -91,7 +89,7 @@ describe('getClientsSection', () => {
         canViewInvoices: true,
         canViewTimesheets: true,
       },
-      exec,
+      testDb,
     );
     // only count + list — activity Promise.all is short-circuited because clientIds is empty
     expect(exec.calls).toHaveLength(2);
@@ -116,7 +114,7 @@ describe('getClientsSection', () => {
     });
     exec.enqueue({ rows: [{ client_id: 'c1', quote_count: '2', net_value: '500' }] });
     // canViewQuotes=true only; orders/invoices/timesheets stay null
-    const result = await repo.getClientsSection({ ...baseOpts, canViewQuotes: true }, exec);
+    const result = await repo.getClientsSection({ ...baseOpts, canViewQuotes: true }, testDb);
     expect(exec.calls).toHaveLength(3);
     expect(result.activitySummary).toEqual([
       {
@@ -158,7 +156,7 @@ describe('getClientsSection', () => {
         canViewAllTimesheets: false,
         allowedTimesheetUserIds: ['u1', 'u2'],
       },
-      exec,
+      testDb,
     );
     const tsCall = exec.calls.find((c) => c.sql.includes('time_entries'));
     expect(tsCall?.params).toEqual([FROM, TO, ['u1', 'u2'], ['c1']]);

--- a/server/test/repositories/reportsRevenueRepo.test.ts
+++ b/server/test/repositories/reportsRevenueRepo.test.ts
@@ -1,24 +1,22 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
+import type { DbExecutor } from '../../db/drizzle.ts';
 import * as repo from '../../repositories/reportsRevenueRepo.ts';
-import { type FakeExecutor, makeFakeExecutor } from '../helpers/fakeExecutor.ts';
+import { type FakeExecutor, setupTestDb } from '../helpers/fakeExecutor.ts';
 
 let exec: FakeExecutor;
+let testDb: DbExecutor;
 
 beforeEach(() => {
-  exec = makeFakeExecutor();
+  ({ exec, testDb } = setupTestDb());
 });
 
 const FROM = '2026-01-01';
 const TO = '2026-01-31';
 
-const enqueueEmptyN = (n: number) => {
-  for (let i = 0; i < n; i++) exec.enqueue({ rows: [] });
-};
-
 describe('getQuotesSection', () => {
   test('dispatches 5 parallel queries, each scoped to [fromDate, toDate, ...]', async () => {
-    enqueueEmptyN(5);
-    await repo.getQuotesSection({ fromDate: FROM, toDate: TO, topLimit: 10 }, exec);
+    exec.enqueueEmptyN(5);
+    await repo.getQuotesSection({ fromDate: FROM, toDate: TO, topLimit: 10 }, testDb);
     expect(exec.calls).toHaveLength(5);
     for (const call of exec.calls) {
       expect(call.params[0]).toBe(FROM);
@@ -27,8 +25,8 @@ describe('getQuotesSection', () => {
   });
 
   test('parameterizes LIMIT (no string interpolation)', async () => {
-    enqueueEmptyN(5);
-    await repo.getQuotesSection({ fromDate: FROM, toDate: TO, topLimit: 25 }, exec);
+    exec.enqueueEmptyN(5);
+    await repo.getQuotesSection({ fromDate: FROM, toDate: TO, topLimit: 25 }, testDb);
     const limited = exec.calls.filter((c) => /LIMIT \$\d+/.test(c.sql));
     expect(limited.length).toBeGreaterThan(0);
     for (const call of limited) {
@@ -53,7 +51,10 @@ describe('getQuotesSection', () => {
     });
     exec.enqueue({ rows: [{ label: 'Acme', quote_count: '2', value: '500' }] });
 
-    const result = await repo.getQuotesSection({ fromDate: FROM, toDate: TO, topLimit: 10 }, exec);
+    const result = await repo.getQuotesSection(
+      { fromDate: FROM, toDate: TO, topLimit: 10 },
+      testDb,
+    );
 
     expect(result.totals).toEqual({ count: 3, totalNet: 600, avgNet: 200 });
     expect(result.byStatus).toEqual([{ status: 'won', count: 2, totalNet: 400 }]);
@@ -74,8 +75,8 @@ describe('getQuotesSection', () => {
 
 describe('getOrdersSection', () => {
   test('dispatches 5 parallel queries on sales/sale_items', async () => {
-    enqueueEmptyN(5);
-    await repo.getOrdersSection({ fromDate: FROM, toDate: TO, topLimit: 10 }, exec);
+    exec.enqueueEmptyN(5);
+    await repo.getOrdersSection({ fromDate: FROM, toDate: TO, topLimit: 10 }, testDb);
     expect(exec.calls).toHaveLength(5);
     for (const call of exec.calls) {
       expect(call.sql).toContain('FROM sales s');
@@ -99,7 +100,10 @@ describe('getOrdersSection', () => {
     });
     exec.enqueue({ rows: [{ label: 'Acme', order_count: '2', value: '900' }] });
 
-    const result = await repo.getOrdersSection({ fromDate: FROM, toDate: TO, topLimit: 10 }, exec);
+    const result = await repo.getOrdersSection(
+      { fromDate: FROM, toDate: TO, topLimit: 10 },
+      testDb,
+    );
     expect(result.totals.count).toBe(2);
     expect(result.topOrdersByNet).toEqual([
       {
@@ -116,8 +120,8 @@ describe('getOrdersSection', () => {
 
 describe('getInvoicesSection', () => {
   test('dispatches 6 parallel queries on invoices', async () => {
-    enqueueEmptyN(6);
-    await repo.getInvoicesSection({ fromDate: FROM, toDate: TO, topLimit: 10 }, exec);
+    exec.enqueueEmptyN(6);
+    await repo.getInvoicesSection({ fromDate: FROM, toDate: TO, topLimit: 10 }, testDb);
     expect(exec.calls).toHaveLength(6);
     for (const call of exec.calls) {
       expect(call.sql).toContain('FROM invoices');
@@ -157,7 +161,7 @@ describe('getInvoicesSection', () => {
 
     const result = await repo.getInvoicesSection(
       { fromDate: FROM, toDate: TO, topLimit: 10 },
-      exec,
+      testDb,
     );
     expect(result.totals).toEqual({ count: 4, total: 1000, outstanding: 300, paidAmount: 700 });
     expect(result.aging).toEqual([{ bucket: '0-30', count: 1, outstanding: 300 }]);


### PR DESCRIPTION
## Summary

- Converts the four reports-domain repositories from raw `pg` to Drizzle:
  - `reportsAiChatRepo` uses the typed query builder for chat session/message CRUD (tracks the new `report_chat_sessions` / `report_chat_messages` schemas).
  - `reportsCatalogRepo`, `reportsClientsRepo`, and `reportsRevenueRepo` keep their CTE-heavy analytic SQL but route it through the shared `executeRows(exec, sql\`...\`)` helper so they participate in the Drizzle executor surface.
- Models the previously-untracked `report_chat_sessions` and `report_chat_messages` tables in Drizzle and adds a guarded claim migration (`0017_claim_report_chat_tables.sql`) — `IF NOT EXISTS` and a shape-based FK check make it a no-op against existing dev/prod DBs that already have the tables from `schema.sql`.
- Lifts `setupTestDb` and `enqueueEmptyN` onto the shared `FakeExecutor` so the four reports test files use the same Drizzle-backed fake instead of duplicating local helpers.

## Notes for reviewers

- `CHAT_ROLE` mirrors a DB-side `CHECK (role IN ('user', 'assistant'))` constraint — the schema file flags this, since `pg-core` has no first-class CHECK helper. Don't broaden the union without coordinating a CHECK update.
- `sql.param(...)` wrapping `ANY(...)` array binds in catalog/clients repos is load-bearing — Drizzle splays bare arrays into individual params, which `ANY` rejects.
- The `idx_report_chat_sessions_user_archived` index is mostly defensive; `listSessionsForUser`'s `ORDER BY updated_at DESC LIMIT 50` will prefer the user_updated index. Kept anyway given low write traffic.
- Migration journal entry is `0017_claim_report_chat_tables` (idx 17), continuing from tier 5's `0016_claim_products_and_categories`.

## Test plan

- [x] `bun test test/repositories` — 620 passes / 0 failures (28 files), including the four refactored reports repos.
- [ ] Smoke-test the AI Reporting chat UI (create session, send message, archive, retry) against a dev DB with existing `report_chat_*` data — the guarded migration should be a no-op.
- [ ] Run `bun run db:check` to confirm the 0017 snapshot lines up with `schema.sql` for the chat tables.