### PR TITLE
fix(sales): lock supplier quote modal once status leaves draft

### DIFF
--- a/components/sales/SupplierQuotesView.tsx
+++ b/components/sales/SupplierQuotesView.tsx
@@ -116,12 +116,16 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
   const [formData, setFormData] = useState<Partial<SupplierQuote>>(getDefaultFormData());
   const [previewVersion, setPreviewVersion] = useState<SupplierQuoteVersion | null>(null);
 
-  const baseReadOnly = Boolean(editingQuote?.linkedOrderId);
+  const baseReadOnly = Boolean(editingQuote && editingQuote.status !== 'draft');
   const isReadOnly = baseReadOnly || previewVersion !== null;
 
-  const readOnlyReason = t('sales:supplierQuotes.readOnlyLinked', {
+  const readOnlyLinkedReason = t('sales:supplierQuotes.readOnlyLinked', {
     defaultValue: 'This quote is read-only because an order was created from it.',
   });
+  const readOnlyStatusReason = t('sales:supplierQuotes.readOnlyStatus', {
+    defaultValue: 'Read-only due to non-draft status',
+  });
+  const readOnlyReason = editingQuote?.linkedOrderId ? readOnlyLinkedReason : readOnlyStatusReason;
   const statusEditable = t('sales:fieldInfo.statusEditable', { defaultValue: 'Editable' });
   const statusLabel = t('sales:fieldInfo.statusLabel', { defaultValue: 'Status:' });
   const readOnlyStatus = isReadOnly ? readOnlyReason : statusEditable;
@@ -404,13 +408,16 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
         cell: ({ row }) => {
           const hasOrder = hasOrderForQuote(row);
           const history = isHistoryRow(row);
+          const isRowReadOnly = row.status !== 'draft';
 
           const isEditDisabled = hasOrder;
           const editTitle = hasOrder
             ? t('sales:supplierQuotes.orderAlreadyExists', {
                 defaultValue: 'An order for this quote already exists.',
               })
-            : t('common:buttons.edit', { defaultValue: 'Edit' });
+            : isRowReadOnly
+              ? t('sales:supplierQuotes.viewQuote', { defaultValue: 'View quote' })
+              : t('common:buttons.edit', { defaultValue: 'Edit' });
 
           const isCreateOrderDisabled = history || hasOrder;
           const createOrderTitle = hasOrder
@@ -449,7 +456,9 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
                     disabled={isEditDisabled}
                     className={`p-2 rounded-lg transition-all ${isEditDisabled ? 'cursor-not-allowed opacity-50 text-slate-400' : 'text-slate-400 hover:text-praetor hover:bg-slate-100'}`}
                   >
-                    <i className="fa-solid fa-pen-to-square"></i>
+                    <i
+                      className={`fa-solid ${isRowReadOnly && !hasOrder ? 'fa-eye' : 'fa-pen-to-square'}`}
+                    ></i>
                   </button>
                 )}
               </Tooltip>
@@ -677,11 +686,7 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
               )}
               {baseReadOnly && (
                 <div className="flex items-center gap-3 px-4 py-3 rounded-xl border border-amber-200 bg-amber-50">
-                  <span className="text-amber-700 text-xs font-bold">
-                    {t('sales:supplierQuotes.readOnlyLinked', {
-                      defaultValue: 'This quote is read-only because an order was created from it.',
-                    })}
-                  </span>
+                  <span className="text-amber-700 text-xs font-bold">{readOnlyReason}</span>
                 </div>
               )}
               {editingQuote?.linkedOrderId && (

--- a/locales/en/sales.json
+++ b/locales/en/sales.json
@@ -235,6 +235,7 @@
     "addQuote": "Add quote",
     "viewQuote": "View quote",
     "readOnlyLinked": "This quote is read-only because an order was created from it.",
+    "readOnlyStatus": "Read-only due to non-draft status",
     "linkedOrderTitle": "Linked Order",
     "linkedOrderInfo": "Order #{{number}}",
     "orderDetailsReadOnly": "(Quote details are read-only)",

--- a/locales/it/sales.json
+++ b/locales/it/sales.json
@@ -235,6 +235,7 @@
     "addQuote": "Aggiungi preventivo",
     "viewQuote": "Vedi preventivo",
     "readOnlyLinked": "Questo preventivo è in sola lettura perché è stato creato un ordine da esso.",
+    "readOnlyStatus": "Sola lettura per stato non bozza",
     "linkedOrderTitle": "Ordine Collegato",
     "linkedOrderInfo": "Ordine #{{number}}",
     "orderDetailsReadOnly": "(I dettagli del preventivo sono in sola lettura)",

--- a/test/components/SupplierQuotesView.test.tsx
+++ b/test/components/SupplierQuotesView.test.tsx
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import type { Product, Supplier, SupplierQuote } from '../../types';
+import { installI18nMock } from '../helpers/i18n';
+
+installI18nMock();
+
+// Modal renders into a portal via createPortal, which doesn't reliably surface in
+// screen queries with happy-dom + React 19. Replace it with a passthrough that
+// renders children inline when isOpen.
+mock.module('../../components/shared/Modal', () => ({
+  default: ({ isOpen, children }: { isOpen: boolean; children: ReactNode }) =>
+    isOpen ? <div data-testid="modal">{children}</div> : null,
+}));
+
+const SupplierQuotesView = (await import('../../components/sales/SupplierQuotesView')).default;
+
+const supplier: Supplier = {
+  id: 'sup-1',
+  name: 'Acme Supplies',
+};
+
+const products: Product[] = [];
+
+const buildQuote = (overrides: Partial<SupplierQuote>): SupplierQuote => ({
+  id: 'SQ-base',
+  supplierId: 'sup-1',
+  supplierName: 'Acme Supplies',
+  items: [
+    {
+      id: 'sqi-1',
+      quoteId: overrides.id ?? 'SQ-base',
+      productName: 'Widget',
+      quantity: 1,
+      unitPrice: 100,
+      unitType: 'unit',
+    },
+  ],
+  paymentTerms: 'immediate',
+  status: 'draft',
+  expirationDate: '2026-12-31',
+  createdAt: 1_700_000_000_000,
+  updatedAt: 1_700_000_000_000,
+  ...overrides,
+});
+
+const draft = buildQuote({ id: 'SQ-DRAFT', status: 'draft' });
+const sent = buildQuote({ id: 'SQ-SENT', status: 'sent' });
+const accepted = buildQuote({ id: 'SQ-ACCEPTED', status: 'accepted' });
+const denied = buildQuote({ id: 'SQ-DENIED', status: 'denied' });
+const acceptedWithOrder = buildQuote({
+  id: 'SQ-ACCEPTED-ORDER',
+  status: 'accepted',
+  linkedOrderId: 'SO-100',
+});
+
+const baseProps = {
+  quotes: [draft, sent, accepted, denied, acceptedWithOrder],
+  suppliers: [supplier],
+  products,
+  onAddQuote: () => {},
+  onUpdateQuote: () => {},
+  onDeleteQuote: () => {},
+  currency: 'EUR',
+};
+
+afterEach(() => {
+  // Modal sets body.style.overflow='hidden'; reset defensively even though we mock it.
+  document.body.style.overflow = '';
+});
+
+describe('<SupplierQuotesView /> read-only gating', () => {
+  test('clicking a draft row opens the modal in editable mode', () => {
+    render(<SupplierQuotesView {...baseProps} />);
+    fireEvent.click(screen.getByText('SQ-DRAFT'));
+    expect(screen.getByTestId('modal')).toBeInTheDocument();
+    // Edit modal title and Update submit button are rendered.
+    expect(screen.getByText('sales:supplierQuotes.editQuote')).toBeInTheDocument();
+    expect(screen.getByText('common:buttons.update')).toBeInTheDocument();
+    // Read-only banner is NOT shown.
+    expect(screen.queryByText('sales:supplierQuotes.readOnlyStatus')).not.toBeInTheDocument();
+    expect(screen.queryByText('sales:supplierQuotes.readOnlyLinked')).not.toBeInTheDocument();
+  });
+
+  test('clicking a sent row opens the modal in read-only mode', () => {
+    render(<SupplierQuotesView {...baseProps} />);
+    fireEvent.click(screen.getByText('SQ-SENT'));
+    expect(screen.getByTestId('modal')).toBeInTheDocument();
+    expect(screen.getByText('sales:supplierQuotes.viewQuote')).toBeInTheDocument();
+    expect(screen.queryByText('common:buttons.update')).not.toBeInTheDocument();
+    expect(screen.getByText('sales:supplierQuotes.readOnlyStatus')).toBeInTheDocument();
+  });
+
+  test('clicking an accepted row (without linked order) opens the modal in read-only mode', () => {
+    render(<SupplierQuotesView {...baseProps} />);
+    fireEvent.click(screen.getByText('SQ-ACCEPTED'));
+    expect(screen.getByTestId('modal')).toBeInTheDocument();
+    expect(screen.getByText('sales:supplierQuotes.viewQuote')).toBeInTheDocument();
+    expect(screen.queryByText('common:buttons.update')).not.toBeInTheDocument();
+    expect(screen.getByText('sales:supplierQuotes.readOnlyStatus')).toBeInTheDocument();
+  });
+
+  test('clicking a denied row opens the modal in read-only mode', () => {
+    render(<SupplierQuotesView {...baseProps} />);
+    fireEvent.click(screen.getByText('SQ-DENIED'));
+    expect(screen.getByTestId('modal')).toBeInTheDocument();
+    expect(screen.getByText('sales:supplierQuotes.viewQuote')).toBeInTheDocument();
+    expect(screen.queryByText('common:buttons.update')).not.toBeInTheDocument();
+    expect(screen.getByText('sales:supplierQuotes.readOnlyStatus')).toBeInTheDocument();
+  });
+
+  test('clicking an accepted row with a linked order shows the linked-order banner', () => {
+    render(<SupplierQuotesView {...baseProps} />);
+    fireEvent.click(screen.getByText('SQ-ACCEPTED-ORDER'));
+    expect(screen.getByTestId('modal')).toBeInTheDocument();
+    expect(screen.getByText('sales:supplierQuotes.viewQuote')).toBeInTheDocument();
+    expect(screen.queryByText('common:buttons.update')).not.toBeInTheDocument();
+    // Linked-order copy wins over the generic non-draft copy.
+    expect(screen.getByText('sales:supplierQuotes.readOnlyLinked')).toBeInTheDocument();
+    expect(screen.queryByText('sales:supplierQuotes.readOnlyStatus')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- The supplier quote edit modal previously only entered read-only mode when a quote had a `linkedOrderId`, so quotes with status `sent`, `accepted`, or `denied` were still fully editable through the modal — inconsistent with [`ClientOffersView`](components/sales/ClientOffersView.tsx#L229) and [`SupplierOrdersView`](components/accounting/SupplierOrdersView.tsx#L129), both of which lock on `status !== 'draft'`.
- `isReadOnly` now matches the sibling pattern. The amber banner picks the right copy (linked-order vs. non-draft), and the row pencil icon flips to a view-eye for non-draft rows so the affordance matches what opening the row actually does.
- Adds a `supplierQuotes.readOnlyStatus` translation key in `en` and `it`.

## Why this is safe
All non-draft status transitions (`draft→sent`, `sent→accepted/denied`, `denied→draft`, `accepted→linked-order`) are driven by row buttons that call `onUpdateQuote(id, { status })` directly — they never went through the modal. Locking the modal does not block any existing workflow.

## Test plan
- [x] `bun run lint` — passes
- [x] `bun test` — 1344 pass, 0 fail (includes 5 new tests covering each status path and the linked-order banner regression)
- [ ] Manual: in Supplier Quotes, mark a draft quote as sent → click the row → modal opens as "View quote" with disabled inputs, no Save button, banner reads "Read-only due to non-draft status".
- [ ] Manual: create an order from an accepted quote → reopen the quote → banner reverts to "This quote is read-only because an order was created from it." and the linked-order block is rendered.
- [ ] Manual: open a draft quote → all fields editable, "Update" button visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)