### PR TITLE
fix(sales): show unit-selector value in supplier quotes; add FieldTooltips

### DIFF
--- a/components/sales/SupplierQuotesView.tsx
+++ b/components/sales/SupplierQuotesView.tsx
@@ -19,10 +19,12 @@ import { convertUnitPrice, parseNumberInputValue } from '../../utils/numbers';
 import { getPaymentTermsOptions } from '../../utils/options';
 import CostSummaryPanel from '../shared/CostSummaryPanel';
 import CustomSelect from '../shared/CustomSelect';
+import FieldTooltip from '../shared/FieldTooltip';
 import Modal from '../shared/Modal';
 import StandardTable, { type Column } from '../shared/StandardTable';
 import StatusBadge, { type StatusType } from '../shared/StatusBadge';
 import Tooltip from '../shared/Tooltip';
+import UnitTypeSelector from '../shared/UnitTypeSelector';
 import ValidatedNumberInput from '../shared/ValidatedNumberInput';
 
 interface TotalsBreakdown {
@@ -109,6 +111,13 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
   const [formData, setFormData] = useState<Partial<SupplierQuote>>(getDefaultFormData());
 
   const isReadOnly = Boolean(editingQuote?.linkedOrderId);
+
+  const readOnlyReason = t('sales:supplierQuotes.readOnlyLinked', {
+    defaultValue: 'This quote is read-only because an order was created from it.',
+  });
+  const statusEditable = t('sales:fieldInfo.statusEditable', { defaultValue: 'Editable' });
+  const statusLabel = t('sales:fieldInfo.statusLabel', { defaultValue: 'Status:' });
+  const readOnlyStatus = isReadOnly ? readOnlyReason : statusEditable;
 
   const hasOrderForQuote = useCallback((quote: SupplierQuote) => Boolean(quote.linkedOrderId), []);
 
@@ -221,36 +230,6 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
       unitPrice: adjustedPrice,
     };
     setFormData({ ...formData, items: newItems });
-  };
-
-  const renderUnitSelector = (index: number, item: SupplierQuoteItem) => {
-    const product = item.productId ? products.find((p) => p.id === item.productId) : undefined;
-    const isSupply = product?.type === 'supply';
-
-    if (isSupply) {
-      const qty = Number(item.quantity) || 0;
-      return (
-        <span className="text-xs font-semibold text-slate-400 shrink-0 whitespace-nowrap">
-          {qty === 1 ? t('sales:supplierQuotes.unit') : t('sales:supplierQuotes.units')}
-        </span>
-      );
-    }
-
-    const unitOptions = [
-      { id: 'unit', name: t('sales:supplierQuotes.unit') },
-      { id: 'hours', name: t('sales:supplierQuotes.hours') },
-      { id: 'days', name: t('sales:supplierQuotes.days') },
-    ];
-
-    return (
-      <CustomSelect
-        options={unitOptions}
-        value={item.unitType || 'unit'}
-        onChange={(value) => handleUnitTypeChange(index, value as SupplierUnitType)}
-        disabled={isReadOnly}
-        buttonClassName="py-2 text-xs px-2"
-      />
-    );
   };
 
   const columns = useMemo<Column<SupplierQuote>[]>(
@@ -671,6 +650,13 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
                 {t('sales:supplierQuotes.supplierInformation', {
                   defaultValue: 'Supplier Information',
                 })}
+                <FieldTooltip
+                  description={t('sales:fieldInfo.supplierInformation', {
+                    defaultValue: 'Supplier and document details',
+                  })}
+                  status={readOnlyStatus}
+                  statusLabel={statusLabel}
+                />
               </h4>
               <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
                 <div className="space-y-1.5">
@@ -761,6 +747,13 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
                 <h4 className="text-xs font-black text-praetor uppercase tracking-widest flex items-center gap-2">
                   <span className="w-1.5 h-1.5 rounded-full bg-praetor"></span>
                   {t('sales:supplierQuotes.items', { defaultValue: 'Items' })}
+                  <FieldTooltip
+                    description={t('sales:fieldInfo.supplierItems', {
+                      defaultValue: 'Line items for this quote',
+                    })}
+                    status={readOnlyStatus}
+                    statusLabel={statusLabel}
+                  />
                 </h4>
                 {!isReadOnly && (
                   <button
@@ -801,6 +794,10 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
                 <div className="space-y-3">
                   {formData.items.map((item, index) => {
                     const lineTotal = item.quantity * item.unitPrice;
+                    const itemProduct = item.productId
+                      ? products.find((p) => p.id === item.productId)
+                      : undefined;
+                    const isSupply = itemProduct?.type === 'supply';
                     return (
                       <div
                         key={item.id}
@@ -841,7 +838,14 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
                                 <span className="text-xs font-semibold text-slate-400 shrink-0">
                                   /
                                 </span>
-                                {renderUnitSelector(index, item)}
+                                <UnitTypeSelector
+                                  value={item.unitType || 'unit'}
+                                  onChange={(val) => handleUnitTypeChange(index, val)}
+                                  isSupply={isSupply}
+                                  quantity={Number(item.quantity) || 0}
+                                  disabled={isReadOnly}
+                                  i18nPrefix="sales:supplierQuotes"
+                                />
                               </div>
                             </div>
                           </div>
@@ -911,7 +915,14 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
                               <span className="text-xs font-semibold text-slate-400 shrink-0">
                                 /
                               </span>
-                              {renderUnitSelector(index, item)}
+                              <UnitTypeSelector
+                                value={item.unitType || 'unit'}
+                                onChange={(val) => handleUnitTypeChange(index, val)}
+                                isSupply={isSupply}
+                                quantity={Number(item.quantity) || 0}
+                                disabled={isReadOnly}
+                                i18nPrefix="sales:supplierQuotes"
+                              />
                             </div>
                             <div className="col-span-3 flex items-center gap-1.5">
                               <ValidatedNumberInput
@@ -972,6 +983,13 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
                 <h4 className="flex items-center gap-2 text-xs font-black uppercase tracking-widest text-praetor">
                   <span className="h-1.5 w-1.5 rounded-full bg-praetor"></span>
                   {t('sales:supplierQuotes.notes', { defaultValue: 'Notes' })}
+                  <FieldTooltip
+                    description={t('sales:fieldInfo.notes', {
+                      defaultValue: 'Additional notes for the entire document',
+                    })}
+                    status={readOnlyStatus}
+                    statusLabel={statusLabel}
+                  />
                 </h4>
                 <textarea
                   rows={4}

--- a/locales/en/sales.json
+++ b/locales/en/sales.json
@@ -10,6 +10,8 @@
     "clientInformation": "Client and document details",
     "productsServices": "Products and services for this quote",
     "items": "Line items for this offer",
+    "supplierInformation": "Supplier and document details",
+    "supplierItems": "Line items for this quote",
     "statusLabel": "Status:",
     "fieldLockedBySupplierQuote": "Locked due to linked supplier quote"
   },

--- a/locales/it/sales.json
+++ b/locales/it/sales.json
@@ -10,6 +10,8 @@
     "clientInformation": "Dettagli cliente e documento",
     "productsServices": "Prodotti e servizi per questo preventivo",
     "items": "Voci per questa offerta",
+    "supplierInformation": "Dettagli fornitore e documento",
+    "supplierItems": "Voci di questo preventivo",
     "statusLabel": "Stato:",
     "fieldLockedBySupplierQuote": "Bloccato per preventivo fornitore collegato"
   },

--- a/test/components/UnitTypeSelector.test.tsx
+++ b/test/components/UnitTypeSelector.test.tsx
@@ -1,0 +1,65 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { installI18nMock } from '../helpers/i18n';
+
+installI18nMock();
+
+const UnitTypeSelector = (await import('../../components/shared/UnitTypeSelector')).default;
+
+describe('<UnitTypeSelector />', () => {
+  test('renders the selected unit label text on the trigger button', () => {
+    render(
+      <UnitTypeSelector
+        value="hours"
+        onChange={() => {}}
+        isSupply={false}
+        quantity={2}
+        i18nPrefix="sales:supplierQuotes"
+      />,
+    );
+    expect(screen.getByRole('button').textContent).toContain('sales:supplierQuotes.hours');
+  });
+
+  test('renders a static label (no dropdown) when isSupply is true', () => {
+    render(
+      <UnitTypeSelector
+        value="unit"
+        onChange={() => {}}
+        isSupply={true}
+        quantity={1}
+        i18nPrefix="sales:supplierQuotes"
+      />,
+    );
+    expect(screen.queryByRole('button')).toBeNull();
+    expect(screen.getByText('sales:supplierQuotes.unit')).toBeInTheDocument();
+  });
+
+  test('static label uses plural form when quantity is not 1', () => {
+    render(
+      <UnitTypeSelector
+        value="unit"
+        onChange={() => {}}
+        isSupply={true}
+        quantity={3}
+        i18nPrefix="sales:supplierQuotes"
+      />,
+    );
+    expect(screen.getByText('sales:supplierQuotes.units')).toBeInTheDocument();
+  });
+
+  test('selecting a different unit calls onChange with the new id', () => {
+    const onChange = mock((_v: string) => {});
+    render(
+      <UnitTypeSelector
+        value="unit"
+        onChange={onChange}
+        isSupply={false}
+        quantity={1}
+        i18nPrefix="sales:supplierQuotes"
+      />,
+    );
+    fireEvent.click(screen.getByRole('button'));
+    fireEvent.click(screen.getByText('sales:supplierQuotes.hour'));
+    expect(onChange).toHaveBeenCalledWith('hours');
+  });
+});


### PR DESCRIPTION
## Summary
- The unit dropdown (`unit` / `hours` / `days`) in supplier-quote item rows rendered only a chevron — the value text was invisible. Root cause: the inline `CustomSelect` had no min-width and was placed in a tight `col-span-2` flex container, so its `truncate` label collapsed to empty.
- Swap the inline `CustomSelect` for the shared `UnitTypeSelector` already used in `ClientQuotesView` — it sets `min-w-[4rem]` and provides correct singular/plural unit labels via the `i18nPrefix` prop.
- Also add `FieldTooltip` to the three section headers (Supplier Information, Items, Notes) to mirror the `ClientQuotesView` UX, surfacing the read-only state when a quote is linked to an order.

## Before / after
**Before** — chevron only, no value text:
> `80 / [v] 182…`

**After** — value text now visible (`Unit` / `Hours` / `Days`).

## Changes
- `components/sales/SupplierQuotesView.tsx` — replace local `renderUnitSelector` helper (using `CustomSelect` directly) with the shared `UnitTypeSelector`; introduce `readOnlyStatus` derivation; add three `<FieldTooltip>` instances on section headers.
- `locales/{en,it}/sales.json` — two new keys under `fieldInfo`: `supplierInformation`, `supplierItems`.
- `test/components/UnitTypeSelector.test.tsx` (new) — 4 tests covering selected-label rendering, static-label `isSupply` branch, plural form, and `onChange`.

## Test plan
- [ ] Open Sales → Supplier Quotes → "Add quote" → add an item → unit dropdown shows `Unit` / `Hours` / `Days` text alongside the chevron at default zoom and on narrow viewports.
- [ ] Hover the `?` icon next to "Supplier Information", "Items", and "Notes" → tooltip shows description + `Status: Editable`.
- [ ] Open a supplier quote that has a linked order → same tooltips show `Status: This quote is read-only because an order was created from it.`.
- [ ] Switch language to Italian → tooltips and unit labels are translated.
- [ ] `bun run lint` and `bun test test/components/UnitTypeSelector.test.tsx` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)