### PR TITLE
test(server/utils): add unit tests for small server utility modules

### DIFF
--- a/server/test/utils/ai-models.test.ts
+++ b/server/test/utils/ai-models.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from 'bun:test';
+import { normalizeGeminiModelPath } from '../../utils/ai-models.ts';
+
+describe('normalizeGeminiModelPath', () => {
+  test('rejects empty string', () => {
+    const result = normalizeGeminiModelPath('');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toBe('modelId is required');
+    }
+  });
+
+  test('rejects whitespace-only after trim', () => {
+    const result = normalizeGeminiModelPath('   ');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toBe('modelId is required');
+    }
+  });
+
+  test('rejects internal whitespace', () => {
+    const result = normalizeGeminiModelPath('gemini pro');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain('whitespace');
+    }
+  });
+
+  test('rejects modelIds with ".." traversal', () => {
+    const result = normalizeGeminiModelPath('models/..');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toBe('modelId contains invalid characters');
+    }
+  });
+
+  test('rejects modelIds with "?"', () => {
+    const result = normalizeGeminiModelPath('models/foo?bar');
+    expect(result.ok).toBe(false);
+  });
+
+  test('rejects modelIds with "#"', () => {
+    const result = normalizeGeminiModelPath('models/foo#bar');
+    expect(result.ok).toBe(false);
+  });
+
+  test('rejects modelIds with "%"', () => {
+    const result = normalizeGeminiModelPath('models/foo%20bar');
+    expect(result.ok).toBe(false);
+  });
+
+  test('rejects modelIds with ":"', () => {
+    const result = normalizeGeminiModelPath('models:foo');
+    expect(result.ok).toBe(false);
+  });
+
+  test('prefixes a bare model id with "models/"', () => {
+    const result = normalizeGeminiModelPath('gemini-1.5-pro');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe('models/gemini-1.5-pro');
+    }
+  });
+
+  test('trims whitespace before normalizing', () => {
+    const result = normalizeGeminiModelPath('  gemini-1.5-pro  ');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe('models/gemini-1.5-pro');
+    }
+  });
+
+  test('rejects bare model id with disallowed characters', () => {
+    const result = normalizeGeminiModelPath('gemini@1.5');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toBe('modelId contains invalid characters');
+    }
+  });
+
+  test('accepts the "models/<name>" path verbatim', () => {
+    const result = normalizeGeminiModelPath('models/gemini-1.5-pro');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe('models/gemini-1.5-pro');
+    }
+  });
+
+  test('accepts the "tunedModels/<name>" path verbatim', () => {
+    const result = normalizeGeminiModelPath('tunedModels/my-tuned-model');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe('tunedModels/my-tuned-model');
+    }
+  });
+
+  test('rejects unsupported two-segment prefix', () => {
+    const result = normalizeGeminiModelPath('publishers/gemini-1.5-pro');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toBe('modelId must use a supported Gemini model path');
+    }
+  });
+
+  test('rejects two-segment id with bad characters in the second segment', () => {
+    const result = normalizeGeminiModelPath('models/foo$bar');
+    expect(result.ok).toBe(false);
+  });
+
+  test('rejects deep paths (three or more segments)', () => {
+    const result = normalizeGeminiModelPath('models/foo/bar');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toBe('modelId must use a supported Gemini model path');
+    }
+  });
+
+  test('accepts hyphens, underscores, dots, digits', () => {
+    const result = normalizeGeminiModelPath('models/Gemini_1.5-pro_v2');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe('models/Gemini_1.5-pro_v2');
+    }
+  });
+});

--- a/server/test/utils/auth-assert.test.ts
+++ b/server/test/utils/auth-assert.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from 'bun:test';
+import type { FastifyReply, FastifyRequest } from 'fastify';
+import { assertAuthenticated } from '../../utils/auth-assert.ts';
+
+type FakeReply = {
+  statusCode: number;
+  body: unknown;
+  sentCount: number;
+  code(c: number): FakeReply;
+  send(body: unknown): FakeReply;
+};
+
+const buildFakeReply = (): FakeReply => {
+  const reply: FakeReply = {
+    statusCode: 0,
+    body: undefined,
+    sentCount: 0,
+    code(c: number) {
+      reply.statusCode = c;
+      return reply;
+    },
+    send(body: unknown) {
+      reply.sentCount += 1;
+      reply.body = body;
+      return reply;
+    },
+  };
+  return reply;
+};
+
+const HAPPY_USER = {
+  id: 'u1',
+  name: 'Alice',
+  username: 'alice',
+  role: 'manager',
+  avatarInitials: 'AL',
+  permissions: ['timesheets.tracker.view'],
+};
+
+const callAssert = (user: unknown, reply = buildFakeReply()) => {
+  const request = { user } as unknown as FastifyRequest;
+  const result = assertAuthenticated(request, reply as unknown as FastifyReply);
+  return { result, reply };
+};
+
+describe('assertAuthenticated', () => {
+  test('returns true and does not touch reply when request.user is present', () => {
+    const { result, reply } = callAssert(HAPPY_USER);
+
+    expect(result).toBe(true);
+    expect(reply.sentCount).toBe(0);
+    expect(reply.statusCode).toBe(0);
+  });
+
+  test('returns false and sends a 401 when request.user is missing', () => {
+    // Pass an empty object so request.user is undefined via property access.
+    const { result, reply } = callAssert(undefined);
+
+    expect(result).toBe(false);
+    expect(reply.statusCode).toBe(401);
+    expect(reply.sentCount).toBe(1);
+    expect(reply.body).toEqual({ error: 'Authentication required' });
+  });
+
+  test('treats explicit null user the same as missing user', () => {
+    const { result, reply } = callAssert(null);
+
+    expect(result).toBe(false);
+    expect(reply.statusCode).toBe(401);
+  });
+});

--- a/server/test/utils/cost-unit.test.ts
+++ b/server/test/utils/cost-unit.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from 'bun:test';
+import type { CostUnit } from '../../utils/cost-unit.ts';
+
+// cost-unit.ts only exports the CostUnit string-union type. There is no runtime
+// surface to exercise, so we simply pin the documented members.
+describe('CostUnit', () => {
+  test('accepts the documented "unit" and "hours" members', () => {
+    const a: CostUnit = 'unit';
+    const b: CostUnit = 'hours';
+    expect([a, b]).toEqual(['unit', 'hours']);
+  });
+});

--- a/server/test/utils/http-errors.test.ts
+++ b/server/test/utils/http-errors.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'bun:test';
+import { ForeignKeyError, NotFoundError } from '../../utils/http-errors.ts';
+
+describe('NotFoundError', () => {
+  test('is an Error instance', () => {
+    const err = new NotFoundError('User');
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(NotFoundError);
+  });
+
+  test('message uses the entity name with " not found" suffix', () => {
+    expect(new NotFoundError('User').message).toBe('User not found');
+    expect(new NotFoundError('Project').message).toBe('Project not found');
+  });
+
+  test('name is "NotFoundError"', () => {
+    expect(new NotFoundError('Anything').name).toBe('NotFoundError');
+  });
+
+  test('stack trace is captured', () => {
+    const err = new NotFoundError('User');
+    expect(typeof err.stack).toBe('string');
+    expect(err.stack?.length ?? 0).toBeGreaterThan(0);
+  });
+});
+
+describe('ForeignKeyError', () => {
+  test('is an Error instance', () => {
+    const err = new ForeignKeyError('Project');
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(ForeignKeyError);
+  });
+
+  test('message uses the target name with " not found" suffix', () => {
+    expect(new ForeignKeyError('Project').message).toBe('Project not found');
+  });
+
+  test('exposes the target on the readonly property', () => {
+    const err = new ForeignKeyError('Customer');
+    expect(err.target).toBe('Customer');
+  });
+
+  test('name is "ForeignKeyError"', () => {
+    expect(new ForeignKeyError('any').name).toBe('ForeignKeyError');
+  });
+
+  test('is distinguishable from NotFoundError despite identical message format', () => {
+    const fk = new ForeignKeyError('Project');
+    expect(fk).not.toBeInstanceOf(NotFoundError);
+  });
+});

--- a/server/test/utils/logger.test.ts
+++ b/server/test/utils/logger.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from 'bun:test';
+import { createChildLogger, logger, loggerOptions, serializeError } from '../../utils/logger.ts';
+
+// Note on env-branch coverage:
+//   logger.ts reads NODE_ENV / LOG_LEVEL / LOG_PRETTY at module top-level. Once Bun loads
+//   the module, those are baked in. Bun's coverage tool aggregates by source-mapped path,
+//   so re-importing the module with a cache-bust query string evaluates a SECOND copy
+//   under a different specifier — that copy is treated as a separate file by the coverage
+//   collector and so does NOT add to utils/logger.ts coverage. We therefore exercise the
+//   public surface of the *cached* module here, and validate the env-dependent shape of
+//   `loggerOptions` against whatever NODE_ENV happened to be active during import.
+
+const isProduction = (process.env.NODE_ENV ?? 'development') === 'production';
+
+describe('loggerOptions (snapshot of module-load env)', () => {
+  test('level falls back to "info" when LOG_LEVEL is unset, otherwise reflects the env', () => {
+    expect(loggerOptions.level).toBe(process.env.LOG_LEVEL ?? 'info');
+  });
+
+  test('base.service is the constant praetor-api tag', () => {
+    expect((loggerOptions.base as { service: string }).service).toBe('praetor-api');
+  });
+
+  test('base.env reflects NODE_ENV (with the documented "development" fallback)', () => {
+    expect((loggerOptions.base as { env: string }).env).toBe(process.env.NODE_ENV ?? 'development');
+  });
+
+  test('uses isoTime timestamp', () => {
+    // pino exports stdTimeFunctions.isoTime; ensure the option is wired to a function.
+    expect(typeof loggerOptions.timestamp).toBe('function');
+  });
+
+  test('redact configuration covers sensitive fields and removes them', () => {
+    const redact = loggerOptions.redact as { paths: string[]; remove: boolean };
+    expect(redact.remove).toBe(true);
+    expect(redact.paths).toEqual([
+      'req.headers.authorization',
+      'req.headers.cookie',
+      'password',
+      '*.password',
+      '*.password_hash',
+      '*.token',
+      '*.accessToken',
+      '*.refreshToken',
+    ]);
+  });
+
+  test('transport presence matches the LOG_PRETTY/NODE_ENV rules', () => {
+    const explicit = process.env.LOG_PRETTY?.trim().toLowerCase();
+    let shouldBePretty: boolean;
+    if (explicit && explicit.length > 0) {
+      shouldBePretty =
+        explicit === '1' || explicit === 'true' || explicit === 'yes' || explicit === 'on';
+    } else {
+      shouldBePretty = !isProduction;
+    }
+
+    if (shouldBePretty) {
+      expect(loggerOptions.transport).toBeDefined();
+      const transport = loggerOptions.transport as {
+        target: string;
+        options: Record<string, unknown>;
+      };
+      expect(transport.target).toBe('pino-pretty');
+      expect(transport.options).toEqual({
+        colorize: true,
+        translateTime: 'SYS:standard',
+        ignore: 'pid,hostname',
+      });
+    } else {
+      expect(loggerOptions.transport).toBeUndefined();
+    }
+  });
+});
+
+describe('logger instance', () => {
+  test('exposes the standard pino log methods', () => {
+    expect(typeof logger.info).toBe('function');
+    expect(typeof logger.warn).toBe('function');
+    expect(typeof logger.error).toBe('function');
+    expect(typeof logger.debug).toBe('function');
+    expect(typeof logger.fatal).toBe('function');
+    expect(typeof logger.trace).toBe('function');
+    expect(typeof logger.child).toBe('function');
+  });
+
+  test('is configured with the level from loggerOptions', () => {
+    expect(logger.level).toBe(loggerOptions.level ?? 'info');
+  });
+});
+
+describe('createChildLogger', () => {
+  test('returns a child logger with the given bindings', () => {
+    const child = createChildLogger({ requestId: 'abc-123' });
+    expect(typeof child.info).toBe('function');
+    expect(typeof child.child).toBe('function');
+  });
+
+  test('child loggers can themselves spawn grandchildren', () => {
+    const child = createChildLogger({ component: 'parent' });
+    const grandchild = child.child({ component: 'grandchild' });
+    expect(typeof grandchild.info).toBe('function');
+  });
+});
+
+describe('serializeError', () => {
+  test('serializes Error instances with name, message, and stack', () => {
+    const err = new Error('boom');
+    const out = serializeError(err);
+    expect(out.name).toBe('Error');
+    expect(out.message).toBe('boom');
+    expect(typeof out.stack).toBe('string');
+  });
+
+  test('serializes Error subclasses preserving the subclass name', () => {
+    class CustomError extends Error {
+      constructor(msg: string) {
+        super(msg);
+        this.name = 'CustomError';
+      }
+    }
+    const out = serializeError(new CustomError('nope'));
+    expect(out.name).toBe('CustomError');
+    expect(out.message).toBe('nope');
+  });
+
+  test('serializes a TypeError', () => {
+    const out = serializeError(new TypeError('bad type'));
+    expect(out.name).toBe('TypeError');
+    expect(out.message).toBe('bad type');
+  });
+
+  test('wraps non-Error string values under an "error" key', () => {
+    expect(serializeError('string-error')).toEqual({ error: 'string-error' });
+  });
+
+  test('wraps non-Error number values under an "error" key', () => {
+    expect(serializeError(42)).toEqual({ error: 42 });
+  });
+
+  test('wraps non-Error object values under an "error" key', () => {
+    expect(serializeError({ code: 'EFAIL' })).toEqual({ error: { code: 'EFAIL' } });
+  });
+
+  test('wraps null and undefined under an "error" key', () => {
+    expect(serializeError(null)).toEqual({ error: null });
+    expect(serializeError(undefined)).toEqual({ error: undefined });
+  });
+});

--- a/server/test/utils/logger.test.ts
+++ b/server/test/utils/logger.test.ts
@@ -46,13 +46,16 @@ describe('loggerOptions (snapshot of module-load env)', () => {
   });
 
   test('transport presence matches the LOG_PRETTY/NODE_ENV rules', () => {
-    const explicit = process.env.LOG_PRETTY?.trim().toLowerCase();
+    // Mirror parseBooleanEnv from logger.ts: any defined value (even whitespace)
+    // is treated as explicit and only the truthy strings flip pretty on.
+    const raw = process.env.LOG_PRETTY;
     let shouldBePretty: boolean;
-    if (explicit && explicit.length > 0) {
-      shouldBePretty =
-        explicit === '1' || explicit === 'true' || explicit === 'yes' || explicit === 'on';
-    } else {
+    if (raw === undefined) {
       shouldBePretty = !isProduction;
+    } else {
+      const normalized = raw.trim().toLowerCase();
+      shouldBePretty =
+        normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on';
     }
 
     if (shouldBePretty) {

--- a/server/test/utils/rate-limit.test.ts
+++ b/server/test/utils/rate-limit.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  GLOBAL_RATE_LIMIT,
+  LOGIN_RATE_LIMIT,
+  STANDARD_ROUTE_RATE_LIMIT,
+} from '../../utils/rate-limit.ts';
+
+describe('GLOBAL_RATE_LIMIT', () => {
+  test('has the documented max and timeWindow', () => {
+    expect(GLOBAL_RATE_LIMIT.max).toBe(1000);
+    expect(GLOBAL_RATE_LIMIT.timeWindow).toBe('1 minute');
+  });
+});
+
+describe('STANDARD_ROUTE_RATE_LIMIT', () => {
+  test('has the documented max and timeWindow', () => {
+    expect(STANDARD_ROUTE_RATE_LIMIT.max).toBe(120);
+    expect(STANDARD_ROUTE_RATE_LIMIT.timeWindow).toBe('1 minute');
+  });
+});
+
+describe('LOGIN_RATE_LIMIT', () => {
+  test('has the documented max and timeWindow', () => {
+    expect(LOGIN_RATE_LIMIT.max).toBe(10);
+    expect(LOGIN_RATE_LIMIT.timeWindow).toBe('15 minutes');
+  });
+});
+
+describe('rate-limit invariants', () => {
+  test('login is the strictest', () => {
+    expect(LOGIN_RATE_LIMIT.max).toBeLessThan(STANDARD_ROUTE_RATE_LIMIT.max);
+    expect(STANDARD_ROUTE_RATE_LIMIT.max).toBeLessThan(GLOBAL_RATE_LIMIT.max);
+  });
+
+  test('all configs expose a numeric max', () => {
+    for (const cfg of [GLOBAL_RATE_LIMIT, STANDARD_ROUTE_RATE_LIMIT, LOGIN_RATE_LIMIT]) {
+      expect(typeof cfg.max).toBe('number');
+      expect(cfg.max).toBeGreaterThan(0);
+    }
+  });
+
+  test('all configs expose a non-empty timeWindow string', () => {
+    for (const cfg of [GLOBAL_RATE_LIMIT, STANDARD_ROUTE_RATE_LIMIT, LOGIN_RATE_LIMIT]) {
+      expect(typeof cfg.timeWindow).toBe('string');
+      expect(cfg.timeWindow.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/server/test/utils/ssl.test.ts
+++ b/server/test/utils/ssl.test.ts
@@ -1,0 +1,196 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import realFs from 'fs';
+import realSelfsigned from 'selfsigned';
+
+// Suppress the "Generated self-signed SSL certificate" log line so test output stays clean.
+const ORIGINAL_CONSOLE_LOG = console.log;
+console.log = () => undefined;
+
+// Snapshot real exports before installing mocks (mock.module inside beforeAll is not hoisted).
+const fsSnapshot = { ...realFs };
+const selfsignedSnapshot = { ...realSelfsigned };
+
+const existsSyncMock = mock<(p: string) => boolean>(() => false);
+const readFileSyncMock = mock<(p: string) => Buffer>(() => Buffer.from(''));
+const writeFileSyncMock = mock<(p: string, data: string | Buffer) => void>(() => undefined);
+const mkdirSyncMock = mock<(p: string, opts?: unknown) => void>(() => undefined);
+const generateMock = mock<(attrs: unknown, opts: unknown) => { private: string; cert: string }>(
+  () => ({ private: 'GENERATED-KEY', cert: 'GENERATED-CERT' }),
+);
+
+beforeAll(() => {
+  // ssl.ts only consumes these four named exports from `fs`; preserve the rest verbatim
+  // so any other module loaded by the test harness keeps working.
+  mock.module('fs', () => ({
+    ...fsSnapshot,
+    existsSync: existsSyncMock,
+    readFileSync: readFileSyncMock,
+    writeFileSync: writeFileSyncMock,
+    mkdirSync: mkdirSyncMock,
+  }));
+  mock.module('selfsigned', () => ({
+    ...selfsignedSnapshot,
+    default: { ...selfsignedSnapshot, generate: generateMock },
+    generate: generateMock,
+  }));
+});
+
+afterAll(() => {
+  mock.module('fs', () => ({ ...fsSnapshot, default: fsSnapshot }));
+  mock.module('selfsigned', () => ({ ...selfsignedSnapshot, default: selfsignedSnapshot }));
+  console.log = ORIGINAL_CONSOLE_LOG;
+});
+
+beforeEach(() => {
+  existsSyncMock.mockReset().mockImplementation(() => false);
+  readFileSyncMock.mockReset().mockImplementation(() => Buffer.from(''));
+  writeFileSyncMock.mockReset().mockImplementation(() => undefined);
+  mkdirSyncMock.mockReset().mockImplementation(() => undefined);
+  generateMock
+    .mockReset()
+    .mockImplementation(() => ({ private: 'GENERATED-KEY', cert: 'GENERATED-CERT' }));
+});
+
+describe('getSSLConfig', () => {
+  test('returns existing certs from disk when both files exist', async () => {
+    const { getSSLConfig } = await import('../../utils/ssl.ts');
+
+    existsSyncMock.mockImplementation((p: string) => {
+      if (p.endsWith('server.key')) return true;
+      if (p.endsWith('server.cert')) return true;
+      return false;
+    });
+    readFileSyncMock.mockImplementation((p: string) => {
+      if (p.endsWith('server.key')) return Buffer.from('EXISTING-KEY');
+      if (p.endsWith('server.cert')) return Buffer.from('EXISTING-CERT');
+      return Buffer.from('');
+    });
+
+    const result = await getSSLConfig('example.com');
+
+    expect(result.key.toString()).toBe('EXISTING-KEY');
+    expect(result.cert.toString()).toBe('EXISTING-CERT');
+    expect(generateMock).not.toHaveBeenCalled();
+    expect(writeFileSyncMock).not.toHaveBeenCalled();
+    expect(mkdirSyncMock).not.toHaveBeenCalled();
+  });
+
+  test('generates and writes new certs when neither file exists', async () => {
+    const { getSSLConfig } = await import('../../utils/ssl.ts');
+
+    existsSyncMock.mockImplementation(() => false);
+
+    const result = await getSSLConfig('example.com');
+
+    expect(generateMock).toHaveBeenCalledTimes(1);
+    const generateCall = generateMock.mock.calls[0] as unknown as [
+      Array<{ name: string; value: string }>,
+      { keySize: number; algorithm: string; extensions: Array<Record<string, unknown>> },
+    ];
+    const [attrs, opts] = generateCall;
+    expect(attrs).toEqual([{ name: 'commonName', value: 'example.com' }]);
+    expect(opts.keySize).toBe(2048);
+    expect(opts.algorithm).toBe('sha256');
+    const subjectAltName = opts.extensions.find((e) => e.name === 'subjectAltName');
+    expect(subjectAltName).toBeDefined();
+    expect(
+      (subjectAltName as { altNames: Array<{ type: number; value?: string; ip?: string }> })
+        .altNames,
+    ).toEqual([
+      { type: 2, value: 'example.com' },
+      { type: 2, value: 'localhost' },
+      { type: 7, ip: '127.0.0.1' },
+    ]);
+
+    expect(mkdirSyncMock).toHaveBeenCalledTimes(1);
+    const mkdirCall = mkdirSyncMock.mock.calls[0] as unknown as [string, { recursive: boolean }];
+    const [mkdirPath, mkdirOpts] = mkdirCall;
+    expect(mkdirPath).toMatch(/certs$/);
+    expect(mkdirOpts).toEqual({ recursive: true });
+
+    expect(writeFileSyncMock).toHaveBeenCalledTimes(2);
+    const writePaths = writeFileSyncMock.mock.calls.map(
+      (call) => (call as unknown as [string, unknown])[0],
+    );
+    expect(writePaths.some((p) => p.endsWith('server.key'))).toBe(true);
+    expect(writePaths.some((p) => p.endsWith('server.cert'))).toBe(true);
+
+    expect(result.key.toString()).toBe('GENERATED-KEY');
+    expect(result.cert.toString()).toBe('GENERATED-CERT');
+  });
+
+  test('does not call mkdirSync if certs directory already exists', async () => {
+    const { getSSLConfig } = await import('../../utils/ssl.ts');
+
+    existsSyncMock.mockImplementation((p: string) => {
+      if (p.endsWith('server.key') || p.endsWith('server.cert')) return false;
+      return true; // certs dir exists
+    });
+
+    await getSSLConfig('example.com');
+
+    expect(mkdirSyncMock).not.toHaveBeenCalled();
+    expect(writeFileSyncMock).toHaveBeenCalledTimes(2);
+  });
+
+  test('regenerates when only the key file is missing', async () => {
+    const { getSSLConfig } = await import('../../utils/ssl.ts');
+
+    existsSyncMock.mockImplementation((p: string) => {
+      if (p.endsWith('server.key')) return false;
+      if (p.endsWith('server.cert')) return true;
+      return false;
+    });
+
+    await getSSLConfig('example.com');
+
+    expect(generateMock).toHaveBeenCalledTimes(1);
+    expect(readFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  test('regenerates when only the cert file is missing', async () => {
+    const { getSSLConfig } = await import('../../utils/ssl.ts');
+
+    existsSyncMock.mockImplementation((p: string) => {
+      if (p.endsWith('server.key')) return true;
+      if (p.endsWith('server.cert')) return false;
+      return false;
+    });
+
+    await getSSLConfig('example.com');
+
+    expect(generateMock).toHaveBeenCalledTimes(1);
+    expect(readFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  test('returns Buffer instances even when generator returns strings', async () => {
+    const { getSSLConfig } = await import('../../utils/ssl.ts');
+    existsSyncMock.mockImplementation(() => false);
+
+    const result = await getSSLConfig('foo.test');
+
+    expect(Buffer.isBuffer(result.key)).toBe(true);
+    expect(Buffer.isBuffer(result.cert)).toBe(true);
+  });
+
+  test('uses the provided domain as the commonName', async () => {
+    const { getSSLConfig } = await import('../../utils/ssl.ts');
+    existsSyncMock.mockImplementation(() => false);
+
+    await getSSLConfig('praetor.local');
+
+    const call = generateMock.mock.calls[0] as unknown as [
+      Array<{ name: string; value: string }>,
+      {
+        extensions: Array<{
+          name: string;
+          altNames?: Array<{ type: number; value?: string; ip?: string }>;
+        }>;
+      },
+    ];
+    const [attrs, opts] = call;
+    expect(attrs[0]).toEqual({ name: 'commonName', value: 'praetor.local' });
+    const san = opts.extensions.find((e) => e.name === 'subjectAltName');
+    expect(san?.altNames?.[0]).toEqual({ type: 2, value: 'praetor.local' });
+  });
+});

--- a/server/test/utils/unit-type.test.ts
+++ b/server/test/utils/unit-type.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'bun:test';
+import { normalizeUnitType, type UnitType } from '../../utils/unit-type.ts';
+
+describe('normalizeUnitType', () => {
+  test('returns "days" for the literal "days"', () => {
+    expect(normalizeUnitType('days')).toBe('days');
+  });
+
+  test('returns "unit" for the literal "unit"', () => {
+    expect(normalizeUnitType('unit')).toBe('unit');
+  });
+
+  test('returns "hours" for the literal "hours"', () => {
+    expect(normalizeUnitType('hours')).toBe('hours');
+  });
+
+  test('falls back to "hours" for unknown strings', () => {
+    expect(normalizeUnitType('week')).toBe('hours');
+    expect(normalizeUnitType('')).toBe('hours');
+    expect(normalizeUnitType('DAYS')).toBe('hours'); // case sensitive
+  });
+
+  test('falls back to "hours" for nullish input', () => {
+    expect(normalizeUnitType(null)).toBe('hours');
+    expect(normalizeUnitType(undefined)).toBe('hours');
+  });
+
+  test('falls back to "hours" for non-string input', () => {
+    expect(normalizeUnitType(0)).toBe('hours');
+    expect(normalizeUnitType({})).toBe('hours');
+    expect(normalizeUnitType([])).toBe('hours');
+    expect(normalizeUnitType(true)).toBe('hours');
+  });
+
+  test('return type is assignable to UnitType', () => {
+    const value: UnitType = normalizeUnitType('days');
+    expect(value).toBe('days');
+  });
+});


### PR DESCRIPTION
## Summary

Adds unit tests for eight previously untested or partially-tested small server
utility modules, lifting their coverage to 100% line coverage (96.6% for
`logger.ts` — the only uncovered line is the `LOG_PRETTY` truthy-trim branch,
which only fires when the env var is set at module load).

Modules covered:

- `server/utils/ai-models.ts` (Gemini model-path normalization, all branches)
- `server/utils/auth-assert.ts` (`assertAuthenticated` happy path + 401 path)
- `server/utils/cost-unit.ts` (type-only export pin)
- `server/utils/http-errors.ts` (`NotFoundError`, `ForeignKeyError`)
- `server/utils/logger.ts` (`loggerOptions` shape, `logger` smoke,
  `createChildLogger`, `serializeError` for Error / non-Error values)
- `server/utils/rate-limit.ts` (constant snapshots + invariants)
- `server/utils/ssl.ts` (existing-cert read path, generation+write path,
  partial-file regeneration, generator argument shape — uses `mock.module`
  to swap `fs` and `selfsigned`)
- `server/utils/unit-type.ts` (`normalizeUnitType` for all known + nullish +
  non-string inputs)

No production code was modified.

## Test plan

- [x] `bun run test` — full suite green (1167 backend + 302 frontend)
- [x] `cd server && bun test ./test --coverage` — target files at 100%
      line coverage (logger 96.61%)
- [x] `bun run lint` — Biome + tsc + i18n key check all pass

https://claude.ai/code/session_0111c2dFZ99BbKBQtghz8kGJ

---
_Generated by [Claude Code](https://claude.ai/code/session_0111c2dFZ99BbKBQtghz8kGJ)_