### PR TITLE
test(shared): add unit tests for Checkbox, Toggle, Modal, ValidatedNumberInput, Tooltip

### DIFF
--- a/test/components/Checkbox.test.tsx
+++ b/test/components/Checkbox.test.tsx
@@ -1,0 +1,77 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { fireEvent, render } from '@testing-library/react';
+
+const Checkbox = (await import('../../components/shared/Checkbox')).default;
+
+const getInput = (container: HTMLElement) =>
+  container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+
+const getBox = (container: HTMLElement) =>
+  container.querySelector('input[type="checkbox"] + div') as HTMLDivElement;
+
+describe('<Checkbox />', () => {
+  test('renders an unchecked checkbox by default', () => {
+    const { container } = render(<Checkbox checked={false} onChange={() => {}} />);
+    const input = getInput(container);
+    expect(input).toBeInTheDocument();
+    expect(input.checked).toBe(false);
+    expect(input.disabled).toBe(false);
+  });
+
+  test('renders a checked checkbox when checked is true', () => {
+    const { container } = render(<Checkbox checked={true} onChange={() => {}} />);
+    const input = getInput(container);
+    expect(input.checked).toBe(true);
+    // Check the SVG checkmark is visible (scale-100 class)
+    const svg = container.querySelector('svg');
+    expect(svg?.className).toContain('scale-100');
+  });
+
+  test('calls onChange when clicked', () => {
+    const onChange = mock((_e: React.ChangeEvent<HTMLInputElement>) => {});
+    const { container } = render(<Checkbox checked={false} onChange={onChange} />);
+    const input = getInput(container);
+    fireEvent.click(input);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  test('disabled prop renders disabled input and not-allowed cursor', () => {
+    const { container } = render(<Checkbox checked={false} onChange={() => {}} disabled />);
+    const input = getInput(container);
+    expect(input.disabled).toBe(true);
+    const label = container.querySelector('label');
+    expect(label?.className).toContain('cursor-not-allowed');
+    expect(label?.className).toContain('opacity-50');
+  });
+
+  test('indeterminate state renders the dash indicator (not checked)', () => {
+    const { container } = render(<Checkbox checked={false} onChange={() => {}} indeterminate />);
+    // No SVG checkmark when indeterminate and not checked
+    expect(container.querySelector('svg')).toBeNull();
+    // The indicator span is rendered inside the box
+    const box = getBox(container);
+    expect(box.querySelector('span')).not.toBeNull();
+    // The box gets praetor styling
+    expect(box.className).toContain('bg-praetor');
+  });
+
+  test('checked state takes precedence over indeterminate', () => {
+    const { container } = render(<Checkbox checked={true} onChange={() => {}} indeterminate />);
+    // SVG is rendered when checked, even with indeterminate true
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+
+  test('size sm uses smaller dimension classes', () => {
+    const { container } = render(<Checkbox checked={false} onChange={() => {}} size="sm" />);
+    const box = getBox(container);
+    expect(box.className).toContain('w-3.5');
+    expect(box.className).toContain('h-3.5');
+  });
+
+  test('size md (default) uses regular dimension classes', () => {
+    const { container } = render(<Checkbox checked={false} onChange={() => {}} />);
+    const box = getBox(container);
+    expect(box.className).toContain('w-5');
+    expect(box.className).toContain('h-5');
+  });
+});

--- a/test/components/Modal.test.tsx
+++ b/test/components/Modal.test.tsx
@@ -1,0 +1,125 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+const Modal = (await import('../../components/shared/Modal')).default;
+
+describe('<Modal />', () => {
+  test('renders nothing when isOpen is false', () => {
+    render(
+      <Modal isOpen={false} onClose={() => {}}>
+        <div data-testid="modal-content">Hi</div>
+      </Modal>,
+    );
+    expect(screen.queryByTestId('modal-content')).toBeNull();
+  });
+
+  test('renders children inside a portal when isOpen is true', () => {
+    render(
+      <Modal isOpen={true} onClose={() => {}}>
+        <div data-testid="modal-content">Hi</div>
+      </Modal>,
+    );
+    expect(screen.getByTestId('modal-content')).toBeInTheDocument();
+    expect(document.body.style.overflow).toBe('hidden');
+  });
+
+  test('clicking the backdrop calls onClose', () => {
+    const onClose = mock(() => {});
+    render(
+      <Modal isOpen={true} onClose={onClose}>
+        <div data-testid="modal-content">Hi</div>
+      </Modal>,
+    );
+    const backdrop = screen.getByTestId('modal-content').parentElement as HTMLElement;
+    fireEvent.click(backdrop);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('clicking inside the modal content does not call onClose', () => {
+    const onClose = mock(() => {});
+    render(
+      <Modal isOpen={true} onClose={onClose}>
+        <div data-testid="modal-content">Hi</div>
+      </Modal>,
+    );
+    fireEvent.click(screen.getByTestId('modal-content'));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  test('closeOnBackdrop=false prevents backdrop close', () => {
+    const onClose = mock(() => {});
+    render(
+      <Modal isOpen={true} onClose={onClose} closeOnBackdrop={false}>
+        <div data-testid="modal-content">Hi</div>
+      </Modal>,
+    );
+    const backdrop = screen.getByTestId('modal-content').parentElement as HTMLElement;
+    fireEvent.click(backdrop);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  test('Escape key calls onClose by default', () => {
+    const onClose = mock(() => {});
+    render(
+      <Modal isOpen={true} onClose={onClose}>
+        <div data-testid="modal-content">Hi</div>
+      </Modal>,
+    );
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('non-Escape keys do not call onClose', () => {
+    const onClose = mock(() => {});
+    render(
+      <Modal isOpen={true} onClose={onClose}>
+        <div data-testid="modal-content">Hi</div>
+      </Modal>,
+    );
+    fireEvent.keyDown(document, { key: 'Enter' });
+    fireEvent.keyDown(document, { key: 'a' });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  test('closeOnEsc=false ignores Escape key', () => {
+    const onClose = mock(() => {});
+    render(
+      <Modal isOpen={true} onClose={onClose} closeOnEsc={false}>
+        <div data-testid="modal-content">Hi</div>
+      </Modal>,
+    );
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  test('custom zIndex is applied to backdrop style', () => {
+    render(
+      <Modal isOpen={true} onClose={() => {}} zIndex={999}>
+        <div data-testid="modal-content">Hi</div>
+      </Modal>,
+    );
+    const backdrop = screen.getByTestId('modal-content').parentElement as HTMLElement;
+    expect(backdrop.style.zIndex).toBe('999');
+  });
+
+  test('custom backdropClass is applied', () => {
+    render(
+      <Modal isOpen={true} onClose={() => {}} backdropClass="custom-backdrop">
+        <div data-testid="modal-content">Hi</div>
+      </Modal>,
+    );
+    const backdrop = screen.getByTestId('modal-content').parentElement as HTMLElement;
+    expect(backdrop.className).toContain('custom-backdrop');
+  });
+
+  test('unmounting restores body overflow', () => {
+    const { unmount } = render(
+      <Modal isOpen={true} onClose={() => {}}>
+        <div data-testid="modal-content">Hi</div>
+      </Modal>,
+    );
+    expect(document.body.style.overflow).toBe('hidden');
+    unmount();
+    expect(document.body.style.overflow).toBe('');
+  });
+});

--- a/test/components/SupplierQuotesView.test.tsx
+++ b/test/components/SupplierQuotesView.test.tsx
@@ -6,12 +6,16 @@ import { installI18nMock } from '../helpers/i18n';
 
 installI18nMock();
 
-// Modal renders into a portal via createPortal, which doesn't reliably surface in
-// screen queries with happy-dom + React 19. Replace it with a passthrough that
-// renders children inline when isOpen.
-mock.module('../../components/shared/Modal', () => ({
-  default: ({ isOpen, children }: { isOpen: boolean; children: ReactNode }) =>
-    isOpen ? <div data-testid="modal">{children}</div> : null,
+// Modal renders via createPortal, which doesn't reliably surface in screen
+// queries with happy-dom + React 19. Replace createPortal with a passthrough
+// so the real Modal source still runs but its children render inline. This
+// also avoids globally mocking '../../components/shared/Modal', which would
+// leak across test files in the same Bun process.
+const reactDom = await import('react-dom');
+mock.module('react-dom', () => ({
+  ...reactDom,
+  default: reactDom.default,
+  createPortal: (children: ReactNode) => <div data-testid="modal">{children}</div>,
 }));
 
 const SupplierQuotesView = (await import('../../components/sales/SupplierQuotesView')).default;

--- a/test/components/Toggle.test.tsx
+++ b/test/components/Toggle.test.tsx
@@ -1,0 +1,68 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+const Toggle = (await import('../../components/shared/Toggle')).default;
+
+describe('<Toggle />', () => {
+  test('renders a button', () => {
+    render(<Toggle checked={false} onChange={() => {}} />);
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  test('clicking the toggle calls onChange with the inverted value (off -> on)', () => {
+    const onChange = mock((_v: boolean) => {});
+    render(<Toggle checked={false} onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  test('clicking the toggle when checked sends false (on -> off)', () => {
+    const onChange = mock((_v: boolean) => {});
+    render(<Toggle checked={true} onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(onChange).toHaveBeenCalledWith(false);
+  });
+
+  test('disabled prop disables the button and adds disabled styles', () => {
+    render(<Toggle checked={false} onChange={() => {}} disabled />);
+    const btn = screen.getByRole('button') as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+    expect(btn.className).toContain('cursor-not-allowed');
+    expect(btn.className).toContain('opacity-50');
+  });
+
+  test('checked state uses praetor background by default', () => {
+    render(<Toggle checked={true} onChange={() => {}} />);
+    const btn = screen.getByRole('button');
+    expect(btn.className).toContain('bg-praetor');
+  });
+
+  test('checked + color="red" uses red background', () => {
+    render(<Toggle checked={true} onChange={() => {}} color="red" />);
+    const btn = screen.getByRole('button');
+    expect(btn.className).toContain('bg-red-500');
+  });
+
+  test('unchecked uses slate background', () => {
+    render(<Toggle checked={false} onChange={() => {}} />);
+    const btn = screen.getByRole('button');
+    expect(btn.className).toContain('bg-slate-200');
+  });
+
+  test('partial state renders intermediate background and the partial dash indicator', () => {
+    const { container } = render(<Toggle checked={false} onChange={() => {}} partial />);
+    const btn = screen.getByRole('button');
+    expect(btn.className).toContain('bg-praetor/40');
+    const dash = container.querySelector('span > span');
+    expect(dash).not.toBeNull();
+    const knob = container.querySelector('span');
+    expect(knob?.className).toContain('translate-x-5');
+  });
+
+  test('disabled toggle does not fire onChange on click', () => {
+    const onChange = mock((_v: boolean) => {});
+    render(<Toggle checked={false} onChange={onChange} disabled />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/test/components/Tooltip.test.tsx
+++ b/test/components/Tooltip.test.tsx
@@ -1,0 +1,142 @@
+import { describe, expect, test } from 'bun:test';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+const Tooltip = (await import('../../components/shared/Tooltip')).default;
+
+describe('<Tooltip />', () => {
+  test('renders children only when not hovered', () => {
+    render(<Tooltip label="Tip text">{() => <button type="button">trigger</button>}</Tooltip>);
+    expect(screen.getByRole('button', { name: 'trigger' })).toBeInTheDocument();
+    expect(screen.queryByText('Tip text')).toBeNull();
+  });
+
+  test('shows tooltip label on mouse enter and hides on mouse leave', () => {
+    const { container } = render(
+      <Tooltip label="Tip text">{() => <button type="button">trigger</button>}</Tooltip>,
+    );
+    const wrapper = container.querySelector('span') as HTMLElement;
+    fireEvent.mouseEnter(wrapper);
+    expect(screen.getByText('Tip text')).toBeInTheDocument();
+    fireEvent.mouseLeave(wrapper);
+    expect(screen.queryByText('Tip text')).toBeNull();
+  });
+
+  test('shows tooltip on focus and hides on blur', () => {
+    const { container } = render(
+      <Tooltip label="Focus tip">{() => <button type="button">trigger</button>}</Tooltip>,
+    );
+    const wrapper = container.querySelector('span') as HTMLElement;
+    fireEvent.focus(wrapper);
+    expect(screen.getByText('Focus tip')).toBeInTheDocument();
+    fireEvent.blur(wrapper);
+    expect(screen.queryByText('Focus tip')).toBeNull();
+  });
+
+  test('does not render tooltip when disabled (children returned directly)', () => {
+    const { container } = render(
+      <Tooltip label="Tip text" disabled>
+        {() => <button type="button">trigger</button>}
+      </Tooltip>,
+    );
+    fireEvent.mouseEnter(screen.getByRole('button', { name: 'trigger' }));
+    expect(screen.queryByText('Tip text')).toBeNull();
+    expect(container.querySelector('span')).toBeNull();
+  });
+
+  test('does not render tooltip when label is empty string', () => {
+    render(<Tooltip label="">{() => <button type="button">trigger</button>}</Tooltip>);
+    fireEvent.mouseEnter(screen.getByRole('button', { name: 'trigger' }));
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  test('does not render tooltip when label is null (children returned directly)', () => {
+    render(<Tooltip label={null}>{() => <button type="button">trigger</button>}</Tooltip>);
+    fireEvent.mouseEnter(screen.getByRole('button', { name: 'trigger' }));
+    expect(screen.getByRole('button', { name: 'trigger' })).toBeInTheDocument();
+  });
+
+  test('renders ReactNode label content', () => {
+    const { container } = render(
+      <Tooltip label={<span data-testid="custom-label">Rich</span>}>
+        {() => <button type="button">trigger</button>}
+      </Tooltip>,
+    );
+    const wrapper = container.querySelector('span') as HTMLElement;
+    fireEvent.mouseEnter(wrapper);
+    expect(screen.getByTestId('custom-label')).toBeInTheDocument();
+  });
+
+  test('applies wrapperClassName to the wrapper span', () => {
+    const { container } = render(
+      <Tooltip label="Tip" wrapperClassName="my-wrapper">
+        {() => <button type="button">trigger</button>}
+      </Tooltip>,
+    );
+    const wrapper = container.querySelector('span') as HTMLElement;
+    expect(wrapper.className).toContain('my-wrapper');
+  });
+
+  test('applies tooltipClassName when shown', () => {
+    const { container } = render(
+      <Tooltip label="Tip" tooltipClassName="my-tooltip">
+        {() => <button type="button">trigger</button>}
+      </Tooltip>,
+    );
+    const wrapper = container.querySelector('span') as HTMLElement;
+    fireEvent.mouseEnter(wrapper);
+    const tip = screen.getByText('Tip');
+    expect(tip.className).toContain('my-tooltip');
+  });
+
+  test('applies position-specific classes for "bottom"', () => {
+    const { container } = render(
+      <Tooltip label="Tip" position="bottom">
+        {() => <button type="button">trigger</button>}
+      </Tooltip>,
+    );
+    const wrapper = container.querySelector('span') as HTMLElement;
+    fireEvent.mouseEnter(wrapper);
+    const tip = screen.getByText('Tip');
+    expect(tip.className).toContain('-translate-x-1/2');
+  });
+
+  test('applies position-specific classes for "right"', () => {
+    const { container } = render(
+      <Tooltip label="Tip" position="right">
+        {() => <button type="button">trigger</button>}
+      </Tooltip>,
+    );
+    const wrapper = container.querySelector('span') as HTMLElement;
+    fireEvent.mouseEnter(wrapper);
+    const tip = screen.getByText('Tip');
+    expect(tip.className).toContain('-translate-y-1/2');
+  });
+
+  test('auto-flips "left" to "right" when the wrapper is at the viewport edge', () => {
+    // happy-dom places the wrapper at x=0, which would push the tooltip off
+    // screen on the left, so the component flips to "right".
+    const { container } = render(
+      <Tooltip label="Tip" position="left">
+        {() => <button type="button">trigger</button>}
+      </Tooltip>,
+    );
+    const wrapper = container.querySelector('span') as HTMLElement;
+    fireEvent.mouseEnter(wrapper);
+    const tip = screen.getByText('Tip');
+    expect(tip.className).toContain('-translate-y-1/2');
+  });
+
+  test('clicking outside hides the tooltip', () => {
+    const { container } = render(
+      <div>
+        <div data-testid="outside">outside</div>
+        <Tooltip label="Tip text">{() => <button type="button">trigger</button>}</Tooltip>
+      </div>,
+    );
+    const wrapper = container.querySelector('span') as HTMLElement;
+    fireEvent.mouseEnter(wrapper);
+    expect(screen.getByText('Tip text')).toBeInTheDocument();
+    fireEvent.mouseDown(screen.getByTestId('outside'));
+    expect(screen.queryByText('Tip text')).toBeNull();
+  });
+});

--- a/test/components/ValidatedNumberInput.test.tsx
+++ b/test/components/ValidatedNumberInput.test.tsx
@@ -1,0 +1,178 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { fireEvent, render } from '@testing-library/react';
+import { useState } from 'react';
+
+const ValidatedNumberInput = (await import('../../components/shared/ValidatedNumberInput')).default;
+
+const getInput = (container: HTMLElement) => container.querySelector('input') as HTMLInputElement;
+
+describe('<ValidatedNumberInput />', () => {
+  test('renders an input with type="text", inputMode="decimal" and pattern', () => {
+    const { container } = render(<ValidatedNumberInput value="" onValueChange={() => {}} />);
+    const input = getInput(container);
+    expect(input.type).toBe('text');
+    expect(input.inputMode).toBe('decimal');
+    expect(input.getAttribute('pattern')).toBe('^[0-9]*([.,][0-9]*)?$');
+  });
+
+  test('displays a numeric value when not focused', () => {
+    const { container } = render(<ValidatedNumberInput value="42" onValueChange={() => {}} />);
+    const input = getInput(container);
+    expect(input.value).toBe('42');
+  });
+
+  test('formats display value with formatDecimals when not focused', () => {
+    const { container } = render(
+      <ValidatedNumberInput value={3.5} onValueChange={() => {}} formatDecimals={2} />,
+    );
+    const input = getInput(container);
+    expect(input.value).toBe('3.50');
+  });
+
+  test('formatDecimals: empty string yields empty display', () => {
+    const { container } = render(
+      <ValidatedNumberInput value="" onValueChange={() => {}} formatDecimals={2} />,
+    );
+    expect(getInput(container).value).toBe('');
+  });
+
+  test('formatDecimals: invalid value yields empty display', () => {
+    const { container } = render(
+      <ValidatedNumberInput value="abc" onValueChange={() => {}} formatDecimals={2} />,
+    );
+    expect(getInput(container).value).toBe('');
+  });
+
+  test('typing valid digits triggers onValueChange with normalized value', () => {
+    const onValueChange = mock((_v: string) => {});
+    const Wrapper = () => {
+      const [v, setV] = useState('');
+      return (
+        <ValidatedNumberInput
+          value={v}
+          onValueChange={(val) => {
+            setV(val);
+            onValueChange(val);
+          }}
+        />
+      );
+    };
+    const { container } = render(<Wrapper />);
+    const input = getInput(container);
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: '12' } });
+    expect(onValueChange).toHaveBeenLastCalledWith('12');
+  });
+
+  test('comma is normalized to dot in onValueChange', () => {
+    const onValueChange = mock((_v: string) => {});
+    const { container } = render(<ValidatedNumberInput value="" onValueChange={onValueChange} />);
+    const input = getInput(container);
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: '1,5' } });
+    expect(onValueChange).toHaveBeenCalledWith('1.5');
+  });
+
+  test('invalid characters in input are rejected (no onValueChange)', () => {
+    const onValueChange = mock((_v: string) => {});
+    const { container } = render(<ValidatedNumberInput value="" onValueChange={onValueChange} />);
+    const input = getInput(container);
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: 'abc' } });
+    expect(onValueChange).not.toHaveBeenCalled();
+  });
+
+  test('keyDown: numeric keys are allowed and call onKeyDown', () => {
+    const onKeyDown = mock((_e: React.KeyboardEvent<HTMLInputElement>) => {});
+    const { container } = render(
+      <ValidatedNumberInput value="" onValueChange={() => {}} onKeyDown={onKeyDown} />,
+    );
+    const input = getInput(container);
+    const evt = fireEvent.keyDown(input, { key: '5' });
+    expect(evt).toBe(true); // not prevented
+    expect(onKeyDown).toHaveBeenCalled();
+  });
+
+  test('keyDown: non-numeric/non-allowed key is prevented', () => {
+    const onKeyDown = mock((_e: React.KeyboardEvent<HTMLInputElement>) => {});
+    const { container } = render(
+      <ValidatedNumberInput value="" onValueChange={() => {}} onKeyDown={onKeyDown} />,
+    );
+    const input = getInput(container);
+    const evt = fireEvent.keyDown(input, { key: 'a' });
+    expect(evt).toBe(false); // prevented
+    expect(onKeyDown).toHaveBeenCalled();
+  });
+
+  test('keyDown: Backspace is allowed', () => {
+    const { container } = render(<ValidatedNumberInput value="" onValueChange={() => {}} />);
+    const input = getInput(container);
+    const evt = fireEvent.keyDown(input, { key: 'Backspace' });
+    expect(evt).toBe(true);
+  });
+
+  test('keyDown: ctrl/meta combinations are passed through', () => {
+    const onKeyDown = mock((_e: React.KeyboardEvent<HTMLInputElement>) => {});
+    const { container } = render(
+      <ValidatedNumberInput value="" onValueChange={() => {}} onKeyDown={onKeyDown} />,
+    );
+    const input = getInput(container);
+    const evt = fireEvent.keyDown(input, { key: 'a', ctrlKey: true });
+    expect(evt).toBe(true);
+    expect(onKeyDown).toHaveBeenCalled();
+  });
+
+  test('keyDown: second decimal separator is prevented', () => {
+    const { container } = render(<ValidatedNumberInput value="" onValueChange={() => {}} />);
+    const input = getInput(container);
+    // Set value first to ensure currentTarget.value already has a decimal
+    input.value = '1.5';
+    const evt = fireEvent.keyDown(input, { key: '.' });
+    expect(evt).toBe(false); // prevented
+  });
+
+  test('keyDown: first decimal separator is allowed', () => {
+    const { container } = render(<ValidatedNumberInput value="" onValueChange={() => {}} />);
+    const input = getInput(container);
+    input.value = '1';
+    const evt = fireEvent.keyDown(input, { key: '.' });
+    expect(evt).toBe(true);
+  });
+
+  test('focus initializes internal value from current value and calls onFocus', () => {
+    const onFocus = mock((_e: React.FocusEvent<HTMLInputElement>) => {});
+    const { container } = render(
+      <ValidatedNumberInput value="9" onValueChange={() => {}} onFocus={onFocus} />,
+    );
+    const input = getInput(container);
+    fireEvent.focus(input);
+    expect(onFocus).toHaveBeenCalledTimes(1);
+    expect(input.value).toBe('9');
+  });
+
+  test('blur calls onBlur and reverts to displayed value', () => {
+    const onBlur = mock((_e: React.FocusEvent<HTMLInputElement>) => {});
+    const { container } = render(
+      <ValidatedNumberInput
+        value="9"
+        onValueChange={() => {}}
+        onBlur={onBlur}
+        formatDecimals={1}
+      />,
+    );
+    const input = getInput(container);
+    fireEvent.focus(input);
+    fireEvent.blur(input);
+    expect(onBlur).toHaveBeenCalledTimes(1);
+    expect(input.value).toBe('9.0');
+  });
+
+  test('forwards extra props to the underlying input (placeholder, name)', () => {
+    const { container } = render(
+      <ValidatedNumberInput value="" onValueChange={() => {}} placeholder="0.00" name="amount" />,
+    );
+    const input = getInput(container);
+    expect(input.placeholder).toBe('0.00');
+    expect(input.name).toBe('amount');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds new unit tests for previously low/zero-coverage shared React components: Checkbox, Toggle, Modal, ValidatedNumberInput, and Tooltip.
- Switches `SupplierQuotesView.test.tsx` from globally mocking the Modal module to mocking `react-dom`'s `createPortal`. The previous mock leaked across test files in the same Bun process and prevented the real Modal source from being exercised by the new `Modal.test.tsx`. The new approach keeps the real Modal implementation in play while still rendering portal children inline for assertions.

## Coverage after
- `components/shared/Checkbox.tsx`: 100% (was 4%)
- `components/shared/Modal.tsx`: 100%
- `components/shared/Toggle.tsx`: 100%
- `components/shared/ValidatedNumberInput.tsx`: 100% (was 41%)
- `components/shared/Tooltip.tsx`: 84.62% (was 41%)

All exceed the 80% target.

## Test plan
- [x] `bun run test` passes (1098 server + 360 frontend)
- [x] `bun test ./test --coverage` confirms each target file is at >=80% line coverage
- [x] `bun run lint` passes (i18n + tsc + biome)
- [x] No production code modified — tests only

https://claude.ai/code/session_0111c2dFZ99BbKBQtghz8kGJ

---
_Generated by [Claude Code](https://claude.ai/code/session_0111c2dFZ99BbKBQtghz8kGJ)_