### PR TITLE
fix(docker): run drizzle migrations before backend startup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Wait for Drizzle startup migration
         run: |
           for i in $(seq 1 30); do
-            container_id=$(docker compose ps -q db-migrations)
+            container_id=$(docker compose ps -a -q db-migrations)
             if [ -n "$container_id" ]; then
               state=$(docker inspect "$container_id" --format '{{.State.Status}}')
               exit_code=$(docker inspect "$container_id" --format '{{.State.ExitCode}}')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,8 +111,31 @@ jobs:
       - name: Build images
         run: docker compose build
 
-      - name: Start stack and wait for healthchecks
-        run: docker compose up -d --wait --wait-timeout 60
+      - name: Start stack
+        run: docker compose up -d
+
+      - name: Wait for Drizzle startup migration
+        run: |
+          for i in $(seq 1 30); do
+            container_id=$(docker compose ps -q db-migrations)
+            if [ -n "$container_id" ]; then
+              state=$(docker inspect "$container_id" --format '{{.State.Status}}')
+              exit_code=$(docker inspect "$container_id" --format '{{.State.ExitCode}}')
+              if [ "$state" = "exited" ] && [ "$exit_code" = "0" ]; then
+                echo "db-migrations completed after ~$((i*2))s"
+                exit 0
+              fi
+              if [ "$state" = "exited" ]; then
+                echo "::error::db-migrations exited with code $exit_code"
+                docker compose logs db-migrations
+                exit 1
+              fi
+            fi
+            sleep 2
+          done
+          echo "::error::db-migrations did not complete within 60s"
+          docker compose logs db-migrations
+          exit 1
 
       - name: Wait for backend startup signal
         run: |
@@ -127,16 +150,7 @@ jobs:
           docker compose logs backend
           exit 1
 
-      # The backend image is built with `bun install --frozen-lockfile` (no
-      # production flag), so drizzle-orm and the drizzle.config.ts/db/* sources
-      # are all present in the running container. Running migrate inside the
-      # backend container exercises the exact code path a deploy would use, on
-      # a Postgres that was bootstrapped from schema.sql by the postgres init
-      # mount — mirroring the dev/prod baseline scenario.
-      - name: Apply Drizzle baseline migration
-        run: docker compose exec -T backend bun run db:migrate
-
-      - name: Verify Drizzle baseline migration is idempotent
+      - name: Verify Drizzle startup migration is idempotent
         run: docker compose exec -T backend bun run db:migrate
 
       - name: Verify migration recorded in __drizzle_migrations
@@ -178,7 +192,7 @@ jobs:
 
       - name: Verify all defined services are running
         run: |
-          expected=$(docker compose config --services | sort | paste -sd, -)
+          expected=$(docker compose config --services | grep -vx 'db-migrations' | sort | paste -sd, -)
           running=$(docker compose ps --status running --services | sort | paste -sd, -)
           echo "running:  $running"
           echo "expected: $expected"
@@ -192,14 +206,15 @@ jobs:
         run: |
           mkdir -p logs
           docker compose logs --no-color --no-log-prefix postgres > logs/postgres.log 2>&1 || true
+          docker compose logs --no-color --no-log-prefix db-migrations > logs/db-migrations.log 2>&1 || true
           docker compose logs --no-color --no-log-prefix backend > logs/backend.log 2>&1 || true
           docker compose logs --no-color --no-log-prefix frontend > logs/frontend.log 2>&1 || true
-          perl -i -pe 's/\e\[[\d;]*[A-Za-z]//g' logs/postgres.log logs/backend.log logs/frontend.log
+          perl -i -pe 's/\e\[[\d;]*[A-Za-z]//g' logs/postgres.log logs/db-migrations.log logs/backend.log logs/frontend.log
 
       - name: Dump container logs to console
         if: always()
         run: |
-          for svc in postgres backend frontend; do
+          for svc in postgres db-migrations backend frontend; do
             echo "===== $svc ====="
             cat "logs/$svc.log"
           done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
     build:
       context: ./server
       dockerfile: Dockerfile
+    image: praetor-backend
     container_name: praetor-backend
     environment:
       PORT: 3001
@@ -45,9 +46,28 @@ services:
     expose:
       - '3001'
     depends_on:
+      db-migrations:
+        condition: service_completed_successfully
+    restart: unless-stopped
+
+  # Apply pending Drizzle migrations before the API starts
+  db-migrations:
+    build:
+      context: ./server
+      dockerfile: Dockerfile
+    image: praetor-backend
+    container_name: praetor-db-migrations
+    command: ['bun', 'run', 'db:migrate']
+    environment:
+      DB_HOST: postgres
+      DB_PORT: 5432
+      DB_NAME: ${POSTGRES_DB:-praetor}
+      DB_USER: ${POSTGRES_USER:-praetor}
+      DB_PASSWORD: ${POSTGRES_PASSWORD:-praetor}
+    depends_on:
       postgres:
         condition: service_healthy
-    restart: unless-stopped
+    restart: 'no'
 
   # Frontend (Caddy serving static files)
   frontend:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,16 @@
+x-backend-image: &backend-image praetor-backend
+
+x-backend-build: &backend-build
+  context: ./server
+  dockerfile: Dockerfile
+
+x-backend-db-env: &backend-db-env
+  DB_HOST: postgres
+  DB_PORT: 5432
+  DB_NAME: ${POSTGRES_DB:-praetor}
+  DB_USER: ${POSTGRES_USER:-praetor}
+  DB_PASSWORD: ${POSTGRES_PASSWORD:-praetor}
+
 services:
   # Developer compose (builds images from local source).
   # PostgreSQL Database
@@ -23,18 +36,12 @@ services:
 
   # Backend API Server
   backend:
-    build:
-      context: ./server
-      dockerfile: Dockerfile
-    image: praetor-backend
+    build: *backend-build
+    image: *backend-image
     container_name: praetor-backend
     environment:
+      <<: *backend-db-env
       PORT: 3001
-      DB_HOST: postgres
-      DB_PORT: 5432
-      DB_NAME: ${POSTGRES_DB:-praetor}
-      DB_USER: ${POSTGRES_USER:-praetor}
-      DB_PASSWORD: ${POSTGRES_PASSWORD:-praetor}
       JWT_SECRET: ${JWT_SECRET:-praetor-secret-key-change-in-production}
       ENCRYPTION_KEY: ${ENCRYPTION_KEY:-praetor-encryption-key-change-in-production}
       TRUST_PROXY: ${TRUST_PROXY:-1}
@@ -52,18 +59,11 @@ services:
 
   # Apply pending Drizzle migrations before the API starts
   db-migrations:
-    build:
-      context: ./server
-      dockerfile: Dockerfile
-    image: praetor-backend
+    build: *backend-build
+    image: *backend-image
     container_name: praetor-db-migrations
     command: ['bun', 'run', 'db:migrate']
-    environment:
-      DB_HOST: postgres
-      DB_PORT: 5432
-      DB_NAME: ${POSTGRES_DB:-praetor}
-      DB_USER: ${POSTGRES_USER:-praetor}
-      DB_PASSWORD: ${POSTGRES_PASSWORD:-praetor}
+    environment: *backend-db-env
     depends_on:
       postgres:
         condition: service_healthy

--- a/server/db/README.md
+++ b/server/db/README.md
@@ -60,6 +60,12 @@ Use the same pattern for indexes (`CREATE INDEX IF NOT EXISTS`) and tables that 
 
 ## Applying migrations
 
+Docker Compose applies pending migrations automatically through the one-shot
+`db-migrations` service. The backend service waits for that service to complete
+successfully before starting.
+
+For a non-Compose local DB, apply migrations manually:
+
 ```bash
 cd server
 bun run db:migrate
@@ -72,7 +78,10 @@ Idempotent: re-running is a no-op if everything's applied. The runner is `script
 Bootstrap order for a fresh local DB:
 
 1. Apply `schema.sql` (`psql -f db/schema.sql` or via the existing Docker bootstrap).
-2. From `server/`, run `bun run db:migrate`. The migrations are written with `IF NOT EXISTS` guards so they're no-ops on a DB that already matches; their rows still land in `__drizzle_migrations` so subsequent migrations apply normally.
+2. If using Docker Compose, the `db-migrations` service runs automatically before the backend
+   starts. Otherwise, from `server/`, run `bun run db:migrate`. The migrations are written
+   with `IF NOT EXISTS` guards so they're no-ops on a DB that already matches; their rows
+   still land in `__drizzle_migrations` so subsequent migrations apply normally.
 
 For a Drizzle-only fresh DB (skipping `schema.sql`): every existing migration uses `CREATE TABLE IF NOT EXISTS` and friends, so applying them in order produces a fully-formed schema. This path isn't the production bootstrap, but it's how `db:check` and CI verify the migrations.
 


### PR DESCRIPTION
## Summary
- add a one-shot `db-migrations` Compose service that runs `bun run db:migrate` after Postgres is healthy
- make the backend wait for successful migration completion before starting
- update CI Docker stack checks and database migration docs for the new startup flow

## Verification
- `bun run lint` (passes; reports existing unrelated Biome warnings)
- `cd server && bun run db:check`
- `git diff --check`

Docker runtime verification was not run locally because Docker is not available in this environment.