### PR TITLE
fix(table): render empty filter values as "N/A"

### DIFF
--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -235,6 +235,18 @@ const StandardTable = <T extends object>({
     return null;
   }, []);
 
+  // Normalize empty raw values to a single sentinel so the filter list shows
+  // one "N/A" entry instead of "", "null", "undefined" duplicates. Columns
+  // with their own `filterFormat` returning a placeholder (e.g. '-') are
+  // unaffected because their raw value isn't null/empty.
+  const formatForFilter = useCallback(
+    (rawVal: T[keyof T] | string | number | boolean | null | undefined, col: Column<T>): string => {
+      if (rawVal === null || rawVal === undefined || rawVal === '') return '';
+      return col.filterFormat ? col.filterFormat(rawVal) : String(rawVal);
+    },
+    [],
+  );
+
   // Derived Data
   const processedData = useMemo(() => {
     if (!data || !columns) return [];
@@ -248,7 +260,7 @@ const StandardTable = <T extends object>({
         if (col) {
           result = result.filter((row) => {
             const rawVal = getValue(row, col);
-            const val = col.filterFormat ? col.filterFormat(rawVal) : String(rawVal);
+            const val = formatForFilter(rawVal, col);
             return selectedValues.includes(val);
           });
         }
@@ -277,7 +289,7 @@ const StandardTable = <T extends object>({
     }
 
     return result;
-  }, [data, columns, filterState, sortState, getValue, getColId]);
+  }, [data, columns, filterState, sortState, getValue, getColId, formatForFilter]);
 
   // Pagination
   const totalItems = data ? processedData.length : externalTotalCount || 0;
@@ -295,7 +307,7 @@ const StandardTable = <T extends object>({
     const values = new Set<string>();
     data.forEach((row) => {
       const val = getValue(row, col);
-      values.add(col.filterFormat ? col.filterFormat(val) : String(val));
+      values.add(formatForFilter(val, col));
     });
     return Array.from(values).sort();
   };

--- a/components/shared/TableFilter.tsx
+++ b/components/shared/TableFilter.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import Checkbox from './Checkbox';
 import Tooltip from './Tooltip';
@@ -26,10 +26,13 @@ const TableFilter: React.FC<TableFilterProps> = ({
   const { t } = useTranslation('common');
   const [searchTerm, setSearchTerm] = useState('');
 
+  const displayLabel = useCallback((opt: string) => (opt === '' ? t('table.empty') : opt), [t]);
+
   const filteredOptions = useMemo(() => {
     if (!searchTerm) return options;
-    return options.filter((opt) => String(opt).toLowerCase().includes(searchTerm.toLowerCase()));
-  }, [options, searchTerm]);
+    const needle = searchTerm.toLowerCase();
+    return options.filter((opt) => displayLabel(opt).toLowerCase().includes(needle));
+  }, [options, searchTerm, displayLabel]);
 
   const handleCheckboxChange = (value: string) => {
     const newSelected = selectedValues.includes(value)
@@ -132,9 +135,11 @@ const TableFilter: React.FC<TableFilterProps> = ({
                 checked={selectedValues.includes(opt)}
                 onChange={() => handleCheckboxChange(opt)}
               />
-              <Tooltip label={opt}>
+              <Tooltip label={displayLabel(opt)}>
                 {() => (
-                  <span className="text-[11px] text-slate-600 truncate select-none">{opt}</span>
+                  <span className="text-[11px] text-slate-600 truncate select-none">
+                    {displayLabel(opt)}
+                  </span>
                 )}
               </Tooltip>
             </label>

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -248,7 +248,8 @@
     "decreaseFont": "Decrease font size",
     "columnSettings": "Column settings",
     "columns": "Columns",
-    "resetColumns": "Reset columns"
+    "resetColumns": "Reset columns",
+    "empty": "N/A"
   },
   "select": {
     "placeholder": "Select...",

--- a/locales/it/common.json
+++ b/locales/it/common.json
@@ -248,7 +248,8 @@
     "decreaseFont": "Riduci dimensione testo",
     "columnSettings": "Impostazioni colonne",
     "columns": "Colonne",
-    "resetColumns": "Ripristina colonne"
+    "resetColumns": "Ripristina colonne",
+    "empty": "N/A"
   },
   "select": {
     "placeholder": "Seleziona...",


### PR DESCRIPTION
## Summary

The shared `TableFilter` popup previously rendered a **blank, unlabeled checkbox** for any column whose rows contained `null`/`undefined`/empty values. Worse, when no `filterFormat` was defined, `String(null)` and `String(undefined)` produced literal `"null"` and `"undefined"` entries — so a single column could surface multiple confusing empty options.

This PR normalizes all empty representations to a single `""` sentinel inside `StandardTable`'s filter pipeline (deduping naturally via the existing `Set<string>`), then renders that sentinel as a localized **"N/A"** label inside `TableFilter`'s option list, tooltip, and search filter.

## What changed

- **`components/shared/StandardTable.tsx`** — added `formatForFilter(rawVal, col)` helper. It short-circuits `null`/`undefined`/`""` to `""` *before* `filterFormat` runs, then defers to the column's `filterFormat` (or `String(...)`) for everything else. Used in both the row-matching loop and `getFilterOptions`.
- **`components/shared/TableFilter.tsx`** — added `displayLabel(opt)` helper that renders the empty sentinel as `t('table.empty')`. Applied to the rendered span, the `Tooltip` label, and the search-filter match string (so typing `n/a` finds the empty entry).
- **`locales/en/common.json`** + **`locales/it/common.json`** — added `table.empty: "N/A"` (universal across both languages).

## Why this design

- **Normalize at the raw-value layer, not after `filterFormat`** — columns that already define `filterFormat` to return a custom placeholder like `'-'` or `'—'` (e.g. [`ClientsView.tsx:703-709`](https://github.com/xBounceIT/praetor/blob/main/components/CRM/ClientsView.tsx#L703-L709) for the `insertDate` column) are intentional and remain untouched. Only the `String(null) === "null"` fall-through path triggers the sentinel.
- **Display-only translation in `TableFilter`** — the `""` sentinel must round-trip through `selectedValues` for filter matching to work. Translating to `"N/A"` earlier (e.g. inside `StandardTable` before passing options) would break the round-trip identity.
- **Empty-string sentinel** dedupes cleanly via the existing `Set<string>` and sorts lexicographically first, so "N/A" floats to the top of the option list (Excel-style convention).

## Test plan

App runs in remote Docker per `CLAUDE.md`, so verify in the browser:

- [ ] Open the **Clients** view, click the filter icon on the **P.IVA / C.F.** column. The previously-blank entry should now display **"N/A"** (with a matching tooltip).
- [ ] Repeat for **EMAIL**, **TELEFONO**, **NUMERO DI SEDI**, **SETTORE** — each should show one **"N/A"** entry.
- [ ] Uncheck **"N/A"**: rows with no tax ID disappear from the table; re-check returns them.
- [ ] Type `n/a` in the filter search box — the **"N/A"** entry stays visible.
- [ ] Toggle **(Seleziona Tutto)** with **"N/A"** in the list — all options including **"N/A"** toggle together; indeterminate state works correctly.
- [ ] Spot-check a column with custom `filterFormat` returning `'-'` (e.g. **Data Inserimento** on Clients) — should still show `'-'`, NOT `"N/A"`, confirming custom formats are respected.
- [ ] Switch language to English (`/settings`) — `"N/A"` still resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)