### PR TITLE
feat(layout): auto-expand collapsed sidebar on hover

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -569,8 +569,12 @@ const Layout: React.FC<LayoutProps> = ({
         className={`hidden md:block shrink-0 transition-all duration-300 ease-in-out ${isCollapsedPinned ? 'md:w-20' : 'md:w-64'}`}
       />
       <nav
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
+        onMouseEnter={() => {
+          if (isCollapsedPinned) setIsHovered(true);
+        }}
+        onMouseLeave={() => {
+          if (isCollapsedPinned) setIsHovered(false);
+        }}
         className={`bg-praetor text-white/90 flex flex-col border-r border-white/10 shrink-0 transition-all duration-300 ease-in-out relative z-30 md:absolute md:inset-y-0 md:left-0
           ${isCollapsed ? 'md:w-20' : 'md:w-64'}
           ${isCollapsedPinned && isHovered ? 'md:shadow-2xl md:shadow-black/30' : ''}

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -88,7 +88,9 @@ const Layout: React.FC<LayoutProps> = ({
   const [isProfileMenuOpen, setIsProfileMenuOpen] = useState(false);
   const [isRoleSubmenuOpen, setIsRoleSubmenuOpen] = useState(false);
   const roleSubmenuTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const [isCollapsed, setIsCollapsed] = useState(false);
+  const [isCollapsedPinned, setIsCollapsedPinned] = useState(false);
+  const [isHovered, setIsHovered] = useState(false);
+  const isCollapsed = isCollapsedPinned && !isHovered;
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   /* Removed module switcher state and refs */
   const menuRef = useRef<HTMLDivElement>(null);
@@ -182,7 +184,10 @@ const Layout: React.FC<LayoutProps> = ({
     });
   };
 
-  const toggleSidebar = () => setIsCollapsed(!isCollapsed);
+  const toggleSidebar = () => {
+    setIsCollapsedPinned(!isCollapsedPinned);
+    setIsHovered(false);
+  };
   /* Removed module switcher state and refs */
   const toggleMobileMenu = () => setIsMobileMenuOpen(!isMobileMenuOpen);
 
@@ -558,10 +563,17 @@ const Layout: React.FC<LayoutProps> = ({
   };
 
   return (
-    <div className="h-screen flex flex-col md:flex-row bg-slate-50 overflow-hidden">
+    <div className="h-screen flex flex-col md:flex-row md:relative bg-slate-50 overflow-hidden">
+      <div
+        aria-hidden="true"
+        className={`hidden md:block shrink-0 transition-all duration-300 ease-in-out ${isCollapsedPinned ? 'md:w-20' : 'md:w-64'}`}
+      />
       <nav
-        className={`bg-praetor text-white/90 flex flex-col border-r border-white/10 shrink-0 transition-all duration-300 ease-in-out relative z-30
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+        className={`bg-praetor text-white/90 flex flex-col border-r border-white/10 shrink-0 transition-all duration-300 ease-in-out relative z-30 md:absolute md:inset-y-0 md:left-0
           ${isCollapsed ? 'md:w-20' : 'md:w-64'}
+          ${isCollapsedPinned && isHovered ? 'md:shadow-2xl md:shadow-black/30' : ''}
           w-full`}
       >
         <div
@@ -588,7 +600,7 @@ const Layout: React.FC<LayoutProps> = ({
           <button
             onClick={toggleSidebar}
             className={`hidden md:flex absolute -right-3 top-12 w-6 h-6 bg-praetor border border-white/20 rounded-full items-center justify-center text-white/70 hover:text-white hover:bg-praetor transition-all z-40
-              ${isCollapsed ? 'rotate-180' : ''}`}
+              ${isCollapsedPinned ? 'rotate-180' : ''}`}
           >
             <i className="fa-solid fa-chevron-left text-[10px]"></i>
           </button>

--- a/test/components/Layout.test.tsx
+++ b/test/components/Layout.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import type { Role, User } from '../../types';
 import { installI18nMock } from '../helpers/i18n';
 
@@ -18,25 +18,73 @@ const mockUser: User = {
 
 const mockRoles: Role[] = [];
 
+const renderLayout = () =>
+  render(
+    <Layout
+      activeView="timesheets/tracker"
+      onViewChange={() => {}}
+      currentUser={mockUser}
+      onLogout={() => {}}
+      onSwitchRole={() => {}}
+      roles={mockRoles}
+    >
+      <div>content</div>
+    </Layout>,
+  );
+
 describe('<Layout />', () => {
   test('header sits at z-40 so it paints above the table sticky-right cells (z-20)', () => {
-    const { container } = render(
-      <Layout
-        activeView="timesheets/tracker"
-        onViewChange={() => {}}
-        currentUser={mockUser}
-        onLogout={() => {}}
-        onSwitchRole={() => {}}
-        roles={mockRoles}
-      >
-        <div>content</div>
-      </Layout>,
-    );
+    const { container } = renderLayout();
 
     const header = container.querySelector('header');
     expect(header).not.toBeNull();
     const classes = header?.className.split(/\s+/) ?? [];
     expect(classes).toContain('z-40');
     expect(classes).not.toContain('z-20');
+  });
+
+  test('collapsed sidebar auto-expands on hover and collapses again on mouse leave', () => {
+    const { container } = renderLayout();
+
+    const nav = container.querySelector('nav');
+    const collapseToggle = container.querySelector(
+      'button.hidden.md\\:flex',
+    ) as HTMLButtonElement | null;
+    expect(nav).not.toBeNull();
+    expect(collapseToggle).not.toBeNull();
+
+    // Pin sidebar to collapsed state.
+    fireEvent.click(collapseToggle as HTMLButtonElement);
+    expect(nav?.className).toContain('md:w-20');
+    expect(nav?.className).not.toContain('md:w-64');
+
+    // Hovering the collapsed sidebar expands it visually without unpinning.
+    fireEvent.mouseEnter(nav as HTMLElement);
+    expect(nav?.className).toContain('md:w-64');
+    expect(nav?.className).not.toContain('md:w-20');
+    // Toggle chevron still reflects the pinned (collapsed) state.
+    expect(collapseToggle?.className).toContain('rotate-180');
+
+    // Leaving the sidebar collapses it back.
+    fireEvent.mouseLeave(nav as HTMLElement);
+    expect(nav?.className).toContain('md:w-20');
+    expect(nav?.className).not.toContain('md:w-64');
+  });
+
+  test('layout spacer keeps content from reflowing when sidebar hover-expands', () => {
+    const { container } = renderLayout();
+
+    const collapseToggle = container.querySelector('button.hidden.md\\:flex') as HTMLButtonElement;
+    const spacer = container.querySelector('div[aria-hidden="true"]');
+    const nav = container.querySelector('nav');
+    expect(spacer).not.toBeNull();
+
+    fireEvent.click(collapseToggle);
+    expect(spacer?.className).toContain('md:w-20');
+
+    fireEvent.mouseEnter(nav as HTMLElement);
+    // Spacer reserves the pinned (collapsed) width even while hover-expanded.
+    expect(spacer?.className).toContain('md:w-20');
+    expect(spacer?.className).not.toContain('md:w-64');
   });
 });

--- a/test/components/Layout.test.tsx
+++ b/test/components/Layout.test.tsx
@@ -46,45 +46,39 @@ describe('<Layout />', () => {
   test('collapsed sidebar auto-expands on hover and collapses again on mouse leave', () => {
     const { container } = renderLayout();
 
-    const nav = container.querySelector('nav');
-    const collapseToggle = container.querySelector(
-      'button.hidden.md\\:flex',
-    ) as HTMLButtonElement | null;
+    const nav = container.querySelector('nav') as HTMLElement;
+    const collapseToggle = container.querySelector('button.hidden.md\\:flex') as HTMLButtonElement;
     expect(nav).not.toBeNull();
     expect(collapseToggle).not.toBeNull();
 
-    // Pin sidebar to collapsed state.
-    fireEvent.click(collapseToggle as HTMLButtonElement);
-    expect(nav?.className).toContain('md:w-20');
-    expect(nav?.className).not.toContain('md:w-64');
+    fireEvent.click(collapseToggle);
+    expect(nav.className).toContain('md:w-20');
+    expect(nav.className).not.toContain('md:w-64');
 
-    // Hovering the collapsed sidebar expands it visually without unpinning.
-    fireEvent.mouseEnter(nav as HTMLElement);
-    expect(nav?.className).toContain('md:w-64');
-    expect(nav?.className).not.toContain('md:w-20');
-    // Toggle chevron still reflects the pinned (collapsed) state.
-    expect(collapseToggle?.className).toContain('rotate-180');
+    fireEvent.mouseEnter(nav);
+    expect(nav.className).toContain('md:w-64');
+    expect(nav.className).not.toContain('md:w-20');
+    // Chevron must keep reflecting the pinned state, not the hover-expanded visual.
+    expect(collapseToggle.className).toContain('rotate-180');
 
-    // Leaving the sidebar collapses it back.
-    fireEvent.mouseLeave(nav as HTMLElement);
-    expect(nav?.className).toContain('md:w-20');
-    expect(nav?.className).not.toContain('md:w-64');
+    fireEvent.mouseLeave(nav);
+    expect(nav.className).toContain('md:w-20');
+    expect(nav.className).not.toContain('md:w-64');
   });
 
   test('layout spacer keeps content from reflowing when sidebar hover-expands', () => {
     const { container } = renderLayout();
 
     const collapseToggle = container.querySelector('button.hidden.md\\:flex') as HTMLButtonElement;
-    const spacer = container.querySelector('div[aria-hidden="true"]');
-    const nav = container.querySelector('nav');
+    const spacer = container.querySelector('div[aria-hidden="true"]') as HTMLElement;
+    const nav = container.querySelector('nav') as HTMLElement;
     expect(spacer).not.toBeNull();
 
     fireEvent.click(collapseToggle);
-    expect(spacer?.className).toContain('md:w-20');
+    expect(spacer.className).toContain('md:w-20');
 
-    fireEvent.mouseEnter(nav as HTMLElement);
-    // Spacer reserves the pinned (collapsed) width even while hover-expanded.
-    expect(spacer?.className).toContain('md:w-20');
-    expect(spacer?.className).not.toContain('md:w-64');
+    fireEvent.mouseEnter(nav);
+    expect(spacer.className).toContain('md:w-20');
+    expect(spacer.className).not.toContain('md:w-64');
   });
 });


### PR DESCRIPTION
Hovering a pinned-collapsed sidebar now overlays the expanded panel
without reflowing main content (a layout spacer reserves the collapsed
width). The chevron toggle keeps reflecting the pinned state.