### PR TITLE
feat(table): add CSV export to StandardTable toolbar

### DIFF
--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -510,11 +510,16 @@ const StandardTable = <T extends object>({
 
   // Exports the currently visible columns and the post-filter/sort rows so the
   // CSV mirrors what the user sees (active view, manual filters, hidden cols).
+  // Skips columns without an accessor (Actions, etc.) — they render UI from
+  // `cell` and have no scalar value to serialize.
   const handleExportToCsv = () => {
+    const exportColumns = visibleColumns.filter(
+      (c) => c.accessorKey != null || c.accessorFn != null,
+    );
     const rows = [
-      visibleColumns.map((c) => c.header),
+      exportColumns.map((c) => c.header),
       ...processedData.map((row) =>
-        visibleColumns.map((col) => formatForFilter(getValue(row, col), col)),
+        exportColumns.map((col) => formatForFilter(getValue(row, col), col)),
       ),
     ];
     downloadCsv(rows, `${slugify(title)}_${getLocalDateString()}.csv`);

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -2,6 +2,8 @@ import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } fro
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { readTextFromClipboard, writeTextToClipboard } from '../../utils/clipboard';
+import { downloadCsv } from '../../utils/csv';
+import { getLocalDateString } from '../../utils/date';
 import Checkbox from './Checkbox';
 import CustomSelect from './CustomSelect';
 import CustomViewModal from './CustomViewModal';
@@ -33,8 +35,9 @@ const STORAGE_SUFFIX = {
 } as const;
 type StorageSuffix = (typeof STORAGE_SUFFIX)[keyof typeof STORAGE_SUFFIX];
 
-const getStorageKey = (t: string, suffix: StorageSuffix) =>
-  `praetor_table_${suffix}_${t.replace(/[^a-zA-Z0-9]/g, '_').toLowerCase()}`;
+const slugify = (s: string) => s.replace(/[^a-zA-Z0-9]/g, '_').toLowerCase();
+
+const getStorageKey = (t: string, suffix: StorageSuffix) => `praetor_table_${suffix}_${slugify(t)}`;
 
 const FONT_SIZES = ['xs', 'sm', 'base'] as const;
 type FontSize = (typeof FONT_SIZES)[number];
@@ -505,6 +508,18 @@ const StandardTable = <T extends object>({
     });
   };
 
+  // Exports the currently visible columns and the post-filter/sort rows so the
+  // CSV mirrors what the user sees (active view, manual filters, hidden cols).
+  const handleExportToCsv = () => {
+    const rows = [
+      visibleColumns.map((c) => c.header),
+      ...processedData.map((row) =>
+        visibleColumns.map((col) => formatForFilter(getValue(row, col), col)),
+      ),
+    ];
+    downloadCsv(rows, `${slugify(title)}_${getLocalDateString()}.csv`);
+  };
+
   const toggleColumnVisibility = (colId: string) => {
     setHiddenColIds((prev) => {
       const next = new Set(prev);
@@ -689,6 +704,38 @@ const StandardTable = <T extends object>({
     setResizingColId(colId);
   };
 
+  const renderToolbarButton = ({
+    tooltipKey,
+    iconClass,
+    onClick,
+    disabled = false,
+  }: {
+    tooltipKey: string;
+    iconClass: string;
+    onClick: () => void;
+    disabled?: boolean;
+  }) => {
+    const label = t(tooltipKey);
+    return (
+      <Tooltip label={label} position="bottom">
+        {() => (
+          <button
+            type="button"
+            aria-label={label}
+            onClick={(e) => {
+              e.stopPropagation();
+              onClick();
+            }}
+            disabled={disabled}
+            className="w-7 h-7 flex items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-500 disabled:opacity-40 disabled:cursor-not-allowed hover:bg-slate-100 transition-colors"
+          >
+            <i className={`fa-solid ${iconClass} text-[10px]`} aria-hidden="true"></i>
+          </button>
+        )}
+      </Tooltip>
+    );
+  };
+
   const renderInternalFooter = () => (
     <>
       <div className="flex items-center gap-3">
@@ -792,36 +839,24 @@ const StandardTable = <T extends object>({
           <div className="flex items-center gap-3">
             {data != null && columns != null && (
               <div className="flex items-center gap-1">
-                <Tooltip label={t('table.decreaseFont')} position="bottom">
-                  {() => (
-                    <button
-                      type="button"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        stepFontSize(-1);
-                      }}
-                      disabled={fontSize === 'xs'}
-                      className="w-7 h-7 flex items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-500 disabled:opacity-40 disabled:cursor-not-allowed hover:bg-slate-100 transition-colors"
-                    >
-                      <i className="fa-solid fa-minus text-[10px]"></i>
-                    </button>
-                  )}
-                </Tooltip>
-                <Tooltip label={t('table.increaseFont')} position="bottom">
-                  {() => (
-                    <button
-                      type="button"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        stepFontSize(1);
-                      }}
-                      disabled={fontSize === 'base'}
-                      className="w-7 h-7 flex items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-500 disabled:opacity-40 disabled:cursor-not-allowed hover:bg-slate-100 transition-colors"
-                    >
-                      <i className="fa-solid fa-plus text-[10px]"></i>
-                    </button>
-                  )}
-                </Tooltip>
+                {renderToolbarButton({
+                  tooltipKey: 'table.exportToCsv',
+                  iconClass: 'fa-file-csv',
+                  onClick: handleExportToCsv,
+                  disabled: processedData.length === 0,
+                })}
+                {renderToolbarButton({
+                  tooltipKey: 'table.decreaseFont',
+                  iconClass: 'fa-minus',
+                  onClick: () => stepFontSize(-1),
+                  disabled: fontSize === 'xs',
+                })}
+                {renderToolbarButton({
+                  tooltipKey: 'table.increaseFont',
+                  iconClass: 'fa-plus',
+                  onClick: () => stepFontSize(1),
+                  disabled: fontSize === 'base',
+                })}
                 <div className="relative">
                   <Tooltip label={t('table.columnSettings')} position="bottom" disabled={gearOpen}>
                     {() => (

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { type ReactNode, type Ref, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { readTextFromClipboard, writeTextToClipboard } from '../../utils/clipboard';
@@ -714,27 +714,39 @@ const StandardTable = <T extends object>({
     iconClass,
     onClick,
     disabled = false,
+    active = false,
+    buttonRef,
+    tooltipDisabled = false,
+    text,
   }: {
     tooltipKey: string;
     iconClass: string;
     onClick: () => void;
     disabled?: boolean;
+    active?: boolean;
+    buttonRef?: Ref<HTMLButtonElement>;
+    tooltipDisabled?: boolean;
+    text?: string;
   }) => {
     const label = t(tooltipKey);
     return (
-      <Tooltip label={label} position="bottom">
+      <Tooltip label={label} position="bottom" disabled={tooltipDisabled}>
         {() => (
           <button
             type="button"
+            ref={buttonRef}
             aria-label={label}
             onClick={(e) => {
               e.stopPropagation();
               onClick();
             }}
             disabled={disabled}
-            className="w-7 h-7 flex items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-500 disabled:opacity-40 disabled:cursor-not-allowed hover:bg-slate-100 transition-colors"
+            className={`h-7 ${text ? 'px-2 gap-1.5' : 'w-7 justify-center'} flex items-center rounded-lg border border-slate-200 transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
+              active ? 'bg-slate-100 text-praetor' : 'bg-white text-slate-500 hover:bg-slate-100'
+            }`}
           >
             <i className={`fa-solid ${iconClass} text-[10px]`} aria-hidden="true"></i>
+            {text && <span className="text-[10px] font-bold">{text}</span>}
           </button>
         )}
       </Tooltip>
@@ -846,9 +858,10 @@ const StandardTable = <T extends object>({
               <div className="flex items-center gap-1">
                 {renderToolbarButton({
                   tooltipKey: 'table.exportToCsv',
-                  iconClass: 'fa-file-csv',
+                  iconClass: 'fa-file-export',
                   onClick: handleExportToCsv,
                   disabled: processedData.length === 0,
+                  text: t('table.export'),
                 })}
                 {renderToolbarButton({
                   tooltipKey: 'table.decreaseFont',
@@ -863,21 +876,14 @@ const StandardTable = <T extends object>({
                   disabled: fontSize === 'base',
                 })}
                 <div className="relative">
-                  <Tooltip label={t('table.columnSettings')} position="bottom" disabled={gearOpen}>
-                    {() => (
-                      <button
-                        type="button"
-                        ref={gearButtonRef}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setGearOpen((prev) => !prev);
-                        }}
-                        className={`w-7 h-7 flex items-center justify-center rounded-lg border border-slate-200 bg-white transition-colors ${gearOpen ? 'text-praetor bg-slate-100' : 'text-slate-500 hover:bg-slate-100'}`}
-                      >
-                        <i className="fa-solid fa-gear text-[10px]"></i>
-                      </button>
-                    )}
-                  </Tooltip>
+                  {renderToolbarButton({
+                    tooltipKey: 'table.columnSettings',
+                    iconClass: 'fa-gear',
+                    onClick: () => setGearOpen((prev) => !prev),
+                    active: gearOpen,
+                    buttonRef: gearButtonRef,
+                    tooltipDisabled: gearOpen,
+                  })}
                   {gearOpen && (
                     <div
                       ref={gearPopupRef}

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -249,6 +249,7 @@
     "columnSettings": "Column settings",
     "columns": "Columns",
     "resetColumns": "Reset columns",
+    "export": "Export",
     "exportToCsv": "Export to CSV",
     "customViews": "Custom views",
     "addCustomView": "Add custom view",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -249,6 +249,7 @@
     "columnSettings": "Column settings",
     "columns": "Columns",
     "resetColumns": "Reset columns",
+    "exportToCsv": "Export to CSV",
     "customViews": "Custom views",
     "addCustomView": "Add custom view",
     "editView": "Edit view",

--- a/locales/it/common.json
+++ b/locales/it/common.json
@@ -249,6 +249,7 @@
     "columnSettings": "Impostazioni colonne",
     "columns": "Colonne",
     "resetColumns": "Ripristina colonne",
+    "exportToCsv": "Esporta in CSV",
     "customViews": "Viste personalizzate",
     "addCustomView": "Aggiungi vista",
     "editView": "Modifica vista",

--- a/locales/it/common.json
+++ b/locales/it/common.json
@@ -249,6 +249,7 @@
     "columnSettings": "Impostazioni colonne",
     "columns": "Colonne",
     "resetColumns": "Ripristina colonne",
+    "export": "Esporta",
     "exportToCsv": "Esporta in CSV",
     "customViews": "Viste personalizzate",
     "addCustomView": "Aggiungi vista",

--- a/utils/csv.ts
+++ b/utils/csv.ts
@@ -1,7 +1,12 @@
 // Prefix values that spreadsheet apps would interpret as formulas (CSV injection).
-// Allows leading whitespace (incl. tab/CR) before the formula char, since
-// Excel/Sheets ignore it before parsing.
-const FORMULA_PREFIXES = /^\s*[=+\-@]/;
+// OWASP-recommended trigger set: =, +, -, @, plus the control chars \t and \r —
+// some spreadsheet parsers strip leading whitespace before the formula char,
+// so we also catch those whitespace-prefixed cases.
+const FORMULA_PREFIXES = /^[\t\r]|^\s*[=+\-@]/;
+
+// UTF-8 BOM (U+FEFF), prepended so Excel auto-detects the encoding —
+// otherwise non-ASCII characters render as mojibake. Built from the code
+// point so the source stays free of invisible characters.
 const UTF8_BOM = String.fromCharCode(0xfeff);
 
 const escapeCsvCell = (val: string) => {

--- a/utils/csv.ts
+++ b/utils/csv.ts
@@ -1,0 +1,25 @@
+// Prefix values that spreadsheet apps would interpret as formulas (CSV injection).
+// Allows leading whitespace (incl. tab/CR) before the formula char, since
+// Excel/Sheets ignore it before parsing.
+const FORMULA_PREFIXES = /^\s*[=+\-@]/;
+const UTF8_BOM = String.fromCharCode(0xfeff);
+
+const escapeCsvCell = (val: string) => {
+  const safe = FORMULA_PREFIXES.test(val) ? `'${val}` : val;
+  return /[",\r\n]/.test(safe) ? `"${safe.replace(/"/g, '""')}"` : safe;
+};
+
+export const downloadCsv = (rows: string[][], filename: string) => {
+  const csv = rows.map((row) => row.map(escapeCsvCell).join(',')).join('\r\n');
+  const blob = new Blob([UTF8_BOM, csv], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  setTimeout(() => {
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  }, 0);
+};


### PR DESCRIPTION
## Summary

- Adds a **CSV export** button to the `StandardTable` toolbar (left of the existing font-size controls). Exports the currently filtered/sorted view, using each column's `filterFormat` for cell formatting; file is named `<title>_<date>.csv`.
- Hardens the export against **CSV injection**: cells starting with `=`, `+`, `-`, `@`, tab, or CR are prefixed with a single quote so spreadsheet apps don't execute exported strings (e.g. user-entered client names) as formulas.
- Refactors the toolbar at the same time:
  - Extracts a shared `slugify()` helper that was inlined twice (`getStorageKey` and the new export filename) — kept the existing no-`+` regex so `localStorage` keys stay backwards-compatible.
  - Reworks `renderToolbarButton` to take an object of named props (`tooltipKey`, `iconClass`, `onClick`, optional `disabled`/`active`/`buttonRef`/`tooltipDisabled`). Call sites are now self-documenting.
  - Folds the **gear button** through the same helper — it had an identical 7×7 button shell + active state + ref, so this removes the in-file near-duplicate.

## Files

- `utils/csv.ts` *(new)* — `downloadCsv(rows, filename)` with RFC 4180 escaping + injection guard + UTF-8 BOM.
- `components/shared/StandardTable.tsx` — new export handler, `slugify` extraction, `renderToolbarButton` rework, gear button consolidated.
- `locales/{en,it}/common.json` — `table.exportToCsv` translation.

## Test plan

- [ ] Toolbar shows a new CSV icon to the left of the font-size buttons; tooltip reads "Export to CSV" / "Esporta in CSV".
- [ ] Clicking it downloads `<slugified-title>_<YYYY-MM-DD>.csv` containing only the visible columns and the currently filtered/sorted rows (not the entire raw dataset).
- [ ] The button is disabled when there are no rows after filtering.
- [ ] Verify a cell whose value starts with `=` (e.g. `=1+1`) is prefixed with `'` in the exported CSV and does not execute when opened in Excel/Sheets.
- [ ] Verify a cell containing commas/quotes/newlines is correctly quoted.
- [ ] Gear button still opens/closes the column-settings popup, shows its active style, and the click-outside detection still works (it relies on `gearButtonRef`).
- [ ] Saved table preferences (font size, hidden columns) survive a page reload — confirms `getStorageKey` slugifying behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)