### PR TITLE
fix(timesheet): cap weekly day-column width on large screens

### DIFF
--- a/components/timesheet/WeeklyView.tsx
+++ b/components/timesheet/WeeklyView.tsx
@@ -459,7 +459,7 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
                 {weekDays.map((day) => (
                   <th
                     key={day.dateStr}
-                    className={`px-2 py-2 text-center relative ${day.isToday ? 'bg-slate-100' : ''} ${day.isWeekendOrHoliday ? 'bg-red-50/50' : ''}`}
+                    className={`w-28 px-2 py-2 text-center relative ${day.isToday ? 'bg-slate-100' : ''} ${day.isWeekendOrHoliday ? 'bg-red-50/50' : ''}`}
                   >
                     <div
                       className={`flex items-center justify-center gap-1 text-[10px] font-black uppercase ${day.isToday ? 'text-praetor' : day.isWeekendOrHoliday ? 'text-red-500' : 'text-slate-400'}`}
@@ -578,7 +578,7 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
                   {weekDays.map((day) => (
                     <td
                       key={day.dateStr}
-                      className={`px-2 py-4 transition-all duration-700 ${day.isToday ? 'bg-slate-50' : ''} ${day.isWeekendOrHoliday ? 'bg-red-50/30' : ''} ${showSuccess && row.days[day.dateStr]?.duration > 0 ? 'bg-emerald-50' : ''}`}
+                      className={`w-28 px-2 py-4 transition-all duration-700 ${day.isToday ? 'bg-slate-50' : ''} ${day.isWeekendOrHoliday ? 'bg-red-50/30' : ''} ${showSuccess && row.days[day.dateStr]?.duration > 0 ? 'bg-emerald-50' : ''}`}
                     >
                       <div className="flex flex-col gap-2 items-center relative">
                         {showSuccess && row.days[day.dateStr]?.duration > 0 && (
@@ -641,7 +641,7 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
                 {weekDays.map((day) => (
                   <td
                     key={day.dateStr}
-                    className={`px-2 py-4 text-center ${day.isToday ? 'bg-slate-100' : ''} ${day.isWeekendOrHoliday ? 'bg-red-50/50' : ''}`}
+                    className={`w-28 px-2 py-4 text-center ${day.isToday ? 'bg-slate-100' : ''} ${day.isWeekendOrHoliday ? 'bg-red-50/50' : ''}`}
                   >
                     <p
                       className={`text-xs font-black ${(dayTotals[day.dateStr] as number) > 8 ? 'text-red-600' : 'text-praetor'}`}


### PR DESCRIPTION
## Summary

- Day cells in `WeeklyView` had no width constraint, so on wide monitors each column stretched to 200–300px and the hour input — which only ever holds a 1–2 digit value — looked absurdly oversized (see screenshot in the spawning thread).
- Adds `w-28` (112px) to the day `<th>`, body `<td>`, and footer `<td>`. Inputs keep `w-full` so they fill whatever the cell becomes; with the cap, that's a sensible ~96px after padding.
- Extra horizontal space now flows to the unconstrained Client/Project/Task columns, which is where it should go (those hold dropdowns + a week-note input).

## Why this approach

- Matches the existing convention — left column widths are already controlled at the cell level via `min-w-28`/`min-w-24`, and `StandardTable.tsx` does column sizing on `<th>`/`<td>`, not on the inputs inside.
- No `<colgroup>` pattern exists in this codebase; introducing one for a single file would be a net-new pattern for three identical literals.
- Width chosen so `99.9` fits comfortably centered and the short note placeholder underneath stays readable.

## Test plan

- [ ] Open the Weekly timesheet view on a wide monitor (≥1440px) and confirm each day column is now ~112px wide; hour inputs and notes are no longer stretched.
- [ ] Type `12.5` into a day cell — fits comfortably, centered, no clipping.
- [ ] Resize the browser narrower (~1024px) — day columns hold at `w-28`; the wrapper's existing `overflow-x-auto` still kicks in if total table width exceeds the container.
- [ ] Verify the tfoot day-totals row still aligns under each day column.
- [ ] Verify the sticky right-hand "Total" column still renders correctly with its shadow/border.

🤖 Generated with [Claude Code](https://claude.com/claude-code)