### PR TITLE
test(routes): add inject() tests for top 5 backend routes; enforce invoice totals server-side

### DIFF
--- a/server/repositories/invoicesRepo.ts
+++ b/server/repositories/invoicesRepo.ts
@@ -124,6 +124,18 @@ export const findTotal = async (
   return parseDbNumber(rows[0].total, 0);
 };
 
+export const findAmountPaid = async (
+  invoiceId: string,
+  exec: DbExecutor = db,
+): Promise<number | null> => {
+  const rows = await exec
+    .select({ amountPaid: invoices.amountPaid })
+    .from(invoices)
+    .where(eq(invoices.id, invoiceId));
+  if (!rows[0]) return null;
+  return parseDbNumber(rows[0].amountPaid, 0);
+};
+
 export const findIdConflict = async (
   newId: string,
   currentId: string,

--- a/server/repositories/invoicesRepo.ts
+++ b/server/repositories/invoicesRepo.ts
@@ -112,6 +112,18 @@ export const findDates = async (
   };
 };
 
+export const findTotal = async (
+  invoiceId: string,
+  exec: DbExecutor = db,
+): Promise<number | null> => {
+  const rows = await exec
+    .select({ total: invoices.total })
+    .from(invoices)
+    .where(eq(invoices.id, invoiceId));
+  if (!rows[0]) return null;
+  return parseDbNumber(rows[0].total, 0);
+};
+
 export const findIdConflict = async (
   newId: string,
   currentId: string,

--- a/server/routes/invoices.ts
+++ b/server/routes/invoices.ts
@@ -5,6 +5,7 @@ import * as invoicesRepo from '../repositories/invoicesRepo.ts';
 import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
 import { logAudit } from '../utils/audit.ts';
 import { getForeignKeyViolation, getUniqueViolation } from '../utils/db-errors.ts';
+import { computeInvoiceTotals } from '../utils/invoice-math.ts';
 import { generateItemId } from '../utils/order-ids.ts';
 import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
@@ -146,10 +147,10 @@ type NormalizedInvoiceItemInput = {
 
 const generateInvoiceItemId = () => generateItemId('inv-item-');
 
-const validateAndNormalizeItems = async (
+const validateAndNormalizeItems = (
   items: unknown[],
   reply: FastifyReply,
-): Promise<NormalizedInvoiceItemInput[] | null> => {
+): NormalizedInvoiceItemInput[] | null => {
   const normalizedItems: NormalizedInvoiceItemInput[] = [];
 
   for (let i = 0; i < items.length; i++) {
@@ -274,8 +275,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         issueDate,
         dueDate,
         status,
-        subtotal,
-        total,
         amountPaid,
         notes,
         items,
@@ -287,8 +286,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         issueDate: unknown;
         dueDate: unknown;
         status: unknown;
-        subtotal: unknown;
-        total: unknown;
         amountPaid: unknown;
         notes: unknown;
         items: unknown;
@@ -313,17 +310,18 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       if (!Array.isArray(items) || items.length === 0) {
         return badRequest(reply, 'Items must be a non-empty array');
       }
-      const normalizedItems = await validateAndNormalizeItems(items, reply);
+      const normalizedItems = validateAndNormalizeItems(items, reply);
       if (!normalizedItems) return;
 
-      const subtotalResult = optionalLocalizedNonNegativeNumber(subtotal, 'subtotal');
-      if (!subtotalResult.ok) return badRequest(reply, subtotalResult.message);
-
-      const totalResult = optionalLocalizedNonNegativeNumber(total, 'total');
-      if (!totalResult.ok) return badRequest(reply, totalResult.message);
+      const { subtotal: computedSubtotal, total: computedTotal } =
+        computeInvoiceTotals(normalizedItems);
 
       const amountPaidResult = optionalLocalizedNonNegativeNumber(amountPaid, 'amountPaid');
       if (!amountPaidResult.ok) return badRequest(reply, amountPaidResult.message);
+      const amountPaidValue = amountPaidResult.value || 0;
+      if (amountPaidValue > computedTotal) {
+        return badRequest(reply, 'amountPaid cannot exceed total');
+      }
 
       const nextIdResult = optionalNonEmptyString(nextId, 'id');
       if (!nextIdResult.ok) return badRequest(reply, nextIdResult.message);
@@ -342,9 +340,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
               issueDate: issueDateResult.value,
               dueDate: dueDateResult.value,
               status: (status as string) || 'draft',
-              subtotal: subtotalResult.value || 0,
-              total: totalResult.value || 0,
-              amountPaid: amountPaidResult.value || 0,
+              subtotal: computedSubtotal,
+              total: computedTotal,
+              amountPaid: amountPaidValue,
               notes: (notes as string | null | undefined) ?? null,
             },
             tx,
@@ -406,8 +404,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         issueDate,
         dueDate,
         status,
-        subtotal,
-        total,
         amountPaid,
         notes,
         items,
@@ -418,8 +414,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         issueDate: unknown;
         dueDate: unknown;
         status: unknown;
-        subtotal: unknown;
-        total: unknown;
         amountPaid: unknown;
         notes: unknown;
         items: unknown;
@@ -488,28 +482,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         }
       }
 
-      if (subtotal !== undefined) {
-        const subtotalResult = optionalLocalizedNonNegativeNumber(subtotal, 'subtotal');
-        if (!subtotalResult.ok) return badRequest(reply, subtotalResult.message);
-        if (subtotalResult.value !== null && subtotalResult.value !== undefined) {
-          patch.subtotal = subtotalResult.value;
-        }
-      }
-
-      if (total !== undefined) {
-        const totalResult = optionalLocalizedNonNegativeNumber(total, 'total');
-        if (!totalResult.ok) return badRequest(reply, totalResult.message);
-        if (totalResult.value !== null && totalResult.value !== undefined) {
-          patch.total = totalResult.value;
-        }
-      }
-
+      let amountPaidValue: number | undefined;
       if (amountPaid !== undefined) {
         const amountPaidResult = optionalLocalizedNonNegativeNumber(amountPaid, 'amountPaid');
         if (!amountPaidResult.ok) return badRequest(reply, amountPaidResult.message);
-        if (amountPaidResult.value !== null && amountPaidResult.value !== undefined) {
-          patch.amountPaid = amountPaidResult.value;
-        }
+        amountPaidValue = amountPaidResult.value ?? undefined;
       }
 
       if (status !== undefined) patch.status = status as string;
@@ -520,8 +497,22 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         if (!Array.isArray(items) || items.length === 0) {
           return badRequest(reply, 'Items must be a non-empty array');
         }
-        normalizedItemsForUpdate = await validateAndNormalizeItems(items, reply);
+        normalizedItemsForUpdate = validateAndNormalizeItems(items, reply);
         if (!normalizedItemsForUpdate) return;
+        const computed = computeInvoiceTotals(normalizedItemsForUpdate);
+        patch.subtotal = computed.subtotal;
+        patch.total = computed.total;
+      }
+
+      if (amountPaidValue !== undefined) {
+        const totalForCheck = patch.total ?? (await invoicesRepo.findTotal(idResult.value));
+        if (totalForCheck === null) {
+          return reply.code(404).send({ error: 'Invoice not found' });
+        }
+        if (amountPaidValue > totalForCheck) {
+          return badRequest(reply, 'amountPaid cannot exceed total');
+        }
+        patch.amountPaid = amountPaidValue;
       }
 
       let result: {

--- a/server/routes/invoices.ts
+++ b/server/routes/invoices.ts
@@ -200,6 +200,13 @@ const validateAndNormalizeItems = (
       badRequest(reply, discountResult.message);
       return null;
     }
+    // Without an upper bound a compromised client can send discount > 100, which makes
+    // (1 - discount/100) negative and produces negative line totals — corrupting SUM(total)
+    // in the revenue reports.
+    if (discountResult.value !== null && discountResult.value > 100) {
+      badRequest(reply, `items[${i}].discount must be at most 100`);
+      return null;
+    }
 
     normalizedItems.push({
       productId: productIdResult.value || null,

--- a/server/routes/invoices.ts
+++ b/server/routes/invoices.ts
@@ -100,6 +100,7 @@ const invoiceItemBodySchema = {
   required: ['description', 'unitOfMeasure', 'quantity', 'unitPrice'],
 } as const;
 
+// subtotal/total are server-computed from items; clients cannot set them.
 const invoiceCreateBodySchema = {
   type: 'object',
   properties: {
@@ -110,8 +111,6 @@ const invoiceCreateBodySchema = {
     issueDate: { type: 'string', format: 'date' },
     dueDate: { type: 'string', format: 'date' },
     status: { type: 'string' },
-    subtotal: { type: 'number' },
-    total: { type: 'number' },
     amountPaid: { type: 'number' },
     notes: { type: 'string' },
     items: { type: 'array', items: invoiceItemBodySchema },
@@ -128,8 +127,6 @@ const invoiceUpdateBodySchema = {
     issueDate: { type: 'string', format: 'date' },
     dueDate: { type: 'string', format: 'date' },
     status: { type: 'string' },
-    subtotal: { type: 'number' },
-    total: { type: 'number' },
     amountPaid: { type: 'number' },
     notes: { type: 'string' },
     items: { type: 'array', items: invoiceItemBodySchema },
@@ -146,6 +143,10 @@ type NormalizedInvoiceItemInput = {
 };
 
 const generateInvoiceItemId = () => generateItemId('inv-item-');
+
+// Match the NUMERIC(_, 2) precision used for invoice_items columns so the totals computed
+// here align with what would be re-derived from the persisted rows.
+const round2 = (value: number) => Math.round(value * 100) / 100;
 
 const validateAndNormalizeItems = (
   items: unknown[],
@@ -212,9 +213,9 @@ const validateAndNormalizeItems = (
       productId: productIdResult.value || null,
       description: descriptionResult.value,
       unitOfMeasure: unitOfMeasureResult.value as 'unit' | 'hours',
-      quantity: quantityResult.value,
-      unitPrice: unitPriceResult.value,
-      discount: discountResult.value || 0,
+      quantity: round2(quantityResult.value),
+      unitPrice: round2(unitPriceResult.value),
+      discount: round2(discountResult.value || 0),
     });
   }
 
@@ -520,6 +521,17 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           return badRequest(reply, 'amountPaid cannot exceed total');
         }
         patch.amountPaid = amountPaidValue;
+      } else if (patch.total !== undefined) {
+        // Items replaced (so total may be lower) but amountPaid not in this patch — verify the
+        // persisted amountPaid still fits under the new total. Without this, paying-down to a
+        // partial total would leave amountPaid > total and skew SUM(GREATEST(total - paid, 0)).
+        const persistedAmountPaid = await invoicesRepo.findAmountPaid(idResult.value);
+        if (persistedAmountPaid === null) {
+          return reply.code(404).send({ error: 'Invoice not found' });
+        }
+        if (persistedAmountPaid > patch.total) {
+          return badRequest(reply, 'amountPaid cannot exceed total');
+        }
       }
 
       let result: {

--- a/server/test/helpers/authMiddlewareMock.ts
+++ b/server/test/helpers/authMiddlewareMock.ts
@@ -1,0 +1,38 @@
+// Wraps the auth middleware so that under Fastify's `inject()` an early `reply.send()` actually
+// halts the chain. Two quirks compound: the real middleware does `return reply.send(...)` so
+// wrap-thenable.js re-sends the reply, and `reply.sent` lags `raw.headersSent` until the next
+// tick so subsequent hooks and the route handler still run. Hijacking after each hook flips
+// `reply.sent` synchronously, which Fastify treats as a hard stop.
+//
+// Used in route tests via `installAuthMiddlewareMock()` in `beforeAll`.
+
+import { mock } from 'bun:test';
+import type { FastifyReply, FastifyRequest } from 'fastify';
+import * as realMiddleware from '../../middleware/auth.ts';
+
+const middlewareSnap = { ...realMiddleware };
+
+const wrapHook = (hook: (req: FastifyRequest, reply: FastifyReply) => Promise<unknown>) => {
+  return async (req: FastifyRequest, reply: FastifyReply) => {
+    if (reply.sent || reply.raw.headersSent) return;
+    await hook(req, reply);
+    if (reply.raw.headersSent && !reply.sent) reply.hijack();
+  };
+};
+
+export const installAuthMiddlewareMock = () => {
+  mock.module('../../middleware/auth.ts', () => ({
+    ...middlewareSnap,
+    authenticateToken: wrapHook(middlewareSnap.authenticateToken),
+    requireRole: (...args: Parameters<typeof middlewareSnap.requireRole>) =>
+      wrapHook(middlewareSnap.requireRole(...args)),
+    requirePermission: (...args: Parameters<typeof middlewareSnap.requirePermission>) =>
+      wrapHook(middlewareSnap.requirePermission(...args)),
+    requireAnyPermission: (...args: Parameters<typeof middlewareSnap.requireAnyPermission>) =>
+      wrapHook(middlewareSnap.requireAnyPermission(...args)),
+  }));
+};
+
+export const restoreAuthMiddlewareMock = () => {
+  mock.module('../../middleware/auth.ts', () => middlewareSnap);
+};

--- a/server/test/helpers/buildRouteTestApp.ts
+++ b/server/test/helpers/buildRouteTestApp.ts
@@ -1,0 +1,15 @@
+import Fastify, { type FastifyInstance, type FastifyPluginAsync } from 'fastify';
+
+// Why no `@fastify/rate-limit`: the plugin's onResponse hook double-writes after
+// `authMiddlewareMock` hijacks an early-401/403 reply. Decorating `rateLimit` as a no-op gives
+// route files the decorator they expect without that hook.
+export const buildRouteTestApp = async (
+  routePlugin: FastifyPluginAsync,
+  prefix: string,
+): Promise<FastifyInstance> => {
+  const app = Fastify({ logger: false });
+  app.decorate('rateLimit', () => async () => {});
+  await app.register(routePlugin, { prefix });
+  await app.ready();
+  return app;
+};

--- a/server/test/repositories/invoicesRepo.test.ts
+++ b/server/test/repositories/invoicesRepo.test.ts
@@ -142,6 +142,41 @@ describe('findDates', () => {
   });
 });
 
+describe('findTotal', () => {
+  test('returns parsed numeric when row exists', async () => {
+    exec.enqueue({ rows: [['250.50']] });
+    const result = await invoicesRepo.findTotal('INV-1', testDb);
+    expect(result).toBe(250.5);
+    expect(exec.calls[0].sql.toLowerCase()).toContain('select "total" from "invoices"');
+    expect(exec.calls[0].params).toContain('INV-1');
+  });
+
+  test('returns 0 when total column is null (defensive default)', async () => {
+    exec.enqueue({ rows: [[null]] });
+    expect(await invoicesRepo.findTotal('INV-1', testDb)).toBe(0);
+  });
+
+  test('returns null when invoice not found', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await invoicesRepo.findTotal('INV-X', testDb)).toBeNull();
+  });
+});
+
+describe('findAmountPaid', () => {
+  test('returns parsed numeric when row exists', async () => {
+    exec.enqueue({ rows: [['100.00']] });
+    const result = await invoicesRepo.findAmountPaid('INV-1', testDb);
+    expect(result).toBe(100);
+    expect(exec.calls[0].sql.toLowerCase()).toContain('select "amount_paid" from "invoices"');
+    expect(exec.calls[0].params).toContain('INV-1');
+  });
+
+  test('returns null when invoice not found', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await invoicesRepo.findAmountPaid('INV-X', testDb)).toBeNull();
+  });
+});
+
 describe('findIdConflict', () => {
   test('excludes self with both id-equality and id-inequality predicates', async () => {
     exec.enqueue({ rows: [] });

--- a/server/test/routes/auth.test.ts
+++ b/server/test/routes/auth.test.ts
@@ -1,0 +1,449 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as realBcrypt from 'bcryptjs';
+import type { FastifyInstance, FastifyPluginAsync } from 'fastify';
+import * as realRolesRepo from '../../repositories/rolesRepo.ts';
+import * as realUsersRepo from '../../repositories/usersRepo.ts';
+import * as realLdapService from '../../services/ldap.ts';
+import * as realAudit from '../../utils/audit.ts';
+import * as realPermissions from '../../utils/permissions.ts';
+import {
+  installAuthMiddlewareMock,
+  restoreAuthMiddlewareMock,
+} from '../helpers/authMiddlewareMock.ts';
+import { buildRouteTestApp } from '../helpers/buildRouteTestApp.ts';
+import { decodeForAssertion, signToken } from '../helpers/jwt.ts';
+
+// Snapshot real exports so afterAll can restore them. Snapshot must run BEFORE mock.module
+// fires (i.e., before beforeAll executes) — see comment in middleware/auth.test.ts.
+const usersRepoSnap = { ...realUsersRepo };
+const rolesRepoSnap = { ...realRolesRepo };
+const permissionsSnap = { ...realPermissions };
+const auditSnap = { ...realAudit };
+const bcryptSnap = { ...(realBcrypt as Record<string, unknown>) };
+const ldapServiceSnap = { ...(realLdapService as Record<string, unknown>) };
+
+// Auth-middleware deps: the real authenticateToken runs end-to-end on /me and /switch-role,
+// so we mock its three downstream calls.
+const findAuthUserByIdMock = mock();
+const userHasRoleMock = mock();
+const getRolePermissionsMock = mock();
+
+// Auth route deps
+const findLoginUserByUsernameMock = mock();
+const listAvailableRolesForUserMock = mock();
+const logAuditMock = mock(async () => undefined);
+
+// External: bcryptjs.compare and the LDAP service (dynamically imported by /login)
+const bcryptCompareMock = mock();
+const ldapAuthenticateMock = mock();
+
+let authRoutePlugin: FastifyPluginAsync;
+
+beforeAll(async () => {
+  installAuthMiddlewareMock();
+  mock.module('../../repositories/usersRepo.ts', () => ({
+    ...usersRepoSnap,
+    findAuthUserById: findAuthUserByIdMock,
+    findLoginUserByUsername: findLoginUserByUsernameMock,
+  }));
+  mock.module('../../repositories/rolesRepo.ts', () => ({
+    ...rolesRepoSnap,
+    userHasRole: userHasRoleMock,
+    listAvailableRolesForUser: listAvailableRolesForUserMock,
+  }));
+  mock.module('../../utils/permissions.ts', () => ({
+    ...permissionsSnap,
+    getRolePermissions: getRolePermissionsMock,
+  }));
+  mock.module('../../utils/audit.ts', () => ({
+    ...auditSnap,
+    logAudit: logAuditMock,
+  }));
+  mock.module('bcryptjs', () => ({
+    default: { compare: bcryptCompareMock },
+    compare: bcryptCompareMock,
+  }));
+  mock.module('../../services/ldap.ts', () => ({
+    default: { authenticate: ldapAuthenticateMock },
+  }));
+
+  authRoutePlugin = (await import('../../routes/auth.ts')).default as FastifyPluginAsync;
+});
+
+afterAll(() => {
+  restoreAuthMiddlewareMock();
+  mock.module('../../repositories/usersRepo.ts', () => usersRepoSnap);
+  mock.module('../../repositories/rolesRepo.ts', () => rolesRepoSnap);
+  mock.module('../../utils/permissions.ts', () => permissionsSnap);
+  mock.module('../../utils/audit.ts', () => auditSnap);
+  mock.module('bcryptjs', () => bcryptSnap);
+  mock.module('../../services/ldap.ts', () => ldapServiceSnap);
+});
+
+const HAPPY_USER = {
+  id: 'u1',
+  name: 'Alice',
+  username: 'alice',
+  role: 'manager',
+  avatarInitials: 'AL',
+  isDisabled: false,
+};
+
+const LOGIN_USER = {
+  ...HAPPY_USER,
+  passwordHash: '$2a$hashed',
+};
+
+const HAPPY_PERMISSIONS = ['timesheets.tracker.view', 'timesheets.tracker.create'];
+
+const HAPPY_ROLES = [
+  { id: 'manager', name: 'Manager', isSystem: true, isAdmin: false },
+  { id: 'user', name: 'User', isSystem: true, isAdmin: false },
+];
+
+const allMocks = [
+  findAuthUserByIdMock,
+  userHasRoleMock,
+  getRolePermissionsMock,
+  findLoginUserByUsernameMock,
+  listAvailableRolesForUserMock,
+  logAuditMock,
+  bcryptCompareMock,
+  ldapAuthenticateMock,
+];
+
+let testApp: FastifyInstance;
+
+beforeEach(async () => {
+  for (const m of allMocks) m.mockReset();
+
+  // Defaults: happy auth path for /me and /switch-role
+  findAuthUserByIdMock.mockResolvedValue(HAPPY_USER);
+  userHasRoleMock.mockResolvedValue(true);
+  getRolePermissionsMock.mockResolvedValue(HAPPY_PERMISSIONS);
+  listAvailableRolesForUserMock.mockResolvedValue(HAPPY_ROLES);
+  logAuditMock.mockImplementation(async () => undefined);
+
+  // Defaults for /login: LDAP off (returns false), bcrypt fails by default
+  ldapAuthenticateMock.mockResolvedValue(false);
+  bcryptCompareMock.mockResolvedValue(false);
+
+  testApp = await buildRouteTestApp(authRoutePlugin, '/api/auth');
+});
+
+afterEach(async () => {
+  await testApp.close();
+});
+
+const authHeader = (userId = 'u1', activeRole?: string, sessionStart?: number) => ({
+  authorization: `Bearer ${signToken({ userId, activeRole, sessionStart })}`,
+});
+
+describe('POST /api/auth/login', () => {
+  test('200 happy path: local password match', async () => {
+    findLoginUserByUsernameMock.mockResolvedValue(LOGIN_USER);
+    bcryptCompareMock.mockResolvedValue(true);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/auth/login',
+      payload: { username: 'alice', password: 'secret' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.token).toEqual(expect.any(String));
+    expect(body.user).toEqual({
+      id: 'u1',
+      name: 'Alice',
+      username: 'alice',
+      role: 'manager',
+      avatarInitials: 'AL',
+      permissions: HAPPY_PERMISSIONS,
+      availableRoles: HAPPY_ROLES,
+    });
+
+    // Token encodes userId and role
+    const decoded = decodeForAssertion(body.token);
+    expect(decoded.userId).toBe('u1');
+    expect(decoded.activeRole).toBe('manager');
+
+    // bcrypt was called with plaintext + stored hash
+    expect(bcryptCompareMock).toHaveBeenCalledWith('secret', LOGIN_USER.passwordHash);
+
+    // Audit emission
+    expect(logAuditMock).toHaveBeenCalledTimes(1);
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'user.login',
+        entityType: 'user',
+        entityId: 'u1',
+        userId: 'u1',
+      }),
+    );
+  });
+
+  test('200: LDAP success skips bcrypt', async () => {
+    findLoginUserByUsernameMock.mockResolvedValue(LOGIN_USER);
+    ldapAuthenticateMock.mockResolvedValue(true);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/auth/login',
+      payload: { username: 'alice', password: 'secret' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(ldapAuthenticateMock).toHaveBeenCalledWith('alice', 'secret');
+    expect(bcryptCompareMock).not.toHaveBeenCalled();
+  });
+
+  test('200: LDAP returns false, bcrypt succeeds (fallback)', async () => {
+    findLoginUserByUsernameMock.mockResolvedValue(LOGIN_USER);
+    ldapAuthenticateMock.mockResolvedValue(false);
+    bcryptCompareMock.mockResolvedValue(true);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/auth/login',
+      payload: { username: 'alice', password: 'secret' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(bcryptCompareMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('200: LDAP throws, bcrypt fallback succeeds', async () => {
+    findLoginUserByUsernameMock.mockResolvedValue(LOGIN_USER);
+    ldapAuthenticateMock.mockRejectedValue(new Error('LDAP server unreachable'));
+    bcryptCompareMock.mockResolvedValue(true);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/auth/login',
+      payload: { username: 'alice', password: 'secret' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(bcryptCompareMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('200: empty availableRoles falls back to user.role synthetic role', async () => {
+    findLoginUserByUsernameMock.mockResolvedValue(LOGIN_USER);
+    bcryptCompareMock.mockResolvedValue(true);
+    listAvailableRolesForUserMock.mockResolvedValue([]);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/auth/login',
+      payload: { username: 'alice', password: 'secret' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.user.availableRoles).toEqual([
+      { id: 'manager', name: 'manager', isSystem: false, isAdmin: false },
+    ]);
+  });
+
+  test('401 user not found', async () => {
+    findLoginUserByUsernameMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/auth/login',
+      payload: { username: 'ghost', password: 'whatever' },
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Invalid username or password' });
+    expect(logAuditMock).not.toHaveBeenCalled();
+  });
+
+  test('401 disabled user', async () => {
+    findLoginUserByUsernameMock.mockResolvedValue({ ...LOGIN_USER, isDisabled: true });
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/auth/login',
+      payload: { username: 'alice', password: 'secret' },
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Invalid username or password' });
+  });
+
+  test('401 wrong password (LDAP off, bcrypt fails)', async () => {
+    findLoginUserByUsernameMock.mockResolvedValue(LOGIN_USER);
+    ldapAuthenticateMock.mockResolvedValue(false);
+    bcryptCompareMock.mockResolvedValue(false);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/auth/login',
+      payload: { username: 'alice', password: 'wrong' },
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Invalid username or password' });
+  });
+
+  test('400 whitespace-only username triggers in-handler validator', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/auth/login',
+      payload: { username: '   ', password: 'secret' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({ error: 'username is required' });
+  });
+
+  test('400 whitespace-only password triggers in-handler validator', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/auth/login',
+      payload: { username: 'alice', password: '   ' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({ error: 'password is required' });
+  });
+
+  test('400 missing username (Fastify schema rejection)', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/auth/login',
+      payload: { password: 'secret' },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe('GET /api/auth/me', () => {
+  test('200 returns current user with availableRoles', async () => {
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/auth/me',
+      headers: authHeader('u1'),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body).toEqual({
+      id: 'u1',
+      name: 'Alice',
+      username: 'alice',
+      role: 'manager',
+      avatarInitials: 'AL',
+      permissions: HAPPY_PERMISSIONS,
+      availableRoles: HAPPY_ROLES,
+    });
+  });
+
+  test('200 sets x-auth-token sliding-window header', async () => {
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/auth/me',
+      headers: authHeader('u1'),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const newToken = res.headers['x-auth-token'];
+    expect(typeof newToken).toBe('string');
+    expect(newToken).not.toBe('');
+    const decoded = decodeForAssertion(newToken as string);
+    expect(decoded.userId).toBe('u1');
+  });
+
+  test('401 missing Authorization header', async () => {
+    const res = await testApp.inject({ method: 'GET', url: '/api/auth/me' });
+    expect(res.statusCode).toBe(401);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Access token required' });
+  });
+});
+
+describe('POST /api/auth/switch-role', () => {
+  test('200 switches role, sets x-auth-token, audits user.role_switched', async () => {
+    userHasRoleMock.mockResolvedValue(true);
+    getRolePermissionsMock.mockResolvedValueOnce(HAPPY_PERMISSIONS); // for authenticateToken
+    getRolePermissionsMock.mockResolvedValueOnce(['admin.everything']); // for switch-role handler
+    listAvailableRolesForUserMock.mockResolvedValue(HAPPY_ROLES);
+
+    const sessionStart = Date.now() - 1000;
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/auth/switch-role',
+      headers: authHeader('u1', undefined, sessionStart),
+      payload: { roleId: 'admin' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.user.role).toBe('admin');
+    expect(body.user.permissions).toEqual(['admin.everything']);
+
+    // Header rotation
+    const headerToken = res.headers['x-auth-token'];
+    expect(typeof headerToken).toBe('string');
+    const decoded = decodeForAssertion(headerToken as string);
+    expect(decoded.activeRole).toBe('admin');
+    // sessionStart preserved
+    expect(decoded.sessionStart).toBe(sessionStart);
+
+    // userHasRole called for the target role
+    expect(userHasRoleMock).toHaveBeenCalledWith('u1', 'admin');
+
+    // Audit emission with from/to
+    expect(logAuditMock).toHaveBeenCalledTimes(1);
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'user.role_switched',
+        entityType: 'user',
+        entityId: 'u1',
+        details: expect.objectContaining({
+          fromValue: 'manager',
+          toValue: 'admin',
+        }),
+      }),
+    );
+  });
+
+  test('403 user lacks the target role', async () => {
+    // First userHasRole (in authenticateToken) succeeds; second (in switch-role handler) fails
+    userHasRoleMock.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/auth/switch-role',
+      headers: authHeader('u1'),
+      payload: { roleId: 'admin' },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Insufficient permissions' });
+    expect(logAuditMock).not.toHaveBeenCalled();
+  });
+
+  test('400 whitespace-only roleId', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/auth/switch-role',
+      headers: authHeader('u1'),
+      payload: { roleId: '   ' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({ error: 'roleId is required' });
+  });
+
+  test('401 missing token', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/auth/switch-role',
+      payload: { roleId: 'admin' },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+});

--- a/server/test/routes/entries.test.ts
+++ b/server/test/routes/entries.test.ts
@@ -1,0 +1,701 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { FastifyInstance, FastifyPluginAsync } from 'fastify';
+import * as realEntriesRepo from '../../repositories/entriesRepo.ts';
+import * as realGeneralSettingsRepo from '../../repositories/generalSettingsRepo.ts';
+import * as realRolesRepo from '../../repositories/rolesRepo.ts';
+import * as realTasksRepo from '../../repositories/tasksRepo.ts';
+import * as realUsersRepo from '../../repositories/usersRepo.ts';
+import * as realWorkUnitsRepo from '../../repositories/workUnitsRepo.ts';
+import * as realPermissions from '../../utils/permissions.ts';
+import {
+  installAuthMiddlewareMock,
+  restoreAuthMiddlewareMock,
+} from '../helpers/authMiddlewareMock.ts';
+import { buildRouteTestApp } from '../helpers/buildRouteTestApp.ts';
+import { signToken } from '../helpers/jwt.ts';
+
+const usersRepoSnap = { ...realUsersRepo };
+const rolesRepoSnap = { ...realRolesRepo };
+const permissionsSnap = { ...realPermissions };
+const entriesRepoSnap = { ...realEntriesRepo };
+const generalSettingsRepoSnap = { ...realGeneralSettingsRepo };
+const tasksRepoSnap = { ...realTasksRepo };
+const workUnitsRepoSnap = { ...realWorkUnitsRepo };
+
+// Auth-middleware deps (real authenticateToken runs)
+const findAuthUserByIdMock = mock();
+const userHasRoleMock = mock();
+const getRolePermissionsMock = mock();
+
+// Route deps
+const findCostPerHourMock = mock();
+const findIdByProjectAndNameMock = mock();
+const isUserManagedByMock = mock();
+const generalSettingsGetMock = mock();
+const entriesListAllMock = mock();
+const entriesListForUserMock = mock();
+const entriesListForManagerViewMock = mock();
+const entriesCreateMock = mock();
+const entriesUpdateMock = mock();
+const entriesDeleteByIdMock = mock();
+const entriesBulkDeleteMock = mock();
+const entriesFindContextMock = mock();
+const entriesFindOwnerMock = mock();
+const entriesDecodeCursorMock = mock();
+const entriesEncodeCursorMock = mock((c: unknown) => `enc:${JSON.stringify(c)}`);
+
+let entriesRoutePlugin: FastifyPluginAsync;
+
+beforeAll(async () => {
+  installAuthMiddlewareMock();
+  mock.module('../../repositories/usersRepo.ts', () => ({
+    ...usersRepoSnap,
+    findAuthUserById: findAuthUserByIdMock,
+    findCostPerHour: findCostPerHourMock,
+  }));
+  mock.module('../../repositories/rolesRepo.ts', () => ({
+    ...rolesRepoSnap,
+    userHasRole: userHasRoleMock,
+  }));
+  mock.module('../../utils/permissions.ts', () => ({
+    ...permissionsSnap,
+    getRolePermissions: getRolePermissionsMock,
+  }));
+  mock.module('../../repositories/entriesRepo.ts', () => ({
+    ...entriesRepoSnap,
+    listAll: entriesListAllMock,
+    listForUser: entriesListForUserMock,
+    listForManagerView: entriesListForManagerViewMock,
+    create: entriesCreateMock,
+    update: entriesUpdateMock,
+    deleteById: entriesDeleteByIdMock,
+    bulkDelete: entriesBulkDeleteMock,
+    findContext: entriesFindContextMock,
+    findOwner: entriesFindOwnerMock,
+    decodeCursor: entriesDecodeCursorMock,
+    encodeCursor: entriesEncodeCursorMock,
+  }));
+  mock.module('../../repositories/generalSettingsRepo.ts', () => ({
+    ...generalSettingsRepoSnap,
+    get: generalSettingsGetMock,
+  }));
+  mock.module('../../repositories/tasksRepo.ts', () => ({
+    ...tasksRepoSnap,
+    findIdByProjectAndName: findIdByProjectAndNameMock,
+  }));
+  mock.module('../../repositories/workUnitsRepo.ts', () => ({
+    ...workUnitsRepoSnap,
+    isUserManagedBy: isUserManagedByMock,
+  }));
+
+  entriesRoutePlugin = (await import('../../routes/entries.ts')).default as FastifyPluginAsync;
+});
+
+afterAll(() => {
+  restoreAuthMiddlewareMock();
+  mock.module('../../repositories/usersRepo.ts', () => usersRepoSnap);
+  mock.module('../../repositories/rolesRepo.ts', () => rolesRepoSnap);
+  mock.module('../../utils/permissions.ts', () => permissionsSnap);
+  mock.module('../../repositories/entriesRepo.ts', () => entriesRepoSnap);
+  mock.module('../../repositories/generalSettingsRepo.ts', () => generalSettingsRepoSnap);
+  mock.module('../../repositories/tasksRepo.ts', () => tasksRepoSnap);
+  mock.module('../../repositories/workUnitsRepo.ts', () => workUnitsRepoSnap);
+});
+
+const HAPPY_USER = {
+  id: 'u1',
+  name: 'Alice',
+  username: 'alice',
+  role: 'manager',
+  avatarInitials: 'AL',
+  isDisabled: false,
+};
+
+const TRACKER_PERMS = [
+  'timesheets.tracker.view',
+  'timesheets.tracker.create',
+  'timesheets.tracker.update',
+  'timesheets.tracker.delete',
+];
+
+const TRACKER_ALL_PERMS = [...TRACKER_PERMS, 'timesheets.tracker_all.view'];
+
+const SAMPLE_ENTRY = {
+  id: 'te-1',
+  userId: 'u1',
+  date: '2025-06-02', // Monday — not a weekend
+  clientId: 'c1',
+  clientName: 'Client',
+  projectId: 'p1',
+  projectName: 'Project',
+  task: 'Dev',
+  taskId: 't1',
+  notes: null,
+  duration: 4,
+  hourlyCost: 50,
+  isPlaceholder: false,
+  location: 'remote',
+  createdAt: 1_700_000_000_000,
+};
+
+const allMocks = [
+  findAuthUserByIdMock,
+  userHasRoleMock,
+  getRolePermissionsMock,
+  findCostPerHourMock,
+  findIdByProjectAndNameMock,
+  isUserManagedByMock,
+  generalSettingsGetMock,
+  entriesListAllMock,
+  entriesListForUserMock,
+  entriesListForManagerViewMock,
+  entriesCreateMock,
+  entriesUpdateMock,
+  entriesDeleteByIdMock,
+  entriesBulkDeleteMock,
+  entriesFindContextMock,
+  entriesFindOwnerMock,
+  entriesDecodeCursorMock,
+];
+
+let testApp: FastifyInstance;
+
+beforeEach(async () => {
+  for (const m of allMocks) m.mockReset();
+  // encodeCursor remains stable across tests
+  entriesEncodeCursorMock.mockImplementation((c: unknown) => `enc:${JSON.stringify(c)}`);
+
+  findAuthUserByIdMock.mockResolvedValue(HAPPY_USER);
+  userHasRoleMock.mockResolvedValue(true);
+  getRolePermissionsMock.mockResolvedValue(TRACKER_PERMS);
+
+  testApp = await buildRouteTestApp(entriesRoutePlugin, '/api/entries');
+});
+
+afterEach(async () => {
+  await testApp.close();
+});
+
+const authHeader = (userId = 'u1') => ({ authorization: `Bearer ${signToken({ userId })}` });
+
+describe('GET /api/entries', () => {
+  test('200: viewer without tracker_all gets manager-scoped list', async () => {
+    entriesListForManagerViewMock.mockResolvedValue({
+      entries: [SAMPLE_ENTRY],
+      nextCursor: null,
+    });
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/entries',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.entries).toHaveLength(1);
+    expect(body.nextCursor).toBeNull();
+    expect(entriesListForManagerViewMock).toHaveBeenCalledWith('u1', expect.any(Object));
+    expect(entriesListAllMock).not.toHaveBeenCalled();
+  });
+
+  test('200: viewer with tracker_all.view gets listAll', async () => {
+    getRolePermissionsMock.mockResolvedValue(TRACKER_ALL_PERMS);
+    entriesListAllMock.mockResolvedValue({ entries: [], nextCursor: null });
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/entries',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(entriesListAllMock).toHaveBeenCalledTimes(1);
+    expect(entriesListForManagerViewMock).not.toHaveBeenCalled();
+  });
+
+  test('200: explicit userId routes to listForUser', async () => {
+    getRolePermissionsMock.mockResolvedValue(TRACKER_ALL_PERMS);
+    entriesListForUserMock.mockResolvedValue({ entries: [], nextCursor: null });
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/entries?userId=u2',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(entriesListForUserMock).toHaveBeenCalledWith('u2', expect.any(Object));
+  });
+
+  test('200: nextCursor encoded when present', async () => {
+    entriesListForManagerViewMock.mockResolvedValue({
+      entries: [],
+      nextCursor: { lastDate: '2025-01-01', lastId: 'te-1' },
+    });
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/entries',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.nextCursor).toMatch(/^enc:/);
+  });
+
+  test('403: cross-user without tracker_all and no manager link', async () => {
+    isUserManagedByMock.mockResolvedValue(false);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/entries?userId=u2',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'Not authorized to view entries for this user',
+    });
+    expect(isUserManagedByMock).toHaveBeenCalledWith('u1', 'u2');
+  });
+
+  test('400: invalid cursor', async () => {
+    entriesDecodeCursorMock.mockReturnValue(null);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/entries?cursor=garbage',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({ error: 'cursor is invalid' });
+  });
+
+  test('401: missing token', async () => {
+    const res = await testApp.inject({ method: 'GET', url: '/api/entries' });
+    expect(res.statusCode).toBe(401);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Access token required' });
+  });
+
+  test('403: missing tracker.view permission', async () => {
+    getRolePermissionsMock.mockResolvedValue([]); // no tracker.view
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/entries',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Insufficient permissions' });
+  });
+});
+
+describe('POST /api/entries', () => {
+  const validBody = {
+    date: '2025-06-02', // Monday
+    clientId: 'c1',
+    clientName: 'Client',
+    projectId: 'p1',
+    projectName: 'Project',
+    task: 'Dev',
+  };
+
+  test('201 happy path', async () => {
+    findCostPerHourMock.mockResolvedValue(75);
+    findIdByProjectAndNameMock.mockResolvedValue('t1');
+    entriesCreateMock.mockImplementation(async (entry: Record<string, unknown>) => ({
+      ...entry,
+      createdAt: 1_700_000_000_000,
+    }));
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/entries',
+      headers: authHeader(),
+      payload: { ...validBody, duration: 5, notes: 'hello', isPlaceholder: false },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(entriesCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'u1',
+        clientId: 'c1',
+        projectId: 'p1',
+        task: 'Dev',
+        taskId: 't1',
+        duration: 5,
+        hourlyCost: 75,
+        location: 'remote',
+        notes: 'hello',
+        isPlaceholder: false,
+      }),
+    );
+  });
+
+  test('201: duration defaults to 0 when omitted', async () => {
+    findCostPerHourMock.mockResolvedValue(50);
+    findIdByProjectAndNameMock.mockResolvedValue(null);
+    entriesCreateMock.mockImplementation(async (entry: Record<string, unknown>) => ({
+      ...entry,
+      createdAt: 1_700_000_000_000,
+    }));
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/entries',
+      headers: authHeader(),
+      payload: validBody,
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(entriesCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ duration: 0, taskId: null }),
+    );
+  });
+
+  test('400 weekend date when allowWeekendSelection=false', async () => {
+    generalSettingsGetMock.mockResolvedValue({ allowWeekendSelection: false });
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/entries',
+      headers: authHeader(),
+      payload: { ...validBody, date: '2025-06-07' }, // Saturday
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'Time entries on weekends are not allowed',
+    });
+    expect(entriesCreateMock).not.toHaveBeenCalled();
+  });
+
+  test('201 weekend date when allowWeekendSelection=true', async () => {
+    generalSettingsGetMock.mockResolvedValue({ allowWeekendSelection: true });
+    findCostPerHourMock.mockResolvedValue(50);
+    findIdByProjectAndNameMock.mockResolvedValue(null);
+    entriesCreateMock.mockImplementation(async (entry: Record<string, unknown>) => ({
+      ...entry,
+      createdAt: 1_700_000_000_000,
+    }));
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/entries',
+      headers: authHeader(),
+      payload: { ...validBody, date: '2025-06-07' }, // Saturday
+    });
+
+    expect(res.statusCode).toBe(201);
+  });
+
+  test('400 invalid date format (Fastify schema rejection)', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/entries',
+      headers: authHeader(),
+      payload: { ...validBody, date: 'June 2nd' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    // AJV's `format: 'date'` rejects this before the in-handler `parseDateString` runs.
+    // The reply shape is Fastify's default `{ statusCode, code, error: 'Bad Request', message }`.
+    expect(JSON.parse(res.body).error).toBe('Bad Request');
+  });
+
+  test('400 whitespace-only clientId', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/entries',
+      headers: authHeader(),
+      payload: { ...validBody, clientId: '   ' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({ error: 'clientId is required' });
+  });
+
+  test('403 cross-user create without manager link', async () => {
+    isUserManagedByMock.mockResolvedValue(false);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/entries',
+      headers: authHeader(),
+      payload: { ...validBody, userId: 'u2' },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'Not authorized to create entries for this user',
+    });
+    expect(entriesCreateMock).not.toHaveBeenCalled();
+  });
+
+  test('201 manager creating for managed user', async () => {
+    isUserManagedByMock.mockResolvedValue(true);
+    findCostPerHourMock.mockResolvedValue(60);
+    findIdByProjectAndNameMock.mockResolvedValue('t1');
+    entriesCreateMock.mockImplementation(async (entry: Record<string, unknown>) => ({
+      ...entry,
+      createdAt: 1_700_000_000_000,
+    }));
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/entries',
+      headers: authHeader(),
+      payload: { ...validBody, userId: 'u2' },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(findCostPerHourMock).toHaveBeenCalledWith('u2');
+    expect(entriesCreateMock).toHaveBeenCalledWith(expect.objectContaining({ userId: 'u2' }));
+  });
+});
+
+describe('PUT /api/entries/:id', () => {
+  test('200 update own entry', async () => {
+    entriesFindContextMock.mockResolvedValue({
+      userId: 'u1',
+      projectId: 'p1',
+      task: 'Dev',
+      taskId: 't1',
+    });
+    entriesUpdateMock.mockResolvedValue({ ...SAMPLE_ENTRY, duration: 6 });
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/entries/te-1',
+      headers: authHeader(),
+      payload: { duration: 6 },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(entriesUpdateMock).toHaveBeenCalledWith(
+      'te-1',
+      expect.objectContaining({ duration: 6 }),
+    );
+  });
+
+  test('200 backfills taskId when context.taskId is null', async () => {
+    entriesFindContextMock.mockResolvedValue({
+      userId: 'u1',
+      projectId: 'p1',
+      task: 'Dev',
+      taskId: null,
+    });
+    findIdByProjectAndNameMock.mockResolvedValue('t-resolved');
+    entriesUpdateMock.mockResolvedValue(SAMPLE_ENTRY);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/entries/te-1',
+      headers: authHeader(),
+      payload: { duration: 5 },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(findIdByProjectAndNameMock).toHaveBeenCalledWith('p1', 'Dev');
+    expect(entriesUpdateMock).toHaveBeenCalledWith(
+      'te-1',
+      expect.objectContaining({ taskId: 't-resolved' }),
+    );
+  });
+
+  test('404 when entry not found via findContext', async () => {
+    entriesFindContextMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/entries/missing',
+      headers: authHeader(),
+      payload: { duration: 5 },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Entry not found' });
+  });
+
+  test('404 when update returns null', async () => {
+    entriesFindContextMock.mockResolvedValue({
+      userId: 'u1',
+      projectId: 'p1',
+      task: 'Dev',
+      taskId: 't1',
+    });
+    entriesUpdateMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/entries/te-1',
+      headers: authHeader(),
+      payload: { duration: 5 },
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  test('403 cross-user update without manager link', async () => {
+    entriesFindContextMock.mockResolvedValue({
+      userId: 'u2',
+      projectId: 'p1',
+      task: 'Dev',
+      taskId: 't1',
+    });
+    isUserManagedByMock.mockResolvedValue(false);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/entries/te-1',
+      headers: authHeader(),
+      payload: { duration: 5 },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Not authorized to update this entry' });
+  });
+
+  test('400 invalid duration', async () => {
+    entriesFindContextMock.mockResolvedValue({
+      userId: 'u1',
+      projectId: 'p1',
+      task: 'Dev',
+      taskId: 't1',
+    });
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/entries/te-1',
+      headers: authHeader(),
+      payload: { duration: -3 },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/duration must be zero or positive/);
+  });
+});
+
+describe('DELETE /api/entries/:id', () => {
+  test('200 own entry', async () => {
+    entriesFindOwnerMock.mockResolvedValue('u1');
+    entriesDeleteByIdMock.mockResolvedValue(undefined);
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/entries/te-1',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ message: 'Entry deleted' });
+    expect(entriesDeleteByIdMock).toHaveBeenCalledWith('te-1');
+  });
+
+  test('404 not found', async () => {
+    entriesFindOwnerMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/entries/missing',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Entry not found' });
+  });
+
+  test('403 cross-user without manager link', async () => {
+    entriesFindOwnerMock.mockResolvedValue('u2');
+    isUserManagedByMock.mockResolvedValue(false);
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/entries/te-1',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Not authorized to delete this entry' });
+  });
+});
+
+describe('DELETE /api/entries (bulk)', () => {
+  test('200 manager-scoped restricts to viewer', async () => {
+    entriesBulkDeleteMock.mockResolvedValue(3);
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/entries?projectId=p1&task=Dev',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ message: 'Deleted 3 entries' });
+    expect(entriesBulkDeleteMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: 'p1',
+        task: 'Dev',
+        restrictToManagerScopeOf: 'u1',
+        placeholderOnly: false,
+      }),
+    );
+  });
+
+  test('200 admin scope deletes across all users', async () => {
+    getRolePermissionsMock.mockResolvedValue(TRACKER_ALL_PERMS);
+    entriesBulkDeleteMock.mockResolvedValue(7);
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/entries?projectId=p1&task=Dev',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(entriesBulkDeleteMock).toHaveBeenCalledWith(
+      expect.objectContaining({ restrictToManagerScopeOf: undefined }),
+    );
+  });
+
+  test('200 futureOnly=true sets fromDate to today', async () => {
+    entriesBulkDeleteMock.mockResolvedValue(1);
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/entries?projectId=p1&task=Dev&futureOnly=true',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const callArgs = entriesBulkDeleteMock.mock.calls[0][0];
+    expect(callArgs.fromDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  test('400 missing projectId (Fastify schema)', async () => {
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/entries?task=Dev',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('403 missing both delete permissions', async () => {
+    getRolePermissionsMock.mockResolvedValue(['timesheets.tracker.view']); // no delete perms
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/entries?projectId=p1&task=Dev',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Insufficient permissions' });
+  });
+});

--- a/server/test/routes/general-settings.test.ts
+++ b/server/test/routes/general-settings.test.ts
@@ -1,0 +1,263 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { FastifyInstance, FastifyPluginAsync } from 'fastify';
+import * as realGeneralSettingsRepo from '../../repositories/generalSettingsRepo.ts';
+import * as realRolesRepo from '../../repositories/rolesRepo.ts';
+import * as realUsersRepo from '../../repositories/usersRepo.ts';
+import * as realAudit from '../../utils/audit.ts';
+import { MASKED_SECRET } from '../../utils/crypto.ts';
+import * as realPermissions from '../../utils/permissions.ts';
+import {
+  installAuthMiddlewareMock,
+  restoreAuthMiddlewareMock,
+} from '../helpers/authMiddlewareMock.ts';
+import { buildRouteTestApp } from '../helpers/buildRouteTestApp.ts';
+import { signToken } from '../helpers/jwt.ts';
+
+const usersRepoSnap = { ...realUsersRepo };
+const rolesRepoSnap = { ...realRolesRepo };
+const permissionsSnap = { ...realPermissions };
+const generalSettingsRepoSnap = { ...realGeneralSettingsRepo };
+const auditSnap = { ...realAudit };
+
+const findAuthUserByIdMock = mock();
+const userHasRoleMock = mock();
+const getRolePermissionsMock = mock();
+const settingsGetMock = mock();
+const settingsUpdateMock = mock();
+const logAuditMock = mock(async () => undefined);
+
+let routePlugin: FastifyPluginAsync;
+
+beforeAll(async () => {
+  installAuthMiddlewareMock();
+
+  mock.module('../../repositories/usersRepo.ts', () => ({
+    ...usersRepoSnap,
+    findAuthUserById: findAuthUserByIdMock,
+  }));
+  mock.module('../../repositories/rolesRepo.ts', () => ({
+    ...rolesRepoSnap,
+    userHasRole: userHasRoleMock,
+  }));
+  mock.module('../../utils/permissions.ts', () => ({
+    ...permissionsSnap,
+    getRolePermissions: getRolePermissionsMock,
+  }));
+  mock.module('../../repositories/generalSettingsRepo.ts', () => ({
+    ...generalSettingsRepoSnap,
+    get: settingsGetMock,
+    update: settingsUpdateMock,
+  }));
+  mock.module('../../utils/audit.ts', () => ({
+    ...auditSnap,
+    logAudit: logAuditMock,
+  }));
+
+  routePlugin = (await import('../../routes/general-settings.ts')).default as FastifyPluginAsync;
+});
+
+afterAll(() => {
+  restoreAuthMiddlewareMock();
+  mock.module('../../repositories/usersRepo.ts', () => usersRepoSnap);
+  mock.module('../../repositories/rolesRepo.ts', () => rolesRepoSnap);
+  mock.module('../../utils/permissions.ts', () => permissionsSnap);
+  mock.module('../../repositories/generalSettingsRepo.ts', () => generalSettingsRepoSnap);
+  mock.module('../../utils/audit.ts', () => auditSnap);
+});
+
+const HAPPY_USER = {
+  id: 'u1',
+  name: 'Alice',
+  username: 'alice',
+  role: 'manager',
+  avatarInitials: 'AL',
+  isDisabled: false,
+};
+
+const SETTINGS_WITH_KEYS = {
+  currency: 'EUR',
+  dailyLimit: 8,
+  startOfWeek: 'Monday',
+  treatSaturdayAsHoliday: true,
+  enableAiReporting: true,
+  geminiApiKey: 'plaintext-gemini-key',
+  aiProvider: 'gemini',
+  openrouterApiKey: 'plaintext-openrouter-key',
+  geminiModelId: 'gemini-2.5-flash',
+  openrouterModelId: 'anthropic/claude-3-haiku',
+  allowWeekendSelection: false,
+  defaultLocation: 'remote',
+};
+
+const allMocks = [
+  findAuthUserByIdMock,
+  userHasRoleMock,
+  getRolePermissionsMock,
+  settingsGetMock,
+  settingsUpdateMock,
+  logAuditMock,
+];
+
+let testApp: FastifyInstance;
+
+beforeEach(async () => {
+  for (const m of allMocks) m.mockReset();
+  findAuthUserByIdMock.mockResolvedValue(HAPPY_USER);
+  userHasRoleMock.mockResolvedValue(true);
+  // Default: viewer with admin perms (reveal API keys, allowed to PUT)
+  getRolePermissionsMock.mockResolvedValue(['administration.general.update']);
+  logAuditMock.mockImplementation(async () => undefined);
+
+  testApp = await buildRouteTestApp(routePlugin, '/api/general-settings');
+});
+
+afterEach(async () => {
+  await testApp.close();
+});
+
+const authHeader = () => ({ authorization: `Bearer ${signToken({ userId: 'u1' })}` });
+
+describe('GET /api/general-settings', () => {
+  test('200 with administration.general.update reveals API keys', async () => {
+    settingsGetMock.mockResolvedValue(SETTINGS_WITH_KEYS);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/general-settings',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.geminiApiKey).toBe('plaintext-gemini-key');
+    expect(body.openrouterApiKey).toBe('plaintext-openrouter-key');
+  });
+
+  test('200 without admin perm masks API keys', async () => {
+    getRolePermissionsMock.mockResolvedValue([]); // no admin perm
+    settingsGetMock.mockResolvedValue(SETTINGS_WITH_KEYS);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/general-settings',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.geminiApiKey).toBe(MASKED_SECRET);
+    expect(body.openrouterApiKey).toBe(MASKED_SECRET);
+  });
+
+  test('200 returns DEFAULT_SETTINGS when repo returns null', async () => {
+    settingsGetMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/general-settings',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.currency).toBe('EUR');
+    expect(body.dailyLimit).toBe(8);
+    expect(body.startOfWeek).toBe('Monday');
+    expect(body.allowWeekendSelection).toBe(true);
+  });
+
+  test('401 missing token', async () => {
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/general-settings',
+    });
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+describe('PUT /api/general-settings', () => {
+  test('200 round-trip: updates fields, emits audit, response unmasked', async () => {
+    settingsUpdateMock.mockResolvedValue({
+      ...SETTINGS_WITH_KEYS,
+      aiProvider: 'openrouter',
+    });
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/general-settings',
+      headers: authHeader(),
+      payload: { aiProvider: 'openrouter', currency: 'USD' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(settingsUpdateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ aiProvider: 'openrouter', currency: 'USD' }),
+    );
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'settings.updated',
+        entityType: 'settings',
+      }),
+    );
+    const body = JSON.parse(res.body);
+    expect(body.geminiApiKey).toBe('plaintext-gemini-key');
+  });
+
+  test('200 boolean strings parsed via parseBoolean', async () => {
+    settingsUpdateMock.mockResolvedValue(SETTINGS_WITH_KEYS);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/general-settings',
+      headers: authHeader(),
+      payload: {
+        treatSaturdayAsHoliday: 'true',
+        enableAiReporting: 'false',
+        allowWeekendSelection: 'true',
+      } as unknown as Record<string, unknown>,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(settingsUpdateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        treatSaturdayAsHoliday: true,
+        enableAiReporting: false,
+        allowWeekendSelection: true,
+      }),
+    );
+  });
+
+  test('400 invalid aiProvider enum', async () => {
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/general-settings',
+      headers: authHeader(),
+      payload: { aiProvider: 'invalid_provider' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/aiProvider must be one of/);
+  });
+
+  test('403 missing administration.general.update', async () => {
+    getRolePermissionsMock.mockResolvedValue([]); // no perm
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/general-settings',
+      headers: authHeader(),
+      payload: { currency: 'USD' },
+    });
+
+    expect(res.statusCode).toBe(403);
+  });
+
+  test('401 missing token', async () => {
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/general-settings',
+      payload: { currency: 'USD' },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+});

--- a/server/test/routes/invoices.test.ts
+++ b/server/test/routes/invoices.test.ts
@@ -401,6 +401,60 @@ describe('POST /api/invoices', () => {
     expect(JSON.parse(res.body).error).toMatch(/quantity must be greater than zero/);
   });
 
+  test('400 discount > 100 rejected (would otherwise produce a negative line total)', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/invoices',
+      headers: authHeader(),
+      payload: {
+        ...validBody,
+        items: [
+          {
+            description: 'X',
+            unitOfMeasure: 'unit',
+            quantity: 1,
+            unitPrice: 100,
+            discount: 150,
+          },
+        ],
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/discount must be at most 100/);
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  test('201 discount = 100 is the upper boundary (yields total 0)', async () => {
+    generateNextIdMock.mockResolvedValue('inv-1');
+    createMock.mockResolvedValue({ ...SAMPLE_INVOICE, subtotal: 0, total: 0 });
+    insertItemsMock.mockResolvedValue([SAMPLE_ITEM]);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/invoices',
+      headers: authHeader(),
+      payload: {
+        ...validBody,
+        items: [
+          {
+            description: 'X',
+            unitOfMeasure: 'unit',
+            quantity: 1,
+            unitPrice: 100,
+            discount: 100,
+          },
+        ],
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({ subtotal: 0, total: 0 }),
+      undefined,
+    );
+  });
+
   test('409 unique violation surfaces as Invoice ID already exists', async () => {
     generateNextIdMock.mockResolvedValue('inv-1');
     withDbTransactionMock.mockImplementation(async () => {
@@ -541,6 +595,42 @@ describe('PUT /api/invoices/:id', () => {
 
     expect(res.statusCode).toBe(404);
     expect(JSON.parse(res.body)).toEqual({ error: 'Invoice not found' });
+  });
+
+  test('200 amountPaid <= persisted total: looks up findTotal and patches amountPaid', async () => {
+    findTotalMock.mockResolvedValue(100);
+    updateMock.mockResolvedValue({ ...SAMPLE_INVOICE, amountPaid: 50 });
+    findItemsForInvoiceMock.mockResolvedValue([SAMPLE_ITEM]);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/invoices/inv-1',
+      headers: authHeader(),
+      payload: { amountPaid: 50 },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(findTotalMock).toHaveBeenCalledWith('inv-1');
+    const patch = updateMock.mock.calls[0][1] as Record<string, unknown>;
+    expect(patch.amountPaid).toBe(50);
+  });
+
+  test('200 status-only update skips findTotal entirely', async () => {
+    updateMock.mockResolvedValue({ ...SAMPLE_INVOICE, status: 'sent' });
+    findItemsForInvoiceMock.mockResolvedValue([SAMPLE_ITEM]);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/invoices/inv-1',
+      headers: authHeader(),
+      payload: { status: 'sent' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(findTotalMock).not.toHaveBeenCalled();
+    const patch = updateMock.mock.calls[0][1] as Record<string, unknown>;
+    expect(patch).not.toHaveProperty('amountPaid');
+    expect(patch).not.toHaveProperty('total');
   });
 
   test('400 dueDate < issueDate using stored findDates for missing side', async () => {

--- a/server/test/routes/invoices.test.ts
+++ b/server/test/routes/invoices.test.ts
@@ -34,6 +34,7 @@ const replaceItemsMock = mock();
 const findItemsForInvoiceMock = mock();
 const findDatesMock = mock();
 const findTotalMock = mock();
+const findAmountPaidMock = mock();
 const findIdConflictMock = mock();
 const deleteByIdMock = mock();
 const logAuditMock = mock(async () => undefined);
@@ -67,6 +68,7 @@ beforeAll(async () => {
     findItemsForInvoice: findItemsForInvoiceMock,
     findDates: findDatesMock,
     findTotal: findTotalMock,
+    findAmountPaid: findAmountPaidMock,
     findIdConflict: findIdConflictMock,
     deleteById: deleteByIdMock,
   }));
@@ -148,6 +150,7 @@ const allMocks = [
   findItemsForInvoiceMock,
   findDatesMock,
   findTotalMock,
+  findAmountPaidMock,
   findIdConflictMock,
   deleteByIdMock,
   logAuditMock,
@@ -507,6 +510,7 @@ describe('PUT /api/invoices/:id', () => {
   });
 
   test('200 with items replaces via replaceItems and recomputes totals', async () => {
+    findAmountPaidMock.mockResolvedValue(0);
     updateMock.mockResolvedValue(SAMPLE_INVOICE);
     replaceItemsMock.mockResolvedValue([SAMPLE_ITEM]);
 
@@ -531,6 +535,60 @@ describe('PUT /api/invoices/:id', () => {
       expect.objectContaining({ subtotal: 100, total: 100 }),
       undefined,
     );
+  });
+
+  test('400 items replace lowers total below persisted amountPaid (no amountPaid in patch)', async () => {
+    // Persisted invoice was paid 100. New items only sum to 50 — that would leave
+    // amountPaid (100) > new total (50). Must reject.
+    findAmountPaidMock.mockResolvedValue(100);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/invoices/inv-1',
+      headers: authHeader(),
+      payload: {
+        items: [{ description: 'X', unitOfMeasure: 'unit', quantity: 1, unitPrice: 50 }],
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({ error: 'amountPaid cannot exceed total' });
+    expect(findAmountPaidMock).toHaveBeenCalledWith('inv-1');
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  test('404 items replace targeting missing invoice (findAmountPaid null)', async () => {
+    findAmountPaidMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/invoices/missing',
+      headers: authHeader(),
+      payload: {
+        items: [{ description: 'X', unitOfMeasure: 'unit', quantity: 1, unitPrice: 50 }],
+      },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Invoice not found' });
+  });
+
+  test('200 items replace, persisted amountPaid still fits under new total', async () => {
+    findAmountPaidMock.mockResolvedValue(40);
+    updateMock.mockResolvedValue(SAMPLE_INVOICE);
+    replaceItemsMock.mockResolvedValue([SAMPLE_ITEM]);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/invoices/inv-1',
+      headers: authHeader(),
+      payload: {
+        items: [{ description: 'X', unitOfMeasure: 'unit', quantity: 1, unitPrice: 50 }],
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(findAmountPaidMock).toHaveBeenCalledWith('inv-1');
   });
 
   test('200 partial update without items leaves totals untouched in patch', async () => {

--- a/server/test/routes/invoices.test.ts
+++ b/server/test/routes/invoices.test.ts
@@ -1,0 +1,641 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { FastifyInstance, FastifyPluginAsync } from 'fastify';
+import * as realDrizzle from '../../db/drizzle.ts';
+import * as realInvoicesRepo from '../../repositories/invoicesRepo.ts';
+import * as realRolesRepo from '../../repositories/rolesRepo.ts';
+import * as realUsersRepo from '../../repositories/usersRepo.ts';
+import * as realAudit from '../../utils/audit.ts';
+import * as realPermissions from '../../utils/permissions.ts';
+import {
+  installAuthMiddlewareMock,
+  restoreAuthMiddlewareMock,
+} from '../helpers/authMiddlewareMock.ts';
+import { buildRouteTestApp } from '../helpers/buildRouteTestApp.ts';
+import { makeDbError } from '../helpers/dbErrors.ts';
+import { signToken } from '../helpers/jwt.ts';
+
+const usersRepoSnap = { ...realUsersRepo };
+const rolesRepoSnap = { ...realRolesRepo };
+const permissionsSnap = { ...realPermissions };
+const invoicesRepoSnap = { ...realInvoicesRepo };
+const auditSnap = { ...realAudit };
+const drizzleSnap = { ...realDrizzle };
+
+const findAuthUserByIdMock = mock();
+const userHasRoleMock = mock();
+const getRolePermissionsMock = mock();
+
+const listAllWithItemsMock = mock();
+const generateNextIdMock = mock();
+const createMock = mock();
+const insertItemsMock = mock();
+const updateMock = mock();
+const replaceItemsMock = mock();
+const findItemsForInvoiceMock = mock();
+const findDatesMock = mock();
+const findTotalMock = mock();
+const findIdConflictMock = mock();
+const deleteByIdMock = mock();
+const logAuditMock = mock(async () => undefined);
+const withDbTransactionMock = mock(async (cb: (tx: unknown) => unknown) => cb(undefined));
+
+let invoicesRoutePlugin: FastifyPluginAsync;
+
+beforeAll(async () => {
+  installAuthMiddlewareMock();
+
+  mock.module('../../repositories/usersRepo.ts', () => ({
+    ...usersRepoSnap,
+    findAuthUserById: findAuthUserByIdMock,
+  }));
+  mock.module('../../repositories/rolesRepo.ts', () => ({
+    ...rolesRepoSnap,
+    userHasRole: userHasRoleMock,
+  }));
+  mock.module('../../utils/permissions.ts', () => ({
+    ...permissionsSnap,
+    getRolePermissions: getRolePermissionsMock,
+  }));
+  mock.module('../../repositories/invoicesRepo.ts', () => ({
+    ...invoicesRepoSnap,
+    listAllWithItems: listAllWithItemsMock,
+    generateNextId: generateNextIdMock,
+    create: createMock,
+    insertItems: insertItemsMock,
+    update: updateMock,
+    replaceItems: replaceItemsMock,
+    findItemsForInvoice: findItemsForInvoiceMock,
+    findDates: findDatesMock,
+    findTotal: findTotalMock,
+    findIdConflict: findIdConflictMock,
+    deleteById: deleteByIdMock,
+  }));
+  mock.module('../../utils/audit.ts', () => ({
+    ...auditSnap,
+    logAudit: logAuditMock,
+  }));
+  mock.module('../../db/drizzle.ts', () => ({
+    ...drizzleSnap,
+    withDbTransaction: withDbTransactionMock,
+  }));
+
+  invoicesRoutePlugin = (await import('../../routes/invoices.ts')).default as FastifyPluginAsync;
+});
+
+afterAll(() => {
+  restoreAuthMiddlewareMock();
+  mock.module('../../repositories/usersRepo.ts', () => usersRepoSnap);
+  mock.module('../../repositories/rolesRepo.ts', () => rolesRepoSnap);
+  mock.module('../../utils/permissions.ts', () => permissionsSnap);
+  mock.module('../../repositories/invoicesRepo.ts', () => invoicesRepoSnap);
+  mock.module('../../utils/audit.ts', () => auditSnap);
+  mock.module('../../db/drizzle.ts', () => drizzleSnap);
+});
+
+const HAPPY_USER = {
+  id: 'u1',
+  name: 'Alice',
+  username: 'alice',
+  role: 'manager',
+  avatarInitials: 'AL',
+  isDisabled: false,
+};
+
+const FULL_PERMS = [
+  'accounting.clients_invoices.view',
+  'accounting.clients_invoices.create',
+  'accounting.clients_invoices.update',
+  'accounting.clients_invoices.delete',
+];
+
+const SAMPLE_INVOICE = {
+  id: 'inv-1',
+  linkedSaleId: null,
+  clientId: 'c1',
+  clientName: 'Client',
+  issueDate: '2025-06-01',
+  dueDate: '2025-07-01',
+  status: 'draft',
+  subtotal: 100,
+  total: 122,
+  amountPaid: 0,
+  notes: null,
+  createdAt: 1_700_000_000_000,
+  updatedAt: 1_700_000_000_000,
+};
+
+const SAMPLE_ITEM = {
+  id: 'inv-item-1',
+  invoiceId: 'inv-1',
+  productId: null,
+  description: 'Service',
+  unitOfMeasure: 'unit' as const,
+  quantity: 1,
+  unitPrice: 100,
+  discount: 0,
+};
+
+const allMocks = [
+  findAuthUserByIdMock,
+  userHasRoleMock,
+  getRolePermissionsMock,
+  listAllWithItemsMock,
+  generateNextIdMock,
+  createMock,
+  insertItemsMock,
+  updateMock,
+  replaceItemsMock,
+  findItemsForInvoiceMock,
+  findDatesMock,
+  findTotalMock,
+  findIdConflictMock,
+  deleteByIdMock,
+  logAuditMock,
+  withDbTransactionMock,
+];
+
+let testApp: FastifyInstance;
+
+beforeEach(async () => {
+  for (const m of allMocks) m.mockReset();
+  findAuthUserByIdMock.mockResolvedValue(HAPPY_USER);
+  userHasRoleMock.mockResolvedValue(true);
+  getRolePermissionsMock.mockResolvedValue(FULL_PERMS);
+  withDbTransactionMock.mockImplementation(async (cb) => cb(undefined));
+  logAuditMock.mockImplementation(async () => undefined);
+
+  testApp = await buildRouteTestApp(invoicesRoutePlugin, '/api/invoices');
+});
+
+afterEach(async () => {
+  await testApp.close();
+});
+
+const authHeader = () => ({ authorization: `Bearer ${signToken({ userId: 'u1' })}` });
+
+describe('GET /api/invoices', () => {
+  test('200 returns list', async () => {
+    listAllWithItemsMock.mockResolvedValue([{ ...SAMPLE_INVOICE, items: [SAMPLE_ITEM] }]);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/invoices',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body).toHaveLength(1);
+    expect(body[0].id).toBe('inv-1');
+  });
+
+  test('401 missing token', async () => {
+    const res = await testApp.inject({ method: 'GET', url: '/api/invoices' });
+    expect(res.statusCode).toBe(401);
+  });
+
+  test('403 missing view permission', async () => {
+    getRolePermissionsMock.mockResolvedValue([]);
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/invoices',
+      headers: authHeader(),
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+describe('POST /api/invoices', () => {
+  const validBody = {
+    clientId: 'c1',
+    clientName: 'Client',
+    issueDate: '2025-06-01',
+    dueDate: '2025-07-01',
+    items: [
+      {
+        description: 'Service',
+        unitOfMeasure: 'unit',
+        quantity: 1,
+        unitPrice: 100,
+      },
+    ],
+  };
+
+  test('201 happy path emits audit', async () => {
+    generateNextIdMock.mockResolvedValue('inv-1');
+    createMock.mockResolvedValue(SAMPLE_INVOICE);
+    insertItemsMock.mockResolvedValue([SAMPLE_ITEM]);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/invoices',
+      headers: authHeader(),
+      payload: validBody,
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = JSON.parse(res.body);
+    expect(body.id).toBe('inv-1');
+    expect(body.items).toHaveLength(1);
+
+    expect(generateNextIdMock).toHaveBeenCalledWith('2025');
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'invoice.created',
+        entityType: 'invoice',
+        entityId: 'inv-1',
+      }),
+    );
+  });
+
+  test('201 server-side recomputes subtotal/total from items, ignoring client-submitted values', async () => {
+    // validBody has 1 item: quantity=1, unitPrice=100, no discount → computed total = 100
+    generateNextIdMock.mockResolvedValue('inv-1');
+    createMock.mockResolvedValue({ ...SAMPLE_INVOICE, subtotal: 100, total: 100 });
+    insertItemsMock.mockResolvedValue([SAMPLE_ITEM]);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/invoices',
+      headers: authHeader(),
+      // Client tries to submit bogus 999s — server must override.
+      payload: { ...validBody, subtotal: 999, total: 999 },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({ subtotal: 100, total: 100 }),
+      undefined,
+    );
+  });
+
+  test('201 default status=draft + computed totals from items', async () => {
+    generateNextIdMock.mockResolvedValue('inv-1');
+    createMock.mockResolvedValue({ ...SAMPLE_INVOICE, subtotal: 100, total: 100 });
+    insertItemsMock.mockResolvedValue([SAMPLE_ITEM]);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/invoices',
+      headers: authHeader(),
+      payload: validBody,
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'draft',
+        subtotal: 100,
+        total: 100,
+        amountPaid: 0,
+      }),
+      undefined,
+    );
+  });
+
+  test('201 applies item discount in computed total', async () => {
+    generateNextIdMock.mockResolvedValue('inv-1');
+    createMock.mockImplementation(async (input: Record<string, unknown>) => ({
+      ...SAMPLE_INVOICE,
+      subtotal: input.subtotal as number,
+      total: input.total as number,
+    }));
+    insertItemsMock.mockResolvedValue([SAMPLE_ITEM]);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/invoices',
+      headers: authHeader(),
+      payload: {
+        ...validBody,
+        items: [
+          {
+            description: 'Service',
+            unitOfMeasure: 'unit',
+            quantity: 2,
+            unitPrice: 50,
+            discount: 10,
+          },
+        ],
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    // 2 * 50 * 0.9 = 90
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({ subtotal: 90, total: 90 }),
+      undefined,
+    );
+  });
+
+  test('400 amountPaid exceeds computed total', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/invoices',
+      headers: authHeader(),
+      payload: { ...validBody, amountPaid: 9999 }, // computed total is 100
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({ error: 'amountPaid cannot exceed total' });
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  test('201 amountPaid equal to computed total is allowed', async () => {
+    generateNextIdMock.mockResolvedValue('inv-1');
+    createMock.mockResolvedValue({ ...SAMPLE_INVOICE, total: 100, amountPaid: 100 });
+    insertItemsMock.mockResolvedValue([SAMPLE_ITEM]);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/invoices',
+      headers: authHeader(),
+      payload: { ...validBody, amountPaid: 100 },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({ amountPaid: 100, total: 100 }),
+      undefined,
+    );
+  });
+
+  test('400 dueDate before issueDate', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/invoices',
+      headers: authHeader(),
+      payload: { ...validBody, issueDate: '2025-07-01', dueDate: '2025-06-01' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'dueDate must be on or after issueDate',
+    });
+  });
+
+  test('400 empty items array', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/invoices',
+      headers: authHeader(),
+      payload: { ...validBody, items: [] },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Items must be a non-empty array' });
+  });
+
+  test('400 invalid item field (negative quantity)', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/invoices',
+      headers: authHeader(),
+      payload: {
+        ...validBody,
+        items: [{ description: 'X', unitOfMeasure: 'unit', quantity: -5, unitPrice: 100 }],
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/quantity must be greater than zero/);
+  });
+
+  test('409 unique violation surfaces as Invoice ID already exists', async () => {
+    generateNextIdMock.mockResolvedValue('inv-1');
+    withDbTransactionMock.mockImplementation(async () => {
+      throw makeDbError('23505', 'invoices_pkey');
+    });
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/invoices',
+      headers: authHeader(),
+      payload: validBody,
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Invoice ID already exists' });
+  });
+
+  test('403 missing create permission', async () => {
+    getRolePermissionsMock.mockResolvedValue(['accounting.clients_invoices.view']);
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/invoices',
+      headers: authHeader(),
+      payload: validBody,
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+describe('PUT /api/invoices/:id', () => {
+  test('200 partial update preserves untouched items via findItemsForInvoice', async () => {
+    updateMock.mockResolvedValue({ ...SAMPLE_INVOICE, status: 'sent' });
+    findItemsForInvoiceMock.mockResolvedValue([SAMPLE_ITEM]);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/invoices/inv-1',
+      headers: authHeader(),
+      payload: { status: 'sent' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(updateMock).toHaveBeenCalledWith(
+      'inv-1',
+      expect.objectContaining({ status: 'sent' }),
+      undefined,
+    );
+    expect(findItemsForInvoiceMock).toHaveBeenCalled();
+    expect(replaceItemsMock).not.toHaveBeenCalled();
+  });
+
+  test('200 with items replaces via replaceItems and recomputes totals', async () => {
+    updateMock.mockResolvedValue(SAMPLE_INVOICE);
+    replaceItemsMock.mockResolvedValue([SAMPLE_ITEM]);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/invoices/inv-1',
+      headers: authHeader(),
+      payload: {
+        items: [{ description: 'Replaced', unitOfMeasure: 'unit', quantity: 2, unitPrice: 50 }],
+        // Client tries to submit a bogus 999 — server must override.
+        subtotal: 999,
+        total: 999,
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(replaceItemsMock).toHaveBeenCalled();
+    expect(findItemsForInvoiceMock).not.toHaveBeenCalled();
+    // 2 * 50 = 100
+    expect(updateMock).toHaveBeenCalledWith(
+      'inv-1',
+      expect.objectContaining({ subtotal: 100, total: 100 }),
+      undefined,
+    );
+  });
+
+  test('200 partial update without items leaves totals untouched in patch', async () => {
+    updateMock.mockResolvedValue({ ...SAMPLE_INVOICE, status: 'sent' });
+    findItemsForInvoiceMock.mockResolvedValue([SAMPLE_ITEM]);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/invoices/inv-1',
+      headers: authHeader(),
+      // Client tries to update totals without items — both should be ignored.
+      payload: { status: 'sent', subtotal: 999, total: 999 },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const patch = updateMock.mock.calls[0][1] as Record<string, unknown>;
+    expect(patch).not.toHaveProperty('subtotal');
+    expect(patch).not.toHaveProperty('total');
+  });
+
+  test('400 amountPaid > computed total when items provided', async () => {
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/invoices/inv-1',
+      headers: authHeader(),
+      payload: {
+        items: [{ description: 'X', unitOfMeasure: 'unit', quantity: 1, unitPrice: 50 }],
+        amountPaid: 9999,
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({ error: 'amountPaid cannot exceed total' });
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  test('400 amountPaid > persisted total when items not provided', async () => {
+    findTotalMock.mockResolvedValue(50);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/invoices/inv-1',
+      headers: authHeader(),
+      payload: { amountPaid: 9999 },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({ error: 'amountPaid cannot exceed total' });
+    expect(findTotalMock).toHaveBeenCalledWith('inv-1');
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  test('404 when amountPaid update targets missing invoice (findTotal null)', async () => {
+    findTotalMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/invoices/missing',
+      headers: authHeader(),
+      payload: { amountPaid: 50 },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Invoice not found' });
+  });
+
+  test('400 dueDate < issueDate using stored findDates for missing side', async () => {
+    findDatesMock.mockResolvedValue({ issueDate: '2025-07-01', dueDate: '2025-08-01' });
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/invoices/inv-1',
+      headers: authHeader(),
+      payload: { dueDate: '2025-06-01' }, // earlier than persisted issueDate
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'dueDate must be on or after issueDate',
+    });
+  });
+
+  test('404 when update returns null', async () => {
+    updateMock.mockResolvedValue(null);
+    findItemsForInvoiceMock.mockResolvedValue([]);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/invoices/missing',
+      headers: authHeader(),
+      payload: { status: 'sent' },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Invoice not found' });
+  });
+
+  test('409 unique violation on rename', async () => {
+    findIdConflictMock.mockResolvedValue(true);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/invoices/inv-1',
+      headers: authHeader(),
+      payload: { id: 'inv-existing' },
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Invoice ID already exists' });
+  });
+});
+
+describe('DELETE /api/invoices/:id', () => {
+  test('204 happy path emits audit', async () => {
+    deleteByIdMock.mockResolvedValue({ id: 'inv-1', clientName: 'Client' });
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/invoices/inv-1',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(204);
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'invoice.deleted',
+        entityType: 'invoice',
+        entityId: 'inv-1',
+      }),
+    );
+  });
+
+  test('404 not found', async () => {
+    deleteByIdMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/invoices/missing',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Invoice not found' });
+  });
+
+  test('409 FK violation maps to referenced-by message', async () => {
+    deleteByIdMock.mockImplementation(async () => {
+      throw makeDbError('23503');
+    });
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/invoices/inv-1',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'Cannot delete invoice because it is referenced by other records',
+    });
+  });
+});

--- a/server/test/routes/work-units.test.ts
+++ b/server/test/routes/work-units.test.ts
@@ -1,0 +1,475 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { FastifyInstance, FastifyPluginAsync } from 'fastify';
+import * as realDrizzle from '../../db/drizzle.ts';
+import * as realRolesRepo from '../../repositories/rolesRepo.ts';
+import * as realUsersRepo from '../../repositories/usersRepo.ts';
+import * as realWorkUnitsRepo from '../../repositories/workUnitsRepo.ts';
+import * as realAudit from '../../utils/audit.ts';
+import { NotFoundError } from '../../utils/http-errors.ts';
+import * as realPermissions from '../../utils/permissions.ts';
+import {
+  installAuthMiddlewareMock,
+  restoreAuthMiddlewareMock,
+} from '../helpers/authMiddlewareMock.ts';
+import { buildRouteTestApp } from '../helpers/buildRouteTestApp.ts';
+import { signToken } from '../helpers/jwt.ts';
+
+const usersRepoSnap = { ...realUsersRepo };
+const rolesRepoSnap = { ...realRolesRepo };
+const permissionsSnap = { ...realPermissions };
+const workUnitsRepoSnap = { ...realWorkUnitsRepo };
+const auditSnap = { ...realAudit };
+const drizzleSnap = { ...realDrizzle };
+
+const findAuthUserByIdMock = mock();
+const userHasRoleMock = mock();
+const getRolePermissionsMock = mock();
+
+const listAllMock = mock();
+const listManagedByMock = mock();
+const createMock = mock();
+const addManagersMock = mock();
+const addUsersToUnitMock = mock();
+const findByIdMock = mock();
+const lockByIdMock = mock();
+const updateFieldsMock = mock();
+const clearManagersMock = mock();
+const clearUsersMock = mock();
+const findNameByIdMock = mock();
+const findUserIdsMock = mock();
+const deleteByIdMock = mock();
+const isUserManagerOfUnitMock = mock();
+const logAuditMock = mock(async () => undefined);
+const withDbTransactionMock = mock(async (cb: (tx: unknown) => unknown) => cb(undefined));
+
+let routePlugin: FastifyPluginAsync;
+
+beforeAll(async () => {
+  installAuthMiddlewareMock();
+
+  mock.module('../../repositories/usersRepo.ts', () => ({
+    ...usersRepoSnap,
+    findAuthUserById: findAuthUserByIdMock,
+  }));
+  mock.module('../../repositories/rolesRepo.ts', () => ({
+    ...rolesRepoSnap,
+    userHasRole: userHasRoleMock,
+  }));
+  mock.module('../../utils/permissions.ts', () => ({
+    ...permissionsSnap,
+    getRolePermissions: getRolePermissionsMock,
+  }));
+  mock.module('../../repositories/workUnitsRepo.ts', () => ({
+    ...workUnitsRepoSnap,
+    listAll: listAllMock,
+    listManagedBy: listManagedByMock,
+    create: createMock,
+    addManagers: addManagersMock,
+    addUsersToUnit: addUsersToUnitMock,
+    findById: findByIdMock,
+    lockById: lockByIdMock,
+    updateFields: updateFieldsMock,
+    clearManagers: clearManagersMock,
+    clearUsers: clearUsersMock,
+    findNameById: findNameByIdMock,
+    findUserIds: findUserIdsMock,
+    deleteById: deleteByIdMock,
+    isUserManagerOfUnit: isUserManagerOfUnitMock,
+  }));
+  mock.module('../../utils/audit.ts', () => ({
+    ...auditSnap,
+    logAudit: logAuditMock,
+    // keep real deriveToggleAction & getAuditChangedFields
+  }));
+  mock.module('../../db/drizzle.ts', () => ({
+    ...drizzleSnap,
+    withDbTransaction: withDbTransactionMock,
+  }));
+
+  routePlugin = (await import('../../routes/work-units.ts')).default as FastifyPluginAsync;
+});
+
+afterAll(() => {
+  restoreAuthMiddlewareMock();
+  mock.module('../../repositories/usersRepo.ts', () => usersRepoSnap);
+  mock.module('../../repositories/rolesRepo.ts', () => rolesRepoSnap);
+  mock.module('../../utils/permissions.ts', () => permissionsSnap);
+  mock.module('../../repositories/workUnitsRepo.ts', () => workUnitsRepoSnap);
+  mock.module('../../utils/audit.ts', () => auditSnap);
+  mock.module('../../db/drizzle.ts', () => drizzleSnap);
+});
+
+const HAPPY_USER = {
+  id: 'u1',
+  name: 'Alice',
+  username: 'alice',
+  role: 'top_manager',
+  avatarInitials: 'AL',
+  isDisabled: false,
+};
+
+const ALL_PERMS = [
+  'hr.work_units.view',
+  'hr.work_units.create',
+  'hr.work_units.update',
+  'hr.work_units.delete',
+  'hr.work_units_all.view',
+];
+
+const SAMPLE_UNIT = {
+  id: 'wu-1',
+  name: 'Engineering',
+  managers: [{ id: 'u1', name: 'Alice' }],
+  description: null,
+  isDisabled: false,
+  userCount: 3,
+};
+
+const allMocks = [
+  findAuthUserByIdMock,
+  userHasRoleMock,
+  getRolePermissionsMock,
+  listAllMock,
+  listManagedByMock,
+  createMock,
+  addManagersMock,
+  addUsersToUnitMock,
+  findByIdMock,
+  lockByIdMock,
+  updateFieldsMock,
+  clearManagersMock,
+  clearUsersMock,
+  findNameByIdMock,
+  findUserIdsMock,
+  deleteByIdMock,
+  isUserManagerOfUnitMock,
+  logAuditMock,
+  withDbTransactionMock,
+];
+
+let testApp: FastifyInstance;
+
+beforeEach(async () => {
+  for (const m of allMocks) m.mockReset();
+  findAuthUserByIdMock.mockResolvedValue(HAPPY_USER);
+  userHasRoleMock.mockResolvedValue(true);
+  getRolePermissionsMock.mockResolvedValue(ALL_PERMS);
+  withDbTransactionMock.mockImplementation(async (cb) => cb(undefined));
+  logAuditMock.mockImplementation(async () => undefined);
+
+  testApp = await buildRouteTestApp(routePlugin, '/api/work-units');
+});
+
+afterEach(async () => {
+  await testApp.close();
+});
+
+const authHeader = () => ({ authorization: `Bearer ${signToken({ userId: 'u1' })}` });
+
+describe('GET /api/work-units', () => {
+  test('200 with hr.work_units_all.view → listAll', async () => {
+    listAllMock.mockResolvedValue([SAMPLE_UNIT]);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/work-units',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(listAllMock).toHaveBeenCalledTimes(1);
+    expect(listManagedByMock).not.toHaveBeenCalled();
+  });
+
+  test('200 without all-view → listManagedBy(viewer.id)', async () => {
+    getRolePermissionsMock.mockResolvedValue(['hr.work_units.view']);
+    listManagedByMock.mockResolvedValue([]);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/work-units',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(listManagedByMock).toHaveBeenCalledWith('u1');
+  });
+
+  test('401 missing token', async () => {
+    const res = await testApp.inject({ method: 'GET', url: '/api/work-units' });
+    expect(res.statusCode).toBe(401);
+  });
+
+  test('403 missing view permission', async () => {
+    getRolePermissionsMock.mockResolvedValue([]);
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/work-units',
+      headers: authHeader(),
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+describe('POST /api/work-units', () => {
+  test('201 creates unit, also adds managers as users (line 136 behavior)', async () => {
+    createMock.mockResolvedValue(undefined);
+    addManagersMock.mockResolvedValue(undefined);
+    addUsersToUnitMock.mockResolvedValue(undefined);
+    findByIdMock.mockResolvedValue(SAMPLE_UNIT);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/work-units',
+      headers: authHeader(),
+      payload: {
+        name: 'Engineering',
+        managerIds: ['u1', 'u2'],
+        description: 'Eng team',
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(addManagersMock).toHaveBeenCalledWith(expect.any(String), ['u1', 'u2'], undefined);
+    expect(addUsersToUnitMock).toHaveBeenCalledWith(expect.any(String), ['u1', 'u2'], undefined);
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'work_unit.created',
+        entityType: 'work_unit',
+      }),
+    );
+  });
+
+  test('400 missing name', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/work-units',
+      headers: authHeader(),
+      payload: { name: '   ', managerIds: ['u1'] },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({ error: 'name is required' });
+  });
+
+  test('400 empty managerIds', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/work-units',
+      headers: authHeader(),
+      payload: { name: 'Eng', managerIds: [] },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/managerIds must contain at least one item/);
+  });
+});
+
+describe('PUT /api/work-units/:id', () => {
+  test('200 happy update emits work_unit.updated audit', async () => {
+    lockByIdMock.mockResolvedValue(true);
+    updateFieldsMock.mockResolvedValue(undefined);
+    findByIdMock.mockResolvedValue({ ...SAMPLE_UNIT, name: 'Renamed' });
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/work-units/wu-1',
+      headers: authHeader(),
+      payload: { name: 'Renamed' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'work_unit.updated' }),
+    );
+    // managerIds not provided → no clear/add manager calls
+    expect(clearManagersMock).not.toHaveBeenCalled();
+  });
+
+  test('200 isDisabled=true alone audits as work_unit.disabled', async () => {
+    lockByIdMock.mockResolvedValue(true);
+    updateFieldsMock.mockResolvedValue(undefined);
+    findByIdMock.mockResolvedValue({ ...SAMPLE_UNIT, isDisabled: true });
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/work-units/wu-1',
+      headers: authHeader(),
+      payload: { isDisabled: true },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'work_unit.disabled' }),
+    );
+  });
+
+  test('200 with managerIds calls clearManagers + addManagers + addUsersToUnit', async () => {
+    lockByIdMock.mockResolvedValue(true);
+    updateFieldsMock.mockResolvedValue(undefined);
+    clearManagersMock.mockResolvedValue(undefined);
+    addManagersMock.mockResolvedValue(undefined);
+    addUsersToUnitMock.mockResolvedValue(undefined);
+    findByIdMock.mockResolvedValue(SAMPLE_UNIT);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/work-units/wu-1',
+      headers: authHeader(),
+      payload: { managerIds: ['u3', 'u4'] },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(clearManagersMock).toHaveBeenCalled();
+    expect(addManagersMock).toHaveBeenCalledWith('wu-1', ['u3', 'u4'], undefined);
+    expect(addUsersToUnitMock).toHaveBeenCalledWith('wu-1', ['u3', 'u4'], undefined);
+  });
+
+  test('404 when lockById throws NotFoundError', async () => {
+    withDbTransactionMock.mockImplementation(async () => {
+      throw new NotFoundError('Work unit');
+    });
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/work-units/missing',
+      headers: authHeader(),
+      payload: { name: 'New' },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Work unit not found' });
+  });
+
+  test('400 whitespace-only name', async () => {
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/work-units/wu-1',
+      headers: authHeader(),
+      payload: { name: '   ' },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/name must be a non-empty string/);
+  });
+});
+
+describe('DELETE /api/work-units/:id', () => {
+  test('200 happy + audit', async () => {
+    deleteByIdMock.mockResolvedValue({ id: 'wu-1', name: 'Engineering' });
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/work-units/wu-1',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ message: 'Work unit deleted' });
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'work_unit.deleted', entityId: 'wu-1' }),
+    );
+  });
+
+  test('404 not found', async () => {
+    deleteByIdMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/work-units/missing',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe('GET /api/work-units/:id/users', () => {
+  test('200 with hr.work_units_all.view skips manager check', async () => {
+    findUserIdsMock.mockResolvedValue(['u1', 'u2']);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/work-units/wu-1/users',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual(['u1', 'u2']);
+    expect(isUserManagerOfUnitMock).not.toHaveBeenCalled();
+  });
+
+  test('200 as manager-of-unit', async () => {
+    getRolePermissionsMock.mockResolvedValue(['hr.work_units.view']);
+    isUserManagerOfUnitMock.mockResolvedValue(true);
+    findUserIdsMock.mockResolvedValue(['u1']);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/work-units/wu-1/users',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(isUserManagerOfUnitMock).toHaveBeenCalledWith('u1', 'wu-1');
+  });
+
+  test('403 not manager and lacks all-view', async () => {
+    getRolePermissionsMock.mockResolvedValue(['hr.work_units.view']);
+    isUserManagerOfUnitMock.mockResolvedValue(false);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/work-units/wu-1/users',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Access denied' });
+  });
+
+  test('401 missing token', async () => {
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/work-units/wu-1/users',
+    });
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+describe('POST /api/work-units/:id/users', () => {
+  test('200 clear+replace flow', async () => {
+    findNameByIdMock.mockResolvedValue('Engineering');
+    clearUsersMock.mockResolvedValue(undefined);
+    addUsersToUnitMock.mockResolvedValue(undefined);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/work-units/wu-1/users',
+      headers: authHeader(),
+      payload: { userIds: ['u1', 'u2', 'u3'] },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ message: 'Work unit users updated' });
+    expect(clearUsersMock).toHaveBeenCalledWith('wu-1', undefined);
+    expect(addUsersToUnitMock).toHaveBeenCalledWith('wu-1', ['u1', 'u2', 'u3'], undefined);
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'work_unit.users_updated',
+        entityId: 'wu-1',
+      }),
+    );
+  });
+
+  test('404 unit not found', async () => {
+    findNameByIdMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/work-units/missing/users',
+      headers: authHeader(),
+      payload: { userIds: [] },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Work unit not found' });
+  });
+});

--- a/server/test/utils/invoice-math.test.ts
+++ b/server/test/utils/invoice-math.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from 'bun:test';
+import { computeInvoiceTotals } from '../../utils/invoice-math.ts';
+
+describe('computeInvoiceTotals', () => {
+  test('empty items → zero subtotal and total', () => {
+    expect(computeInvoiceTotals([])).toEqual({ subtotal: 0, total: 0 });
+  });
+
+  test('single item with no discount', () => {
+    expect(computeInvoiceTotals([{ quantity: 2, unitPrice: 50, discount: 0 }])).toEqual({
+      subtotal: 100,
+      total: 100,
+    });
+  });
+
+  test('single item with 10% discount', () => {
+    expect(computeInvoiceTotals([{ quantity: 2, unitPrice: 50, discount: 10 }])).toEqual({
+      subtotal: 90,
+      total: 90,
+    });
+  });
+
+  test('multiple items sum correctly', () => {
+    expect(
+      computeInvoiceTotals([
+        { quantity: 2, unitPrice: 50, discount: 0 }, // 100
+        { quantity: 3, unitPrice: 20, discount: 0 }, // 60
+        { quantity: 1, unitPrice: 40, discount: 25 }, // 30
+      ]),
+    ).toEqual({ subtotal: 190, total: 190 });
+  });
+
+  test('100% discount yields 0 line', () => {
+    expect(computeInvoiceTotals([{ quantity: 5, unitPrice: 100, discount: 100 }])).toEqual({
+      subtotal: 0,
+      total: 0,
+    });
+  });
+
+  test('rounds to 2 decimals', () => {
+    // 0.1 * 0.2 = 0.020000000000000004 in JS floats; rounding pins it to 0.02
+    expect(computeInvoiceTotals([{ quantity: 0.1, unitPrice: 0.2, discount: 0 }])).toEqual({
+      subtotal: 0.02,
+      total: 0.02,
+    });
+  });
+
+  test('rounds halves up', () => {
+    // 1 * 0.005 = 0.005 → rounds to 0.01
+    expect(computeInvoiceTotals([{ quantity: 1, unitPrice: 0.005, discount: 0 }])).toEqual({
+      subtotal: 0.01,
+      total: 0.01,
+    });
+  });
+
+  test('matches frontend formula: quantity * unitPrice * (1 - discount/100)', () => {
+    // 7 * 13.50 * 0.85 = 80.325 → rounded to 80.33
+    expect(computeInvoiceTotals([{ quantity: 7, unitPrice: 13.5, discount: 15 }])).toEqual({
+      subtotal: 80.33,
+      total: 80.33,
+    });
+  });
+
+  test('subtotal equals total (no tax in this codebase)', () => {
+    const result = computeInvoiceTotals([{ quantity: 1, unitPrice: 99.99, discount: 0 }]);
+    expect(result.subtotal).toBe(result.total);
+  });
+});

--- a/server/utils/invoice-math.ts
+++ b/server/utils/invoice-math.ts
@@ -1,0 +1,12 @@
+type ItemMath = { quantity: number; unitPrice: number; discount: number };
+
+const roundCurrency = (value: number) => Math.round(value * 100) / 100;
+
+export const computeInvoiceTotals = (items: ItemMath[]): { subtotal: number; total: number } => {
+  const subtotal = items.reduce((acc, item) => {
+    const discountFactor = 1 - item.discount / 100;
+    return acc + item.quantity * item.unitPrice * discountFactor;
+  }, 0);
+  const rounded = roundCurrency(subtotal);
+  return { subtotal: rounded, total: rounded };
+};


### PR DESCRIPTION
## Summary

- **Phase 3 of the test coverage roadmap**: 96 happy-path + main-error-path tests for the top 5 backend routes (auth, entries, invoices, general-settings, work-units) using Fastify's `inject()` with stubbed repos, services, and DB transactions. Previously these routes had **zero automated coverage** despite being the most user-visible layer.
- **Server-side invoice total enforcement** (a finding surfaced while writing the invoice route tests): POST/PUT `/api/invoices` now recompute `subtotal`/`total` from items and reject `amountPaid > total`. Reports aggregate these via `SUM(total)` and `SUM(GREATEST(total - amount_paid, 0))` in `reportsRevenueRepo.ts`, so a buggy or compromised client could corrupt the revenue dashboard. Client-submitted totals are silently ignored to keep the existing frontend working unchanged.

## Test infrastructure

Two new helpers under `server/test/helpers/`:

- **`buildRouteTestApp(plugin, prefix)`** — minimal Fastify per test (no CORS/Swagger/global error handler). Decorates `fastify.rateLimit` as a no-op so route files calling `fastify.rateLimit(opts)` resolve cleanly without dragging in `@fastify/rate-limit`'s `onResponse` hook (which clashes with the auth-middleware mock below).

- **`authMiddlewareMock`** — wraps `authenticateToken`/`requireRole`/`requirePermission`/`requireAnyPermission` to call `reply.hijack()` after each hook. Fastify v5's hook chain doesn't observe `reply.sent` synchronously after `reply.send()` (the getter reads `raw.writableEnded`, which flips on the next tick), so under `inject()` the next hook in the chain — and the route handler — still run, each trying to send their own response, and bun:test surfaces the resulting `ERR_HTTP_HEADERS_SENT` as a test failure even though the actual on-the-wire response is correct. Hijacking flips `reply.sent` synchronously and Fastify treats that as a hard stop.

The real `authenticateToken` runs end-to-end (JWT verify, user lookup, sliding-window `x-auth-token` rotation) — only its three downstream calls (`usersRepo.findAuthUserById`, `rolesRepo.userHasRole`, `getRolePermissions`) are mocked. `withDbTransaction` is replaced with `mock(async (cb) => cb(undefined))` for routes that use it.

## What's covered

| Route | Tests | Notable paths |
|---|---|---|
| auth | 18 | login (LDAP off / on / fallback / throws), GET /me, switch-role (audit, sessionStart preservation, x-auth-token rotation) |
| entries | 30 | listForUser/All/ManagerView routing, weekend rules, manager-scope enforcement, taskId backfill on update, bulk-delete fromDate logic |
| invoices | 26 | server-recompute totals (overrides client values), amountPaid <= total, partial-update preservation, 409 on unique/FK violations |
| general-settings | 9 | API key masking by viewer permission, DEFAULT_SETTINGS fallback, `parseBoolean` on string inputs |
| work-units | 20 | permission-based listAll vs listManagedBy, manager-as-user auto-add, isDisabled toggle audit action derivation |

`bun test` runs the full suite (1158 tests across 55 files) in ~2.6s.

## Invoice math change (commit 1)

- Frontend formula `quantity * unitPrice * (1 - discount/100)`, summed and rounded to 2 decimals (matches `numeric(12, 2)` storage).
- New helper `server/utils/invoice-math.ts` with 9 unit tests.
- New `invoicesRepo.findTotal(id)` for the partial-update path where `amountPaid` is patched without items.
- PUT recomputes only when items are in the patch — status-only or notes-only updates leave totals untouched.
- No tax model exists in this codebase, so `total === subtotal`. The dual-field shape stays for forward compatibility.

## Test plan

- [x] `bun test` — 1158 pass, 0 fail in ~2.6s
- [x] `bun run lint` — 0 errors from these changes (4 pre-existing warnings in unrelated files)
- [ ] Manual smoke after merge: create / edit / pay an invoice in the UI, confirm totals reflect items (no frontend changes needed since the frontend already computes the same way)

## Out of scope

- Frontend `ClientsInvoicesView.tsx` could now call `utils/numbers.ts#calculatePricingTotals` (like sibling sales views do) instead of its inline `getLineTotal`/`calculateTotals` — left for a follow-up.
- Folding `findTotal` into the transaction (closes a theoretical race in a manual-UI flow) — declined; the fix would require a `ValidationError` plumbing pattern that doesn't exist in this codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)