### PR TITLE
fix(ui): render thin grey row dividers in StandardTable

### DIFF
--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -594,7 +594,7 @@ const StandardTable = <T extends object>({
             {(paginatedData.length > 0 ||
               Object.keys(filterState).length > 0 ||
               sortState !== null) && (
-              <thead className="bg-slate-50 border-b border-slate-100">
+              <thead className="bg-slate-50">
                 <tr>
                   {visibleColumns.map((col, colIdx) => {
                     const colId = getColId(col);
@@ -620,7 +620,7 @@ const StandardTable = <T extends object>({
                               ? { minWidth: '40px', width: 'auto' }
                               : undefined
                         }
-                        className={`relative group ${isLastColumn ? 'pl-3 pr-2' : 'px-3'} py-1.5 text-[10px] font-black text-slate-400 uppercase tracking-widest whitespace-nowrap ${isLastColumn && col.sticky !== 'right' ? 'w-full' : col.sticky === 'right' ? 'w-auto' : 'w-px'} ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''} ${!isLastColumn ? 'border-r border-slate-100' : ''} ${col.sticky === 'right' ? 'sticky right-0 bg-slate-50 border-l border-slate-200 z-20 shadow-[-4px_0_6px_-1px_rgba(0,0,0,0.05)]' : ''} ${col.headerClassName || ''}`}
+                        className={`relative group ${isLastColumn ? 'pl-3 pr-2' : 'px-3'} py-1.5 text-[10px] font-black text-slate-400 uppercase tracking-widest whitespace-nowrap border-b border-slate-100 ${isLastColumn && col.sticky !== 'right' ? 'w-full' : col.sticky === 'right' ? 'w-auto' : 'w-px'} ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''} ${!isLastColumn ? 'border-r border-slate-100' : ''} ${col.sticky === 'right' ? 'sticky right-0 bg-slate-50 border-l border-slate-200 z-20 shadow-[-4px_0_6px_-1px_rgba(0,0,0,0.05)]' : ''} ${col.headerClassName || ''}`}
                       >
                         {/* Inline wrapper for button beside text */}
                         <span className="inline-flex items-center gap-1">
@@ -692,58 +692,61 @@ const StandardTable = <T extends object>({
                 </tr>
               </thead>
             )}
-            <tbody className="divide-y divide-slate-100">
+            <tbody>
               {paginatedData.length > 0 ? (
-                paginatedData.map((row, idx) => (
-                  <tr
-                    key={idx}
-                    onClick={() => !disabledRow?.(row) && onRowClick?.(row)}
-                    className={`group transition-colors ${fontSizeClass} ${disabledRow?.(row) ? 'bg-slate-300 text-slate-500' : `${onRowClick ? 'cursor-pointer' : ''} ${rowClassName ? rowClassName(row) : 'hover:bg-slate-50/50'}`}`}
-                  >
-                    {visibleColumns.map((col, colIdx) => {
-                      const colId = getColId(col);
-                      const val = getValue(row, col);
-                      const isFirstColumn = colIdx === 0;
-                      const isLastColumn = colIdx === visibleColumns.length - 1;
-                      // Force alignment: first column left, last column right, otherwise use col.align
-                      const effectiveAlign = isFirstColumn
-                        ? 'left'
-                        : isLastColumn
-                          ? 'right'
-                          : col.align;
-                      const colWidth = columnWidths[colId];
-                      return (
-                        <td
-                          key={colId}
-                          onDoubleClick={(e) => {
-                            e.stopPropagation();
-                            col.onCellDoubleClick?.(row);
-                          }}
-                          style={
-                            colWidth
-                              ? { width: colWidth, minWidth: colWidth }
-                              : col.sticky === 'right'
-                                ? { minWidth: '40px' }
-                                : undefined
-                          }
-                          className={`${isLastColumn ? 'pl-3 pr-2' : 'px-3'} py-px whitespace-nowrap ${isLastColumn && col.sticky !== 'right' ? 'w-full' : col.sticky === 'right' ? 'w-auto text-right' : `w-px align-middle ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''}`} ${!isLastColumn ? 'border-r border-slate-100' : ''} ${col.sticky === 'right' ? 'sticky right-0 bg-white group-hover:bg-slate-50 transition-all duration-500 border-l border-slate-200 z-20 shadow-[-4px_0_6px_-1px_rgba(0,0,0,0.05)]' : ''} ${col.className || ''}`}
-                        >
-                          {col.sticky === 'right' ? (
-                            <div className="flex justify-end items-center w-full h-full">
-                              {col.cell
-                                ? col.cell({ getValue: () => val, row, value: val })
-                                : (val as ReactNode)}
-                            </div>
-                          ) : col.cell ? (
-                            col.cell({ getValue: () => val, row, value: val })
-                          ) : (
-                            (val as ReactNode)
-                          )}
-                        </td>
-                      );
-                    })}
-                  </tr>
-                ))
+                paginatedData.map((row, idx) => {
+                  const isLastRow = idx === paginatedData.length - 1;
+                  return (
+                    <tr
+                      key={idx}
+                      onClick={() => !disabledRow?.(row) && onRowClick?.(row)}
+                      className={`group transition-colors ${fontSizeClass} ${disabledRow?.(row) ? 'bg-slate-300 text-slate-500' : `${onRowClick ? 'cursor-pointer' : ''} ${rowClassName ? rowClassName(row) : 'hover:bg-slate-50/50'}`}`}
+                    >
+                      {visibleColumns.map((col, colIdx) => {
+                        const colId = getColId(col);
+                        const val = getValue(row, col);
+                        const isFirstColumn = colIdx === 0;
+                        const isLastColumn = colIdx === visibleColumns.length - 1;
+                        // Force alignment: first column left, last column right, otherwise use col.align
+                        const effectiveAlign = isFirstColumn
+                          ? 'left'
+                          : isLastColumn
+                            ? 'right'
+                            : col.align;
+                        const colWidth = columnWidths[colId];
+                        return (
+                          <td
+                            key={colId}
+                            onDoubleClick={(e) => {
+                              e.stopPropagation();
+                              col.onCellDoubleClick?.(row);
+                            }}
+                            style={
+                              colWidth
+                                ? { width: colWidth, minWidth: colWidth }
+                                : col.sticky === 'right'
+                                  ? { minWidth: '40px' }
+                                  : undefined
+                            }
+                            className={`${isLastColumn ? 'pl-3 pr-2' : 'px-3'} py-px whitespace-nowrap ${isLastColumn && col.sticky !== 'right' ? 'w-full' : col.sticky === 'right' ? 'w-auto text-right' : `w-px align-middle ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''}`} ${!isLastColumn ? 'border-r border-slate-100' : ''} ${!isLastRow ? 'border-b border-slate-100' : ''} ${col.sticky === 'right' ? 'sticky right-0 bg-white group-hover:bg-slate-50 transition-all duration-500 border-l border-slate-200 z-20 shadow-[-4px_0_6px_-1px_rgba(0,0,0,0.05)]' : ''} ${col.className || ''}`}
+                          >
+                            {col.sticky === 'right' ? (
+                              <div className="flex justify-end items-center w-full h-full">
+                                {col.cell
+                                  ? col.cell({ getValue: () => val, row, value: val })
+                                  : (val as ReactNode)}
+                              </div>
+                            ) : col.cell ? (
+                              col.cell({ getValue: () => val, row, value: val })
+                            ) : (
+                              (val as ReactNode)
+                            )}
+                          </td>
+                        );
+                      })}
+                    </tr>
+                  );
+                })
               ) : (
                 <tr>
                   <td


### PR DESCRIPTION
## Summary
- `StandardTable` was missing visible row dividers — `<tbody className="divide-y divide-slate-100">` (and the matching `border-b` on `<thead>`) never rendered because the table is set to `border-separate border-spacing-0`, which Tailwind's `divide-y` utility does not support.
- Mirror the existing column-divider pattern (`border-r border-slate-100` on each non-last cell) by adding `border-b border-slate-100` directly to `<th>` and to each non-last-row `<td>`.
- `border-separate` is preserved so the sticky-right column's `bg-white` + left border + shadow keep working unchanged.

## Notes for reviewers
- Last row deliberately has no `border-b` (mirrors the column pattern that excludes the last column) — the footer's own `border-t border-slate-200` handles the visual seam.
- Empty-state row and `disabledRow` styling are untouched.
- The `paginatedData.map` callback was converted from implicit-return to block body to expose `isLastRow`; otherwise the body is unchanged.

## Test plan
- [ ] Open a page using `StandardTable` (clients/projects/users listing) and confirm thin grey horizontal lines between every row, matching the column divider weight.
- [ ] Confirm a single thin line under the header.
- [ ] Hover a row — `hover:bg-slate-50/50` still applies cleanly with the divider remaining visible.
- [ ] Page with a sticky-right column — sticky cell still floats with left border + shadow and now also has a bottom border consistent with the row.
- [ ] Disabled-row state still renders the slate-300 background with divider visible.
- [ ] Empty/no-results state renders normally with no divider artifact.
- [ ] Last data row has no double line at the footer boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)