### PR TITLE
test(routes): add coverage for settings, email, and logs routes

### DIFF
--- a/server/test/routes/email.test.ts
+++ b/server/test/routes/email.test.ts
@@ -1,0 +1,377 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { FastifyInstance, FastifyPluginAsync } from 'fastify';
+import * as realEmailRepo from '../../repositories/emailRepo.ts';
+import * as realRolesRepo from '../../repositories/rolesRepo.ts';
+import * as realUsersRepo from '../../repositories/usersRepo.ts';
+import * as realEmailService from '../../services/email.ts';
+import * as realAudit from '../../utils/audit.ts';
+import { MASKED_SECRET } from '../../utils/crypto.ts';
+import * as realPermissions from '../../utils/permissions.ts';
+import {
+  installAuthMiddlewareMock,
+  restoreAuthMiddlewareMock,
+} from '../helpers/authMiddlewareMock.ts';
+import { buildRouteTestApp } from '../helpers/buildRouteTestApp.ts';
+import { signToken } from '../helpers/jwt.ts';
+
+const usersRepoSnap = { ...realUsersRepo };
+const rolesRepoSnap = { ...realRolesRepo };
+const permissionsSnap = { ...realPermissions };
+const emailRepoSnap = { ...realEmailRepo };
+const auditSnap = { ...realAudit };
+const emailServiceSnap = { ...(realEmailService as Record<string, unknown>) };
+
+const findAuthUserByIdMock = mock();
+const userHasRoleMock = mock();
+const getRolePermissionsMock = mock();
+const emailRepoGetMock = mock();
+const saveConfigMock = mock();
+const sendTestEmailMock = mock();
+const testConnectionMock = mock();
+const logAuditMock = mock(async () => undefined);
+
+let routePlugin: FastifyPluginAsync;
+
+beforeAll(async () => {
+  installAuthMiddlewareMock();
+
+  mock.module('../../repositories/usersRepo.ts', () => ({
+    ...usersRepoSnap,
+    findAuthUserById: findAuthUserByIdMock,
+  }));
+  mock.module('../../repositories/rolesRepo.ts', () => ({
+    ...rolesRepoSnap,
+    userHasRole: userHasRoleMock,
+  }));
+  mock.module('../../utils/permissions.ts', () => ({
+    ...permissionsSnap,
+    getRolePermissions: getRolePermissionsMock,
+  }));
+  mock.module('../../repositories/emailRepo.ts', () => ({
+    ...emailRepoSnap,
+    get: emailRepoGetMock,
+  }));
+  mock.module('../../utils/audit.ts', () => ({
+    ...auditSnap,
+    logAudit: logAuditMock,
+  }));
+  mock.module('../../services/email.ts', () => ({
+    default: {
+      saveConfig: saveConfigMock,
+      sendTestEmail: sendTestEmailMock,
+      testConnection: testConnectionMock,
+    },
+  }));
+
+  routePlugin = (await import('../../routes/email.ts')).default as FastifyPluginAsync;
+});
+
+afterAll(() => {
+  restoreAuthMiddlewareMock();
+  mock.module('../../repositories/usersRepo.ts', () => usersRepoSnap);
+  mock.module('../../repositories/rolesRepo.ts', () => rolesRepoSnap);
+  mock.module('../../utils/permissions.ts', () => permissionsSnap);
+  mock.module('../../repositories/emailRepo.ts', () => emailRepoSnap);
+  mock.module('../../utils/audit.ts', () => auditSnap);
+  mock.module('../../services/email.ts', () => emailServiceSnap);
+});
+
+const HAPPY_USER = {
+  id: 'u1',
+  name: 'Alice',
+  username: 'alice',
+  role: 'admin',
+  avatarInitials: 'AL',
+  isDisabled: false,
+};
+
+const FULL_PERMS = ['administration.email.view', 'administration.email.update'];
+
+const SAMPLE_CONFIG: realEmailRepo.EmailConfig = {
+  enabled: true,
+  smtpHost: 'smtp.example.com',
+  smtpPort: 587,
+  smtpEncryption: 'tls',
+  smtpRejectUnauthorized: true,
+  smtpUser: 'noreply@example.com',
+  smtpPassword: 'encrypted-ciphertext',
+  fromEmail: 'noreply@example.com',
+  fromName: 'Praetor',
+};
+
+const allMocks = [
+  findAuthUserByIdMock,
+  userHasRoleMock,
+  getRolePermissionsMock,
+  emailRepoGetMock,
+  saveConfigMock,
+  sendTestEmailMock,
+  testConnectionMock,
+  logAuditMock,
+];
+
+let testApp: FastifyInstance;
+
+beforeEach(async () => {
+  for (const m of allMocks) m.mockReset();
+  findAuthUserByIdMock.mockResolvedValue(HAPPY_USER);
+  userHasRoleMock.mockResolvedValue(true);
+  getRolePermissionsMock.mockResolvedValue(FULL_PERMS);
+  logAuditMock.mockImplementation(async () => undefined);
+
+  testApp = await buildRouteTestApp(routePlugin, '/api/email');
+});
+
+afterEach(async () => {
+  await testApp.close();
+});
+
+const authHeader = () => ({ authorization: `Bearer ${signToken({ userId: 'u1' })}` });
+
+describe('GET /api/email/config', () => {
+  test('200 returns config with masked password when present', async () => {
+    emailRepoGetMock.mockResolvedValue(SAMPLE_CONFIG);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/email/config',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.smtpHost).toBe('smtp.example.com');
+    expect(body.smtpPassword).toBe(MASKED_SECRET);
+  });
+
+  test('200 returns DEFAULT_CONFIG when repo returns null', async () => {
+    emailRepoGetMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/email/config',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.enabled).toBe(false);
+    expect(body.smtpPort).toBe(587);
+    // empty password serializes to '' (not masked)
+    expect(body.smtpPassword).toBe('');
+  });
+
+  test('401 missing token', async () => {
+    const res = await testApp.inject({ method: 'GET', url: '/api/email/config' });
+    expect(res.statusCode).toBe(401);
+  });
+
+  test('403 missing administration.email.view permission', async () => {
+    getRolePermissionsMock.mockResolvedValue([]);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/email/config',
+      headers: authHeader(),
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+describe('PUT /api/email/config', () => {
+  test('200 happy update emits audit, returns masked', async () => {
+    saveConfigMock.mockResolvedValue(SAMPLE_CONFIG);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/email/config',
+      headers: authHeader(),
+      payload: {
+        enabled: true,
+        smtpHost: 'smtp.example.com',
+        smtpPort: 587,
+        smtpEncryption: 'tls',
+        smtpRejectUnauthorized: true,
+        smtpUser: 'noreply@example.com',
+        smtpPassword: 'plain-password',
+        fromEmail: 'noreply@example.com',
+        fromName: 'Praetor',
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(saveConfigMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: true,
+        smtpHost: 'smtp.example.com',
+        smtpPassword: 'plain-password',
+      }),
+    );
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'email_config.updated',
+        entityType: 'email_config',
+      }),
+    );
+    const body = JSON.parse(res.body);
+    expect(body.smtpPassword).toBe(MASKED_SECRET);
+  });
+
+  test('400 invalid smtpEncryption enum', async () => {
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/email/config',
+      headers: authHeader(),
+      payload: { smtpEncryption: 'bogus' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('401 missing token', async () => {
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/email/config',
+      payload: { enabled: true },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  test('403 missing administration.email.update permission', async () => {
+    getRolePermissionsMock.mockResolvedValue(['administration.email.view']);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/email/config',
+      headers: authHeader(),
+      payload: { enabled: true },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+describe('POST /api/email/test', () => {
+  test('200 happy: sendTestEmail success', async () => {
+    sendTestEmailMock.mockResolvedValue({
+      success: true,
+      code: 'EMAIL_SENT_SUCCESS',
+      messageId: 'msg-1',
+    });
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/email/test',
+      headers: authHeader(),
+      payload: { recipientEmail: 'to@example.com' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.success).toBe(true);
+    expect(body.code).toBe('EMAIL_SENT_SUCCESS');
+    expect(body.messageId).toBe('msg-1');
+    expect(sendTestEmailMock).toHaveBeenCalledWith('to@example.com');
+  });
+
+  test('400 invalid recipient (missing @)', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/email/test',
+      headers: authHeader(),
+      payload: { recipientEmail: 'not-an-email' },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toBe('INVALID_RECIPIENT');
+    expect(sendTestEmailMock).not.toHaveBeenCalled();
+  });
+
+  test('500 when sendTestEmail returns failure', async () => {
+    sendTestEmailMock.mockResolvedValue({
+      success: false,
+      code: 'SMTP_ERROR',
+      params: { error: 'connect refused' },
+    });
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/email/test',
+      headers: authHeader(),
+      payload: { recipientEmail: 'to@example.com' },
+    });
+    expect(res.statusCode).toBe(500);
+    const body = JSON.parse(res.body);
+    expect(body.error).toBe('SMTP_ERROR');
+  });
+
+  test('401 missing token', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/email/test',
+      payload: { recipientEmail: 'to@example.com' },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  test('403 missing administration.email.update permission', async () => {
+    getRolePermissionsMock.mockResolvedValue([]);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/email/test',
+      headers: authHeader(),
+      payload: { recipientEmail: 'to@example.com' },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+describe('POST /api/email/test-connection', () => {
+  test('200 happy: testConnection success', async () => {
+    testConnectionMock.mockResolvedValue({ success: true, code: 'CONNECTION_SUCCESS' });
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/email/test-connection',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.success).toBe(true);
+    expect(body.code).toBe('CONNECTION_SUCCESS');
+  });
+
+  test('500 when testConnection fails', async () => {
+    testConnectionMock.mockResolvedValue({
+      success: false,
+      code: 'SMTP_ERROR',
+      params: { error: 'auth failed' },
+    });
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/email/test-connection',
+      headers: authHeader(),
+    });
+    expect(res.statusCode).toBe(500);
+    expect(JSON.parse(res.body).error).toBe('SMTP_ERROR');
+  });
+
+  test('401 missing token', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/email/test-connection',
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  test('403 missing administration.email.update permission', async () => {
+    getRolePermissionsMock.mockResolvedValue([]);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/email/test-connection',
+      headers: authHeader(),
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});

--- a/server/test/routes/logs.test.ts
+++ b/server/test/routes/logs.test.ts
@@ -1,0 +1,178 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { FastifyInstance, FastifyPluginAsync } from 'fastify';
+import * as realAuditLogsRepo from '../../repositories/auditLogsRepo.ts';
+import * as realRolesRepo from '../../repositories/rolesRepo.ts';
+import * as realUsersRepo from '../../repositories/usersRepo.ts';
+import * as realPermissions from '../../utils/permissions.ts';
+import {
+  installAuthMiddlewareMock,
+  restoreAuthMiddlewareMock,
+} from '../helpers/authMiddlewareMock.ts';
+import { buildRouteTestApp } from '../helpers/buildRouteTestApp.ts';
+import { signToken } from '../helpers/jwt.ts';
+
+const usersRepoSnap = { ...realUsersRepo };
+const rolesRepoSnap = { ...realRolesRepo };
+const permissionsSnap = { ...realPermissions };
+const auditLogsRepoSnap = { ...realAuditLogsRepo };
+
+const findAuthUserByIdMock = mock();
+const userHasRoleMock = mock();
+const getRolePermissionsMock = mock();
+const listMock = mock();
+
+let routePlugin: FastifyPluginAsync;
+
+beforeAll(async () => {
+  installAuthMiddlewareMock();
+
+  mock.module('../../repositories/usersRepo.ts', () => ({
+    ...usersRepoSnap,
+    findAuthUserById: findAuthUserByIdMock,
+  }));
+  mock.module('../../repositories/rolesRepo.ts', () => ({
+    ...rolesRepoSnap,
+    userHasRole: userHasRoleMock,
+  }));
+  mock.module('../../utils/permissions.ts', () => ({
+    ...permissionsSnap,
+    getRolePermissions: getRolePermissionsMock,
+  }));
+  mock.module('../../repositories/auditLogsRepo.ts', () => ({
+    ...auditLogsRepoSnap,
+    list: listMock,
+  }));
+
+  routePlugin = (await import('../../routes/logs.ts')).default as FastifyPluginAsync;
+});
+
+afterAll(() => {
+  restoreAuthMiddlewareMock();
+  mock.module('../../repositories/usersRepo.ts', () => usersRepoSnap);
+  mock.module('../../repositories/rolesRepo.ts', () => rolesRepoSnap);
+  mock.module('../../utils/permissions.ts', () => permissionsSnap);
+  mock.module('../../repositories/auditLogsRepo.ts', () => auditLogsRepoSnap);
+});
+
+const HAPPY_USER = {
+  id: 'u1',
+  name: 'Alice',
+  username: 'alice',
+  role: 'admin',
+  avatarInitials: 'AL',
+  isDisabled: false,
+};
+
+const FULL_PERMS = ['administration.logs.view'];
+
+const SAMPLE_LOG = {
+  id: 'audit-1',
+  userId: 'u1',
+  userName: 'Alice',
+  username: 'alice',
+  action: 'user.login',
+  entityType: 'user',
+  entityId: 'u1',
+  ipAddress: '127.0.0.1',
+  createdAt: 1_700_000_000_000,
+  details: null,
+};
+
+const allMocks = [findAuthUserByIdMock, userHasRoleMock, getRolePermissionsMock, listMock];
+
+let testApp: FastifyInstance;
+
+beforeEach(async () => {
+  for (const m of allMocks) m.mockReset();
+  findAuthUserByIdMock.mockResolvedValue(HAPPY_USER);
+  userHasRoleMock.mockResolvedValue(true);
+  getRolePermissionsMock.mockResolvedValue(FULL_PERMS);
+
+  testApp = await buildRouteTestApp(routePlugin, '/api/logs');
+});
+
+afterEach(async () => {
+  await testApp.close();
+});
+
+const authHeader = () => ({ authorization: `Bearer ${signToken({ userId: 'u1' })}` });
+
+describe('GET /api/logs/audit', () => {
+  test('200 returns logs with no filter', async () => {
+    listMock.mockResolvedValue([SAMPLE_LOG]);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/logs/audit',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual([SAMPLE_LOG]);
+    expect(listMock).toHaveBeenCalledWith({ startDate: undefined, endDate: undefined });
+  });
+
+  test('200 forwards startDate/endDate filters', async () => {
+    listMock.mockResolvedValue([]);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/logs/audit?startDate=2025-01-01T00:00:00Z&endDate=2025-12-31T23:59:59Z',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(listMock).toHaveBeenCalledWith({
+      startDate: '2025-01-01T00:00:00Z',
+      endDate: '2025-12-31T23:59:59Z',
+    });
+  });
+
+  test('200 with details object passes through', async () => {
+    listMock.mockResolvedValue([
+      {
+        ...SAMPLE_LOG,
+        action: 'work_unit.updated',
+        details: { targetLabel: 'Engineering', changedFields: ['name'] },
+      },
+    ]);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/logs/audit',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body[0].details).toEqual({
+      targetLabel: 'Engineering',
+      changedFields: ['name'],
+    });
+  });
+
+  test('401 missing token', async () => {
+    const res = await testApp.inject({ method: 'GET', url: '/api/logs/audit' });
+    expect(res.statusCode).toBe(401);
+  });
+
+  test('403 missing administration.logs.view permission', async () => {
+    getRolePermissionsMock.mockResolvedValue([]);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/logs/audit',
+      headers: authHeader(),
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  test('400 on invalid startDate format (not date-time)', async () => {
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/logs/audit?startDate=not-a-date',
+      headers: authHeader(),
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/server/test/routes/settings.test.ts
+++ b/server/test/routes/settings.test.ts
@@ -1,0 +1,313 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as realBcrypt from 'bcryptjs';
+import type { FastifyInstance, FastifyPluginAsync } from 'fastify';
+import * as realRolesRepo from '../../repositories/rolesRepo.ts';
+import * as realSettingsRepo from '../../repositories/settingsRepo.ts';
+import * as realUsersRepo from '../../repositories/usersRepo.ts';
+import * as realPermissions from '../../utils/permissions.ts';
+import {
+  installAuthMiddlewareMock,
+  restoreAuthMiddlewareMock,
+} from '../helpers/authMiddlewareMock.ts';
+import { buildRouteTestApp } from '../helpers/buildRouteTestApp.ts';
+import { signToken } from '../helpers/jwt.ts';
+
+const usersRepoSnap = { ...realUsersRepo };
+const rolesRepoSnap = { ...realRolesRepo };
+const permissionsSnap = { ...realPermissions };
+const settingsRepoSnap = { ...realSettingsRepo };
+const bcryptSnap = { ...(realBcrypt as Record<string, unknown>) };
+
+const findAuthUserByIdMock = mock();
+const userHasRoleMock = mock();
+const getRolePermissionsMock = mock();
+const getOrCreateForUserMock = mock();
+const upsertForUserMock = mock();
+const getPasswordHashMock = mock();
+const updatePasswordHashMock = mock();
+const bcryptCompareMock = mock();
+const bcryptHashMock = mock();
+
+let routePlugin: FastifyPluginAsync;
+
+beforeAll(async () => {
+  installAuthMiddlewareMock();
+
+  mock.module('../../repositories/usersRepo.ts', () => ({
+    ...usersRepoSnap,
+    findAuthUserById: findAuthUserByIdMock,
+    getPasswordHash: getPasswordHashMock,
+    updatePasswordHash: updatePasswordHashMock,
+  }));
+  mock.module('../../repositories/rolesRepo.ts', () => ({
+    ...rolesRepoSnap,
+    userHasRole: userHasRoleMock,
+  }));
+  mock.module('../../utils/permissions.ts', () => ({
+    ...permissionsSnap,
+    getRolePermissions: getRolePermissionsMock,
+  }));
+  mock.module('../../repositories/settingsRepo.ts', () => ({
+    ...settingsRepoSnap,
+    getOrCreateForUser: getOrCreateForUserMock,
+    upsertForUser: upsertForUserMock,
+  }));
+  mock.module('bcryptjs', () => ({
+    default: { compare: bcryptCompareMock, hash: bcryptHashMock },
+    compare: bcryptCompareMock,
+    hash: bcryptHashMock,
+  }));
+
+  routePlugin = (await import('../../routes/settings.ts')).default as FastifyPluginAsync;
+});
+
+afterAll(() => {
+  restoreAuthMiddlewareMock();
+  mock.module('../../repositories/usersRepo.ts', () => usersRepoSnap);
+  mock.module('../../repositories/rolesRepo.ts', () => rolesRepoSnap);
+  mock.module('../../utils/permissions.ts', () => permissionsSnap);
+  mock.module('../../repositories/settingsRepo.ts', () => settingsRepoSnap);
+  mock.module('bcryptjs', () => bcryptSnap);
+});
+
+const HAPPY_USER = {
+  id: 'u1',
+  name: 'Alice',
+  username: 'alice',
+  role: 'user',
+  avatarInitials: 'AL',
+  isDisabled: false,
+};
+
+const HAPPY_SETTINGS = {
+  fullName: 'Alice',
+  email: 'alice@example.com',
+  language: 'en',
+};
+
+const allMocks = [
+  findAuthUserByIdMock,
+  userHasRoleMock,
+  getRolePermissionsMock,
+  getOrCreateForUserMock,
+  upsertForUserMock,
+  getPasswordHashMock,
+  updatePasswordHashMock,
+  bcryptCompareMock,
+  bcryptHashMock,
+];
+
+let testApp: FastifyInstance;
+
+beforeEach(async () => {
+  for (const m of allMocks) m.mockReset();
+  findAuthUserByIdMock.mockResolvedValue(HAPPY_USER);
+  userHasRoleMock.mockResolvedValue(true);
+  getRolePermissionsMock.mockResolvedValue([]);
+
+  testApp = await buildRouteTestApp(routePlugin, '/api/settings');
+});
+
+afterEach(async () => {
+  await testApp.close();
+});
+
+const authHeader = () => ({ authorization: `Bearer ${signToken({ userId: 'u1' })}` });
+
+describe('GET /api/settings', () => {
+  test('200 returns settings via getOrCreateForUser with defaults', async () => {
+    getOrCreateForUserMock.mockResolvedValue(HAPPY_SETTINGS);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/settings',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual(HAPPY_SETTINGS);
+    expect(getOrCreateForUserMock).toHaveBeenCalledWith('u1', {
+      fullName: 'Alice',
+      email: 'alice@example.com',
+    });
+  });
+
+  test('401 missing token', async () => {
+    const res = await testApp.inject({ method: 'GET', url: '/api/settings' });
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+describe('PUT /api/settings', () => {
+  test('200 happy update', async () => {
+    upsertForUserMock.mockResolvedValue({
+      ...HAPPY_SETTINGS,
+      fullName: 'Alice B',
+      language: 'it',
+    });
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/settings',
+      headers: authHeader(),
+      payload: { fullName: 'Alice B', email: 'alice@b.com', language: 'it' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(upsertForUserMock).toHaveBeenCalledWith('u1', {
+      fullName: 'Alice B',
+      email: 'alice@b.com',
+      language: 'it',
+    });
+  });
+
+  test('200 with no fields → upsert with all nulls', async () => {
+    upsertForUserMock.mockResolvedValue(HAPPY_SETTINGS);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/settings',
+      headers: authHeader(),
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(upsertForUserMock).toHaveBeenCalledWith('u1', {
+      fullName: null,
+      email: null,
+      language: null,
+    });
+  });
+
+  test('400 fullName whitespace-only', async () => {
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/settings',
+      headers: authHeader(),
+      payload: { fullName: '   ' },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/fullName/);
+  });
+
+  test('400 invalid email format', async () => {
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/settings',
+      headers: authHeader(),
+      payload: { email: 'not-an-email' },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/email/);
+  });
+
+  test('400 invalid language enum (rejected by Fastify schema)', async () => {
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/settings',
+      headers: authHeader(),
+      payload: { language: 'fr' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('401 missing token', async () => {
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/settings',
+      payload: { fullName: 'X' },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+describe('PUT /api/settings/password', () => {
+  test('200 happy password change', async () => {
+    getPasswordHashMock.mockResolvedValue('$2a$existing');
+    bcryptCompareMock.mockResolvedValue(true);
+    bcryptHashMock.mockResolvedValue('$2a$newhash');
+    updatePasswordHashMock.mockResolvedValue(undefined);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/settings/password',
+      headers: authHeader(),
+      payload: { currentPassword: 'old-pw1', newPassword: 'new-secure-pw' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ message: 'Password updated successfully' });
+    expect(bcryptCompareMock).toHaveBeenCalledWith('old-pw1', '$2a$existing');
+    expect(bcryptHashMock).toHaveBeenCalledWith('new-secure-pw', 12);
+    expect(updatePasswordHashMock).toHaveBeenCalledWith('u1', '$2a$newhash');
+  });
+
+  test('400 missing currentPassword', async () => {
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/settings/password',
+      headers: authHeader(),
+      payload: { currentPassword: '   ', newPassword: 'new-secure-pw' },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/currentPassword/);
+  });
+
+  test('400 missing newPassword', async () => {
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/settings/password',
+      headers: authHeader(),
+      payload: { currentPassword: 'old', newPassword: '' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('400 newPassword too short (<8)', async () => {
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/settings/password',
+      headers: authHeader(),
+      payload: { currentPassword: 'old-pw', newPassword: 'short' },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/at least 8/);
+  });
+
+  test('404 user not found (no password hash row)', async () => {
+    getPasswordHashMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/settings/password',
+      headers: authHeader(),
+      payload: { currentPassword: 'old-pw', newPassword: 'new-secure-pw' },
+    });
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body)).toEqual({ error: 'User not found' });
+  });
+
+  test('400 incorrect current password', async () => {
+    getPasswordHashMock.mockResolvedValue('$2a$existing');
+    bcryptCompareMock.mockResolvedValue(false);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/settings/password',
+      headers: authHeader(),
+      payload: { currentPassword: 'wrong-pw', newPassword: 'new-secure-pw' },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/Incorrect current password/);
+    expect(updatePasswordHashMock).not.toHaveBeenCalled();
+  });
+
+  test('401 missing token', async () => {
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/settings/password',
+      payload: { currentPassword: 'a', newPassword: 'b' },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `server/test/routes/settings.test.ts` covering GET/PUT/PUT-password handlers including bcrypt-mocked happy/incorrect-password paths and 404 missing-user branch.
- Adds `server/test/routes/email.test.ts` covering GET/PUT `/config`, POST `/test`, and POST `/test-connection` with mocked `services/email.ts` (saveConfig, sendTestEmail, testConnection) and audit logging.
- Adds `server/test/routes/logs.test.ts` covering GET `/audit` filter passthrough plus auth/permission failures.
- All three route files now report 100% line coverage.

## Test plan
- [x] `bun test ./server/test/routes/settings.test.ts ./server/test/routes/email.test.ts ./server/test/routes/logs.test.ts` (38 pass)
- [x] `bun run test` (full suite green)
- [x] `bun run lint` (Biome + tsc + i18n key check pass)
- [x] `cd server && bun test ./test --coverage` confirms `routes/settings.ts`, `routes/email.ts`, `routes/logs.ts` at 100% line coverage

https://claude.ai/code/session_0111c2dFZ99BbKBQtghz8kGJ

---
_Generated by [Claude Code](https://claude.ai/code/session_0111c2dFZ99BbKBQtghz8kGJ)_