### PR TITLE
test(routes): add coverage for suppliers and products routes

### DIFF
--- a/server/test/routes/products.test.ts
+++ b/server/test/routes/products.test.ts
@@ -1,0 +1,1221 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { FastifyInstance, FastifyPluginAsync } from 'fastify';
+import * as realDrizzle from '../../db/drizzle.ts';
+import * as realProductsRepo from '../../repositories/productsRepo.ts';
+import * as realRolesRepo from '../../repositories/rolesRepo.ts';
+import * as realSuppliersRepo from '../../repositories/suppliersRepo.ts';
+import * as realUsersRepo from '../../repositories/usersRepo.ts';
+import * as realAudit from '../../utils/audit.ts';
+import * as realPermissions from '../../utils/permissions.ts';
+import {
+  installAuthMiddlewareMock,
+  restoreAuthMiddlewareMock,
+} from '../helpers/authMiddlewareMock.ts';
+import { buildRouteTestApp } from '../helpers/buildRouteTestApp.ts';
+import { signToken } from '../helpers/jwt.ts';
+
+const usersRepoSnap = { ...realUsersRepo };
+const rolesRepoSnap = { ...realRolesRepo };
+const permissionsSnap = { ...realPermissions };
+const productsRepoSnap = { ...realProductsRepo };
+const suppliersRepoSnap = { ...realSuppliersRepo };
+const auditSnap = { ...realAudit };
+const drizzleSnap = { ...realDrizzle };
+
+// Auth-middleware deps
+const findAuthUserByIdMock = mock();
+const userHasRoleMock = mock();
+const getRolePermissionsMock = mock();
+
+// Products repo mocks
+const listAllProductsMock = mock();
+const findProductByIdMock = mock();
+const findProductCoreByIdMock = mock();
+const existsProductByNameMock = mock();
+const existsProductByCodeMock = mock();
+const insertProductMock = mock();
+const updateProductDynamicMock = mock();
+const deleteProductByIdMock = mock();
+
+const listAllProductTypesWithCountsMock = mock();
+const findProductTypeByNameMock = mock();
+const getCostUnitForTypeMock = mock();
+const existsProductTypeByNameMock = mock();
+const findProductTypeByIdMock = mock();
+const insertProductTypeMock = mock();
+const updateProductTypeFieldsMock = mock();
+const propagateProductTypeNameMock = mock();
+const propagateProductTypeCostUnitMock = mock();
+const countProductsForTypeMock = mock();
+const countCategoriesForTypeMock = mock();
+const deleteProductTypeByIdMock = mock();
+
+const listInternalCategoriesByTypeMock = mock();
+const findInternalCategoryByIdMock = mock();
+const findCategoryIdByNameAndTypeMock = mock();
+const existsInternalCategoryByNameTypeMock = mock();
+const insertInternalCategoryMock = mock();
+const updateInternalCategoryFieldsMock = mock();
+const propagateCategoryNameToProductsMock = mock();
+const clearProductsCategoryByNameMock = mock();
+const deleteInternalCategoryByIdMock = mock();
+const countProductsForCategoryMock = mock();
+
+const listInternalSubcategoriesByTypeMock = mock();
+const existsInternalSubcategoryByNameInCategoryMock = mock();
+const insertInternalSubcategoryMock = mock();
+const updateInternalSubcategoryNameMock = mock();
+const propagateSubcategoryNameToProductsMock = mock();
+const clearProductsSubcategoryByNameMock = mock();
+const deleteInternalSubcategoryByCategoryAndNameMock = mock();
+const countProductsForSubcategoryMock = mock();
+const checkProductsLinkedToTransactionsMock = mock();
+
+const findSupplierNameByIdMock = mock();
+const logAuditMock = mock(async () => undefined);
+const withDbTransactionMock = mock(async (cb: (tx: unknown) => unknown) => cb(undefined));
+
+let routePlugin: FastifyPluginAsync;
+
+beforeAll(async () => {
+  installAuthMiddlewareMock();
+
+  mock.module('../../repositories/usersRepo.ts', () => ({
+    ...usersRepoSnap,
+    findAuthUserById: findAuthUserByIdMock,
+  }));
+  mock.module('../../repositories/rolesRepo.ts', () => ({
+    ...rolesRepoSnap,
+    userHasRole: userHasRoleMock,
+  }));
+  mock.module('../../utils/permissions.ts', () => ({
+    ...permissionsSnap,
+    getRolePermissions: getRolePermissionsMock,
+  }));
+  mock.module('../../repositories/productsRepo.ts', () => ({
+    ...productsRepoSnap,
+    listAllProducts: listAllProductsMock,
+    findProductById: findProductByIdMock,
+    findProductCoreById: findProductCoreByIdMock,
+    existsProductByName: existsProductByNameMock,
+    existsProductByCode: existsProductByCodeMock,
+    insertProduct: insertProductMock,
+    updateProductDynamic: updateProductDynamicMock,
+    deleteProductById: deleteProductByIdMock,
+    listAllProductTypesWithCounts: listAllProductTypesWithCountsMock,
+    findProductTypeByName: findProductTypeByNameMock,
+    getCostUnitForType: getCostUnitForTypeMock,
+    existsProductTypeByName: existsProductTypeByNameMock,
+    findProductTypeById: findProductTypeByIdMock,
+    insertProductType: insertProductTypeMock,
+    updateProductTypeFields: updateProductTypeFieldsMock,
+    propagateProductTypeName: propagateProductTypeNameMock,
+    propagateProductTypeCostUnit: propagateProductTypeCostUnitMock,
+    countProductsForType: countProductsForTypeMock,
+    countCategoriesForType: countCategoriesForTypeMock,
+    deleteProductTypeById: deleteProductTypeByIdMock,
+    listInternalCategoriesByType: listInternalCategoriesByTypeMock,
+    findInternalCategoryById: findInternalCategoryByIdMock,
+    findCategoryIdByNameAndType: findCategoryIdByNameAndTypeMock,
+    existsInternalCategoryByNameType: existsInternalCategoryByNameTypeMock,
+    insertInternalCategory: insertInternalCategoryMock,
+    updateInternalCategoryFields: updateInternalCategoryFieldsMock,
+    propagateCategoryNameToProducts: propagateCategoryNameToProductsMock,
+    clearProductsCategoryByName: clearProductsCategoryByNameMock,
+    deleteInternalCategoryById: deleteInternalCategoryByIdMock,
+    countProductsForCategory: countProductsForCategoryMock,
+    listInternalSubcategoriesByType: listInternalSubcategoriesByTypeMock,
+    existsInternalSubcategoryByNameInCategory: existsInternalSubcategoryByNameInCategoryMock,
+    insertInternalSubcategory: insertInternalSubcategoryMock,
+    updateInternalSubcategoryName: updateInternalSubcategoryNameMock,
+    propagateSubcategoryNameToProducts: propagateSubcategoryNameToProductsMock,
+    clearProductsSubcategoryByName: clearProductsSubcategoryByNameMock,
+    deleteInternalSubcategoryByCategoryAndName: deleteInternalSubcategoryByCategoryAndNameMock,
+    countProductsForSubcategory: countProductsForSubcategoryMock,
+    checkProductsLinkedToTransactions: checkProductsLinkedToTransactionsMock,
+  }));
+  mock.module('../../repositories/suppliersRepo.ts', () => ({
+    ...suppliersRepoSnap,
+    findNameById: findSupplierNameByIdMock,
+  }));
+  mock.module('../../utils/audit.ts', () => ({
+    ...auditSnap,
+    logAudit: logAuditMock,
+  }));
+  mock.module('../../db/drizzle.ts', () => ({
+    ...drizzleSnap,
+    withDbTransaction: withDbTransactionMock,
+  }));
+
+  routePlugin = (await import('../../routes/products.ts')).default as FastifyPluginAsync;
+});
+
+afterAll(() => {
+  restoreAuthMiddlewareMock();
+  mock.module('../../repositories/usersRepo.ts', () => usersRepoSnap);
+  mock.module('../../repositories/rolesRepo.ts', () => rolesRepoSnap);
+  mock.module('../../utils/permissions.ts', () => permissionsSnap);
+  mock.module('../../repositories/productsRepo.ts', () => productsRepoSnap);
+  mock.module('../../repositories/suppliersRepo.ts', () => suppliersRepoSnap);
+  mock.module('../../utils/audit.ts', () => auditSnap);
+  mock.module('../../db/drizzle.ts', () => drizzleSnap);
+});
+
+const HAPPY_USER = {
+  id: 'u1',
+  name: 'Alice',
+  username: 'alice',
+  role: 'top_manager',
+  avatarInitials: 'AL',
+  isDisabled: false,
+};
+
+const ALL_PERMS = [
+  'catalog.internal_listing.view',
+  'catalog.internal_listing.create',
+  'catalog.internal_listing.update',
+  'catalog.internal_listing.delete',
+  'sales.supplier_quotes.view',
+  'sales.client_offers.view',
+  'accounting.supplier_orders.view',
+  'accounting.supplier_invoices.view',
+];
+
+const SAMPLE_PRODUCT = {
+  id: 'p-1',
+  name: 'Widget',
+  productCode: 'WGT-1',
+  description: null,
+  costo: 10,
+  molPercentage: 30,
+  costUnit: 'unit' as const,
+  category: null,
+  subcategory: null,
+  type: 'goods',
+  supplierId: null,
+  supplierName: null,
+  isDisabled: false,
+  createdAt: 1_700_000_000_000,
+};
+
+const SAMPLE_TYPE = {
+  id: 'pt-1',
+  name: 'goods',
+  costUnit: 'unit' as const,
+  createdAt: 1,
+  updatedAt: 2,
+};
+
+const SAMPLE_CATEGORY = {
+  id: 'ipc-1',
+  name: 'Electronics',
+  type: 'goods',
+  costUnit: 'unit' as const,
+  createdAt: 1,
+  updatedAt: 2,
+  productCount: 0,
+  hasLinkedProducts: false,
+};
+
+const allMocks = [
+  findAuthUserByIdMock,
+  userHasRoleMock,
+  getRolePermissionsMock,
+  listAllProductsMock,
+  findProductByIdMock,
+  findProductCoreByIdMock,
+  existsProductByNameMock,
+  existsProductByCodeMock,
+  insertProductMock,
+  updateProductDynamicMock,
+  deleteProductByIdMock,
+  listAllProductTypesWithCountsMock,
+  findProductTypeByNameMock,
+  getCostUnitForTypeMock,
+  existsProductTypeByNameMock,
+  findProductTypeByIdMock,
+  insertProductTypeMock,
+  updateProductTypeFieldsMock,
+  propagateProductTypeNameMock,
+  propagateProductTypeCostUnitMock,
+  countProductsForTypeMock,
+  countCategoriesForTypeMock,
+  deleteProductTypeByIdMock,
+  listInternalCategoriesByTypeMock,
+  findInternalCategoryByIdMock,
+  findCategoryIdByNameAndTypeMock,
+  existsInternalCategoryByNameTypeMock,
+  insertInternalCategoryMock,
+  updateInternalCategoryFieldsMock,
+  propagateCategoryNameToProductsMock,
+  clearProductsCategoryByNameMock,
+  deleteInternalCategoryByIdMock,
+  countProductsForCategoryMock,
+  listInternalSubcategoriesByTypeMock,
+  existsInternalSubcategoryByNameInCategoryMock,
+  insertInternalSubcategoryMock,
+  updateInternalSubcategoryNameMock,
+  propagateSubcategoryNameToProductsMock,
+  clearProductsSubcategoryByNameMock,
+  deleteInternalSubcategoryByCategoryAndNameMock,
+  countProductsForSubcategoryMock,
+  checkProductsLinkedToTransactionsMock,
+  findSupplierNameByIdMock,
+  logAuditMock,
+  withDbTransactionMock,
+];
+
+let testApp: FastifyInstance;
+
+beforeEach(async () => {
+  for (const m of allMocks) m.mockReset();
+  findAuthUserByIdMock.mockResolvedValue(HAPPY_USER);
+  userHasRoleMock.mockResolvedValue(true);
+  getRolePermissionsMock.mockResolvedValue(ALL_PERMS);
+  withDbTransactionMock.mockImplementation(async (cb) => cb(undefined));
+  logAuditMock.mockImplementation(async () => undefined);
+  // Default: no name/code conflicts
+  existsProductByNameMock.mockResolvedValue(false);
+  existsProductByCodeMock.mockResolvedValue(false);
+  // Default valid type lookup
+  findProductTypeByNameMock.mockResolvedValue('unit');
+  // Default no linked records
+  checkProductsLinkedToTransactionsMock.mockResolvedValue({ linked: false, count: 0 });
+
+  testApp = await buildRouteTestApp(routePlugin, '/api/products');
+});
+
+afterEach(async () => {
+  await testApp.close();
+});
+
+const authHeader = () => ({ authorization: `Bearer ${signToken({ userId: 'u1' })}` });
+
+// ---------------------------------------------------------------------------
+// Products
+// ---------------------------------------------------------------------------
+
+describe('GET /api/products', () => {
+  test('200 returns list', async () => {
+    listAllProductsMock.mockResolvedValue([SAMPLE_PRODUCT]);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/products',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(listAllProductsMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('401 missing token', async () => {
+    const res = await testApp.inject({ method: 'GET', url: '/api/products' });
+    expect(res.statusCode).toBe(401);
+  });
+
+  test('403 missing all view perms', async () => {
+    getRolePermissionsMock.mockResolvedValue([]);
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/products',
+      headers: authHeader(),
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+describe('POST /api/products', () => {
+  test('201 creates product', async () => {
+    insertProductMock.mockResolvedValue({ ...SAMPLE_PRODUCT });
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/products',
+      headers: authHeader(),
+      payload: {
+        name: 'Widget',
+        productCode: 'WGT-1',
+        costo: 10,
+        molPercentage: 30,
+        type: 'goods',
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(insertProductMock).toHaveBeenCalled();
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'product.created' }),
+    );
+  });
+
+  test('400 invalid productCode characters', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/products',
+      headers: authHeader(),
+      payload: {
+        name: 'Widget',
+        productCode: 'bad code!',
+        costo: 10,
+        molPercentage: 30,
+        type: 'goods',
+      },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('400 duplicate name', async () => {
+    existsProductByNameMock.mockResolvedValue(true);
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/products',
+      headers: authHeader(),
+      payload: {
+        name: 'Widget',
+        productCode: 'WGT-1',
+        costo: 10,
+        molPercentage: 30,
+        type: 'goods',
+      },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/Product name must be unique/);
+  });
+
+  test('400 duplicate code', async () => {
+    existsProductByCodeMock.mockResolvedValue(true);
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/products',
+      headers: authHeader(),
+      payload: {
+        name: 'Widget',
+        productCode: 'WGT-1',
+        costo: 10,
+        molPercentage: 30,
+        type: 'goods',
+      },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/Product code must be unique/);
+  });
+
+  test('400 invalid type', async () => {
+    findProductTypeByNameMock.mockResolvedValue(null);
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/products',
+      headers: authHeader(),
+      payload: {
+        name: 'Widget',
+        productCode: 'WGT-1',
+        costo: 10,
+        molPercentage: 30,
+        type: 'unknown',
+      },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('400 molPercentage out of range', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/products',
+      headers: authHeader(),
+      payload: {
+        name: 'Widget',
+        productCode: 'WGT-1',
+        costo: 10,
+        molPercentage: 100,
+        type: 'goods',
+      },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('401 missing token', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/products',
+      payload: { name: 'X', productCode: 'X', costo: 0, molPercentage: 1, type: 'goods' },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  test('403 missing create perm', async () => {
+    getRolePermissionsMock.mockResolvedValue(['catalog.internal_listing.view']);
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/products',
+      headers: authHeader(),
+      payload: { name: 'X', productCode: 'X', costo: 0, molPercentage: 1, type: 'goods' },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+describe('PUT /api/products/:id', () => {
+  test('200 simple update', async () => {
+    updateProductDynamicMock.mockResolvedValue({ ...SAMPLE_PRODUCT, name: 'Renamed' });
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/products/p-1',
+      headers: authHeader(),
+      payload: { name: 'Renamed' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(updateProductDynamicMock).toHaveBeenCalledWith(
+      'p-1',
+      expect.objectContaining({ name: 'Renamed' }),
+    );
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'product.updated' }),
+    );
+  });
+
+  test('200 isDisabled toggle audits as product.disabled', async () => {
+    updateProductDynamicMock.mockResolvedValue({ ...SAMPLE_PRODUCT, isDisabled: true });
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/products/p-1',
+      headers: authHeader(),
+      payload: { isDisabled: true },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'product.disabled' }),
+    );
+  });
+
+  test('200 type change loads currentProduct + recomputes costUnit', async () => {
+    findProductCoreByIdMock.mockResolvedValue({
+      type: 'goods',
+      supplierId: null,
+      category: null,
+      subcategory: null,
+    });
+    findProductTypeByNameMock.mockResolvedValue('hours');
+    updateProductDynamicMock.mockResolvedValue({
+      ...SAMPLE_PRODUCT,
+      type: 'services',
+      costUnit: 'hours',
+    });
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/products/p-1',
+      headers: authHeader(),
+      payload: { type: 'services' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(findProductCoreByIdMock).toHaveBeenCalledWith('p-1');
+    expect(updateProductDynamicMock).toHaveBeenCalledWith(
+      'p-1',
+      expect.objectContaining({ type: 'services', costUnit: 'hours' }),
+    );
+  });
+
+  test('404 currentProduct missing when type provided', async () => {
+    findProductCoreByIdMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/products/missing',
+      headers: authHeader(),
+      payload: { type: 'goods' },
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  test('404 update returns null', async () => {
+    updateProductDynamicMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/products/missing',
+      headers: authHeader(),
+      payload: { name: 'X' },
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  test('400 duplicate name on update', async () => {
+    existsProductByNameMock.mockResolvedValue(true);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/products/p-1',
+      headers: authHeader(),
+      payload: { name: 'Taken' },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('401 missing token', async () => {
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/products/p-1',
+      payload: { name: 'X' },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  test('403 missing update perm', async () => {
+    getRolePermissionsMock.mockResolvedValue(['catalog.internal_listing.view']);
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/products/p-1',
+      headers: authHeader(),
+      payload: { name: 'X' },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+describe('DELETE /api/products/:id', () => {
+  test('204 deletes product', async () => {
+    deleteProductByIdMock.mockResolvedValue({ name: 'Widget', productCode: 'WGT-1' });
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/products/p-1',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(204);
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'product.deleted' }),
+    );
+  });
+
+  test('404 not found', async () => {
+    deleteProductByIdMock.mockResolvedValue(null);
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/products/missing',
+      headers: authHeader(),
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  test('401 missing token', async () => {
+    const res = await testApp.inject({ method: 'DELETE', url: '/api/products/p-1' });
+    expect(res.statusCode).toBe(401);
+  });
+
+  test('403 missing delete perm', async () => {
+    getRolePermissionsMock.mockResolvedValue(['catalog.internal_listing.view']);
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/products/p-1',
+      headers: authHeader(),
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Internal categories
+// ---------------------------------------------------------------------------
+
+describe('GET /api/products/internal-categories', () => {
+  test('200 returns list', async () => {
+    listInternalCategoriesByTypeMock.mockResolvedValue([SAMPLE_CATEGORY]);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/products/internal-categories?type=goods',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(listInternalCategoriesByTypeMock).toHaveBeenCalledWith('goods');
+  });
+
+  test('400 invalid type', async () => {
+    findProductTypeByNameMock.mockResolvedValue(null);
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/products/internal-categories?type=bogus',
+      headers: authHeader(),
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('401 missing token', async () => {
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/products/internal-categories?type=goods',
+    });
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+describe('POST /api/products/internal-categories', () => {
+  test('201 creates category', async () => {
+    existsInternalCategoryByNameTypeMock.mockResolvedValue(false);
+    insertInternalCategoryMock.mockResolvedValue({ ...SAMPLE_CATEGORY });
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/products/internal-categories',
+      headers: authHeader(),
+      payload: { name: 'Electronics', type: 'goods' },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(insertInternalCategoryMock).toHaveBeenCalled();
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'internal_category.created' }),
+    );
+  });
+
+  test('400 duplicate', async () => {
+    existsInternalCategoryByNameTypeMock.mockResolvedValue(true);
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/products/internal-categories',
+      headers: authHeader(),
+      payload: { name: 'Electronics', type: 'goods' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('403 missing create', async () => {
+    getRolePermissionsMock.mockResolvedValue(['catalog.internal_listing.view']);
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/products/internal-categories',
+      headers: authHeader(),
+      payload: { name: 'Electronics', type: 'goods' },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+describe('PUT /api/products/internal-categories/:id', () => {
+  test('200 renames category', async () => {
+    findInternalCategoryByIdMock.mockResolvedValue({ ...SAMPLE_CATEGORY });
+    existsInternalCategoryByNameTypeMock.mockResolvedValue(false);
+    getCostUnitForTypeMock.mockResolvedValue('unit');
+    updateInternalCategoryFieldsMock.mockResolvedValue({
+      ...SAMPLE_CATEGORY,
+      name: 'Renamed',
+    });
+    propagateCategoryNameToProductsMock.mockResolvedValue(undefined);
+    countProductsForCategoryMock.mockResolvedValue(0);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/products/internal-categories/ipc-1',
+      headers: authHeader(),
+      payload: { name: 'Renamed' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'internal_category.updated' }),
+    );
+  });
+
+  test('404 category not found', async () => {
+    findInternalCategoryByIdMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/products/internal-categories/missing',
+      headers: authHeader(),
+      payload: { name: 'X' },
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  test('409 linked to transactions blocks rename', async () => {
+    findInternalCategoryByIdMock.mockResolvedValue({ ...SAMPLE_CATEGORY });
+    getCostUnitForTypeMock.mockResolvedValue('unit');
+    existsInternalCategoryByNameTypeMock.mockResolvedValue(false);
+    checkProductsLinkedToTransactionsMock.mockResolvedValue({ linked: true, count: 3 });
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/products/internal-categories/ipc-1',
+      headers: authHeader(),
+      payload: { name: 'Renamed' },
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body).error).toMatch(/Cannot rename category/);
+  });
+});
+
+describe('DELETE /api/products/internal-categories/:id', () => {
+  test('204 deletes category', async () => {
+    findInternalCategoryByIdMock.mockResolvedValue({ ...SAMPLE_CATEGORY });
+    clearProductsCategoryByNameMock.mockResolvedValue(undefined);
+    deleteInternalCategoryByIdMock.mockResolvedValue(undefined);
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/products/internal-categories/ipc-1',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(204);
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'internal_category.deleted' }),
+    );
+  });
+
+  test('404 not found', async () => {
+    findInternalCategoryByIdMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/products/internal-categories/missing',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  test('409 when linked', async () => {
+    findInternalCategoryByIdMock.mockResolvedValue({ ...SAMPLE_CATEGORY });
+    checkProductsLinkedToTransactionsMock.mockResolvedValue({ linked: true, count: 2 });
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/products/internal-categories/ipc-1',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(409);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Internal subcategories
+// ---------------------------------------------------------------------------
+
+describe('GET /api/products/internal-subcategories', () => {
+  test('200 lists subcategories', async () => {
+    findCategoryIdByNameAndTypeMock.mockResolvedValue('ipc-1');
+    listInternalSubcategoriesByTypeMock.mockResolvedValue([
+      { name: 'Sub', productCount: 0, hasLinkedProducts: false },
+    ]);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/products/internal-subcategories?type=goods&category=Electronics',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(listInternalSubcategoriesByTypeMock).toHaveBeenCalledWith('ipc-1');
+  });
+
+  test('404 category not found', async () => {
+    findCategoryIdByNameAndTypeMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/products/internal-subcategories?type=goods&category=Missing',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe('POST /api/products/internal-subcategories', () => {
+  test('201 creates subcategory', async () => {
+    findCategoryIdByNameAndTypeMock.mockResolvedValue('ipc-1');
+    existsInternalSubcategoryByNameInCategoryMock.mockResolvedValue(false);
+    insertInternalSubcategoryMock.mockResolvedValue({ id: 'ips-1', name: 'Sub' });
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/products/internal-subcategories',
+      headers: authHeader(),
+      payload: { name: 'Sub', type: 'goods', category: 'Electronics' },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'internal_subcategory.created' }),
+    );
+  });
+
+  test('400 duplicate subcategory', async () => {
+    findCategoryIdByNameAndTypeMock.mockResolvedValue('ipc-1');
+    existsInternalSubcategoryByNameInCategoryMock.mockResolvedValue(true);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/products/internal-subcategories',
+      headers: authHeader(),
+      payload: { name: 'Sub', type: 'goods', category: 'Electronics' },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('404 parent category missing', async () => {
+    findCategoryIdByNameAndTypeMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/products/internal-subcategories',
+      headers: authHeader(),
+      payload: { name: 'Sub', type: 'goods', category: 'Missing' },
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe('PUT /api/products/internal-subcategories/:name', () => {
+  test('200 renames subcategory', async () => {
+    findCategoryIdByNameAndTypeMock.mockResolvedValue('ipc-1');
+    updateInternalSubcategoryNameMock.mockResolvedValue({ id: 'ips-1' });
+    propagateSubcategoryNameToProductsMock.mockResolvedValue(undefined);
+    countProductsForSubcategoryMock.mockResolvedValue(0);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/products/internal-subcategories/Old',
+      headers: authHeader(),
+      payload: { newName: 'New', type: 'goods', category: 'Electronics' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'internal_subcategory.renamed' }),
+    );
+  });
+
+  test('400 duplicate new name', async () => {
+    findCategoryIdByNameAndTypeMock.mockResolvedValue('ipc-1');
+    existsInternalSubcategoryByNameInCategoryMock.mockResolvedValue(true);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/products/internal-subcategories/Old',
+      headers: authHeader(),
+      payload: { newName: 'New', type: 'goods', category: 'Electronics' },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('404 category missing', async () => {
+    findCategoryIdByNameAndTypeMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/products/internal-subcategories/Old',
+      headers: authHeader(),
+      payload: { newName: 'New', type: 'goods', category: 'Missing' },
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  test('409 linked products block rename', async () => {
+    findCategoryIdByNameAndTypeMock.mockResolvedValue('ipc-1');
+    checkProductsLinkedToTransactionsMock.mockResolvedValue({ linked: true, count: 5 });
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/products/internal-subcategories/Old',
+      headers: authHeader(),
+      payload: { newName: 'New', type: 'goods', category: 'Electronics' },
+    });
+
+    expect(res.statusCode).toBe(409);
+  });
+});
+
+describe('DELETE /api/products/internal-subcategories/:name', () => {
+  test('204 deletes subcategory', async () => {
+    findCategoryIdByNameAndTypeMock.mockResolvedValue('ipc-1');
+    clearProductsSubcategoryByNameMock.mockResolvedValue(undefined);
+    deleteInternalSubcategoryByCategoryAndNameMock.mockResolvedValue({ id: 'ips-1' });
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/products/internal-subcategories/Sub?type=goods&category=Electronics',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(204);
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'internal_subcategory.deleted' }),
+    );
+  });
+
+  test('404 category missing', async () => {
+    findCategoryIdByNameAndTypeMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/products/internal-subcategories/Sub?type=goods&category=Missing',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  test('404 subcategory missing', async () => {
+    findCategoryIdByNameAndTypeMock.mockResolvedValue('ipc-1');
+    clearProductsSubcategoryByNameMock.mockResolvedValue(undefined);
+    deleteInternalSubcategoryByCategoryAndNameMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/products/internal-subcategories/Sub?type=goods&category=Electronics',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  test('409 linked', async () => {
+    findCategoryIdByNameAndTypeMock.mockResolvedValue('ipc-1');
+    checkProductsLinkedToTransactionsMock.mockResolvedValue({ linked: true, count: 2 });
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/products/internal-subcategories/Sub?type=goods&category=Electronics',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(409);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Product types (internal-types)
+// ---------------------------------------------------------------------------
+
+describe('GET /api/products/internal-types', () => {
+  test('200 lists types', async () => {
+    listAllProductTypesWithCountsMock.mockResolvedValue([
+      { ...SAMPLE_TYPE, productCount: 0, categoryCount: 0 },
+    ]);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/products/internal-types',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(listAllProductTypesWithCountsMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('401 missing token', async () => {
+    const res = await testApp.inject({ method: 'GET', url: '/api/products/internal-types' });
+    expect(res.statusCode).toBe(401);
+  });
+
+  test('403 missing view perm', async () => {
+    getRolePermissionsMock.mockResolvedValue([]);
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/products/internal-types',
+      headers: authHeader(),
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+describe('POST /api/products/internal-types', () => {
+  test('201 creates type', async () => {
+    existsProductTypeByNameMock.mockResolvedValue(false);
+    insertProductTypeMock.mockResolvedValue({ ...SAMPLE_TYPE });
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/products/internal-types',
+      headers: authHeader(),
+      payload: { name: 'goods', costUnit: 'unit' },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'product_type.created' }),
+    );
+  });
+
+  test('400 duplicate name', async () => {
+    existsProductTypeByNameMock.mockResolvedValue(true);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/products/internal-types',
+      headers: authHeader(),
+      payload: { name: 'goods', costUnit: 'unit' },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('400 invalid costUnit', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/products/internal-types',
+      headers: authHeader(),
+      payload: { name: 'goods', costUnit: 'bogus' },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('401 missing token', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/products/internal-types',
+      payload: { name: 'goods', costUnit: 'unit' },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+describe('PUT /api/products/internal-types/:id', () => {
+  test('200 updates type', async () => {
+    findProductTypeByIdMock.mockResolvedValue({ ...SAMPLE_TYPE });
+    existsProductTypeByNameMock.mockResolvedValue(false);
+    updateProductTypeFieldsMock.mockResolvedValue({ ...SAMPLE_TYPE, name: 'svc' });
+    countProductsForTypeMock.mockResolvedValue(0);
+    countCategoriesForTypeMock.mockResolvedValue(0);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/products/internal-types/pt-1',
+      headers: authHeader(),
+      payload: { name: 'svc' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'product_type.updated' }),
+    );
+  });
+
+  test('404 type not found', async () => {
+    findProductTypeByIdMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/products/internal-types/missing',
+      headers: authHeader(),
+      payload: { name: 'X' },
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  test('400 duplicate name', async () => {
+    findProductTypeByIdMock.mockResolvedValue({ ...SAMPLE_TYPE });
+    existsProductTypeByNameMock.mockResolvedValue(true);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/products/internal-types/pt-1',
+      headers: authHeader(),
+      payload: { name: 'taken' },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe('DELETE /api/products/internal-types/:id', () => {
+  test('204 deletes type', async () => {
+    findProductTypeByIdMock.mockResolvedValue({ ...SAMPLE_TYPE });
+    countProductsForTypeMock.mockResolvedValue(0);
+    countCategoriesForTypeMock.mockResolvedValue(0);
+    deleteProductTypeByIdMock.mockResolvedValue(undefined);
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/products/internal-types/pt-1',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(204);
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'product_type.deleted' }),
+    );
+  });
+
+  test('404 not found', async () => {
+    findProductTypeByIdMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/products/internal-types/missing',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  test('409 products linked', async () => {
+    findProductTypeByIdMock.mockResolvedValue({ ...SAMPLE_TYPE });
+    countProductsForTypeMock.mockResolvedValue(3);
+    countCategoriesForTypeMock.mockResolvedValue(0);
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/products/internal-types/pt-1',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body).error).toMatch(/3 product/);
+  });
+
+  test('409 categories linked', async () => {
+    findProductTypeByIdMock.mockResolvedValue({ ...SAMPLE_TYPE });
+    countProductsForTypeMock.mockResolvedValue(0);
+    countCategoriesForTypeMock.mockResolvedValue(2);
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/products/internal-types/pt-1',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body).error).toMatch(/2 categor/);
+  });
+
+  test('401 missing token', async () => {
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/products/internal-types/pt-1',
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  test('403 missing delete perm', async () => {
+    getRolePermissionsMock.mockResolvedValue(['catalog.internal_listing.view']);
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/products/internal-types/pt-1',
+      headers: authHeader(),
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});

--- a/server/test/routes/suppliers.test.ts
+++ b/server/test/routes/suppliers.test.ts
@@ -1,0 +1,385 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { FastifyInstance, FastifyPluginAsync } from 'fastify';
+import * as realRolesRepo from '../../repositories/rolesRepo.ts';
+import * as realSuppliersRepo from '../../repositories/suppliersRepo.ts';
+import * as realUsersRepo from '../../repositories/usersRepo.ts';
+import * as realAudit from '../../utils/audit.ts';
+import * as realPermissions from '../../utils/permissions.ts';
+import {
+  installAuthMiddlewareMock,
+  restoreAuthMiddlewareMock,
+} from '../helpers/authMiddlewareMock.ts';
+import { buildRouteTestApp } from '../helpers/buildRouteTestApp.ts';
+import { signToken } from '../helpers/jwt.ts';
+
+const usersRepoSnap = { ...realUsersRepo };
+const rolesRepoSnap = { ...realRolesRepo };
+const permissionsSnap = { ...realPermissions };
+const suppliersRepoSnap = { ...realSuppliersRepo };
+const auditSnap = { ...realAudit };
+
+const findAuthUserByIdMock = mock();
+const userHasRoleMock = mock();
+const getRolePermissionsMock = mock();
+
+const listAllMock = mock();
+const createMock = mock();
+const updateMock = mock();
+const deleteByIdMock = mock();
+const logAuditMock = mock(async () => undefined);
+
+let routePlugin: FastifyPluginAsync;
+
+beforeAll(async () => {
+  installAuthMiddlewareMock();
+
+  mock.module('../../repositories/usersRepo.ts', () => ({
+    ...usersRepoSnap,
+    findAuthUserById: findAuthUserByIdMock,
+  }));
+  mock.module('../../repositories/rolesRepo.ts', () => ({
+    ...rolesRepoSnap,
+    userHasRole: userHasRoleMock,
+  }));
+  mock.module('../../utils/permissions.ts', () => ({
+    ...permissionsSnap,
+    getRolePermissions: getRolePermissionsMock,
+  }));
+  mock.module('../../repositories/suppliersRepo.ts', () => ({
+    ...suppliersRepoSnap,
+    listAll: listAllMock,
+    create: createMock,
+    update: updateMock,
+    deleteById: deleteByIdMock,
+  }));
+  mock.module('../../utils/audit.ts', () => ({
+    ...auditSnap,
+    logAudit: logAuditMock,
+  }));
+
+  routePlugin = (await import('../../routes/suppliers.ts')).default as FastifyPluginAsync;
+});
+
+afterAll(() => {
+  restoreAuthMiddlewareMock();
+  mock.module('../../repositories/usersRepo.ts', () => usersRepoSnap);
+  mock.module('../../repositories/rolesRepo.ts', () => rolesRepoSnap);
+  mock.module('../../utils/permissions.ts', () => permissionsSnap);
+  mock.module('../../repositories/suppliersRepo.ts', () => suppliersRepoSnap);
+  mock.module('../../utils/audit.ts', () => auditSnap);
+});
+
+const HAPPY_USER = {
+  id: 'u1',
+  name: 'Alice',
+  username: 'alice',
+  role: 'top_manager',
+  avatarInitials: 'AL',
+  isDisabled: false,
+};
+
+const ALL_PERMS = [
+  'crm.suppliers.view',
+  'crm.suppliers_all.view',
+  'crm.suppliers.create',
+  'crm.suppliers.update',
+  'crm.suppliers.delete',
+];
+
+const SAMPLE_SUPPLIER = {
+  id: 's-1',
+  name: 'ACME',
+  isDisabled: false,
+  supplierCode: 'ACM',
+  contactName: 'Jane',
+  email: 'jane@acme.test',
+  phone: '+1-555-0100',
+  address: '1 Main St',
+  vatNumber: 'IT123',
+  taxCode: 'TAX1',
+  paymentTerms: '30 days',
+  notes: null,
+  createdAt: 1_700_000_000_000,
+};
+
+const allMocks = [
+  findAuthUserByIdMock,
+  userHasRoleMock,
+  getRolePermissionsMock,
+  listAllMock,
+  createMock,
+  updateMock,
+  deleteByIdMock,
+  logAuditMock,
+];
+
+let testApp: FastifyInstance;
+
+beforeEach(async () => {
+  for (const m of allMocks) m.mockReset();
+  findAuthUserByIdMock.mockResolvedValue(HAPPY_USER);
+  userHasRoleMock.mockResolvedValue(true);
+  getRolePermissionsMock.mockResolvedValue(ALL_PERMS);
+  logAuditMock.mockImplementation(async () => undefined);
+
+  testApp = await buildRouteTestApp(routePlugin, '/api/suppliers');
+});
+
+afterEach(async () => {
+  await testApp.close();
+});
+
+const authHeader = () => ({ authorization: `Bearer ${signToken({ userId: 'u1' })}` });
+
+describe('GET /api/suppliers', () => {
+  test('200 returns list', async () => {
+    listAllMock.mockResolvedValue([SAMPLE_SUPPLIER]);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/suppliers',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual([SAMPLE_SUPPLIER]);
+    expect(listAllMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('401 missing token', async () => {
+    const res = await testApp.inject({ method: 'GET', url: '/api/suppliers' });
+    expect(res.statusCode).toBe(401);
+  });
+
+  test('403 missing all view permissions', async () => {
+    getRolePermissionsMock.mockResolvedValue([]);
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/suppliers',
+      headers: authHeader(),
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+describe('POST /api/suppliers', () => {
+  test('201 creates supplier with audit', async () => {
+    createMock.mockResolvedValue(SAMPLE_SUPPLIER);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/suppliers',
+      headers: authHeader(),
+      payload: {
+        name: 'ACME',
+        vatNumber: 'IT123',
+        supplierCode: 'ACM',
+        email: 'jane@acme.test',
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(createMock).toHaveBeenCalledTimes(1);
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'supplier.created',
+        entityType: 'supplier',
+      }),
+    );
+  });
+
+  test('400 missing name', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/suppliers',
+      headers: authHeader(),
+      payload: { name: '   ', vatNumber: 'IT123' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('400 missing vatNumber', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/suppliers',
+      headers: authHeader(),
+      payload: { name: 'ACME' },
+    });
+    // Schema enforces vatNumber required
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('400 invalid email', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/suppliers',
+      headers: authHeader(),
+      payload: { name: 'ACME', vatNumber: 'IT123', email: 'not-an-email' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('401 missing token', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/suppliers',
+      payload: { name: 'ACME', vatNumber: 'IT123' },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  test('403 missing create permission', async () => {
+    getRolePermissionsMock.mockResolvedValue(['crm.suppliers.view']);
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/suppliers',
+      headers: authHeader(),
+      payload: { name: 'ACME', vatNumber: 'IT123' },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+describe('PUT /api/suppliers/:id', () => {
+  test('200 updates supplier with supplier.updated audit', async () => {
+    updateMock.mockResolvedValue({ ...SAMPLE_SUPPLIER, name: 'ACME 2' });
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/suppliers/s-1',
+      headers: authHeader(),
+      payload: { name: 'ACME 2' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(updateMock).toHaveBeenCalledWith('s-1', expect.objectContaining({ name: 'ACME 2' }));
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'supplier.updated' }),
+    );
+  });
+
+  test('200 isDisabled=true alone audits as supplier.disabled', async () => {
+    updateMock.mockResolvedValue({ ...SAMPLE_SUPPLIER, isDisabled: true });
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/suppliers/s-1',
+      headers: authHeader(),
+      payload: { isDisabled: true },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'supplier.disabled' }),
+    );
+  });
+
+  test('200 isDisabled=false alone audits as supplier.enabled', async () => {
+    updateMock.mockResolvedValue({ ...SAMPLE_SUPPLIER, isDisabled: false });
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/suppliers/s-1',
+      headers: authHeader(),
+      payload: { isDisabled: false },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'supplier.enabled' }),
+    );
+  });
+
+  test('404 when repo returns null', async () => {
+    updateMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/suppliers/missing',
+      headers: authHeader(),
+      payload: { name: 'New' },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Supplier not found' });
+  });
+
+  test('400 invalid email', async () => {
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/suppliers/s-1',
+      headers: authHeader(),
+      payload: { email: 'not-email' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('401 missing token', async () => {
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/suppliers/s-1',
+      payload: { name: 'X' },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  test('403 missing update permission', async () => {
+    getRolePermissionsMock.mockResolvedValue(['crm.suppliers.view']);
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/suppliers/s-1',
+      headers: authHeader(),
+      payload: { name: 'X' },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+describe('DELETE /api/suppliers/:id', () => {
+  test('204 deletes supplier with audit', async () => {
+    deleteByIdMock.mockResolvedValue({ name: 'ACME', supplierCode: 'ACM' });
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/suppliers/s-1',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(204);
+    expect(deleteByIdMock).toHaveBeenCalledWith('s-1');
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'supplier.deleted',
+        entityId: 's-1',
+      }),
+    );
+  });
+
+  test('404 when not found', async () => {
+    deleteByIdMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/suppliers/missing',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Supplier not found' });
+  });
+
+  test('401 missing token', async () => {
+    const res = await testApp.inject({ method: 'DELETE', url: '/api/suppliers/s-1' });
+    expect(res.statusCode).toBe(401);
+  });
+
+  test('403 missing delete permission', async () => {
+    getRolePermissionsMock.mockResolvedValue(['crm.suppliers.view']);
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/suppliers/s-1',
+      headers: authHeader(),
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `server/test/routes/suppliers.test.ts` covering GET/POST/PUT/DELETE happy-paths plus 400/401/403/404 branches against `routes/suppliers.ts`.
- Adds `server/test/routes/products.test.ts` covering products, productTypes, internalCategories and internalSubcategories sub-resources (create/update/delete + list flows), with auth-failure, validation, not-found and 409-conflict assertions.
- Tests follow the established `installAuthMiddlewareMock` + `buildRouteTestApp` + `signToken` pattern from `work-units.test.ts` / `entries.test.ts`. No production code changed.

## Coverage
- `routes/suppliers.ts`: 100% lines / 100% functions
- `routes/products.ts`: 96% lines / 100% functions

## Test plan
- [x] `cd server && bun test ./test/routes/suppliers.test.ts` — 20 pass
- [x] `cd server && bun test ./test/routes/products.test.ts` — 64 pass
- [x] `cd server && bun test` — 1182 pass, 0 fail
- [x] `bun run test` — 302 frontend tests pass
- [x] `bun run lint` — exit 0

https://claude.ai/code/session_0111c2dFZ99BbKBQtghz8kGJ

---
_Generated by [Claude Code](https://claude.ai/code/session_0111c2dFZ99BbKBQtghz8kGJ)_