### PR TITLE
build(docker): bump Bun runtime from 1.3.12 to 1.3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.12
+          bun-version: 1.3.13
 
       - name: Install root dependencies
         run: bun install --frozen-lockfile
@@ -65,7 +65,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.12
+          bun-version: 1.3.13
 
       - name: Install root dependencies
         run: bun install --frozen-lockfile
@@ -87,7 +87,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.12
+          bun-version: 1.3.13
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # STAGE 1: Install dependencies
-FROM oven/bun:1.3.12 AS install
+FROM oven/bun:1.3.13 AS install
 WORKDIR /temp
 COPY package.json bun.lock ./
 RUN bun install --frozen-lockfile
 
 # STAGE 2: Build
-FROM oven/bun:1.3.12 AS builder
+FROM oven/bun:1.3.13 AS builder
 WORKDIR /app
 COPY --from=install /temp/node_modules node_modules
 COPY . .

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,11 +1,11 @@
 # STAGE 1: Install dependencies
-FROM oven/bun:1.3.12 AS install
+FROM oven/bun:1.3.13 AS install
 WORKDIR /temp
 COPY package.json bun.lock ./
 RUN bun install --frozen-lockfile
 
 # STAGE 2: Production
-FROM oven/bun:1.3.12-slim AS release
+FROM oven/bun:1.3.13-slim AS release
 WORKDIR /app
 
 COPY --from=install /temp/node_modules node_modules


### PR DESCRIPTION
## Summary

- Bumps the pinned Bun version from `1.3.12` to `1.3.13` (latest stable, published to Docker Hub on 2026-04-20).
- Touches both Dockerfiles and the CI workflow so the runtime image and CI Bun version stay aligned.
- Keeps a fully-qualified patch tag (no `:latest`, no floating `1.3` series alias) so builds remain reproducible.

## Files changed

- `Dockerfile` — frontend build stages (`oven/bun:1.3.12` → `oven/bun:1.3.13`, ×2)
- `server/Dockerfile` — backend (`oven/bun:1.3.12` → `oven/bun:1.3.13`; `oven/bun:1.3.12-slim` → `oven/bun:1.3.13-slim` for the production stage)
- `.github/workflows/ci.yml` — `bun-version: 1.3.12` → `1.3.13` across the `lint`, `test`, and `build` jobs

7 line changes total, no logic moves.

## Notes for reviewers

- The repo's `@types/bun` / `bun-types` were already at `1.3.13` in `bun.lock`/`server/bun.lock`, so the dev types and the runtime image are now on the same minor+patch line.
- The `docker-stack` job in `ci.yml` already exercises a full `docker compose build` + healthcheck + migration cycle, so a green CI run is the end-to-end signal here.

## Test plan

- [ ] CI passes (lint, test, build, docker-stack)
- [ ] `docker compose build` resolves the new tags locally without errors
- [ ] `docker compose exec backend bun --version` reports `1.3.13` after stack is up

🤖 Generated with [Claude Code](https://claude.com/claude-code)