### PR TITLE
test(server): add route tests for ai, reports, and supplier-invoices

### DIFF
--- a/server/test/routes/ai.test.ts
+++ b/server/test/routes/ai.test.ts
@@ -1,0 +1,269 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { FastifyInstance, FastifyPluginAsync } from 'fastify';
+import * as realGeneralSettingsRepo from '../../repositories/generalSettingsRepo.ts';
+import * as realRolesRepo from '../../repositories/rolesRepo.ts';
+import * as realUsersRepo from '../../repositories/usersRepo.ts';
+import * as realPermissions from '../../utils/permissions.ts';
+import {
+  installAuthMiddlewareMock,
+  restoreAuthMiddlewareMock,
+} from '../helpers/authMiddlewareMock.ts';
+import { buildRouteTestApp } from '../helpers/buildRouteTestApp.ts';
+import { signToken } from '../helpers/jwt.ts';
+
+const usersRepoSnap = { ...realUsersRepo };
+const rolesRepoSnap = { ...realRolesRepo };
+const permissionsSnap = { ...realPermissions };
+const generalSettingsRepoSnap = { ...realGeneralSettingsRepo };
+
+const findAuthUserByIdMock = mock();
+const userHasRoleMock = mock();
+const getRolePermissionsMock = mock();
+const getGeneralSettingsMock = mock();
+
+let routePlugin: FastifyPluginAsync;
+let originalFetch: typeof fetch;
+const fetchMock = mock();
+
+beforeAll(async () => {
+  installAuthMiddlewareMock();
+
+  mock.module('../../repositories/usersRepo.ts', () => ({
+    ...usersRepoSnap,
+    findAuthUserById: findAuthUserByIdMock,
+  }));
+  mock.module('../../repositories/rolesRepo.ts', () => ({
+    ...rolesRepoSnap,
+    userHasRole: userHasRoleMock,
+  }));
+  mock.module('../../utils/permissions.ts', () => ({
+    ...permissionsSnap,
+    getRolePermissions: getRolePermissionsMock,
+  }));
+  mock.module('../../repositories/generalSettingsRepo.ts', () => ({
+    ...generalSettingsRepoSnap,
+    get: getGeneralSettingsMock,
+  }));
+
+  routePlugin = (await import('../../routes/ai.ts')).default as FastifyPluginAsync;
+
+  originalFetch = globalThis.fetch;
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+});
+
+afterAll(() => {
+  restoreAuthMiddlewareMock();
+  mock.module('../../repositories/usersRepo.ts', () => usersRepoSnap);
+  mock.module('../../repositories/rolesRepo.ts', () => rolesRepoSnap);
+  mock.module('../../utils/permissions.ts', () => permissionsSnap);
+  mock.module('../../repositories/generalSettingsRepo.ts', () => generalSettingsRepoSnap);
+  globalThis.fetch = originalFetch;
+});
+
+const HAPPY_USER = {
+  id: 'u1',
+  name: 'Admin',
+  username: 'admin',
+  role: 'admin',
+  avatarInitials: 'AD',
+  isDisabled: false,
+};
+
+const ADMIN_PERMS = ['administration.general.update'];
+
+let testApp: FastifyInstance;
+
+beforeEach(async () => {
+  findAuthUserByIdMock.mockReset();
+  userHasRoleMock.mockReset();
+  getRolePermissionsMock.mockReset();
+  getGeneralSettingsMock.mockReset();
+  fetchMock.mockReset();
+
+  findAuthUserByIdMock.mockResolvedValue(HAPPY_USER);
+  userHasRoleMock.mockResolvedValue(true);
+  getRolePermissionsMock.mockResolvedValue(ADMIN_PERMS);
+  getGeneralSettingsMock.mockResolvedValue({
+    geminiApiKey: 'test-gemini-key',
+    openrouterApiKey: 'test-openrouter-key',
+  });
+
+  testApp = await buildRouteTestApp(routePlugin, '/api/ai');
+});
+
+afterEach(async () => {
+  await testApp.close();
+});
+
+const authHeader = () => ({ authorization: `Bearer ${signToken({ userId: 'u1' })}` });
+
+const okResponse = (body: unknown, status = 200) =>
+  ({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  }) as unknown as Response;
+
+describe('POST /api/ai/validate-model', () => {
+  test('401 missing token', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/ai/validate-model',
+      payload: { provider: 'gemini', modelId: 'gemini-pro' },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  test('403 missing administration.general.update permission', async () => {
+    getRolePermissionsMock.mockResolvedValue([]);
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/ai/validate-model',
+      headers: authHeader(),
+      payload: { provider: 'gemini', modelId: 'gemini-pro' },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  test('400 invalid provider', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/ai/validate-model',
+      headers: authHeader(),
+      payload: { provider: 'unknown', modelId: 'gemini-pro' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('400 modelId missing', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/ai/validate-model',
+      headers: authHeader(),
+      payload: { provider: 'gemini', modelId: '' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('200 ok=false MISSING_API_KEY when no key in body or settings', async () => {
+    getGeneralSettingsMock.mockResolvedValue({
+      geminiApiKey: '',
+      openrouterApiKey: '',
+    });
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/ai/validate-model',
+      headers: authHeader(),
+      payload: { provider: 'gemini', modelId: 'gemini-pro' },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.ok).toBe(false);
+    expect(body.code).toBe('MISSING_API_KEY');
+  });
+
+  test('200 ok=true gemini happy path', async () => {
+    fetchMock.mockResolvedValue(okResponse({}, 200));
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/ai/validate-model',
+      headers: authHeader(),
+      payload: { provider: 'gemini', modelId: 'gemini-pro', apiKey: 'inline-key' },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.ok).toBe(true);
+    expect(body.normalizedModelId).toMatch(/gemini-pro/);
+    expect(fetchMock).toHaveBeenCalled();
+  });
+
+  test('200 ok=false NOT_FOUND for gemini 404', async () => {
+    fetchMock.mockResolvedValue(okResponse({}, 404));
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/ai/validate-model',
+      headers: authHeader(),
+      payload: { provider: 'gemini', modelId: 'gemini-pro', apiKey: 'inline-key' },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.ok).toBe(false);
+    expect(body.code).toBe('NOT_FOUND');
+  });
+
+  test('200 ok=false PROVIDER_ERROR when fetch throws', async () => {
+    fetchMock.mockRejectedValue(new Error('network down'));
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/ai/validate-model',
+      headers: authHeader(),
+      payload: { provider: 'gemini', modelId: 'gemini-pro', apiKey: 'inline-key' },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.ok).toBe(false);
+    expect(body.code).toBe('PROVIDER_ERROR');
+    expect(body.message).toMatch(/network down/);
+  });
+
+  test('200 ok=true openrouter happy path', async () => {
+    fetchMock.mockResolvedValue(
+      okResponse({ data: [{ id: 'openai/gpt-4o', name: 'GPT-4o' }] }, 200),
+    );
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/ai/validate-model',
+      headers: authHeader(),
+      payload: { provider: 'openrouter', modelId: 'openai/gpt-4o', apiKey: 'inline-key' },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.ok).toBe(true);
+    expect(body.normalizedModelId).toBe('openai/gpt-4o');
+    expect(body.name).toBe('GPT-4o');
+  });
+
+  test('200 ok=false NOT_FOUND for openrouter when model not in list', async () => {
+    fetchMock.mockResolvedValue(okResponse({ data: [{ id: 'other/model' }] }, 200));
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/ai/validate-model',
+      headers: authHeader(),
+      payload: { provider: 'openrouter', modelId: 'openai/gpt-4o', apiKey: 'inline-key' },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.ok).toBe(false);
+    expect(body.code).toBe('NOT_FOUND');
+  });
+
+  test('200 ok=false PROVIDER_ERROR when openrouter list fails', async () => {
+    fetchMock.mockResolvedValue(okResponse({}, 500));
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/ai/validate-model',
+      headers: authHeader(),
+      payload: { provider: 'openrouter', modelId: 'openai/gpt-4o', apiKey: 'inline-key' },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.ok).toBe(false);
+    expect(body.code).toBe('PROVIDER_ERROR');
+  });
+
+  test('200 ok=true uses gemini key from settings when apiKey omitted', async () => {
+    fetchMock.mockResolvedValue(okResponse({}, 200));
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/ai/validate-model',
+      headers: authHeader(),
+      payload: { provider: 'gemini', modelId: 'gemini-pro' },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.ok).toBe(true);
+    const fetchCall = (fetchMock.mock.calls[0] as unknown[])[0];
+    const url = fetchCall instanceof URL ? fetchCall : new URL(String(fetchCall));
+    expect(url.searchParams.get('key')).toBe('test-gemini-key');
+  });
+});

--- a/server/test/routes/reports.test.ts
+++ b/server/test/routes/reports.test.ts
@@ -1,0 +1,847 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { FastifyInstance, FastifyPluginAsync } from 'fastify';
+import * as realGeneralSettingsRepo from '../../repositories/generalSettingsRepo.ts';
+import * as realReportsAiChatRepo from '../../repositories/reportsAiChatRepo.ts';
+import * as realReportsCatalogRepo from '../../repositories/reportsCatalogRepo.ts';
+import * as realReportsClientsRepo from '../../repositories/reportsClientsRepo.ts';
+import * as realReportsHoursRepo from '../../repositories/reportsHoursRepo.ts';
+import * as realReportsRevenueRepo from '../../repositories/reportsRevenueRepo.ts';
+import * as realRolesRepo from '../../repositories/rolesRepo.ts';
+import * as realUsersRepo from '../../repositories/usersRepo.ts';
+import * as realWorkUnitsRepo from '../../repositories/workUnitsRepo.ts';
+import * as realPermissions from '../../utils/permissions.ts';
+import {
+  installAuthMiddlewareMock,
+  restoreAuthMiddlewareMock,
+} from '../helpers/authMiddlewareMock.ts';
+import { buildRouteTestApp } from '../helpers/buildRouteTestApp.ts';
+import { signToken } from '../helpers/jwt.ts';
+
+const usersRepoSnap = { ...realUsersRepo };
+const rolesRepoSnap = { ...realRolesRepo };
+const permissionsSnap = { ...realPermissions };
+const generalSettingsRepoSnap = { ...realGeneralSettingsRepo };
+const aiChatSnap = { ...realReportsAiChatRepo };
+const reportsCatalogSnap = { ...realReportsCatalogRepo };
+const reportsClientsSnap = { ...realReportsClientsRepo };
+const reportsHoursSnap = { ...realReportsHoursRepo };
+const reportsRevenueSnap = { ...realReportsRevenueRepo };
+const workUnitsSnap = { ...realWorkUnitsRepo };
+
+const findAuthUserByIdMock = mock();
+const userHasRoleMock = mock();
+const getRolePermissionsMock = mock();
+const getGeneralSettingsMock = mock();
+
+const listSessionsForUserMock = mock();
+const createSessionMock = mock();
+const archiveSessionMock = mock();
+const sessionExistsForUserMock = mock();
+const getActiveSessionForUserMock = mock();
+const updateSessionTitleAndTouchMock = mock();
+const touchSessionMock = mock();
+const listMessagesForSessionMock = mock();
+const listRecentMessagesMock = mock();
+const insertUserMessageMock = mock();
+const insertAssistantMessageMock = mock();
+const findUserMessageMock = mock();
+const findFirstAssistantAfterMock = mock();
+const deleteMessageMock = mock();
+const updateMessageContentMock = mock();
+const getFirstUserMessageContentMock = mock();
+
+const getTimesheetsSectionMock = mock(async () => ({}));
+const getProjectsSectionMock = mock(async () => ({}));
+const getTasksSectionMock = mock(async () => ({}));
+const getClientsSectionMock = mock(async () => ({}));
+const getQuotesSectionMock = mock(async () => ({}));
+const getOrdersSectionMock = mock(async () => ({}));
+const getInvoicesSectionMock = mock(async () => ({}));
+const getSuppliersSectionMock = mock(async () => ({}));
+const getSupplierQuotesSectionMock = mock(async () => ({}));
+const getCatalogSectionMock = mock(async () => ({}));
+const listManagedUserIdsMock = mock(async () => [] as string[]);
+
+let originalFetch: typeof fetch;
+const fetchMock = mock();
+
+let routePlugin: FastifyPluginAsync;
+
+beforeAll(async () => {
+  installAuthMiddlewareMock();
+
+  mock.module('../../repositories/usersRepo.ts', () => ({
+    ...usersRepoSnap,
+    findAuthUserById: findAuthUserByIdMock,
+  }));
+  mock.module('../../repositories/rolesRepo.ts', () => ({
+    ...rolesRepoSnap,
+    userHasRole: userHasRoleMock,
+  }));
+  mock.module('../../utils/permissions.ts', () => ({
+    ...permissionsSnap,
+    getRolePermissions: getRolePermissionsMock,
+  }));
+  mock.module('../../repositories/generalSettingsRepo.ts', () => ({
+    ...generalSettingsRepoSnap,
+    get: getGeneralSettingsMock,
+  }));
+  mock.module('../../repositories/reportsAiChatRepo.ts', () => ({
+    ...aiChatSnap,
+    listSessionsForUser: listSessionsForUserMock,
+    createSession: createSessionMock,
+    archiveSession: archiveSessionMock,
+    sessionExistsForUser: sessionExistsForUserMock,
+    getActiveSessionForUser: getActiveSessionForUserMock,
+    updateSessionTitleAndTouch: updateSessionTitleAndTouchMock,
+    touchSession: touchSessionMock,
+    listMessagesForSession: listMessagesForSessionMock,
+    listRecentMessages: listRecentMessagesMock,
+    insertUserMessage: insertUserMessageMock,
+    insertAssistantMessage: insertAssistantMessageMock,
+    findUserMessage: findUserMessageMock,
+    findFirstAssistantAfter: findFirstAssistantAfterMock,
+    deleteMessage: deleteMessageMock,
+    updateMessageContent: updateMessageContentMock,
+    getFirstUserMessageContent: getFirstUserMessageContentMock,
+  }));
+  mock.module('../../repositories/reportsCatalogRepo.ts', () => ({
+    ...reportsCatalogSnap,
+    getSuppliersSection: getSuppliersSectionMock,
+    getSupplierQuotesSection: getSupplierQuotesSectionMock,
+    getCatalogSection: getCatalogSectionMock,
+  }));
+  mock.module('../../repositories/reportsClientsRepo.ts', () => ({
+    ...reportsClientsSnap,
+    getClientsSection: getClientsSectionMock,
+  }));
+  mock.module('../../repositories/reportsHoursRepo.ts', () => ({
+    ...reportsHoursSnap,
+    getTimesheetsSection: getTimesheetsSectionMock,
+    getProjectsSection: getProjectsSectionMock,
+    getTasksSection: getTasksSectionMock,
+  }));
+  mock.module('../../repositories/reportsRevenueRepo.ts', () => ({
+    ...reportsRevenueSnap,
+    getQuotesSection: getQuotesSectionMock,
+    getOrdersSection: getOrdersSectionMock,
+    getInvoicesSection: getInvoicesSectionMock,
+  }));
+  mock.module('../../repositories/workUnitsRepo.ts', () => ({
+    ...workUnitsSnap,
+    listManagedUserIds: listManagedUserIdsMock,
+  }));
+
+  routePlugin = (await import('../../routes/reports.ts')).default as FastifyPluginAsync;
+
+  originalFetch = globalThis.fetch;
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+});
+
+afterAll(() => {
+  restoreAuthMiddlewareMock();
+  mock.module('../../repositories/usersRepo.ts', () => usersRepoSnap);
+  mock.module('../../repositories/rolesRepo.ts', () => rolesRepoSnap);
+  mock.module('../../utils/permissions.ts', () => permissionsSnap);
+  mock.module('../../repositories/generalSettingsRepo.ts', () => generalSettingsRepoSnap);
+  mock.module('../../repositories/reportsAiChatRepo.ts', () => aiChatSnap);
+  mock.module('../../repositories/reportsCatalogRepo.ts', () => reportsCatalogSnap);
+  mock.module('../../repositories/reportsClientsRepo.ts', () => reportsClientsSnap);
+  mock.module('../../repositories/reportsHoursRepo.ts', () => reportsHoursSnap);
+  mock.module('../../repositories/reportsRevenueRepo.ts', () => reportsRevenueSnap);
+  mock.module('../../repositories/workUnitsRepo.ts', () => workUnitsSnap);
+  globalThis.fetch = originalFetch;
+});
+
+const HAPPY_USER = {
+  id: 'u1',
+  name: 'Alice',
+  username: 'alice',
+  role: 'manager',
+  avatarInitials: 'AL',
+  isDisabled: false,
+};
+
+const FULL_PERMS = ['reports.ai_reporting.view', 'reports.ai_reporting.create'];
+
+const AI_ENABLED_SETTINGS = {
+  enableAiReporting: true,
+  aiProvider: 'gemini',
+  geminiApiKey: 'test-gemini-key',
+  geminiModelId: 'gemini-pro',
+  openrouterApiKey: '',
+  openrouterModelId: '',
+  currency: 'EUR',
+};
+
+const allMocks = [
+  findAuthUserByIdMock,
+  userHasRoleMock,
+  getRolePermissionsMock,
+  getGeneralSettingsMock,
+  listSessionsForUserMock,
+  createSessionMock,
+  archiveSessionMock,
+  sessionExistsForUserMock,
+  getActiveSessionForUserMock,
+  updateSessionTitleAndTouchMock,
+  touchSessionMock,
+  listMessagesForSessionMock,
+  listRecentMessagesMock,
+  insertUserMessageMock,
+  insertAssistantMessageMock,
+  findUserMessageMock,
+  findFirstAssistantAfterMock,
+  deleteMessageMock,
+  updateMessageContentMock,
+  getFirstUserMessageContentMock,
+  getTimesheetsSectionMock,
+  getProjectsSectionMock,
+  getTasksSectionMock,
+  getClientsSectionMock,
+  getQuotesSectionMock,
+  getOrdersSectionMock,
+  getInvoicesSectionMock,
+  getSuppliersSectionMock,
+  getSupplierQuotesSectionMock,
+  getCatalogSectionMock,
+  listManagedUserIdsMock,
+  fetchMock,
+];
+
+let testApp: FastifyInstance;
+
+beforeEach(async () => {
+  for (const m of allMocks) m.mockReset();
+  findAuthUserByIdMock.mockResolvedValue(HAPPY_USER);
+  userHasRoleMock.mockResolvedValue(true);
+  getRolePermissionsMock.mockResolvedValue(FULL_PERMS);
+  getGeneralSettingsMock.mockResolvedValue(AI_ENABLED_SETTINGS);
+  listManagedUserIdsMock.mockResolvedValue([]);
+
+  testApp = await buildRouteTestApp(routePlugin, '/api/reports');
+});
+
+afterEach(async () => {
+  await testApp.close();
+});
+
+const authHeader = () => ({ authorization: `Bearer ${signToken({ userId: 'u1' })}` });
+
+const okFetchResponse = (body: unknown, status = 200) =>
+  ({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  }) as unknown as Response;
+
+describe('GET /api/reports/ai-reporting/sessions', () => {
+  test('200 returns sessions list for current user', async () => {
+    listSessionsForUserMock.mockResolvedValue([
+      { id: 'rpt-chat-1', title: 'My chat', createdAt: 1000, updatedAt: 2000 },
+    ]);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/reports/ai-reporting/sessions',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body).toHaveLength(1);
+    expect(body[0].id).toBe('rpt-chat-1');
+    expect(listSessionsForUserMock).toHaveBeenCalledWith('u1');
+  });
+
+  test('400 when AI Reporting is disabled in settings', async () => {
+    getGeneralSettingsMock.mockResolvedValue({
+      ...AI_ENABLED_SETTINGS,
+      enableAiReporting: false,
+    });
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/reports/ai-reporting/sessions',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'AI Reporting is disabled by administration.',
+    });
+  });
+
+  test('401 missing token', async () => {
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/reports/ai-reporting/sessions',
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  test('403 missing reports.ai_reporting.view permission', async () => {
+    getRolePermissionsMock.mockResolvedValue([]);
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/reports/ai-reporting/sessions',
+      headers: authHeader(),
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+describe('POST /api/reports/ai-reporting/sessions', () => {
+  test('200 creates a new session and returns its id', async () => {
+    createSessionMock.mockResolvedValue(undefined);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/reports/ai-reporting/sessions',
+      headers: authHeader(),
+      payload: { title: 'My new chat' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.id).toMatch(/^rpt-chat/);
+    expect(createSessionMock).toHaveBeenCalledWith(expect.any(String), 'u1', 'My new chat');
+  });
+
+  test('200 creates a session with empty title', async () => {
+    createSessionMock.mockResolvedValue(undefined);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/reports/ai-reporting/sessions',
+      headers: authHeader(),
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(createSessionMock).toHaveBeenCalledWith(expect.any(String), 'u1', '');
+  });
+
+  test('400 when AI Reporting is disabled', async () => {
+    getGeneralSettingsMock.mockResolvedValue({
+      ...AI_ENABLED_SETTINGS,
+      enableAiReporting: false,
+    });
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/reports/ai-reporting/sessions',
+      headers: authHeader(),
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('401 missing token', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/reports/ai-reporting/sessions',
+      payload: {},
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  test('403 missing reports.ai_reporting.create permission', async () => {
+    getRolePermissionsMock.mockResolvedValue(['reports.ai_reporting.view']);
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/reports/ai-reporting/sessions',
+      headers: authHeader(),
+      payload: {},
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+describe('GET /api/reports/ai-reporting/sessions/:id/messages', () => {
+  test('200 returns reversed messages for an existing session', async () => {
+    sessionExistsForUserMock.mockResolvedValue(true);
+    listMessagesForSessionMock.mockResolvedValue([
+      {
+        id: 'rpt-msg-2',
+        sessionId: 'rpt-chat-1',
+        role: 'assistant',
+        content: 'World',
+        thoughtContent: null,
+        createdAt: 2000,
+      },
+      {
+        id: 'rpt-msg-1',
+        sessionId: 'rpt-chat-1',
+        role: 'user',
+        content: 'Hello',
+        thoughtContent: null,
+        createdAt: 1000,
+      },
+    ]);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/reports/ai-reporting/sessions/rpt-chat-1/messages',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body).toHaveLength(2);
+    // Result is `messages.reverse()`, so the user message comes first now.
+    expect(body[0].id).toBe('rpt-msg-1');
+    expect(body[1].id).toBe('rpt-msg-2');
+  });
+
+  test('200 honors limit and before query params', async () => {
+    sessionExistsForUserMock.mockResolvedValue(true);
+    listMessagesForSessionMock.mockResolvedValue([]);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/reports/ai-reporting/sessions/rpt-chat-1/messages?limit=50&before=1700000000000',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(listMessagesForSessionMock).toHaveBeenCalledWith('rpt-chat-1', {
+      beforeMs: 1_700_000_000_000,
+      limit: 50,
+    });
+  });
+
+  test('400 limit must be a positive integer', async () => {
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/reports/ai-reporting/sessions/rpt-chat-1/messages?limit=0',
+      headers: authHeader(),
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('400 before must be a positive timestamp', async () => {
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/reports/ai-reporting/sessions/rpt-chat-1/messages?before=-1',
+      headers: authHeader(),
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('404 when session is not found', async () => {
+    sessionExistsForUserMock.mockResolvedValue(false);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/reports/ai-reporting/sessions/rpt-chat-missing/messages',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Session not found' });
+  });
+
+  test('401 missing token', async () => {
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/reports/ai-reporting/sessions/rpt-chat-1/messages',
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  test('403 missing view permission', async () => {
+    getRolePermissionsMock.mockResolvedValue([]);
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/reports/ai-reporting/sessions/rpt-chat-1/messages',
+      headers: authHeader(),
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+describe('POST /api/reports/ai-reporting/sessions/:id/archive', () => {
+  test('200 archives a session successfully', async () => {
+    archiveSessionMock.mockResolvedValue(true);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/reports/ai-reporting/sessions/rpt-chat-1/archive',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ success: true });
+    expect(archiveSessionMock).toHaveBeenCalledWith('rpt-chat-1', 'u1');
+  });
+
+  test('404 when session does not exist', async () => {
+    archiveSessionMock.mockResolvedValue(false);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/reports/ai-reporting/sessions/missing/archive',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Session not found' });
+  });
+
+  test('401 missing token', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/reports/ai-reporting/sessions/rpt-chat-1/archive',
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  test('403 missing view permission', async () => {
+    getRolePermissionsMock.mockResolvedValue([]);
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/reports/ai-reporting/sessions/rpt-chat-1/archive',
+      headers: authHeader(),
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+describe('POST /api/reports/ai-reporting/chat (non-streaming)', () => {
+  test('200 happy path generates a response and stores it', async () => {
+    listRecentMessagesMock.mockResolvedValue([]);
+    insertUserMessageMock.mockResolvedValue(undefined);
+    insertAssistantMessageMock.mockResolvedValue(undefined);
+    createSessionMock.mockResolvedValue(undefined);
+    updateSessionTitleAndTouchMock.mockResolvedValue(undefined);
+    getFirstUserMessageContentMock.mockResolvedValue('Hello');
+
+    fetchMock.mockResolvedValue(
+      okFetchResponse({
+        candidates: [
+          {
+            content: {
+              parts: [{ text: 'Hello, how can I help?' }],
+            },
+          },
+        ],
+      }),
+    );
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/reports/ai-reporting/chat',
+      headers: authHeader(),
+      payload: { message: 'Hello' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.text).toBe('Hello, how can I help?');
+    expect(body.sessionId).toMatch(/^rpt-chat/);
+    expect(insertUserMessageMock).toHaveBeenCalled();
+    expect(insertAssistantMessageMock).toHaveBeenCalled();
+  });
+
+  test('200 reuses existing session when sessionId is supplied', async () => {
+    getActiveSessionForUserMock.mockResolvedValue({
+      id: 'rpt-chat-1',
+      title: 'Pre-existing',
+    });
+    listRecentMessagesMock.mockResolvedValue([]);
+    insertUserMessageMock.mockResolvedValue(undefined);
+    insertAssistantMessageMock.mockResolvedValue(undefined);
+    updateSessionTitleAndTouchMock.mockResolvedValue(undefined);
+
+    fetchMock.mockResolvedValue(
+      okFetchResponse({
+        candidates: [{ content: { parts: [{ text: 'Reply' }] } }],
+      }),
+    );
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/reports/ai-reporting/chat',
+      headers: authHeader(),
+      payload: { sessionId: 'rpt-chat-1', message: 'Hi' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.sessionId).toBe('rpt-chat-1');
+    expect(getActiveSessionForUserMock).toHaveBeenCalledWith('rpt-chat-1', 'u1');
+  });
+
+  test('404 when supplied sessionId is not owned by the user', async () => {
+    getActiveSessionForUserMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/reports/ai-reporting/chat',
+      headers: authHeader(),
+      payload: { sessionId: 'rpt-chat-other', message: 'Hi' },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Session not found' });
+  });
+
+  test('400 when message is missing', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/reports/ai-reporting/chat',
+      headers: authHeader(),
+      payload: { message: '' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('400 when message exceeds 4000 chars', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/reports/ai-reporting/chat',
+      headers: authHeader(),
+      payload: { message: 'x'.repeat(4001) },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('400 when AI reporting is disabled', async () => {
+    getGeneralSettingsMock.mockResolvedValue({
+      ...AI_ENABLED_SETTINGS,
+      enableAiReporting: false,
+    });
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/reports/ai-reporting/chat',
+      headers: authHeader(),
+      payload: { message: 'Hi' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('400 when provider api key is missing', async () => {
+    getGeneralSettingsMock.mockResolvedValue({
+      ...AI_ENABLED_SETTINGS,
+      geminiApiKey: '',
+    });
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/reports/ai-reporting/chat',
+      headers: authHeader(),
+      payload: { message: 'Hi' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/Missing gemini API key/);
+  });
+
+  test('400 when provider model id is missing', async () => {
+    getGeneralSettingsMock.mockResolvedValue({
+      ...AI_ENABLED_SETTINGS,
+      geminiModelId: '',
+    });
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/reports/ai-reporting/chat',
+      headers: authHeader(),
+      payload: { message: 'Hi' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/Missing gemini model id/);
+  });
+
+  test('502 when LLM call fails', async () => {
+    listRecentMessagesMock.mockResolvedValue([]);
+    insertUserMessageMock.mockResolvedValue(undefined);
+    createSessionMock.mockResolvedValue(undefined);
+
+    fetchMock.mockRejectedValue(new Error('upstream down'));
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/reports/ai-reporting/chat',
+      headers: authHeader(),
+      payload: { message: 'Hi' },
+    });
+
+    expect(res.statusCode).toBe(502);
+    expect(JSON.parse(res.body).error).toMatch(/upstream down/);
+  });
+
+  test('401 missing token', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/reports/ai-reporting/chat',
+      payload: { message: 'Hi' },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  test('403 missing create permission', async () => {
+    getRolePermissionsMock.mockResolvedValue(['reports.ai_reporting.view']);
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/reports/ai-reporting/chat',
+      headers: authHeader(),
+      payload: { message: 'Hi' },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+describe('POST /api/reports/ai-reporting/chat/stream (streaming)', () => {
+  test('401 missing token', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/reports/ai-reporting/chat/stream',
+      payload: { message: 'Hi' },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  test('403 missing create permission', async () => {
+    getRolePermissionsMock.mockResolvedValue(['reports.ai_reporting.view']);
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/reports/ai-reporting/chat/stream',
+      headers: authHeader(),
+      payload: { message: 'Hi' },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  test('400 when AI reporting is disabled', async () => {
+    getGeneralSettingsMock.mockResolvedValue({
+      ...AI_ENABLED_SETTINGS,
+      enableAiReporting: false,
+    });
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/reports/ai-reporting/chat/stream',
+      headers: authHeader(),
+      payload: { message: 'Hi' },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('400 when message is missing', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/reports/ai-reporting/chat/stream',
+      headers: authHeader(),
+      payload: { message: '' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('404 when supplied sessionId is not owned by the user', async () => {
+    getActiveSessionForUserMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/reports/ai-reporting/chat/stream',
+      headers: authHeader(),
+      payload: { sessionId: 'rpt-chat-other', message: 'Hi' },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Session not found' });
+  });
+});
+
+describe('POST /api/reports/ai-reporting/chat/edit-stream', () => {
+  test('401 missing token', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/reports/ai-reporting/chat/edit-stream',
+      payload: { sessionId: 's', messageId: 'm', content: 'edited' },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  test('403 missing create permission', async () => {
+    getRolePermissionsMock.mockResolvedValue(['reports.ai_reporting.view']);
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/reports/ai-reporting/chat/edit-stream',
+      headers: authHeader(),
+      payload: { sessionId: 's', messageId: 'm', content: 'edited' },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  test('400 missing required content', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/reports/ai-reporting/chat/edit-stream',
+      headers: authHeader(),
+      payload: { sessionId: 's', messageId: 'm', content: '' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('400 content too long', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/reports/ai-reporting/chat/edit-stream',
+      headers: authHeader(),
+      payload: { sessionId: 's', messageId: 'm', content: 'x'.repeat(4001) },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('400 AI disabled', async () => {
+    getGeneralSettingsMock.mockResolvedValue({
+      ...AI_ENABLED_SETTINGS,
+      enableAiReporting: false,
+    });
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/reports/ai-reporting/chat/edit-stream',
+      headers: authHeader(),
+      payload: { sessionId: 's', messageId: 'm', content: 'hi' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('404 session does not exist', async () => {
+    getActiveSessionForUserMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/reports/ai-reporting/chat/edit-stream',
+      headers: authHeader(),
+      payload: { sessionId: 'missing', messageId: 'm', content: 'hi' },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Session not found' });
+  });
+
+  test('404 user message does not exist', async () => {
+    getActiveSessionForUserMock.mockResolvedValue({
+      id: 'rpt-chat-1',
+      title: 'Existing',
+    });
+    findUserMessageMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/reports/ai-reporting/chat/edit-stream',
+      headers: authHeader(),
+      payload: { sessionId: 'rpt-chat-1', messageId: 'm-missing', content: 'hi' },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body)).toEqual({ error: 'User message not found' });
+  });
+});

--- a/server/test/routes/supplier-invoices.test.ts
+++ b/server/test/routes/supplier-invoices.test.ts
@@ -1,0 +1,681 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { FastifyInstance, FastifyPluginAsync } from 'fastify';
+import * as realDrizzle from '../../db/drizzle.ts';
+import * as realRolesRepo from '../../repositories/rolesRepo.ts';
+import * as realSupplierInvoicesRepo from '../../repositories/supplierInvoicesRepo.ts';
+import * as realSupplierOrdersRepo from '../../repositories/supplierOrdersRepo.ts';
+import * as realUsersRepo from '../../repositories/usersRepo.ts';
+import * as realAudit from '../../utils/audit.ts';
+import * as realPermissions from '../../utils/permissions.ts';
+import {
+  installAuthMiddlewareMock,
+  restoreAuthMiddlewareMock,
+} from '../helpers/authMiddlewareMock.ts';
+import { buildRouteTestApp } from '../helpers/buildRouteTestApp.ts';
+import { makeDbError } from '../helpers/dbErrors.ts';
+import { signToken } from '../helpers/jwt.ts';
+
+const usersRepoSnap = { ...realUsersRepo };
+const rolesRepoSnap = { ...realRolesRepo };
+const permissionsSnap = { ...realPermissions };
+const supplierInvoicesRepoSnap = { ...realSupplierInvoicesRepo };
+const supplierOrdersRepoSnap = { ...realSupplierOrdersRepo };
+const auditSnap = { ...realAudit };
+const drizzleSnap = { ...realDrizzle };
+
+const findAuthUserByIdMock = mock();
+const userHasRoleMock = mock();
+const getRolePermissionsMock = mock();
+
+const listAllMock = mock();
+const listAllItemsMock = mock();
+const findInvoiceForLinkedSaleMock = mock();
+const maxSequenceForYearMock = mock();
+const createMock = mock();
+const insertItemsMock = mock();
+const findExistingForUpdateMock = mock();
+const findIdConflictMock = mock();
+const updateMock = mock();
+const replaceItemsMock = mock();
+const findItemsForInvoiceMock = mock();
+const findStatusAndSupplierNameMock = mock();
+const deleteByIdMock = mock();
+
+const findOrderByIdMock = mock();
+
+const logAuditMock = mock(async () => undefined);
+const withDbTransactionMock = mock(async (cb: (tx: unknown) => unknown) => cb(undefined));
+
+let routePlugin: FastifyPluginAsync;
+
+beforeAll(async () => {
+  installAuthMiddlewareMock();
+
+  mock.module('../../repositories/usersRepo.ts', () => ({
+    ...usersRepoSnap,
+    findAuthUserById: findAuthUserByIdMock,
+  }));
+  mock.module('../../repositories/rolesRepo.ts', () => ({
+    ...rolesRepoSnap,
+    userHasRole: userHasRoleMock,
+  }));
+  mock.module('../../utils/permissions.ts', () => ({
+    ...permissionsSnap,
+    getRolePermissions: getRolePermissionsMock,
+  }));
+  mock.module('../../repositories/supplierInvoicesRepo.ts', () => ({
+    ...supplierInvoicesRepoSnap,
+    listAll: listAllMock,
+    listAllItems: listAllItemsMock,
+    findInvoiceForLinkedSale: findInvoiceForLinkedSaleMock,
+    maxSequenceForYear: maxSequenceForYearMock,
+    create: createMock,
+    insertItems: insertItemsMock,
+    findExistingForUpdate: findExistingForUpdateMock,
+    findIdConflict: findIdConflictMock,
+    update: updateMock,
+    replaceItems: replaceItemsMock,
+    findItemsForInvoice: findItemsForInvoiceMock,
+    findStatusAndSupplierName: findStatusAndSupplierNameMock,
+    deleteById: deleteByIdMock,
+  }));
+  mock.module('../../repositories/supplierOrdersRepo.ts', () => ({
+    ...supplierOrdersRepoSnap,
+    findById: findOrderByIdMock,
+  }));
+  mock.module('../../utils/audit.ts', () => ({
+    ...auditSnap,
+    logAudit: logAuditMock,
+  }));
+  mock.module('../../db/drizzle.ts', () => ({
+    ...drizzleSnap,
+    withDbTransaction: withDbTransactionMock,
+  }));
+
+  routePlugin = (await import('../../routes/supplier-invoices.ts')).default as FastifyPluginAsync;
+});
+
+afterAll(() => {
+  restoreAuthMiddlewareMock();
+  mock.module('../../repositories/usersRepo.ts', () => usersRepoSnap);
+  mock.module('../../repositories/rolesRepo.ts', () => rolesRepoSnap);
+  mock.module('../../utils/permissions.ts', () => permissionsSnap);
+  mock.module('../../repositories/supplierInvoicesRepo.ts', () => supplierInvoicesRepoSnap);
+  mock.module('../../repositories/supplierOrdersRepo.ts', () => supplierOrdersRepoSnap);
+  mock.module('../../utils/audit.ts', () => auditSnap);
+  mock.module('../../db/drizzle.ts', () => drizzleSnap);
+});
+
+const HAPPY_USER = {
+  id: 'u1',
+  name: 'Alice',
+  username: 'alice',
+  role: 'manager',
+  avatarInitials: 'AL',
+  isDisabled: false,
+};
+
+const FULL_PERMS = [
+  'accounting.supplier_invoices.view',
+  'accounting.supplier_invoices.create',
+  'accounting.supplier_invoices.update',
+  'accounting.supplier_invoices.delete',
+];
+
+const SAMPLE_INVOICE = {
+  id: 'SINV-2025-0001',
+  linkedSaleId: null,
+  supplierId: 's1',
+  supplierName: 'Acme Supply',
+  issueDate: '2025-06-01',
+  dueDate: '2025-07-01',
+  status: 'draft',
+  subtotal: 100,
+  total: 100,
+  amountPaid: 0,
+  notes: null,
+  createdAt: 1_700_000_000_000,
+  updatedAt: 1_700_000_000_000,
+};
+
+const SAMPLE_ITEM = {
+  id: 'sinv-item-1',
+  invoiceId: 'SINV-2025-0001',
+  productId: null,
+  description: 'Widget',
+  quantity: 1,
+  unitPrice: 100,
+  discount: 0,
+};
+
+const allMocks = [
+  findAuthUserByIdMock,
+  userHasRoleMock,
+  getRolePermissionsMock,
+  listAllMock,
+  listAllItemsMock,
+  findInvoiceForLinkedSaleMock,
+  maxSequenceForYearMock,
+  createMock,
+  insertItemsMock,
+  findExistingForUpdateMock,
+  findIdConflictMock,
+  updateMock,
+  replaceItemsMock,
+  findItemsForInvoiceMock,
+  findStatusAndSupplierNameMock,
+  deleteByIdMock,
+  findOrderByIdMock,
+  logAuditMock,
+  withDbTransactionMock,
+];
+
+let testApp: FastifyInstance;
+
+beforeEach(async () => {
+  for (const m of allMocks) m.mockReset();
+  findAuthUserByIdMock.mockResolvedValue(HAPPY_USER);
+  userHasRoleMock.mockResolvedValue(true);
+  getRolePermissionsMock.mockResolvedValue(FULL_PERMS);
+  withDbTransactionMock.mockImplementation(async (cb) => cb(undefined));
+  logAuditMock.mockImplementation(async () => undefined);
+
+  testApp = await buildRouteTestApp(routePlugin, '/api/supplier-invoices');
+});
+
+afterEach(async () => {
+  await testApp.close();
+});
+
+const authHeader = () => ({ authorization: `Bearer ${signToken({ userId: 'u1' })}` });
+
+describe('GET /api/supplier-invoices', () => {
+  test('200 returns list with grouped items', async () => {
+    listAllMock.mockResolvedValue([SAMPLE_INVOICE]);
+    listAllItemsMock.mockResolvedValue([SAMPLE_ITEM]);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/supplier-invoices',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body).toHaveLength(1);
+    expect(body[0].id).toBe('SINV-2025-0001');
+    expect(body[0].items).toHaveLength(1);
+  });
+
+  test('200 invoice without items has empty array', async () => {
+    listAllMock.mockResolvedValue([SAMPLE_INVOICE]);
+    listAllItemsMock.mockResolvedValue([]);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/supplier-invoices',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body[0].items).toEqual([]);
+  });
+
+  test('401 missing token', async () => {
+    const res = await testApp.inject({ method: 'GET', url: '/api/supplier-invoices' });
+    expect(res.statusCode).toBe(401);
+  });
+
+  test('403 missing view permission', async () => {
+    getRolePermissionsMock.mockResolvedValue([]);
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/supplier-invoices',
+      headers: authHeader(),
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+describe('POST /api/supplier-invoices', () => {
+  const validBody = {
+    supplierId: 's1',
+    supplierName: 'Acme Supply',
+    issueDate: '2025-06-01',
+    dueDate: '2025-07-01',
+    items: [{ description: 'Widget', quantity: 1, unitPrice: 100 }],
+  };
+
+  test('201 creates invoice with auto-generated id', async () => {
+    maxSequenceForYearMock.mockResolvedValue(0);
+    createMock.mockResolvedValue(SAMPLE_INVOICE);
+    insertItemsMock.mockResolvedValue([SAMPLE_ITEM]);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/supplier-invoices',
+      headers: authHeader(),
+      payload: validBody,
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = JSON.parse(res.body);
+    expect(body.id).toBe('SINV-2025-0001');
+    expect(maxSequenceForYearMock).toHaveBeenCalledWith('2025');
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'supplier_invoice.created',
+        entityType: 'supplier_invoice',
+      }),
+    );
+  });
+
+  test('201 uses caller-supplied id when provided', async () => {
+    createMock.mockResolvedValue({ ...SAMPLE_INVOICE, id: 'CUSTOM-1' });
+    insertItemsMock.mockResolvedValue([{ ...SAMPLE_ITEM, invoiceId: 'CUSTOM-1' }]);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/supplier-invoices',
+      headers: authHeader(),
+      payload: { ...validBody, id: 'CUSTOM-1' },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(maxSequenceForYearMock).not.toHaveBeenCalled();
+    const body = JSON.parse(res.body);
+    expect(body.id).toBe('CUSTOM-1');
+  });
+
+  test('400 missing supplierId', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/supplier-invoices',
+      headers: authHeader(),
+      payload: { ...validBody, supplierId: '' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('400 dueDate before issueDate', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/supplier-invoices',
+      headers: authHeader(),
+      payload: { ...validBody, issueDate: '2025-07-01', dueDate: '2025-06-01' },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'dueDate must be on or after issueDate',
+    });
+  });
+
+  test('400 empty items array', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/supplier-invoices',
+      headers: authHeader(),
+      payload: { ...validBody, items: [] },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Items must be a non-empty array' });
+  });
+
+  test('400 invalid item quantity (negative)', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/supplier-invoices',
+      headers: authHeader(),
+      payload: {
+        ...validBody,
+        items: [{ description: 'X', quantity: -1, unitPrice: 100 }],
+      },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('404 linkedSaleId points to missing source order', async () => {
+    findOrderByIdMock.mockResolvedValue(null);
+    findInvoiceForLinkedSaleMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/supplier-invoices',
+      headers: authHeader(),
+      payload: { ...validBody, linkedSaleId: 'so-missing' },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Source order not found' });
+  });
+
+  test('409 source order is not in sent status', async () => {
+    findOrderByIdMock.mockResolvedValue({ id: 'so-1', status: 'draft' });
+    findInvoiceForLinkedSaleMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/supplier-invoices',
+      headers: authHeader(),
+      payload: { ...validBody, linkedSaleId: 'so-1' },
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'Invoices can only be created from sent orders',
+    });
+  });
+
+  test('409 invoice already exists for the linked order', async () => {
+    findOrderByIdMock.mockResolvedValue({ id: 'so-1', status: 'sent' });
+    findInvoiceForLinkedSaleMock.mockResolvedValue('SINV-EXISTING');
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/supplier-invoices',
+      headers: authHeader(),
+      payload: { ...validBody, linkedSaleId: 'so-1' },
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'An invoice already exists for this order',
+    });
+  });
+
+  test('409 unique violation surfaces as Invoice ID already exists when caller-supplied id', async () => {
+    withDbTransactionMock.mockImplementation(async () => {
+      throw makeDbError('23505', 'supplier_invoices_pkey');
+    });
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/supplier-invoices',
+      headers: authHeader(),
+      payload: { ...validBody, id: 'SINV-CUSTOM' },
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Invoice ID already exists' });
+  });
+
+  test('403 missing create permission', async () => {
+    getRolePermissionsMock.mockResolvedValue(['accounting.supplier_invoices.view']);
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/supplier-invoices',
+      headers: authHeader(),
+      payload: validBody,
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  test('401 missing token', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/supplier-invoices',
+      payload: validBody,
+    });
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+describe('PUT /api/supplier-invoices/:id', () => {
+  test('200 partial update on draft invoice', async () => {
+    findExistingForUpdateMock.mockResolvedValue({
+      id: 'SINV-2025-0001',
+      status: 'draft',
+      issueDate: '2025-06-01',
+      dueDate: '2025-07-01',
+    });
+    updateMock.mockResolvedValue({ ...SAMPLE_INVOICE, status: 'sent' });
+    findItemsForInvoiceMock.mockResolvedValue([SAMPLE_ITEM]);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/supplier-invoices/SINV-2025-0001',
+      headers: authHeader(),
+      payload: { status: 'sent' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(updateMock).toHaveBeenCalled();
+    expect(replaceItemsMock).not.toHaveBeenCalled();
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'supplier_invoice.updated' }),
+    );
+  });
+
+  test('200 update with new items uses replaceItems', async () => {
+    findExistingForUpdateMock.mockResolvedValue({
+      id: 'SINV-2025-0001',
+      status: 'draft',
+      issueDate: '2025-06-01',
+      dueDate: '2025-07-01',
+    });
+    updateMock.mockResolvedValue(SAMPLE_INVOICE);
+    replaceItemsMock.mockResolvedValue([SAMPLE_ITEM]);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/supplier-invoices/SINV-2025-0001',
+      headers: authHeader(),
+      payload: {
+        items: [{ description: 'Widget', quantity: 1, unitPrice: 100 }],
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(replaceItemsMock).toHaveBeenCalled();
+  });
+
+  test('404 invoice not found', async () => {
+    findExistingForUpdateMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/supplier-invoices/missing',
+      headers: authHeader(),
+      payload: { status: 'sent' },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Invoice not found' });
+  });
+
+  test('409 non-draft invoice with locked field updates is read-only', async () => {
+    findExistingForUpdateMock.mockResolvedValue({
+      id: 'SINV-2025-0001',
+      status: 'sent',
+      issueDate: '2025-06-01',
+      dueDate: '2025-07-01',
+    });
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/supplier-invoices/SINV-2025-0001',
+      headers: authHeader(),
+      payload: { supplierName: 'Renamed' },
+    });
+
+    expect(res.statusCode).toBe(409);
+    const body = JSON.parse(res.body);
+    expect(body.error).toBe('Non-draft invoices are read-only');
+  });
+
+  test('409 id conflict on rename', async () => {
+    findExistingForUpdateMock.mockResolvedValue({
+      id: 'SINV-2025-0001',
+      status: 'draft',
+      issueDate: '2025-06-01',
+      dueDate: '2025-07-01',
+    });
+    findIdConflictMock.mockResolvedValue(true);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/supplier-invoices/SINV-2025-0001',
+      headers: authHeader(),
+      payload: { id: 'SINV-2025-0002' },
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Invoice ID already exists' });
+  });
+
+  test('400 dueDate before issueDate using effective dates', async () => {
+    findExistingForUpdateMock.mockResolvedValue({
+      id: 'SINV-2025-0001',
+      status: 'draft',
+      issueDate: '2025-06-01',
+      dueDate: '2025-07-01',
+    });
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/supplier-invoices/SINV-2025-0001',
+      headers: authHeader(),
+      payload: { dueDate: '2025-05-01' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'dueDate must be on or after issueDate',
+    });
+  });
+
+  test('400 empty items array on update', async () => {
+    findExistingForUpdateMock.mockResolvedValue({
+      id: 'SINV-2025-0001',
+      status: 'draft',
+      issueDate: '2025-06-01',
+      dueDate: '2025-07-01',
+    });
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/supplier-invoices/SINV-2025-0001',
+      headers: authHeader(),
+      payload: { items: [] },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Items must be a non-empty array' });
+  });
+
+  test('404 update returns null after transaction', async () => {
+    findExistingForUpdateMock.mockResolvedValue({
+      id: 'SINV-2025-0001',
+      status: 'draft',
+      issueDate: '2025-06-01',
+      dueDate: '2025-07-01',
+    });
+    updateMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/supplier-invoices/SINV-2025-0001',
+      headers: authHeader(),
+      payload: { status: 'sent' },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Invoice not found' });
+  });
+
+  test('403 missing update permission', async () => {
+    getRolePermissionsMock.mockResolvedValue(['accounting.supplier_invoices.view']);
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/supplier-invoices/SINV-2025-0001',
+      headers: authHeader(),
+      payload: { status: 'sent' },
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  test('401 missing token', async () => {
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/supplier-invoices/SINV-2025-0001',
+      payload: { status: 'sent' },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+describe('DELETE /api/supplier-invoices/:id', () => {
+  test('204 happy path emits audit', async () => {
+    findStatusAndSupplierNameMock.mockResolvedValue({
+      status: 'draft',
+      supplierName: 'Acme Supply',
+    });
+    deleteByIdMock.mockResolvedValue(true);
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/supplier-invoices/SINV-2025-0001',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(204);
+    expect(deleteByIdMock).toHaveBeenCalledWith('SINV-2025-0001');
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'supplier_invoice.deleted',
+        entityId: 'SINV-2025-0001',
+      }),
+    );
+  });
+
+  test('404 not found', async () => {
+    findStatusAndSupplierNameMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/supplier-invoices/missing',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Invoice not found' });
+  });
+
+  test('409 non-draft invoice cannot be deleted', async () => {
+    findStatusAndSupplierNameMock.mockResolvedValue({
+      status: 'sent',
+      supplierName: 'Acme Supply',
+    });
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/supplier-invoices/SINV-2025-0001',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'Only draft invoices can be deleted',
+    });
+    expect(deleteByIdMock).not.toHaveBeenCalled();
+  });
+
+  test('403 missing delete permission', async () => {
+    getRolePermissionsMock.mockResolvedValue(['accounting.supplier_invoices.view']);
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/supplier-invoices/SINV-2025-0001',
+      headers: authHeader(),
+    });
+    expect(res.statusCode).toBe(403);
+  });
+
+  test('401 missing token', async () => {
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/supplier-invoices/SINV-2025-0001',
+    });
+    expect(res.statusCode).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary
Adds unit tests for three previously-uncovered server route files to push backend coverage above the 80% target.

- `server/test/routes/ai.test.ts` — covers `routes/ai.ts` (12 tests, ~100% function / ~98% line coverage). Mocks `globalThis.fetch` to exercise the gemini and openrouter validate-model branches plus auth/permission guards and missing-key paths.
- `server/test/routes/supplier-invoices.test.ts` — covers `routes/supplier-invoices.ts` (31 tests, ~95% function / ~93% line coverage). Mocks `supplierInvoicesRepo`, `supplierOrdersRepo`, the audit logger, and `withDbTransaction`. Covers GET/POST/PUT/DELETE happy paths plus 400/401/403/404/409 branches (linked-sale validations, draft-only deletion, non-draft locking, unique-violation handling).
- `server/test/routes/reports.test.ts` — covers `routes/reports.ts` (43 tests, ~65% function / ~50% line coverage; the file is ~2090 lines and most uncovered lines are streaming/SSE plumbing and dataset assembly that need real DB connectivity). Mocks `reportsAiChatRepo`, `reportsCatalogRepo`, `reportsClientsRepo`, `reportsHoursRepo`, `reportsRevenueRepo`, `generalSettingsRepo`, and `globalThis.fetch`. Covers chat-session CRUD, message listing, archive, the non-streaming chat happy + 502 path, and the 401/403/404 guards on the streaming endpoints.

All tests follow the existing `installAuthMiddlewareMock` / `buildRouteTestApp` / `signToken` pattern used by `work-units.test.ts`, `entries.test.ts`, and `invoices.test.ts`. No production code was modified.

## Test plan
- [x] `cd server && bun test ./test/routes/{ai,reports,supplier-invoices}.test.ts` — 86 tests pass
- [x] `cd server && bun test ./test/routes/` — full route test suite (290 tests) still green
- [x] `bun run lint` — Biome + tsc + i18n key check all pass
- [x] Coverage spot check via `bun test ./test --coverage` confirms the three target files now report >=50% line coverage (ai.ts and supplier-invoices.ts both >90%)

https://claude.ai/code/session_0111c2dFZ99BbKBQtghz8kGJ

---
_Generated by [Claude Code](https://claude.ai/code/session_0111c2dFZ99BbKBQtghz8kGJ)_