### PR TITLE
test(repositories): cover four version-history repos to 100%

### DIFF
--- a/server/test/repositories/orderVersionsRepo.test.ts
+++ b/server/test/repositories/orderVersionsRepo.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import type { DbExecutor } from '../../db/drizzle.ts';
+import * as orderVersionsRepo from '../../repositories/orderVersionsRepo.ts';
+import { type FakeExecutor, makeRow, setupTestDb } from '../helpers/fakeExecutor.ts';
+
+let exec: FakeExecutor;
+let testDb: DbExecutor;
+
+beforeEach(() => {
+  ({ exec, testDb } = setupTestDb());
+});
+
+// order_versions schema column order:
+// id, order_id, snapshot, reason, created_by_user_id, created_at
+const VERSION_BASE: readonly unknown[] = [
+  'ov-1',
+  'so-1',
+  { schemaVersion: 1, order: { id: 'so-1' }, items: [] },
+  'update',
+  'u-1',
+  new Date('2026-01-01T00:00:00Z'),
+];
+const versionRow = (overrides: Record<number, unknown> = {}) => makeRow(VERSION_BASE, overrides);
+
+// listForOrder projects 5 fields in this order: id, orderId, reason, createdByUserId, createdAt.
+const LIST_BASE: readonly unknown[] = [
+  'ov-1',
+  'so-1',
+  'update',
+  'u-1',
+  new Date('2026-01-01T00:00:00Z'),
+];
+const listRow = (overrides: Record<number, unknown> = {}) => makeRow(LIST_BASE, overrides);
+
+describe('buildSnapshot', () => {
+  test('strips linkedQuoteId and linkedOfferId from the order envelope', () => {
+    const order = {
+      id: 'so-1',
+      linkedQuoteId: 'cq-1',
+      linkedOfferId: 'co-1',
+      clientId: 'c-1',
+      clientName: 'Acme',
+      paymentTerms: 'net30',
+      discount: 5,
+      discountType: 'percentage' as const,
+      status: 'draft',
+      notes: null,
+      createdAt: 0,
+      updatedAt: 0,
+    };
+    const items: Parameters<typeof orderVersionsRepo.buildSnapshot>[1] = [];
+    const snapshot = orderVersionsRepo.buildSnapshot(order, items);
+    expect(snapshot.schemaVersion).toBe(1);
+    expect(snapshot.items).toBe(items);
+    expect(snapshot.order.id).toBe('so-1');
+    expect(snapshot.order.clientId).toBe('c-1');
+    // linkedQuoteId / linkedOfferId are intentionally omitted from the snapshot's order shape.
+    expect((snapshot.order as Record<string, unknown>).linkedQuoteId).toBeUndefined();
+    expect((snapshot.order as Record<string, unknown>).linkedOfferId).toBeUndefined();
+  });
+});
+
+describe('listForOrder', () => {
+  test('filters by order_id and orders newest-first', async () => {
+    exec.enqueue({ rows: [listRow(), listRow({ 0: 'ov-2', 2: 'restore' })] });
+    const result = await orderVersionsRepo.listForOrder('so-1', testDb);
+    const sql = exec.calls[0].sql.toLowerCase();
+    expect(sql).toContain('from "order_versions"');
+    expect(sql).toContain('"order_id" = $1');
+    expect(sql).toContain('order by "order_versions"."created_at" desc');
+    expect(exec.calls[0].params).toEqual(['so-1']);
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe('ov-1');
+    expect(result[1].reason).toBe('restore');
+  });
+
+  test('returns [] when no versions exist', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await orderVersionsRepo.listForOrder('so-x', testDb)).toEqual([]);
+  });
+
+  test('coerces unrecognized reason values to "update"', async () => {
+    exec.enqueue({ rows: [listRow({ 2: 'mystery' })] });
+    const [row] = await orderVersionsRepo.listForOrder('so-1', testDb);
+    expect(row.reason).toBe('update');
+  });
+
+  test('null createdAt falls back to 0', async () => {
+    exec.enqueue({ rows: [listRow({ 4: null })] });
+    const [row] = await orderVersionsRepo.listForOrder('so-1', testDb);
+    expect(row.createdAt).toBe(0);
+  });
+});
+
+describe('findById', () => {
+  test('scopes the WHERE on BOTH order_id and id (cross-order IDOR guard)', async () => {
+    exec.enqueue({ rows: [versionRow()] });
+    const result = await orderVersionsRepo.findById('so-1', 'ov-1', testDb);
+    const sql = exec.calls[0].sql.toLowerCase();
+    expect(sql).toContain('"order_id" = $1');
+    expect(sql).toContain('"id" = $2');
+    expect(sql).toContain('limit $3');
+    expect(exec.calls[0].params).toEqual(['so-1', 'ov-1', 1]);
+    expect(result?.id).toBe('ov-1');
+    expect(result?.snapshot.schemaVersion).toBe(1);
+  });
+
+  test('returns null when no row matches the (orderId, versionId) pair', async () => {
+    exec.enqueue({ rows: [] });
+    const result = await orderVersionsRepo.findById('so-1', 'ov-other', testDb);
+    expect(result).toBeNull();
+  });
+});
+
+describe('insert', () => {
+  test('binds order_id, snapshot JSON, reason, createdByUserId; id gets ov- prefix', async () => {
+    exec.enqueue({ rows: [versionRow({ 0: 'ov-generated' })] });
+    const result = await orderVersionsRepo.insert(
+      {
+        orderId: 'so-1',
+        snapshot: {
+          schemaVersion: 1,
+          order: {
+            id: 'so-1',
+            clientId: 'c-1',
+            clientName: 'Acme',
+            paymentTerms: 'net30',
+            discount: 5,
+            discountType: 'percentage',
+            status: 'draft',
+            notes: null,
+            createdAt: 0,
+            updatedAt: 0,
+          },
+          items: [],
+        },
+        reason: 'restore',
+        createdByUserId: 'u-1',
+      },
+      testDb,
+    );
+    expect(exec.calls[0].sql.toLowerCase()).toContain('insert into "order_versions"');
+    const generatedId = exec.calls[0].params[0] as string;
+    expect(generatedId.startsWith('ov-')).toBe(true);
+    expect(exec.calls[0].params).toContain('so-1');
+    expect(exec.calls[0].params).toContain('restore');
+    expect(exec.calls[0].params).toContain('u-1');
+    expect(result.id).toBe('ov-generated');
+    expect(result.reason).toBe('update'); // mapped from versionRow's index 3 default
+  });
+});
+
+describe('deleteAllForOrder', () => {
+  test('issues DELETE WHERE order_id and returns rowCount', async () => {
+    exec.enqueue({ rows: [], rowCount: 3 });
+    const result = await orderVersionsRepo.deleteAllForOrder('so-1', testDb);
+    expect(exec.calls[0].sql.toLowerCase()).toContain('delete from "order_versions"');
+    expect(exec.calls[0].sql.toLowerCase()).toContain('"order_id" = $1');
+    expect(exec.calls[0].params).toEqual(['so-1']);
+    expect(result).toBe(3);
+  });
+
+  test('returns 0 when rowCount is null', async () => {
+    exec.enqueue({ rows: [], rowCount: null });
+    expect(await orderVersionsRepo.deleteAllForOrder('so-x', testDb)).toBe(0);
+  });
+});

--- a/server/test/repositories/quoteVersionsRepo.test.ts
+++ b/server/test/repositories/quoteVersionsRepo.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import type { DbExecutor } from '../../db/drizzle.ts';
+import * as quoteVersionsRepo from '../../repositories/quoteVersionsRepo.ts';
+import { type FakeExecutor, makeRow, setupTestDb } from '../helpers/fakeExecutor.ts';
+
+let exec: FakeExecutor;
+let testDb: DbExecutor;
+
+beforeEach(() => {
+  ({ exec, testDb } = setupTestDb());
+});
+
+// quote_versions schema column order:
+// id, quote_id, snapshot, reason, created_by_user_id, created_at
+const VERSION_BASE: readonly unknown[] = [
+  'qv-1',
+  'cq-1',
+  { schemaVersion: 1, quote: { id: 'cq-1' }, items: [] },
+  'update',
+  'u-1',
+  new Date('2026-01-01T00:00:00Z'),
+];
+const versionRow = (overrides: Record<number, unknown> = {}) => makeRow(VERSION_BASE, overrides);
+
+// listForQuote projects 5 fields in this order: id, quoteId, reason, createdByUserId, createdAt.
+const LIST_BASE: readonly unknown[] = [
+  'qv-1',
+  'cq-1',
+  'update',
+  'u-1',
+  new Date('2026-01-01T00:00:00Z'),
+];
+const listRow = (overrides: Record<number, unknown> = {}) => makeRow(LIST_BASE, overrides);
+
+describe('buildSnapshot', () => {
+  test('strips linkedOfferId from the quote envelope', () => {
+    const quote = {
+      id: 'cq-1',
+      linkedOfferId: 'co-1',
+      clientId: 'c-1',
+      clientName: 'Acme',
+      paymentTerms: 'net30',
+      discount: 5,
+      discountType: 'percentage' as const,
+      status: 'draft',
+      expirationDate: '2026-06-01',
+      notes: null,
+      createdAt: 0,
+      updatedAt: 0,
+    };
+    const items: Parameters<typeof quoteVersionsRepo.buildSnapshot>[1] = [];
+    const snapshot = quoteVersionsRepo.buildSnapshot(quote, items);
+    expect(snapshot.schemaVersion).toBe(1);
+    expect(snapshot.items).toBe(items);
+    expect(snapshot.quote.id).toBe('cq-1');
+    expect(snapshot.quote.clientId).toBe('c-1');
+    // linkedOfferId is intentionally omitted from the snapshot's quote shape.
+    expect((snapshot.quote as Record<string, unknown>).linkedOfferId).toBeUndefined();
+  });
+});
+
+describe('listForQuote', () => {
+  test('filters by quote_id and orders newest-first', async () => {
+    exec.enqueue({ rows: [listRow(), listRow({ 0: 'qv-2', 2: 'restore' })] });
+    const result = await quoteVersionsRepo.listForQuote('cq-1', testDb);
+    const sql = exec.calls[0].sql.toLowerCase();
+    expect(sql).toContain('from "quote_versions"');
+    expect(sql).toContain('"quote_id" = $1');
+    expect(sql).toContain('order by "quote_versions"."created_at" desc');
+    expect(exec.calls[0].params).toEqual(['cq-1']);
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe('qv-1');
+    expect(result[1].reason).toBe('restore');
+  });
+
+  test('returns [] when no versions exist', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await quoteVersionsRepo.listForQuote('cq-x', testDb)).toEqual([]);
+  });
+
+  test('coerces unrecognized reason values to "update"', async () => {
+    exec.enqueue({ rows: [listRow({ 2: 'mystery' })] });
+    const [row] = await quoteVersionsRepo.listForQuote('cq-1', testDb);
+    expect(row.reason).toBe('update');
+  });
+
+  test('null createdAt falls back to 0', async () => {
+    exec.enqueue({ rows: [listRow({ 4: null })] });
+    const [row] = await quoteVersionsRepo.listForQuote('cq-1', testDb);
+    expect(row.createdAt).toBe(0);
+  });
+});
+
+describe('findById', () => {
+  test('scopes the WHERE on BOTH quote_id and id (cross-quote IDOR guard)', async () => {
+    exec.enqueue({ rows: [versionRow()] });
+    const result = await quoteVersionsRepo.findById('cq-1', 'qv-1', testDb);
+    const sql = exec.calls[0].sql.toLowerCase();
+    expect(sql).toContain('"quote_id" = $1');
+    expect(sql).toContain('"id" = $2');
+    expect(sql).toContain('limit $3');
+    expect(exec.calls[0].params).toEqual(['cq-1', 'qv-1', 1]);
+    expect(result?.id).toBe('qv-1');
+    expect(result?.snapshot.schemaVersion).toBe(1);
+  });
+
+  test('returns null when no row matches the (quoteId, versionId) pair', async () => {
+    exec.enqueue({ rows: [] });
+    const result = await quoteVersionsRepo.findById('cq-1', 'qv-other', testDb);
+    expect(result).toBeNull();
+  });
+});
+
+describe('insert', () => {
+  test('binds quote_id, snapshot JSON, reason, createdByUserId; id gets qv- prefix', async () => {
+    exec.enqueue({ rows: [versionRow({ 0: 'qv-generated' })] });
+    const result = await quoteVersionsRepo.insert(
+      {
+        quoteId: 'cq-1',
+        snapshot: {
+          schemaVersion: 1,
+          quote: {
+            id: 'cq-1',
+            clientId: 'c-1',
+            clientName: 'Acme',
+            paymentTerms: 'net30',
+            discount: 5,
+            discountType: 'percentage',
+            status: 'draft',
+            expirationDate: '2026-06-01',
+            notes: null,
+            createdAt: 0,
+            updatedAt: 0,
+          },
+          items: [],
+        },
+        reason: 'restore',
+        createdByUserId: 'u-1',
+      },
+      testDb,
+    );
+    expect(exec.calls[0].sql.toLowerCase()).toContain('insert into "quote_versions"');
+    const generatedId = exec.calls[0].params[0] as string;
+    expect(generatedId.startsWith('qv-')).toBe(true);
+    expect(exec.calls[0].params).toContain('cq-1');
+    expect(exec.calls[0].params).toContain('restore');
+    expect(exec.calls[0].params).toContain('u-1');
+    expect(result.id).toBe('qv-generated');
+    expect(result.reason).toBe('update'); // mapped from versionRow's index 3 default
+  });
+});
+
+describe('deleteAllForQuote', () => {
+  test('issues DELETE WHERE quote_id and returns rowCount', async () => {
+    exec.enqueue({ rows: [], rowCount: 3 });
+    const result = await quoteVersionsRepo.deleteAllForQuote('cq-1', testDb);
+    expect(exec.calls[0].sql.toLowerCase()).toContain('delete from "quote_versions"');
+    expect(exec.calls[0].sql.toLowerCase()).toContain('"quote_id" = $1');
+    expect(exec.calls[0].params).toEqual(['cq-1']);
+    expect(result).toBe(3);
+  });
+
+  test('returns 0 when rowCount is null', async () => {
+    exec.enqueue({ rows: [], rowCount: null });
+    expect(await quoteVersionsRepo.deleteAllForQuote('cq-x', testDb)).toBe(0);
+  });
+});

--- a/server/test/repositories/supplierOrderVersionsRepo.test.ts
+++ b/server/test/repositories/supplierOrderVersionsRepo.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import type { DbExecutor } from '../../db/drizzle.ts';
+import * as supplierOrderVersionsRepo from '../../repositories/supplierOrderVersionsRepo.ts';
+import { type FakeExecutor, makeRow, setupTestDb } from '../helpers/fakeExecutor.ts';
+
+let exec: FakeExecutor;
+let testDb: DbExecutor;
+
+beforeEach(() => {
+  ({ exec, testDb } = setupTestDb());
+});
+
+// supplier_order_versions schema column order:
+// id, order_id, snapshot, reason, created_by_user_id, created_at
+const VERSION_BASE: readonly unknown[] = [
+  'sov-1',
+  'sso-1',
+  { schemaVersion: 1, order: { id: 'sso-1' }, items: [] },
+  'update',
+  'u-1',
+  new Date('2026-01-01T00:00:00Z'),
+];
+const versionRow = (overrides: Record<number, unknown> = {}) => makeRow(VERSION_BASE, overrides);
+
+// listForOrder projects 5 fields in this order: id, orderId, reason, createdByUserId, createdAt.
+const LIST_BASE: readonly unknown[] = [
+  'sov-1',
+  'sso-1',
+  'update',
+  'u-1',
+  new Date('2026-01-01T00:00:00Z'),
+];
+const listRow = (overrides: Record<number, unknown> = {}) => makeRow(LIST_BASE, overrides);
+
+describe('buildSnapshot', () => {
+  test('wraps supplier order + items in a versioned envelope', () => {
+    const order = {
+      id: 'sso-1',
+      linkedQuoteId: 'sqv-1',
+      supplierId: 's-1',
+      supplierName: 'Acme',
+      paymentTerms: 'net30',
+      discount: 5,
+      discountType: 'percentage' as const,
+      status: 'draft',
+      notes: null,
+      createdAt: 0,
+      updatedAt: 0,
+    };
+    const items: Parameters<typeof supplierOrderVersionsRepo.buildSnapshot>[1] = [];
+    const snapshot = supplierOrderVersionsRepo.buildSnapshot(order, items);
+    expect(snapshot.schemaVersion).toBe(1);
+    expect(snapshot.order).toBe(order);
+    expect(snapshot.items).toBe(items);
+  });
+});
+
+describe('listForOrder', () => {
+  test('filters by order_id and orders newest-first', async () => {
+    exec.enqueue({ rows: [listRow(), listRow({ 0: 'sov-2', 2: 'restore' })] });
+    const result = await supplierOrderVersionsRepo.listForOrder('sso-1', testDb);
+    const sql = exec.calls[0].sql.toLowerCase();
+    expect(sql).toContain('from "supplier_order_versions"');
+    expect(sql).toContain('"order_id" = $1');
+    expect(sql).toContain('order by "supplier_order_versions"."created_at" desc');
+    expect(exec.calls[0].params).toEqual(['sso-1']);
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe('sov-1');
+    expect(result[1].reason).toBe('restore');
+  });
+
+  test('returns [] when no versions exist', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await supplierOrderVersionsRepo.listForOrder('sso-x', testDb)).toEqual([]);
+  });
+
+  test('coerces unrecognized reason values to "update"', async () => {
+    exec.enqueue({ rows: [listRow({ 2: 'mystery' })] });
+    const [row] = await supplierOrderVersionsRepo.listForOrder('sso-1', testDb);
+    expect(row.reason).toBe('update');
+  });
+
+  test('null createdAt falls back to 0', async () => {
+    exec.enqueue({ rows: [listRow({ 4: null })] });
+    const [row] = await supplierOrderVersionsRepo.listForOrder('sso-1', testDb);
+    expect(row.createdAt).toBe(0);
+  });
+});
+
+describe('findById', () => {
+  test('scopes the WHERE on BOTH order_id and id (cross-order IDOR guard)', async () => {
+    exec.enqueue({ rows: [versionRow()] });
+    const result = await supplierOrderVersionsRepo.findById('sso-1', 'sov-1', testDb);
+    const sql = exec.calls[0].sql.toLowerCase();
+    expect(sql).toContain('"order_id" = $1');
+    expect(sql).toContain('"id" = $2');
+    expect(sql).toContain('limit $3');
+    expect(exec.calls[0].params).toEqual(['sso-1', 'sov-1', 1]);
+    expect(result?.id).toBe('sov-1');
+    expect(result?.snapshot.schemaVersion).toBe(1);
+  });
+
+  test('returns null when no row matches the (orderId, versionId) pair', async () => {
+    exec.enqueue({ rows: [] });
+    const result = await supplierOrderVersionsRepo.findById('sso-1', 'sov-other', testDb);
+    expect(result).toBeNull();
+  });
+});
+
+describe('insert', () => {
+  test('binds order_id, snapshot JSON, reason, createdByUserId; id gets sov- prefix', async () => {
+    exec.enqueue({ rows: [versionRow({ 0: 'sov-generated' })] });
+    const result = await supplierOrderVersionsRepo.insert(
+      {
+        orderId: 'sso-1',
+        snapshot: {
+          schemaVersion: 1,
+          order: {
+            id: 'sso-1',
+            linkedQuoteId: null,
+            supplierId: 's-1',
+            supplierName: 'Acme',
+            paymentTerms: 'net30',
+            discount: 5,
+            discountType: 'percentage',
+            status: 'draft',
+            notes: null,
+            createdAt: 0,
+            updatedAt: 0,
+          },
+          items: [],
+        },
+        reason: 'restore',
+        createdByUserId: 'u-1',
+      },
+      testDb,
+    );
+    expect(exec.calls[0].sql.toLowerCase()).toContain('insert into "supplier_order_versions"');
+    const generatedId = exec.calls[0].params[0] as string;
+    expect(generatedId.startsWith('sov-')).toBe(true);
+    expect(exec.calls[0].params).toContain('sso-1');
+    expect(exec.calls[0].params).toContain('restore');
+    expect(exec.calls[0].params).toContain('u-1');
+    expect(result.id).toBe('sov-generated');
+    expect(result.reason).toBe('update'); // mapped from versionRow's index 3 default
+  });
+});
+
+describe('deleteAllForOrder', () => {
+  test('issues DELETE WHERE order_id and returns rowCount', async () => {
+    exec.enqueue({ rows: [], rowCount: 3 });
+    const result = await supplierOrderVersionsRepo.deleteAllForOrder('sso-1', testDb);
+    expect(exec.calls[0].sql.toLowerCase()).toContain('delete from "supplier_order_versions"');
+    expect(exec.calls[0].sql.toLowerCase()).toContain('"order_id" = $1');
+    expect(exec.calls[0].params).toEqual(['sso-1']);
+    expect(result).toBe(3);
+  });
+
+  test('returns 0 when rowCount is null', async () => {
+    exec.enqueue({ rows: [], rowCount: null });
+    expect(await supplierOrderVersionsRepo.deleteAllForOrder('sso-x', testDb)).toBe(0);
+  });
+});

--- a/server/test/repositories/supplierQuoteVersionsRepo.test.ts
+++ b/server/test/repositories/supplierQuoteVersionsRepo.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import type { DbExecutor } from '../../db/drizzle.ts';
+import * as supplierQuoteVersionsRepo from '../../repositories/supplierQuoteVersionsRepo.ts';
+import { type FakeExecutor, makeRow, setupTestDb } from '../helpers/fakeExecutor.ts';
+
+let exec: FakeExecutor;
+let testDb: DbExecutor;
+
+beforeEach(() => {
+  ({ exec, testDb } = setupTestDb());
+});
+
+// supplier_quote_versions schema column order:
+// id, quote_id, snapshot, reason, created_by_user_id, created_at
+const VERSION_BASE: readonly unknown[] = [
+  'sqv-1',
+  'sq-1',
+  { schemaVersion: 1, quote: { id: 'sq-1' }, items: [] },
+  'update',
+  'u-1',
+  new Date('2026-01-01T00:00:00Z'),
+];
+const versionRow = (overrides: Record<number, unknown> = {}) => makeRow(VERSION_BASE, overrides);
+
+// listForQuote projects 5 fields in this order: id, quoteId, reason, createdByUserId, createdAt.
+const LIST_BASE: readonly unknown[] = [
+  'sqv-1',
+  'sq-1',
+  'update',
+  'u-1',
+  new Date('2026-01-01T00:00:00Z'),
+];
+const listRow = (overrides: Record<number, unknown> = {}) => makeRow(LIST_BASE, overrides);
+
+describe('buildSnapshot', () => {
+  test('strips linkedOrderId from the supplier-quote envelope', () => {
+    const quote = {
+      id: 'sq-1',
+      supplierId: 's-1',
+      supplierName: 'Acme',
+      paymentTerms: 'net30',
+      status: 'draft',
+      expirationDate: '2026-06-01',
+      linkedOrderId: 'sso-1',
+      notes: null,
+      createdAt: 0,
+      updatedAt: 0,
+    };
+    const items: Parameters<typeof supplierQuoteVersionsRepo.buildSnapshot>[1] = [];
+    const snapshot = supplierQuoteVersionsRepo.buildSnapshot(quote, items);
+    expect(snapshot.schemaVersion).toBe(1);
+    expect(snapshot.items).toBe(items);
+    expect(snapshot.quote.id).toBe('sq-1');
+    expect(snapshot.quote.supplierId).toBe('s-1');
+    // linkedOrderId is intentionally omitted from the snapshot's quote shape.
+    expect((snapshot.quote as Record<string, unknown>).linkedOrderId).toBeUndefined();
+  });
+});
+
+describe('listForQuote', () => {
+  test('filters by quote_id and orders newest-first', async () => {
+    exec.enqueue({ rows: [listRow(), listRow({ 0: 'sqv-2', 2: 'restore' })] });
+    const result = await supplierQuoteVersionsRepo.listForQuote('sq-1', testDb);
+    const sql = exec.calls[0].sql.toLowerCase();
+    expect(sql).toContain('from "supplier_quote_versions"');
+    expect(sql).toContain('"quote_id" = $1');
+    expect(sql).toContain('order by "supplier_quote_versions"."created_at" desc');
+    expect(exec.calls[0].params).toEqual(['sq-1']);
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe('sqv-1');
+    expect(result[1].reason).toBe('restore');
+  });
+
+  test('returns [] when no versions exist', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await supplierQuoteVersionsRepo.listForQuote('sq-x', testDb)).toEqual([]);
+  });
+
+  test('coerces unrecognized reason values to "update"', async () => {
+    exec.enqueue({ rows: [listRow({ 2: 'mystery' })] });
+    const [row] = await supplierQuoteVersionsRepo.listForQuote('sq-1', testDb);
+    expect(row.reason).toBe('update');
+  });
+
+  test('null createdAt falls back to 0', async () => {
+    exec.enqueue({ rows: [listRow({ 4: null })] });
+    const [row] = await supplierQuoteVersionsRepo.listForQuote('sq-1', testDb);
+    expect(row.createdAt).toBe(0);
+  });
+});
+
+describe('findById', () => {
+  test('scopes the WHERE on BOTH quote_id and id (cross-quote IDOR guard)', async () => {
+    exec.enqueue({ rows: [versionRow()] });
+    const result = await supplierQuoteVersionsRepo.findById('sq-1', 'sqv-1', testDb);
+    const sql = exec.calls[0].sql.toLowerCase();
+    expect(sql).toContain('"quote_id" = $1');
+    expect(sql).toContain('"id" = $2');
+    expect(sql).toContain('limit $3');
+    expect(exec.calls[0].params).toEqual(['sq-1', 'sqv-1', 1]);
+    expect(result?.id).toBe('sqv-1');
+    expect(result?.snapshot.schemaVersion).toBe(1);
+  });
+
+  test('returns null when no row matches the (quoteId, versionId) pair', async () => {
+    exec.enqueue({ rows: [] });
+    const result = await supplierQuoteVersionsRepo.findById('sq-1', 'sqv-other', testDb);
+    expect(result).toBeNull();
+  });
+});
+
+describe('insert', () => {
+  test('binds quote_id, snapshot JSON, reason, createdByUserId; id gets sqv- prefix', async () => {
+    exec.enqueue({ rows: [versionRow({ 0: 'sqv-generated' })] });
+    const result = await supplierQuoteVersionsRepo.insert(
+      {
+        quoteId: 'sq-1',
+        snapshot: {
+          schemaVersion: 1,
+          quote: {
+            id: 'sq-1',
+            supplierId: 's-1',
+            supplierName: 'Acme',
+            paymentTerms: 'net30',
+            status: 'draft',
+            expirationDate: '2026-06-01',
+            notes: null,
+            createdAt: 0,
+            updatedAt: 0,
+          },
+          items: [],
+        },
+        reason: 'restore',
+        createdByUserId: 'u-1',
+      },
+      testDb,
+    );
+    expect(exec.calls[0].sql.toLowerCase()).toContain('insert into "supplier_quote_versions"');
+    const generatedId = exec.calls[0].params[0] as string;
+    expect(generatedId.startsWith('sqv-')).toBe(true);
+    expect(exec.calls[0].params).toContain('sq-1');
+    expect(exec.calls[0].params).toContain('restore');
+    expect(exec.calls[0].params).toContain('u-1');
+    expect(result.id).toBe('sqv-generated');
+    expect(result.reason).toBe('update'); // mapped from versionRow's index 3 default
+  });
+});
+
+describe('deleteAllForQuote', () => {
+  test('issues DELETE WHERE quote_id and returns rowCount', async () => {
+    exec.enqueue({ rows: [], rowCount: 3 });
+    const result = await supplierQuoteVersionsRepo.deleteAllForQuote('sq-1', testDb);
+    expect(exec.calls[0].sql.toLowerCase()).toContain('delete from "supplier_quote_versions"');
+    expect(exec.calls[0].sql.toLowerCase()).toContain('"quote_id" = $1');
+    expect(exec.calls[0].params).toEqual(['sq-1']);
+    expect(result).toBe(3);
+  });
+
+  test('returns 0 when rowCount is null', async () => {
+    exec.enqueue({ rows: [], rowCount: null });
+    expect(await supplierQuoteVersionsRepo.deleteAllForQuote('sq-x', testDb)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds unit tests for `orderVersionsRepo`, `quoteVersionsRepo`, `supplierOrderVersionsRepo`, and `supplierQuoteVersionsRepo` (all previously at 0% line coverage; now 100%).
- Tests mirror the existing `offerVersionsRepo.test.ts` pattern, using `FakeExecutor` + `makeRow` to assert SQL shape and result mapping.
- Exercises every public function: `buildSnapshot`, `listForXxx`, `findById` (including the cross-entity IDOR scoping), `insert`, and `deleteAllForXxx`. Also covers the reason-coercion fallback and null `createdAt` handling in `mapRow`.

## Test plan
- [x] `bun test` (server + frontend) — all 1138 + 302 tests green
- [x] `bun run lint` — passes (only pre-existing warnings unrelated to this change)
- [x] Coverage check on the four repos — all four report 100% line / 100% function coverage

https://claude.ai/code/session_0111c2dFZ99BbKBQtghz8kGJ

---
_Generated by [Claude Code](https://claude.ai/code/session_0111c2dFZ99BbKBQtghz8kGJ)_