### PR TITLE
docs: de-stale CLAUDE.md and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,26 +2,23 @@
 
 ## Project Structure & Module Organization
 
-- Frontend (Vite + React/TS) lives at repo root.
-- Entry points: `index.html`, `index.tsx`, `App.tsx`.
-- UI modules: `components/` (feature folders like `components/HR/`, shared primitives in `components/shared/`).
-- Client-side helpers: `services/` (API + Gemini integration), `utils/`, shared types in `types.ts` and `constants.tsx`.
-- Static assets: `public/`, translations in `locales/`.
-- Backend API (Fastify + TS) is in `server/`.
-- API entry/build: `server/index.ts`, app wiring in `server/app.ts`, routes in `server/routes/`, Drizzle schema in `server/db/schema/` and migrations in `server/db/migrations/`.
-- Generated docs are committed under `docs/` (`docs/frontend/`, `docs/api/openapi.json`).
+- Frontend (Vite + React/TS) lives at the repo root: app entry in `index.tsx` / `App.tsx`, UI in `components/` (feature folders + a `shared/` primitives folder), client helpers in `services/` and `utils/`, static assets in `public/`, translations in `locales/`.
+- Backend (Fastify + TS) lives under `server/`: app wiring in `server/app.ts`, HTTP routes in `server/routes/`, data access in `server/repositories/`, schema and migrations under `server/db/`.
+- Generated docs are committed under `docs/` (frontend TypeDoc + API OpenAPI).
 
 ## Build, Test, and Development Commands
 
 - `bun install` (and `cd server && bun install`): install deps.
-- `bun run dev`: run frontend dev server (defaults to `http://localhost:3000`).
+- `bun run dev`: run the frontend dev server.
 - `bun run build`: production frontend build to `dist/`.
 - `bun run preview`: serve the production build.
-- `cd server && bun run dev`: run API with watch.
-- `cd server && bun run build`: typecheck/compile API (`tsc`).
-- `cd server && bun run start`: run the built API (defaults to `http://localhost:3001`).
-- `bun run docs`: generate TypeDoc + OpenAPI into `docs/`.
-- `docker compose up -d --build`: run full stack (Postgres/API/Caddy).
+- `bun run test`: run the Bun test suites.
+- `bun run lint`: i18n-key check + typecheck + Biome (in that order). `bun run lint:fix` and `bun run format` apply Biome auto-fixes / formatting.
+- `cd server && bun run dev`: run the API with watch.
+- `cd server && bun run build`: typecheck/compile the API (`tsc`).
+- `cd server && bun run start`: run the built API.
+- `bun run docs`: regenerate TypeDoc + OpenAPI under `docs/`.
+- `docker compose up -d --build`: bring up the full stack (see `docker-compose.yml` for the current service set).
 
 ## Coding Style & Naming Conventions
 
@@ -32,15 +29,15 @@
 
 ## Testing Guidelines
 
-- No dedicated unit/integration test runner is configured currently.
-- Treat `bun run build`, `cd server && bun run build`, and `bun run lint` as the minimum CI-quality gate.
-- For changes touching UI flows, do a manual smoke test against `server/index.ts` and key routes under `server/routes/`.
-- If you introduce tests, prefer `*.test.ts` / `*.test.tsx` (co-located or under `__tests__/`).
+- Bun test runner. Backend repository-layer suites live under `server/test/` (fakes; no DB). Run via `bun run test` from the repo root.
+- Other layers (UI flows, end-to-end route behavior) still rely on manual testing.
+- Treat `bun run lint` (which also runs typecheck and the i18n key check) and `bun run build` as the minimum CI-quality gate.
+- New backend tests should live under `server/test/`, mirroring the source layout.
 
 ## Commit & Pull Request Guidelines
 
 - Prefer Conventional Commits as seen in history: `feat:`, `fix(scope):`, `refactor:`, `docs:`, `perf:`.
-- Husky pre-commit runs build, server build, docs generation, lint-staged, and lint. Expect `docs/` and `bun.lock` to update and be staged.
+- Husky runs `lint-staged` plus a typecheck on pre-commit. Expect Biome auto-fixes to be staged. Generated `docs/` and `bun.lock` may also need to be staged when a PR touches APIs or dependencies.
 - PRs should include: what/why, screenshots for UI changes, and notes for any DB/schema/migration changes in `server/db/`.
 
 ## Security & Configuration Tips

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,18 +28,16 @@ bun run start        # Run compiled server
 ## Architecture
 
 ### State Management
-- No Redux/MobX - uses React hooks with centralized state in `App.tsx`
-- `App.tsx` (~83KB) manages all application state and passes via props
-- Components receive data through props, not global stores
+- No Redux/MobX. `App.tsx` is the central state hub: it owns shared state and passes it down via props.
+- Components receive data through props, not global stores.
 
 ### API Layer
-- `/services/api.ts` - Custom fetch wrapper with token management
-- RESTful endpoints at `/api/*`
-- Sliding window JWT auth (30min idle timeout, 8hr max session)
-- Server returns new token in `x-auth-token` header on each request
+- Client-side API helpers live under `services/api/` (custom fetch wrapper with token management)
+- RESTful endpoints under `/api/*`
+- Sliding-window JWT auth: server rotates the token in the `x-auth-token` response header on each request. Idle and max-session limits are configured in `server/middleware/auth.ts`.
 
 ### Database
-- PostgreSQL accessed via Drizzle ORM (`server/db/schema/`); every repository goes through Drizzle (`db/drizzle.ts` exports the `db` instance, the `DbExecutor` type, and the `withDbTransaction` / `executeRows` helpers).
+- PostgreSQL via Drizzle ORM (`server/db/schema/`). All repositories go through the Drizzle helpers exported from `server/db/drizzle.ts` (db instance, executor type, transaction wrapper).
 - Snake_case in DB → camelCase in API responses
 
 ### Database migrations
@@ -47,39 +45,37 @@ bun run start        # Run compiled server
 - The legacy `server/db/add_*.ts` scripts and `server/db/schema.sql` are frozen historical artifacts — see `server/db/README.md` for the full workflow.
 
 ### Authentication
-- JWT (HS256) with optional LDAP/AD fallback
+- JWT-based, with optional LDAP/AD fallback
 - Roles: admin (full access), manager (CRM/reports), user (personal tracking)
 
 ### Internationalization
-- i18next with English (en) and Italian (it)
+- i18next; translation files under `locales/`
 
 ## Key Patterns
 
 ### Route Organization
-Backend routes in `/server/routes/` with prefix-based registration:
-- `auth.ts` → `/api/auth`
-- `clients.ts` → `/api/clients`
-- Pattern: `fastify.get('/', { onRequest: [authenticateToken, requireRole('manager')] }, handler)`
+Backend routes live in `server/routes/` and are registered with URL prefixes in `server/app.ts` — see that file for the current map.
+
+Handler pattern: `fastify.get('/', { onRequest: [authenticateToken, requireRole('manager')] }, handler)`
 
 ### Repositories (data access)
 SQL belongs in `/server/repositories/<domain>Repo.ts`, not inline in route handlers.
 
 - Each function takes an optional `DbExecutor` parameter (default `db`) so it works both standalone and inside `withDbTransaction(async (tx) => repo.fn(args, tx))`. Type imported from `../db/drizzle.ts`.
 - Row types and any `mapXxxRow` helpers live in the repo file alongside the SQL they belong to.
-- Routes import the repo as a namespace: `import * as notificationsRepo from '../repositories/notificationsRepo.ts'`.
+- Routes import the repo as a namespace: `import * as <domain>Repo from '../repositories/<domain>Repo.ts'`.
 - Repos return domain shapes (camelCase, parsed numbers, mapped enums); they do not touch `request`, `reply`, validation, or HTTP status codes.
 
 ### Component Naming
-- Views: PascalCase `*View.tsx` (e.g., `ClientsView.tsx`, `SalesView.tsx`)
-- Utilities: camelCase (e.g., `geminiService.ts`)
-- Routes: kebab-case (e.g., `general-settings.ts`)
+- Views: PascalCase `*View.tsx`
+- Utilities: camelCase
+- Route files: kebab-case
 
 ## Important Notes
 
 - **Path aliases**: `@/` maps to project root (Vite + TypeScript config)
-- **CDN dependencies**: React, Recharts
-- **Test accounts**: admin/password, manager/password, user/password
-- **Tests**: `bun test server/test` covers the repository layer (fakes; no DB required). Other layers still rely on manual testing.
+- **CDN-pinned deps**: see the importmap in `index.html`
+- **Tests**: `bun run test` (Bun test runner; suites under `server/test/`). Other layers still rely on manual testing.
 - **Ports**: Frontend 3000, Backend 3001, PostgreSQL 5432
-- **Remote Testing**: App runs on remote Docker containers - do not run commands locally for testing
+- **Remote Testing**: App runs on remote Docker containers — do not run commands locally for testing
 - **Docs**: Always use Context7 MCP when I need library/API documentation, code generation, setup or configuration steps without me having to explicitly ask.


### PR DESCRIPTION
## Summary

- Fixed several already-wrong claims in `CLAUDE.md` and `AGENTS.md`: `App.tsx (~83KB)`, `/services/api.ts` path, the "no test runner configured" line in AGENTS.md, and the Husky pre-commit description.
- Removed brittle specifics that drift silently — exhaustive lists, exact JWT timeouts, hardcoded language list, CDN dep names, named example files (`ClientsView.tsx`, `notificationsRepo.ts`, `auth.ts → /api/auth`, etc.), and the seed-data test-account credentials.
- Pointed at the real source of truth where one already exists: `index.html` importmap for CDN deps, `server/middleware/auth.ts` for JWT limits, `server/app.ts` for route prefixes, `server/db/README.md` for migration workflow, `docker-compose.yml` for the stack's services.
- Kept stable conventions intact: stack overview, repo layer pattern, snake_case→camelCase, Drizzle Kit workflow, Biome rules, Conventional Commits, the remote-testing warning, and the Context7 MCP note.

## Why

Several details in the agent docs were already stale and the rest were the kind of thing that goes stale silently — file sizes drift, lists go out of date when feature folders are added, exact timeout values change in code without anyone updating docs. Trimming to stable patterns makes the docs survive normal codebase movement.

## Test plan

- [ ] Re-read `CLAUDE.md` and `AGENTS.md` end-to-end and confirm no orphaned references remain.
- [ ] Spot-check that every named file/dir still mentioned exists (`server/app.ts`, `server/middleware/auth.ts`, `services/api/`, `locales/`, `docs/`, `server/db/drizzle.ts`).
- [ ] Confirm every script mentioned (`bun run test`, `bun run lint`, `bun run build`, `bun run dev`, `db:generate`, `db:generate:custom`, `db:migrate`, `bun run docs`) exists in the relevant `package.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)