### PR TITLE
fix(hr): right-align action buttons on Internal Employees page

### DIFF
--- a/components/HR/InternalEmployeesView.tsx
+++ b/components/HR/InternalEmployeesView.tsx
@@ -216,8 +216,9 @@ const InternalEmployeesView: React.FC<InternalEmployeesViewProps> = ({
     {
       header: t('internalEmployees.actions'),
       id: 'actions',
+      align: 'right' as const,
       cell: ({ row }) => (
-        <div className="flex items-center gap-2">
+        <div className="flex items-center justify-end gap-2">
           {canManageEmployeeAssignments &&
             !row.hasTopManagerRole &&
             row.role !== TOP_MANAGER_ROLE_ID && (


### PR DESCRIPTION
## Summary
- Action buttons on the Internal Employees page now align flush against the right edge of the Actions column, matching its right-aligned header and the pattern used in [components/clients/ClientsView.tsx](https://github.com/xBounceIT/praetor/blob/main/components/clients/ClientsView.tsx) and [components/clients/ClientsInvoicesView.tsx](https://github.com/xBounceIT/praetor/blob/main/components/clients/ClientsInvoicesView.tsx).
- Two-line change in [components/HR/InternalEmployeesView.tsx](https://github.com/xBounceIT/praetor/blob/main/components/HR/InternalEmployeesView.tsx): added `align: 'right' as const` on the column and `justify-end` on the cell's flex wrapper.

## Why
`StandardTable` already applies `text-right` to the last column's `<th>`/`<td>`, but the cell wrapped its buttons in a `flex` container — and flex containers ignore `text-align`, defaulting to `justify-content: flex-start`. So the buttons clustered on the left while the header sat on the right, an inconsistent look against sibling pages.

## Out of scope
`ExternalEmployeesView.tsx` has the identical issue. Not touched here per scope; happy to follow up if desired.

## Test plan
- [ ] Visit HR → Internal Employees as `admin`; confirm the manage-assignments / edit / delete icons sit flush right, in line with the header
- [ ] Compare side-by-side with HR → External Employees (still left-aligned — known) and Clients (already right-aligned, should match)
- [ ] `bun run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)