### PR TITLE
test(repos): push 8 partial-coverage server repos to 100% line coverage

### DIFF
--- a/server/test/repositories/clientQuotesRepo.test.ts
+++ b/server/test/repositories/clientQuotesRepo.test.ts
@@ -318,3 +318,76 @@ describe('replaceItems', () => {
     expect(result).toEqual([]);
   });
 });
+
+describe('findStatusAndClientName', () => {
+  test('returns status and clientName when found', async () => {
+    exec.enqueue({ rows: [['draft', 'Acme']] });
+    expect(await clientQuotesRepo.findStatusAndClientName('cq-1', testDb)).toEqual({
+      status: 'draft',
+      clientName: 'Acme',
+    });
+  });
+
+  test('returns null when not found', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await clientQuotesRepo.findStatusAndClientName('cq-x', testDb)).toBeNull();
+  });
+});
+
+describe('findAnyLinkedSale', () => {
+  test('returns sale id when found', async () => {
+    exec.enqueue({ rows: [['s-1']] });
+    expect(await clientQuotesRepo.findAnyLinkedSale('cq-1', testDb)).toBe('s-1');
+    expect(exec.calls[0].sql.toLowerCase()).toContain('from "sales"');
+    expect(exec.calls[0].params).toContain('cq-1');
+  });
+
+  test('returns null when no linked sale', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await clientQuotesRepo.findAnyLinkedSale('cq-x', testDb)).toBeNull();
+  });
+});
+
+describe('findItemsForQuote', () => {
+  test('selects items filtered by quoteId and maps them', async () => {
+    exec.enqueue({ rows: [itemRow()] });
+    const result = await clientQuotesRepo.findItemsForQuote('cq-1', testDb);
+    expect(exec.calls[0].sql.toLowerCase()).toContain('from "quote_items"');
+    expect(exec.calls[0].params).toContain('cq-1');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('qi-1');
+  });
+});
+
+describe('findFullForSnapshot', () => {
+  test('returns quote and items when quote exists', async () => {
+    // Promise.all dispatches `findItemsForQuote(id)` first (its async body runs to its first
+    // await before the sibling thenable is consumed), so the items query is what dequeues the
+    // first response.
+    exec.enqueue({ rows: [itemRow()] });
+    exec.enqueue({ rows: [quoteRow()] });
+    const result = await clientQuotesRepo.findFullForSnapshot('cq-1', testDb);
+    expect(result).not.toBeNull();
+    expect(result?.quote.id).toBe('cq-1');
+    expect(result?.items).toHaveLength(1);
+    expect(result?.items[0].id).toBe('qi-1');
+  });
+
+  test('returns null when quote not found', async () => {
+    exec.enqueue({ rows: [] });
+    exec.enqueue({ rows: [] });
+    expect(await clientQuotesRepo.findFullForSnapshot('cq-x', testDb)).toBeNull();
+  });
+});
+
+describe('deleteById', () => {
+  test('returns true when row deleted', async () => {
+    exec.enqueue({ rows: [], rowCount: 1 });
+    expect(await clientQuotesRepo.deleteById('cq-1', testDb)).toBe(true);
+  });
+
+  test('returns false when no row matched', async () => {
+    exec.enqueue({ rows: [], rowCount: 0 });
+    expect(await clientQuotesRepo.deleteById('cq-x', testDb)).toBe(false);
+  });
+});

--- a/server/test/repositories/clientsOrdersRepo.test.ts
+++ b/server/test/repositories/clientsOrdersRepo.test.ts
@@ -304,3 +304,182 @@ describe('deleteById', () => {
     expect(await repo.deleteById('co-x', testDb)).toBe(false);
   });
 });
+
+describe('listAllItems', () => {
+  test('orders items by created_at ASC and maps fields', async () => {
+    exec.enqueue({ rows: [itemRow()] });
+    const result = await repo.listAllItems(testDb);
+    expect(exec.calls[0].sql.toLowerCase()).toContain('from "sale_items"');
+    expect(exec.calls[0].sql.toLowerCase()).toContain('order by "sale_items"."created_at"');
+    expect(result[0].id).toBe('si-1');
+    expect(result[0].orderId).toBe('co-1');
+    expect(result[0].quantity).toBe(2);
+  });
+});
+
+describe('existsById', () => {
+  test('returns true when matching row exists', async () => {
+    exec.enqueue({ rows: [['co-1']] });
+    expect(await repo.existsById('co-1', testDb)).toBe(true);
+  });
+
+  test('returns false when not found', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await repo.existsById('co-x', testDb)).toBe(false);
+  });
+});
+
+describe('findIdConflict', () => {
+  test('binds both ids and excludes self', async () => {
+    exec.enqueue({ rows: [['co-2']] });
+    const result = await repo.findIdConflict('co-2', 'co-1', testDb);
+    expect(exec.calls[0].params).toEqual(['co-2', 'co-1']);
+    expect(result).toBe(true);
+  });
+
+  test('returns false when no conflict', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await repo.findIdConflict('co-2', 'co-1', testDb)).toBe(false);
+  });
+});
+
+describe('findForUpdate', () => {
+  test('returns mapped existing order when found', async () => {
+    exec.enqueue({
+      rows: [['co-1', null, null, 'c-1', 'Acme', 'net30', '5', 'currency', 'draft', null]],
+    });
+    const result = await repo.findForUpdate('co-1', testDb);
+    expect(result).toEqual({
+      id: 'co-1',
+      linkedQuoteId: null,
+      linkedOfferId: null,
+      clientId: 'c-1',
+      clientName: 'Acme',
+      paymentTerms: 'net30',
+      discount: 5,
+      discountType: 'currency',
+      status: 'draft',
+      notes: null,
+    });
+  });
+
+  test('coerces unknown discountType to percentage', async () => {
+    exec.enqueue({
+      rows: [['co-1', null, null, 'c-1', 'Acme', 'net30', '0', 'weird', 'draft', null]],
+    });
+    const result = await repo.findForUpdate('co-1', testDb);
+    expect(result?.discountType).toBe('percentage');
+  });
+
+  test('returns null when not found', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await repo.findForUpdate('co-x', testDb)).toBeNull();
+  });
+});
+
+describe('findStatusAndClientName', () => {
+  test('returns status and clientName when found', async () => {
+    exec.enqueue({ rows: [['draft', 'Acme']] });
+    expect(await repo.findStatusAndClientName('co-1', testDb)).toEqual({
+      status: 'draft',
+      clientName: 'Acme',
+    });
+  });
+
+  test('returns null when not found', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await repo.findStatusAndClientName('co-x', testDb)).toBeNull();
+  });
+});
+
+describe('findItemsForOrder', () => {
+  test('selects items filtered by orderId and maps them', async () => {
+    exec.enqueue({ rows: [itemRow()] });
+    const result = await repo.findItemsForOrder('co-1', testDb);
+    expect(exec.calls[0].sql.toLowerCase()).toContain('from "sale_items"');
+    expect(exec.calls[0].params).toContain('co-1');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('si-1');
+  });
+});
+
+describe('findFullForSnapshot', () => {
+  test('returns order and items when order exists', async () => {
+    // Promise.all dispatches `findItemsForOrder(id)` first (its async body runs to its first
+    // await before the sibling thenable is consumed), so the items query dequeues first.
+    exec.enqueue({ rows: [itemRow()] });
+    exec.enqueue({ rows: [orderRow()] });
+    const result = await repo.findFullForSnapshot('co-1', testDb);
+    expect(result).not.toBeNull();
+    expect(result?.order.id).toBe('co-1');
+    expect(result?.items).toHaveLength(1);
+  });
+
+  test('returns null when order not found', async () => {
+    exec.enqueue({ rows: [] });
+    exec.enqueue({ rows: [] });
+    expect(await repo.findFullForSnapshot('co-x', testDb)).toBeNull();
+  });
+});
+
+describe('restoreSnapshotOrder', () => {
+  test('updates the order with snapshot fields and returns mapped order', async () => {
+    exec.enqueue({ rows: [orderRow()] });
+    const result = await repo.restoreSnapshotOrder(
+      'co-1',
+      {
+        clientId: 'c-1',
+        clientName: 'Acme',
+        paymentTerms: 'net30',
+        discount: 7,
+        discountType: 'percentage',
+        status: 'confirmed',
+        notes: 'restored',
+      },
+      testDb,
+    );
+    const sql = exec.calls[0].sql.toLowerCase();
+    expect(sql).toContain('update "sales"');
+    expect(sql).toContain('current_timestamp');
+    expect(exec.calls[0].params).toContain('confirmed');
+    expect(exec.calls[0].params).toContain('Acme');
+    expect(exec.calls[0].params).toContain('co-1');
+    expect(result?.id).toBe('co-1');
+  });
+
+  test('falls back to "immediate" paymentTerms when snapshot.paymentTerms is null', async () => {
+    exec.enqueue({ rows: [orderRow()] });
+    await repo.restoreSnapshotOrder(
+      'co-1',
+      {
+        clientId: 'c-1',
+        clientName: 'Acme',
+        paymentTerms: null,
+        discount: 0,
+        discountType: 'percentage',
+        status: 'draft',
+        notes: null,
+      },
+      testDb,
+    );
+    expect(exec.calls[0].params).toContain('immediate');
+  });
+
+  test('returns null when no row updated', async () => {
+    exec.enqueue({ rows: [] });
+    const result = await repo.restoreSnapshotOrder(
+      'co-x',
+      {
+        clientId: 'c-1',
+        clientName: 'Acme',
+        paymentTerms: 'net30',
+        discount: 0,
+        discountType: 'percentage',
+        status: 'draft',
+        notes: null,
+      },
+      testDb,
+    );
+    expect(result).toBeNull();
+  });
+});

--- a/server/test/repositories/reportsCatalogRepo.test.ts
+++ b/server/test/repositories/reportsCatalogRepo.test.ts
@@ -83,6 +83,85 @@ describe('getSuppliersSection', () => {
       },
     ]);
   });
+
+  test('product stats branch fires only when canListProducts; rows map per-supplier', async () => {
+    exec.enqueue({ rows: [{ count: '1', disabled_count: '0' }] });
+    exec.enqueue({
+      rows: [
+        {
+          id: 's1',
+          name: 'ACorp',
+          supplier_code: null,
+          contact_name: null,
+          email: null,
+          phone: null,
+          address: null,
+          is_disabled: false,
+        },
+      ],
+    });
+    // Promise.all order: quoteStatsPromise (null) then productStatsPromise.
+    exec.enqueue({
+      rows: [
+        { supplier_id: 's1', product_count: '7' },
+        { supplier_id: 'unknown', product_count: '99' },
+      ],
+    });
+    const result = await repo.getSuppliersSection(
+      {
+        fromDate: FROM,
+        toDate: TO,
+        canViewSupplierQuotes: false,
+        canListProducts: true,
+        itemsLimit: 50,
+      },
+      testDb,
+    );
+    expect(exec.calls).toHaveLength(3);
+    expect(result.activitySummary).toEqual([
+      {
+        supplierId: 's1',
+        quotesCount: null,
+        quotesNet: null,
+        productsCount: 7,
+      },
+    ]);
+  });
+
+  test('quote stats rows for unknown supplier_ids are silently ignored', async () => {
+    exec.enqueue({ rows: [{ count: '1', disabled_count: '0' }] });
+    exec.enqueue({
+      rows: [
+        {
+          id: 's1',
+          name: 'ACorp',
+          supplier_code: null,
+          contact_name: null,
+          email: null,
+          phone: null,
+          address: null,
+          is_disabled: false,
+        },
+      ],
+    });
+    exec.enqueue({ rows: [{ supplier_id: 'unknown', quote_count: '99', net_value: '999' }] });
+    const result = await repo.getSuppliersSection(
+      {
+        fromDate: FROM,
+        toDate: TO,
+        canViewSupplierQuotes: true,
+        canListProducts: false,
+        itemsLimit: 50,
+      },
+      testDb,
+    );
+    expect(result.activitySummary[0]).toEqual({
+      supplierId: 's1',
+      quotesCount: null,
+      quotesNet: null,
+      productsCount: null,
+    });
+  });
 });
 
 describe('getSupplierQuotesSection', () => {
@@ -136,6 +215,23 @@ describe('getSupplierQuotesSection', () => {
       },
     ]);
   });
+
+  test('byMonth/byStatus/topSuppliersByNet rows are mapped through helpers', async () => {
+    // Promise.all order: totals, byStatus, byMonth, topSuppliers, topQuotes.
+    exec.enqueue({ rows: [{ count: '0', total_net: '0', avg_net: '0' }] });
+    exec.enqueue({ rows: [{ status: 'sent', count: '4', total_net: '900' }] });
+    exec.enqueue({ rows: [{ label: '2026-01', count: '4', total_net: '900' }] });
+    exec.enqueue({ rows: [{ label: 'ACorp', quote_count: '4', value: '900' }] });
+    exec.enqueue({ rows: [] });
+
+    const result = await repo.getSupplierQuotesSection(
+      { fromDate: FROM, toDate: TO, topLimit: 10 },
+      testDb,
+    );
+    expect(result.byStatus).toEqual([{ status: 'sent', count: 4, totalNet: 900 }]);
+    expect(result.byMonth).toEqual([{ label: '2026-01', count: 4, totalNet: 900 }]);
+    expect(result.topSuppliersByNet).toEqual([{ label: 'ACorp', value: 900, quoteCount: 4 }]);
+  });
 });
 
 describe('getCatalogSection', () => {
@@ -171,5 +267,43 @@ describe('getCatalogSection', () => {
     const usageCall = exec.calls.find((c) => c.sql.includes('WITH usage_rows'));
     expect(usageCall?.params).toEqual([FROM, TO, FROM, TO, FROM, TO, 8]);
     expect(usageCall?.sql).toContain('LIMIT $7');
+  });
+
+  test('byType / byCategory / bySubcategory / productsBySupplier / top* rows are mapped through helpers', async () => {
+    // Promise.all order: counts, byType, byCategory, bySubcategory, productsBySupplier,
+    // topProductsByUsage, topProductsByRevenue.
+    exec.enqueue({
+      rows: [{ internal_count: '0', external_count: '0', disabled_count: '0' }],
+    });
+    exec.enqueue({ rows: [{ label: 'service', value: '5' }] });
+    exec.enqueue({ rows: [{ label: 'consulting', value: '4' }] });
+    exec.enqueue({ rows: [{ label: 'training', value: '3' }] });
+    exec.enqueue({ rows: [{ label: 'ACorp', value: '2' }] });
+    exec.enqueue({
+      rows: [
+        {
+          product_id: 'p1',
+          product_name: 'Widget',
+          usage_count: '7',
+          quantity_total: '15',
+        },
+      ],
+    });
+    exec.enqueue({ rows: [{ product_id: 'p2', product_name: 'Gadget', value: '420' }] });
+
+    const result = await repo.getCatalogSection(
+      { fromDate: FROM, toDate: TO, topLimit: 10 },
+      testDb,
+    );
+    expect(result.byType).toEqual([{ label: 'service', value: 5 }]);
+    expect(result.byCategory).toEqual([{ label: 'consulting', value: 4 }]);
+    expect(result.bySubcategory).toEqual([{ label: 'training', value: 3 }]);
+    expect(result.productsBySupplierCount).toEqual([{ label: 'ACorp', value: 2 }]);
+    expect(result.topProductsByUsage).toEqual([
+      { productId: 'p1', productName: 'Widget', usageCount: 7, quantity: 15 },
+    ]);
+    expect(result.topProductsByRevenue).toEqual([
+      { productId: 'p2', productName: 'Gadget', value: 420 },
+    ]);
   });
 });

--- a/server/test/repositories/reportsClientsRepo.test.ts
+++ b/server/test/repositories/reportsClientsRepo.test.ts
@@ -131,6 +131,121 @@ describe('getClientsSection', () => {
     ]);
   });
 
+  test('orders/invoices/timesheets activity rows are mapped per-client', async () => {
+    exec.enqueue({ rows: [{ count: '1' }] });
+    exec.enqueue({
+      rows: [
+        {
+          id: 'c1',
+          name: 'Acme',
+          client_code: null,
+          type: null,
+          contact_name: null,
+          email: null,
+          phone: null,
+          address: null,
+          is_disabled: false,
+        },
+      ],
+    });
+    // Activity Promise.all order: quotes, orders, invoices, timesheets.
+    // Only orders + invoices + timesheets enabled here, so 3 activity queries.
+    exec.enqueue({ rows: [{ client_id: 'c1', order_count: '3', net_value: '750' }] });
+    exec.enqueue({
+      rows: [
+        {
+          client_id: 'c1',
+          invoice_count: '4',
+          total_sum: '1200',
+          outstanding_sum: '300',
+        },
+      ],
+    });
+    exec.enqueue({ rows: [{ client_id: 'c1', hours: '12' }] });
+
+    const result = await repo.getClientsSection(
+      {
+        ...baseOpts,
+        canViewOrders: true,
+        canViewInvoices: true,
+        canViewTimesheets: true,
+        canViewAllTimesheets: true,
+      },
+      testDb,
+    );
+    expect(exec.calls).toHaveLength(5);
+    expect(result.activitySummary).toEqual([
+      {
+        clientId: 'c1',
+        quotesCount: null,
+        quotesNet: null,
+        ordersCount: 3,
+        ordersNet: 750,
+        invoicesCount: 4,
+        invoicesTotal: 1200,
+        invoicesOutstanding: 300,
+        timesheetHours: 12,
+      },
+    ]);
+  });
+
+  test('activity rows for unknown client_ids are silently ignored', async () => {
+    exec.enqueue({ rows: [{ count: '1' }] });
+    exec.enqueue({
+      rows: [
+        {
+          id: 'c1',
+          name: 'Acme',
+          client_code: null,
+          type: null,
+          contact_name: null,
+          email: null,
+          phone: null,
+          address: null,
+          is_disabled: false,
+        },
+      ],
+    });
+    // Quote/order/invoice/timesheet rows reference an unknown client; map.get(...) returns
+    // undefined, the `if (!target) continue` skips them, and the existing entry stays unchanged.
+    exec.enqueue({ rows: [{ client_id: 'unknown', quote_count: '99', net_value: '999' }] });
+    exec.enqueue({ rows: [{ client_id: 'unknown', order_count: '5', net_value: '5' }] });
+    exec.enqueue({
+      rows: [
+        {
+          client_id: 'unknown',
+          invoice_count: '5',
+          total_sum: '5',
+          outstanding_sum: '5',
+        },
+      ],
+    });
+    exec.enqueue({ rows: [{ client_id: 'unknown', hours: '99' }] });
+
+    const result = await repo.getClientsSection(
+      {
+        ...baseOpts,
+        canViewQuotes: true,
+        canViewOrders: true,
+        canViewInvoices: true,
+        canViewTimesheets: true,
+        canViewAllTimesheets: true,
+      },
+      testDb,
+    );
+    expect(result.activitySummary[0]).toEqual({
+      clientId: 'c1',
+      quotesCount: null,
+      quotesNet: null,
+      ordersCount: null,
+      ordersNet: null,
+      invoicesCount: null,
+      invoicesTotal: null,
+      invoicesOutstanding: null,
+      timesheetHours: null,
+    });
+  });
+
   test('timesheet activity respects canViewAllTimesheets scoping', async () => {
     exec.enqueue({ rows: [{ count: '1' }] });
     exec.enqueue({

--- a/server/test/repositories/reportsHoursRepo.test.ts
+++ b/server/test/repositories/reportsHoursRepo.test.ts
@@ -76,6 +76,30 @@ describe('getTimesheetsSection', () => {
     );
     expect(result.totals.avgEntryHours).toBe(0);
   });
+
+  test('top* / byMonth / byLocation rows are mapped through helpers', async () => {
+    // Promise.all order: totals, topUsers, topClients, topProjects, topTasks, byMonth, byLocation.
+    exec.enqueue({ rows: [{ hours: '10', entry_count: '1', total_cost: '50' }] });
+    exec.enqueue({ rows: [{ label: 'Alice', value: '8', entry_count: '4' }] });
+    exec.enqueue({ rows: [{ label: 'Acme', value: '6', entry_count: '3' }] });
+    exec.enqueue({ rows: [{ label: 'Phoenix', value: '5', entry_count: '2' }] });
+    exec.enqueue({ rows: [{ label: 'Implement', value: '4', entry_count: '1' }] });
+    exec.enqueue({
+      rows: [{ label: '2026-01', hours: '10', entry_count: '1', total_cost: '50' }],
+    });
+    exec.enqueue({ rows: [{ location: 'office', hours: '7', entry_count: '2' }] });
+
+    const result = await repo.getTimesheetsSection(
+      { fromDate: FROM, toDate: TO, allowedTimesheetUserIds: null, topLimit: 10 },
+      testDb,
+    );
+    expect(result.topHoursByUser).toEqual([{ label: 'Alice', value: 8, entryCount: 4 }]);
+    expect(result.topHoursByClient).toEqual([{ label: 'Acme', value: 6, entryCount: 3 }]);
+    expect(result.topHoursByProject).toEqual([{ label: 'Phoenix', value: 5, entryCount: 2 }]);
+    expect(result.topHoursByTask).toEqual([{ label: 'Implement', value: 4, entryCount: 1 }]);
+    expect(result.byMonth).toEqual([{ label: '2026-01', hours: 10, entryCount: 1, cost: 50 }]);
+    expect(result.byLocation).toEqual([{ location: 'office', hours: 7, entryCount: 2 }]);
+  });
 });
 
 describe('getProjectsSection', () => {
@@ -214,6 +238,47 @@ describe('getProjectsSection', () => {
     expect(exec.calls[0].params).toEqual(['u1']);
     expect(exec.calls[1].params).toEqual(['u1', 50]);
   });
+
+  test('items rows are mapped through toDbText/Boolean coercion', async () => {
+    exec.enqueue({ rows: [{ count: '1', disabled_count: '0' }] });
+    exec.enqueue({
+      rows: [
+        {
+          id: 'p1',
+          name: 'Phoenix',
+          client_id: 'c1',
+          client_name: 'Acme',
+          description: 'desc',
+          is_disabled: false,
+        },
+      ],
+    });
+    exec.enqueue({ rows: [] });
+    const result = await repo.getProjectsSection(
+      {
+        viewerId: 'u1',
+        fromDate: FROM,
+        toDate: TO,
+        canViewAllProjects: true,
+        canViewTimesheets: true,
+        canViewAllTimesheets: true,
+        allowedTimesheetUserIds: null,
+        itemsLimit: 50,
+        topLimit: 10,
+      },
+      testDb,
+    );
+    expect(result.items).toEqual([
+      {
+        id: 'p1',
+        name: 'Phoenix',
+        clientId: 'c1',
+        clientName: 'Acme',
+        description: 'desc',
+        isDisabled: false,
+      },
+    ]);
+  });
 });
 
 describe('getTasksSection', () => {
@@ -301,6 +366,50 @@ describe('getTasksSection', () => {
       disabledCount: 1,
       recurringCount: 3,
     });
+  });
+
+  test('items + topByHours rows are mapped through helpers', async () => {
+    exec.enqueue({ rows: [{ count: '1', disabled_count: '0', recurring_count: '1' }] });
+    exec.enqueue({
+      rows: [
+        {
+          id: 't1',
+          name: 'Build',
+          project_id: 'p1',
+          project_name: 'Phoenix',
+          is_disabled: false,
+          is_recurring: true,
+          recurrence_pattern: 'weekly',
+        },
+      ],
+    });
+    exec.enqueue({ rows: [{ label: 'Build', hours: '12.5', entry_count: '3' }] });
+    const result = await repo.getTasksSection(
+      {
+        viewerId: 'u1',
+        fromDate: FROM,
+        toDate: TO,
+        canViewAllTasks: true,
+        canViewTimesheets: true,
+        canViewAllTimesheets: true,
+        allowedTimesheetUserIds: null,
+        itemsLimit: 50,
+        topLimit: 10,
+      },
+      testDb,
+    );
+    expect(result.items).toEqual([
+      {
+        id: 't1',
+        name: 'Build',
+        projectId: 'p1',
+        projectName: 'Phoenix',
+        isDisabled: false,
+        isRecurring: true,
+        recurrencePattern: 'weekly',
+      },
+    ]);
+    expect(result.topByHours).toEqual([{ label: 'Build', value: 12.5, entryCount: 3 }]);
   });
 
   // The !canViewAllTasks branches funnel through `timeEntriesTasksJoin` (defined in tasksRepo).

--- a/server/test/repositories/reportsRevenueRepo.test.ts
+++ b/server/test/repositories/reportsRevenueRepo.test.ts
@@ -116,6 +116,20 @@ describe('getOrdersSection', () => {
     ]);
     expect(result.topClientsByNet).toEqual([{ label: 'Acme', value: 900, orderCount: 2 }]);
   });
+
+  test('byStatus and byMonth rows are mapped through toDbText/toDbNumber', async () => {
+    exec.enqueue({ rows: [{ count: '0', total_net: '0', avg_net: '0' }] });
+    exec.enqueue({ rows: [{ status: 'shipped', count: '2', total_net: '900' }] });
+    exec.enqueue({ rows: [{ label: '2026-01', count: '2', total_net: '900' }] });
+    exec.enqueueEmptyN(2);
+
+    const result = await repo.getOrdersSection(
+      { fromDate: FROM, toDate: TO, topLimit: 10 },
+      testDb,
+    );
+    expect(result.byStatus).toEqual([{ status: 'shipped', count: 2, totalNet: 900 }]);
+    expect(result.byMonth).toEqual([{ label: '2026-01', count: 2, totalNet: 900 }]);
+  });
 });
 
 describe('getInvoicesSection', () => {

--- a/server/test/repositories/supplierOrdersRepo.test.ts
+++ b/server/test/repositories/supplierOrdersRepo.test.ts
@@ -197,3 +197,154 @@ describe('deleteById', () => {
     expect(await supplierOrdersRepo.deleteById('so-x', testDb)).toBe(false);
   });
 });
+
+describe('listAllItems', () => {
+  test('orders items by created_at ASC and maps fields', async () => {
+    exec.enqueue({ rows: [itemRow()] });
+    const result = await supplierOrdersRepo.listAllItems(testDb);
+    expect(exec.calls[0].sql).toContain('order by "supplier_sale_items"."created_at" asc');
+    expect(result[0].id).toBe('ssi-1');
+    expect(result[0].orderId).toBe('so-1');
+    expect(result[0].quantity).toBe(1);
+  });
+});
+
+describe('existsById', () => {
+  test('returns true when row exists', async () => {
+    exec.enqueue({ rows: [['so-1']] });
+    expect(await supplierOrdersRepo.existsById('so-1', testDb)).toBe(true);
+  });
+
+  test('returns false when not found', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await supplierOrdersRepo.existsById('so-x', testDb)).toBe(false);
+  });
+});
+
+describe('findItemsForOrder', () => {
+  test('selects items filtered by orderId and maps them', async () => {
+    exec.enqueue({ rows: [itemRow()] });
+    const result = await supplierOrdersRepo.findItemsForOrder('so-1', testDb);
+    expect(exec.calls[0].sql).toContain('from "supplier_sale_items"');
+    expect(exec.calls[0].params).toContain('so-1');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('ssi-1');
+  });
+});
+
+describe('findFullForSnapshot', () => {
+  test('returns order and items when order exists', async () => {
+    // Promise.all dispatches `findItemsForOrder(id)` first (its async body runs to its first
+    // await before the sibling thenable is consumed), so the items query dequeues first.
+    exec.enqueue({ rows: [itemRow()] });
+    exec.enqueue({ rows: [orderRow()] });
+    const result = await supplierOrdersRepo.findFullForSnapshot('so-1', testDb);
+    expect(result).not.toBeNull();
+    expect(result?.order.id).toBe('so-1');
+    expect(result?.items).toHaveLength(1);
+  });
+
+  test('returns null when order not found', async () => {
+    exec.enqueue({ rows: [] });
+    exec.enqueue({ rows: [] });
+    expect(await supplierOrdersRepo.findFullForSnapshot('so-x', testDb)).toBeNull();
+  });
+});
+
+describe('findExistingByLinkedQuote', () => {
+  test('returns id when found', async () => {
+    exec.enqueue({ rows: [['so-1']] });
+    expect(await supplierOrdersRepo.findExistingByLinkedQuote('q-1', testDb)).toBe('so-1');
+    expect(exec.calls[0].params).toContain('q-1');
+  });
+
+  test('returns null when not found', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await supplierOrdersRepo.findExistingByLinkedQuote('q-x', testDb)).toBeNull();
+  });
+});
+
+describe('create', () => {
+  test('inserts and returns mapped order', async () => {
+    exec.enqueue({ rows: [orderRow()] });
+    const result = await supplierOrdersRepo.create(
+      {
+        id: 'so-1',
+        linkedQuoteId: 'q-1',
+        supplierId: 's-1',
+        supplierName: 'Acme',
+        paymentTerms: 'net30',
+        discount: 5,
+        discountType: 'percentage',
+        status: 'draft',
+        notes: null,
+      },
+      testDb,
+    );
+    expect(exec.calls[0].sql).toContain('insert into "supplier_sales"');
+    expect(exec.calls[0].params).toContain('so-1');
+    expect(exec.calls[0].params).toContain('q-1');
+    expect(exec.calls[0].params).toContain('Acme');
+    expect(result.id).toBe('so-1');
+  });
+});
+
+describe('restoreSnapshotOrder', () => {
+  test('updates with snapshot fields and returns mapped order', async () => {
+    exec.enqueue({ rows: [orderRow()] });
+    const result = await supplierOrdersRepo.restoreSnapshotOrder(
+      'so-1',
+      {
+        supplierId: 's-1',
+        supplierName: 'Acme',
+        paymentTerms: 'net30',
+        discount: 5,
+        discountType: 'percentage',
+        status: 'draft',
+        notes: 'restored',
+      },
+      testDb,
+    );
+    expect(exec.calls[0].sql).toContain('update "supplier_sales"');
+    expect(exec.calls[0].sql).toContain('CURRENT_TIMESTAMP');
+    expect(exec.calls[0].params).toContain('Acme');
+    expect(exec.calls[0].params).toContain('so-1');
+    expect(result?.id).toBe('so-1');
+  });
+
+  test('falls back to "immediate" paymentTerms when snapshot.paymentTerms is null', async () => {
+    exec.enqueue({ rows: [orderRow()] });
+    await supplierOrdersRepo.restoreSnapshotOrder(
+      'so-1',
+      {
+        supplierId: 's-1',
+        supplierName: 'Acme',
+        paymentTerms: null,
+        discount: 0,
+        discountType: 'percentage',
+        status: 'draft',
+        notes: null,
+      },
+      testDb,
+    );
+    expect(exec.calls[0].params).toContain('immediate');
+  });
+
+  test('returns null when no row updated', async () => {
+    exec.enqueue({ rows: [] });
+    const result = await supplierOrdersRepo.restoreSnapshotOrder(
+      'so-x',
+      {
+        supplierId: 's-1',
+        supplierName: 'Acme',
+        paymentTerms: 'net30',
+        discount: 0,
+        discountType: 'percentage',
+        status: 'draft',
+        notes: null,
+      },
+      testDb,
+    );
+    expect(result).toBeNull();
+  });
+});

--- a/server/test/repositories/supplierQuotesRepo.test.ts
+++ b/server/test/repositories/supplierQuotesRepo.test.ts
@@ -227,3 +227,109 @@ describe('deleteById', () => {
     expect(await supplierQuotesRepo.deleteById('q-x', testDb)).toBeNull();
   });
 });
+
+describe('existsById', () => {
+  test('returns true when matching row exists', async () => {
+    exec.enqueue({ rows: [['q-1']] });
+    expect(await supplierQuotesRepo.existsById('q-1', testDb)).toBe(true);
+  });
+
+  test('returns false when not found', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await supplierQuotesRepo.existsById('q-x', testDb)).toBe(false);
+  });
+});
+
+describe('findItemsForQuote', () => {
+  test('selects items filtered by quoteId and maps them', async () => {
+    exec.enqueue({ rows: [itemRow()] });
+    const result = await supplierQuotesRepo.findItemsForQuote('q-1', testDb);
+    expect(exec.calls[0].sql).toContain('from "supplier_quote_items"');
+    expect(exec.calls[0].params).toContain('q-1');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('sqi-1');
+  });
+});
+
+describe('findFullForSnapshot', () => {
+  test('returns quote and items when quote exists', async () => {
+    // Promise.all dispatches `findItemsForQuote(id)` first (its async body runs to its first
+    // await before the sibling thenable is consumed), so the items query dequeues first.
+    exec.enqueue({ rows: [itemRow()] });
+    exec.enqueue({ rows: [quoteRow()] });
+    const result = await supplierQuotesRepo.findFullForSnapshot('q-1', testDb);
+    expect(result).not.toBeNull();
+    expect(result?.quote.id).toBe('q-1');
+    expect(result?.items).toHaveLength(1);
+  });
+
+  test('returns null when quote not found', async () => {
+    exec.enqueue({ rows: [] });
+    exec.enqueue({ rows: [] });
+    expect(await supplierQuotesRepo.findFullForSnapshot('q-x', testDb)).toBeNull();
+  });
+});
+
+describe('create', () => {
+  test('inserts and returns mapped quote', async () => {
+    exec.enqueue({ rows: [quoteRow()] });
+    const result = await supplierQuotesRepo.create(
+      {
+        id: 'q-1',
+        supplierId: 's-1',
+        supplierName: 'Acme',
+        paymentTerms: 'net30',
+        status: 'draft',
+        expirationDate: '2026-06-01',
+        notes: null,
+      },
+      testDb,
+    );
+    expect(exec.calls[0].sql).toContain('insert into "supplier_quotes"');
+    expect(exec.calls[0].params).toContain('q-1');
+    expect(exec.calls[0].params).toContain('Acme');
+    expect(exec.calls[0].params).toContain('2026-06-01');
+    expect(result.id).toBe('q-1');
+  });
+});
+
+describe('restoreSnapshotQuote', () => {
+  test('updates with snapshot fields and returns mapped quote', async () => {
+    exec.enqueue({ rows: [quoteRow()] });
+    const result = await supplierQuotesRepo.restoreSnapshotQuote(
+      'q-1',
+      {
+        supplierId: 's-1',
+        supplierName: 'Acme',
+        paymentTerms: 'net30',
+        status: 'sent',
+        expirationDate: '2026-06-01',
+        notes: 'restored',
+      },
+      testDb,
+    );
+    expect(exec.calls[0].sql).toContain('update "supplier_quotes"');
+    expect(exec.calls[0].sql).toContain('CURRENT_TIMESTAMP');
+    expect(exec.calls[0].params).toContain('Acme');
+    expect(exec.calls[0].params).toContain('sent');
+    expect(exec.calls[0].params).toContain('q-1');
+    expect(result?.id).toBe('q-1');
+  });
+
+  test('returns null when no row updated', async () => {
+    exec.enqueue({ rows: [] });
+    const result = await supplierQuotesRepo.restoreSnapshotQuote(
+      'q-x',
+      {
+        supplierId: 's-1',
+        supplierName: 'Acme',
+        paymentTerms: 'net30',
+        status: 'draft',
+        expirationDate: '2026-06-01',
+        notes: null,
+      },
+      testDb,
+    );
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds focused unit tests covering the previously uncovered helper functions and row-mapping closures in 8 server repositories so each reaches 100% line coverage.
- All new cases use the existing `FakeExecutor` harness (`setupTestDb`, `enqueue`, `makeRow`) and follow the style of the existing tests in each file.
- Files touched (tests only — no production code changes):
  - `server/test/repositories/clientQuotesRepo.test.ts` (87 -> 100%)
  - `server/test/repositories/clientsOrdersRepo.test.ts` (78 -> 100%)
  - `server/test/repositories/supplierOrdersRepo.test.ts` (77 -> 100%)
  - `server/test/repositories/supplierQuotesRepo.test.ts` (82 -> 100%)
  - `server/test/repositories/reportsCatalogRepo.test.ts` (50 -> 100%)
  - `server/test/repositories/reportsHoursRepo.test.ts` (64 -> 100%)
  - `server/test/repositories/reportsClientsRepo.test.ts` (81 -> 100%)
  - `server/test/repositories/reportsRevenueRepo.test.ts` (89 -> 100%)

## Test plan
- [x] `cd server && bun test` (1153 pass, 0 fail)
- [x] `bun run test` (frontend 302 pass, 0 fail)
- [x] `cd server && bun test ./test --coverage` reports 100% lines for each touched repo
- [x] `bun run lint` exits 0 (Biome + tsc + i18n key check)

https://claude.ai/code/session_0111c2dFZ99BbKBQtghz8kGJ

---
_Generated by [Claude Code](https://claude.ai/code/session_0111c2dFZ99BbKBQtghz8kGJ)_