### PR TITLE
fix(layout): keep profile dropdown above table sticky-right column

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -672,7 +672,7 @@ const Layout: React.FC<LayoutProps> = ({
       </nav>
 
       <main className="flex-1 overflow-y-auto">
-        <header className="sticky top-0 z-20 bg-white/80 backdrop-blur-md border-b border-slate-200 px-8 py-4 flex justify-between items-center">
+        <header className="sticky top-0 z-40 bg-white/80 backdrop-blur-md border-b border-slate-200 px-8 py-4 flex justify-between items-center">
           <h2 className="text-lg font-semibold text-slate-800 capitalize flex items-center gap-3">
             <span className="md:hidden w-2 h-6 bg-praetor rounded-full"></span>
             {isNotFound

--- a/test/components/Layout.test.tsx
+++ b/test/components/Layout.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test';
+import { render } from '@testing-library/react';
+import type { Role, User } from '../../types';
+import { installI18nMock } from '../helpers/i18n';
+
+installI18nMock();
+
+const Layout = (await import('../../components/Layout')).default;
+
+const mockUser: User = {
+  id: 'u1',
+  name: 'Test User',
+  role: 'manager',
+  avatarInitials: 'TU',
+  username: 'testuser',
+  permissions: [],
+};
+
+const mockRoles: Role[] = [];
+
+describe('<Layout />', () => {
+  test('header sits at z-40 so it paints above the table sticky-right cells (z-20)', () => {
+    const { container } = render(
+      <Layout
+        activeView="timesheets/tracker"
+        onViewChange={() => {}}
+        currentUser={mockUser}
+        onLogout={() => {}}
+        onSwitchRole={() => {}}
+        roles={mockRoles}
+      >
+        <div>content</div>
+      </Layout>,
+    );
+
+    const header = container.querySelector('header');
+    expect(header).not.toBeNull();
+    const classes = header?.className.split(/\s+/) ?? [];
+    expect(classes).toContain('z-40');
+    expect(classes).not.toContain('z-20');
+  });
+});


### PR DESCRIPTION
## Summary

- The user-profile dropdown opened from the avatar in the top-right header was being painted **under** the table's sticky-right action column ("AZIONI"). The popup itself rendered at the right coordinates — it just lost the z-index battle with the table.
- Bump the header from `z-20` to `z-40` so its stacking context paints above the table's sticky-right cells (`z-20` in `components/shared/StandardTable.tsx`).

## Why this happened (stacking context, not a missing z-index)

- The `<header>` in `components/Layout.tsx` has `sticky top-0` + `backdrop-blur-md` — both force it to create its own stacking context at level `z-20` in the parent.
- The dropdown's internal `z-30` only matters *inside* the header's context. From the outside, the whole header (popup included) paints at level 20.
- The table's sticky-right action header/body cells also sit at `z-20`, in the same parent stacking context, and come *later* in the DOM — so the table wins the tie.
- Raising the header to `z-40` makes its entire context (popup, notification bell, etc.) paint above the table's sticky cells. Modal overlays at `z-50` still cover the header, preserving existing behavior.

## Why `z-40` specifically

Existing layers in the codebase (no Tailwind theme overrides):

| Level | Used by |
|---|---|
| `z-10` | Table column resize handle |
| `z-20` | Header (was), table sticky-right cells |
| `z-30` | Sidebar, profile dropdown (inside header), notification-bell trigger |
| `z-40` | Sidebar collapse-toggle button |
| `z-50` | Modal overlays, notification-bell dropdown, table filter popups |

`z-40` puts the header above sticky cells and sidebar (flex siblings — no visual overlap, just semantically the topmost layer of in-page content) while staying below `z-50` so modals still dim the header.

## Test plan

- [x] New regression test `test/components/Layout.test.tsx` asserts the header className contains `z-40` and not `z-20`. Verified it **fails** on the old code and **passes** on the fix (per CLAUDE.md's bug-fix-test rule).
- [x] `bun run test:frontend` — 285/285 pass.
- [x] `tsc -p tsconfig.json --noEmit` — clean.
- [x] `biome check` on changed files — clean.
- [ ] Manual: open a view with a sticky-right action column (Offerte / Preventivi / time tracking), click the avatar — confirm the dropdown sits above the AZIONI column header and action icons.
- [ ] Manual: open any modal — confirm the header is still dimmed under the overlay (modals at `z-50` still win).
- [ ] Manual: open the notification bell — confirm it still opens above the header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)