### PR TITLE
test(auth/services): add unit tests for auth middleware, email & LDAP services

### DIFF
--- a/server/test/helpers/jwt.ts
+++ b/server/test/helpers/jwt.ts
@@ -27,5 +27,3 @@ export const signOverMaxSessionToken = (userId: string): string =>
 
 export const decodeForAssertion = (token: string): jwt.JwtPayload =>
   jwt.verify(token, TEST_JWT_SECRET) as jwt.JwtPayload;
-
-export const TEST_SECRET_FOR_DEBUG = TEST_JWT_SECRET;

--- a/server/test/helpers/jwt.ts
+++ b/server/test/helpers/jwt.ts
@@ -1,0 +1,31 @@
+import jwt from 'jsonwebtoken';
+
+const TEST_JWT_SECRET = process.env.JWT_SECRET || 'praetor-secret-key-change-in-production';
+
+const SESSION_MAX_DURATION_MS = 8 * 60 * 60 * 1000;
+
+export type SignTokenInput = {
+  userId: string;
+  sessionStart?: number;
+  activeRole?: string;
+  expiresIn?: jwt.SignOptions['expiresIn'];
+  secret?: string;
+};
+
+export const signToken = ({
+  userId,
+  sessionStart = Date.now(),
+  activeRole,
+  expiresIn = '30m',
+  secret = TEST_JWT_SECRET,
+}: SignTokenInput): string => jwt.sign({ userId, sessionStart, activeRole }, secret, { expiresIn });
+
+export const signExpiredToken = (userId: string): string => signToken({ userId, expiresIn: '-1s' });
+
+export const signOverMaxSessionToken = (userId: string): string =>
+  signToken({ userId, sessionStart: Date.now() - SESSION_MAX_DURATION_MS - 60_000 });
+
+export const decodeForAssertion = (token: string): jwt.JwtPayload =>
+  jwt.verify(token, TEST_JWT_SECRET) as jwt.JwtPayload;
+
+export const TEST_SECRET_FOR_DEBUG = TEST_JWT_SECRET;

--- a/server/test/middleware/auth.test.ts
+++ b/server/test/middleware/auth.test.ts
@@ -1,0 +1,407 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import type jwt from 'jsonwebtoken';
+import {
+  authenticateToken,
+  generateToken,
+  requireAnyPermission,
+  requirePermission,
+  requireRole,
+} from '../../middleware/auth.ts';
+import * as realRolesRepo from '../../repositories/rolesRepo.ts';
+import * as realUsersRepo from '../../repositories/usersRepo.ts';
+import * as realPermissions from '../../utils/permissions.ts';
+import {
+  decodeForAssertion,
+  signExpiredToken,
+  signOverMaxSessionToken,
+  signToken,
+} from '../helpers/jwt.ts';
+
+// Snapshot the real exports BEFORE mock.module fires so afterAll can restore them. The
+// `mock.module` calls inside beforeAll are NOT hoisted (verified empirically on Bun 1.3.13);
+// only top-level mock.module calls get hoisted ahead of imports.
+const usersRepoSnapshot = { ...realUsersRepo };
+const rolesRepoSnapshot = { ...realRolesRepo };
+const permissionsSnapshot = { ...realPermissions };
+
+const findAuthUserByIdMock = mock();
+const userHasRoleMock = mock();
+const getRolePermissionsMock = mock();
+
+beforeAll(() => {
+  mock.module('../../repositories/usersRepo.ts', () => ({
+    ...usersRepoSnapshot,
+    findAuthUserById: findAuthUserByIdMock,
+  }));
+  mock.module('../../repositories/rolesRepo.ts', () => ({
+    ...rolesRepoSnapshot,
+    userHasRole: userHasRoleMock,
+  }));
+  mock.module('../../utils/permissions.ts', () => ({
+    ...permissionsSnapshot,
+    getRolePermissions: getRolePermissionsMock,
+  }));
+});
+
+afterAll(() => {
+  // Restore: future imports of these modules see the real exports again.
+  mock.module('../../repositories/usersRepo.ts', () => usersRepoSnapshot);
+  mock.module('../../repositories/rolesRepo.ts', () => rolesRepoSnapshot);
+  mock.module('../../utils/permissions.ts', () => permissionsSnapshot);
+});
+
+const HAPPY_USER = {
+  id: 'u1',
+  name: 'Alice',
+  username: 'alice',
+  role: 'manager',
+  avatarInitials: 'AL',
+  isDisabled: false,
+};
+
+const HAPPY_PERMISSIONS = ['timesheets.tracker.view', 'timesheets.tracker.create'];
+
+type FakeReply = {
+  statusCode: number;
+  body: unknown;
+  headers: Record<string, string>;
+  sentCount: number;
+  code(c: number): FakeReply;
+  send(body: unknown): FakeReply;
+  header(name: string, value: string): FakeReply;
+};
+
+const buildFakeReply = (): FakeReply => {
+  const reply: FakeReply = {
+    statusCode: 0,
+    body: undefined,
+    headers: {},
+    sentCount: 0,
+    code(c: number) {
+      reply.statusCode = c;
+      return reply;
+    },
+    send(body: unknown) {
+      reply.sentCount += 1;
+      reply.body = body;
+      return reply;
+    },
+    header(name: string, value: string) {
+      reply.headers[name.toLowerCase()] = value;
+      return reply;
+    },
+  };
+  return reply;
+};
+
+type FakeRequest = {
+  headers: Record<string, string | undefined>;
+  auth?: { userId: string; sessionStart: number };
+  user?: {
+    id: string;
+    name: string;
+    username: string;
+    role: string;
+    avatarInitials: string;
+    permissions: string[];
+  };
+};
+
+const buildFakeRequest = (token?: string): FakeRequest => ({
+  headers: token ? { authorization: `Bearer ${token}` } : {},
+});
+
+beforeEach(() => {
+  findAuthUserByIdMock.mockReset();
+  userHasRoleMock.mockReset();
+  getRolePermissionsMock.mockReset();
+
+  findAuthUserByIdMock.mockResolvedValue(HAPPY_USER);
+  userHasRoleMock.mockResolvedValue(true);
+  getRolePermissionsMock.mockResolvedValue(HAPPY_PERMISSIONS);
+});
+
+describe('authenticateToken', () => {
+  test('401 when Authorization header missing', async () => {
+    const request = buildFakeRequest();
+    const reply = buildFakeReply();
+    await authenticateToken(request as never, reply as never);
+    expect(reply.statusCode).toBe(401);
+    expect(reply.body).toEqual({ error: 'Access token required' });
+  });
+
+  test('403 when token is malformed (jwt.verify throws)', async () => {
+    const request = buildFakeRequest('not-a-real-jwt');
+    const reply = buildFakeReply();
+    await authenticateToken(request as never, reply as never);
+    expect(reply.statusCode).toBe(403);
+    expect(reply.body).toEqual({ error: 'Invalid or expired token' });
+  });
+
+  test('403 when token is idle-expired', async () => {
+    const request = buildFakeRequest(signExpiredToken('u1'));
+    const reply = buildFakeReply();
+    await authenticateToken(request as never, reply as never);
+    expect(reply.statusCode).toBe(403);
+    expect(reply.body).toEqual({ error: 'Invalid or expired token' });
+  });
+
+  test('401 when sessionStart is older than the 8h max session', async () => {
+    const request = buildFakeRequest(signOverMaxSessionToken('u1'));
+    const reply = buildFakeReply();
+    await authenticateToken(request as never, reply as never);
+    expect(reply.statusCode).toBe(401);
+    expect(reply.body).toEqual({ error: 'Session expired (max duration exceeded)' });
+  });
+
+  test('401 when usersRepo.findAuthUserById returns null', async () => {
+    findAuthUserByIdMock.mockResolvedValue(null);
+    const request = buildFakeRequest(signToken({ userId: 'u1' }));
+    const reply = buildFakeReply();
+    await authenticateToken(request as never, reply as never);
+    expect(reply.statusCode).toBe(401);
+    expect(reply.body).toEqual({ error: 'User not found' });
+  });
+
+  test('401 when user.isDisabled is true', async () => {
+    findAuthUserByIdMock.mockResolvedValue({ ...HAPPY_USER, isDisabled: true });
+    const request = buildFakeRequest(signToken({ userId: 'u1' }));
+    const reply = buildFakeReply();
+    await authenticateToken(request as never, reply as never);
+    expect(reply.statusCode).toBe(401);
+    expect(reply.body).toEqual({ error: 'Invalid or expired token' });
+  });
+
+  test('403 when rolesRepo.userHasRole returns false', async () => {
+    userHasRoleMock.mockResolvedValue(false);
+    const request = buildFakeRequest(signToken({ userId: 'u1' }));
+    const reply = buildFakeReply();
+    await authenticateToken(request as never, reply as never);
+    expect(reply.statusCode).toBe(403);
+    expect(reply.body).toEqual({ error: 'Invalid or expired token' });
+  });
+
+  test('200 happy path: populates request.user and rotates the x-auth-token header', async () => {
+    const sessionStart = Date.now() - 60_000;
+    const request = buildFakeRequest(signToken({ userId: 'u1', sessionStart }));
+    const reply = buildFakeReply();
+    await authenticateToken(request as never, reply as never);
+
+    expect(reply.statusCode).toBe(0);
+    expect(reply.body).toBeUndefined();
+    expect(request.user).toEqual({
+      id: 'u1',
+      name: 'Alice',
+      username: 'alice',
+      role: 'manager',
+      avatarInitials: 'AL',
+      permissions: HAPPY_PERMISSIONS,
+    });
+    expect(request.auth).toEqual({ userId: 'u1', sessionStart });
+
+    const rotated = reply.headers['x-auth-token'];
+    expect(typeof rotated).toBe('string');
+    const decoded = decodeForAssertion(rotated) as jwt.JwtPayload & {
+      userId: string;
+      sessionStart: number;
+      activeRole?: string;
+    };
+    expect(decoded.userId).toBe('u1');
+    expect(decoded.sessionStart).toBe(sessionStart);
+    expect(decoded.activeRole).toBe('manager');
+  });
+
+  test('decoded.activeRole overrides user.role when present', async () => {
+    const request = buildFakeRequest(signToken({ userId: 'u1', activeRole: 'admin' }));
+    const reply = buildFakeReply();
+    await authenticateToken(request as never, reply as never);
+
+    expect(reply.statusCode).toBe(0);
+    expect(request.user?.role).toBe('admin');
+    expect(userHasRoleMock).toHaveBeenCalledWith('u1', 'admin');
+    expect(getRolePermissionsMock).toHaveBeenCalledWith('admin');
+  });
+
+  test('userHasRole and getRolePermissions are invoked concurrently (no serial await)', async () => {
+    let resolveRole!: () => void;
+    let resolvePerms!: () => void;
+    const rolePromise = new Promise<void>((resolve) => {
+      resolveRole = resolve;
+    });
+    const permsPromise = new Promise<void>((resolve) => {
+      resolvePerms = resolve;
+    });
+
+    userHasRoleMock.mockImplementation(async () => {
+      await rolePromise;
+      return true;
+    });
+    getRolePermissionsMock.mockImplementation(async () => {
+      await permsPromise;
+      return HAPPY_PERMISSIONS;
+    });
+
+    const request = buildFakeRequest(signToken({ userId: 'u1' }));
+    const reply = buildFakeReply();
+    const inflight = authenticateToken(request as never, reply as never);
+
+    // Yield enough microtasks for the middleware to fire both calls before either resolves.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(userHasRoleMock).toHaveBeenCalledTimes(1);
+    expect(getRolePermissionsMock).toHaveBeenCalledTimes(1);
+
+    resolveRole();
+    resolvePerms();
+    await inflight;
+    expect(reply.statusCode).toBe(0);
+    expect(request.user).toBeDefined();
+  });
+
+  test('a rejection in the parallel lookup produces a single 403 response', async () => {
+    userHasRoleMock.mockRejectedValue(new Error('db down'));
+    getRolePermissionsMock.mockResolvedValue(HAPPY_PERMISSIONS);
+
+    const request = buildFakeRequest(signToken({ userId: 'u1' }));
+    const reply = buildFakeReply();
+    await authenticateToken(request as never, reply as never);
+
+    expect(reply.statusCode).toBe(403);
+    expect(reply.body).toEqual({ error: 'Invalid or expired token' });
+    expect(reply.sentCount).toBe(1);
+  });
+});
+
+describe('requireRole', () => {
+  test('401 when request.user is undefined', async () => {
+    const reply = buildFakeReply();
+    await requireRole('manager')({} as never, reply as never);
+    expect(reply.statusCode).toBe(401);
+    expect(reply.body).toEqual({ error: 'Authentication required' });
+  });
+
+  test('403 when role is not in the allowed list', async () => {
+    const reply = buildFakeReply();
+    await requireRole('admin')(
+      { user: { ...HAPPY_USER, permissions: [] } } as never,
+      reply as never,
+    );
+    expect(reply.statusCode).toBe(403);
+    expect(reply.body).toEqual({ error: 'Insufficient permissions' });
+  });
+
+  test('passes when role matches one of the allowed roles', async () => {
+    const reply = buildFakeReply();
+    await requireRole(
+      'admin',
+      'manager',
+      'user',
+    )({ user: { ...HAPPY_USER, permissions: [] } } as never, reply as never);
+    expect(reply.statusCode).toBe(0);
+    expect(reply.body).toBeUndefined();
+  });
+});
+
+describe('requirePermission (ALL semantics)', () => {
+  test('401 when no request.user', async () => {
+    const reply = buildFakeReply();
+    await requirePermission('timesheets.tracker.view')({} as never, reply as never);
+    expect(reply.statusCode).toBe(401);
+    expect(reply.body).toEqual({ error: 'Authentication required' });
+  });
+
+  test('403 when missing one of two required perms', async () => {
+    const reply = buildFakeReply();
+    await requirePermission('timesheets.tracker.view', 'crm.clients.view')(
+      { user: { ...HAPPY_USER, permissions: ['timesheets.tracker.view'] } } as never,
+      reply as never,
+    );
+    expect(reply.statusCode).toBe(403);
+    expect(reply.body).toEqual({ error: 'Insufficient permissions' });
+  });
+
+  test('passes when all required perms are present', async () => {
+    const reply = buildFakeReply();
+    await requirePermission('a.view', 'b.view')(
+      { user: { ...HAPPY_USER, permissions: ['a.view', 'b.view', 'c.view'] } } as never,
+      reply as never,
+    );
+    expect(reply.statusCode).toBe(0);
+    expect(reply.body).toBeUndefined();
+  });
+
+  test('vacuous: empty perms list passes (Array.every over zero elements)', async () => {
+    const reply = buildFakeReply();
+    await requirePermission()(
+      { user: { ...HAPPY_USER, permissions: [] } } as never,
+      reply as never,
+    );
+    expect(reply.statusCode).toBe(0);
+    expect(reply.body).toBeUndefined();
+  });
+});
+
+describe('requireAnyPermission (ANY semantics)', () => {
+  test('401 when no request.user', async () => {
+    const reply = buildFakeReply();
+    await requireAnyPermission('timesheets.tracker.view')({} as never, reply as never);
+    expect(reply.statusCode).toBe(401);
+    expect(reply.body).toEqual({ error: 'Authentication required' });
+  });
+
+  test('403 when none of the required perms are present', async () => {
+    const reply = buildFakeReply();
+    await requireAnyPermission('a.view', 'b.view')(
+      { user: { ...HAPPY_USER, permissions: ['c.view'] } } as never,
+      reply as never,
+    );
+    expect(reply.statusCode).toBe(403);
+    expect(reply.body).toEqual({ error: 'Insufficient permissions' });
+  });
+
+  test('passes when at least one matches', async () => {
+    const reply = buildFakeReply();
+    await requireAnyPermission('a.view', 'b.view')(
+      { user: { ...HAPPY_USER, permissions: ['b.view'] } } as never,
+      reply as never,
+    );
+    expect(reply.statusCode).toBe(0);
+    expect(reply.body).toBeUndefined();
+  });
+
+  test('vacuous: empty perms list returns 403 (Array.some over zero elements is false)', async () => {
+    const reply = buildFakeReply();
+    await requireAnyPermission()(
+      { user: { ...HAPPY_USER, permissions: ['anything'] } } as never,
+      reply as never,
+    );
+    expect(reply.statusCode).toBe(403);
+    expect(reply.body).toEqual({ error: 'Insufficient permissions' });
+  });
+});
+
+describe('generateToken', () => {
+  test('embeds userId, sessionStart and activeRole; expires in 30m', () => {
+    const sessionStart = 1_700_000_000_000;
+    const token = generateToken('u1', sessionStart, 'admin');
+    const decoded = decodeForAssertion(token) as jwt.JwtPayload & {
+      userId: string;
+      sessionStart: number;
+      activeRole: string;
+    };
+    expect(decoded.userId).toBe('u1');
+    expect(decoded.sessionStart).toBe(sessionStart);
+    expect(decoded.activeRole).toBe('admin');
+    expect(decoded.exp).toBeDefined();
+    expect(decoded.iat).toBeDefined();
+    expect((decoded.exp as number) - (decoded.iat as number)).toBe(30 * 60);
+  });
+
+  test('default sessionStart is approximately Date.now()', () => {
+    const before = Date.now();
+    const token = generateToken('u1');
+    const after = Date.now();
+    const decoded = decodeForAssertion(token) as jwt.JwtPayload & { sessionStart: number };
+    expect(decoded.sessionStart).toBeGreaterThanOrEqual(before);
+    expect(decoded.sessionStart).toBeLessThanOrEqual(after);
+  });
+});

--- a/server/test/middleware/auth.test.ts
+++ b/server/test/middleware/auth.test.ts
@@ -225,18 +225,29 @@ describe('authenticateToken', () => {
   test('userHasRole and getRolePermissions are invoked concurrently (no serial await)', async () => {
     let resolveRole!: () => void;
     let resolvePerms!: () => void;
+    let signalRoleCalled!: () => void;
+    let signalPermsCalled!: () => void;
+
     const rolePromise = new Promise<void>((resolve) => {
       resolveRole = resolve;
     });
     const permsPromise = new Promise<void>((resolve) => {
       resolvePerms = resolve;
     });
+    const roleCalledPromise = new Promise<void>((resolve) => {
+      signalRoleCalled = resolve;
+    });
+    const permsCalledPromise = new Promise<void>((resolve) => {
+      signalPermsCalled = resolve;
+    });
 
     userHasRoleMock.mockImplementation(async () => {
+      signalRoleCalled();
       await rolePromise;
       return true;
     });
     getRolePermissionsMock.mockImplementation(async () => {
+      signalPermsCalled();
       await permsPromise;
       return HAPPY_PERMISSIONS;
     });
@@ -245,8 +256,10 @@ describe('authenticateToken', () => {
     const reply = buildFakeReply();
     const inflight = authenticateToken(request as never, reply as never);
 
-    // Yield enough microtasks for the middleware to fire both calls before either resolves.
-    await new Promise((r) => setTimeout(r, 10));
+    // Deterministic sync point: both mocks signal as soon as their bodies start. If either
+    // were awaiting the other, this Promise.all would hang past the test timeout instead
+    // of relying on a fixed sleep that's flaky under CI load.
+    await Promise.all([roleCalledPromise, permsCalledPromise]);
     expect(userHasRoleMock).toHaveBeenCalledTimes(1);
     expect(getRolePermissionsMock).toHaveBeenCalledTimes(1);
 

--- a/server/test/services/email.test.ts
+++ b/server/test/services/email.test.ts
@@ -7,7 +7,6 @@ import * as realCrypto from '../../utils/crypto.ts';
 // Snapshot real exports BEFORE registering mocks (mock.module inside beforeAll is not hoisted).
 const emailRepoSnapshot = { ...realEmailRepo };
 const cryptoSnapshot = { ...realCrypto };
-const nodemailerSnapshot = nodemailerReal;
 
 const encryptMock = mock((plaintext: string) => `enc(${plaintext})`);
 const decryptMock = mock((ciphertext: string) =>
@@ -21,10 +20,7 @@ const transporterStub = {
   verify: mock(),
   sendMail: mock(),
 };
-const createTransportMock = mock((opts: unknown) => {
-  (createTransportMock as unknown as { lastOptions: unknown }).lastOptions = opts;
-  return transporterStub;
-});
+const createTransportMock = mock((_opts: unknown) => transporterStub);
 
 const DEFAULT_REPO_CONFIG = realEmailRepo.DEFAULT_CONFIG;
 
@@ -47,7 +43,7 @@ beforeAll(() => {
 });
 
 afterAll(() => {
-  mock.module('nodemailer', () => ({ default: nodemailerSnapshot }));
+  mock.module('nodemailer', () => ({ default: nodemailerReal }));
   mock.module('../../utils/crypto.ts', () => cryptoSnapshot);
   mock.module('../../repositories/emailRepo.ts', () => emailRepoSnapshot);
 });
@@ -75,7 +71,6 @@ beforeEach(() => {
   emailRepoGetMock.mockReset();
   emailRepoUpdateMock.mockReset();
   createTransportMock.mockClear();
-  (createTransportMock as unknown as { lastOptions?: unknown }).lastOptions = undefined;
   transporterStub.verify.mockReset();
   transporterStub.sendMail.mockReset();
 
@@ -152,7 +147,7 @@ describe('ensureReady (via testConnection)', () => {
 
 describe('createTransporter (observed via createTransport spy)', () => {
   const lastOpts = () =>
-    (createTransportMock as unknown as { lastOptions?: Record<string, unknown> }).lastOptions ?? {};
+    (createTransportMock.mock.calls.at(-1)?.[0] ?? {}) as Record<string, unknown>;
 
   test('smtpEncryption: ssl → secure:true, no ignoreTLS', async () => {
     emailRepoGetMock.mockResolvedValue(buildEnabledConfig({ smtpEncryption: 'ssl' }));

--- a/server/test/services/email.test.ts
+++ b/server/test/services/email.test.ts
@@ -1,0 +1,289 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import nodemailerReal from 'nodemailer';
+import * as realEmailRepo from '../../repositories/emailRepo.ts';
+import emailService from '../../services/email.ts';
+import * as realCrypto from '../../utils/crypto.ts';
+
+// Snapshot real exports BEFORE registering mocks (mock.module inside beforeAll is not hoisted).
+const emailRepoSnapshot = { ...realEmailRepo };
+const cryptoSnapshot = { ...realCrypto };
+const nodemailerSnapshot = nodemailerReal;
+
+const encryptMock = mock((plaintext: string) => `enc(${plaintext})`);
+const decryptMock = mock((ciphertext: string) =>
+  ciphertext.startsWith('enc(') && ciphertext.endsWith(')') ? ciphertext.slice(4, -1) : ciphertext,
+);
+
+const emailRepoGetMock = mock();
+const emailRepoUpdateMock = mock();
+
+const transporterStub = {
+  verify: mock(),
+  sendMail: mock(),
+};
+const createTransportMock = mock((opts: unknown) => {
+  (createTransportMock as unknown as { lastOptions: unknown }).lastOptions = opts;
+  return transporterStub;
+});
+
+const DEFAULT_REPO_CONFIG = realEmailRepo.DEFAULT_CONFIG;
+
+beforeAll(() => {
+  mock.module('nodemailer', () => ({
+    default: { createTransport: createTransportMock },
+  }));
+  mock.module('../../utils/crypto.ts', () => ({
+    ...cryptoSnapshot,
+    encrypt: encryptMock,
+    decrypt: decryptMock,
+    MASKED_SECRET: '********',
+  }));
+  mock.module('../../repositories/emailRepo.ts', () => ({
+    ...emailRepoSnapshot,
+    get: emailRepoGetMock,
+    update: emailRepoUpdateMock,
+    DEFAULT_CONFIG: DEFAULT_REPO_CONFIG,
+  }));
+});
+
+afterAll(() => {
+  mock.module('nodemailer', () => ({ default: nodemailerSnapshot }));
+  mock.module('../../utils/crypto.ts', () => cryptoSnapshot);
+  mock.module('../../repositories/emailRepo.ts', () => emailRepoSnapshot);
+});
+
+const buildEnabledConfig = (overrides: Partial<typeof DEFAULT_REPO_CONFIG> = {}) => ({
+  ...DEFAULT_REPO_CONFIG,
+  enabled: true,
+  smtpHost: 'smtp.example.com',
+  smtpPort: 587,
+  smtpUser: 'mailer@example.com',
+  smtpPassword: 'enc(plaintext-pw)',
+  fromEmail: 'no-reply@example.com',
+  fromName: 'Praetor',
+  ...overrides,
+});
+
+const resetSingleton = () => {
+  (emailService as unknown as { config: unknown }).config = null;
+};
+
+beforeEach(() => {
+  resetSingleton();
+  encryptMock.mockClear();
+  decryptMock.mockClear();
+  emailRepoGetMock.mockReset();
+  emailRepoUpdateMock.mockReset();
+  createTransportMock.mockClear();
+  (createTransportMock as unknown as { lastOptions?: unknown }).lastOptions = undefined;
+  transporterStub.verify.mockReset();
+  transporterStub.sendMail.mockReset();
+
+  emailRepoGetMock.mockResolvedValue(buildEnabledConfig());
+  emailRepoUpdateMock.mockImplementation(async (patch: Record<string, unknown>) => ({
+    ...buildEnabledConfig(),
+    ...patch,
+  }));
+  transporterStub.verify.mockResolvedValue(true);
+  transporterStub.sendMail.mockResolvedValue({ messageId: '<msg-id@example.com>' });
+});
+
+describe('saveConfig', () => {
+  test('encrypts smtpPassword via encrypt() and passes ciphertext to the repo', async () => {
+    await emailService.saveConfig({ smtpPassword: 'plaintext-pw', enabled: true });
+
+    expect(encryptMock).toHaveBeenCalledWith('plaintext-pw');
+    expect(emailRepoUpdateMock).toHaveBeenCalledTimes(1);
+    const patch = emailRepoUpdateMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(patch.smtpPasswordCiphertext).toBe('enc(plaintext-pw)');
+    expect('smtpPassword' in patch).toBe(false);
+  });
+
+  test('skips encryption when smtpPassword equals MASKED_SECRET', async () => {
+    await emailService.saveConfig({ smtpPassword: '********', enabled: true });
+
+    expect(encryptMock).not.toHaveBeenCalled();
+    const patch = emailRepoUpdateMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(patch.smtpPasswordCiphertext).toBeUndefined();
+  });
+
+  test('omits smtpPasswordCiphertext when smtpPassword is undefined', async () => {
+    await emailService.saveConfig({ enabled: true });
+
+    expect(encryptMock).not.toHaveBeenCalled();
+    const patch = emailRepoUpdateMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(patch.smtpPasswordCiphertext).toBeUndefined();
+  });
+
+  test('caches the returned config: a subsequent testConnection does not re-call emailRepo.get', async () => {
+    await emailService.saveConfig({ enabled: true, smtpHost: 'smtp.cached.com' });
+    emailRepoGetMock.mockClear();
+    await emailService.testConnection();
+    expect(emailRepoGetMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('ensureReady (via testConnection)', () => {
+  test('returns EMAIL_NOT_ENABLED when config.enabled is false', async () => {
+    emailRepoGetMock.mockResolvedValue({ ...DEFAULT_REPO_CONFIG, enabled: false });
+    const result = await emailService.testConnection();
+    expect(result).toEqual({ success: false, code: 'EMAIL_NOT_ENABLED' });
+  });
+
+  test('returns SMTP_NOT_CONFIGURED when smtpHost is blank', async () => {
+    emailRepoGetMock.mockResolvedValue({ ...DEFAULT_REPO_CONFIG, enabled: true, smtpHost: '' });
+    const result = await emailService.testConnection();
+    expect(result).toEqual({ success: false, code: 'SMTP_NOT_CONFIGURED' });
+  });
+
+  test('falls back to DEFAULT_CONFIG when emailRepo.get returns null', async () => {
+    emailRepoGetMock.mockResolvedValue(null);
+    const result = await emailService.testConnection();
+    // DEFAULT is enabled:false, so we expect the disabled branch.
+    expect(result).toEqual({ success: false, code: 'EMAIL_NOT_ENABLED' });
+  });
+
+  test('loads config exactly once across two consecutive testConnection calls', async () => {
+    await emailService.testConnection();
+    await emailService.testConnection();
+    expect(emailRepoGetMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('createTransporter (observed via createTransport spy)', () => {
+  const lastOpts = () =>
+    (createTransportMock as unknown as { lastOptions?: Record<string, unknown> }).lastOptions ?? {};
+
+  test('smtpEncryption: ssl → secure:true, no ignoreTLS', async () => {
+    emailRepoGetMock.mockResolvedValue(buildEnabledConfig({ smtpEncryption: 'ssl' }));
+    await emailService.testConnection();
+    expect(lastOpts().secure).toBe(true);
+    expect('ignoreTLS' in lastOpts()).toBe(false);
+  });
+
+  test('smtpEncryption: insecure → secure:false, ignoreTLS:true', async () => {
+    emailRepoGetMock.mockResolvedValue(buildEnabledConfig({ smtpEncryption: 'insecure' }));
+    await emailService.testConnection();
+    expect(lastOpts().secure).toBe(false);
+    expect(lastOpts().ignoreTLS).toBe(true);
+  });
+
+  test('smtpEncryption: tls (default) → secure:false, no ignoreTLS', async () => {
+    emailRepoGetMock.mockResolvedValue(buildEnabledConfig({ smtpEncryption: 'tls' }));
+    await emailService.testConnection();
+    expect(lastOpts().secure).toBe(false);
+    expect('ignoreTLS' in lastOpts()).toBe(false);
+  });
+
+  test('decrypted password reaches transportOptions.auth.pass', async () => {
+    emailRepoGetMock.mockResolvedValue(
+      buildEnabledConfig({
+        smtpUser: 'user@x.com',
+        smtpPassword: 'enc(real-secret)',
+      }),
+    );
+    await emailService.testConnection();
+    expect(decryptMock).toHaveBeenCalledWith('enc(real-secret)');
+    expect((lastOpts() as { auth?: { user: string; pass: string } }).auth).toEqual({
+      user: 'user@x.com',
+      pass: 'real-secret',
+    });
+  });
+
+  test('omits auth when smtpUser is empty', async () => {
+    emailRepoGetMock.mockResolvedValue(buildEnabledConfig({ smtpUser: '' }));
+    await emailService.testConnection();
+    expect('auth' in lastOpts()).toBe(false);
+  });
+
+  test('smtpRejectUnauthorized:false → tls.rejectUnauthorized:false', async () => {
+    emailRepoGetMock.mockResolvedValue(buildEnabledConfig({ smtpRejectUnauthorized: false }));
+    await emailService.testConnection();
+    expect((lastOpts() as { tls?: { rejectUnauthorized: boolean } }).tls).toEqual({
+      rejectUnauthorized: false,
+    });
+  });
+});
+
+describe('testConnection (success/failure)', () => {
+  test('returns CONNECTION_SUCCESS when transporter.verify resolves', async () => {
+    const result = await emailService.testConnection();
+    expect(result).toEqual({ success: true, code: 'CONNECTION_SUCCESS' });
+    expect(transporterStub.verify).toHaveBeenCalledTimes(1);
+  });
+
+  test('returns SMTP_ERROR with err.message in params when verify rejects', async () => {
+    transporterStub.verify.mockRejectedValue(new Error('connect refused'));
+    const result = await emailService.testConnection();
+    expect(result.success).toBe(false);
+    expect(result.code).toBe('SMTP_ERROR');
+    expect(result.params).toEqual({ error: 'connect refused' });
+  });
+});
+
+describe('sendEmail', () => {
+  test('returns EMAIL_SENT_SUCCESS with messageId on transporter success', async () => {
+    transporterStub.sendMail.mockResolvedValue({ messageId: '<abc@x>' });
+    const result = await emailService.sendEmail('to@x.com', 'subj', '<p>html</p>');
+    expect(result).toEqual({
+      success: true,
+      code: 'EMAIL_SENT_SUCCESS',
+      messageId: '<abc@x>',
+    });
+  });
+
+  test('returns SMTP_ERROR with err.message in params on transporter throw', async () => {
+    transporterStub.sendMail.mockRejectedValue(new Error('relay denied'));
+    const result = await emailService.sendEmail('to@x.com', 'subj', '<p>html</p>');
+    expect(result.success).toBe(false);
+    expect(result.code).toBe('SMTP_ERROR');
+    expect(result.params).toEqual({ error: 'relay denied' });
+  });
+
+  test('formats from-address as "Name" <email> when fromName is present', async () => {
+    emailRepoGetMock.mockResolvedValue(
+      buildEnabledConfig({ fromName: 'Praetor Bot', fromEmail: 'bot@example.com' }),
+    );
+    await emailService.sendEmail('to@x.com', 'subj', '<p>html</p>');
+    const call = transporterStub.sendMail.mock.calls[0]?.[0] as { from: string };
+    expect(call.from).toBe('"Praetor Bot" <bot@example.com>');
+  });
+
+  test('uses bare email when fromName is empty', async () => {
+    emailRepoGetMock.mockResolvedValue(
+      buildEnabledConfig({ fromName: '', fromEmail: 'bare@example.com' }),
+    );
+    await emailService.sendEmail('to@x.com', 'subj', '<p>html</p>');
+    const call = transporterStub.sendMail.mock.calls[0]?.[0] as { from: string };
+    expect(call.from).toBe('bare@example.com');
+  });
+
+  test('falls back to default text when text arg is undefined', async () => {
+    await emailService.sendEmail('to@x.com', 'subj', '<p>html</p>');
+    const call = transporterStub.sendMail.mock.calls[0]?.[0] as { text: string };
+    expect(call.text).toContain('HTML-capable email client');
+  });
+
+  test('passes through provided text when supplied', async () => {
+    await emailService.sendEmail('to@x.com', 'subj', '<p>html</p>', 'plain version');
+    const call = transporterStub.sendMail.mock.calls[0]?.[0] as { text: string };
+    expect(call.text).toBe('plain version');
+  });
+});
+
+describe('sendTestEmail', () => {
+  test('delegates to sendEmail with the recipient and a test subject', async () => {
+    await emailService.sendTestEmail('hello@x.com');
+    expect(transporterStub.sendMail).toHaveBeenCalledTimes(1);
+    const call = transporterStub.sendMail.mock.calls[0]?.[0] as {
+      to: string;
+      subject: string;
+      html: string;
+      text: string;
+    };
+    expect(call.to).toBe('hello@x.com');
+    expect(call.subject).toBe('Praetor Email Configuration Test');
+    expect(call.html).toContain('Email Configuration Test');
+    expect(call.text).toContain('Praetor Email Configuration Test');
+  });
+});

--- a/server/test/services/ldap.test.ts
+++ b/server/test/services/ldap.test.ts
@@ -1,0 +1,536 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import realLdap from 'ldapjs';
+import * as realLdapRepo from '../../repositories/ldapRepo.ts';
+import * as realUsersRepo from '../../repositories/usersRepo.ts';
+import ldapService from '../../services/ldap.ts';
+import * as realInitials from '../../utils/initials.ts';
+import * as realLogger from '../../utils/logger.ts';
+import * as realOrderIds from '../../utils/order-ids.ts';
+
+// Snapshot real exports BEFORE the beforeAll fires (mock.module inside beforeAll is not hoisted).
+const ldapjsSnapshot = realLdap;
+const ldapRepoSnapshot = { ...realLdapRepo };
+const usersRepoSnapshot = { ...realUsersRepo };
+const initialsSnapshot = { ...realInitials };
+const loggerSnapshot = { ...realLogger };
+const orderIdsSnapshot = { ...realOrderIds };
+
+const ldapRepoGetMock = mock();
+const findLoginUserByUsernameMock = mock();
+const updateNameByUsernameMock = mock();
+const createUserMock = mock();
+
+// ─── ldapjs harness ───────────────────────────────────────────────────────────
+type SearchResponse = {
+  err?: Error;
+  entries?: { objectName: string; object?: Record<string, unknown> }[];
+  errorEvent?: Error;
+  status?: number;
+};
+
+type ClientFixture = {
+  bindResponses?: (Error | null)[];
+  searchResponses?: SearchResponse[];
+};
+
+type ClientStats = {
+  options: unknown;
+  bindCalls: { dn: string; password: string }[];
+  searchCalls: { base: string; options: Record<string, unknown> }[];
+  unbindCalls: number;
+};
+
+let nextFixture: ClientFixture = {};
+let lastClientStats: ClientStats | null = null;
+
+const createClientMock = mock((opts: unknown) => {
+  const fixture = nextFixture;
+  let bindIdx = 0;
+  let searchIdx = 0;
+
+  const stats: ClientStats = {
+    options: opts,
+    bindCalls: [],
+    searchCalls: [],
+    unbindCalls: 0,
+  };
+  lastClientStats = stats;
+
+  return {
+    bind(dn: string, password: string, cb: (err: Error | null) => void) {
+      stats.bindCalls.push({ dn, password });
+      const response = fixture.bindResponses?.[bindIdx++] ?? null;
+      cb(response);
+    },
+    search(
+      base: string,
+      options: Record<string, unknown>,
+      cb: (err: Error | null, res: unknown) => void,
+    ) {
+      stats.searchCalls.push({ base, options });
+      const response = fixture.searchResponses?.[searchIdx++];
+      if (response?.err) {
+        cb(response.err, null);
+        return;
+      }
+      const handlers: Record<string, ((arg: unknown) => void)[]> = {};
+      const res = {
+        on(event: string, handler: (arg: unknown) => void) {
+          if (!handlers[event]) handlers[event] = [];
+          handlers[event].push(handler);
+        },
+      };
+      cb(null, res);
+      for (const entry of response?.entries ?? []) {
+        for (const h of handlers.searchEntry ?? []) h(entry);
+      }
+      if (response?.errorEvent) {
+        const err = response.errorEvent as unknown as Error;
+        for (const h of handlers.error ?? []) h(err);
+      }
+      const endArg = { status: response?.status ?? 0 };
+      for (const h of handlers.end ?? []) h(endArg);
+    },
+    unbind(cb: (err?: Error) => void) {
+      stats.unbindCalls += 1;
+      cb();
+    },
+  };
+});
+
+const noop = () => {};
+const silentLogger = {
+  info: noop,
+  warn: noop,
+  error: noop,
+  debug: noop,
+  fatal: noop,
+  trace: noop,
+  child: () => silentLogger,
+};
+
+beforeAll(() => {
+  // Mock only `createClient` of ldapjs; preserve the real `parseFilter` so the
+  // util/ldap-filter tests (which exercise parseFilter) still pass once we restore.
+  mock.module('ldapjs', () => ({
+    default: {
+      ...ldapjsSnapshot,
+      createClient: createClientMock,
+    },
+  }));
+  mock.module('../../repositories/ldapRepo.ts', () => ({
+    ...ldapRepoSnapshot,
+    get: ldapRepoGetMock,
+  }));
+  mock.module('../../repositories/usersRepo.ts', () => ({
+    ...usersRepoSnapshot,
+    findLoginUserByUsername: findLoginUserByUsernameMock,
+    updateNameByUsername: updateNameByUsernameMock,
+    createUser: createUserMock,
+  }));
+  mock.module('../../utils/initials.ts', () => ({
+    ...initialsSnapshot,
+    computeAvatarInitials: (name: string) => name.slice(0, 2).toUpperCase(),
+  }));
+  mock.module('../../utils/logger.ts', () => ({
+    ...loggerSnapshot,
+    createChildLogger: () => silentLogger,
+    serializeError: (e: unknown) => (e instanceof Error ? { message: e.message } : { error: e }),
+    logger: silentLogger,
+  }));
+  mock.module('../../utils/order-ids.ts', () => ({
+    ...orderIdsSnapshot,
+    generatePrefixedId: (prefix: string) => `${prefix}_test_id`,
+  }));
+});
+
+afterAll(() => {
+  mock.module('ldapjs', () => ({ default: ldapjsSnapshot }));
+  mock.module('../../repositories/ldapRepo.ts', () => ldapRepoSnapshot);
+  mock.module('../../repositories/usersRepo.ts', () => usersRepoSnapshot);
+  mock.module('../../utils/initials.ts', () => initialsSnapshot);
+  mock.module('../../utils/logger.ts', () => loggerSnapshot);
+  mock.module('../../utils/order-ids.ts', () => orderIdsSnapshot);
+});
+
+const ENABLED_LDAP_CONFIG = {
+  enabled: true,
+  serverUrl: 'ldap://ldap.test:389',
+  baseDn: 'dc=test,dc=com',
+  bindDn: 'cn=admin,dc=test,dc=com',
+  bindPassword: 'admin-pw',
+  userFilter: '(uid={0})',
+  groupBaseDn: 'ou=groups,dc=test,dc=com',
+  groupFilter: '(member={0})',
+  roleMappings: [],
+};
+
+const resetService = () => {
+  (ldapService as unknown as { config: unknown }).config = null;
+};
+
+const ENV_KEYS = [
+  'LDAP_REJECT_UNAUTHORIZED',
+  'LDAP_TLS_CA_FILE',
+  'LDAP_TLS_CERT_FILE',
+  'LDAP_TLS_KEY_FILE',
+];
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  resetService();
+  for (const key of ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+
+  ldapRepoGetMock.mockReset();
+  findLoginUserByUsernameMock.mockReset();
+  updateNameByUsernameMock.mockReset();
+  createUserMock.mockReset();
+  createClientMock.mockClear();
+
+  ldapRepoGetMock.mockResolvedValue(ENABLED_LDAP_CONFIG);
+  nextFixture = {};
+  lastClientStats = null;
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+});
+
+describe('getClient', () => {
+  test('returns null when config.enabled is false', async () => {
+    ldapRepoGetMock.mockResolvedValue({ ...ENABLED_LDAP_CONFIG, enabled: false });
+    const client = await ldapService.getClient();
+    expect(client).toBeNull();
+    expect(createClientMock).not.toHaveBeenCalled();
+  });
+
+  test('calls loadConfig when cache is empty', async () => {
+    await ldapService.getClient();
+    expect(ldapRepoGetMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('default tlsOptions.rejectUnauthorized is true', async () => {
+    await ldapService.getClient();
+    const opts = createClientMock.mock.calls[0]?.[0] as {
+      tlsOptions: { rejectUnauthorized: boolean };
+    };
+    expect(opts.tlsOptions.rejectUnauthorized).toBe(true);
+  });
+
+  test('LDAP_REJECT_UNAUTHORIZED="false" → rejectUnauthorized:false', async () => {
+    process.env.LDAP_REJECT_UNAUTHORIZED = 'false';
+    await ldapService.getClient();
+    const opts = createClientMock.mock.calls[0]?.[0] as {
+      tlsOptions: { rejectUnauthorized: boolean };
+    };
+    expect(opts.tlsOptions.rejectUnauthorized).toBe(false);
+  });
+
+  test('passes config.serverUrl to ldapjs.createClient', async () => {
+    await ldapService.getClient();
+    const opts = createClientMock.mock.calls[0]?.[0] as { url: string };
+    expect(opts.url).toBe('ldap://ldap.test:389');
+  });
+
+  test('LDAP_TLS_CA_FILE pointing to non-existent path → no ca attached', async () => {
+    process.env.LDAP_TLS_CA_FILE = '/path/that/does/not/exist/ca.pem';
+    await ldapService.getClient();
+    const opts = createClientMock.mock.calls[0]?.[0] as {
+      tlsOptions: { ca?: Buffer };
+    };
+    expect(opts.tlsOptions.ca).toBeUndefined();
+  });
+
+  test('LDAP_TLS_CA_FILE pointing to an existing file → ca buffer attached', async () => {
+    // The test file itself is a stable, always-existing readable fixture for the existsSync gate.
+    process.env.LDAP_TLS_CA_FILE = import.meta.path;
+    await ldapService.getClient();
+    const opts = createClientMock.mock.calls[0]?.[0] as {
+      tlsOptions: { ca?: Buffer };
+    };
+    expect(opts.tlsOptions.ca).toBeInstanceOf(Buffer);
+    expect((opts.tlsOptions.ca as Buffer).length).toBeGreaterThan(0);
+  });
+});
+
+describe('authenticate', () => {
+  test('returns false when getClient returns null (LDAP disabled)', async () => {
+    ldapRepoGetMock.mockResolvedValue({ ...ENABLED_LDAP_CONFIG, enabled: false });
+    const ok = await ldapService.authenticate('alice', 'pw');
+    expect(ok).toBe(false);
+  });
+
+  test('returns false when service-account bind errors; unbind still called', async () => {
+    nextFixture = { bindResponses: [new Error('bad creds')] };
+    const ok = await ldapService.authenticate('alice', 'pw');
+    expect(ok).toBe(false);
+    expect(lastClientStats?.unbindCalls).toBe(1);
+  });
+
+  test('returns false when findUserDn yields null (no entries before end)', async () => {
+    nextFixture = {
+      bindResponses: [null],
+      searchResponses: [{ entries: [], status: 0 }],
+    };
+    const ok = await ldapService.authenticate('alice', 'pw');
+    expect(ok).toBe(false);
+    expect(lastClientStats?.unbindCalls).toBe(1);
+  });
+
+  test('returns false when user re-bind errors (wrong password)', async () => {
+    nextFixture = {
+      bindResponses: [null, new Error('wrong password')],
+      searchResponses: [
+        {
+          entries: [{ objectName: 'uid=alice,dc=test,dc=com', object: {} }],
+          status: 0,
+        },
+      ],
+    };
+    const ok = await ldapService.authenticate('alice', 'pw');
+    expect(ok).toBe(false);
+    expect(lastClientStats?.unbindCalls).toBe(1);
+  });
+
+  test('returns true on bind→search→re-bind happy path; unbind still called', async () => {
+    nextFixture = {
+      bindResponses: [null, null],
+      searchResponses: [
+        {
+          entries: [{ objectName: 'uid=alice,dc=test,dc=com', object: {} }],
+          status: 0,
+        },
+      ],
+    };
+    const ok = await ldapService.authenticate('alice', 'pw');
+    expect(ok).toBe(true);
+    expect(lastClientStats?.unbindCalls).toBe(1);
+    expect(lastClientStats?.bindCalls).toEqual([
+      { dn: 'cn=admin,dc=test,dc=com', password: 'admin-pw' },
+      { dn: 'uid=alice,dc=test,dc=com', password: 'pw' },
+    ]);
+  });
+
+  test('search receives the parsed userFilter with the escaped username', async () => {
+    nextFixture = {
+      bindResponses: [null, null],
+      searchResponses: [
+        {
+          entries: [{ objectName: 'uid=alice,dc=test,dc=com', object: {} }],
+          status: 0,
+        },
+      ],
+    };
+    await ldapService.authenticate('alice', 'pw');
+    const search = lastClientStats?.searchCalls[0];
+    expect(search?.base).toBe('dc=test,dc=com');
+    expect(search?.options.scope).toBe('sub');
+    // The real parseFilter (preserved via snapshot) returns a Filter instance whose
+    // `toString()` renders the canonical filter text.
+    expect(String(search?.options.filter)).toBe('(uid=alice)');
+  });
+});
+
+describe('findUserDn (direct, with config preloaded)', () => {
+  beforeEach(() => {
+    (ldapService as unknown as { config: unknown }).config = ENABLED_LDAP_CONFIG;
+  });
+
+  const buildClient = (response: SearchResponse) => {
+    nextFixture = { searchResponses: [response] };
+    return createClientMock({ url: ENABLED_LDAP_CONFIG.serverUrl, tlsOptions: {} });
+  };
+
+  test('resolves to entry.objectName from first searchEntry event', async () => {
+    const client = buildClient({
+      entries: [
+        { objectName: 'uid=alice,dc=test,dc=com' },
+        { objectName: 'uid=bob,dc=test,dc=com' },
+      ],
+      status: 0,
+    });
+    const dn = await ldapService.findUserDn(client as never, 'alice');
+    expect(dn).toBe('uid=bob,dc=test,dc=com'); // last searchEntry wins (foundDn reassignment)
+  });
+
+  test('resolves null when no searchEntry fires before end (status 0)', async () => {
+    const client = buildClient({ entries: [], status: 0 });
+    const dn = await ldapService.findUserDn(client as never, 'alice');
+    expect(dn).toBeNull();
+  });
+
+  test('rejects when end fires with non-zero status', async () => {
+    const client = buildClient({ entries: [], status: 32 });
+    await expect(ldapService.findUserDn(client as never, 'alice')).rejects.toThrow(/status: 32/);
+  });
+
+  test('rejects when search callback returns err', async () => {
+    const client = buildClient({ err: new Error('search blew up') });
+    await expect(ldapService.findUserDn(client as never, 'alice')).rejects.toThrow(
+      'search blew up',
+    );
+  });
+
+  test('rejects when res.error event fires', async () => {
+    const client = buildClient({
+      entries: [],
+      errorEvent: new Error('ldap protocol error'),
+      status: 0,
+    });
+    await expect(ldapService.findUserDn(client as never, 'alice')).rejects.toThrow(
+      'ldap protocol error',
+    );
+  });
+
+  test('returns null when service config is unset', async () => {
+    (ldapService as unknown as { config: unknown }).config = null;
+    const dn = await ldapService.findUserDn({} as never, 'alice');
+    expect(dn).toBeNull();
+  });
+});
+
+describe('syncUsers', () => {
+  test('returns { skipped: true, reason: "LDAP is disabled" } when getClient returns null', async () => {
+    ldapRepoGetMock.mockResolvedValue({ ...ENABLED_LDAP_CONFIG, enabled: false });
+    const result = await ldapService.syncUsers();
+    expect(result).toEqual({ skipped: true, reason: 'LDAP is disabled' });
+  });
+
+  test('binds with service account and searches with buildUserSyncFilter (wildcard)', async () => {
+    nextFixture = {
+      bindResponses: [null],
+      searchResponses: [{ entries: [], status: 0 }],
+    };
+    await ldapService.syncUsers();
+    expect(lastClientStats?.bindCalls).toEqual([
+      { dn: 'cn=admin,dc=test,dc=com', password: 'admin-pw' },
+    ]);
+    const search = lastClientStats?.searchCalls[0];
+    expect(String(search?.options.filter)).toBe('(uid=*)');
+    expect(search?.options.attributes).toEqual([
+      'uid',
+      'cn',
+      'sn',
+      'givenName',
+      'mail',
+      'displayName',
+      'sAMAccountName',
+    ]);
+  });
+
+  test('falls back to sAMAccountName when uid is missing (AD path)', async () => {
+    nextFixture = {
+      bindResponses: [null],
+      searchResponses: [
+        {
+          entries: [
+            {
+              objectName: 'cn=carol,dc=test,dc=com',
+              object: { sAMAccountName: 'carol', cn: 'Carol' },
+            },
+          ],
+          status: 0,
+        },
+      ],
+    };
+    findLoginUserByUsernameMock.mockResolvedValue(null);
+    const result = await ldapService.syncUsers();
+    expect(createUserMock).toHaveBeenCalledWith({
+      id: 'u_test_id',
+      name: 'Carol',
+      username: 'carol',
+      passwordHash: realUsersRepo.LDAP_PLACEHOLDER_PASSWORD_HASH,
+      role: 'user',
+      avatarInitials: 'CA',
+    });
+    expect(result).toEqual({ synced: 0, created: 1 });
+  });
+
+  test('uses cn for name; falls back through displayName then username', async () => {
+    nextFixture = {
+      bindResponses: [null],
+      searchResponses: [
+        {
+          entries: [
+            { objectName: 'uid=a,dc=x', object: { uid: 'a', cn: 'CN Name' } },
+            { objectName: 'uid=b,dc=x', object: { uid: 'b', displayName: 'DN Name' } },
+            { objectName: 'uid=c,dc=x', object: { uid: 'c' } },
+          ],
+          status: 0,
+        },
+      ],
+    };
+    findLoginUserByUsernameMock.mockResolvedValue(null);
+    await ldapService.syncUsers();
+    const names = createUserMock.mock.calls.map((call) => (call[0] as { name: string }).name);
+    expect(names).toEqual(['CN Name', 'DN Name', 'c']);
+  });
+
+  test('flattens single-element arrays for uid and name attributes', async () => {
+    nextFixture = {
+      bindResponses: [null],
+      searchResponses: [
+        {
+          entries: [{ objectName: 'uid=a,dc=x', object: { uid: ['flat-uid'], cn: ['Flat CN'] } }],
+          status: 0,
+        },
+      ],
+    };
+    findLoginUserByUsernameMock.mockResolvedValue(null);
+    await ldapService.syncUsers();
+    const created = createUserMock.mock.calls[0]?.[0] as {
+      username: string;
+      name: string;
+    };
+    expect(created.username).toBe('flat-uid');
+    expect(created.name).toBe('Flat CN');
+  });
+
+  test('updates existing user via updateNameByUsername instead of creating', async () => {
+    nextFixture = {
+      bindResponses: [null],
+      searchResponses: [
+        {
+          entries: [{ objectName: 'uid=alice,dc=x', object: { uid: 'alice', cn: 'Alice New' } }],
+          status: 0,
+        },
+      ],
+    };
+    findLoginUserByUsernameMock.mockResolvedValue({ id: 'u-old' });
+    const result = await ldapService.syncUsers();
+    expect(updateNameByUsernameMock).toHaveBeenCalledWith('alice', 'Alice New');
+    expect(createUserMock).not.toHaveBeenCalled();
+    expect(result).toEqual({ synced: 1, created: 0 });
+  });
+
+  test('skips entries without a username (no uid and no sAMAccountName)', async () => {
+    nextFixture = {
+      bindResponses: [null],
+      searchResponses: [
+        {
+          entries: [
+            { objectName: 'cn=stub,dc=x', object: { cn: 'No Username Here' } },
+            { objectName: 'uid=ok,dc=x', object: { uid: 'ok', cn: 'Ok' } },
+          ],
+          status: 0,
+        },
+      ],
+    };
+    findLoginUserByUsernameMock.mockResolvedValue(null);
+    const result = await ldapService.syncUsers();
+    expect(result).toEqual({ synced: 0, created: 1 });
+    expect(createUserMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('rethrows on outer error after unbind', async () => {
+    nextFixture = { bindResponses: [new Error('bind failed in sync')] };
+    await expect(ldapService.syncUsers()).rejects.toThrow('bind failed in sync');
+    expect(lastClientStats?.unbindCalls).toBe(1);
+  });
+});

--- a/server/test/services/ldap.test.ts
+++ b/server/test/services/ldap.test.ts
@@ -347,7 +347,7 @@ describe('findUserDn (direct, with config preloaded)', () => {
     return createClientMock({ url: ENABLED_LDAP_CONFIG.serverUrl, tlsOptions: {} });
   };
 
-  test('resolves to entry.objectName from first searchEntry event', async () => {
+  test('resolves to the last searchEntry.objectName when multiple entries fire (foundDn reassignment)', async () => {
     const client = buildClient({
       entries: [
         { objectName: 'uid=alice,dc=test,dc=com' },
@@ -356,7 +356,16 @@ describe('findUserDn (direct, with config preloaded)', () => {
       status: 0,
     });
     const dn = await ldapService.findUserDn(client as never, 'alice');
-    expect(dn).toBe('uid=bob,dc=test,dc=com'); // last searchEntry wins (foundDn reassignment)
+    expect(dn).toBe('uid=bob,dc=test,dc=com');
+  });
+
+  test('resolves to entry.objectName when a single searchEntry fires', async () => {
+    const client = buildClient({
+      entries: [{ objectName: 'uid=alice,dc=test,dc=com' }],
+      status: 0,
+    });
+    const dn = await ldapService.findUserDn(client as never, 'alice');
+    expect(dn).toBe('uid=alice,dc=test,dc=com');
   });
 
   test('resolves null when no searchEntry fires before end (status 0)', async () => {


### PR DESCRIPTION
## Summary

Phase 2 of the test coverage roadmap. Adds 74 unit tests across three high-risk integration modules that previously had zero automated coverage.

- **`server/middleware/auth.ts`** — JWT validation, sliding-window token rotation, 8h max-session check, disabled-user check, parallel role/permissions lookup, and the `requireRole` / `requirePermission` / `requireAnyPermission` / `generateToken` helpers.
- **`server/services/email.ts`** — `saveConfig` encrypt round-trip, `ensureReady` codes, transporter encryption modes (ssl/tls/insecure), `sendEmail` success & error paths, `sendTestEmail`.
- **`server/services/ldap.ts`** — `getClient` TLS/CA flow, `authenticate` bind→search→re-bind, `findUserDn` event paths, `syncUsers` with `uid`/`sAMAccountName` fallback, `cn`/`displayName` chain, array flattening, update-vs-create routing, and error rethrow with `unbind` in finally.

All new tests run under `bun:test` without a real PostgreSQL or LDAP server.

## Files

```
server/test/
├── helpers/
│   └── jwt.ts                 (new) — signToken / signExpiredToken / signOverMaxSessionToken / decodeForAssertion
├── middleware/
│   └── auth.test.ts           (new) — 24 tests
└── services/
    ├── email.test.ts          (new) — 23 tests
    └── ldap.test.ts           (new) — 27 tests
```

## Design notes worth a reviewer's eye

1. **Direct middleware calls instead of Fastify `inject()`.** Fastify v5's `inject()` errors with `ERR_HTTP_HEADERS_SENT` when an async `onRequest` hook calls `reply.send()` — verified against a real listening HTTP server (production path works fine). Fake `request`/`reply` objects test the same logic without that runtime quirk and run faster.

2. **`mock.module()` placed inside `beforeAll`, restored in `afterAll`.** Bun 1.3.13's top-level `mock.module()` calls leak across test files. Calls inside `beforeAll` are **not** hoisted, which lets us snapshot the real exports at static-import time and re-mock with the snapshot in `afterAll`. Without this, Phase 1 tests (`crypto`, `initials`, `order-ids`, `ldap-filter`, `usersRepo`, `rolesRepo`) failed because of leaked Phase 2 mocks.

## Test plan

- [x] `bun run test` — 1045 pass / 0 fail across 49 files (74 new)
- [x] `bun run lint` — exit 0 (only pre-existing warnings remain)
- [x] `bun run build` (frontend) — builds successfully
- [x] `cd server && bun run build` (backend tsc) — passes
- [ ] Verify CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)