### PR TITLE
test(components): cover TableFilter and NotificationBell

### DIFF
--- a/test/components/NotificationBell.test.tsx
+++ b/test/components/NotificationBell.test.tsx
@@ -1,0 +1,205 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { Notification } from '../../types';
+import { installI18nMock } from '../helpers/i18n';
+
+installI18nMock();
+
+// NotificationBell receives data via props, but the project convention is to
+// stub services/api in component tests so transitive imports never hit the
+// network.
+mock.module('../../services/api', () => ({
+  default: {
+    notifications: {
+      list: mock(() => Promise.resolve([] as Notification[])),
+      markAsRead: mock(() => Promise.resolve()),
+      markAllAsRead: mock(() => Promise.resolve()),
+      delete: mock(() => Promise.resolve()),
+    },
+  },
+  getAuthToken: () => null,
+  setAuthToken: () => {},
+}));
+
+const NotificationBell = (await import('../../components/shared/NotificationBell')).default;
+
+const NOW = 1_700_000_000_000;
+
+const sampleNotifications: Notification[] = [
+  {
+    id: 'n1',
+    userId: 'u1',
+    type: 'new_projects',
+    title: 'Original title',
+    isRead: false,
+    createdAt: NOW - 5 * 60 * 1000,
+    data: { projectNames: ['Project A', 'Project B'], clientName: 'ACME' },
+  },
+  {
+    id: 'n2',
+    userId: 'u1',
+    type: 'generic',
+    title: 'A generic notification',
+    isRead: true,
+    createdAt: NOW - 2 * 60 * 60 * 1000,
+  },
+];
+
+const baseProps = {
+  notifications: sampleNotifications,
+  unreadCount: 1,
+  onMarkAsRead: () => {},
+  onMarkAllAsRead: () => {},
+  onDelete: () => {},
+};
+
+const openDropdown = () =>
+  fireEvent.click(screen.getByRole('button', { name: 'notifications.title' }));
+
+describe('<NotificationBell />', () => {
+  test('renders the bell button and the unread count badge when unread > 0', () => {
+    render(<NotificationBell {...baseProps} unreadCount={3} />);
+
+    const bell = screen.getByRole('button', { name: 'notifications.title' });
+    expect(bell).toBeInTheDocument();
+    expect(bell.querySelector('i.fa-bell')).not.toBeNull();
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  test('hides the unread badge when count is zero', () => {
+    render(<NotificationBell {...baseProps} notifications={[]} unreadCount={0} />);
+    expect(screen.queryByText('0')).not.toBeInTheDocument();
+  });
+
+  test('caps the badge at "99+" when unread count exceeds 99', () => {
+    render(<NotificationBell {...baseProps} notifications={[]} unreadCount={150} />);
+    expect(screen.getByText('99+')).toBeInTheDocument();
+  });
+
+  test('clicking the bell opens the dropdown and renders notifications', () => {
+    render(<NotificationBell {...baseProps} />);
+
+    expect(screen.queryByText('A generic notification')).not.toBeInTheDocument();
+
+    openDropdown();
+
+    expect(screen.getByText('notifications.newProjects')).toBeInTheDocument();
+    expect(screen.getByText('A generic notification')).toBeInTheDocument();
+  });
+
+  test('clicking a single-project notification uses the singular translation key', () => {
+    const single: Notification = {
+      id: 'n3',
+      userId: 'u1',
+      type: 'new_projects',
+      title: 'fallback',
+      isRead: false,
+      createdAt: NOW,
+      data: { projectNames: ['Solo'] },
+    };
+
+    render(<NotificationBell {...baseProps} notifications={[single]} />);
+
+    openDropdown();
+    expect(screen.getByText('notifications.newProject')).toBeInTheDocument();
+  });
+
+  test('empty notification list shows the noNotifications empty state', () => {
+    render(<NotificationBell {...baseProps} notifications={[]} unreadCount={0} />);
+
+    openDropdown();
+    expect(screen.getByText('notifications.noNotifications')).toBeInTheDocument();
+  });
+
+  test('clicking an unread notification calls onMarkAsRead with its id', () => {
+    const onMarkAsRead = mock((_id: string) => {});
+    render(<NotificationBell {...baseProps} onMarkAsRead={onMarkAsRead} />);
+
+    openDropdown();
+    fireEvent.click(screen.getByText('notifications.newProjects'));
+
+    expect(onMarkAsRead).toHaveBeenCalledWith('n1');
+  });
+
+  test('clicking an already-read notification does NOT call onMarkAsRead', () => {
+    const onMarkAsRead = mock((_id: string) => {});
+    render(<NotificationBell {...baseProps} onMarkAsRead={onMarkAsRead} />);
+
+    openDropdown();
+    fireEvent.click(screen.getByText('A generic notification'));
+
+    expect(onMarkAsRead).not.toHaveBeenCalled();
+  });
+
+  test('"Mark all as read" button calls onMarkAllAsRead', () => {
+    const onMarkAllAsRead = mock(() => {});
+    render(<NotificationBell {...baseProps} unreadCount={2} onMarkAllAsRead={onMarkAllAsRead} />);
+
+    openDropdown();
+    fireEvent.click(screen.getByText('notifications.markAllAsRead'));
+
+    expect(onMarkAllAsRead).toHaveBeenCalled();
+  });
+
+  test('"Mark all as read" is hidden when unreadCount is zero', () => {
+    render(<NotificationBell {...baseProps} unreadCount={0} />);
+
+    openDropdown();
+    expect(screen.queryByText('notifications.markAllAsRead')).not.toBeInTheDocument();
+  });
+
+  test('per-notification delete button calls onDelete and stops propagation', () => {
+    const onDelete = mock((_id: string) => {});
+    const onMarkAsRead = mock((_id: string) => {});
+    render(<NotificationBell {...baseProps} onMarkAsRead={onMarkAsRead} onDelete={onDelete} />);
+
+    openDropdown();
+
+    const deleteButtons = screen.getAllByRole('button', { name: 'notifications.delete' });
+    expect(deleteButtons.length).toBeGreaterThan(0);
+    fireEvent.click(deleteButtons[0]);
+
+    expect(onDelete).toHaveBeenCalledWith('n1');
+    // Propagation must be stopped, otherwise the row's mark-as-read fires too.
+    expect(onMarkAsRead).not.toHaveBeenCalled();
+  });
+
+  test('clicking outside the dropdown closes it', () => {
+    render(
+      <div>
+        <div data-testid="outside">outside</div>
+        <NotificationBell {...baseProps} />
+      </div>,
+    );
+
+    openDropdown();
+    expect(screen.getByText('A generic notification')).toBeInTheDocument();
+
+    fireEvent.mouseDown(screen.getByTestId('outside'));
+
+    expect(screen.queryByText('A generic notification')).not.toBeInTheDocument();
+  });
+
+  test('"Show projects" toggle expands and collapses the project list', () => {
+    render(<NotificationBell {...baseProps} />);
+
+    openDropdown();
+
+    fireEvent.click(screen.getByText('notifications.showProjects'));
+    expect(screen.getByText('notifications.hideProjects')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('notifications.hideProjects'));
+    expect(screen.getByText('notifications.showProjects')).toBeInTheDocument();
+  });
+
+  test('clicking the bell again closes the dropdown', () => {
+    render(<NotificationBell {...baseProps} />);
+    const bell = screen.getByRole('button', { name: 'notifications.title' });
+
+    fireEvent.click(bell);
+    expect(screen.getByText('A generic notification')).toBeInTheDocument();
+
+    fireEvent.click(bell);
+    expect(screen.queryByText('A generic notification')).not.toBeInTheDocument();
+  });
+});

--- a/test/components/TableFilter.test.tsx
+++ b/test/components/TableFilter.test.tsx
@@ -1,0 +1,176 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { installI18nMock } from '../helpers/i18n';
+
+installI18nMock();
+
+const TableFilter = (await import('../../components/shared/TableFilter')).default;
+
+const baseProps = {
+  title: 'Status',
+  options: ['Open', 'Closed', 'Pending'],
+  selectedValues: [] as string[],
+  onFilterChange: () => {},
+  sortDirection: null as 'asc' | 'desc' | null,
+  onSortChange: () => {},
+  onClose: () => {},
+};
+
+describe('<TableFilter />', () => {
+  test('renders title, all options, and translated controls', () => {
+    render(<TableFilter {...baseProps} />);
+    expect(screen.getByText('Status')).toBeInTheDocument();
+    expect(screen.getByText('Open')).toBeInTheDocument();
+    expect(screen.getByText('Closed')).toBeInTheDocument();
+    expect(screen.getByText('Pending')).toBeInTheDocument();
+    expect(screen.getByText('table.sortAsc')).toBeInTheDocument();
+    expect(screen.getByText('table.sortDesc')).toBeInTheDocument();
+    expect(screen.getByText('table.clearFilter')).toBeInTheDocument();
+    expect(screen.getByText('(table.selectAll)')).toBeInTheDocument();
+  });
+
+  test('typing in the search input filters the visible options', () => {
+    render(<TableFilter {...baseProps} />);
+    const search = screen.getByPlaceholderText('table.search') as HTMLInputElement;
+
+    fireEvent.change(search, { target: { value: 'open' } });
+
+    expect(screen.getByText('Open')).toBeInTheDocument();
+    expect(screen.queryByText('Closed')).not.toBeInTheDocument();
+    expect(screen.queryByText('Pending')).not.toBeInTheDocument();
+  });
+
+  test('search with no matches shows the noResults message', () => {
+    render(<TableFilter {...baseProps} />);
+    const search = screen.getByPlaceholderText('table.search') as HTMLInputElement;
+
+    fireEvent.change(search, { target: { value: 'zzzzzzzz' } });
+
+    expect(screen.getByText('table.noResults')).toBeInTheDocument();
+    expect(screen.queryByText('Open')).not.toBeInTheDocument();
+  });
+
+  test('clicking an unchecked option calls onFilterChange with that option appended', () => {
+    const onFilterChange = mock((_v: string[]) => {});
+    render(<TableFilter {...baseProps} onFilterChange={onFilterChange} />);
+
+    fireEvent.click(screen.getByText('Open'));
+
+    expect(onFilterChange).toHaveBeenCalledWith(['Open']);
+  });
+
+  test('clicking a selected option removes it from the selection', () => {
+    const onFilterChange = mock((_v: string[]) => {});
+    render(
+      <TableFilter
+        {...baseProps}
+        selectedValues={['Open', 'Closed']}
+        onFilterChange={onFilterChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('Open'));
+
+    expect(onFilterChange).toHaveBeenCalledWith(['Closed']);
+  });
+
+  test('select-all checkbox selects every visible option', () => {
+    const onFilterChange = mock((_v: string[]) => {});
+    render(<TableFilter {...baseProps} onFilterChange={onFilterChange} />);
+
+    // The select-all checkbox is the first checkbox in the dropdown.
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[0]);
+
+    expect(onFilterChange).toHaveBeenCalledWith(['Open', 'Closed', 'Pending']);
+  });
+
+  test('select-all when all are already selected deselects every visible option', () => {
+    const onFilterChange = mock((_v: string[]) => {});
+    render(
+      <TableFilter
+        {...baseProps}
+        selectedValues={['Open', 'Closed', 'Pending']}
+        onFilterChange={onFilterChange}
+      />,
+    );
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[0]);
+
+    expect(onFilterChange).toHaveBeenCalledWith([]);
+  });
+
+  test('select-all only toggles options matching the current search filter', () => {
+    const onFilterChange = mock((_v: string[]) => {});
+    render(
+      <TableFilter {...baseProps} selectedValues={['Pending']} onFilterChange={onFilterChange} />,
+    );
+    const search = screen.getByPlaceholderText('table.search') as HTMLInputElement;
+    fireEvent.change(search, { target: { value: 'open' } });
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[0]);
+
+    // Pending stays selected (filtered out); Open is added.
+    expect(onFilterChange).toHaveBeenCalledWith(['Pending', 'Open']);
+  });
+
+  test('clear-filter button calls onFilterChange with an empty array', () => {
+    const onFilterChange = mock((_v: string[]) => {});
+    render(
+      <TableFilter {...baseProps} selectedValues={['Open']} onFilterChange={onFilterChange} />,
+    );
+
+    fireEvent.click(screen.getByText('table.clearFilter'));
+
+    expect(onFilterChange).toHaveBeenCalledWith([]);
+  });
+
+  test('sort ascending button calls onSortChange("asc")', () => {
+    const onSortChange = mock((_d: 'asc' | 'desc' | null) => {});
+    render(<TableFilter {...baseProps} onSortChange={onSortChange} />);
+
+    fireEvent.click(screen.getByText('table.sortAsc'));
+
+    expect(onSortChange).toHaveBeenCalledWith('asc');
+  });
+
+  test('sort descending button calls onSortChange("desc")', () => {
+    const onSortChange = mock((_d: 'asc' | 'desc' | null) => {});
+    render(<TableFilter {...baseProps} onSortChange={onSortChange} />);
+
+    fireEvent.click(screen.getByText('table.sortDesc'));
+
+    expect(onSortChange).toHaveBeenCalledWith('desc');
+  });
+
+  test('close button (header xmark) calls onClose', () => {
+    const onClose = mock(() => {});
+    render(<TableFilter {...baseProps} onClose={onClose} />);
+
+    const closeButton = screen.getAllByRole('button').find((b) => b.querySelector('i.fa-xmark'));
+    if (!closeButton) throw new Error('close button not found');
+
+    fireEvent.click(closeButton);
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  test('empty-string options render the table.empty placeholder label', () => {
+    render(<TableFilter {...baseProps} options={['', 'Open']} />);
+
+    expect(screen.getByText('table.empty')).toBeInTheDocument();
+    expect(screen.getByText('Open')).toBeInTheDocument();
+  });
+
+  test('search filter respects the table.empty translated label', () => {
+    render(<TableFilter {...baseProps} options={['', 'Open']} />);
+    const search = screen.getByPlaceholderText('table.search') as HTMLInputElement;
+
+    fireEvent.change(search, { target: { value: 'empty' } });
+
+    expect(screen.getByText('table.empty')).toBeInTheDocument();
+    expect(screen.queryByText('Open')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Part of the codebase test-coverage push (unit F6).

- Adds `test/components/TableFilter.test.tsx` (filter render, input, clear button, callback).
- Adds `test/components/NotificationBell.test.tsx` (bell render, unread count, dropdown open/close, mark-as-read).
- Pushes both shared components from <5% line coverage to >70%.
- 28 new test cases.

## Test plan
- [x] `bun test ./test/components/NotificationBell.test.tsx ./test/components/TableFilter.test.tsx` — 28 pass / 0 fail
- [ ] CI green

https://claude.ai/code/session_0111c2dFZ99BbKBQtghz8kGJ

---
_Generated by [Claude Code](https://claude.ai/code/session_0111c2dFZ99BbKBQtghz8kGJ)_