### PR TITLE
test(utils): add unit tests for 7 small frontend utilities

### DIFF
--- a/test/utils/clipboard.test.ts
+++ b/test/utils/clipboard.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { readTextFromClipboard, writeTextToClipboard } from '../../utils/clipboard';
+
+// Save the original `navigator.clipboard` so each test can restore it cleanly,
+// regardless of whether happy-dom provided a real one or it's undefined.
+const originalClipboardDescriptor = Object.getOwnPropertyDescriptor(
+  globalThis.navigator,
+  'clipboard',
+);
+
+const setClipboard = (clipboard: unknown) => {
+  Object.defineProperty(globalThis.navigator, 'clipboard', {
+    configurable: true,
+    writable: true,
+    value: clipboard,
+  });
+};
+
+const restoreClipboard = () => {
+  if (originalClipboardDescriptor) {
+    Object.defineProperty(globalThis.navigator, 'clipboard', originalClipboardDescriptor);
+  } else {
+    Object.defineProperty(globalThis.navigator, 'clipboard', {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    });
+  }
+};
+
+describe('writeTextToClipboard', () => {
+  afterEach(() => {
+    restoreClipboard();
+  });
+
+  test('uses navigator.clipboard.writeText when available and resolves to true', async () => {
+    const writeText = mock((_text: string) => Promise.resolve());
+    setClipboard({ writeText });
+
+    const ok = await writeTextToClipboard('hello');
+    expect(ok).toBe(true);
+    expect(writeText).toHaveBeenCalledWith('hello');
+  });
+
+  test('returns false when clipboard.writeText rejects', async () => {
+    const writeText = mock((_text: string) => Promise.reject(new Error('denied')));
+    setClipboard({ writeText });
+
+    const ok = await writeTextToClipboard('hello');
+    expect(ok).toBe(false);
+  });
+
+  test('falls back to document.execCommand when navigator.clipboard is unavailable', async () => {
+    setClipboard(undefined);
+    const execCommand = mock((_cmd: string) => true);
+    const original = document.execCommand;
+    document.execCommand = execCommand as unknown as typeof document.execCommand;
+
+    try {
+      const ok = await writeTextToClipboard('fallback-text');
+      expect(ok).toBe(true);
+      expect(execCommand).toHaveBeenCalledWith('copy');
+      // The temporary textarea should have been removed from the DOM.
+      const textareas = document.body.querySelectorAll('textarea');
+      expect(textareas.length).toBe(0);
+    } finally {
+      document.execCommand = original;
+    }
+  });
+
+  test('returns false when execCommand reports failure in the fallback path', async () => {
+    setClipboard(undefined);
+    const original = document.execCommand;
+    document.execCommand = (() => false) as unknown as typeof document.execCommand;
+
+    try {
+      const ok = await writeTextToClipboard('x');
+      expect(ok).toBe(false);
+    } finally {
+      document.execCommand = original;
+    }
+  });
+
+  test('falls back when navigator.clipboard exists but lacks writeText', async () => {
+    setClipboard({}); // present, but no writeText
+    const original = document.execCommand;
+    document.execCommand = (() => true) as unknown as typeof document.execCommand;
+
+    try {
+      const ok = await writeTextToClipboard('hi');
+      expect(ok).toBe(true);
+    } finally {
+      document.execCommand = original;
+    }
+  });
+});
+
+describe('readTextFromClipboard', () => {
+  afterEach(() => {
+    restoreClipboard();
+  });
+
+  test('returns { ok: true, text } on success', async () => {
+    setClipboard({ readText: () => Promise.resolve('clipboard contents') });
+    const result = await readTextFromClipboard();
+    expect(result).toEqual({ ok: true, text: 'clipboard contents' });
+  });
+
+  test('returns "unavailable" when navigator.clipboard is missing', async () => {
+    setClipboard(undefined);
+    const result = await readTextFromClipboard();
+    expect(result).toEqual({ ok: false, reason: 'unavailable' });
+  });
+
+  test('returns "unavailable" when navigator.clipboard exists but lacks readText', async () => {
+    setClipboard({});
+    const result = await readTextFromClipboard();
+    expect(result).toEqual({ ok: false, reason: 'unavailable' });
+  });
+
+  test('returns "denied" when readText rejects (permission error)', async () => {
+    setClipboard({ readText: () => Promise.reject(new Error('NotAllowedError')) });
+    const result = await readTextFromClipboard();
+    expect(result).toEqual({ ok: false, reason: 'denied' });
+  });
+});

--- a/test/utils/errors.test.ts
+++ b/test/utils/errors.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'bun:test';
+import { getErrorMessage } from '../../utils/errors';
+
+describe('getErrorMessage', () => {
+  test('returns Error.message when given an Error instance', () => {
+    expect(getErrorMessage(new Error('boom'))).toBe('boom');
+  });
+
+  test('returns "Unknown error" when given an Error with empty message', () => {
+    expect(getErrorMessage(new Error(''))).toBe('Unknown error');
+  });
+
+  test('returns "Unknown error" for non-Error values (string)', () => {
+    expect(getErrorMessage('something failed')).toBe('Unknown error');
+  });
+
+  test('returns "Unknown error" for non-Error values (object without message)', () => {
+    expect(getErrorMessage({ code: 500 })).toBe('Unknown error');
+  });
+
+  test('returns "Unknown error" for null', () => {
+    expect(getErrorMessage(null)).toBe('Unknown error');
+  });
+
+  test('returns "Unknown error" for undefined', () => {
+    expect(getErrorMessage(undefined)).toBe('Unknown error');
+  });
+
+  test('uses message from a subclass of Error', () => {
+    class CustomError extends Error {}
+    expect(getErrorMessage(new CustomError('custom'))).toBe('custom');
+  });
+});

--- a/test/utils/fieldStatus.test.ts
+++ b/test/utils/fieldStatus.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'bun:test';
+import { getLinkedFieldStatus } from '../../utils/fieldStatus';
+
+const baseOptions = {
+  isReadOnly: false,
+  isLinkedToSupplierQuote: false,
+  readOnlyReason: 'read-only',
+  supplierLockedReason: 'supplier-locked',
+  statusEditable: 'editable',
+};
+
+describe('getLinkedFieldStatus', () => {
+  test('returns the read-only reason when isReadOnly is true (highest priority)', () => {
+    expect(getLinkedFieldStatus({ ...baseOptions, isReadOnly: true })).toBe('read-only');
+  });
+
+  test('read-only takes precedence even when also linked to a supplier quote', () => {
+    expect(
+      getLinkedFieldStatus({
+        ...baseOptions,
+        isReadOnly: true,
+        isLinkedToSupplierQuote: true,
+      }),
+    ).toBe('read-only');
+  });
+
+  test('returns the supplier-locked reason when not read-only and linked to a supplier quote', () => {
+    expect(getLinkedFieldStatus({ ...baseOptions, isLinkedToSupplierQuote: true })).toBe(
+      'supplier-locked',
+    );
+  });
+
+  test('returns the editable status when neither flag is set', () => {
+    expect(getLinkedFieldStatus(baseOptions)).toBe('editable');
+  });
+});

--- a/test/utils/language.test.ts
+++ b/test/utils/language.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+// Mock the i18n module BEFORE importing the SUT, so the import binding picks up
+// our stub (mirrors the pattern in test/hooks/useAuth.test.ts).
+const i18nMock = {
+  changeLanguage: mock((_lang: string) => {}),
+};
+
+mock.module('../../i18n', () => ({
+  default: i18nMock,
+}));
+
+const { applyLanguagePreference } = await import('../../utils/language');
+
+const setNavigatorLanguage = (lang: string) => {
+  Object.defineProperty(globalThis.navigator, 'language', {
+    configurable: true,
+    value: lang,
+  });
+};
+
+describe('applyLanguagePreference', () => {
+  beforeEach(() => {
+    i18nMock.changeLanguage.mockReset();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  test('does nothing when given undefined', () => {
+    applyLanguagePreference(undefined);
+    expect(i18nMock.changeLanguage).not.toHaveBeenCalled();
+    expect(localStorage.getItem('i18nextLng')).toBeNull();
+  });
+
+  test('does nothing when given an empty string', () => {
+    applyLanguagePreference('');
+    expect(i18nMock.changeLanguage).not.toHaveBeenCalled();
+  });
+
+  test('persists explicit language choice and applies it via i18n', () => {
+    applyLanguagePreference('it');
+    expect(localStorage.getItem('i18nextLng')).toBe('it');
+    expect(i18nMock.changeLanguage).toHaveBeenCalledWith('it');
+  });
+
+  test('overwrites a previously stored preference', () => {
+    localStorage.setItem('i18nextLng', 'en');
+    applyLanguagePreference('it');
+    expect(localStorage.getItem('i18nextLng')).toBe('it');
+  });
+
+  test('"auto" clears storage and uses the supported browser language', () => {
+    localStorage.setItem('i18nextLng', 'it');
+    setNavigatorLanguage('it-IT');
+
+    applyLanguagePreference('auto');
+
+    expect(localStorage.getItem('i18nextLng')).toBeNull();
+    expect(i18nMock.changeLanguage).toHaveBeenCalledWith('it');
+  });
+
+  test('"auto" falls back to "en" when the browser language is unsupported', () => {
+    setNavigatorLanguage('fr-FR');
+    applyLanguagePreference('auto');
+    expect(i18nMock.changeLanguage).toHaveBeenCalledWith('en');
+  });
+
+  test('"auto" honors the bare language code without region', () => {
+    setNavigatorLanguage('en');
+    applyLanguagePreference('auto');
+    expect(i18nMock.changeLanguage).toHaveBeenCalledWith('en');
+  });
+
+  test('arbitrary explicit language strings are passed through without validation', () => {
+    // The SUT only validates browser-derived languages, not user-supplied ones.
+    applyLanguagePreference('zh');
+    expect(localStorage.getItem('i18nextLng')).toBe('zh');
+    expect(i18nMock.changeLanguage).toHaveBeenCalledWith('zh');
+  });
+});

--- a/test/utils/options.test.ts
+++ b/test/utils/options.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'bun:test';
+import { getPaymentTermsOptions } from '../../utils/options';
+
+describe('getPaymentTermsOptions', () => {
+  // Stub `t` function: simply echoes the key so we can assert ids/keys map up.
+  const t = (key: string) => key;
+
+  test('returns the canonical list of 11 payment-term options', () => {
+    const opts = getPaymentTermsOptions(t);
+    expect(opts).toHaveLength(11);
+  });
+
+  test('first option is "immediate" with the matching translation key', () => {
+    const opts = getPaymentTermsOptions(t);
+    expect(opts[0]).toEqual({ id: 'immediate', name: 'crm:paymentTerms.immediate' });
+  });
+
+  test('every option uses the crm:paymentTerms.<id> translation key naming convention', () => {
+    const opts = getPaymentTermsOptions(t);
+    for (const opt of opts) {
+      expect(opt.name).toBe(`crm:paymentTerms.${opt.id}`);
+    }
+  });
+
+  test('preserves the documented order (immediate, 15gg, 21gg, 30gg, ...)', () => {
+    const ids = getPaymentTermsOptions(t).map((o) => o.id);
+    expect(ids).toEqual([
+      'immediate',
+      '15gg',
+      '21gg',
+      '30gg',
+      '45gg',
+      '60gg',
+      '90gg',
+      '120gg',
+      '180gg',
+      '240gg',
+      '365gg',
+    ]);
+  });
+
+  test('passes the key through to the supplied translator (no fallback strings)', () => {
+    const calls: string[] = [];
+    const recorder = (key: string) => {
+      calls.push(key);
+      return `tr(${key})`;
+    };
+    const opts = getPaymentTermsOptions(recorder);
+    expect(calls).toHaveLength(11);
+    expect(opts[2]).toEqual({ id: '21gg', name: 'tr(crm:paymentTerms.21gg)' });
+  });
+});

--- a/test/utils/tempId.test.ts
+++ b/test/utils/tempId.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'bun:test';
+import { makeTempId } from '../../utils/tempId';
+
+describe('makeTempId', () => {
+  test('uses the default "tmp" prefix when none is provided', () => {
+    expect(makeTempId()).toMatch(/^tmp-[0-9a-z]+$/);
+  });
+
+  test('uses the supplied prefix', () => {
+    expect(makeTempId('row')).toMatch(/^row-[0-9a-z]+$/);
+  });
+
+  test('produces base36 random suffix with length up to 7 characters', () => {
+    const id = makeTempId('x');
+    const suffix = id.slice('x-'.length);
+    expect(suffix.length).toBeGreaterThan(0);
+    expect(suffix.length).toBeLessThanOrEqual(7);
+    expect(suffix).toMatch(/^[0-9a-z]+$/);
+  });
+
+  test('returns distinct ids on consecutive calls (random component)', () => {
+    const ids = new Set<string>();
+    for (let i = 0; i < 50; i++) ids.add(makeTempId());
+    // Allow up to one collision in 50 (extremely unlikely with 36^7 space).
+    expect(ids.size).toBeGreaterThanOrEqual(49);
+  });
+
+  test('accepts an empty prefix and still returns a hyphen-separated id', () => {
+    const id = makeTempId('');
+    expect(id.startsWith('-')).toBe(true);
+  });
+});

--- a/test/utils/theme.test.ts
+++ b/test/utils/theme.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { applyTheme, getTheme, THEMES, type Theme } from '../../utils/theme';
+
+const STORAGE_KEY = 'praetor_theme';
+
+describe('THEMES constant', () => {
+  test('exposes both "default" and "tempo" themes', () => {
+    expect(Object.keys(THEMES).sort()).toEqual(['default', 'tempo']);
+  });
+
+  test('every theme defines --color-primary and --color-primary-hover', () => {
+    for (const theme of Object.keys(THEMES) as Theme[]) {
+      expect(THEMES[theme]['--color-primary']).toBeDefined();
+      expect(THEMES[theme]['--color-primary-hover']).toBeDefined();
+    }
+  });
+});
+
+describe('getTheme', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('returns "default" when nothing is stored', () => {
+    expect(getTheme()).toBe('default');
+  });
+
+  test('returns "default" when stored value is unrecognized', () => {
+    localStorage.setItem(STORAGE_KEY, 'unknown-theme');
+    expect(getTheme()).toBe('default');
+  });
+
+  test('returns "tempo" when explicitly stored', () => {
+    localStorage.setItem(STORAGE_KEY, 'tempo');
+    expect(getTheme()).toBe('tempo');
+  });
+
+  test('returns "default" when explicitly stored', () => {
+    localStorage.setItem(STORAGE_KEY, 'default');
+    expect(getTheme()).toBe('default');
+  });
+
+  test('rejects empty-string storage value', () => {
+    localStorage.setItem(STORAGE_KEY, '');
+    expect(getTheme()).toBe('default');
+  });
+});
+
+describe('applyTheme', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    // Clear inline CSS variables that any prior test (or default styles) may have set.
+    const root = document.documentElement;
+    root.style.removeProperty('--color-primary');
+    root.style.removeProperty('--color-primary-hover');
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    const root = document.documentElement;
+    root.style.removeProperty('--color-primary');
+    root.style.removeProperty('--color-primary-hover');
+  });
+
+  test('writes the chosen theme name to localStorage', () => {
+    applyTheme('tempo');
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('tempo');
+  });
+
+  test('writes "default" theme name to localStorage', () => {
+    applyTheme('default');
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('default');
+  });
+
+  test('sets the documented CSS custom properties for the "default" theme', () => {
+    applyTheme('default');
+    const root = document.documentElement;
+    expect(root.style.getPropertyValue('--color-primary')).toBe(THEMES.default['--color-primary']);
+    expect(root.style.getPropertyValue('--color-primary-hover')).toBe(
+      THEMES.default['--color-primary-hover'],
+    );
+  });
+
+  test('sets the documented CSS custom properties for the "tempo" theme', () => {
+    applyTheme('tempo');
+    const root = document.documentElement;
+    expect(root.style.getPropertyValue('--color-primary')).toBe(THEMES.tempo['--color-primary']);
+    expect(root.style.getPropertyValue('--color-primary-hover')).toBe(
+      THEMES.tempo['--color-primary-hover'],
+    );
+  });
+
+  test('switching themes overwrites the previously applied custom properties', () => {
+    applyTheme('default');
+    applyTheme('tempo');
+    const root = document.documentElement;
+    expect(root.style.getPropertyValue('--color-primary')).toBe(THEMES.tempo['--color-primary']);
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('tempo');
+  });
+
+  test('round-trips with getTheme', () => {
+    applyTheme('tempo');
+    expect(getTheme()).toBe('tempo');
+    applyTheme('default');
+    expect(getTheme()).toBe('default');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds dedicated `test/utils/*.test.ts` files for `clipboard`, `errors`, `fieldStatus`, `language`, `options`, `tempId`, and `theme` — all previously at 0% coverage, now at 100% line + function coverage.
- `clipboard.test.ts` swaps `navigator.clipboard` and stubs `document.execCommand` to exercise both the modern API path and the legacy textarea fallback (success + failure).
- `language.test.ts` mocks the `../../i18n` module before importing the SUT (mirrors the pattern in `test/hooks/useAuth.test.ts`) and overrides `navigator.language` to cover the `auto` browser-detection branches.
- `theme.test.ts` exercises both themes against `localStorage` and the documented CSS custom properties on `document.documentElement` (happy-dom env preloaded by `bunfig.toml`).
- No production code was modified.

## Test plan
- [x] `bun test ./test/utils/` — 202 pass, 0 fail
- [x] `bun run test` — server 1098 pass, frontend 353 pass, 0 fail
- [x] `bun run lint` — exits 0 (no new warnings)
- [x] `bun test ./test --coverage` confirms each of the 7 target utils at 100% line + function coverage

https://claude.ai/code/session_0111c2dFZ99BbKBQtghz8kGJ

---
_Generated by [Claude Code](https://claude.ai/code/session_0111c2dFZ99BbKBQtghz8kGJ)_