### PR TITLE
feat(quotes): add version history with preview and atomic restore

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2122,6 +2122,9 @@ const App: React.FC = () => {
                   supplierQuotes={supplierQuotes}
                   onAddQuote={addQuote}
                   onUpdateQuote={handleUpdateQuote}
+                  onQuoteRestored={(restored) => {
+                    setQuotes((prev) => prev.map((q) => (q.id === restored.id ? restored : q)));
+                  }}
                   onDeleteQuote={handleDeleteQuote}
                   onCreateOffer={handleCreateClientOfferFromQuote}
                   offers={clientOffers}

--- a/App.tsx
+++ b/App.tsx
@@ -2122,8 +2122,12 @@ const App: React.FC = () => {
                   supplierQuotes={supplierQuotes}
                   onAddQuote={addQuote}
                   onUpdateQuote={handleUpdateQuote}
-                  onQuoteRestored={(restored) => {
+                  onQuoteRestored={async (restored) => {
+                    // Patch the restored quote eagerly so the modal reflects it instantly,
+                    // then refetch the whole flow because restore can also delete draft
+                    // linked sales server-side.
                     setQuotes((prev) => prev.map((q) => (q.id === restored.id ? restored : q)));
+                    await refreshClientQuoteFlow();
                   }}
                   onDeleteQuote={handleDeleteQuote}
                   onCreateOffer={handleCreateClientOfferFromQuote}

--- a/App.tsx
+++ b/App.tsx
@@ -2127,7 +2127,14 @@ const App: React.FC = () => {
                     // then refetch the whole flow because restore can also delete draft
                     // linked sales server-side.
                     setQuotes((prev) => prev.map((q) => (q.id === restored.id ? restored : q)));
-                    await refreshClientQuoteFlow();
+                    const [quotesData, offersData, ordersData] = await Promise.all([
+                      api.quotes.list(),
+                      api.clientOffers.list(),
+                      api.clientsOrders.list(),
+                    ]);
+                    setQuotes(quotesData);
+                    setClientOffers(offersData);
+                    setClientsOrders(ordersData);
                   }}
                   onDeleteQuote={handleDeleteQuote}
                   onCreateOffer={handleCreateClientOfferFromQuote}

--- a/components/sales/ClientQuotesView.tsx
+++ b/components/sales/ClientQuotesView.tsx
@@ -1194,515 +1194,364 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
     <div className="space-y-8 animate-in fade-in duration-500">
       {/* Add/Edit Modal */}
       <Modal isOpen={isModalOpen} onClose={closeModal}>
-        {editingQuote?.id && (
-          <QuoteVersionsPanel
-            quoteId={editingQuote.id}
-            selectedVersionId={previewVersion?.id ?? null}
-            onPreview={handleVersionPreview}
-            onClearPreview={handleClearPreview}
-            onRestored={handleVersionRestored}
-            disabled={baseReadOnly}
-          />
-        )}
-        <div className="flex max-h-[90vh] w-full max-w-7xl flex-col overflow-hidden rounded-2xl bg-white shadow-2xl animate-in zoom-in duration-200">
-          <div className="p-6 border-b border-slate-100 flex justify-between items-center bg-slate-50/50">
-            <h3 className="text-xl font-black text-slate-800 flex items-center gap-3">
-              <div className="w-10 h-10 bg-slate-100 rounded-xl flex items-center justify-center text-praetor">
-                <i className={`fa-solid ${editingQuote ? 'fa-pen-to-square' : 'fa-plus'}`}></i>
-              </div>
-              {isReadOnly
-                ? t('sales:clientQuotes.viewQuote')
-                : editingQuote
-                  ? t('sales:clientQuotes.editQuote')
-                  : t('sales:clientQuotes.createNewQuote')}
-            </h3>
-            <button
-              onClick={closeModal}
-              className="w-10 h-10 flex items-center justify-center rounded-xl hover:bg-slate-100 text-slate-400 transition-colors"
-            >
-              <i className="fa-solid fa-xmark text-lg"></i>
-            </button>
-          </div>
-
-          <form onSubmit={handleSubmit} className="flex-1 space-y-4 overflow-y-auto p-8">
-            {previewVersion && (
-              <div className="flex items-center justify-between gap-3 px-4 py-3 rounded-xl border border-amber-300 bg-amber-50">
-                <span className="text-amber-800 text-xs font-bold flex items-center gap-2">
-                  <i className="fa-solid fa-clock-rotate-left"></i>
-                  {t('sales:clientQuotes.versionHistory.previewBanner', {
-                    date: formatInsertDateTime(previewVersion.createdAt, i18n.language),
-                    defaultValue: 'Previewing version from {{date}}',
-                  })}
-                </span>
-                <button
-                  type="button"
-                  onClick={handleClearPreview}
-                  className="text-xs font-bold text-amber-800 hover:underline whitespace-nowrap"
-                >
-                  {t('sales:clientQuotes.versionHistory.backToCurrent', {
-                    defaultValue: 'Back to current',
-                  })}
-                </button>
-              </div>
-            )}
-            {baseReadOnly && (
-              <div className="flex items-center gap-3 px-4 py-3 rounded-xl border border-amber-200 bg-amber-50">
-                <span className="text-amber-700 text-xs font-bold">
-                  {editingQuote?.linkedOfferId
-                    ? t('sales:clientQuotes.readOnlyBecauseOffer', {
-                        defaultValue: 'Read-only due to linked offer',
-                      })
-                    : t('sales:clientQuotes.readOnlyBecauseFinal', {
-                        defaultValue: 'Read-only due to finalized status',
-                      })}
-                </span>
-              </div>
-            )}
-            {editingQuote?.linkedOfferId && (
-              <div className="bg-slate-50 border border-slate-100 rounded-xl p-4 flex items-center justify-between">
-                <div className="flex items-center gap-3">
-                  <div className="w-8 h-8 bg-slate-100 rounded-lg flex items-center justify-center text-praetor">
-                    <i className="fa-solid fa-link"></i>
-                  </div>
-                  <div>
-                    <div className="text-sm font-bold text-slate-900">
-                      {t('sales:clientQuotes.linkedOffer', { defaultValue: 'Linked Offer' })}
-                    </div>
-                    <div className="text-xs text-praetor">
-                      {t('sales:clientQuotes.linkedOfferInfo', {
-                        number: editingQuote.linkedOfferId,
-                        defaultValue: 'Offer #{{number}}',
-                      })}
-                    </div>
-                    <div className="text-[10px] text-slate-400 mt-0.5">
-                      {t('sales:clientQuotes.offerDetailsReadOnly', {
-                        defaultValue: '(Quote details are read-only)',
-                      })}
-                    </div>
-                  </div>
+        <div className="flex items-start gap-4 max-w-full">
+          <div className="flex max-h-[90vh] w-full max-w-7xl flex-col overflow-hidden rounded-2xl bg-white shadow-2xl animate-in zoom-in duration-200">
+            <div className="p-6 border-b border-slate-100 flex justify-between items-center bg-slate-50/50">
+              <h3 className="text-xl font-black text-slate-800 flex items-center gap-3">
+                <div className="w-10 h-10 bg-slate-100 rounded-xl flex items-center justify-center text-praetor">
+                  <i className={`fa-solid ${editingQuote ? 'fa-pen-to-square' : 'fa-plus'}`}></i>
                 </div>
-                {onViewOffers && (
-                  <button
-                    type="button"
-                    onClick={() => onViewOffers(editingQuote.id)}
-                    className="text-xs font-bold text-praetor hover:text-slate-800 hover:underline"
-                  >
-                    {t('sales:clientQuotes.viewOffer', { defaultValue: 'View Offer' })}
-                  </button>
-                )}
-              </div>
-            )}
-            {/* Client Selection */}
-            <div className="space-y-2">
-              <h4 className="text-xs font-black text-praetor uppercase tracking-widest flex items-center gap-2">
-                <span className="w-1.5 h-1.5 rounded-full bg-praetor"></span>
-                {t('sales:clientQuotes.clientInformation')}
-                <FieldTooltip
-                  description={t('sales:fieldInfo.clientInformation', {
-                    defaultValue: 'Client and document details',
-                  })}
-                  status={readOnlyStatus}
-                  statusLabel={statusLabel}
-                />
-              </h4>
-              <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
-                <div className="space-y-1.5">
-                  <label className="text-xs font-bold text-slate-500 ml-1">
-                    {t('sales:clientQuotes.client')}
-                  </label>
-                  <CustomSelect
-                    options={activeClients.map((c) => ({ id: c.id, name: c.name }))}
-                    value={formData.clientId || ''}
-                    onChange={(val) => handleClientChange(val as string)}
-                    placeholder={t('sales:clientQuotes.selectAClient')}
-                    searchable={true}
-                    disabled={isReadOnly}
-                    className={errors.clientId ? 'border-red-300' : ''}
-                  />
-                  {errors.clientId && (
-                    <p className="text-red-500 text-[10px] font-bold ml-1">{errors.clientId}</p>
-                  )}
-                </div>
-                <div className="space-y-1.5">
-                  <label className="text-xs font-bold text-slate-500 ml-1">
-                    {t('sales:clientQuotes.quoteCode', { defaultValue: 'Quote Code' })}
-                  </label>
-                  <input
-                    type="text"
-                    value={formData.id || ''}
-                    onChange={(e) => {
-                      setFormData({ ...formData, id: e.target.value });
-                      if (errors.id) {
-                        setErrors((prev) => {
-                          const next = { ...prev };
-                          delete next.id;
-                          return next;
-                        });
-                      }
-                    }}
-                    placeholder="Q0000"
-                    disabled={isReadOnly}
-                    className={`w-full rounded-xl border ${
-                      errors.id ? 'border-red-300' : 'border-slate-200'
-                    } bg-slate-50 px-4 py-2.5 text-sm font-bold outline-none focus:ring-2 focus:ring-praetor disabled:opacity-50 disabled:cursor-not-allowed`}
-                  />
-                  {errors.id && (
-                    <p className="text-red-500 text-[10px] font-bold ml-1">{errors.id}</p>
-                  )}
-                </div>
-                <div className="space-y-1.5">
-                  <label className="text-xs font-bold text-slate-500 ml-1">
-                    {t('sales:clientQuotes.paymentTerms')}
-                  </label>
-                  <CustomSelect
-                    options={paymentTermsOptions}
-                    value={formData.paymentTerms || 'immediate'}
-                    onChange={(val) =>
-                      setFormData({ ...formData, paymentTerms: val as Quote['paymentTerms'] })
-                    }
-                    searchable={false}
-                    disabled={isReadOnly}
-                  />
-                </div>
-                <div className="space-y-1.5">
-                  <label className="text-xs font-bold text-slate-500 ml-1">
-                    {t('sales:clientQuotes.expirationDateLabel')}
-                  </label>
-                  <input
-                    type="date"
-                    required
-                    value={formData.expirationDate}
-                    onChange={(e) => setFormData({ ...formData, expirationDate: e.target.value })}
-                    disabled={isReadOnly}
-                    className="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-2.5 text-sm outline-none focus:ring-2 focus:ring-praetor disabled:opacity-50 disabled:cursor-not-allowed"
-                  />
-                </div>
-              </div>
+                {isReadOnly
+                  ? t('sales:clientQuotes.viewQuote')
+                  : editingQuote
+                    ? t('sales:clientQuotes.editQuote')
+                    : t('sales:clientQuotes.createNewQuote')}
+              </h3>
+              <button
+                onClick={closeModal}
+                className="w-10 h-10 flex items-center justify-center rounded-xl hover:bg-slate-100 text-slate-400 transition-colors"
+              >
+                <i className="fa-solid fa-xmark text-lg"></i>
+              </button>
             </div>
 
-            {/* Products */}
-            <div className="space-y-2 border-t border-slate-100 pt-4">
-              <div className="flex justify-between items-center">
+            <form onSubmit={handleSubmit} className="flex-1 space-y-4 overflow-y-auto p-8">
+              {previewVersion && (
+                <div className="flex items-center justify-between gap-3 px-4 py-3 rounded-xl border border-amber-300 bg-amber-50">
+                  <span className="text-amber-800 text-xs font-bold flex items-center gap-2">
+                    <i className="fa-solid fa-clock-rotate-left"></i>
+                    {t('sales:clientQuotes.versionHistory.previewBanner', {
+                      date: formatInsertDateTime(previewVersion.createdAt, i18n.language),
+                      defaultValue: 'Previewing version from {{date}}',
+                    })}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={handleClearPreview}
+                    className="text-xs font-bold text-amber-800 hover:underline whitespace-nowrap"
+                  >
+                    {t('sales:clientQuotes.versionHistory.backToCurrent', {
+                      defaultValue: 'Back to current',
+                    })}
+                  </button>
+                </div>
+              )}
+              {baseReadOnly && (
+                <div className="flex items-center gap-3 px-4 py-3 rounded-xl border border-amber-200 bg-amber-50">
+                  <span className="text-amber-700 text-xs font-bold">
+                    {editingQuote?.linkedOfferId
+                      ? t('sales:clientQuotes.readOnlyBecauseOffer', {
+                          defaultValue: 'Read-only due to linked offer',
+                        })
+                      : t('sales:clientQuotes.readOnlyBecauseFinal', {
+                          defaultValue: 'Read-only due to finalized status',
+                        })}
+                  </span>
+                </div>
+              )}
+              {editingQuote?.linkedOfferId && (
+                <div className="bg-slate-50 border border-slate-100 rounded-xl p-4 flex items-center justify-between">
+                  <div className="flex items-center gap-3">
+                    <div className="w-8 h-8 bg-slate-100 rounded-lg flex items-center justify-center text-praetor">
+                      <i className="fa-solid fa-link"></i>
+                    </div>
+                    <div>
+                      <div className="text-sm font-bold text-slate-900">
+                        {t('sales:clientQuotes.linkedOffer', { defaultValue: 'Linked Offer' })}
+                      </div>
+                      <div className="text-xs text-praetor">
+                        {t('sales:clientQuotes.linkedOfferInfo', {
+                          number: editingQuote.linkedOfferId,
+                          defaultValue: 'Offer #{{number}}',
+                        })}
+                      </div>
+                      <div className="text-[10px] text-slate-400 mt-0.5">
+                        {t('sales:clientQuotes.offerDetailsReadOnly', {
+                          defaultValue: '(Quote details are read-only)',
+                        })}
+                      </div>
+                    </div>
+                  </div>
+                  {onViewOffers && (
+                    <button
+                      type="button"
+                      onClick={() => onViewOffers(editingQuote.id)}
+                      className="text-xs font-bold text-praetor hover:text-slate-800 hover:underline"
+                    >
+                      {t('sales:clientQuotes.viewOffer', { defaultValue: 'View Offer' })}
+                    </button>
+                  )}
+                </div>
+              )}
+              {/* Client Selection */}
+              <div className="space-y-2">
                 <h4 className="text-xs font-black text-praetor uppercase tracking-widest flex items-center gap-2">
                   <span className="w-1.5 h-1.5 rounded-full bg-praetor"></span>
-                  {t('sales:clientQuotes.productsServices')}
+                  {t('sales:clientQuotes.clientInformation')}
                   <FieldTooltip
-                    description={t('sales:fieldInfo.productsServices', {
-                      defaultValue: 'Products and services for this quote',
+                    description={t('sales:fieldInfo.clientInformation', {
+                      defaultValue: 'Client and document details',
                     })}
                     status={readOnlyStatus}
                     statusLabel={statusLabel}
                   />
                 </h4>
-                <button
-                  type="button"
-                  onClick={addProductRow}
-                  disabled={isReadOnly}
-                  className="text-xs font-bold text-praetor hover:text-slate-700 flex items-center gap-1 disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  <i className="fa-solid fa-plus"></i> {t('sales:clientQuotes.addProduct')}
-                </button>
-              </div>
-              {errors.items && (
-                <p className="text-red-500 text-[10px] font-bold ml-1 -mt-2">{errors.items}</p>
-              )}
-
-              {formData.items && formData.items.length > 0 && (
-                <div className="hidden lg:flex gap-2 px-3 mb-1 items-center">
-                  <div className="flex-1 min-w-0 grid grid-cols-13 gap-2">
-                    <div className="col-span-3 text-[10px] font-black text-slate-400 uppercase tracking-wider ml-1">
-                      {t('sales:clientQuotes.supplierQuoteColumn')}
-                    </div>
-                    <div className="col-span-3 text-[10px] font-black text-slate-400 uppercase tracking-wider">
-                      {t('sales:clientQuotes.productsServices')}
-                    </div>
-                    <div className="col-span-2 text-[10px] font-black text-slate-400 uppercase tracking-wider text-center">
-                      {t('sales:clientQuotes.qty')}
-                    </div>
-                    <div className="col-span-1 text-[10px] font-black text-slate-400 uppercase tracking-wider text-center">
-                      {t('crm:internalListing.cost')}
-                    </div>
-                    <div className="col-span-1 text-[10px] font-black text-slate-400 uppercase tracking-wider text-center whitespace-nowrap">
-                      MOL
-                    </div>
-                    <div className="col-span-1 text-[10px] font-black text-slate-400 uppercase tracking-wider text-center whitespace-nowrap">
-                      {t('sales:clientQuotes.totalCost', { defaultValue: 'Total cost' })}
-                    </div>
-                    <div className="col-span-1 text-[10px] font-black text-slate-400 uppercase tracking-wider text-center">
-                      {t('sales:clientQuotes.marginLabel')}
-                    </div>
-                    <div className="col-span-1 text-[10px] font-black text-slate-400 uppercase tracking-wider text-center">
-                      {t('sales:clientQuotes.revenue')}
-                    </div>
+                <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+                  <div className="space-y-1.5">
+                    <label className="text-xs font-bold text-slate-500 ml-1">
+                      {t('sales:clientQuotes.client')}
+                    </label>
+                    <CustomSelect
+                      options={activeClients.map((c) => ({ id: c.id, name: c.name }))}
+                      value={formData.clientId || ''}
+                      onChange={(val) => handleClientChange(val as string)}
+                      placeholder={t('sales:clientQuotes.selectAClient')}
+                      searchable={true}
+                      disabled={isReadOnly}
+                      className={errors.clientId ? 'border-red-300' : ''}
+                    />
+                    {errors.clientId && (
+                      <p className="text-red-500 text-[10px] font-bold ml-1">{errors.clientId}</p>
+                    )}
                   </div>
-                  <div className="w-10 shrink-0"></div>
+                  <div className="space-y-1.5">
+                    <label className="text-xs font-bold text-slate-500 ml-1">
+                      {t('sales:clientQuotes.quoteCode', { defaultValue: 'Quote Code' })}
+                    </label>
+                    <input
+                      type="text"
+                      value={formData.id || ''}
+                      onChange={(e) => {
+                        setFormData({ ...formData, id: e.target.value });
+                        if (errors.id) {
+                          setErrors((prev) => {
+                            const next = { ...prev };
+                            delete next.id;
+                            return next;
+                          });
+                        }
+                      }}
+                      placeholder="Q0000"
+                      disabled={isReadOnly}
+                      className={`w-full rounded-xl border ${
+                        errors.id ? 'border-red-300' : 'border-slate-200'
+                      } bg-slate-50 px-4 py-2.5 text-sm font-bold outline-none focus:ring-2 focus:ring-praetor disabled:opacity-50 disabled:cursor-not-allowed`}
+                    />
+                    {errors.id && (
+                      <p className="text-red-500 text-[10px] font-bold ml-1">{errors.id}</p>
+                    )}
+                  </div>
+                  <div className="space-y-1.5">
+                    <label className="text-xs font-bold text-slate-500 ml-1">
+                      {t('sales:clientQuotes.paymentTerms')}
+                    </label>
+                    <CustomSelect
+                      options={paymentTermsOptions}
+                      value={formData.paymentTerms || 'immediate'}
+                      onChange={(val) =>
+                        setFormData({ ...formData, paymentTerms: val as Quote['paymentTerms'] })
+                      }
+                      searchable={false}
+                      disabled={isReadOnly}
+                    />
+                  </div>
+                  <div className="space-y-1.5">
+                    <label className="text-xs font-bold text-slate-500 ml-1">
+                      {t('sales:clientQuotes.expirationDateLabel')}
+                    </label>
+                    <input
+                      type="date"
+                      required
+                      value={formData.expirationDate}
+                      onChange={(e) => setFormData({ ...formData, expirationDate: e.target.value })}
+                      disabled={isReadOnly}
+                      className="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-2.5 text-sm outline-none focus:ring-2 focus:ring-praetor disabled:opacity-50 disabled:cursor-not-allowed"
+                    />
+                  </div>
                 </div>
-              )}
+              </div>
 
-              {formData.items && formData.items.length > 0 ? (
-                <div className="space-y-3">
-                  {formData.items.map((item, index) => {
-                    const {
-                      unitCost: cost,
-                      molPercentage,
-                      lineCost,
-                      quantity,
-                    } = getItemPricingContext(item);
-                    const product = products.find((p) => p.id === item.productId);
-                    const isSupply = product?.type === 'supply';
-                    const unitSalePrice = Number(item.unitPrice || 0);
-                    const lineSalePrice = unitSalePrice * quantity;
-                    const lineMargin = lineSalePrice - lineCost;
+              {/* Products */}
+              <div className="space-y-2 border-t border-slate-100 pt-4">
+                <div className="flex justify-between items-center">
+                  <h4 className="text-xs font-black text-praetor uppercase tracking-widest flex items-center gap-2">
+                    <span className="w-1.5 h-1.5 rounded-full bg-praetor"></span>
+                    {t('sales:clientQuotes.productsServices')}
+                    <FieldTooltip
+                      description={t('sales:fieldInfo.productsServices', {
+                        defaultValue: 'Products and services for this quote',
+                      })}
+                      status={readOnlyStatus}
+                      statusLabel={statusLabel}
+                    />
+                  </h4>
+                  <button
+                    type="button"
+                    onClick={addProductRow}
+                    disabled={isReadOnly}
+                    className="text-xs font-bold text-praetor hover:text-slate-700 flex items-center gap-1 disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    <i className="fa-solid fa-plus"></i> {t('sales:clientQuotes.addProduct')}
+                  </button>
+                </div>
+                {errors.items && (
+                  <p className="text-red-500 text-[10px] font-bold ml-1 -mt-2">{errors.items}</p>
+                )}
 
-                    const isLinkedToSupplierQuote = Boolean(item.supplierQuoteItemId);
-                    const linkedFieldStatus = getLinkedFieldStatus({
-                      isReadOnly,
-                      isLinkedToSupplierQuote,
-                      readOnlyReason,
-                      supplierLockedReason,
-                      statusEditable,
-                    });
+                {formData.items && formData.items.length > 0 && (
+                  <div className="hidden lg:flex gap-2 px-3 mb-1 items-center">
+                    <div className="flex-1 min-w-0 grid grid-cols-13 gap-2">
+                      <div className="col-span-3 text-[10px] font-black text-slate-400 uppercase tracking-wider ml-1">
+                        {t('sales:clientQuotes.supplierQuoteColumn')}
+                      </div>
+                      <div className="col-span-3 text-[10px] font-black text-slate-400 uppercase tracking-wider">
+                        {t('sales:clientQuotes.productsServices')}
+                      </div>
+                      <div className="col-span-2 text-[10px] font-black text-slate-400 uppercase tracking-wider text-center">
+                        {t('sales:clientQuotes.qty')}
+                      </div>
+                      <div className="col-span-1 text-[10px] font-black text-slate-400 uppercase tracking-wider text-center">
+                        {t('crm:internalListing.cost')}
+                      </div>
+                      <div className="col-span-1 text-[10px] font-black text-slate-400 uppercase tracking-wider text-center whitespace-nowrap">
+                        MOL
+                      </div>
+                      <div className="col-span-1 text-[10px] font-black text-slate-400 uppercase tracking-wider text-center whitespace-nowrap">
+                        {t('sales:clientQuotes.totalCost', { defaultValue: 'Total cost' })}
+                      </div>
+                      <div className="col-span-1 text-[10px] font-black text-slate-400 uppercase tracking-wider text-center">
+                        {t('sales:clientQuotes.marginLabel')}
+                      </div>
+                      <div className="col-span-1 text-[10px] font-black text-slate-400 uppercase tracking-wider text-center">
+                        {t('sales:clientQuotes.revenue')}
+                      </div>
+                    </div>
+                    <div className="w-10 shrink-0"></div>
+                  </div>
+                )}
 
-                    const handleCostChange = (value: string) => {
-                      if (isReadOnly) return;
-                      setFormData(makeCostUpdater<Partial<Quote>>(index, value));
-                    };
+                {formData.items && formData.items.length > 0 ? (
+                  <div className="space-y-3">
+                    {formData.items.map((item, index) => {
+                      const {
+                        unitCost: cost,
+                        molPercentage,
+                        lineCost,
+                        quantity,
+                      } = getItemPricingContext(item);
+                      const product = products.find((p) => p.id === item.productId);
+                      const isSupply = product?.type === 'supply';
+                      const unitSalePrice = Number(item.unitPrice || 0);
+                      const lineSalePrice = unitSalePrice * quantity;
+                      const lineMargin = lineSalePrice - lineCost;
 
-                    const handleMolChange = (value: string) => {
-                      if (isReadOnly) return;
-                      setFormData(makeMolUpdater<Partial<Quote>>(index, value));
-                    };
+                      const isLinkedToSupplierQuote = Boolean(item.supplierQuoteItemId);
+                      const linkedFieldStatus = getLinkedFieldStatus({
+                        isReadOnly,
+                        isLinkedToSupplierQuote,
+                        readOnlyReason,
+                        supplierLockedReason,
+                        statusEditable,
+                      });
 
-                    return (
-                      <div
-                        key={item.id}
-                        className="rounded-xl border border-slate-100 bg-slate-50 p-3 space-y-3"
-                      >
-                        <div className="lg:hidden flex items-start gap-3">
-                          <div className="grid flex-1 min-w-0 grid-cols-1 md:grid-cols-2 gap-3">
-                            <div className="min-w-0">
-                              <div className="mb-1 text-[10px] font-black text-slate-400 uppercase tracking-wider flex items-center gap-1">
-                                {t('sales:clientQuotes.supplierQuoteColumn')}
-                                <FieldTooltip
-                                  description={t('sales:fieldInfo.supplierQuote', {
-                                    defaultValue:
-                                      'Link this item to a supplier quote for cost tracking',
-                                  })}
-                                  status={readOnlyStatus}
-                                  statusLabel={statusLabel}
+                      const handleCostChange = (value: string) => {
+                        if (isReadOnly) return;
+                        setFormData(makeCostUpdater<Partial<Quote>>(index, value));
+                      };
+
+                      const handleMolChange = (value: string) => {
+                        if (isReadOnly) return;
+                        setFormData(makeMolUpdater<Partial<Quote>>(index, value));
+                      };
+
+                      return (
+                        <div
+                          key={item.id}
+                          className="rounded-xl border border-slate-100 bg-slate-50 p-3 space-y-3"
+                        >
+                          <div className="lg:hidden flex items-start gap-3">
+                            <div className="grid flex-1 min-w-0 grid-cols-1 md:grid-cols-2 gap-3">
+                              <div className="min-w-0">
+                                <div className="mb-1 text-[10px] font-black text-slate-400 uppercase tracking-wider flex items-center gap-1">
+                                  {t('sales:clientQuotes.supplierQuoteColumn')}
+                                  <FieldTooltip
+                                    description={t('sales:fieldInfo.supplierQuote', {
+                                      defaultValue:
+                                        'Link this item to a supplier quote for cost tracking',
+                                    })}
+                                    status={readOnlyStatus}
+                                    statusLabel={statusLabel}
+                                  />
+                                </div>
+                                <CustomSelect
+                                  options={[
+                                    {
+                                      id: 'none',
+                                      name: t('sales:clientQuotes.noSupplierQuote'),
+                                    },
+                                    ...supplierQuoteItemOptions.map((o) => ({
+                                      id: o.id,
+                                      name: o.name,
+                                    })),
+                                  ]}
+                                  value={item.supplierQuoteItemId || 'none'}
+                                  onChange={(val) =>
+                                    updateProductRow(
+                                      index,
+                                      'supplierQuoteItemId',
+                                      val === 'none' ? '' : (val as string),
+                                    )
+                                  }
+                                  placeholder={t('sales:clientQuotes.selectSupplierQuote')}
+                                  displayValue={getSupplierQuoteItemDisplayValue(
+                                    item.supplierQuoteItemId,
+                                  )}
+                                  searchable={true}
+                                  disabled={isReadOnly}
+                                  className="min-w-0"
+                                  buttonClassName="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm"
                                 />
                               </div>
-                              <CustomSelect
-                                options={[
-                                  {
-                                    id: 'none',
-                                    name: t('sales:clientQuotes.noSupplierQuote'),
-                                  },
-                                  ...supplierQuoteItemOptions.map((o) => ({
-                                    id: o.id,
-                                    name: o.name,
-                                  })),
-                                ]}
-                                value={item.supplierQuoteItemId || 'none'}
-                                onChange={(val) =>
-                                  updateProductRow(
-                                    index,
-                                    'supplierQuoteItemId',
-                                    val === 'none' ? '' : (val as string),
-                                  )
-                                }
-                                placeholder={t('sales:clientQuotes.selectSupplierQuote')}
-                                displayValue={getSupplierQuoteItemDisplayValue(
-                                  item.supplierQuoteItemId,
-                                )}
-                                searchable={true}
-                                disabled={isReadOnly}
-                                className="min-w-0"
-                                buttonClassName="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm"
-                              />
+                              <div className="min-w-0">
+                                <div className="mb-1 text-[10px] font-black text-slate-400 uppercase tracking-wider flex items-center gap-1">
+                                  {t('sales:clientQuotes.productsServices')}
+                                  <FieldTooltip
+                                    description={t('sales:fieldInfo.product', {
+                                      defaultValue:
+                                        'Select a product or service for this line item',
+                                    })}
+                                    status={linkedFieldStatus}
+                                    statusLabel={statusLabel}
+                                  />
+                                </div>
+                                {renderProductSelectOrFallback(item, index, {
+                                  className: 'min-w-0',
+                                  buttonClassName:
+                                    'w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm',
+                                })}
+                              </div>
                             </div>
-                            <div className="min-w-0">
+                            <button
+                              type="button"
+                              onClick={() => removeProductRow(index)}
+                              disabled={isReadOnly}
+                              className="mt-5 w-10 h-10 flex items-center justify-center text-slate-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-all shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
+                            >
+                              <i className="fa-solid fa-trash-can"></i>
+                            </button>
+                          </div>
+                          <div className="grid grid-cols-2 gap-3 md:grid-cols-6 lg:hidden">
+                            <div>
                               <div className="mb-1 text-[10px] font-black text-slate-400 uppercase tracking-wider flex items-center gap-1">
-                                {t('sales:clientQuotes.productsServices')}
+                                {t('sales:clientQuotes.qty')}
                                 <FieldTooltip
-                                  description={t('sales:fieldInfo.product', {
-                                    defaultValue: 'Select a product or service for this line item',
+                                  description={t('sales:fieldInfo.qty', {
+                                    defaultValue: 'Quantity of items or hours',
                                   })}
                                   status={linkedFieldStatus}
                                   statusLabel={statusLabel}
                                 />
                               </div>
-                              {renderProductSelectOrFallback(item, index, {
-                                className: 'min-w-0',
-                                buttonClassName:
-                                  'w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm',
-                              })}
-                            </div>
-                          </div>
-                          <button
-                            type="button"
-                            onClick={() => removeProductRow(index)}
-                            disabled={isReadOnly}
-                            className="mt-5 w-10 h-10 flex items-center justify-center text-slate-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-all shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
-                          >
-                            <i className="fa-solid fa-trash-can"></i>
-                          </button>
-                        </div>
-                        <div className="grid grid-cols-2 gap-3 md:grid-cols-6 lg:hidden">
-                          <div>
-                            <div className="mb-1 text-[10px] font-black text-slate-400 uppercase tracking-wider flex items-center gap-1">
-                              {t('sales:clientQuotes.qty')}
-                              <FieldTooltip
-                                description={t('sales:fieldInfo.qty', {
-                                  defaultValue: 'Quantity of items or hours',
-                                })}
-                                status={linkedFieldStatus}
-                                statusLabel={statusLabel}
-                              />
-                            </div>
-                            <div className="flex items-center gap-1">
-                              <ValidatedNumberInput
-                                step="0.01"
-                                min="0"
-                                required
-                                placeholder={t('sales:clientQuotes.qty')}
-                                value={item.quantity}
-                                onValueChange={(value) => {
-                                  const parsed = parseFloat(value);
-                                  updateProductRow(
-                                    index,
-                                    'quantity',
-                                    value === '' || Number.isNaN(parsed) ? 0 : parsed,
-                                  );
-                                }}
-                                disabled={isReadOnly || isLinkedToSupplierQuote}
-                                className="w-full text-sm px-3 py-2 bg-white border border-slate-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed flex-1"
-                              />
-                              <span className="text-xs font-semibold text-slate-400 shrink-0">
-                                /
-                              </span>
-                              <UnitTypeSelector
-                                value={(item.unitType || 'hours') as SupplierUnitType}
-                                onChange={(val) => handleUnitTypeChange(index, val)}
-                                isSupply={isSupply}
-                                quantity={Number(item.quantity) || 0}
-                                disabled={isReadOnly || isLinkedToSupplierQuote}
-                              />
-                            </div>
-                          </div>
-                          <div className="rounded-lg border border-slate-200 bg-white px-3 py-2 space-y-1">
-                            <div className="text-[10px] font-black text-slate-400 uppercase tracking-wider flex items-center gap-1">
-                              {t('crm:internalListing.cost')}
-                              <FieldTooltip
-                                description={t('sales:fieldInfo.cost', {
-                                  defaultValue: 'Unit cost for this item',
-                                })}
-                                status={linkedFieldStatus}
-                                statusLabel={statusLabel}
-                              />
-                            </div>
-                            <div className="flex items-center gap-1">
-                              <ValidatedNumberInput
-                                value={cost}
-                                formatDecimals={2}
-                                onValueChange={handleCostChange}
-                                disabled={isReadOnly || isLinkedToSupplierQuote}
-                                className="w-full text-sm px-2 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
-                              />
-                              <span className="text-[9px] font-semibold text-slate-400 shrink-0">
-                                {currency}
-                              </span>
-                            </div>
-                          </div>
-                          <div className="rounded-lg border border-slate-200 bg-white px-3 py-2 space-y-1">
-                            <div className="text-[10px] font-black text-slate-400 uppercase tracking-wider flex items-center gap-1">
-                              MOL (%)
-                              <FieldTooltip
-                                description={t('sales:fieldInfo.mol', {
-                                  defaultValue: 'Margin overhead loading percentage',
-                                })}
-                                status={readOnlyStatus}
-                                statusLabel={statusLabel}
-                              />
-                            </div>
-                            <div className="flex items-center gap-1">
-                              <ValidatedNumberInput
-                                value={molPercentage}
-                                formatDecimals={1}
-                                onValueChange={handleMolChange}
-                                disabled={isReadOnly}
-                                className="w-full text-sm px-2 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
-                              />
-                              <span className="text-[9px] font-semibold text-slate-400 shrink-0">
-                                %
-                              </span>
-                            </div>
-                          </div>
-                          <div className="rounded-lg border border-slate-200 bg-white px-3 py-2 space-y-1">
-                            <div className="text-[10px] font-black text-slate-400 uppercase tracking-wider">
-                              {t('sales:clientQuotes.totalCost', { defaultValue: 'Total cost' })}
-                            </div>
-                            <div className="text-xs font-bold text-slate-700 whitespace-nowrap">
-                              {lineCost.toFixed(2)} {currency}
-                            </div>
-                          </div>
-                          <div className="rounded-lg border border-slate-200 bg-white px-3 py-2 space-y-1">
-                            <div className="text-[10px] font-black text-slate-400 uppercase tracking-wider">
-                              {t('sales:clientQuotes.marginLabel')}
-                            </div>
-                            <div className="text-xs font-bold text-emerald-600 whitespace-nowrap">
-                              {lineMargin.toFixed(2)} {currency}
-                            </div>
-                          </div>
-                          <div className="rounded-lg border border-slate-200 bg-white px-3 py-2 space-y-1 col-span-2 md:col-span-1">
-                            <div className="text-[10px] font-black text-slate-400 uppercase tracking-wider">
-                              {t('sales:clientQuotes.revenue')}
-                            </div>
-                            <div className="text-sm font-semibold whitespace-nowrap text-slate-800">
-                              {lineSalePrice.toFixed(2)} {currency}
-                            </div>
-                          </div>
-                        </div>
-                        <div className="hidden lg:flex gap-2 items-center">
-                          <div className="flex-1 min-w-0 grid grid-cols-13 gap-2 items-center">
-                            <div className="col-span-3 min-w-0">
-                              <CustomSelect
-                                options={[
-                                  {
-                                    id: 'none',
-                                    name: t('sales:clientQuotes.noSupplierQuote'),
-                                  },
-                                  ...supplierQuoteItemOptions.map((o) => ({
-                                    id: o.id,
-                                    name: o.name,
-                                  })),
-                                ]}
-                                value={item.supplierQuoteItemId || 'none'}
-                                onChange={(val) =>
-                                  updateProductRow(
-                                    index,
-                                    'supplierQuoteItemId',
-                                    val === 'none' ? '' : (val as string),
-                                  )
-                                }
-                                placeholder={t('sales:clientQuotes.selectSupplierQuote')}
-                                displayValue={getSupplierQuoteItemDisplayValue(
-                                  item.supplierQuoteItemId,
-                                )}
-                                searchable={true}
-                                disabled={isReadOnly}
-                                className="min-w-0"
-                                buttonClassName="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm"
-                              />
-                            </div>
-                            <div className="col-span-3 min-w-0">
-                              {renderProductSelectOrFallback(item, index, {
-                                className: 'min-w-0',
-                                buttonClassName:
-                                  'w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm',
-                              })}
-                            </div>
-                            <div className="col-span-2">
                               <div className="flex items-center gap-1">
                                 <ValidatedNumberInput
                                   step="0.01"
@@ -1719,7 +1568,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                                     );
                                   }}
                                   disabled={isReadOnly || isLinkedToSupplierQuote}
-                                  className="w-full text-sm px-2 py-2 bg-white border border-slate-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
+                                  className="w-full text-sm px-3 py-2 bg-white border border-slate-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed flex-1"
                                 />
                                 <span className="text-xs font-semibold text-slate-400 shrink-0">
                                   /
@@ -1733,182 +1582,336 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                                 />
                               </div>
                             </div>
-                            <div className="col-span-1 flex flex-col items-center justify-center gap-1">
-                              {isLinkedToSupplierQuote && (
-                                <span className="px-2 py-0.5 rounded-full bg-emerald-600 text-white text-[8px] font-black uppercase tracking-wider">
-                                  {t('sales:clientQuotes.supplierQuoteBadge')}
-                                </span>
-                              )}
-                              <div className="flex items-center gap-1 w-full">
+                            <div className="rounded-lg border border-slate-200 bg-white px-3 py-2 space-y-1">
+                              <div className="text-[10px] font-black text-slate-400 uppercase tracking-wider flex items-center gap-1">
+                                {t('crm:internalListing.cost')}
+                                <FieldTooltip
+                                  description={t('sales:fieldInfo.cost', {
+                                    defaultValue: 'Unit cost for this item',
+                                  })}
+                                  status={linkedFieldStatus}
+                                  statusLabel={statusLabel}
+                                />
+                              </div>
+                              <div className="flex items-center gap-1">
                                 <ValidatedNumberInput
                                   value={cost}
                                   formatDecimals={2}
                                   onValueChange={handleCostChange}
                                   disabled={isReadOnly || isLinkedToSupplierQuote}
-                                  className="w-full text-sm px-1 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
+                                  className="w-full text-sm px-2 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
                                 />
                                 <span className="text-[9px] font-semibold text-slate-400 shrink-0">
                                   {currency}
                                 </span>
                               </div>
                             </div>
-                            <div className="col-span-1 flex items-center justify-center gap-1">
-                              <ValidatedNumberInput
-                                value={molPercentage}
-                                formatDecimals={1}
-                                onValueChange={handleMolChange}
-                                disabled={isReadOnly}
-                                className="w-full text-sm px-1 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
-                              />
-                              <span className="text-[9px] font-semibold text-slate-400 shrink-0">
-                                %
-                              </span>
+                            <div className="rounded-lg border border-slate-200 bg-white px-3 py-2 space-y-1">
+                              <div className="text-[10px] font-black text-slate-400 uppercase tracking-wider flex items-center gap-1">
+                                MOL (%)
+                                <FieldTooltip
+                                  description={t('sales:fieldInfo.mol', {
+                                    defaultValue: 'Margin overhead loading percentage',
+                                  })}
+                                  status={readOnlyStatus}
+                                  statusLabel={statusLabel}
+                                />
+                              </div>
+                              <div className="flex items-center gap-1">
+                                <ValidatedNumberInput
+                                  value={molPercentage}
+                                  formatDecimals={1}
+                                  onValueChange={handleMolChange}
+                                  disabled={isReadOnly}
+                                  className="w-full text-sm px-2 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
+                                />
+                                <span className="text-[9px] font-semibold text-slate-400 shrink-0">
+                                  %
+                                </span>
+                              </div>
                             </div>
-                            <div className="col-span-1 flex items-center justify-center">
-                              <span className="text-xs font-bold text-slate-700 whitespace-nowrap">
+                            <div className="rounded-lg border border-slate-200 bg-white px-3 py-2 space-y-1">
+                              <div className="text-[10px] font-black text-slate-400 uppercase tracking-wider">
+                                {t('sales:clientQuotes.totalCost', { defaultValue: 'Total cost' })}
+                              </div>
+                              <div className="text-xs font-bold text-slate-700 whitespace-nowrap">
                                 {lineCost.toFixed(2)} {currency}
-                              </span>
+                              </div>
                             </div>
-                            <div className="col-span-1 flex items-center justify-center">
-                              <span className="text-xs font-bold text-emerald-600 whitespace-nowrap">
+                            <div className="rounded-lg border border-slate-200 bg-white px-3 py-2 space-y-1">
+                              <div className="text-[10px] font-black text-slate-400 uppercase tracking-wider">
+                                {t('sales:clientQuotes.marginLabel')}
+                              </div>
+                              <div className="text-xs font-bold text-emerald-600 whitespace-nowrap">
                                 {lineMargin.toFixed(2)} {currency}
-                              </span>
+                              </div>
                             </div>
-                            <div className="col-span-1 flex items-center justify-center">
-                              <span className="text-xs font-semibold whitespace-nowrap text-slate-800">
+                            <div className="rounded-lg border border-slate-200 bg-white px-3 py-2 space-y-1 col-span-2 md:col-span-1">
+                              <div className="text-[10px] font-black text-slate-400 uppercase tracking-wider">
+                                {t('sales:clientQuotes.revenue')}
+                              </div>
+                              <div className="text-sm font-semibold whitespace-nowrap text-slate-800">
                                 {lineSalePrice.toFixed(2)} {currency}
-                              </span>
+                              </div>
                             </div>
                           </div>
-                          <button
-                            type="button"
-                            onClick={() => removeProductRow(index)}
-                            disabled={isReadOnly}
-                            className="w-10 h-10 flex items-center justify-center text-slate-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-all shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
-                          >
-                            <i className="fa-solid fa-trash-can"></i>
-                          </button>
+                          <div className="hidden lg:flex gap-2 items-center">
+                            <div className="flex-1 min-w-0 grid grid-cols-13 gap-2 items-center">
+                              <div className="col-span-3 min-w-0">
+                                <CustomSelect
+                                  options={[
+                                    {
+                                      id: 'none',
+                                      name: t('sales:clientQuotes.noSupplierQuote'),
+                                    },
+                                    ...supplierQuoteItemOptions.map((o) => ({
+                                      id: o.id,
+                                      name: o.name,
+                                    })),
+                                  ]}
+                                  value={item.supplierQuoteItemId || 'none'}
+                                  onChange={(val) =>
+                                    updateProductRow(
+                                      index,
+                                      'supplierQuoteItemId',
+                                      val === 'none' ? '' : (val as string),
+                                    )
+                                  }
+                                  placeholder={t('sales:clientQuotes.selectSupplierQuote')}
+                                  displayValue={getSupplierQuoteItemDisplayValue(
+                                    item.supplierQuoteItemId,
+                                  )}
+                                  searchable={true}
+                                  disabled={isReadOnly}
+                                  className="min-w-0"
+                                  buttonClassName="w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm"
+                                />
+                              </div>
+                              <div className="col-span-3 min-w-0">
+                                {renderProductSelectOrFallback(item, index, {
+                                  className: 'min-w-0',
+                                  buttonClassName:
+                                    'w-full px-3 py-2 bg-white border border-slate-200 rounded-lg text-sm',
+                                })}
+                              </div>
+                              <div className="col-span-2">
+                                <div className="flex items-center gap-1">
+                                  <ValidatedNumberInput
+                                    step="0.01"
+                                    min="0"
+                                    required
+                                    placeholder={t('sales:clientQuotes.qty')}
+                                    value={item.quantity}
+                                    onValueChange={(value) => {
+                                      const parsed = parseFloat(value);
+                                      updateProductRow(
+                                        index,
+                                        'quantity',
+                                        value === '' || Number.isNaN(parsed) ? 0 : parsed,
+                                      );
+                                    }}
+                                    disabled={isReadOnly || isLinkedToSupplierQuote}
+                                    className="w-full text-sm px-2 py-2 bg-white border border-slate-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
+                                  />
+                                  <span className="text-xs font-semibold text-slate-400 shrink-0">
+                                    /
+                                  </span>
+                                  <UnitTypeSelector
+                                    value={(item.unitType || 'hours') as SupplierUnitType}
+                                    onChange={(val) => handleUnitTypeChange(index, val)}
+                                    isSupply={isSupply}
+                                    quantity={Number(item.quantity) || 0}
+                                    disabled={isReadOnly || isLinkedToSupplierQuote}
+                                  />
+                                </div>
+                              </div>
+                              <div className="col-span-1 flex flex-col items-center justify-center gap-1">
+                                {isLinkedToSupplierQuote && (
+                                  <span className="px-2 py-0.5 rounded-full bg-emerald-600 text-white text-[8px] font-black uppercase tracking-wider">
+                                    {t('sales:clientQuotes.supplierQuoteBadge')}
+                                  </span>
+                                )}
+                                <div className="flex items-center gap-1 w-full">
+                                  <ValidatedNumberInput
+                                    value={cost}
+                                    formatDecimals={2}
+                                    onValueChange={handleCostChange}
+                                    disabled={isReadOnly || isLinkedToSupplierQuote}
+                                    className="w-full text-sm px-1 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
+                                  />
+                                  <span className="text-[9px] font-semibold text-slate-400 shrink-0">
+                                    {currency}
+                                  </span>
+                                </div>
+                              </div>
+                              <div className="col-span-1 flex items-center justify-center gap-1">
+                                <ValidatedNumberInput
+                                  value={molPercentage}
+                                  formatDecimals={1}
+                                  onValueChange={handleMolChange}
+                                  disabled={isReadOnly}
+                                  className="w-full text-sm px-1 py-2 bg-white border border-slate-200 rounded-lg focus:ring-1 focus:ring-praetor outline-none text-center disabled:opacity-50 disabled:cursor-not-allowed"
+                                />
+                                <span className="text-[9px] font-semibold text-slate-400 shrink-0">
+                                  %
+                                </span>
+                              </div>
+                              <div className="col-span-1 flex items-center justify-center">
+                                <span className="text-xs font-bold text-slate-700 whitespace-nowrap">
+                                  {lineCost.toFixed(2)} {currency}
+                                </span>
+                              </div>
+                              <div className="col-span-1 flex items-center justify-center">
+                                <span className="text-xs font-bold text-emerald-600 whitespace-nowrap">
+                                  {lineMargin.toFixed(2)} {currency}
+                                </span>
+                              </div>
+                              <div className="col-span-1 flex items-center justify-center">
+                                <span className="text-xs font-semibold whitespace-nowrap text-slate-800">
+                                  {lineSalePrice.toFixed(2)} {currency}
+                                </span>
+                              </div>
+                            </div>
+                            <button
+                              type="button"
+                              onClick={() => removeProductRow(index)}
+                              disabled={isReadOnly}
+                              className="w-10 h-10 flex items-center justify-center text-slate-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-all shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
+                            >
+                              <i className="fa-solid fa-trash-can"></i>
+                            </button>
+                          </div>
+                          <div>
+                            <input
+                              type="text"
+                              placeholder={t('form:placeholderNotes')}
+                              value={item.note || ''}
+                              onChange={(e) => updateProductRow(index, 'note', e.target.value)}
+                              disabled={isReadOnly}
+                              className="w-full text-sm px-3 py-2 bg-white border border-slate-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none disabled:opacity-50 disabled:cursor-not-allowed"
+                            />
+                          </div>
                         </div>
-                        <div>
-                          <input
-                            type="text"
-                            placeholder={t('form:placeholderNotes')}
-                            value={item.note || ''}
-                            onChange={(e) => updateProductRow(index, 'note', e.target.value)}
-                            disabled={isReadOnly}
-                            className="w-full text-sm px-3 py-2 bg-white border border-slate-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none disabled:opacity-50 disabled:cursor-not-allowed"
-                          />
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
-              ) : (
-                <div className="text-center py-8 text-slate-400 text-sm">
-                  {t('sales:clientQuotes.noProductsAdded')}
-                </div>
-              )}
-            </div>
-
-            {/* Notes & Cost Summary */}
-            <div className="flex flex-col gap-4 border-t border-slate-100 pt-4 md:flex-row">
-              <div className="w-full space-y-2 md:w-2/3">
-                <h4 className="flex items-center gap-2 text-xs font-black uppercase tracking-widest text-praetor">
-                  <span className="h-1.5 w-1.5 rounded-full bg-praetor"></span>
-                  {t('sales:clientQuotes.notesLabel')}
-                  <FieldTooltip
-                    description={t('sales:fieldInfo.notes', {
-                      defaultValue: 'Additional notes for the entire document',
+                      );
                     })}
-                    status={readOnlyStatus}
-                    statusLabel={statusLabel}
-                  />
-                </h4>
-                <textarea
-                  rows={4}
-                  value={formData.notes}
-                  onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
-                  placeholder={t('sales:clientQuotes.additionalNotesPlaceholder')}
-                  disabled={isReadOnly}
-                  className="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-2 text-sm outline-none resize-none disabled:opacity-50 disabled:cursor-not-allowed"
-                />
-              </div>
-
-              <div className="w-full md:w-1/3">
-                {errors.total && (
-                  <p className="text-red-500 text-[10px] font-bold mb-2">{errors.total}</p>
+                  </div>
+                ) : (
+                  <div className="text-center py-8 text-slate-400 text-sm">
+                    {t('sales:clientQuotes.noProductsAdded')}
+                  </div>
                 )}
-                <CostSummaryPanel
-                  currency={currency}
-                  subtotal={formTotals.subtotal}
-                  total={formTotals.total}
-                  subtotalLabel={t('sales:clientQuotes.subtotal', { defaultValue: 'Subtotal' })}
-                  totalLabel={t('sales:clientQuotes.totalLabel')}
-                  globalDiscount={{
-                    label: t('sales:clientQuotes.globalDiscount'),
-                    value: formData.discount ?? 0,
-                    type: formData.discountType || 'percentage',
-                    onChange: (value) => {
-                      const parsed = parseNumberInputValue(value);
-                      setFormData({ ...formData, discount: parsed });
-                      if (errors.total) {
-                        setErrors((prev) => {
-                          const next = { ...prev };
-                          delete next.total;
-                          return next;
-                        });
-                      }
-                    },
-                    onTypeChange: (type) => setFormData({ ...formData, discountType: type }),
-                    disabled: isReadOnly,
-                  }}
-                  discountRow={
-                    formTotals.discountAmount > 0
-                      ? {
-                          label: t('sales:clientQuotes.discountAmount', {
-                            value: formatDiscountValue(
-                              formData.discount ?? 0,
-                              formData.discountType ?? 'percentage',
-                              currency,
-                            ),
-                          }),
-                          amount: formTotals.discountAmount,
-                        }
-                      : undefined
-                  }
-                  margin={{
-                    label: `${t('sales:clientQuotes.marginLabel')} (${(formTotals.marginPercentage || 0).toFixed(1)}%)`,
-                    amount: formTotals.margin,
-                  }}
-                />
               </div>
-            </div>
 
-            <div className="flex justify-end gap-3 pt-4">
-              <button
-                type="button"
-                onClick={closeModal}
-                className="rounded-xl px-6 py-3 font-bold text-slate-500 hover:bg-slate-50"
-              >
-                {t('common:buttons.cancel')}
-              </button>
-              {!previewVersion && (
+              {/* Notes & Cost Summary */}
+              <div className="flex flex-col gap-4 border-t border-slate-100 pt-4 md:flex-row">
+                <div className="w-full space-y-2 md:w-2/3">
+                  <h4 className="flex items-center gap-2 text-xs font-black uppercase tracking-widest text-praetor">
+                    <span className="h-1.5 w-1.5 rounded-full bg-praetor"></span>
+                    {t('sales:clientQuotes.notesLabel')}
+                    <FieldTooltip
+                      description={t('sales:fieldInfo.notes', {
+                        defaultValue: 'Additional notes for the entire document',
+                      })}
+                      status={readOnlyStatus}
+                      statusLabel={statusLabel}
+                    />
+                  </h4>
+                  <textarea
+                    rows={4}
+                    value={formData.notes}
+                    onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
+                    placeholder={t('sales:clientQuotes.additionalNotesPlaceholder')}
+                    disabled={isReadOnly}
+                    className="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-2 text-sm outline-none resize-none disabled:opacity-50 disabled:cursor-not-allowed"
+                  />
+                </div>
+
+                <div className="w-full md:w-1/3">
+                  {errors.total && (
+                    <p className="text-red-500 text-[10px] font-bold mb-2">{errors.total}</p>
+                  )}
+                  <CostSummaryPanel
+                    currency={currency}
+                    subtotal={formTotals.subtotal}
+                    total={formTotals.total}
+                    subtotalLabel={t('sales:clientQuotes.subtotal', { defaultValue: 'Subtotal' })}
+                    totalLabel={t('sales:clientQuotes.totalLabel')}
+                    globalDiscount={{
+                      label: t('sales:clientQuotes.globalDiscount'),
+                      value: formData.discount ?? 0,
+                      type: formData.discountType || 'percentage',
+                      onChange: (value) => {
+                        const parsed = parseNumberInputValue(value);
+                        setFormData({ ...formData, discount: parsed });
+                        if (errors.total) {
+                          setErrors((prev) => {
+                            const next = { ...prev };
+                            delete next.total;
+                            return next;
+                          });
+                        }
+                      },
+                      onTypeChange: (type) => setFormData({ ...formData, discountType: type }),
+                      disabled: isReadOnly,
+                    }}
+                    discountRow={
+                      formTotals.discountAmount > 0
+                        ? {
+                            label: t('sales:clientQuotes.discountAmount', {
+                              value: formatDiscountValue(
+                                formData.discount ?? 0,
+                                formData.discountType ?? 'percentage',
+                                currency,
+                              ),
+                            }),
+                            amount: formTotals.discountAmount,
+                          }
+                        : undefined
+                    }
+                    margin={{
+                      label: `${t('sales:clientQuotes.marginLabel')} (${(formTotals.marginPercentage || 0).toFixed(1)}%)`,
+                      amount: formTotals.margin,
+                    }}
+                  />
+                </div>
+              </div>
+
+              <div className="flex justify-end gap-3 pt-4">
                 <button
-                  type="submit"
-                  disabled={isReadOnly}
-                  className="rounded-xl bg-praetor px-8 py-3 font-bold text-white shadow-lg shadow-slate-200 hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                  type="button"
+                  onClick={closeModal}
+                  className="rounded-xl px-6 py-3 font-bold text-slate-500 hover:bg-slate-50"
                 >
-                  {isReadOnly
-                    ? t('sales:clientQuotes.statusQuote', {
-                        status: getStatusLabel(editingQuote?.status || ''),
-                      })
-                    : editingQuote
-                      ? t('sales:clientQuotes.updateQuote')
-                      : t('sales:clientQuotes.createQuote')}
+                  {t('common:buttons.cancel')}
                 </button>
-              )}
-            </div>
-          </form>
+                {!previewVersion && (
+                  <button
+                    type="submit"
+                    disabled={isReadOnly}
+                    className="rounded-xl bg-praetor px-8 py-3 font-bold text-white shadow-lg shadow-slate-200 hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {isReadOnly
+                      ? t('sales:clientQuotes.statusQuote', {
+                          status: getStatusLabel(editingQuote?.status || ''),
+                        })
+                      : editingQuote
+                        ? t('sales:clientQuotes.updateQuote')
+                        : t('sales:clientQuotes.createQuote')}
+                  </button>
+                )}
+              </div>
+            </form>
+          </div>
+          {editingQuote?.id && (
+            <QuoteVersionsPanel
+              quoteId={editingQuote.id}
+              selectedVersionId={previewVersion?.id ?? null}
+              onPreview={handleVersionPreview}
+              onClearPreview={handleClearPreview}
+              onRestored={handleVersionRestored}
+              disabled={baseReadOnly}
+            />
+          )}
         </div>
       </Modal>
 

--- a/components/sales/ClientQuotesView.tsx
+++ b/components/sales/ClientQuotesView.tsx
@@ -250,17 +250,21 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
     setIsModalOpen(true);
   }, []);
 
-  const handleVersionPreview = useCallback((version: QuoteVersion) => {
-    setPreviewVersion(version);
-    setFormData(
-      quoteToFormData({
-        ...version.snapshot.quote,
-        items: version.snapshot.items.map(normalizeQuoteItem),
-        status: version.snapshot.quote.status as Quote['status'],
-      }),
-    );
-    setErrors({});
-  }, []);
+  const handleVersionPreview = useCallback(
+    (version: QuoteVersion) => {
+      setPreviewVersion(version);
+      setFormData(
+        quoteToFormData({
+          ...version.snapshot.quote,
+          id: editingQuote?.id ?? version.snapshot.quote.id,
+          items: version.snapshot.items.map(normalizeQuoteItem),
+          status: version.snapshot.quote.status as Quote['status'],
+        }),
+      );
+      setErrors({});
+    },
+    [editingQuote],
+  );
 
   const handleClearPreview = useCallback(() => {
     if (editingQuote) setFormData(quoteToFormData(editingQuote));

--- a/components/sales/ClientQuotesView.tsx
+++ b/components/sales/ClientQuotesView.tsx
@@ -1,12 +1,14 @@
 import type React from 'react';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { normalizeQuoteItem } from '../../services/api/normalizers';
 import type {
   Client,
   ClientOffer,
   Product,
   Quote,
   QuoteItem,
+  QuoteVersion,
   SupplierQuote,
   SupplierUnitType,
 } from '../../types';
@@ -14,6 +16,7 @@ import {
   addMonthsToDateOnly,
   formatDateOnlyForLocale,
   formatInsertDate,
+  formatInsertDateTime,
   getLocalDateString,
   isDateOnlyBeforeToday,
   normalizeDateOnlyString,
@@ -38,6 +41,7 @@ import StatusBadge, { type StatusType } from '../shared/StatusBadge';
 import Tooltip from '../shared/Tooltip';
 import UnitTypeSelector from '../shared/UnitTypeSelector';
 import ValidatedNumberInput from '../shared/ValidatedNumberInput';
+import QuoteVersionsPanel from './QuoteVersionsPanel';
 
 export interface ClientQuotesViewProps {
   quotes: Quote[];
@@ -46,6 +50,7 @@ export interface ClientQuotesViewProps {
   supplierQuotes: SupplierQuote[];
   onAddQuote: (quoteData: Partial<Quote>) => void | Promise<void>;
   onUpdateQuote: (id: string, updates: Partial<Quote>) => void | Promise<void>;
+  onQuoteRestored?: (quote: Quote) => void;
   onDeleteQuote: (id: string) => void;
   onCreateOffer?: (quote: Quote) => void;
   onViewOffer?: (offerId: string) => void;
@@ -70,6 +75,19 @@ const getDefaultFormData = (): Partial<Quote> => ({
   notes: '',
 });
 
+const quoteToFormData = (quote: Quote): Partial<Quote> => ({
+  id: quote.id,
+  clientId: quote.clientId,
+  clientName: quote.clientName,
+  items: quote.items,
+  paymentTerms: quote.paymentTerms,
+  discount: quote.discount,
+  discountType: quote.discountType || 'percentage',
+  status: quote.status,
+  expirationDate: quote.expirationDate ? normalizeDateOnlyString(quote.expirationDate) : '',
+  notes: quote.notes || '',
+});
+
 const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
   quotes,
   clients,
@@ -77,6 +95,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
   supplierQuotes,
   onAddQuote,
   onUpdateQuote,
+  onQuoteRestored,
   onDeleteQuote,
   onCreateOffer,
   onViewOffer,
@@ -88,7 +107,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
   // biome-ignore lint/correctness/noUnusedFunctionParameters: part of public API
   offers = [],
 }) => {
-  const { t } = useTranslation(['sales', 'crm', 'common', 'form']);
+  const { t, i18n } = useTranslation(['sales', 'crm', 'common', 'form']);
 
   const paymentTermsOptions = useMemo(() => getPaymentTermsOptions(t), [t]);
 
@@ -167,12 +186,14 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
   );
 
   const [formData, setFormData] = useState<Partial<Quote>>(getDefaultFormData());
-  const isReadOnly = Boolean(
+  const [previewVersion, setPreviewVersion] = useState<QuoteVersion | null>(null);
+  const baseReadOnly = Boolean(
     editingQuote &&
       (editingQuote.linkedOfferId ||
         editingQuote.status === 'accepted' ||
         editingQuote.status === 'denied'),
   );
+  const isReadOnly = baseReadOnly || previewVersion !== null;
 
   const readOnlyReason = editingQuote?.linkedOfferId
     ? t('sales:clientQuotes.readOnlyBecauseOffer', {
@@ -202,33 +223,55 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
     };
   }, [formData.items, formData.discount, formData.discountType]);
 
+  const closeModal = useCallback(() => {
+    setIsModalOpen(false);
+    setPreviewVersion(null);
+  }, []);
+
   const openAddModal = () => {
     setEditingQuote(null);
     setPendingClientChange(null);
     setFormData(getDefaultFormData());
     setErrors({});
+    setPreviewVersion(null);
     setIsModalOpen(true);
   };
 
   const openEditModal = useCallback((quote: Quote) => {
     setEditingQuote(quote);
     setPendingClientChange(null);
-    const formattedDate = quote.expirationDate ? normalizeDateOnlyString(quote.expirationDate) : '';
-    setFormData({
-      id: quote.id,
-      clientId: quote.clientId,
-      clientName: quote.clientName,
-      items: quote.items,
-      paymentTerms: quote.paymentTerms,
-      discount: quote.discount,
-      discountType: quote.discountType || 'percentage',
-      status: quote.status,
-      expirationDate: formattedDate,
-      notes: quote.notes || '',
-    });
+    setFormData(quoteToFormData(quote));
     setErrors({});
+    setPreviewVersion(null);
     setIsModalOpen(true);
   }, []);
+
+  const handleVersionPreview = useCallback((version: QuoteVersion) => {
+    setPreviewVersion(version);
+    setFormData(
+      quoteToFormData({
+        ...version.snapshot.quote,
+        items: version.snapshot.items.map(normalizeQuoteItem),
+        status: version.snapshot.quote.status as Quote['status'],
+      }),
+    );
+    setErrors({});
+  }, []);
+
+  const handleClearPreview = useCallback(() => {
+    if (editingQuote) setFormData(quoteToFormData(editingQuote));
+    setPreviewVersion(null);
+  }, [editingQuote]);
+
+  const handleVersionRestored = useCallback(
+    (updated: Quote) => {
+      setEditingQuote(updated);
+      setFormData(quoteToFormData(updated));
+      setPreviewVersion(null);
+      onQuoteRestored?.(updated);
+    },
+    [onQuoteRestored],
+  );
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -321,7 +364,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
     } else {
       await onAddQuote(payload);
     }
-    setIsModalOpen(false);
+    closeModal();
   };
 
   const confirmDelete = useCallback((quote: Quote) => {
@@ -1150,7 +1193,17 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
   return (
     <div className="space-y-8 animate-in fade-in duration-500">
       {/* Add/Edit Modal */}
-      <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)}>
+      <Modal isOpen={isModalOpen} onClose={closeModal}>
+        {editingQuote?.id && (
+          <QuoteVersionsPanel
+            quoteId={editingQuote.id}
+            selectedVersionId={previewVersion?.id ?? null}
+            onPreview={handleVersionPreview}
+            onClearPreview={handleClearPreview}
+            onRestored={handleVersionRestored}
+            disabled={baseReadOnly}
+          />
+        )}
         <div className="flex max-h-[90vh] w-full max-w-7xl flex-col overflow-hidden rounded-2xl bg-white shadow-2xl animate-in zoom-in duration-200">
           <div className="p-6 border-b border-slate-100 flex justify-between items-center bg-slate-50/50">
             <h3 className="text-xl font-black text-slate-800 flex items-center gap-3">
@@ -1164,7 +1217,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                   : t('sales:clientQuotes.createNewQuote')}
             </h3>
             <button
-              onClick={() => setIsModalOpen(false)}
+              onClick={closeModal}
               className="w-10 h-10 flex items-center justify-center rounded-xl hover:bg-slate-100 text-slate-400 transition-colors"
             >
               <i className="fa-solid fa-xmark text-lg"></i>
@@ -1172,7 +1225,27 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
           </div>
 
           <form onSubmit={handleSubmit} className="flex-1 space-y-4 overflow-y-auto p-8">
-            {isReadOnly && (
+            {previewVersion && (
+              <div className="flex items-center justify-between gap-3 px-4 py-3 rounded-xl border border-amber-300 bg-amber-50">
+                <span className="text-amber-800 text-xs font-bold flex items-center gap-2">
+                  <i className="fa-solid fa-clock-rotate-left"></i>
+                  {t('sales:clientQuotes.versionHistory.previewBanner', {
+                    date: formatInsertDateTime(previewVersion.createdAt, i18n.language),
+                    defaultValue: 'Previewing version from {{date}}',
+                  })}
+                </span>
+                <button
+                  type="button"
+                  onClick={handleClearPreview}
+                  className="text-xs font-bold text-amber-800 hover:underline whitespace-nowrap"
+                >
+                  {t('sales:clientQuotes.versionHistory.backToCurrent', {
+                    defaultValue: 'Back to current',
+                  })}
+                </button>
+              </div>
+            )}
+            {baseReadOnly && (
               <div className="flex items-center gap-3 px-4 py-3 rounded-xl border border-amber-200 bg-amber-50">
                 <span className="text-amber-700 text-xs font-bold">
                   {editingQuote?.linkedOfferId
@@ -1814,24 +1887,26 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
             <div className="flex justify-end gap-3 pt-4">
               <button
                 type="button"
-                onClick={() => setIsModalOpen(false)}
+                onClick={closeModal}
                 className="rounded-xl px-6 py-3 font-bold text-slate-500 hover:bg-slate-50"
               >
                 {t('common:buttons.cancel')}
               </button>
-              <button
-                type="submit"
-                disabled={isReadOnly}
-                className="rounded-xl bg-praetor px-8 py-3 font-bold text-white shadow-lg shadow-slate-200 hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {isReadOnly
-                  ? t('sales:clientQuotes.statusQuote', {
-                      status: getStatusLabel(editingQuote?.status || ''),
-                    })
-                  : editingQuote
-                    ? t('sales:clientQuotes.updateQuote')
-                    : t('sales:clientQuotes.createQuote')}
-              </button>
+              {!previewVersion && (
+                <button
+                  type="submit"
+                  disabled={isReadOnly}
+                  className="rounded-xl bg-praetor px-8 py-3 font-bold text-white shadow-lg shadow-slate-200 hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {isReadOnly
+                    ? t('sales:clientQuotes.statusQuote', {
+                        status: getStatusLabel(editingQuote?.status || ''),
+                      })
+                    : editingQuote
+                      ? t('sales:clientQuotes.updateQuote')
+                      : t('sales:clientQuotes.createQuote')}
+                </button>
+              )}
             </div>
           </form>
         </div>

--- a/components/sales/ClientQuotesView.tsx
+++ b/components/sales/ClientQuotesView.tsx
@@ -191,7 +191,11 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
     editingQuote &&
       (editingQuote.linkedOfferId ||
         editingQuote.status === 'accepted' ||
-        editingQuote.status === 'denied'),
+        editingQuote.status === 'denied' ||
+        // Backend stores 'confirmed' for finalized quotes (PUT and restore both 409 it).
+        // The Quote type doesn't include this status today, but rows from the API can
+        // have it — cast to compare without widening the union project-wide.
+        (editingQuote.status as string) === 'confirmed'),
   );
   const isReadOnly = baseReadOnly || previewVersion !== null;
 

--- a/components/sales/QuoteVersionsPanel.tsx
+++ b/components/sales/QuoteVersionsPanel.tsx
@@ -77,7 +77,7 @@ const QuoteVersionsPanel: React.FC<QuoteVersionsPanelProps> = ({
 
   return (
     <>
-      <div className="hidden 2xl:flex fixed top-4 right-4 w-72 max-h-[calc(100vh-2rem)] z-[61] flex-col rounded-2xl bg-white shadow-2xl overflow-hidden animate-in fade-in slide-in-from-right duration-200">
+      <div className="hidden 2xl:flex w-72 max-h-[90vh] flex-col flex-shrink-0 rounded-2xl bg-white shadow-2xl overflow-hidden animate-in fade-in slide-in-from-right duration-200">
         <div className="px-4 py-3 border-b border-slate-100 bg-slate-50/50 flex items-center justify-between">
           <h4 className="text-sm font-black text-slate-800 flex items-center gap-2">
             <i className="fa-solid fa-clock-rotate-left text-praetor"></i>

--- a/components/sales/QuoteVersionsPanel.tsx
+++ b/components/sales/QuoteVersionsPanel.tsx
@@ -1,0 +1,171 @@
+import type React from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { clientQuotesApi } from '../../services/api/clientQuotes';
+import type { Quote, QuoteVersion, QuoteVersionRow } from '../../types';
+import { formatInsertDateTime } from '../../utils/date';
+import DeleteConfirmModal from '../shared/DeleteConfirmModal';
+
+interface QuoteVersionsPanelProps {
+  quoteId: string;
+  selectedVersionId: string | null;
+  onPreview: (version: QuoteVersion) => void;
+  onClearPreview: () => void;
+  onRestored: (updatedQuote: Quote) => void;
+  disabled?: boolean;
+}
+
+const QuoteVersionsPanel: React.FC<QuoteVersionsPanelProps> = ({
+  quoteId,
+  selectedVersionId,
+  onPreview,
+  onClearPreview,
+  onRestored,
+  disabled,
+}) => {
+  const { t, i18n } = useTranslation('sales');
+  const [rows, setRows] = useState<QuoteVersionRow[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [restoreInFlight, setRestoreInFlight] = useState(false);
+
+  const reload = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const versions = await clientQuotesApi.listVersions(quoteId);
+      setRows(versions);
+    } catch {
+      setError(t('clientQuotes.versionHistory.loadFailed'));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [quoteId, t]);
+
+  useEffect(() => {
+    reload();
+  }, [reload]);
+
+  const handleSelect = useCallback(
+    async (row: QuoteVersionRow) => {
+      if (row.id === selectedVersionId) return;
+      try {
+        const version = await clientQuotesApi.getVersion(quoteId, row.id);
+        onPreview(version);
+      } catch {
+        setError(t('clientQuotes.versionHistory.loadFailed'));
+      }
+    },
+    [quoteId, onPreview, selectedVersionId, t],
+  );
+
+  const handleRestoreConfirmed = useCallback(async () => {
+    if (!selectedVersionId) return;
+    setRestoreInFlight(true);
+    try {
+      const updated = await clientQuotesApi.restoreVersion(quoteId, selectedVersionId);
+      onRestored(updated);
+      setConfirmOpen(false);
+      await reload();
+    } catch {
+      setError(t('clientQuotes.versionHistory.loadFailed'));
+    } finally {
+      setRestoreInFlight(false);
+    }
+  }, [selectedVersionId, quoteId, onRestored, reload, t]);
+
+  return (
+    <>
+      <div className="hidden 2xl:flex fixed top-4 right-4 w-72 max-h-[calc(100vh-2rem)] z-[61] flex-col rounded-2xl bg-white shadow-2xl overflow-hidden animate-in fade-in slide-in-from-right duration-200">
+        <div className="px-4 py-3 border-b border-slate-100 bg-slate-50/50 flex items-center justify-between">
+          <h4 className="text-sm font-black text-slate-800 flex items-center gap-2">
+            <i className="fa-solid fa-clock-rotate-left text-praetor"></i>
+            {t('clientQuotes.versionHistory.title')}
+          </h4>
+          <span className="text-[10px] font-bold uppercase tracking-wider text-slate-500 bg-slate-100 px-2 py-0.5 rounded-full">
+            {rows.length}
+          </span>
+        </div>
+        <div className="flex-1 overflow-y-auto">
+          {isLoading && (
+            <div className="p-6 text-xs text-slate-400 text-center">
+              <i className="fa-solid fa-spinner fa-spin"></i>
+            </div>
+          )}
+          {error && !isLoading && (
+            <div className="m-3 p-3 text-xs text-red-700 bg-red-50 border border-red-100 rounded-lg">
+              {error}
+            </div>
+          )}
+          {!isLoading && !error && rows.length === 0 && (
+            <div className="p-6 text-xs text-slate-400 text-center leading-relaxed">
+              {t('clientQuotes.versionHistory.empty')}
+            </div>
+          )}
+          {!isLoading && !error && rows.length > 0 && (
+            <ul className="divide-y divide-slate-100">
+              {rows.map((row) => {
+                const selected = row.id === selectedVersionId;
+                return (
+                  <li key={row.id}>
+                    <button
+                      type="button"
+                      onClick={() => handleSelect(row)}
+                      className={`w-full text-left px-4 py-3 hover:bg-slate-50 transition-colors flex flex-col gap-1 ${
+                        selected ? 'bg-praetor/5 border-l-4 border-praetor pl-3' : ''
+                      }`}
+                    >
+                      <span className="text-xs font-bold text-slate-700">
+                        {formatInsertDateTime(row.createdAt, i18n.language)}
+                      </span>
+                      <span
+                        className={`text-[9px] font-black uppercase tracking-wider ${
+                          row.reason === 'restore' ? 'text-amber-600' : 'text-slate-400'
+                        }`}
+                      >
+                        {row.reason === 'restore'
+                          ? t('clientQuotes.versionHistory.reasonRestore')
+                          : t('clientQuotes.versionHistory.reasonUpdate')}
+                      </span>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+        {selectedVersionId && (
+          <div className="border-t border-slate-100 p-3 space-y-2 bg-slate-50/50">
+            <button
+              type="button"
+              onClick={onClearPreview}
+              className="w-full py-2 text-xs font-bold text-slate-500 hover:bg-slate-100 rounded-lg transition-colors"
+            >
+              <i className="fa-solid fa-arrow-left mr-1.5"></i>
+              {t('clientQuotes.versionHistory.backToCurrent')}
+            </button>
+            <button
+              type="button"
+              disabled={Boolean(disabled) || restoreInFlight}
+              onClick={() => setConfirmOpen(true)}
+              className="w-full py-2 bg-praetor text-white text-xs font-bold rounded-lg shadow-md shadow-slate-200 hover:bg-slate-700 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed transition-all"
+            >
+              <i className="fa-solid fa-rotate-left mr-1.5"></i>
+              {t('clientQuotes.versionHistory.restoreButton')}
+            </button>
+          </div>
+        )}
+      </div>
+      <DeleteConfirmModal
+        isOpen={confirmOpen}
+        onClose={() => setConfirmOpen(false)}
+        onConfirm={handleRestoreConfirmed}
+        title={t('clientQuotes.versionHistory.restoreConfirmTitle')}
+        description={t('clientQuotes.versionHistory.restoreConfirmDescription')}
+      />
+    </>
+  );
+};
+
+export default QuoteVersionsPanel;

--- a/components/sales/QuoteVersionsPanel.tsx
+++ b/components/sales/QuoteVersionsPanel.tsx
@@ -52,6 +52,7 @@ const QuoteVersionsPanel: React.FC<QuoteVersionsPanelProps> = ({
       if (row.id === selectedVersionId) return;
       try {
         const version = await clientQuotesApi.getVersion(quoteId, row.id);
+        setError(null);
         onPreview(version);
       } catch {
         setError(t('clientQuotes.versionHistory.loadFailed'));
@@ -65,11 +66,16 @@ const QuoteVersionsPanel: React.FC<QuoteVersionsPanelProps> = ({
     setRestoreInFlight(true);
     try {
       const updated = await clientQuotesApi.restoreVersion(quoteId, selectedVersionId);
+      setError(null);
       onRestored(updated);
       setConfirmOpen(false);
       await reload();
-    } catch {
-      setError(t('clientQuotes.versionHistory.loadFailed'));
+    } catch (e) {
+      // Restore failures (409 linked-offer / 409 confirmed / 409 non-draft sale / 404)
+      // carry actionable server messages — surface them instead of a generic load error.
+      setError(
+        e instanceof Error && e.message ? e.message : t('clientQuotes.versionHistory.loadFailed'),
+      );
     } finally {
       setRestoreInFlight(false);
     }

--- a/locales/en/sales.json
+++ b/locales/en/sales.json
@@ -145,7 +145,19 @@
     "clientChangeRepriceCancel": "Cancel",
     "supplierQuoteColumn": "Supplier Quote",
     "revenue": "Revenue",
-    "molLabel": "MOL"
+    "molLabel": "MOL",
+    "versionHistory": {
+      "title": "Version History",
+      "empty": "No previous versions yet. Saves will appear here.",
+      "previewBanner": "Previewing version from {{date}}",
+      "backToCurrent": "Back to current",
+      "restoreButton": "Restore this version",
+      "restoreConfirmTitle": "Restore this version?",
+      "restoreConfirmDescription": "The current values will be saved as a new version before being replaced. This action can be undone by restoring the version that gets created now.",
+      "reasonUpdate": "Save",
+      "reasonRestore": "Restored",
+      "loadFailed": "Failed to load version history."
+    }
   },
   "clientOffers": {
     "title": "Client Offers",

--- a/locales/it/sales.json
+++ b/locales/it/sales.json
@@ -145,7 +145,19 @@
     "clientChangeRepriceCancel": "Annulla",
     "supplierQuoteColumn": "Preventivo Fornitore",
     "revenue": "Ricavi",
-    "molLabel": "MOL"
+    "molLabel": "MOL",
+    "versionHistory": {
+      "title": "Cronologia versioni",
+      "empty": "Nessuna versione precedente. I salvataggi appariranno qui.",
+      "previewBanner": "Anteprima della versione del {{date}}",
+      "backToCurrent": "Torna alla versione corrente",
+      "restoreButton": "Ripristina questa versione",
+      "restoreConfirmTitle": "Ripristinare questa versione?",
+      "restoreConfirmDescription": "I valori attuali verranno salvati come nuova versione prima della sostituzione. Puoi annullare l'azione ripristinando la versione che verrà creata ora.",
+      "reasonUpdate": "Salvataggio",
+      "reasonRestore": "Ripristino",
+      "loadFailed": "Caricamento della cronologia non riuscito."
+    }
   },
   "clientOffers": {
     "title": "Offerte Clienti",

--- a/server/db/migrations/0019_add_quote_versions.sql
+++ b/server/db/migrations/0019_add_quote_versions.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "quote_versions" (
+	"id" varchar(50) PRIMARY KEY NOT NULL,
+	"quote_id" varchar(100) NOT NULL,
+	"snapshot" jsonb NOT NULL,
+	"reason" varchar(20) DEFAULT 'update' NOT NULL,
+	"created_by_user_id" varchar(50),
+	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP,
+	CONSTRAINT "chk_quote_versions_reason" CHECK ("quote_versions"."reason" IN ('update', 'restore'))
+);
+--> statement-breakpoint
+ALTER TABLE "quote_versions" ADD CONSTRAINT "quote_versions_quote_id_quotes_id_fk" FOREIGN KEY ("quote_id") REFERENCES "public"."quotes"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
+ALTER TABLE "quote_versions" ADD CONSTRAINT "quote_versions_created_by_user_id_users_id_fk" FOREIGN KEY ("created_by_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_quote_versions_quote_id_created_at" ON "quote_versions" USING btree ("quote_id","created_at" DESC NULLS LAST);

--- a/server/db/migrations/meta/0019_snapshot.json
+++ b/server/db/migrations/meta/0019_snapshot.json
@@ -1,0 +1,5014 @@
+{
+  "id": "33370702-59c0-4a67-bdef-a6f4eb6e7dae",
+  "prevId": "5d227e38-7e19-452f-9d53-6eca4eeba0cb",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user.login'"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_audit_logs_created_at": {
+          "name": "idx_audit_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_user_id": {
+          "name": "idx_audit_logs_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_action": {
+          "name": "idx_audit_logs_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.client_profile_options": {
+      "name": "client_profile_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_client_profile_options_category_value_unique": {
+          "name": "idx_client_profile_options_category_value_unique",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "LOWER(\"value\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_client_profile_options_category_sort": {
+          "name": "idx_client_profile_options_category_sort",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_client_profile_options_category": {
+          "name": "chk_client_profile_options_category",
+          "value": "\"client_profile_options\".\"category\" IN ('sector', 'numberOfEmployees', 'revenue', 'officeCountRange')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'company'"
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_code": {
+          "name": "client_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ateco_code": {
+          "name": "ateco_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sector": {
+          "name": "sector",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_of_employees": {
+          "name": "number_of_employees",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revenue": {
+          "name": "revenue",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fiscal_code": {
+          "name": "fiscal_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "office_count_range": {
+          "name": "office_count_range",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "address_country": {
+          "name": "address_country",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_state": {
+          "name": "address_state",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_cap": {
+          "name": "address_cap",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_province": {
+          "name": "address_province",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_civic_number": {
+          "name": "address_civic_number",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line": {
+          "name": "address_line",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_clients_fiscal_code_unique": {
+          "name": "idx_clients_fiscal_code_unique",
+          "columns": [
+            {
+              "expression": "LOWER(\"fiscal_code\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"fiscal_code\" IS NOT NULL AND \"clients\".\"fiscal_code\" <> ''",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_clients_client_code_unique": {
+          "name": "idx_clients_client_code_unique",
+          "columns": [
+            {
+              "expression": "client_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"client_code\" IS NOT NULL AND \"clients\".\"client_code\" <> ''",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_clients": {
+      "name": "user_clients",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_source": {
+          "name": "assignment_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_clients_user_id_users_id_fk": {
+          "name": "user_clients_user_id_users_id_fk",
+          "tableFrom": "user_clients",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_clients_client_id_clients_id_fk": {
+          "name": "user_clients_client_id_clients_id_fk",
+          "tableFrom": "user_clients",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_clients_user_id_client_id_pk": {
+          "name": "user_clients_user_id_client_id_pk",
+          "columns": ["user_id", "client_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_clients_assignment_source_check": {
+          "name": "user_clients_assignment_source_check",
+          "value": "\"user_clients\".\"assignment_source\" IN ('manual', 'top_manager_auto', 'project_cascade')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.customer_offer_items": {
+      "name": "customer_offer_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "offer_id": {
+          "name": "offer_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_cost": {
+          "name": "product_cost",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_mol_percentage": {
+          "name": "product_mol_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "unit_type": {
+          "name": "unit_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'hours'"
+        },
+        "supplier_quote_id": {
+          "name": "supplier_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_item_id": {
+          "name": "supplier_quote_item_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_supplier_name": {
+          "name": "supplier_quote_supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_unit_price": {
+          "name": "supplier_quote_unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_customer_offer_items_offer_id": {
+          "name": "idx_customer_offer_items_offer_id",
+          "columns": [
+            {
+              "expression": "offer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_offer_items_offer_id_customer_offers_id_fk": {
+          "name": "customer_offer_items_offer_id_customer_offers_id_fk",
+          "tableFrom": "customer_offer_items",
+          "tableTo": "customer_offers",
+          "columnsFrom": ["offer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "customer_offer_items_product_id_products_id_fk": {
+          "name": "customer_offer_items_product_id_products_id_fk",
+          "tableFrom": "customer_offer_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_customer_offer_items_unit_type": {
+          "name": "chk_customer_offer_items_unit_type",
+          "value": "\"customer_offer_items\".\"unit_type\" IN ('hours', 'days', 'unit')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.customer_offers": {
+      "name": "customer_offers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_quote_id": {
+          "name": "linked_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_customer_offers_linked_quote_id": {
+          "name": "idx_customer_offers_linked_quote_id",
+          "columns": [
+            {
+              "expression": "linked_quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_offers_client_id": {
+          "name": "idx_customer_offers_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_offers_status": {
+          "name": "idx_customer_offers_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_offers_created_at": {
+          "name": "idx_customer_offers_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_offers_linked_quote_id_quotes_id_fk": {
+          "name": "customer_offers_linked_quote_id_quotes_id_fk",
+          "tableFrom": "customer_offers",
+          "tableTo": "quotes",
+          "columnsFrom": ["linked_quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "customer_offers_client_id_clients_id_fk": {
+          "name": "customer_offers_client_id_clients_id_fk",
+          "tableFrom": "customer_offers",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "customer_offers_status_check": {
+          "name": "customer_offers_status_check",
+          "value": "\"customer_offers\".\"status\" IN ('draft', 'sent', 'accepted', 'denied')"
+        },
+        "chk_customer_offers_discount_type": {
+          "name": "chk_customer_offers_discount_type",
+          "value": "\"customer_offers\".\"discount_type\" IN ('percentage', 'currency')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.email_config": {
+      "name": "email_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "smtp_host": {
+          "name": "smtp_host",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "smtp_port": {
+          "name": "smtp_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 587
+        },
+        "smtp_encryption": {
+          "name": "smtp_encryption",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'tls'"
+        },
+        "smtp_reject_unauthorized": {
+          "name": "smtp_reject_unauthorized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "smtp_user": {
+          "name": "smtp_user",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "smtp_password": {
+          "name": "smtp_password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "from_email": {
+          "name": "from_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Praetor'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "email_config_id_check": {
+          "name": "email_config_id_check",
+          "value": "\"email_config\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.general_settings": {
+      "name": "general_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'€'"
+        },
+        "daily_limit": {
+          "name": "daily_limit",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'8.00'"
+        },
+        "start_of_week": {
+          "name": "start_of_week",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Monday'"
+        },
+        "treat_saturday_as_holiday": {
+          "name": "treat_saturday_as_holiday",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "enable_ai_reporting": {
+          "name": "enable_ai_reporting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "gemini_api_key": {
+          "name": "gemini_api_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_provider": {
+          "name": "ai_provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'gemini'"
+        },
+        "openrouter_api_key": {
+          "name": "openrouter_api_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gemini_model_id": {
+          "name": "gemini_model_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "openrouter_model_id": {
+          "name": "openrouter_model_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_weekend_selection": {
+          "name": "allow_weekend_selection",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "default_location": {
+          "name": "default_location",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'remote'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "general_settings_id_check": {
+          "name": "general_settings_id_check",
+          "value": "\"general_settings\".\"id\" = 1"
+        },
+        "general_settings_start_of_week_check": {
+          "name": "general_settings_start_of_week_check",
+          "value": "\"general_settings\".\"start_of_week\" IN ('Monday', 'Sunday')"
+        },
+        "general_settings_ai_provider_check": {
+          "name": "general_settings_ai_provider_check",
+          "value": "\"general_settings\".\"ai_provider\" IN ('gemini', 'openrouter')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invoice_items": {
+      "name": "invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_of_measure": {
+          "name": "unit_of_measure",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unit'"
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_invoice_items_invoice_id": {
+          "name": "idx_invoice_items_invoice_id",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "invoices",
+          "columnsFrom": ["invoice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "invoice_items_product_id_products_id_fk": {
+          "name": "invoice_items_product_id_products_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_sale_id": {
+          "name": "linked_sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_date": {
+          "name": "issue_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "amount_paid": {
+          "name": "amount_paid",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_invoices_client_id": {
+          "name": "idx_invoices_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_status": {
+          "name": "idx_invoices_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_issue_date": {
+          "name": "idx_invoices_issue_date",
+          "columns": [
+            {
+              "expression": "issue_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_linked_sale_id_sales_id_fk": {
+          "name": "invoices_linked_sale_id_sales_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "sales",
+          "columnsFrom": ["linked_sale_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "invoices_client_id_clients_id_fk": {
+          "name": "invoices_client_id_clients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invoices_status_check": {
+          "name": "invoices_status_check",
+          "value": "\"invoices\".\"status\" IN ('draft', 'sent', 'paid', 'overdue', 'cancelled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ldap_config": {
+      "name": "ldap_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "server_url": {
+          "name": "server_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ldap://ldap.example.com:389'"
+        },
+        "base_dn": {
+          "name": "base_dn",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'dc=example,dc=com'"
+        },
+        "bind_dn": {
+          "name": "bind_dn",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'cn=read-only-admin,dc=example,dc=com'"
+        },
+        "bind_password": {
+          "name": "bind_password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "user_filter": {
+          "name": "user_filter",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'(uid={0})'"
+        },
+        "group_base_dn": {
+          "name": "group_base_dn",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ou=groups,dc=example,dc=com'"
+        },
+        "group_filter": {
+          "name": "group_filter",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'(member={0})'"
+        },
+        "role_mappings": {
+          "name": "role_mappings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ldap_config_id_check": {
+          "name": "ldap_config_id_check",
+          "value": "\"ldap_config\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_notifications_user_id": {
+          "name": "idx_notifications_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_user_unread": {
+          "name": "idx_notifications_user_unread",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notifications\".\"is_read\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.internal_product_categories": {
+      "name": "internal_product_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_unit": {
+          "name": "cost_unit",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unit'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_internal_product_categories_type": {
+          "name": "idx_internal_product_categories_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "internal_product_categories_name_type_key": {
+          "name": "internal_product_categories_name_type_key",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "internal_product_categories_cost_unit_check": {
+          "name": "internal_product_categories_cost_unit_check",
+          "value": "\"internal_product_categories\".\"cost_unit\" IN ('unit', 'hours')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.internal_product_subcategories": {
+      "name": "internal_product_subcategories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_internal_product_subcategories_category_id": {
+          "name": "idx_internal_product_subcategories_category_id",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "internal_product_subcategories_category_id_name_key": {
+          "name": "internal_product_subcategories_category_id_name_key",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "internal_product_subcategories_category_id_internal_product_categories_id_fk": {
+          "name": "internal_product_subcategories_category_id_internal_product_categories_id_fk",
+          "tableFrom": "internal_product_subcategories",
+          "tableTo": "internal_product_categories",
+          "columnsFrom": ["category_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_code": {
+          "name": "product_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "costo": {
+          "name": "costo",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "mol_percentage": {
+          "name": "mol_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "cost_unit": {
+          "name": "cost_unit",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unit'"
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'item'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subcategory": {
+          "name": "subcategory",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_products_name": {
+          "name": "idx_products_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_name_unique": {
+          "name": "idx_products_name_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_product_code_unique": {
+          "name": "idx_products_product_code_unique",
+          "columns": [
+            {
+              "expression": "product_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_supplier_id": {
+          "name": "idx_products_supplier_id",
+          "columns": [
+            {
+              "expression": "supplier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_type": {
+          "name": "idx_products_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "products_supplier_id_suppliers_id_fk": {
+          "name": "products_supplier_id_suppliers_id_fk",
+          "tableFrom": "products",
+          "tableTo": "suppliers",
+          "columnsFrom": ["supplier_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_types": {
+      "name": "product_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_unit": {
+          "name": "cost_unit",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unit'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_product_types_name": {
+          "name": "idx_product_types_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "product_types_name_unique": {
+          "name": "product_types_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "product_types_cost_unit_check": {
+          "name": "product_types_cost_unit_check",
+          "value": "\"product_types\".\"cost_unit\" IN ('unit', 'hours')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#3b82f6'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_projects_client_id": {
+          "name": "idx_projects_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_client_id_clients_id_fk": {
+          "name": "projects_client_id_clients_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_projects": {
+      "name": "user_projects",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_source": {
+          "name": "assignment_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_projects_user_id_users_id_fk": {
+          "name": "user_projects_user_id_users_id_fk",
+          "tableFrom": "user_projects",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_projects_project_id_projects_id_fk": {
+          "name": "user_projects_project_id_projects_id_fk",
+          "tableFrom": "user_projects",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_projects_user_id_project_id_pk": {
+          "name": "user_projects_user_id_project_id_pk",
+          "columns": ["user_id", "project_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_projects_assignment_source_check": {
+          "name": "user_projects_assignment_source_check",
+          "value": "\"user_projects\".\"assignment_source\" IN ('manual', 'top_manager_auto', 'project_cascade')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.quote_items": {
+      "name": "quote_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_cost": {
+          "name": "product_cost",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_mol_percentage": {
+          "name": "product_mol_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_id": {
+          "name": "supplier_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_item_id": {
+          "name": "supplier_quote_item_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_supplier_name": {
+          "name": "supplier_quote_supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_unit_price": {
+          "name": "supplier_quote_unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_type": {
+          "name": "unit_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'hours'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_quote_items_quote_id": {
+          "name": "idx_quote_items_quote_id",
+          "columns": [
+            {
+              "expression": "quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quote_items_quote_id_quotes_id_fk": {
+          "name": "quote_items_quote_id_quotes_id_fk",
+          "tableFrom": "quote_items",
+          "tableTo": "quotes",
+          "columnsFrom": ["quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "quote_items_product_id_products_id_fk": {
+          "name": "quote_items_product_id_products_id_fk",
+          "tableFrom": "quote_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_quote_items_unit_type": {
+          "name": "chk_quote_items_unit_type",
+          "value": "\"quote_items\".\"unit_type\" IN ('hours', 'days', 'unit')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.quotes": {
+      "name": "quotes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_quotes_client_id": {
+          "name": "idx_quotes_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quotes_status": {
+          "name": "idx_quotes_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quotes_created_at": {
+          "name": "idx_quotes_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quotes_client_id_clients_id_fk": {
+          "name": "quotes_client_id_clients_id_fk",
+          "tableFrom": "quotes",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "quotes_status_check": {
+          "name": "quotes_status_check",
+          "value": "\"quotes\".\"status\" IN ('quoted', 'confirmed', 'draft', 'sent', 'accepted', 'denied')"
+        },
+        "chk_quotes_discount_type": {
+          "name": "chk_quotes_discount_type",
+          "value": "\"quotes\".\"discount_type\" IN ('percentage', 'currency')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.quote_versions": {
+      "name": "quote_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'update'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_quote_versions_quote_id_created_at": {
+          "name": "idx_quote_versions_quote_id_created_at",
+          "columns": [
+            {
+              "expression": "quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quote_versions_quote_id_quotes_id_fk": {
+          "name": "quote_versions_quote_id_quotes_id_fk",
+          "tableFrom": "quote_versions",
+          "tableTo": "quotes",
+          "columnsFrom": ["quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "quote_versions_created_by_user_id_users_id_fk": {
+          "name": "quote_versions_created_by_user_id_users_id_fk",
+          "tableFrom": "quote_versions",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_quote_versions_reason": {
+          "name": "chk_quote_versions_reason",
+          "value": "\"quote_versions\".\"reason\" IN ('update', 'restore')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.report_chat_messages": {
+      "name": "report_chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thought_content": {
+          "name": "thought_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_report_chat_messages_session_created": {
+          "name": "idx_report_chat_messages_session_created",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_chat_messages_session_id_report_chat_sessions_id_fk": {
+          "name": "report_chat_messages_session_id_report_chat_sessions_id_fk",
+          "tableFrom": "report_chat_messages",
+          "tableTo": "report_chat_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "report_chat_messages_role_check": {
+          "name": "report_chat_messages_role_check",
+          "value": "\"report_chat_messages\".\"role\" IN ('user', 'assistant')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.report_chat_sessions": {
+      "name": "report_chat_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'AI Reporting'"
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_report_chat_sessions_user_updated": {
+          "name": "idx_report_chat_sessions_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_report_chat_sessions_user_archived": {
+          "name": "idx_report_chat_sessions_user_archived",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_chat_sessions_user_id_users_id_fk": {
+          "name": "report_chat_sessions_user_id_users_id_fk",
+          "tableFrom": "report_chat_sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_permissions": {
+      "name": "role_permissions",
+      "schema": "",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_permissions_role_id_roles_id_fk": {
+          "name": "role_permissions_role_id_roles_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "roles",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "role_permissions_role_id_permission_pk": {
+          "name": "role_permissions_role_id_permission_pk",
+          "columns": ["role_id", "permission"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roles": {
+      "name": "roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_roles": {
+      "name": "user_roles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_roles_user_id_users_id_fk": {
+          "name": "user_roles_user_id_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_role_id_roles_id_fk": {
+          "name": "user_roles_role_id_roles_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "roles",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_roles_user_id_role_id_pk": {
+          "name": "user_roles_user_id_role_id_pk",
+          "columns": ["user_id", "role_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sale_items": {
+      "name": "sale_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sale_id": {
+          "name": "sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_cost": {
+          "name": "product_cost",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_mol_percentage": {
+          "name": "product_mol_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "unit_type": {
+          "name": "unit_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'hours'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_id": {
+          "name": "supplier_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_item_id": {
+          "name": "supplier_quote_item_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_supplier_name": {
+          "name": "supplier_quote_supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_unit_price": {
+          "name": "supplier_quote_unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_sale_id": {
+          "name": "supplier_sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_sale_item_id": {
+          "name": "supplier_sale_item_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_sale_supplier_name": {
+          "name": "supplier_sale_supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_sale_items_sale_id": {
+          "name": "idx_sale_items_sale_id",
+          "columns": [
+            {
+              "expression": "sale_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sale_items_supplier_sale_id": {
+          "name": "idx_sale_items_supplier_sale_id",
+          "columns": [
+            {
+              "expression": "supplier_sale_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sale_items_sale_id_sales_id_fk": {
+          "name": "sale_items_sale_id_sales_id_fk",
+          "tableFrom": "sale_items",
+          "tableTo": "sales",
+          "columnsFrom": ["sale_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "sale_items_product_id_products_id_fk": {
+          "name": "sale_items_product_id_products_id_fk",
+          "tableFrom": "sale_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_sale_items_unit_type": {
+          "name": "chk_sale_items_unit_type",
+          "value": "\"sale_items\".\"unit_type\" IN ('hours', 'days', 'unit')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sales": {
+      "name": "sales",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_quote_id": {
+          "name": "linked_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_offer_id": {
+          "name": "linked_offer_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_sales_client_id": {
+          "name": "idx_sales_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_status": {
+          "name": "idx_sales_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_linked_quote_id": {
+          "name": "idx_sales_linked_quote_id",
+          "columns": [
+            {
+              "expression": "linked_quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_linked_offer_id": {
+          "name": "idx_sales_linked_offer_id",
+          "columns": [
+            {
+              "expression": "linked_offer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_linked_offer_id_unique": {
+          "name": "idx_sales_linked_offer_id_unique",
+          "columns": [
+            {
+              "expression": "linked_offer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sales\".\"linked_offer_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_created_at": {
+          "name": "idx_sales_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sales_linked_quote_id_quotes_id_fk": {
+          "name": "sales_linked_quote_id_quotes_id_fk",
+          "tableFrom": "sales",
+          "tableTo": "quotes",
+          "columnsFrom": ["linked_quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "sales_linked_offer_id_customer_offers_id_fk": {
+          "name": "sales_linked_offer_id_customer_offers_id_fk",
+          "tableFrom": "sales",
+          "tableTo": "customer_offers",
+          "columnsFrom": ["linked_offer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "sales_client_id_clients_id_fk": {
+          "name": "sales_client_id_clients_id_fk",
+          "tableFrom": "sales",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sales_status_check": {
+          "name": "sales_status_check",
+          "value": "\"sales\".\"status\" IN ('draft', 'confirmed', 'denied')"
+        },
+        "chk_sales_discount_type": {
+          "name": "chk_sales_discount_type",
+          "value": "\"sales\".\"discount_type\" IN ('percentage', 'currency')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "daily_goal": {
+          "name": "daily_goal",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'8.00'"
+        },
+        "start_of_week": {
+          "name": "start_of_week",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Monday'"
+        },
+        "compact_view": {
+          "name": "compact_view",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "treat_saturday_as_holiday": {
+          "name": "treat_saturday_as_holiday",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "settings_user_id_users_id_fk": {
+          "name": "settings_user_id_users_id_fk",
+          "tableFrom": "settings",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "settings_user_id_unique": {
+          "name": "settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "settings_language_check": {
+          "name": "settings_language_check",
+          "value": "\"settings\".\"language\" IN ('en', 'it', 'auto')"
+        },
+        "settings_start_of_week_check": {
+          "name": "settings_start_of_week_check",
+          "value": "\"settings\".\"start_of_week\" IN ('Monday', 'Sunday')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier_invoice_items": {
+      "name": "supplier_invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_invoice_items_invoice_id": {
+          "name": "idx_supplier_invoice_items_invoice_id",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_invoice_items_invoice_id_supplier_invoices_id_fk": {
+          "name": "supplier_invoice_items_invoice_id_supplier_invoices_id_fk",
+          "tableFrom": "supplier_invoice_items",
+          "tableTo": "supplier_invoices",
+          "columnsFrom": ["invoice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "supplier_invoice_items_product_id_products_id_fk": {
+          "name": "supplier_invoice_items_product_id_products_id_fk",
+          "tableFrom": "supplier_invoice_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_invoices": {
+      "name": "supplier_invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_sale_id": {
+          "name": "linked_sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_name": {
+          "name": "supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_date": {
+          "name": "issue_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "amount_paid": {
+          "name": "amount_paid",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_invoices_supplier_id": {
+          "name": "idx_supplier_invoices_supplier_id",
+          "columns": [
+            {
+              "expression": "supplier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_invoices_status": {
+          "name": "idx_supplier_invoices_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_invoices_issue_date": {
+          "name": "idx_supplier_invoices_issue_date",
+          "columns": [
+            {
+              "expression": "issue_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_invoices_linked_sale_id": {
+          "name": "idx_supplier_invoices_linked_sale_id",
+          "columns": [
+            {
+              "expression": "linked_sale_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_invoices_linked_sale_id_unique": {
+          "name": "idx_supplier_invoices_linked_sale_id_unique",
+          "columns": [
+            {
+              "expression": "linked_sale_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"supplier_invoices\".\"linked_sale_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_invoices_linked_sale_id_supplier_sales_id_fk": {
+          "name": "supplier_invoices_linked_sale_id_supplier_sales_id_fk",
+          "tableFrom": "supplier_invoices",
+          "tableTo": "supplier_sales",
+          "columnsFrom": ["linked_sale_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "supplier_invoices_supplier_id_suppliers_id_fk": {
+          "name": "supplier_invoices_supplier_id_suppliers_id_fk",
+          "tableFrom": "supplier_invoices",
+          "tableTo": "suppliers",
+          "columnsFrom": ["supplier_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "supplier_invoices_status_check": {
+          "name": "supplier_invoices_status_check",
+          "value": "\"supplier_invoices\".\"status\" IN ('draft', 'sent', 'paid', 'overdue', 'cancelled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier_quote_items": {
+      "name": "supplier_quote_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "unit_type": {
+          "name": "unit_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'hours'"
+        }
+      },
+      "indexes": {
+        "idx_supplier_quote_items_quote_id": {
+          "name": "idx_supplier_quote_items_quote_id",
+          "columns": [
+            {
+              "expression": "quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_quote_items_quote_id_supplier_quotes_id_fk": {
+          "name": "supplier_quote_items_quote_id_supplier_quotes_id_fk",
+          "tableFrom": "supplier_quote_items",
+          "tableTo": "supplier_quotes",
+          "columnsFrom": ["quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "supplier_quote_items_product_id_products_id_fk": {
+          "name": "supplier_quote_items_product_id_products_id_fk",
+          "tableFrom": "supplier_quote_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_supplier_quote_items_unit_type": {
+          "name": "chk_supplier_quote_items_unit_type",
+          "value": "\"supplier_quote_items\".\"unit_type\" IN ('hours', 'days', 'unit')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier_quotes": {
+      "name": "supplier_quotes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_name": {
+          "name": "supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_quotes_supplier_id": {
+          "name": "idx_supplier_quotes_supplier_id",
+          "columns": [
+            {
+              "expression": "supplier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_quotes_status": {
+          "name": "idx_supplier_quotes_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_quotes_created_at": {
+          "name": "idx_supplier_quotes_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_quotes_supplier_id_suppliers_id_fk": {
+          "name": "supplier_quotes_supplier_id_suppliers_id_fk",
+          "tableFrom": "supplier_quotes",
+          "tableTo": "suppliers",
+          "columnsFrom": ["supplier_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "supplier_quotes_status_check": {
+          "name": "supplier_quotes_status_check",
+          "value": "\"supplier_quotes\".\"status\" IN ('received', 'approved', 'rejected', 'draft', 'sent', 'accepted', 'denied')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier_sale_items": {
+      "name": "supplier_sale_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sale_id": {
+          "name": "sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_sale_items_sale_id": {
+          "name": "idx_supplier_sale_items_sale_id",
+          "columns": [
+            {
+              "expression": "sale_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_sale_items_sale_id_supplier_sales_id_fk": {
+          "name": "supplier_sale_items_sale_id_supplier_sales_id_fk",
+          "tableFrom": "supplier_sale_items",
+          "tableTo": "supplier_sales",
+          "columnsFrom": ["sale_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "supplier_sale_items_product_id_products_id_fk": {
+          "name": "supplier_sale_items_product_id_products_id_fk",
+          "tableFrom": "supplier_sale_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_sales": {
+      "name": "supplier_sales",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_quote_id": {
+          "name": "linked_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_name": {
+          "name": "supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_sales_supplier_id": {
+          "name": "idx_supplier_sales_supplier_id",
+          "columns": [
+            {
+              "expression": "supplier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_sales_status": {
+          "name": "idx_supplier_sales_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_sales_linked_quote_id": {
+          "name": "idx_supplier_sales_linked_quote_id",
+          "columns": [
+            {
+              "expression": "linked_quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_sales_linked_quote_id_supplier_quotes_id_fk": {
+          "name": "supplier_sales_linked_quote_id_supplier_quotes_id_fk",
+          "tableFrom": "supplier_sales",
+          "tableTo": "supplier_quotes",
+          "columnsFrom": ["linked_quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "supplier_sales_supplier_id_suppliers_id_fk": {
+          "name": "supplier_sales_supplier_id_suppliers_id_fk",
+          "tableFrom": "supplier_sales",
+          "tableTo": "suppliers",
+          "columnsFrom": ["supplier_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "supplier_sales_status_check": {
+          "name": "supplier_sales_status_check",
+          "value": "\"supplier_sales\".\"status\" IN ('draft', 'sent')"
+        },
+        "chk_supplier_sales_discount_type": {
+          "name": "chk_supplier_sales_discount_type",
+          "value": "\"supplier_sales\".\"discount_type\" IN ('percentage', 'currency')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.suppliers": {
+      "name": "suppliers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "supplier_code": {
+          "name": "supplier_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_code": {
+          "name": "tax_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_suppliers_name": {
+          "name": "idx_suppliers_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "recurrence_pattern": {
+          "name": "recurrence_pattern",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_start": {
+          "name": "recurrence_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_end": {
+          "name": "recurrence_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_duration": {
+          "name": "recurrence_duration",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "expected_effort": {
+          "name": "expected_effort",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "revenue": {
+          "name": "revenue",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tasks_project_id_projects_id_fk": {
+          "name": "tasks_project_id_projects_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_tasks": {
+      "name": "user_tasks",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_source": {
+          "name": "assignment_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_tasks_user_id_users_id_fk": {
+          "name": "user_tasks_user_id_users_id_fk",
+          "tableFrom": "user_tasks",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_tasks_task_id_tasks_id_fk": {
+          "name": "user_tasks_task_id_tasks_id_fk",
+          "tableFrom": "user_tasks",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_tasks_user_id_task_id_pk": {
+          "name": "user_tasks_user_id_task_id_pk",
+          "columns": ["user_id", "task_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_tasks_assignment_source_check": {
+          "name": "user_tasks_assignment_source_check",
+          "value": "\"user_tasks\".\"assignment_source\" IN ('manual', 'top_manager_auto', 'project_cascade')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.time_entries": {
+      "name": "time_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_name": {
+          "name": "project_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task": {
+          "name": "task",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "hourly_cost": {
+          "name": "hourly_cost",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "is_placeholder": {
+          "name": "is_placeholder",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'remote'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_time_entries_user_id": {
+          "name": "idx_time_entries_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_time_entries_date": {
+          "name": "idx_time_entries_date",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_time_entries_project_id": {
+          "name": "idx_time_entries_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_time_entries_task_id": {
+          "name": "idx_time_entries_task_id",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_time_entries_created_at_id": {
+          "name": "idx_time_entries_created_at_id",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_time_entries_user_id_created_at_id": {
+          "name": "idx_time_entries_user_id_created_at_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "time_entries_user_id_users_id_fk": {
+          "name": "time_entries_user_id_users_id_fk",
+          "tableFrom": "time_entries",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "time_entries_client_id_clients_id_fk": {
+          "name": "time_entries_client_id_clients_id_fk",
+          "tableFrom": "time_entries",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "time_entries_project_id_projects_id_fk": {
+          "name": "time_entries_project_id_projects_id_fk",
+          "tableFrom": "time_entries",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "time_entries_task_id_tasks_id_fk": {
+          "name": "time_entries_task_id_tasks_id_fk",
+          "tableFrom": "time_entries",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "time_entries_location_check": {
+          "name": "time_entries_location_check",
+          "value": "\"time_entries\".\"location\" IN ('remote', 'office', 'customer_premise', 'transfer')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_initials": {
+          "name": "avatar_initials",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_per_hour": {
+          "name": "cost_per_hour",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "employee_type": {
+          "name": "employee_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'app_user'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_role_roles_id_fk": {
+          "name": "users_role_roles_id_fk",
+          "tableFrom": "users",
+          "tableTo": "roles",
+          "columnsFrom": ["role"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": ["username"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_employee_type_check": {
+          "name": "users_employee_type_check",
+          "value": "\"users\".\"employee_type\" IN ('app_user', 'internal', 'external')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_work_units": {
+      "name": "user_work_units",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "work_unit_id": {
+          "name": "work_unit_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_work_units_user_id_users_id_fk": {
+          "name": "user_work_units_user_id_users_id_fk",
+          "tableFrom": "user_work_units",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_work_units_work_unit_id_work_units_id_fk": {
+          "name": "user_work_units_work_unit_id_work_units_id_fk",
+          "tableFrom": "user_work_units",
+          "tableTo": "work_units",
+          "columnsFrom": ["work_unit_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_work_units_user_id_work_unit_id_pk": {
+          "name": "user_work_units_user_id_work_unit_id_pk",
+          "columns": ["user_id", "work_unit_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.work_unit_managers": {
+      "name": "work_unit_managers",
+      "schema": "",
+      "columns": {
+        "work_unit_id": {
+          "name": "work_unit_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "work_unit_managers_work_unit_id_work_units_id_fk": {
+          "name": "work_unit_managers_work_unit_id_work_units_id_fk",
+          "tableFrom": "work_unit_managers",
+          "tableTo": "work_units",
+          "columnsFrom": ["work_unit_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "work_unit_managers_user_id_users_id_fk": {
+          "name": "work_unit_managers_user_id_users_id_fk",
+          "tableFrom": "work_unit_managers",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "work_unit_managers_work_unit_id_user_id_pk": {
+          "name": "work_unit_managers_work_unit_id_user_id_pk",
+          "columns": ["work_unit_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.work_units": {
+      "name": "work_units",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1777832429529,
       "tag": "0018_model_remaining_constraints_and_fks",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1778019372919,
+      "tag": "0019_add_quote_versions",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/schema/index.ts
+++ b/server/db/schema/index.ts
@@ -14,6 +14,7 @@ export * from './products.ts';
 export * from './productTypes.ts';
 export * from './projects.ts';
 export * from './quotes.ts';
+export * from './quoteVersions.ts';
 export * from './reportChatMessages.ts';
 export * from './reportChatSessions.ts';
 export * from './roles.ts';

--- a/server/db/schema/quoteVersions.ts
+++ b/server/db/schema/quoteVersions.ts
@@ -1,0 +1,35 @@
+import { sql } from 'drizzle-orm';
+import { check, index, jsonb, pgTable, timestamp, varchar } from 'drizzle-orm/pg-core';
+import type { ClientQuote, ClientQuoteItem } from '../../repositories/clientQuotesRepo.ts';
+import { quotes } from './quotes.ts';
+import { users } from './users.ts';
+
+// Versioned envelope so future schema changes on quotes/quote_items can normalize old
+// snapshots on read instead of being trapped by a frozen JSONB shape. Bump `schemaVersion`
+// when the underlying domain types change in a non-additive way. `linkedOfferId` is omitted
+// because it's derived from a join, not stored on the row.
+export interface QuoteVersionSnapshot {
+  schemaVersion: 1;
+  quote: Omit<ClientQuote, 'linkedOfferId'>;
+  items: ClientQuoteItem[];
+}
+
+export const quoteVersions = pgTable(
+  'quote_versions',
+  {
+    id: varchar('id', { length: 50 }).primaryKey(),
+    quoteId: varchar('quote_id', { length: 100 })
+      .notNull()
+      .references(() => quotes.id, { onDelete: 'cascade', onUpdate: 'cascade' }),
+    snapshot: jsonb('snapshot').$type<QuoteVersionSnapshot>().notNull(),
+    reason: varchar('reason', { length: 20 }).notNull().default('update'),
+    createdByUserId: varchar('created_by_user_id', { length: 50 }).references(() => users.id, {
+      onDelete: 'set null',
+    }),
+    createdAt: timestamp('created_at').default(sql`CURRENT_TIMESTAMP`),
+  },
+  (table) => [
+    index('idx_quote_versions_quote_id_created_at').on(table.quoteId, table.createdAt.desc()),
+    check('chk_quote_versions_reason', sql`${table.reason} IN ('update', 'restore')`),
+  ],
+);

--- a/server/repositories/clientQuotesRepo.ts
+++ b/server/repositories/clientQuotesRepo.ts
@@ -309,6 +309,20 @@ export const findItemsForQuote = async (
   return rows.map(mapItem);
 };
 
+// Uses BASE projection (linkedOfferId NULL) because snapshots store on-row data only;
+// the offer-link join is reconstructed on read, not frozen into history.
+export const findFullForSnapshot = async (
+  id: string,
+  exec: DbExecutor = db,
+): Promise<{ quote: ClientQuote; items: ClientQuoteItem[] } | null> => {
+  const [quoteRows, items] = await Promise.all([
+    exec.select(QUOTE_BASE_PROJECTION).from(quotes).where(eq(quotes.id, id)).limit(1),
+    findItemsForQuote(id, exec),
+  ]);
+  if (quoteRows.length === 0) return null;
+  return { quote: mapQuote(quoteRows[0]), items };
+};
+
 export type NewClientQuote = {
   id: string;
   clientId: string;

--- a/server/repositories/clientQuotesRepo.ts
+++ b/server/repositories/clientQuotesRepo.ts
@@ -368,6 +368,14 @@ export type ClientQuoteUpdate = {
   notes?: string | null;
 };
 
+export type ClientQuoteRestoreFields = Pick<
+  ClientQuote,
+  'clientId' | 'clientName' | 'discount' | 'discountType' | 'status' | 'notes'
+> & {
+  paymentTerms: string;
+  expirationDate: string;
+};
+
 export const update = async (
   id: string,
   patch: ClientQuoteUpdate,
@@ -385,6 +393,29 @@ export const update = async (
       status: sql`COALESCE(${patch.status ?? null}, ${quotes.status})`,
       expirationDate: sql`COALESCE(${patch.expirationDate ?? null}::date, ${quotes.expirationDate})`,
       notes: sql`COALESCE(${patch.notes ?? null}, ${quotes.notes})`,
+      updatedAt: sql`CURRENT_TIMESTAMP`,
+    })
+    .where(eq(quotes.id, id))
+    .returning(QUOTE_BASE_PROJECTION);
+  return rows[0] ? mapQuote(rows[0]) : null;
+};
+
+export const restoreSnapshotQuote = async (
+  id: string,
+  snapshot: ClientQuoteRestoreFields,
+  exec: DbExecutor = db,
+): Promise<ClientQuote | null> => {
+  const rows = await exec
+    .update(quotes)
+    .set({
+      clientId: snapshot.clientId,
+      clientName: snapshot.clientName,
+      paymentTerms: snapshot.paymentTerms,
+      discount: numericForDb(snapshot.discount),
+      discountType: snapshot.discountType,
+      status: snapshot.status,
+      expirationDate: snapshot.expirationDate,
+      notes: snapshot.notes,
       updatedAt: sql`CURRENT_TIMESTAMP`,
     })
     .where(eq(quotes.id, id))

--- a/server/repositories/clientsRepo.ts
+++ b/server/repositories/clientsRepo.ts
@@ -224,6 +224,11 @@ export const findContactsForUpdate = async (
   return { contacts: parseContactsFromDb(rows[0].contacts) };
 };
 
+export const existsById = async (id: string, exec: DbExecutor = db): Promise<boolean> => {
+  const rows = await exec.select({ id: clients.id }).from(clients).where(eq(clients.id, id));
+  return rows.length > 0;
+};
+
 export const findByFiscalCode = async (
   fiscalCode: string,
   excludeId: string | null,

--- a/server/repositories/quoteVersionsRepo.ts
+++ b/server/repositories/quoteVersionsRepo.ts
@@ -1,0 +1,110 @@
+import { and, desc, eq } from 'drizzle-orm';
+import { type DbExecutor, db } from '../db/drizzle.ts';
+import { type QuoteVersionSnapshot, quoteVersions } from '../db/schema/quoteVersions.ts';
+import { generatePrefixedId } from '../utils/order-ids.ts';
+import type { ClientQuote, ClientQuoteItem } from './clientQuotesRepo.ts';
+
+export type { QuoteVersionSnapshot } from '../db/schema/quoteVersions.ts';
+
+export type QuoteVersionReason = 'update' | 'restore';
+
+export type QuoteVersionRow = {
+  id: string;
+  quoteId: string;
+  reason: QuoteVersionReason;
+  createdByUserId: string | null;
+  createdAt: number;
+};
+
+export type QuoteVersion = QuoteVersionRow & { snapshot: QuoteVersionSnapshot };
+
+type QuoteVersionRowSelect = Pick<
+  typeof quoteVersions.$inferSelect,
+  'id' | 'quoteId' | 'reason' | 'createdByUserId' | 'createdAt'
+>;
+
+const mapRow = (row: QuoteVersionRowSelect): QuoteVersionRow => ({
+  id: row.id,
+  quoteId: row.quoteId,
+  reason: row.reason === 'restore' ? 'restore' : 'update',
+  createdByUserId: row.createdByUserId,
+  createdAt: row.createdAt?.getTime() ?? 0,
+});
+
+const mapVersion = (row: typeof quoteVersions.$inferSelect): QuoteVersion => ({
+  ...mapRow(row),
+  snapshot: row.snapshot,
+});
+
+export const buildSnapshot = (
+  quote: ClientQuote,
+  items: ClientQuoteItem[],
+): QuoteVersionSnapshot => {
+  const { linkedOfferId: _linked, ...quoteSnapshot } = quote;
+  return { schemaVersion: 1, quote: quoteSnapshot, items };
+};
+
+export const listForQuote = async (
+  quoteId: string,
+  exec: DbExecutor = db,
+): Promise<QuoteVersionRow[]> => {
+  const rows = await exec
+    .select({
+      id: quoteVersions.id,
+      quoteId: quoteVersions.quoteId,
+      reason: quoteVersions.reason,
+      createdByUserId: quoteVersions.createdByUserId,
+      createdAt: quoteVersions.createdAt,
+    })
+    .from(quoteVersions)
+    .where(eq(quoteVersions.quoteId, quoteId))
+    .orderBy(desc(quoteVersions.createdAt));
+  return rows.map(mapRow);
+};
+
+// Scoped on BOTH quoteId and id so a versionId cannot be used to read a snapshot from a
+// different quote (cross-quote restore would otherwise be possible).
+export const findById = async (
+  quoteId: string,
+  versionId: string,
+  exec: DbExecutor = db,
+): Promise<QuoteVersion | null> => {
+  const rows = await exec
+    .select()
+    .from(quoteVersions)
+    .where(and(eq(quoteVersions.quoteId, quoteId), eq(quoteVersions.id, versionId)))
+    .limit(1);
+  return rows[0] ? mapVersion(rows[0]) : null;
+};
+
+export type NewQuoteVersionInput = {
+  quoteId: string;
+  snapshot: QuoteVersionSnapshot;
+  reason: QuoteVersionReason;
+  createdByUserId: string | null;
+};
+
+export const insert = async (
+  input: NewQuoteVersionInput,
+  exec: DbExecutor = db,
+): Promise<QuoteVersionRow> => {
+  const rows = await exec
+    .insert(quoteVersions)
+    .values({
+      id: generatePrefixedId('qv'),
+      quoteId: input.quoteId,
+      snapshot: input.snapshot,
+      reason: input.reason,
+      createdByUserId: input.createdByUserId,
+    })
+    .returning();
+  return mapRow(rows[0]);
+};
+
+export const deleteAllForQuote = async (
+  quoteId: string,
+  exec: DbExecutor = db,
+): Promise<number> => {
+  const result = await exec.delete(quoteVersions).where(eq(quoteVersions.quoteId, quoteId));
+  return result.rowCount ?? 0;
+};

--- a/server/routes/client-quotes.ts
+++ b/server/routes/client-quotes.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { type DbExecutor, withDbTransaction } from '../db/drizzle.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
 import * as clientQuotesRepo from '../repositories/clientQuotesRepo.ts';
+import * as clientsRepo from '../repositories/clientsRepo.ts';
 import * as productsRepo from '../repositories/productsRepo.ts';
 import * as quoteVersionsRepo from '../repositories/quoteVersionsRepo.ts';
 import * as supplierQuotesRepo from '../repositories/supplierQuotesRepo.ts';
@@ -438,6 +439,28 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       },
       tx,
     );
+  };
+
+  const findMissingSnapshotReference = async (
+    snapshot: quoteVersionsRepo.QuoteVersionSnapshot,
+  ): Promise<string | null> => {
+    const clientExists = await clientsRepo.existsById(snapshot.quote.clientId);
+    if (!clientExists) {
+      return `Snapshot client "${snapshot.quote.clientId}" no longer exists`;
+    }
+
+    const productIds = Array.from(
+      new Set(
+        snapshot.items
+          .map((item) => item.productId)
+          .filter((id): id is string => typeof id === 'string' && id.length > 0),
+      ),
+    );
+    if (productIds.length === 0) return null;
+
+    const products = await productsRepo.getSnapshots(productIds);
+    const missingProductId = productIds.find((id) => !products.has(id));
+    return missingProductId ? `Snapshot product "${missingProductId}" no longer exists` : null;
   };
 
   // GET / - List all quotes with their items
@@ -1035,6 +1058,14 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       if (!version) {
         return reply.code(404).send({ error: 'Version not found' });
       }
+      const missingSnapshotReference = await findMissingSnapshotReference(version.snapshot);
+      if (missingSnapshotReference) {
+        return reply.code(409).send({ error: missingSnapshotReference });
+      }
+      const snapshotExpirationDate = version.snapshot.quote.expirationDate;
+      if (!snapshotExpirationDate) {
+        return reply.code(409).send({ error: 'Snapshot expiration date is missing' });
+      }
 
       const snapshotItems: clientQuotesRepo.NewClientQuoteItem[] = version.snapshot.items.map(
         ({ quoteId: _q, ...rest }) => ({
@@ -1055,16 +1086,16 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         // Snapshot current with reason='restore' so the just-replaced data stays recoverable.
         await snapshotPreState(idResult.value, 'restore', request, tx);
 
-        const quote = await clientQuotesRepo.update(
+        const quote = await clientQuotesRepo.restoreSnapshotQuote(
           idResult.value,
           {
             clientId: version.snapshot.quote.clientId,
             clientName: version.snapshot.quote.clientName,
-            paymentTerms: version.snapshot.quote.paymentTerms,
+            paymentTerms: version.snapshot.quote.paymentTerms ?? 'immediate',
             discount: version.snapshot.quote.discount,
             discountType: version.snapshot.quote.discountType,
             status: version.snapshot.quote.status,
-            expirationDate: version.snapshot.quote.expirationDate,
+            expirationDate: snapshotExpirationDate,
             notes: version.snapshot.quote.notes,
           },
           tx,

--- a/server/routes/client-quotes.ts
+++ b/server/routes/client-quotes.ts
@@ -1,8 +1,9 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
-import { withDbTransaction } from '../db/drizzle.ts';
+import { type DbExecutor, withDbTransaction } from '../db/drizzle.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
 import * as clientQuotesRepo from '../repositories/clientQuotesRepo.ts';
 import * as productsRepo from '../repositories/productsRepo.ts';
+import * as quoteVersionsRepo from '../repositories/quoteVersionsRepo.ts';
 import * as supplierQuotesRepo from '../repositories/supplierQuotesRepo.ts';
 import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
 import { logAudit } from '../utils/audit.ts';
@@ -420,6 +421,25 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
     return isPastLocalDate(expirationDate);
   };
 
+  const snapshotPreState = async (
+    quoteId: string,
+    reason: quoteVersionsRepo.QuoteVersionReason,
+    request: FastifyRequest,
+    tx: DbExecutor,
+  ) => {
+    const pre = await clientQuotesRepo.findFullForSnapshot(quoteId, tx);
+    if (!pre) return;
+    await quoteVersionsRepo.insert(
+      {
+        quoteId,
+        snapshot: quoteVersionsRepo.buildSnapshot(pre.quote, pre.items),
+        reason,
+        createdByUserId: request.user?.id ?? null,
+      },
+      tx,
+    );
+  };
+
   // GET / - List all quotes with their items
   fastify.get(
     '/',
@@ -797,6 +817,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       };
       try {
         result = await withDbTransaction(async (tx) => {
+          // ID-only renames cascade through the FK and don't alter snapshot content, so we
+          // skip them to keep the history clean.
+          if (!isIdOnlyUpdate) {
+            await snapshotPreState(idResult.value, 'update', request, tx);
+          }
           const quote = await clientQuotesRepo.update(
             idResult.value,
             {
@@ -860,6 +885,214 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           typeof isExpiredOverride === 'boolean'
             ? isExpiredOverride
             : isQuoteExpired(updatedQuote.status, updatedQuote.expirationDate),
+      };
+    },
+  );
+
+  // ---------------------------------------------------------------------------------------
+  // Version history
+  // ---------------------------------------------------------------------------------------
+
+  const versionParamSchema = {
+    type: 'object',
+    properties: {
+      id: { type: 'string' },
+      versionId: { type: 'string' },
+    },
+    required: ['id', 'versionId'],
+  } as const;
+
+  const quoteVersionRowSchema = {
+    type: 'object',
+    properties: {
+      id: { type: 'string' },
+      quoteId: { type: 'string' },
+      reason: { type: 'string', enum: ['update', 'restore'] },
+      createdByUserId: { type: ['string', 'null'] },
+      createdAt: { type: 'number' },
+    },
+    required: ['id', 'quoteId', 'reason', 'createdAt'],
+  } as const;
+
+  const quoteVersionSchema = {
+    type: 'object',
+    properties: { ...quoteVersionRowSchema.properties, snapshot: {} },
+    required: [...quoteVersionRowSchema.required, 'snapshot'],
+  } as const;
+
+  // GET /:id/versions - List versions for a quote
+  fastify.get(
+    '/:id/versions',
+    {
+      onRequest: [
+        fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
+        requirePermission('sales.client_quotes.view'),
+      ],
+      schema: {
+        tags: ['client-quotes'],
+        summary: 'List versions for a client quote',
+        params: idParamSchema,
+        response: {
+          200: { type: 'array', items: quoteVersionRowSchema },
+          ...standardRateLimitedErrorResponses,
+        },
+      },
+    },
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      const { id } = request.params as { id: string };
+      const idResult = requireNonEmptyString(id, 'id');
+      if (!idResult.ok) return badRequest(reply, idResult.message);
+
+      const [exists, versions] = await Promise.all([
+        clientQuotesRepo.existsById(idResult.value),
+        quoteVersionsRepo.listForQuote(idResult.value),
+      ]);
+      if (!exists) {
+        return reply.code(404).send({ error: 'Quote not found' });
+      }
+      return versions;
+    },
+  );
+
+  // GET /:id/versions/:versionId - Get a single version with its snapshot
+  fastify.get(
+    '/:id/versions/:versionId',
+    {
+      onRequest: [
+        fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
+        requirePermission('sales.client_quotes.view'),
+      ],
+      schema: {
+        tags: ['client-quotes'],
+        summary: 'Get a single client quote version',
+        params: versionParamSchema,
+        response: {
+          200: quoteVersionSchema,
+          ...standardRateLimitedErrorResponses,
+        },
+      },
+    },
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      const { id, versionId } = request.params as { id: string; versionId: string };
+      const idResult = requireNonEmptyString(id, 'id');
+      if (!idResult.ok) return badRequest(reply, idResult.message);
+      const versionIdResult = requireNonEmptyString(versionId, 'versionId');
+      if (!versionIdResult.ok) return badRequest(reply, versionIdResult.message);
+
+      const version = await quoteVersionsRepo.findById(idResult.value, versionIdResult.value);
+      if (!version) {
+        return reply.code(404).send({ error: 'Version not found' });
+      }
+      return version;
+    },
+  );
+
+  // POST /:id/versions/:versionId/restore - Atomic restore (snapshots current first)
+  fastify.post(
+    '/:id/versions/:versionId/restore',
+    {
+      onRequest: [requirePermission('sales.client_quotes.update')],
+      schema: {
+        tags: ['client-quotes'],
+        summary: 'Restore a client quote to a prior version',
+        params: versionParamSchema,
+        response: {
+          200: quoteSchema,
+          ...standardErrorResponses,
+        },
+      },
+    },
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      const { id, versionId } = request.params as { id: string; versionId: string };
+      const idResult = requireNonEmptyString(id, 'id');
+      if (!idResult.ok) return badRequest(reply, idResult.message);
+      const versionIdResult = requireNonEmptyString(versionId, 'versionId');
+      if (!versionIdResult.ok) return badRequest(reply, versionIdResult.message);
+
+      // Independent reads — fan out, then run the gating ladder against resolved values.
+      // Same read-only rules as PUT.
+      const [linkedOfferId, current, nonDraftLinkedSale, version] = await Promise.all([
+        clientQuotesRepo.findLinkedOfferId(idResult.value),
+        clientQuotesRepo.findCurrentForUpdate(idResult.value),
+        clientQuotesRepo.findNonDraftLinkedSale(idResult.value),
+        quoteVersionsRepo.findById(idResult.value, versionIdResult.value),
+      ]);
+
+      if (linkedOfferId) {
+        return reply.code(409).send({ error: 'Quotes become read-only once an offer exists' });
+      }
+      if (!current) {
+        return reply.code(404).send({ error: 'Quote not found' });
+      }
+      if (current.status === 'confirmed') {
+        return reply.code(409).send({ error: 'Confirmed quotes are read-only' });
+      }
+      if (nonDraftLinkedSale) {
+        return reply.code(409).send({
+          error: 'Restore is only possible when linked sale orders are in draft status',
+        });
+      }
+      if (!version) {
+        return reply.code(404).send({ error: 'Version not found' });
+      }
+
+      // Drop draft sales mirroring the PUT-restore branch — historical line items may not
+      // line up with the current draft sale's row references.
+      await clientQuotesRepo.deleteDraftSalesForQuote(idResult.value);
+
+      const snapshotItems: clientQuotesRepo.NewClientQuoteItem[] = version.snapshot.items.map(
+        ({ quoteId: _q, ...rest }) => ({
+          ...rest,
+          id: generateQuoteItemId(),
+          // `productId: ''` slips through the snapshot when sourced from a supplier quote;
+          // the `quote_items` row needs NULL there.
+          productId: rest.productId || null,
+        }),
+      );
+
+      const restored = await withDbTransaction(async (tx) => {
+        // Snapshot current with reason='restore' so the just-replaced data stays recoverable.
+        await snapshotPreState(idResult.value, 'restore', request, tx);
+
+        const quote = await clientQuotesRepo.update(
+          idResult.value,
+          {
+            clientId: version.snapshot.quote.clientId,
+            clientName: version.snapshot.quote.clientName,
+            paymentTerms: version.snapshot.quote.paymentTerms,
+            discount: version.snapshot.quote.discount,
+            discountType: version.snapshot.quote.discountType,
+            status: version.snapshot.quote.status,
+            expirationDate: version.snapshot.quote.expirationDate,
+            notes: version.snapshot.quote.notes,
+          },
+          tx,
+        );
+        if (!quote) return { quote: null, items: [] };
+        const items = await clientQuotesRepo.replaceItems(quote.id, snapshotItems, tx);
+        return { quote, items };
+      });
+
+      if (!restored.quote) {
+        return reply.code(404).send({ error: 'Quote not found' });
+      }
+
+      await logAudit({
+        request,
+        action: 'client_quote.restored',
+        entityType: 'client_quote',
+        entityId: restored.quote.id,
+        details: {
+          targetLabel: restored.quote.id,
+          secondaryLabel: restored.quote.clientName,
+          toValue: versionIdResult.value,
+        },
+      });
+
+      return {
+        ...restored.quote,
+        items: restored.items,
+        isExpired: isQuoteExpired(restored.quote.status, restored.quote.expirationDate),
       };
     },
   );

--- a/server/routes/client-quotes.ts
+++ b/server/routes/client-quotes.ts
@@ -1036,10 +1036,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         return reply.code(404).send({ error: 'Version not found' });
       }
 
-      // Drop draft sales mirroring the PUT-restore branch — historical line items may not
-      // line up with the current draft sale's row references.
-      await clientQuotesRepo.deleteDraftSalesForQuote(idResult.value);
-
       const snapshotItems: clientQuotesRepo.NewClientQuoteItem[] = version.snapshot.items.map(
         ({ quoteId: _q, ...rest }) => ({
           ...rest,
@@ -1051,6 +1047,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       );
 
       const restored = await withDbTransaction(async (tx) => {
+        // Drop draft sales inside the tx — historical line items may not line up with the
+        // current draft sale's row references, but if the snapshot/update later fails the
+        // rollback must take the deletes with it (otherwise users lose draft orders for
+        // an unchanged quote).
+        await clientQuotesRepo.deleteDraftSalesForQuote(idResult.value, tx);
         // Snapshot current with reason='restore' so the just-replaced data stays recoverable.
         await snapshotPreState(idResult.value, 'restore', request, tx);
 

--- a/server/test/repositories/clientQuotesRepo.test.ts
+++ b/server/test/repositories/clientQuotesRepo.test.ts
@@ -218,6 +218,50 @@ describe('update', () => {
   });
 });
 
+describe('restoreSnapshotQuote', () => {
+  test('sets nullable notes directly instead of COALESCE-keeping the old value', async () => {
+    exec.enqueue({ rows: [quoteRow()] });
+    await clientQuotesRepo.restoreSnapshotQuote(
+      'cq-1',
+      {
+        clientId: 'c-1',
+        clientName: 'Acme',
+        paymentTerms: 'net30',
+        discount: 10,
+        discountType: 'percentage',
+        status: 'draft',
+        expirationDate: '2026-06-01',
+        notes: null,
+      },
+      testDb,
+    );
+    const sql = exec.calls[0].sql.toLowerCase();
+    expect(sql).toContain('update "quotes"');
+    expect(sql).not.toContain('coalesce');
+    expect(exec.calls[0].params).toContain(null);
+    expect(exec.calls[0].params).toContain('cq-1');
+  });
+
+  test('returns null when no row is restored', async () => {
+    exec.enqueue({ rows: [] });
+    const result = await clientQuotesRepo.restoreSnapshotQuote(
+      'cq-x',
+      {
+        clientId: 'c-1',
+        clientName: 'Acme',
+        paymentTerms: 'net30',
+        discount: 10,
+        discountType: 'percentage',
+        status: 'draft',
+        expirationDate: '2026-06-01',
+        notes: null,
+      },
+      testDb,
+    );
+    expect(result).toBeNull();
+  });
+});
+
 describe('replaceItems', () => {
   test('issues DELETE then bulk INSERT and preserves order', async () => {
     exec.enqueue({ rows: [] });

--- a/server/test/repositories/clientsRepo.test.ts
+++ b/server/test/repositories/clientsRepo.test.ts
@@ -162,6 +162,19 @@ describe('findContactsForUpdate', () => {
   });
 });
 
+describe('existsById', () => {
+  test('returns true when a client row exists', async () => {
+    exec.enqueue({ rows: [['c-1']] });
+    expect(await clientsRepo.existsById('c-1', testDb)).toBe(true);
+    expect(exec.calls[0].params).toContain('c-1');
+  });
+
+  test('returns false when a client row is missing', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await clientsRepo.existsById('c-x', testDb)).toBe(false);
+  });
+});
+
 describe('findByFiscalCode', () => {
   test('queries with LOWER for case-insensitive match without exclude', async () => {
     exec.enqueue({ rows: [['c-1']] });

--- a/server/test/routes/client-quotes-versions.test.ts
+++ b/server/test/routes/client-quotes-versions.test.ts
@@ -2,6 +2,8 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, tes
 import type { FastifyInstance, FastifyPluginAsync } from 'fastify';
 import * as realDrizzle from '../../db/drizzle.ts';
 import * as realClientQuotesRepo from '../../repositories/clientQuotesRepo.ts';
+import * as realClientsRepo from '../../repositories/clientsRepo.ts';
+import * as realProductsRepo from '../../repositories/productsRepo.ts';
 import * as realQuoteVersionsRepo from '../../repositories/quoteVersionsRepo.ts';
 import * as realRolesRepo from '../../repositories/rolesRepo.ts';
 import * as realSupplierQuotesRepo from '../../repositories/supplierQuotesRepo.ts';
@@ -18,7 +20,9 @@ import { signToken } from '../helpers/jwt.ts';
 const usersRepoSnap = { ...realUsersRepo };
 const rolesRepoSnap = { ...realRolesRepo };
 const permissionsSnap = { ...realPermissions };
+const clientsRepoSnap = { ...realClientsRepo };
 const clientQuotesRepoSnap = { ...realClientQuotesRepo };
+const productsRepoSnap = { ...realProductsRepo };
 const quoteVersionsRepoSnap = { ...realQuoteVersionsRepo };
 const supplierQuotesRepoSnap = { ...realSupplierQuotesRepo };
 const auditSnap = { ...realAudit };
@@ -38,7 +42,11 @@ const cqFindFullForSnapshotMock = mock();
 const cqFindItemsForQuoteMock = mock();
 const cqFindIdConflictMock = mock();
 const cqUpdateMock = mock();
+const cqRestoreSnapshotQuoteMock = mock();
 const cqReplaceItemsMock = mock();
+
+const clientsExistsByIdMock = mock();
+const productsGetSnapshotsMock = mock();
 
 const qvListForQuoteMock = mock();
 const qvFindByIdMock = mock();
@@ -65,6 +73,10 @@ beforeAll(async () => {
     ...permissionsSnap,
     getRolePermissions: getRolePermissionsMock,
   }));
+  mock.module('../../repositories/clientsRepo.ts', () => ({
+    ...clientsRepoSnap,
+    existsById: clientsExistsByIdMock,
+  }));
   mock.module('../../repositories/clientQuotesRepo.ts', () => ({
     ...clientQuotesRepoSnap,
     existsById: cqExistsByIdMock,
@@ -77,7 +89,12 @@ beforeAll(async () => {
     findItemsForQuote: cqFindItemsForQuoteMock,
     findIdConflict: cqFindIdConflictMock,
     update: cqUpdateMock,
+    restoreSnapshotQuote: cqRestoreSnapshotQuoteMock,
     replaceItems: cqReplaceItemsMock,
+  }));
+  mock.module('../../repositories/productsRepo.ts', () => ({
+    ...productsRepoSnap,
+    getSnapshots: productsGetSnapshotsMock,
   }));
   mock.module('../../repositories/quoteVersionsRepo.ts', () => ({
     ...quoteVersionsRepoSnap,
@@ -106,7 +123,9 @@ afterAll(() => {
   mock.module('../../repositories/usersRepo.ts', () => usersRepoSnap);
   mock.module('../../repositories/rolesRepo.ts', () => rolesRepoSnap);
   mock.module('../../utils/permissions.ts', () => permissionsSnap);
+  mock.module('../../repositories/clientsRepo.ts', () => clientsRepoSnap);
   mock.module('../../repositories/clientQuotesRepo.ts', () => clientQuotesRepoSnap);
+  mock.module('../../repositories/productsRepo.ts', () => productsRepoSnap);
   mock.module('../../repositories/quoteVersionsRepo.ts', () => quoteVersionsRepoSnap);
   mock.module('../../repositories/supplierQuotesRepo.ts', () => supplierQuotesRepoSnap);
   mock.module('../../utils/audit.ts', () => auditSnap);
@@ -192,7 +211,10 @@ const allMocks = [
   cqFindItemsForQuoteMock,
   cqFindIdConflictMock,
   cqUpdateMock,
+  cqRestoreSnapshotQuoteMock,
   cqReplaceItemsMock,
+  clientsExistsByIdMock,
+  productsGetSnapshotsMock,
   qvListForQuoteMock,
   qvFindByIdMock,
   qvInsertMock,
@@ -316,7 +338,11 @@ describe('POST /api/sales/client-quotes/:id/versions/:versionId/restore', () => 
       items: [SAMPLE_ITEM],
     });
     qvInsertMock.mockResolvedValue({ ...SAMPLE_VERSION_ROW, reason: 'restore' });
-    cqUpdateMock.mockResolvedValue(SAMPLE_QUOTE);
+    clientsExistsByIdMock.mockResolvedValue(true);
+    productsGetSnapshotsMock.mockResolvedValue(
+      new Map([['p-1', { productCost: 50, productMolPercentage: null }]]),
+    );
+    cqRestoreSnapshotQuoteMock.mockResolvedValue(SAMPLE_QUOTE);
     cqReplaceItemsMock.mockResolvedValue([SAMPLE_ITEM]);
   };
 
@@ -340,7 +366,13 @@ describe('POST /api/sales/client-quotes/:id/versions/:versionId/restore', () => 
       undefined,
     );
     // Quote and items applied
-    expect(cqUpdateMock).toHaveBeenCalled();
+    expect(clientsExistsByIdMock).toHaveBeenCalledWith('c1');
+    expect(productsGetSnapshotsMock).toHaveBeenCalledWith(['p-1']);
+    expect(cqRestoreSnapshotQuoteMock).toHaveBeenCalledWith(
+      'q-1',
+      expect.objectContaining({ notes: null }),
+      undefined,
+    );
     expect(cqReplaceItemsMock).toHaveBeenCalled();
     // Atomically wrapped
     expect(withDbTransactionMock).toHaveBeenCalled();
@@ -365,7 +397,7 @@ describe('POST /api/sales/client-quotes/:id/versions/:versionId/restore', () => 
     });
 
     expect(res.statusCode).toBe(409);
-    expect(cqUpdateMock).not.toHaveBeenCalled();
+    expect(cqRestoreSnapshotQuoteMock).not.toHaveBeenCalled();
     expect(qvInsertMock).not.toHaveBeenCalled();
   });
 
@@ -380,7 +412,7 @@ describe('POST /api/sales/client-quotes/:id/versions/:versionId/restore', () => 
     });
 
     expect(res.statusCode).toBe(404);
-    expect(cqUpdateMock).not.toHaveBeenCalled();
+    expect(cqRestoreSnapshotQuoteMock).not.toHaveBeenCalled();
   });
 
   test('409 when quote is confirmed', async () => {
@@ -398,7 +430,7 @@ describe('POST /api/sales/client-quotes/:id/versions/:versionId/restore', () => 
     });
 
     expect(res.statusCode).toBe(409);
-    expect(cqUpdateMock).not.toHaveBeenCalled();
+    expect(cqRestoreSnapshotQuoteMock).not.toHaveBeenCalled();
   });
 
   test('409 when non-draft linked sale exists', async () => {
@@ -418,7 +450,39 @@ describe('POST /api/sales/client-quotes/:id/versions/:versionId/restore', () => 
 
     expect(res.statusCode).toBe(409);
     expect(cqDeleteDraftSalesForQuoteMock).not.toHaveBeenCalled();
-    expect(cqUpdateMock).not.toHaveBeenCalled();
+    expect(cqRestoreSnapshotQuoteMock).not.toHaveBeenCalled();
+  });
+
+  test('409 when snapshot client no longer exists', async () => {
+    setupHappyPath();
+    clientsExistsByIdMock.mockResolvedValue(false);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/sales/client-quotes/q-1/versions/qv-1/restore',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body).error).toContain('Snapshot client');
+    expect(cqDeleteDraftSalesForQuoteMock).not.toHaveBeenCalled();
+    expect(cqRestoreSnapshotQuoteMock).not.toHaveBeenCalled();
+  });
+
+  test('409 when snapshot product no longer exists', async () => {
+    setupHappyPath();
+    productsGetSnapshotsMock.mockResolvedValue(new Map());
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/sales/client-quotes/q-1/versions/qv-1/restore',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body).error).toContain('Snapshot product');
+    expect(cqDeleteDraftSalesForQuoteMock).not.toHaveBeenCalled();
+    expect(cqRestoreSnapshotQuoteMock).not.toHaveBeenCalled();
   });
 
   test('404 when version not found (and no cross-quote leak)', async () => {
@@ -440,7 +504,7 @@ describe('POST /api/sales/client-quotes/:id/versions/:versionId/restore', () => 
     expect(res.statusCode).toBe(404);
     // findById should be scoped on (quoteId, versionId) so a foreign versionId returns null
     expect(qvFindByIdMock).toHaveBeenCalledWith('q-1', 'qv-other');
-    expect(cqUpdateMock).not.toHaveBeenCalled();
+    expect(cqRestoreSnapshotQuoteMock).not.toHaveBeenCalled();
   });
 
   test('403 without update permission (view only)', async () => {

--- a/server/test/routes/client-quotes-versions.test.ts
+++ b/server/test/routes/client-quotes-versions.test.ts
@@ -1,0 +1,507 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { FastifyInstance, FastifyPluginAsync } from 'fastify';
+import * as realDrizzle from '../../db/drizzle.ts';
+import * as realClientQuotesRepo from '../../repositories/clientQuotesRepo.ts';
+import * as realQuoteVersionsRepo from '../../repositories/quoteVersionsRepo.ts';
+import * as realRolesRepo from '../../repositories/rolesRepo.ts';
+import * as realSupplierQuotesRepo from '../../repositories/supplierQuotesRepo.ts';
+import * as realUsersRepo from '../../repositories/usersRepo.ts';
+import * as realAudit from '../../utils/audit.ts';
+import * as realPermissions from '../../utils/permissions.ts';
+import {
+  installAuthMiddlewareMock,
+  restoreAuthMiddlewareMock,
+} from '../helpers/authMiddlewareMock.ts';
+import { buildRouteTestApp } from '../helpers/buildRouteTestApp.ts';
+import { signToken } from '../helpers/jwt.ts';
+
+const usersRepoSnap = { ...realUsersRepo };
+const rolesRepoSnap = { ...realRolesRepo };
+const permissionsSnap = { ...realPermissions };
+const clientQuotesRepoSnap = { ...realClientQuotesRepo };
+const quoteVersionsRepoSnap = { ...realQuoteVersionsRepo };
+const supplierQuotesRepoSnap = { ...realSupplierQuotesRepo };
+const auditSnap = { ...realAudit };
+const drizzleSnap = { ...realDrizzle };
+
+const findAuthUserByIdMock = mock();
+const userHasRoleMock = mock();
+const getRolePermissionsMock = mock();
+
+const cqExistsByIdMock = mock();
+const cqFindLinkedOfferIdMock = mock();
+const cqFindCurrentForUpdateMock = mock();
+const cqFindNonDraftLinkedSaleMock = mock();
+const cqFindAnyLinkedSaleMock = mock();
+const cqDeleteDraftSalesForQuoteMock = mock();
+const cqFindFullForSnapshotMock = mock();
+const cqFindItemsForQuoteMock = mock();
+const cqFindIdConflictMock = mock();
+const cqUpdateMock = mock();
+const cqReplaceItemsMock = mock();
+
+const qvListForQuoteMock = mock();
+const qvFindByIdMock = mock();
+const qvInsertMock = mock();
+const qvBuildSnapshotMock = mock();
+
+const logAuditMock = mock(async () => undefined);
+const withDbTransactionMock = mock(async (cb: (tx: unknown) => unknown) => cb(undefined));
+
+let routePlugin: FastifyPluginAsync;
+
+beforeAll(async () => {
+  installAuthMiddlewareMock();
+
+  mock.module('../../repositories/usersRepo.ts', () => ({
+    ...usersRepoSnap,
+    findAuthUserById: findAuthUserByIdMock,
+  }));
+  mock.module('../../repositories/rolesRepo.ts', () => ({
+    ...rolesRepoSnap,
+    userHasRole: userHasRoleMock,
+  }));
+  mock.module('../../utils/permissions.ts', () => ({
+    ...permissionsSnap,
+    getRolePermissions: getRolePermissionsMock,
+  }));
+  mock.module('../../repositories/clientQuotesRepo.ts', () => ({
+    ...clientQuotesRepoSnap,
+    existsById: cqExistsByIdMock,
+    findLinkedOfferId: cqFindLinkedOfferIdMock,
+    findCurrentForUpdate: cqFindCurrentForUpdateMock,
+    findNonDraftLinkedSale: cqFindNonDraftLinkedSaleMock,
+    findAnyLinkedSale: cqFindAnyLinkedSaleMock,
+    deleteDraftSalesForQuote: cqDeleteDraftSalesForQuoteMock,
+    findFullForSnapshot: cqFindFullForSnapshotMock,
+    findItemsForQuote: cqFindItemsForQuoteMock,
+    findIdConflict: cqFindIdConflictMock,
+    update: cqUpdateMock,
+    replaceItems: cqReplaceItemsMock,
+  }));
+  mock.module('../../repositories/quoteVersionsRepo.ts', () => ({
+    ...quoteVersionsRepoSnap,
+    listForQuote: qvListForQuoteMock,
+    findById: qvFindByIdMock,
+    insert: qvInsertMock,
+    buildSnapshot: qvBuildSnapshotMock,
+  }));
+  mock.module('../../repositories/supplierQuotesRepo.ts', () => ({
+    ...supplierQuotesRepoSnap,
+  }));
+  mock.module('../../utils/audit.ts', () => ({
+    ...auditSnap,
+    logAudit: logAuditMock,
+  }));
+  mock.module('../../db/drizzle.ts', () => ({
+    ...drizzleSnap,
+    withDbTransaction: withDbTransactionMock,
+  }));
+
+  routePlugin = (await import('../../routes/client-quotes.ts')).default as FastifyPluginAsync;
+});
+
+afterAll(() => {
+  restoreAuthMiddlewareMock();
+  mock.module('../../repositories/usersRepo.ts', () => usersRepoSnap);
+  mock.module('../../repositories/rolesRepo.ts', () => rolesRepoSnap);
+  mock.module('../../utils/permissions.ts', () => permissionsSnap);
+  mock.module('../../repositories/clientQuotesRepo.ts', () => clientQuotesRepoSnap);
+  mock.module('../../repositories/quoteVersionsRepo.ts', () => quoteVersionsRepoSnap);
+  mock.module('../../repositories/supplierQuotesRepo.ts', () => supplierQuotesRepoSnap);
+  mock.module('../../utils/audit.ts', () => auditSnap);
+  mock.module('../../db/drizzle.ts', () => drizzleSnap);
+});
+
+const HAPPY_USER = {
+  id: 'u1',
+  name: 'Alice',
+  username: 'alice',
+  role: 'manager',
+  avatarInitials: 'AL',
+  isDisabled: false,
+};
+
+const FULL_PERMS = [
+  'sales.client_quotes.view',
+  'sales.client_quotes.create',
+  'sales.client_quotes.update',
+  'sales.client_quotes.delete',
+];
+
+const SAMPLE_QUOTE = {
+  id: 'q-1',
+  linkedOfferId: null,
+  clientId: 'c1',
+  clientName: 'Client',
+  paymentTerms: 'immediate',
+  discount: 0,
+  discountType: 'percentage' as const,
+  status: 'draft',
+  expirationDate: '2026-12-31',
+  notes: null,
+  createdAt: 1_700_000_000_000,
+  updatedAt: 1_700_000_000_000,
+};
+
+const SAMPLE_ITEM = {
+  id: 'qi-1',
+  quoteId: 'q-1',
+  productId: 'p-1',
+  productName: 'Service',
+  quantity: 2,
+  unitPrice: 100,
+  productCost: 50,
+  productMolPercentage: null,
+  supplierQuoteId: null,
+  supplierQuoteItemId: null,
+  supplierQuoteSupplierName: null,
+  supplierQuoteUnitPrice: null,
+  discount: 0,
+  note: null,
+  unitType: 'hours' as const,
+};
+
+const SAMPLE_SNAPSHOT = {
+  schemaVersion: 1 as const,
+  quote: SAMPLE_QUOTE,
+  items: [SAMPLE_ITEM],
+};
+
+const SAMPLE_VERSION_ROW = {
+  id: 'qv-1',
+  quoteId: 'q-1',
+  reason: 'update' as const,
+  createdByUserId: 'u1',
+  createdAt: 1_700_000_001_000,
+};
+
+const SAMPLE_VERSION = { ...SAMPLE_VERSION_ROW, snapshot: SAMPLE_SNAPSHOT };
+
+const allMocks = [
+  findAuthUserByIdMock,
+  userHasRoleMock,
+  getRolePermissionsMock,
+  cqExistsByIdMock,
+  cqFindLinkedOfferIdMock,
+  cqFindCurrentForUpdateMock,
+  cqFindNonDraftLinkedSaleMock,
+  cqFindAnyLinkedSaleMock,
+  cqDeleteDraftSalesForQuoteMock,
+  cqFindFullForSnapshotMock,
+  cqFindItemsForQuoteMock,
+  cqFindIdConflictMock,
+  cqUpdateMock,
+  cqReplaceItemsMock,
+  qvListForQuoteMock,
+  qvFindByIdMock,
+  qvInsertMock,
+  qvBuildSnapshotMock,
+  logAuditMock,
+  withDbTransactionMock,
+];
+
+let testApp: FastifyInstance;
+
+beforeEach(async () => {
+  for (const m of allMocks) m.mockReset();
+  findAuthUserByIdMock.mockResolvedValue(HAPPY_USER);
+  userHasRoleMock.mockResolvedValue(true);
+  getRolePermissionsMock.mockResolvedValue(FULL_PERMS);
+  withDbTransactionMock.mockImplementation(async (cb) => cb(undefined));
+  logAuditMock.mockImplementation(async () => undefined);
+  qvBuildSnapshotMock.mockImplementation((quote, items) => ({
+    schemaVersion: 1,
+    quote,
+    items,
+  }));
+  // Default safe values for repos that PUT calls but most tests don't care about.
+  cqFindItemsForQuoteMock.mockResolvedValue([SAMPLE_ITEM]);
+  cqFindIdConflictMock.mockResolvedValue(false);
+  cqFindAnyLinkedSaleMock.mockResolvedValue(null);
+
+  testApp = await buildRouteTestApp(routePlugin, '/api/sales/client-quotes');
+});
+
+afterEach(async () => {
+  await testApp.close();
+});
+
+const authHeader = () => ({ authorization: `Bearer ${signToken({ userId: 'u1' })}` });
+
+describe('GET /api/sales/client-quotes/:id/versions', () => {
+  test('200 returns versions newest-first when quote exists', async () => {
+    cqExistsByIdMock.mockResolvedValue(true);
+    qvListForQuoteMock.mockResolvedValue([SAMPLE_VERSION_ROW]);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/sales/client-quotes/q-1/versions',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body).toHaveLength(1);
+    expect(body[0].id).toBe('qv-1');
+    expect(qvListForQuoteMock).toHaveBeenCalledWith('q-1');
+  });
+
+  test('404 when quote does not exist', async () => {
+    cqExistsByIdMock.mockResolvedValue(false);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/sales/client-quotes/missing/versions',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  test('403 missing view permission', async () => {
+    getRolePermissionsMock.mockResolvedValue([]);
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/sales/client-quotes/q-1/versions',
+      headers: authHeader(),
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+describe('GET /api/sales/client-quotes/:id/versions/:versionId', () => {
+  test('200 returns version with snapshot scoped by both ids', async () => {
+    qvFindByIdMock.mockResolvedValue(SAMPLE_VERSION);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/sales/client-quotes/q-1/versions/qv-1',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.id).toBe('qv-1');
+    expect(body.snapshot.quote.id).toBe('q-1');
+    expect(qvFindByIdMock).toHaveBeenCalledWith('q-1', 'qv-1');
+  });
+
+  test('404 when version not found (also covers cross-quote ids)', async () => {
+    qvFindByIdMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/sales/client-quotes/q-1/versions/qv-other',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe('POST /api/sales/client-quotes/:id/versions/:versionId/restore', () => {
+  const setupHappyPath = () => {
+    cqFindLinkedOfferIdMock.mockResolvedValue(null);
+    cqFindCurrentForUpdateMock.mockResolvedValue({
+      status: 'draft',
+      discount: 0,
+      discountType: 'percentage',
+    });
+    cqFindNonDraftLinkedSaleMock.mockResolvedValue(null);
+    cqDeleteDraftSalesForQuoteMock.mockResolvedValue(undefined);
+    qvFindByIdMock.mockResolvedValue(SAMPLE_VERSION);
+    cqFindFullForSnapshotMock.mockResolvedValue({
+      quote: SAMPLE_QUOTE,
+      items: [SAMPLE_ITEM],
+    });
+    qvInsertMock.mockResolvedValue({ ...SAMPLE_VERSION_ROW, reason: 'restore' });
+    cqUpdateMock.mockResolvedValue(SAMPLE_QUOTE);
+    cqReplaceItemsMock.mockResolvedValue([SAMPLE_ITEM]);
+  };
+
+  test('200 happy path snapshots current then applies version atomically', async () => {
+    setupHappyPath();
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/sales/client-quotes/q-1/versions/qv-1/restore',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.id).toBe('q-1');
+    expect(body.items).toHaveLength(1);
+
+    // Pre-restore snapshot inserted with reason='restore'
+    expect(qvInsertMock).toHaveBeenCalledWith(
+      expect.objectContaining({ quoteId: 'q-1', reason: 'restore', createdByUserId: 'u1' }),
+      undefined,
+    );
+    // Quote and items applied
+    expect(cqUpdateMock).toHaveBeenCalled();
+    expect(cqReplaceItemsMock).toHaveBeenCalled();
+    // Atomically wrapped
+    expect(withDbTransactionMock).toHaveBeenCalled();
+    // Audit logged
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'client_quote.restored',
+        entityType: 'client_quote',
+        entityId: 'q-1',
+        details: expect.objectContaining({ toValue: 'qv-1' }),
+      }),
+    );
+  });
+
+  test('409 when linked offer exists', async () => {
+    cqFindLinkedOfferIdMock.mockResolvedValue('off-1');
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/sales/client-quotes/q-1/versions/qv-1/restore',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(cqUpdateMock).not.toHaveBeenCalled();
+    expect(qvInsertMock).not.toHaveBeenCalled();
+  });
+
+  test('404 when current quote does not exist', async () => {
+    cqFindLinkedOfferIdMock.mockResolvedValue(null);
+    cqFindCurrentForUpdateMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/sales/client-quotes/q-1/versions/qv-1/restore',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(cqUpdateMock).not.toHaveBeenCalled();
+  });
+
+  test('409 when quote is confirmed', async () => {
+    cqFindLinkedOfferIdMock.mockResolvedValue(null);
+    cqFindCurrentForUpdateMock.mockResolvedValue({
+      status: 'confirmed',
+      discount: 0,
+      discountType: 'percentage',
+    });
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/sales/client-quotes/q-1/versions/qv-1/restore',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(cqUpdateMock).not.toHaveBeenCalled();
+  });
+
+  test('409 when non-draft linked sale exists', async () => {
+    cqFindLinkedOfferIdMock.mockResolvedValue(null);
+    cqFindCurrentForUpdateMock.mockResolvedValue({
+      status: 'draft',
+      discount: 0,
+      discountType: 'percentage',
+    });
+    cqFindNonDraftLinkedSaleMock.mockResolvedValue('sale-99');
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/sales/client-quotes/q-1/versions/qv-1/restore',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(cqDeleteDraftSalesForQuoteMock).not.toHaveBeenCalled();
+    expect(cqUpdateMock).not.toHaveBeenCalled();
+  });
+
+  test('404 when version not found (and no cross-quote leak)', async () => {
+    cqFindLinkedOfferIdMock.mockResolvedValue(null);
+    cqFindCurrentForUpdateMock.mockResolvedValue({
+      status: 'draft',
+      discount: 0,
+      discountType: 'percentage',
+    });
+    cqFindNonDraftLinkedSaleMock.mockResolvedValue(null);
+    qvFindByIdMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/sales/client-quotes/q-1/versions/qv-other/restore',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(404);
+    // findById should be scoped on (quoteId, versionId) so a foreign versionId returns null
+    expect(qvFindByIdMock).toHaveBeenCalledWith('q-1', 'qv-other');
+    expect(cqUpdateMock).not.toHaveBeenCalled();
+  });
+
+  test('403 without update permission (view only)', async () => {
+    getRolePermissionsMock.mockResolvedValue(['sales.client_quotes.view']);
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/sales/client-quotes/q-1/versions/qv-1/restore',
+      headers: authHeader(),
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+describe('PUT /api/sales/client-quotes/:id snapshots pre-update state', () => {
+  test('PUT with content changes inserts a snapshot inside the transaction', async () => {
+    cqFindLinkedOfferIdMock.mockResolvedValue(null);
+    cqFindCurrentForUpdateMock.mockResolvedValue({
+      status: 'draft',
+      discount: 0,
+      discountType: 'percentage',
+    });
+    cqFindFullForSnapshotMock.mockResolvedValue({
+      quote: SAMPLE_QUOTE,
+      items: [SAMPLE_ITEM],
+    });
+    cqUpdateMock.mockResolvedValue({ ...SAMPLE_QUOTE, status: 'sent' });
+    cqReplaceItemsMock.mockResolvedValue([SAMPLE_ITEM]);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/sales/client-quotes/q-1',
+      headers: authHeader(),
+      payload: { status: 'sent' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(cqFindFullForSnapshotMock).toHaveBeenCalled();
+    expect(qvInsertMock).toHaveBeenCalledWith(
+      expect.objectContaining({ quoteId: 'q-1', reason: 'update', createdByUserId: 'u1' }),
+      undefined,
+    );
+  });
+
+  test('PUT with id-only rename does NOT snapshot (no content change)', async () => {
+    cqFindLinkedOfferIdMock.mockResolvedValue(null);
+    cqFindCurrentForUpdateMock.mockResolvedValue({
+      status: 'draft',
+      discount: 0,
+      discountType: 'percentage',
+    });
+    cqUpdateMock.mockResolvedValue({ ...SAMPLE_QUOTE, id: 'q-1-renamed' });
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/sales/client-quotes/q-1',
+      headers: authHeader(),
+      payload: { id: 'q-1-renamed' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(qvInsertMock).not.toHaveBeenCalled();
+    expect(cqFindFullForSnapshotMock).not.toHaveBeenCalled();
+  });
+});

--- a/services/api/clientQuotes.ts
+++ b/services/api/clientQuotes.ts
@@ -1,4 +1,4 @@
-import type { Quote } from '../../types';
+import type { Quote, QuoteVersion, QuoteVersionRow } from '../../types';
 import { fetchApi } from './client';
 import { normalizeQuote } from './normalizers';
 
@@ -20,4 +20,15 @@ export const clientQuotesApi = {
 
   delete: (id: string): Promise<void> =>
     fetchApi(`/sales/client-quotes/${id}`, { method: 'DELETE' }),
+
+  listVersions: (id: string): Promise<QuoteVersionRow[]> =>
+    fetchApi<QuoteVersionRow[]>(`/sales/client-quotes/${id}/versions`),
+
+  getVersion: (id: string, versionId: string): Promise<QuoteVersion> =>
+    fetchApi<QuoteVersion>(`/sales/client-quotes/${id}/versions/${versionId}`),
+
+  restoreVersion: (id: string, versionId: string): Promise<Quote> =>
+    fetchApi<Quote>(`/sales/client-quotes/${id}/versions/${versionId}/restore`, {
+      method: 'POST',
+    }).then(normalizeQuote),
 };

--- a/types.ts
+++ b/types.ts
@@ -279,6 +279,26 @@ export interface Quote {
   updatedAt: number;
 }
 
+export type QuoteVersionReason = 'update' | 'restore';
+
+export interface QuoteVersionSnapshot {
+  schemaVersion: 1;
+  quote: Omit<Quote, 'items' | 'isExpired' | 'linkedOfferId'>;
+  items: QuoteItem[];
+}
+
+export interface QuoteVersionRow {
+  id: string;
+  quoteId: string;
+  reason: QuoteVersionReason;
+  createdByUserId: string | null;
+  createdAt: number;
+}
+
+export interface QuoteVersion extends QuoteVersionRow {
+  snapshot: QuoteVersionSnapshot;
+}
+
 export interface ClientOfferItem {
   id: string;
   offerId: string;

--- a/utils/date.ts
+++ b/utils/date.ts
@@ -65,3 +65,19 @@ export const formatInsertDate = (timestamp: number | null | undefined): string =
   const year = date.getFullYear();
   return `${day}/${month}/${year}`;
 };
+
+export const formatInsertDateTime = (
+  timestamp: number | null | undefined,
+  locales?: string | string[],
+): string => {
+  if (timestamp === null || timestamp === undefined) return '-';
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return '-';
+  return date.toLocaleString(locales, {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+};


### PR DESCRIPTION
## Summary

- Adds a floating version-history panel to the **Modifica Preventivo** modal listing past versions (newest-first, with timestamp + `update`/`restore` badge).
- Each successful `PUT /api/sales/client-quotes/:id` auto-snapshots the *pre-update* state into a new `quote_versions` table inside the same transaction (skipped on id-only renames since the FK cascades).
- New `POST /:id/versions/:versionId/restore` endpoint atomically snapshots the current state with `reason='restore'`, then applies the chosen version's quote + items in one transaction. Same read-only gating as PUT (linked offer / confirmed / non-draft sale → 409).

## Implementation notes

- **Storage**: single `quote_versions` table with a JSONB `snapshot` column (versioned envelope `{ schemaVersion: 1, quote: Omit<ClientQuote, 'linkedOfferId'>, items: ClientQuoteItem[] }`). FK to `quotes` with `ON DELETE CASCADE` and `ON UPDATE CASCADE` so history follows id renames.
- **Routes**: `GET /:id/versions` (newest-first list, no snapshot bodies), `GET /:id/versions/:versionId` (single version with snapshot), `POST /:id/versions/:versionId/restore`. Cross-quote 404 enforced by scoping `findById` on both `quoteId` and `id`.
- **Repository**: new `quoteVersionsRepo` (`listForQuote`, `findById`, `insert`, `buildSnapshot`, `deleteAllForQuote`); plus `clientQuotesRepo.findFullForSnapshot` which reads quote + items in parallel.
- **Frontend**: `components/sales/QuoteVersionsPanel.tsx` rendered as a sibling inside the existing `Modal` portal (`hidden 2xl:flex` so it sits clean of the modal box on ≥1536px screens). Click a row → fetches the snapshot, populates the form as a read-only preview with a `Back to current` banner. Restore goes through `DeleteConfirmModal`. New `onQuoteRestored` prop in [App.tsx](https://github.com/xBounceIT/praetor/blob/claude/blissful-yalow-6e36e6/App.tsx#L3214) patches local state without re-PUTting.
- **i18n**: new keys under `sales:clientQuotes.versionHistory.*` (EN + IT).
- **Audit**: emits `client_quote.restored` action via existing `logAudit` helper.

## Test plan

- [x] `cd server && bun test` — full suite passes (991/991, 14 new tests in `client-quotes-versions.test.ts` covering all three endpoints, PUT auto-snapshot, id-only skip, all 409s, cross-quote 404, permission gating).
- [x] `bun run lint` — clean (the 4 pre-existing warnings are in untouched files).
- [x] Server `tsc -p tsconfig.json` and frontend Vite build both succeed.
- [ ] On the dev Docker: `cd server && bun run db:migrate` to apply `0019_add_quote_versions.sql`.
- [ ] Manual UI walkthrough: edit a draft quote → save → reopen → verify panel shows 1 version → make 2 more edits → preview an older version → `Back to current` rehydrates the live form → Restore → confirm → quote in list reflects restored data and panel now has the new `restore`-reason snapshot.
- [ ] Verify Restore is disabled (server returns 409 if forced) for quotes with a linked offer or `confirmed` status.
- [ ] Delete a quote with versions → confirm `quote_versions` rows are cascade-deleted.

## Known limitations

- The panel is hidden under 1536px viewport (the modal is `max-w-7xl` = 1280px, plus 288px panel + gap doesn't fit cleanly on smaller screens). Reasonable for a desktop ERP; revisit if users hit it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)