### PR TITLE
test(handlers): cover the seven untested frontend handler factories

### DIFF
--- a/test/handlers/entryHandlers.test.ts
+++ b/test/handlers/entryHandlers.test.ts
@@ -1,0 +1,261 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const apiMocks = {
+  entriesCreate: mock(
+    (data: unknown): Promise<unknown> =>
+      Promise.resolve({ id: 'e-new', createdAt: 1000, ...(data as object) }),
+  ),
+  entriesUpdate: mock(
+    (id: string, updates: unknown): Promise<unknown> =>
+      Promise.resolve({ id, ...(updates as object) }),
+  ),
+  entriesDelete: mock((_id: string): Promise<void> => Promise.resolve()),
+};
+
+mock.module('../../services/api', () => ({
+  default: {
+    entries: {
+      create: (data: unknown) => apiMocks.entriesCreate(data),
+      update: (id: string, updates: unknown) => apiMocks.entriesUpdate(id, updates),
+      delete: (id: string) => apiMocks.entriesDelete(id),
+    },
+  },
+  getAuthToken: () => null,
+  setAuthToken: () => {},
+}));
+
+const { makeEntryHandlers } = await import('../../hooks/handlers/entryHandlers');
+
+type EntryLike = {
+  id: string;
+  createdAt: number;
+  userId?: string;
+  hourlyCost?: number;
+  task?: string;
+};
+
+const makeStubSetter = <T>(initial: T[]) => {
+  let value = initial;
+  const setter = (updater: T[] | ((prev: T[]) => T[])) => {
+    value = typeof updater === 'function' ? (updater as (prev: T[]) => T[])(value) : updater;
+  };
+  return {
+    setter: setter as never,
+    get: () => value,
+  };
+};
+
+const silenceConsole = () => {
+  const originalError = console.error;
+  const originalAlert = globalThis.alert;
+  console.error = mock(() => {}) as unknown as typeof console.error;
+  globalThis.alert = mock(() => {}) as unknown as typeof globalThis.alert;
+  return () => {
+    console.error = originalError;
+    globalThis.alert = originalAlert;
+  };
+};
+
+describe('makeEntryHandlers', () => {
+  beforeEach(() => {
+    for (const m of Object.values(apiMocks)) m.mockClear();
+  });
+
+  afterEach(() => {
+    for (const m of Object.values(apiMocks)) m.mockReset();
+  });
+
+  test('add returns early when no current user', async () => {
+    const entries = makeStubSetter<EntryLike>([]);
+    const handlers = makeEntryHandlers({
+      currentUser: null,
+      viewingUserId: '',
+      setEntries: entries.setter,
+    });
+
+    await handlers.add({ task: 'no-op' } as never);
+    expect(apiMocks.entriesCreate).not.toHaveBeenCalled();
+    expect(entries.get()).toEqual([]);
+  });
+
+  test('add prepends created entry using viewingUserId override', async () => {
+    apiMocks.entriesCreate.mockImplementation((data: unknown) =>
+      Promise.resolve({ id: 'e-new', createdAt: 1000, ...(data as object) }),
+    );
+    const entries = makeStubSetter<EntryLike>([{ id: 'e1', createdAt: 500 }]);
+    const handlers = makeEntryHandlers({
+      currentUser: { id: 'u-current', costPerHour: 50 } as never,
+      viewingUserId: 'u-viewing',
+      setEntries: entries.setter,
+    });
+
+    await handlers.add({ task: 'work' } as never);
+
+    const callArg = apiMocks.entriesCreate.mock.calls[0][0] as Record<string, unknown>;
+    expect(callArg.userId).toBe('u-viewing');
+    expect(callArg.hourlyCost).toBe(50);
+    expect(callArg.task).toBe('work');
+    expect(entries.get()).toHaveLength(2);
+    expect(entries.get()[0].id).toBe('e-new');
+  });
+
+  test('add falls back to currentUser id when viewingUserId is empty', async () => {
+    apiMocks.entriesCreate.mockImplementation((data: unknown) =>
+      Promise.resolve({ id: 'e-new', createdAt: 1, ...(data as object) }),
+    );
+    const handlers = makeEntryHandlers({
+      currentUser: { id: 'u-current', costPerHour: 0 } as never,
+      viewingUserId: '',
+      setEntries: makeStubSetter<EntryLike>([]).setter,
+    });
+
+    await handlers.add({ task: 'work' } as never);
+    const callArg = apiMocks.entriesCreate.mock.calls[0][0] as Record<string, unknown>;
+    expect(callArg.userId).toBe('u-current');
+    expect(callArg.hourlyCost).toBe(0);
+  });
+
+  test('add swallows errors and alerts user', async () => {
+    apiMocks.entriesCreate.mockImplementation(() => Promise.reject(new Error('boom')));
+    const entries = makeStubSetter<EntryLike>([{ id: 'e1', createdAt: 1 }]);
+    const handlers = makeEntryHandlers({
+      currentUser: { id: 'u', costPerHour: 10 } as never,
+      viewingUserId: '',
+      setEntries: entries.setter,
+    });
+
+    const restore = silenceConsole();
+    try {
+      await handlers.add({ task: 'fail' } as never);
+      expect(entries.get()).toEqual([{ id: 'e1', createdAt: 1 }]);
+    } finally {
+      restore();
+    }
+  });
+
+  test('addBulk returns early when no current user', async () => {
+    const entries = makeStubSetter<EntryLike>([]);
+    const handlers = makeEntryHandlers({
+      currentUser: null,
+      viewingUserId: '',
+      setEntries: entries.setter,
+    });
+
+    await handlers.addBulk([{ task: 'a' } as never]);
+    expect(apiMocks.entriesCreate).not.toHaveBeenCalled();
+  });
+
+  test('addBulk creates and prepends sorted by createdAt desc', async () => {
+    let counter = 0;
+    apiMocks.entriesCreate.mockImplementation((data: unknown) => {
+      counter += 1;
+      return Promise.resolve({
+        id: `e-new-${counter}`,
+        createdAt: counter * 100,
+        ...(data as object),
+      });
+    });
+    const entries = makeStubSetter<EntryLike>([{ id: 'e0', createdAt: 50 }]);
+    const handlers = makeEntryHandlers({
+      currentUser: { id: 'u1', costPerHour: 25 } as never,
+      viewingUserId: 'u2',
+      setEntries: entries.setter,
+    });
+
+    await handlers.addBulk([{ task: 'a' } as never, { task: 'b' } as never]);
+
+    expect(apiMocks.entriesCreate).toHaveBeenCalledTimes(2);
+    const result = entries.get();
+    expect(result.map((e) => e.createdAt)).toEqual([200, 100, 50]);
+  });
+
+  test('addBulk swallows errors', async () => {
+    apiMocks.entriesCreate.mockImplementation(() => Promise.reject(new Error('boom')));
+    const entries = makeStubSetter<EntryLike>([]);
+    const handlers = makeEntryHandlers({
+      currentUser: { id: 'u', costPerHour: 0 } as never,
+      viewingUserId: '',
+      setEntries: entries.setter,
+    });
+
+    const restore = silenceConsole();
+    try {
+      await handlers.addBulk([{ task: 'a' } as never]);
+      expect(entries.get()).toEqual([]);
+    } finally {
+      restore();
+    }
+  });
+
+  test('delete removes matching entry', async () => {
+    apiMocks.entriesDelete.mockImplementation(() => Promise.resolve());
+    const entries = makeStubSetter<EntryLike>([
+      { id: 'e1', createdAt: 1 },
+      { id: 'e2', createdAt: 2 },
+    ]);
+    const handlers = makeEntryHandlers({
+      currentUser: { id: 'u' } as never,
+      viewingUserId: '',
+      setEntries: entries.setter,
+    });
+
+    await handlers.delete('e1');
+    expect(apiMocks.entriesDelete).toHaveBeenCalledWith('e1');
+    expect(entries.get()).toEqual([{ id: 'e2', createdAt: 2 }]);
+  });
+
+  test('delete swallows errors', async () => {
+    apiMocks.entriesDelete.mockImplementation(() => Promise.reject(new Error('nope')));
+    const entries = makeStubSetter<EntryLike>([{ id: 'e1', createdAt: 1 }]);
+    const handlers = makeEntryHandlers({
+      currentUser: { id: 'u' } as never,
+      viewingUserId: '',
+      setEntries: entries.setter,
+    });
+
+    const restore = silenceConsole();
+    try {
+      await handlers.delete('e1');
+      expect(entries.get()).toEqual([{ id: 'e1', createdAt: 1 }]);
+    } finally {
+      restore();
+    }
+  });
+
+  test('update replaces matching entry', async () => {
+    apiMocks.entriesUpdate.mockImplementation((id: string, updates: unknown) =>
+      Promise.resolve({ id, createdAt: 5, ...(updates as object) }),
+    );
+    const entries = makeStubSetter<EntryLike>([
+      { id: 'e1', createdAt: 1, task: 'A' },
+      { id: 'e2', createdAt: 2, task: 'B' },
+    ]);
+    const handlers = makeEntryHandlers({
+      currentUser: { id: 'u' } as never,
+      viewingUserId: '',
+      setEntries: entries.setter,
+    });
+
+    await handlers.update('e1', { task: 'A2' } as never);
+    expect(entries.get()[0]).toEqual({ id: 'e1', createdAt: 5, task: 'A2' });
+    expect(entries.get()[1]).toEqual({ id: 'e2', createdAt: 2, task: 'B' });
+  });
+
+  test('update swallows errors', async () => {
+    apiMocks.entriesUpdate.mockImplementation(() => Promise.reject(new Error('boom')));
+    const entries = makeStubSetter<EntryLike>([{ id: 'e1', createdAt: 1, task: 'A' }]);
+    const handlers = makeEntryHandlers({
+      currentUser: { id: 'u' } as never,
+      viewingUserId: '',
+      setEntries: entries.setter,
+    });
+
+    const restore = silenceConsole();
+    try {
+      await handlers.update('e1', { task: 'A2' } as never);
+      expect(entries.get()).toEqual([{ id: 'e1', createdAt: 1, task: 'A' }]);
+    } finally {
+      restore();
+    }
+  });
+});

--- a/test/handlers/invoiceHandlers.test.ts
+++ b/test/handlers/invoiceHandlers.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const apiMocks = {
+  invoicesCreate: mock(
+    (data: unknown): Promise<unknown> => Promise.resolve({ id: 'inv-new', ...(data as object) }),
+  ),
+  invoicesUpdate: mock(
+    (id: string, updates: unknown): Promise<unknown> =>
+      Promise.resolve({ id, ...(updates as object) }),
+  ),
+  invoicesDelete: mock((_id: string): Promise<void> => Promise.resolve()),
+};
+
+mock.module('../../services/api', () => ({
+  default: {
+    invoices: {
+      create: (data: unknown) => apiMocks.invoicesCreate(data),
+      update: (id: string, updates: unknown) => apiMocks.invoicesUpdate(id, updates),
+      delete: (id: string) => apiMocks.invoicesDelete(id),
+    },
+  },
+  getAuthToken: () => null,
+  setAuthToken: () => {},
+}));
+
+const { makeInvoiceHandlers } = await import('../../hooks/handlers/invoiceHandlers');
+
+type InvoiceLike = { id: string; status?: string; total?: number };
+
+const makeStubSetter = <T>(initial: T[]) => {
+  let value = initial;
+  const setter = (updater: T[] | ((prev: T[]) => T[])) => {
+    value = typeof updater === 'function' ? (updater as (prev: T[]) => T[])(value) : updater;
+  };
+  return {
+    setter: setter as never,
+    get: () => value,
+  };
+};
+
+const silenceConsole = () => {
+  const original = console.error;
+  console.error = mock(() => {}) as unknown as typeof console.error;
+  return () => {
+    console.error = original;
+  };
+};
+
+describe('makeInvoiceHandlers', () => {
+  beforeEach(() => {
+    for (const m of Object.values(apiMocks)) m.mockClear();
+  });
+
+  afterEach(() => {
+    for (const m of Object.values(apiMocks)) m.mockReset();
+  });
+
+  test('add appends invoice to list', async () => {
+    apiMocks.invoicesCreate.mockImplementation((data: unknown) =>
+      Promise.resolve({ id: 'inv-new', ...(data as object) }),
+    );
+    const invoices = makeStubSetter<InvoiceLike>([{ id: 'inv-1' }]);
+    const handlers = makeInvoiceHandlers({ setInvoices: invoices.setter });
+
+    await handlers.add({ status: 'draft' } as never);
+    expect(apiMocks.invoicesCreate).toHaveBeenCalledWith({ status: 'draft' });
+    expect(invoices.get()).toEqual([{ id: 'inv-1' }, { id: 'inv-new', status: 'draft' }]);
+  });
+
+  test('add swallows errors', async () => {
+    apiMocks.invoicesCreate.mockImplementation(() => Promise.reject(new Error('boom')));
+    const invoices = makeStubSetter<InvoiceLike>([]);
+    const handlers = makeInvoiceHandlers({ setInvoices: invoices.setter });
+
+    const restore = silenceConsole();
+    try {
+      await handlers.add({ status: 'draft' } as never);
+      expect(invoices.get()).toEqual([]);
+    } finally {
+      restore();
+    }
+  });
+
+  test('update replaces matching invoice', async () => {
+    apiMocks.invoicesUpdate.mockImplementation((id: string, updates: unknown) =>
+      Promise.resolve({ id, ...(updates as object) }),
+    );
+    const invoices = makeStubSetter<InvoiceLike>([
+      { id: 'inv-1', status: 'draft' },
+      { id: 'inv-2', status: 'sent' },
+    ]);
+    const handlers = makeInvoiceHandlers({ setInvoices: invoices.setter });
+
+    await handlers.update('inv-1', { status: 'paid' } as never);
+    expect(invoices.get()[0]).toEqual({ id: 'inv-1', status: 'paid' });
+    expect(invoices.get()[1]).toEqual({ id: 'inv-2', status: 'sent' });
+  });
+
+  test('update swallows errors', async () => {
+    apiMocks.invoicesUpdate.mockImplementation(() => Promise.reject(new Error('nope')));
+    const invoices = makeStubSetter<InvoiceLike>([{ id: 'inv-1', status: 'draft' }]);
+    const handlers = makeInvoiceHandlers({ setInvoices: invoices.setter });
+
+    const restore = silenceConsole();
+    try {
+      await handlers.update('inv-1', { status: 'paid' } as never);
+      expect(invoices.get()).toEqual([{ id: 'inv-1', status: 'draft' }]);
+    } finally {
+      restore();
+    }
+  });
+
+  test('delete removes matching invoice', async () => {
+    apiMocks.invoicesDelete.mockImplementation(() => Promise.resolve());
+    const invoices = makeStubSetter<InvoiceLike>([{ id: 'inv-1' }, { id: 'inv-2' }]);
+    const handlers = makeInvoiceHandlers({ setInvoices: invoices.setter });
+
+    await handlers.delete('inv-1');
+    expect(apiMocks.invoicesDelete).toHaveBeenCalledWith('inv-1');
+    expect(invoices.get()).toEqual([{ id: 'inv-2' }]);
+  });
+
+  test('delete swallows errors', async () => {
+    apiMocks.invoicesDelete.mockImplementation(() => Promise.reject(new Error('fail')));
+    const invoices = makeStubSetter<InvoiceLike>([{ id: 'inv-1' }]);
+    const handlers = makeInvoiceHandlers({ setInvoices: invoices.setter });
+
+    const restore = silenceConsole();
+    try {
+      await handlers.delete('inv-1');
+      expect(invoices.get()).toEqual([{ id: 'inv-1' }]);
+    } finally {
+      restore();
+    }
+  });
+});

--- a/test/handlers/quoteHandlers.test.ts
+++ b/test/handlers/quoteHandlers.test.ts
@@ -1,0 +1,508 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const apiMocks = {
+  quotesList: mock((): Promise<unknown[]> => Promise.resolve([])),
+  quotesCreate: mock(
+    (data: unknown): Promise<unknown> => Promise.resolve({ id: 'q-new', ...(data as object) }),
+  ),
+  quotesUpdate: mock(
+    (id: string, updates: unknown): Promise<unknown> =>
+      Promise.resolve({ id, ...(updates as object) }),
+  ),
+  quotesDelete: mock((_id: string): Promise<void> => Promise.resolve()),
+  clientOffersList: mock((): Promise<unknown[]> => Promise.resolve([])),
+  clientOffersCreate: mock(
+    (data: unknown): Promise<unknown> => Promise.resolve({ id: 'of-new', ...(data as object) }),
+  ),
+  clientOffersUpdate: mock(
+    (id: string, updates: unknown): Promise<unknown> =>
+      Promise.resolve({ id, ...(updates as object) }),
+  ),
+  clientOffersDelete: mock((_id: string): Promise<void> => Promise.resolve()),
+  clientsOrdersList: mock((): Promise<unknown[]> => Promise.resolve([])),
+  clientsOrdersCreate: mock(
+    (data: unknown): Promise<unknown> => Promise.resolve({ id: 'order-new', ...(data as object) }),
+  ),
+  clientsOrdersUpdate: mock(
+    (id: string, updates: unknown): Promise<unknown> =>
+      Promise.resolve({ id, ...(updates as object) }),
+  ),
+  clientsOrdersDelete: mock((_id: string): Promise<void> => Promise.resolve()),
+  invoicesList: mock((): Promise<unknown[]> => Promise.resolve([])),
+};
+
+mock.module('../../services/api', () => ({
+  default: {
+    quotes: {
+      list: () => apiMocks.quotesList(),
+      create: (data: unknown) => apiMocks.quotesCreate(data),
+      update: (id: string, updates: unknown) => apiMocks.quotesUpdate(id, updates),
+      delete: (id: string) => apiMocks.quotesDelete(id),
+    },
+    clientOffers: {
+      list: () => apiMocks.clientOffersList(),
+      create: (data: unknown) => apiMocks.clientOffersCreate(data),
+      update: (id: string, updates: unknown) => apiMocks.clientOffersUpdate(id, updates),
+      delete: (id: string) => apiMocks.clientOffersDelete(id),
+    },
+    clientsOrders: {
+      list: () => apiMocks.clientsOrdersList(),
+      create: (data: unknown) => apiMocks.clientsOrdersCreate(data),
+      update: (id: string, updates: unknown) => apiMocks.clientsOrdersUpdate(id, updates),
+      delete: (id: string) => apiMocks.clientsOrdersDelete(id),
+    },
+    invoices: {
+      list: () => apiMocks.invoicesList(),
+    },
+  },
+  getAuthToken: () => null,
+  setAuthToken: () => {},
+}));
+
+const { makeQuoteHandlers } = await import('../../hooks/handlers/quoteHandlers');
+
+type QuoteLike = {
+  id: string;
+  status?: string;
+  isExpired?: boolean;
+  expirationDate?: string;
+  linkedOfferId?: string;
+  clientId?: string;
+};
+type ClientOfferLike = { id: string; clientId?: string; linkedQuoteId?: string };
+type ClientsOrderLike = { id: string; clientId?: string };
+type InvoiceLike = { id: string };
+
+type AnyFn = (...args: unknown[]) => void;
+const makeStubSetter = <T>(initial: T[]) => {
+  let value = initial;
+  const setter = ((updater: T[] | ((prev: T[]) => T[])) => {
+    value = typeof updater === 'function' ? (updater as (prev: T[]) => T[])(value) : updater;
+  }) as AnyFn;
+  return { setter, get: () => value };
+};
+
+const makeStubScalar = <T>(initial: T) => {
+  let value = initial;
+  const setter = ((updater: T | ((prev: T) => T)) => {
+    value = typeof updater === 'function' ? (updater as (prev: T) => T)(value) : updater;
+  }) as AnyFn;
+  return { setter, get: () => value };
+};
+
+const buildHandlers = (overrides: Record<string, unknown> = {}) => {
+  const quotes = makeStubSetter<QuoteLike>((overrides.quotes as QuoteLike[] | undefined) ?? []);
+  const clientOffers = makeStubSetter<ClientOfferLike>([]);
+  const clientsOrders = makeStubSetter<ClientsOrderLike>([]);
+  const invoices = makeStubSetter<InvoiceLike>([]);
+  const clientQuoteFilterId = makeStubScalar<string | null>(
+    (overrides.clientQuoteFilterId as string | null | undefined) ?? null,
+  );
+  const clientOfferFilterId = makeStubScalar<string | null>(
+    (overrides.clientOfferFilterId as string | null | undefined) ?? null,
+  );
+  const setActiveView = mock(() => {});
+  const refreshSupplierQuoteFlow = mock(() => Promise.resolve()) as unknown as () => Promise<void>;
+
+  const handlers = makeQuoteHandlers({
+    quotes: quotes.get() as never,
+    clientQuoteFilterId: clientQuoteFilterId.get(),
+    clientOfferFilterId: clientOfferFilterId.get(),
+    setQuotes: quotes.setter as never,
+    setClientOffers: clientOffers.setter as never,
+    setClientsOrders: clientsOrders.setter as never,
+    setInvoices: invoices.setter as never,
+    setClientQuoteFilterId: clientQuoteFilterId.setter as never,
+    setClientOfferFilterId: clientOfferFilterId.setter as never,
+    setActiveView: setActiveView as never,
+    refreshSupplierQuoteFlow:
+      (overrides.refreshSupplierQuoteFlow as (() => Promise<void>) | undefined) ??
+      refreshSupplierQuoteFlow,
+  });
+
+  return {
+    handlers,
+    quotes,
+    clientOffers,
+    clientsOrders,
+    invoices,
+    clientQuoteFilterId,
+    clientOfferFilterId,
+    setActiveView,
+    refreshSupplierQuoteFlow,
+  };
+};
+
+const silenceConsole = () => {
+  const originalError = console.error;
+  const originalAlert = globalThis.alert;
+  console.error = mock(() => {}) as unknown as typeof console.error;
+  globalThis.alert = mock(() => {}) as unknown as typeof globalThis.alert;
+  return () => {
+    console.error = originalError;
+    globalThis.alert = originalAlert;
+  };
+};
+
+describe('makeQuoteHandlers', () => {
+  beforeEach(() => {
+    for (const m of Object.values(apiMocks)) m.mockClear();
+  });
+
+  afterEach(() => {
+    for (const m of Object.values(apiMocks)) m.mockReset();
+  });
+
+  test('refreshClientQuoteFlow loads quotes/offers/orders', async () => {
+    apiMocks.quotesList.mockImplementation(() => Promise.resolve([{ id: 'q-fresh' }]));
+    apiMocks.clientOffersList.mockImplementation(() => Promise.resolve([{ id: 'of-fresh' }]));
+    apiMocks.clientsOrdersList.mockImplementation(() => Promise.resolve([{ id: 'or-fresh' }]));
+
+    const ctx = buildHandlers();
+    await ctx.handlers.refreshClientQuoteFlow();
+
+    expect(ctx.quotes.get()).toEqual([{ id: 'q-fresh' }]);
+    expect(ctx.clientOffers.get()).toEqual([{ id: 'of-fresh' }]);
+    expect(ctx.clientsOrders.get()).toEqual([{ id: 'or-fresh' }]);
+  });
+
+  test('refreshClientOrderFlow loads orders and invoices', async () => {
+    apiMocks.clientsOrdersList.mockImplementation(() => Promise.resolve([{ id: 'or-fresh' }]));
+    apiMocks.invoicesList.mockImplementation(() => Promise.resolve([{ id: 'inv-fresh' }]));
+
+    const ctx = buildHandlers();
+    await ctx.handlers.refreshClientOrderFlow();
+    expect(ctx.clientsOrders.get()).toEqual([{ id: 'or-fresh' }]);
+    expect(ctx.invoices.get()).toEqual([{ id: 'inv-fresh' }]);
+  });
+
+  test('addQuote prepends created quote', async () => {
+    apiMocks.quotesCreate.mockImplementation((data: unknown) =>
+      Promise.resolve({ id: 'q-new', ...(data as object) }),
+    );
+    const ctx = buildHandlers();
+    ctx.quotes.setter([{ id: 'q1' }] as never);
+
+    await ctx.handlers.addQuote({ status: 'draft' } as never);
+    expect(ctx.quotes.get()[0].id).toBe('q-new');
+  });
+
+  test('addQuote swallows errors', async () => {
+    apiMocks.quotesCreate.mockImplementation(() => Promise.reject(new Error('boom')));
+    const ctx = buildHandlers();
+    const restore = silenceConsole();
+    try {
+      await ctx.handlers.addQuote({} as never);
+    } finally {
+      restore();
+    }
+  });
+
+  test('updateQuote restores expirationDate when status flips back to draft', async () => {
+    apiMocks.quotesUpdate.mockImplementation((id: string, updates: unknown) =>
+      Promise.resolve({ id, ...(updates as object) }),
+    );
+    apiMocks.quotesList.mockImplementation(() => Promise.resolve([]));
+    apiMocks.clientOffersList.mockImplementation(() => Promise.resolve([]));
+    apiMocks.clientsOrdersList.mockImplementation(() => Promise.resolve([]));
+    const ctx = buildHandlers({
+      quotes: [{ id: 'q1', status: 'rejected', isExpired: true, expirationDate: '2020-01-01' }],
+    });
+
+    await ctx.handlers.updateQuote('q1', { status: 'draft', isExpired: false } as never);
+
+    const callArgs = apiMocks.quotesUpdate.mock.calls[0] as [string, Record<string, unknown>];
+    expect(callArgs[0]).toBe('q1');
+    expect(callArgs[1].status).toBe('draft');
+    expect(callArgs[1].isExpired).toBe(false);
+    expect(callArgs[1].expirationDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  test('updateQuote does not inject expirationDate when not a restore', async () => {
+    apiMocks.quotesUpdate.mockImplementation((id: string, updates: unknown) =>
+      Promise.resolve({ id, ...(updates as object) }),
+    );
+    apiMocks.quotesList.mockImplementation(() => Promise.resolve([]));
+    apiMocks.clientOffersList.mockImplementation(() => Promise.resolve([]));
+    apiMocks.clientsOrdersList.mockImplementation(() => Promise.resolve([]));
+    const ctx = buildHandlers({
+      quotes: [{ id: 'q1', status: 'draft', isExpired: false }],
+    });
+
+    await ctx.handlers.updateQuote('q1', { status: 'sent' } as never);
+    const callArgs = apiMocks.quotesUpdate.mock.calls[0] as [string, Record<string, unknown>];
+    expect(callArgs[1].expirationDate).toBeUndefined();
+  });
+
+  test('updateQuote updates client filter when ids match', async () => {
+    apiMocks.quotesUpdate.mockImplementation((id: string, updates: unknown) =>
+      Promise.resolve({ id, ...(updates as object) }),
+    );
+    apiMocks.quotesList.mockImplementation(() => Promise.resolve([]));
+    apiMocks.clientOffersList.mockImplementation(() => Promise.resolve([]));
+    apiMocks.clientsOrdersList.mockImplementation(() => Promise.resolve([]));
+    const ctx = buildHandlers({
+      quotes: [{ id: 'q1', status: 'draft' }],
+      clientQuoteFilterId: 'q1',
+    });
+
+    await ctx.handlers.updateQuote('q1', { status: 'sent' } as never);
+    expect(ctx.clientQuoteFilterId.get()).toBe('q1');
+  });
+
+  test('updateQuote swallows errors', async () => {
+    apiMocks.quotesUpdate.mockImplementation(() => Promise.reject(new Error('boom')));
+    const ctx = buildHandlers({ quotes: [{ id: 'q1' }] });
+    const restore = silenceConsole();
+    try {
+      await ctx.handlers.updateQuote('q1', {} as never);
+    } finally {
+      restore();
+    }
+  });
+
+  test('deleteQuote removes from list', async () => {
+    apiMocks.quotesDelete.mockImplementation(() => Promise.resolve());
+    const ctx = buildHandlers();
+    ctx.quotes.setter([{ id: 'q1' }, { id: 'q2' }] as never);
+
+    await ctx.handlers.deleteQuote('q1');
+    expect(ctx.quotes.get()).toEqual([{ id: 'q2' }]);
+  });
+
+  test('deleteQuote swallows errors', async () => {
+    apiMocks.quotesDelete.mockImplementation(() => Promise.reject(new Error('boom')));
+    const ctx = buildHandlers();
+    const restore = silenceConsole();
+    try {
+      await ctx.handlers.deleteQuote('q1');
+    } finally {
+      restore();
+    }
+  });
+
+  test('updateClientOffer refreshes flow and updates filter when matched', async () => {
+    apiMocks.clientOffersUpdate.mockImplementation((id: string, updates: unknown) =>
+      Promise.resolve({ id, ...(updates as object) }),
+    );
+    apiMocks.quotesList.mockImplementation(() => Promise.resolve([]));
+    apiMocks.clientOffersList.mockImplementation(() => Promise.resolve([]));
+    apiMocks.clientsOrdersList.mockImplementation(() => Promise.resolve([]));
+    const ctx = buildHandlers({ clientOfferFilterId: 'of-1' });
+
+    await ctx.handlers.updateClientOffer('of-1', { status: 'sent' } as never);
+    expect(ctx.clientOfferFilterId.get()).toBe('of-1');
+  });
+
+  test('updateClientOffer rethrows api error', async () => {
+    apiMocks.clientOffersUpdate.mockImplementation(() => Promise.reject(new Error('boom')));
+    const ctx = buildHandlers();
+    const restore = silenceConsole();
+    try {
+      await expect(ctx.handlers.updateClientOffer('of-1', {} as never)).rejects.toThrow('boom');
+    } finally {
+      restore();
+    }
+  });
+
+  test('deleteClientOffer removes offer and unlinks affected quotes', async () => {
+    apiMocks.clientOffersDelete.mockImplementation(() => Promise.resolve());
+    const ctx = buildHandlers();
+    ctx.clientOffers.setter([{ id: 'of-1' }, { id: 'of-2' }] as never);
+    ctx.quotes.setter([
+      { id: 'q1', linkedOfferId: 'of-1' },
+      { id: 'q2', linkedOfferId: 'of-2' },
+    ] as never);
+
+    await ctx.handlers.deleteClientOffer('of-1');
+    expect(ctx.clientOffers.get()).toEqual([{ id: 'of-2' }]);
+    expect(ctx.quotes.get()[0].linkedOfferId).toBeUndefined();
+    expect(ctx.quotes.get()[1].linkedOfferId).toBe('of-2');
+  });
+
+  test('deleteClientOffer rethrows api error', async () => {
+    apiMocks.clientOffersDelete.mockImplementation(() => Promise.reject(new Error('boom')));
+    const ctx = buildHandlers();
+    const restore = silenceConsole();
+    try {
+      await expect(ctx.handlers.deleteClientOffer('of-1')).rejects.toThrow('boom');
+    } finally {
+      restore();
+    }
+  });
+
+  test('createClientOfferFromQuote creates offer, links quote, switches view', async () => {
+    apiMocks.clientOffersCreate.mockImplementation((data: unknown) =>
+      Promise.resolve({ ...(data as object), id: 'of-new' }),
+    );
+    const ctx = buildHandlers();
+    ctx.quotes.setter([{ id: 'q1', clientId: 'c1' }] as never);
+
+    const quote = {
+      id: 'q1',
+      clientId: 'c1',
+      clientName: 'Acme',
+      paymentTerms: '30',
+      discount: 5,
+      expirationDate: '2026-12-31',
+      notes: 'note',
+      items: [{ id: 'orig-1', productId: 'p1', quantity: 1, unitPrice: 10 }],
+    };
+
+    await ctx.handlers.createClientOfferFromQuote(quote as never);
+
+    expect(apiMocks.clientOffersCreate).toHaveBeenCalled();
+    const callArg = apiMocks.clientOffersCreate.mock.calls[0][0] as Record<string, unknown>;
+    expect(callArg.id).toBe('q1-OF');
+    expect(callArg.linkedQuoteId).toBe('q1');
+    expect(callArg.status).toBe('draft');
+    const items = callArg.items as Array<Record<string, unknown>>;
+    expect(items[0].offerId).toBe('');
+    // ID is replaced with a temp id, not the original.
+    expect(items[0].id).not.toBe('orig-1');
+
+    expect(ctx.clientOffers.get()[0].id).toBe('of-new');
+    expect(ctx.quotes.get()[0].linkedOfferId).toBe('of-new');
+    expect(ctx.setActiveView).toHaveBeenCalledWith('sales/client-offers');
+  });
+
+  test('createClientOfferFromQuote alerts on api error', async () => {
+    apiMocks.clientOffersCreate.mockImplementation(() => Promise.reject(new Error('boom')));
+    const ctx = buildHandlers();
+    const restore = silenceConsole();
+    try {
+      await ctx.handlers.createClientOfferFromQuote({
+        id: 'q1',
+        clientId: 'c1',
+        clientName: 'Acme',
+        paymentTerms: '30',
+        discount: 0,
+        expirationDate: '2026-12-31',
+        notes: '',
+        items: [],
+      } as never);
+      expect(ctx.setActiveView).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+
+  test('updateClientsOrder refreshes order flow', async () => {
+    apiMocks.clientsOrdersUpdate.mockImplementation(() => Promise.resolve({}));
+    apiMocks.clientsOrdersList.mockImplementation(() => Promise.resolve([{ id: 'or-fresh' }]));
+    apiMocks.invoicesList.mockImplementation(() => Promise.resolve([]));
+    const ctx = buildHandlers();
+
+    await ctx.handlers.updateClientsOrder('or-1', { status: 'confirmed' } as never);
+    expect(ctx.clientsOrders.get()).toEqual([{ id: 'or-fresh' }]);
+  });
+
+  test('updateClientsOrder swallows errors', async () => {
+    apiMocks.clientsOrdersUpdate.mockImplementation(() => Promise.reject(new Error('boom')));
+    const ctx = buildHandlers();
+    const restore = silenceConsole();
+    try {
+      await ctx.handlers.updateClientsOrder('or-1', {} as never);
+    } finally {
+      restore();
+    }
+  });
+
+  test('deleteClientsOrder removes from list', async () => {
+    apiMocks.clientsOrdersDelete.mockImplementation(() => Promise.resolve());
+    const ctx = buildHandlers();
+    ctx.clientsOrders.setter([{ id: 'or-1' }, { id: 'or-2' }] as never);
+
+    await ctx.handlers.deleteClientsOrder('or-1');
+    expect(ctx.clientsOrders.get()).toEqual([{ id: 'or-2' }]);
+  });
+
+  test('deleteClientsOrder swallows errors', async () => {
+    apiMocks.clientsOrdersDelete.mockImplementation(() => Promise.reject(new Error('nope')));
+    const ctx = buildHandlers();
+    const restore = silenceConsole();
+    try {
+      await ctx.handlers.deleteClientsOrder('or-1');
+    } finally {
+      restore();
+    }
+  });
+
+  test('createClientsOrderFromOffer creates order, switches view, refreshes supplier flow', async () => {
+    apiMocks.clientsOrdersCreate.mockImplementation((data: unknown) =>
+      Promise.resolve({ id: 'or-new', ...(data as object) }),
+    );
+    const refreshSupplierQuoteFlow = mock(() =>
+      Promise.resolve(),
+    ) as unknown as () => Promise<void>;
+    const ctx = buildHandlers({ refreshSupplierQuoteFlow });
+
+    const offer = {
+      id: 'of-1',
+      clientId: 'c1',
+      clientName: 'Acme',
+      paymentTerms: '30',
+      discount: 0,
+      linkedQuoteId: 'q1',
+      notes: 'note',
+      items: [{ id: 'orig', productId: 'p1', quantity: 1, unitPrice: 10 }],
+    };
+
+    await ctx.handlers.createClientsOrderFromOffer(offer as never);
+    expect(apiMocks.clientsOrdersCreate).toHaveBeenCalled();
+    const callArg = apiMocks.clientsOrdersCreate.mock.calls[0][0] as Record<string, unknown>;
+    expect(callArg.linkedOfferId).toBe('of-1');
+    expect(callArg.status).toBe('draft');
+    const items = callArg.items as Array<Record<string, unknown>>;
+    expect(items[0].orderId).toBe('');
+
+    expect(ctx.clientsOrders.get()[0].id).toBe('or-new');
+    expect(ctx.setActiveView).toHaveBeenCalledWith('accounting/clients-orders');
+    expect(refreshSupplierQuoteFlow).toHaveBeenCalled();
+  });
+
+  test('createClientsOrderFromOffer alerts on api error', async () => {
+    apiMocks.clientsOrdersCreate.mockImplementation(() => Promise.reject(new Error('boom')));
+    const ctx = buildHandlers();
+    const restore = silenceConsole();
+    try {
+      await ctx.handlers.createClientsOrderFromOffer({
+        id: 'of-1',
+        clientId: 'c1',
+        clientName: 'Acme',
+        paymentTerms: '30',
+        discount: 0,
+        linkedQuoteId: 'q1',
+        notes: '',
+        items: [],
+      } as never);
+      expect(ctx.setActiveView).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+
+  test('createClientsOrderFromOffer swallows refresh errors after success', async () => {
+    apiMocks.clientsOrdersCreate.mockImplementation(() => Promise.resolve({ id: 'or-new' }));
+    const refreshSupplierQuoteFlow = mock(() =>
+      Promise.reject(new Error('refresh-fail')),
+    ) as unknown as () => Promise<void>;
+    const ctx = buildHandlers({ refreshSupplierQuoteFlow });
+    const restore = silenceConsole();
+    try {
+      await ctx.handlers.createClientsOrderFromOffer({
+        id: 'of-1',
+        clientId: 'c1',
+        clientName: 'Acme',
+        paymentTerms: '30',
+        discount: 0,
+        linkedQuoteId: 'q1',
+        notes: '',
+        items: [],
+      } as never);
+      expect(ctx.setActiveView).toHaveBeenCalledWith('accounting/clients-orders');
+    } finally {
+      restore();
+    }
+  });
+});

--- a/test/handlers/supplierHandlers.test.ts
+++ b/test/handlers/supplierHandlers.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const apiMocks = {
+  suppliersCreate: mock(
+    (data: unknown): Promise<unknown> => Promise.resolve({ id: 's-new', ...(data as object) }),
+  ),
+  suppliersUpdate: mock(
+    (id: string, updates: unknown): Promise<unknown> =>
+      Promise.resolve({ id, ...(updates as object) }),
+  ),
+  suppliersDelete: mock((_id: string): Promise<void> => Promise.resolve()),
+};
+
+mock.module('../../services/api', () => ({
+  default: {
+    suppliers: {
+      create: (data: unknown) => apiMocks.suppliersCreate(data),
+      update: (id: string, updates: unknown) => apiMocks.suppliersUpdate(id, updates),
+      delete: (id: string) => apiMocks.suppliersDelete(id),
+    },
+  },
+  getAuthToken: () => null,
+  setAuthToken: () => {},
+}));
+
+const { makeSupplierHandlers } = await import('../../hooks/handlers/supplierHandlers');
+
+type SupplierLike = { id: string; name?: string };
+
+const makeStubSetter = <T>(initial: T[]) => {
+  let value = initial;
+  const setter = (updater: T[] | ((prev: T[]) => T[])) => {
+    value = typeof updater === 'function' ? (updater as (prev: T[]) => T[])(value) : updater;
+  };
+  return {
+    setter: setter as never,
+    get: () => value,
+  };
+};
+
+const silenceConsole = () => {
+  const original = console.error;
+  console.error = mock(() => {}) as unknown as typeof console.error;
+  return () => {
+    console.error = original;
+  };
+};
+
+describe('makeSupplierHandlers', () => {
+  beforeEach(() => {
+    for (const m of Object.values(apiMocks)) m.mockClear();
+  });
+
+  afterEach(() => {
+    for (const m of Object.values(apiMocks)) m.mockReset();
+  });
+
+  test('add appends supplier to list', async () => {
+    apiMocks.suppliersCreate.mockImplementation((data: unknown) =>
+      Promise.resolve({ id: 's-new', ...(data as object) }),
+    );
+    const suppliers = makeStubSetter<SupplierLike>([{ id: 's1' }]);
+    const handlers = makeSupplierHandlers({ setSuppliers: suppliers.setter });
+
+    await handlers.add({ name: 'Acme' } as never);
+    expect(apiMocks.suppliersCreate).toHaveBeenCalledWith({ name: 'Acme' });
+    expect(suppliers.get()).toEqual([{ id: 's1' }, { id: 's-new', name: 'Acme' }]);
+  });
+
+  test('add swallows errors', async () => {
+    apiMocks.suppliersCreate.mockImplementation(() => Promise.reject(new Error('boom')));
+    const suppliers = makeStubSetter<SupplierLike>([]);
+    const handlers = makeSupplierHandlers({ setSuppliers: suppliers.setter });
+
+    const restore = silenceConsole();
+    try {
+      await handlers.add({ name: 'Acme' } as never);
+      expect(suppliers.get()).toEqual([]);
+    } finally {
+      restore();
+    }
+  });
+
+  test('update replaces matching supplier', async () => {
+    apiMocks.suppliersUpdate.mockImplementation((id: string, updates: unknown) =>
+      Promise.resolve({ id, ...(updates as object) }),
+    );
+    const suppliers = makeStubSetter<SupplierLike>([
+      { id: 's1', name: 'Old' },
+      { id: 's2', name: 'B' },
+    ]);
+    const handlers = makeSupplierHandlers({ setSuppliers: suppliers.setter });
+
+    await handlers.update('s1', { name: 'New' } as never);
+    expect(suppliers.get()[0]).toEqual({ id: 's1', name: 'New' });
+    expect(suppliers.get()[1]).toEqual({ id: 's2', name: 'B' });
+  });
+
+  test('update swallows errors', async () => {
+    apiMocks.suppliersUpdate.mockImplementation(() => Promise.reject(new Error('nope')));
+    const suppliers = makeStubSetter<SupplierLike>([{ id: 's1', name: 'Old' }]);
+    const handlers = makeSupplierHandlers({ setSuppliers: suppliers.setter });
+
+    const restore = silenceConsole();
+    try {
+      await handlers.update('s1', { name: 'X' } as never);
+      expect(suppliers.get()).toEqual([{ id: 's1', name: 'Old' }]);
+    } finally {
+      restore();
+    }
+  });
+
+  test('delete removes matching supplier', async () => {
+    apiMocks.suppliersDelete.mockImplementation(() => Promise.resolve());
+    const suppliers = makeStubSetter<SupplierLike>([{ id: 's1' }, { id: 's2' }]);
+    const handlers = makeSupplierHandlers({ setSuppliers: suppliers.setter });
+
+    await handlers.delete('s1');
+    expect(apiMocks.suppliersDelete).toHaveBeenCalledWith('s1');
+    expect(suppliers.get()).toEqual([{ id: 's2' }]);
+  });
+
+  test('delete swallows errors', async () => {
+    apiMocks.suppliersDelete.mockImplementation(() => Promise.reject(new Error('fail')));
+    const suppliers = makeStubSetter<SupplierLike>([{ id: 's1' }]);
+    const handlers = makeSupplierHandlers({ setSuppliers: suppliers.setter });
+
+    const restore = silenceConsole();
+    try {
+      await handlers.delete('s1');
+      expect(suppliers.get()).toEqual([{ id: 's1' }]);
+    } finally {
+      restore();
+    }
+  });
+});

--- a/test/handlers/supplierInvoiceHandlers.test.ts
+++ b/test/handlers/supplierInvoiceHandlers.test.ts
@@ -1,0 +1,238 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const apiMocks = {
+  supplierInvoicesUpdate: mock(
+    (id: string, updates: unknown): Promise<unknown> =>
+      Promise.resolve({ id, ...(updates as object) }),
+  ),
+  supplierInvoicesDelete: mock((_id: string): Promise<void> => Promise.resolve()),
+  supplierInvoicesCreate: mock(
+    (data: unknown): Promise<unknown> => Promise.resolve({ id: 'si-new', ...(data as object) }),
+  ),
+};
+
+mock.module('../../services/api', () => ({
+  default: {
+    supplierInvoices: {
+      update: (id: string, updates: unknown) => apiMocks.supplierInvoicesUpdate(id, updates),
+      delete: (id: string) => apiMocks.supplierInvoicesDelete(id),
+      create: (data: unknown) => apiMocks.supplierInvoicesCreate(data),
+    },
+  },
+  getAuthToken: () => null,
+  setAuthToken: () => {},
+}));
+
+const { makeSupplierInvoiceHandlers } = await import(
+  '../../hooks/handlers/supplierInvoiceHandlers'
+);
+
+type SupplierInvoiceLike = {
+  id: string;
+  status?: string;
+  supplierId?: string;
+  total?: number;
+};
+
+const makeStubSetter = <T>(initial: T[]) => {
+  let value = initial;
+  const setter = (updater: T[] | ((prev: T[]) => T[])) => {
+    value = typeof updater === 'function' ? (updater as (prev: T[]) => T[])(value) : updater;
+  };
+  return {
+    setter: setter as never,
+    get: () => value,
+  };
+};
+
+const silenceConsole = () => {
+  const originalError = console.error;
+  const originalAlert = globalThis.alert;
+  console.error = mock(() => {}) as unknown as typeof console.error;
+  globalThis.alert = mock(() => {}) as unknown as typeof globalThis.alert;
+  return () => {
+    console.error = originalError;
+    globalThis.alert = originalAlert;
+  };
+};
+
+describe('makeSupplierInvoiceHandlers', () => {
+  beforeEach(() => {
+    for (const m of Object.values(apiMocks)) m.mockClear();
+  });
+
+  afterEach(() => {
+    for (const m of Object.values(apiMocks)) m.mockReset();
+  });
+
+  test('update replaces matching invoice', async () => {
+    apiMocks.supplierInvoicesUpdate.mockImplementation((id: string, updates: unknown) =>
+      Promise.resolve({ id, ...(updates as object) }),
+    );
+    const invoices = makeStubSetter<SupplierInvoiceLike>([
+      { id: 'si-1', status: 'draft' },
+      { id: 'si-2', status: 'sent' },
+    ]);
+    const setActiveView = mock(() => {}) as never;
+    const handlers = makeSupplierInvoiceHandlers({
+      setSupplierInvoices: invoices.setter,
+      setActiveView,
+    });
+
+    await handlers.update('si-1', { status: 'paid' } as never);
+    expect(invoices.get()[0]).toEqual({ id: 'si-1', status: 'paid' });
+    expect(invoices.get()[1]).toEqual({ id: 'si-2', status: 'sent' });
+  });
+
+  test('update rethrows on api error', async () => {
+    apiMocks.supplierInvoicesUpdate.mockImplementation(() => Promise.reject(new Error('boom')));
+    const handlers = makeSupplierInvoiceHandlers({
+      setSupplierInvoices: makeStubSetter<SupplierInvoiceLike>([]).setter,
+      setActiveView: mock(() => {}) as never,
+    });
+
+    const restore = silenceConsole();
+    try {
+      await expect(handlers.update('si-1', {} as never)).rejects.toThrow('boom');
+    } finally {
+      restore();
+    }
+  });
+
+  test('delete removes matching invoice', async () => {
+    apiMocks.supplierInvoicesDelete.mockImplementation(() => Promise.resolve());
+    const invoices = makeStubSetter<SupplierInvoiceLike>([{ id: 'si-1' }, { id: 'si-2' }]);
+    const handlers = makeSupplierInvoiceHandlers({
+      setSupplierInvoices: invoices.setter,
+      setActiveView: mock(() => {}) as never,
+    });
+
+    await handlers.delete('si-1');
+    expect(apiMocks.supplierInvoicesDelete).toHaveBeenCalledWith('si-1');
+    expect(invoices.get()).toEqual([{ id: 'si-2' }]);
+  });
+
+  test('delete rethrows on api error', async () => {
+    apiMocks.supplierInvoicesDelete.mockImplementation(() => Promise.reject(new Error('nope')));
+    const handlers = makeSupplierInvoiceHandlers({
+      setSupplierInvoices: makeStubSetter<SupplierInvoiceLike>([]).setter,
+      setActiveView: mock(() => {}) as never,
+    });
+
+    const restore = silenceConsole();
+    try {
+      await expect(handlers.delete('si-1')).rejects.toThrow('nope');
+    } finally {
+      restore();
+    }
+  });
+
+  test('createFromOrder builds invoice with computed totals and switches view', async () => {
+    apiMocks.supplierInvoicesCreate.mockImplementation((data: unknown) =>
+      Promise.resolve({ id: 'si-new', ...(data as object) }),
+    );
+    const invoices = makeStubSetter<SupplierInvoiceLike>([{ id: 'si-existing' }]);
+    const setActiveView = mock(() => {});
+    const handlers = makeSupplierInvoiceHandlers({
+      setSupplierInvoices: invoices.setter,
+      setActiveView: setActiveView as never,
+    });
+
+    const order = {
+      id: 'order-1',
+      supplierId: 'sup-1',
+      supplierName: 'Acme',
+      paymentTerms: '45 days',
+      notes: 'note',
+      items: [
+        {
+          productId: 'p1',
+          productName: 'Widget',
+          quantity: 2,
+          unitPrice: 100,
+          discount: 10,
+        },
+        {
+          productId: 'p2',
+          productName: 'Gadget',
+          quantity: 3,
+          unitPrice: 50,
+          // no discount → defaults to 0
+        },
+      ],
+    };
+
+    await handlers.createFromOrder(order as never);
+
+    expect(apiMocks.supplierInvoicesCreate).toHaveBeenCalledTimes(1);
+    const callArg = apiMocks.supplierInvoicesCreate.mock.calls[0][0] as Record<string, unknown>;
+    expect(callArg.linkedSaleId).toBe('order-1');
+    expect(callArg.supplierId).toBe('sup-1');
+    expect(callArg.supplierName).toBe('Acme');
+    expect(callArg.status).toBe('draft');
+    // 2*100*(1-0.10) + 3*50 = 180 + 150 = 330
+    expect(callArg.subtotal).toBe(330);
+    expect(callArg.total).toBe(330);
+    expect(callArg.amountPaid).toBe(0);
+    expect(callArg.notes).toBe('note');
+    expect(callArg.issueDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(callArg.dueDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    const items = callArg.items as Array<Record<string, unknown>>;
+    expect(items).toHaveLength(2);
+    expect(items[0].discount).toBe(10);
+    expect(items[1].discount).toBe(0);
+
+    expect(invoices.get()[0].id).toBe('si-new');
+    expect(setActiveView).toHaveBeenCalledWith('accounting/supplier-invoices');
+  });
+
+  test('createFromOrder defaults paymentTerms to 30 days when missing', async () => {
+    apiMocks.supplierInvoicesCreate.mockImplementation((data: unknown) =>
+      Promise.resolve({ id: 'si-new', ...(data as object) }),
+    );
+    const handlers = makeSupplierInvoiceHandlers({
+      setSupplierInvoices: makeStubSetter<SupplierInvoiceLike>([]).setter,
+      setActiveView: mock(() => {}) as never,
+    });
+
+    await handlers.createFromOrder({
+      id: 'order-1',
+      supplierId: 's1',
+      supplierName: 'S',
+      paymentTerms: undefined,
+      notes: '',
+      items: [],
+    } as never);
+
+    expect(apiMocks.supplierInvoicesCreate).toHaveBeenCalled();
+    const callArg = apiMocks.supplierInvoicesCreate.mock.calls[0][0] as Record<string, unknown>;
+    expect(callArg.subtotal).toBe(0);
+    expect(callArg.total).toBe(0);
+  });
+
+  test('createFromOrder alerts and swallows on api error', async () => {
+    apiMocks.supplierInvoicesCreate.mockImplementation(() => Promise.reject(new Error('boom')));
+    const invoices = makeStubSetter<SupplierInvoiceLike>([{ id: 'si-existing' }]);
+    const setActiveView = mock(() => {});
+    const handlers = makeSupplierInvoiceHandlers({
+      setSupplierInvoices: invoices.setter,
+      setActiveView: setActiveView as never,
+    });
+
+    const restore = silenceConsole();
+    try {
+      await handlers.createFromOrder({
+        id: 'o',
+        supplierId: 's',
+        supplierName: 'S',
+        paymentTerms: '30',
+        notes: '',
+        items: [],
+      } as never);
+      expect(invoices.get()).toEqual([{ id: 'si-existing' }]);
+      expect(setActiveView).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+});

--- a/test/handlers/supplierQuoteHandlers.test.ts
+++ b/test/handlers/supplierQuoteHandlers.test.ts
@@ -77,7 +77,11 @@ const buildHandlers = (overrides: Record<string, unknown> = {}) => {
   const supplierQuotes = makeStubSetter<SupplierQuoteLike>([]);
   const supplierOrders = makeStubSetter<SupplierOrderLike>([]);
   const supplierInvoices = makeStubSetter<SupplierInvoiceLike>([]);
-  const supplierQuoteFilterId = makeStubScalar<string | null>(null);
+  const initialFilterId =
+    typeof overrides.supplierQuoteFilterId === 'string' || overrides.supplierQuoteFilterId === null
+      ? (overrides.supplierQuoteFilterId as string | null)
+      : null;
+  const supplierQuoteFilterId = makeStubScalar<string | null>(initialFilterId);
   const setActiveView = mock(() => {});
   const handlers = makeSupplierQuoteHandlers({
     supplierQuoteFilterId: supplierQuoteFilterId.get(),
@@ -183,7 +187,7 @@ describe('makeSupplierQuoteHandlers', () => {
     const ctx = buildHandlers({ supplierQuoteFilterId: 'sq-other' });
 
     await ctx.handlers.updateSupplierQuote('sq-1', { status: 'sent' } as never);
-    expect(ctx.supplierQuoteFilterId.get()).toBeNull();
+    expect(ctx.supplierQuoteFilterId.get()).toBe('sq-other');
   });
 
   test('updateSupplierQuote swallows errors', async () => {

--- a/test/handlers/supplierQuoteHandlers.test.ts
+++ b/test/handlers/supplierQuoteHandlers.test.ts
@@ -1,0 +1,350 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const apiMocks = {
+  supplierQuotesList: mock((): Promise<unknown[]> => Promise.resolve([])),
+  supplierQuotesCreate: mock(
+    (data: unknown): Promise<unknown> => Promise.resolve({ id: 'sq-new', ...(data as object) }),
+  ),
+  supplierQuotesUpdate: mock(
+    (id: string, updates: unknown): Promise<unknown> =>
+      Promise.resolve({ id, ...(updates as object) }),
+  ),
+  supplierQuotesDelete: mock((_id: string): Promise<void> => Promise.resolve()),
+  supplierOrdersList: mock((): Promise<unknown[]> => Promise.resolve([])),
+  supplierOrdersCreate: mock(
+    (data: unknown): Promise<unknown> => Promise.resolve({ id: 'so-new', ...(data as object) }),
+  ),
+  supplierOrdersUpdate: mock(
+    (id: string, updates: unknown): Promise<unknown> =>
+      Promise.resolve({ id, ...(updates as object) }),
+  ),
+  supplierOrdersDelete: mock((_id: string): Promise<void> => Promise.resolve()),
+  supplierInvoicesList: mock((): Promise<unknown[]> => Promise.resolve([])),
+};
+
+mock.module('../../services/api', () => ({
+  default: {
+    supplierQuotes: {
+      list: () => apiMocks.supplierQuotesList(),
+      create: (data: unknown) => apiMocks.supplierQuotesCreate(data),
+      update: (id: string, updates: unknown) => apiMocks.supplierQuotesUpdate(id, updates),
+      delete: (id: string) => apiMocks.supplierQuotesDelete(id),
+    },
+    supplierOrders: {
+      list: () => apiMocks.supplierOrdersList(),
+      create: (data: unknown) => apiMocks.supplierOrdersCreate(data),
+      update: (id: string, updates: unknown) => apiMocks.supplierOrdersUpdate(id, updates),
+      delete: (id: string) => apiMocks.supplierOrdersDelete(id),
+    },
+    supplierInvoices: {
+      list: () => apiMocks.supplierInvoicesList(),
+    },
+  },
+  getAuthToken: () => null,
+  setAuthToken: () => {},
+}));
+
+const { makeSupplierQuoteHandlers } = await import('../../hooks/handlers/supplierQuoteHandlers');
+
+type SupplierQuoteLike = { id: string; status?: string; supplierId?: string };
+type SupplierOrderLike = { id: string; status?: string };
+type SupplierInvoiceLike = { id: string };
+
+type AnyFn = (...args: unknown[]) => void;
+const makeStubSetter = <T>(initial: T[]) => {
+  let value = initial;
+  const setter = ((updater: T[] | ((prev: T[]) => T[])) => {
+    value = typeof updater === 'function' ? (updater as (prev: T[]) => T[])(value) : updater;
+  }) as AnyFn;
+  return {
+    setter,
+    get: () => value,
+  };
+};
+
+const makeStubScalar = <T>(initial: T) => {
+  let value = initial;
+  const setter = ((updater: T | ((prev: T) => T)) => {
+    value = typeof updater === 'function' ? (updater as (prev: T) => T)(value) : updater;
+  }) as AnyFn;
+  return {
+    setter,
+    get: () => value,
+  };
+};
+
+const buildHandlers = (overrides: Record<string, unknown> = {}) => {
+  const supplierQuotes = makeStubSetter<SupplierQuoteLike>([]);
+  const supplierOrders = makeStubSetter<SupplierOrderLike>([]);
+  const supplierInvoices = makeStubSetter<SupplierInvoiceLike>([]);
+  const supplierQuoteFilterId = makeStubScalar<string | null>(null);
+  const setActiveView = mock(() => {});
+  const handlers = makeSupplierQuoteHandlers({
+    supplierQuoteFilterId: supplierQuoteFilterId.get(),
+    setSupplierQuotes: supplierQuotes.setter as never,
+    setSupplierOrders: supplierOrders.setter as never,
+    setSupplierInvoices: supplierInvoices.setter as never,
+    setSupplierQuoteFilterId: supplierQuoteFilterId.setter as never,
+    setActiveView: setActiveView as never,
+    ...overrides,
+  });
+  return {
+    handlers,
+    supplierQuotes,
+    supplierOrders,
+    supplierInvoices,
+    supplierQuoteFilterId,
+    setActiveView,
+  };
+};
+
+const silenceConsole = () => {
+  const originalError = console.error;
+  const originalAlert = globalThis.alert;
+  console.error = mock(() => {}) as unknown as typeof console.error;
+  globalThis.alert = mock(() => {}) as unknown as typeof globalThis.alert;
+  return () => {
+    console.error = originalError;
+    globalThis.alert = originalAlert;
+  };
+};
+
+describe('makeSupplierQuoteHandlers', () => {
+  beforeEach(() => {
+    for (const m of Object.values(apiMocks)) m.mockClear();
+  });
+
+  afterEach(() => {
+    for (const m of Object.values(apiMocks)) m.mockReset();
+  });
+
+  test('refreshSupplierQuoteFlow loads quotes and orders', async () => {
+    apiMocks.supplierQuotesList.mockImplementation(() => Promise.resolve([{ id: 'sq-fresh' }]));
+    apiMocks.supplierOrdersList.mockImplementation(() => Promise.resolve([{ id: 'so-fresh' }]));
+    const ctx = buildHandlers();
+
+    await ctx.handlers.refreshSupplierQuoteFlow();
+
+    expect(ctx.supplierQuotes.get()).toEqual([{ id: 'sq-fresh' }]);
+    expect(ctx.supplierOrders.get()).toEqual([{ id: 'so-fresh' }]);
+  });
+
+  test('refreshSupplierOrderFlow loads orders and invoices', async () => {
+    apiMocks.supplierOrdersList.mockImplementation(() => Promise.resolve([{ id: 'so-fresh' }]));
+    apiMocks.supplierInvoicesList.mockImplementation(() => Promise.resolve([{ id: 'si-fresh' }]));
+    const ctx = buildHandlers();
+
+    await ctx.handlers.refreshSupplierOrderFlow();
+    expect(ctx.supplierOrders.get()).toEqual([{ id: 'so-fresh' }]);
+    expect(ctx.supplierInvoices.get()).toEqual([{ id: 'si-fresh' }]);
+  });
+
+  test('addSupplierQuote appends to list', async () => {
+    apiMocks.supplierQuotesCreate.mockImplementation((data: unknown) =>
+      Promise.resolve({ id: 'sq-new', ...(data as object) }),
+    );
+    const ctx = buildHandlers();
+
+    await ctx.handlers.addSupplierQuote({ status: 'draft' } as never);
+    expect(ctx.supplierQuotes.get()).toEqual([{ id: 'sq-new', status: 'draft' }]);
+  });
+
+  test('addSupplierQuote swallows errors', async () => {
+    apiMocks.supplierQuotesCreate.mockImplementation(() => Promise.reject(new Error('boom')));
+    const ctx = buildHandlers();
+    const restore = silenceConsole();
+    try {
+      await ctx.handlers.addSupplierQuote({} as never);
+      expect(ctx.supplierQuotes.get()).toEqual([]);
+    } finally {
+      restore();
+    }
+  });
+
+  test('updateSupplierQuote refreshes flow and updates filter when matched', async () => {
+    apiMocks.supplierQuotesUpdate.mockImplementation((id: string, updates: unknown) =>
+      Promise.resolve({ id, ...(updates as object) }),
+    );
+    apiMocks.supplierQuotesList.mockImplementation(() => Promise.resolve([{ id: 'sq-1' }]));
+    apiMocks.supplierOrdersList.mockImplementation(() => Promise.resolve([]));
+    const ctx = buildHandlers({ supplierQuoteFilterId: 'sq-1' });
+
+    await ctx.handlers.updateSupplierQuote('sq-1', { status: 'sent' } as never);
+    expect(ctx.supplierQuoteFilterId.get()).toBe('sq-1');
+    expect(ctx.supplierQuotes.get()).toEqual([{ id: 'sq-1' }]);
+  });
+
+  test('updateSupplierQuote does not change filter when ids differ', async () => {
+    apiMocks.supplierQuotesUpdate.mockImplementation((id: string, updates: unknown) =>
+      Promise.resolve({ id, ...(updates as object) }),
+    );
+    apiMocks.supplierQuotesList.mockImplementation(() => Promise.resolve([]));
+    apiMocks.supplierOrdersList.mockImplementation(() => Promise.resolve([]));
+    const ctx = buildHandlers({ supplierQuoteFilterId: 'sq-other' });
+
+    await ctx.handlers.updateSupplierQuote('sq-1', { status: 'sent' } as never);
+    expect(ctx.supplierQuoteFilterId.get()).toBeNull();
+  });
+
+  test('updateSupplierQuote swallows errors', async () => {
+    apiMocks.supplierQuotesUpdate.mockImplementation(() => Promise.reject(new Error('boom')));
+    const ctx = buildHandlers();
+    const restore = silenceConsole();
+    try {
+      await ctx.handlers.updateSupplierQuote('sq-1', {} as never);
+    } finally {
+      restore();
+    }
+  });
+
+  test('deleteSupplierQuote removes from list', async () => {
+    apiMocks.supplierQuotesDelete.mockImplementation(() => Promise.resolve());
+    const ctx = buildHandlers();
+    ctx.supplierQuotes.setter([{ id: 'sq-1' }, { id: 'sq-2' }] as never);
+
+    await ctx.handlers.deleteSupplierQuote('sq-1');
+    expect(ctx.supplierQuotes.get()).toEqual([{ id: 'sq-2' }]);
+  });
+
+  test('deleteSupplierQuote swallows errors', async () => {
+    apiMocks.supplierQuotesDelete.mockImplementation(() => Promise.reject(new Error('nope')));
+    const ctx = buildHandlers();
+    const restore = silenceConsole();
+    try {
+      await ctx.handlers.deleteSupplierQuote('sq-1');
+    } finally {
+      restore();
+    }
+  });
+
+  test('updateSupplierOrder refreshes order flow', async () => {
+    apiMocks.supplierOrdersUpdate.mockImplementation(() => Promise.resolve({}));
+    apiMocks.supplierOrdersList.mockImplementation(() => Promise.resolve([{ id: 'so-fresh' }]));
+    apiMocks.supplierInvoicesList.mockImplementation(() => Promise.resolve([]));
+    const ctx = buildHandlers();
+
+    await ctx.handlers.updateSupplierOrder('so-1', { status: 'confirmed' } as never);
+    expect(ctx.supplierOrders.get()).toEqual([{ id: 'so-fresh' }]);
+  });
+
+  test('updateSupplierOrder rethrows on api error', async () => {
+    apiMocks.supplierOrdersUpdate.mockImplementation(() => Promise.reject(new Error('boom')));
+    const ctx = buildHandlers();
+    const restore = silenceConsole();
+    try {
+      await expect(ctx.handlers.updateSupplierOrder('so-1', {} as never)).rejects.toThrow('boom');
+    } finally {
+      restore();
+    }
+  });
+
+  test('deleteSupplierOrder removes order from list', async () => {
+    apiMocks.supplierOrdersDelete.mockImplementation(() => Promise.resolve());
+    const ctx = buildHandlers();
+    ctx.supplierOrders.setter([{ id: 'so-1' }, { id: 'so-2' }] as never);
+
+    await ctx.handlers.deleteSupplierOrder('so-1');
+    expect(ctx.supplierOrders.get()).toEqual([{ id: 'so-2' }]);
+  });
+
+  test('deleteSupplierOrder rethrows on api error', async () => {
+    apiMocks.supplierOrdersDelete.mockImplementation(() => Promise.reject(new Error('nope')));
+    const ctx = buildHandlers();
+    const restore = silenceConsole();
+    try {
+      await expect(ctx.handlers.deleteSupplierOrder('so-1')).rejects.toThrow('nope');
+    } finally {
+      restore();
+    }
+  });
+
+  test('createSupplierOrderFromQuote creates order, sets filter, switches view, refreshes', async () => {
+    apiMocks.supplierOrdersCreate.mockImplementation((data: unknown) =>
+      Promise.resolve({ id: 'so-new', ...(data as object) }),
+    );
+    apiMocks.supplierQuotesList.mockImplementation(() => Promise.resolve([{ id: 'sq-1' }]));
+    apiMocks.supplierOrdersList.mockImplementation(() => Promise.resolve([{ id: 'so-new' }]));
+    const ctx = buildHandlers();
+
+    const quote = {
+      id: 'sq-1',
+      supplierId: 'sup-1',
+      supplierName: 'Acme',
+      paymentTerms: '30',
+      notes: 'note',
+      items: [{ productId: 'p1', quantity: 1, unitPrice: 10 }],
+    };
+
+    await ctx.handlers.createSupplierOrderFromQuote(quote as never);
+
+    expect(apiMocks.supplierOrdersCreate).toHaveBeenCalled();
+    const callArg = apiMocks.supplierOrdersCreate.mock.calls[0][0] as Record<string, unknown>;
+    expect(callArg.linkedQuoteId).toBe('sq-1');
+    expect(callArg.supplierId).toBe('sup-1');
+    expect(callArg.status).toBe('draft');
+    expect(ctx.supplierQuoteFilterId.get()).toBe('sq-1');
+    expect(ctx.setActiveView).toHaveBeenCalledWith('accounting/supplier-orders');
+    expect(ctx.supplierQuotes.get()).toEqual([{ id: 'sq-1' }]);
+  });
+
+  test('createSupplierOrderFromQuote handles missing productId by defaulting to empty string', async () => {
+    apiMocks.supplierOrdersCreate.mockImplementation((data: unknown) =>
+      Promise.resolve({ id: 'so-new', ...(data as object) }),
+    );
+    apiMocks.supplierQuotesList.mockImplementation(() => Promise.resolve([]));
+    apiMocks.supplierOrdersList.mockImplementation(() => Promise.resolve([]));
+    const ctx = buildHandlers();
+
+    await ctx.handlers.createSupplierOrderFromQuote({
+      id: 'sq-1',
+      supplierId: 's',
+      supplierName: 'S',
+      paymentTerms: '30',
+      notes: '',
+      items: [{ quantity: 1, unitPrice: 10 }],
+    } as never);
+
+    const callArg = apiMocks.supplierOrdersCreate.mock.calls[0][0] as Record<string, unknown>;
+    const items = callArg.items as Array<Record<string, unknown>>;
+    expect(items[0].productId).toBe('');
+  });
+
+  test('createSupplierOrderFromQuote alerts on create error', async () => {
+    apiMocks.supplierOrdersCreate.mockImplementation(() => Promise.reject(new Error('boom')));
+    const ctx = buildHandlers();
+    const restore = silenceConsole();
+    try {
+      await ctx.handlers.createSupplierOrderFromQuote({
+        id: 'sq-1',
+        supplierId: 's',
+        supplierName: 'S',
+        paymentTerms: '30',
+        notes: '',
+        items: [],
+      } as never);
+      expect(ctx.setActiveView).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+
+  test('createSupplierOrderFromQuote swallows refresh errors after success', async () => {
+    apiMocks.supplierOrdersCreate.mockImplementation(() => Promise.resolve({ id: 'so-new' }));
+    apiMocks.supplierQuotesList.mockImplementation(() => Promise.reject(new Error('refresh-fail')));
+    const ctx = buildHandlers();
+    const restore = silenceConsole();
+    try {
+      await ctx.handlers.createSupplierOrderFromQuote({
+        id: 'sq-1',
+        supplierId: 's',
+        supplierName: 'S',
+        paymentTerms: '30',
+        notes: '',
+        items: [],
+      } as never);
+      expect(ctx.setActiveView).toHaveBeenCalledWith('accounting/supplier-orders');
+    } finally {
+      restore();
+    }
+  });
+});

--- a/test/handlers/userHandlers.test.ts
+++ b/test/handlers/userHandlers.test.ts
@@ -1,0 +1,563 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const apiMocks = {
+  usersCreate: mock(
+    (
+      name: string,
+      _username: string,
+      _password: string,
+      role: string,
+      email?: string,
+    ): Promise<unknown> => Promise.resolve({ id: 'u-new', name, role, email }),
+  ),
+  usersUpdate: mock(
+    (id: string, updates: unknown): Promise<unknown> =>
+      Promise.resolve({ id, ...(updates as object) }),
+  ),
+  usersUpdateRoles: mock(
+    (_id: string, _roleIds: string[], primaryRoleId: string): Promise<unknown> =>
+      Promise.resolve({ primaryRoleId }),
+  ),
+  usersDelete: mock((_id: string): Promise<void> => Promise.resolve()),
+  employeesCreate: mock(
+    (data: unknown): Promise<unknown> => Promise.resolve({ id: 'e-new', ...(data as object) }),
+  ),
+  employeesUpdate: mock(
+    (id: string, updates: unknown): Promise<unknown> =>
+      Promise.resolve({ id, ...(updates as object) }),
+  ),
+  employeesDelete: mock((_id: string): Promise<void> => Promise.resolve()),
+  rolesCreate: mock(
+    (name: string, permissions: string[]): Promise<unknown> =>
+      Promise.resolve({ id: 'r-new', name, permissions }),
+  ),
+  rolesRename: mock((id: string, name: string): Promise<unknown> => Promise.resolve({ id, name })),
+  rolesUpdatePermissions: mock(
+    (id: string, permissions: string[]): Promise<unknown> => Promise.resolve({ id, permissions }),
+  ),
+  rolesDelete: mock((_id: string): Promise<void> => Promise.resolve()),
+  workUnitsCreate: mock(
+    (data: unknown): Promise<unknown> => Promise.resolve({ id: 'wu-new', ...(data as object) }),
+  ),
+  workUnitsUpdate: mock(
+    (id: string, updates: unknown): Promise<unknown> =>
+      Promise.resolve({ id, ...(updates as object) }),
+  ),
+  workUnitsDelete: mock((_id: string): Promise<void> => Promise.resolve()),
+  workUnitsList: mock((): Promise<unknown[]> => Promise.resolve([])),
+};
+
+mock.module('../../services/api', () => ({
+  default: {
+    users: {
+      create: (name: string, username: string, password: string, role: string, email?: string) =>
+        apiMocks.usersCreate(name, username, password, role, email),
+      update: (id: string, updates: unknown) => apiMocks.usersUpdate(id, updates),
+      updateRoles: (id: string, roleIds: string[], primaryRoleId: string) =>
+        apiMocks.usersUpdateRoles(id, roleIds, primaryRoleId),
+      delete: (id: string) => apiMocks.usersDelete(id),
+    },
+    employees: {
+      create: (data: unknown) => apiMocks.employeesCreate(data),
+      update: (id: string, updates: unknown) => apiMocks.employeesUpdate(id, updates),
+      delete: (id: string) => apiMocks.employeesDelete(id),
+    },
+    roles: {
+      create: (name: string, permissions: string[]) => apiMocks.rolesCreate(name, permissions),
+      rename: (id: string, name: string) => apiMocks.rolesRename(id, name),
+      updatePermissions: (id: string, permissions: string[]) =>
+        apiMocks.rolesUpdatePermissions(id, permissions),
+      delete: (id: string) => apiMocks.rolesDelete(id),
+    },
+    workUnits: {
+      create: (data: unknown) => apiMocks.workUnitsCreate(data),
+      update: (id: string, updates: unknown) => apiMocks.workUnitsUpdate(id, updates),
+      delete: (id: string) => apiMocks.workUnitsDelete(id),
+      list: () => apiMocks.workUnitsList(),
+    },
+  },
+  getAuthToken: () => null,
+  setAuthToken: () => {},
+}));
+
+const { makeUserHandlers } = await import('../../hooks/handlers/userHandlers');
+
+type UserLike = {
+  id: string;
+  name?: string;
+  role?: string;
+  hasTopManagerRole?: boolean;
+  isAdminOnly?: boolean;
+  costPerHour?: number;
+};
+type RoleLike = { id: string; name?: string; permissions?: string[] };
+type WorkUnitLike = { id: string; name?: string };
+
+type AnyFn = (...args: unknown[]) => void;
+const makeStubSetter = <T>(initial: T[]) => {
+  let value = initial;
+  const setter = ((updater: T[] | ((prev: T[]) => T[])) => {
+    value = typeof updater === 'function' ? (updater as (prev: T[]) => T[])(value) : updater;
+  }) as AnyFn;
+  return { setter, get: () => value };
+};
+
+const makeStubScalar = <T>(initial: T) => {
+  let value = initial;
+  const setter = ((updater: T | ((prev: T) => T)) => {
+    value = typeof updater === 'function' ? (updater as (prev: T) => T)(value) : updater;
+  }) as AnyFn;
+  return { setter, get: () => value };
+};
+
+const buildHandlers = (overrides: Record<string, unknown> = {}) => {
+  const users = makeStubSetter<UserLike>((overrides.users as UserLike[] | undefined) ?? []);
+  const roles = makeStubSetter<RoleLike>([]);
+  const workUnits = makeStubSetter<WorkUnitLike>([]);
+  const viewingUserId = makeStubScalar<string>(
+    (overrides.viewingUserId as string | undefined) ?? '',
+  );
+  const handlers = makeUserHandlers({
+    currentUser: (overrides.currentUser as never) ?? null,
+    viewingUserId: viewingUserId.get(),
+    setUsers: users.setter as never,
+    setRoles: roles.setter as never,
+    setWorkUnits: workUnits.setter as never,
+    setViewingUserId: viewingUserId.setter as never,
+  });
+  return { handlers, users, roles, workUnits, viewingUserId };
+};
+
+const silenceConsole = () => {
+  const originalError = console.error;
+  const originalAlert = globalThis.alert;
+  console.error = mock(() => {}) as unknown as typeof console.error;
+  globalThis.alert = mock(() => {}) as unknown as typeof globalThis.alert;
+  return () => {
+    console.error = originalError;
+    globalThis.alert = originalAlert;
+  };
+};
+
+describe('makeUserHandlers — users', () => {
+  beforeEach(() => {
+    for (const m of Object.values(apiMocks)) m.mockClear();
+  });
+
+  afterEach(() => {
+    for (const m of Object.values(apiMocks)) m.mockReset();
+  });
+
+  test('addUser appends and returns success', async () => {
+    apiMocks.usersCreate.mockImplementation((name: string) =>
+      Promise.resolve({ id: 'u-new', name }),
+    );
+    const ctx = buildHandlers();
+    const result = await ctx.handlers.addUser('Alice', 'alice', 'pw', 'admin', 'a@x');
+    expect(result).toEqual({ success: true });
+    expect(apiMocks.usersCreate).toHaveBeenCalledWith('Alice', 'alice', 'pw', 'admin', 'a@x');
+    expect(ctx.users.get()).toEqual([{ id: 'u-new', name: 'Alice' }]);
+  });
+
+  test('addUser returns failure on api error', async () => {
+    apiMocks.usersCreate.mockImplementation(() => Promise.reject(new Error('dup')));
+    const ctx = buildHandlers();
+    const restore = silenceConsole();
+    try {
+      const result = await ctx.handlers.addUser('A', 'a', 'p', 'admin');
+      expect(result).toEqual({ success: false, error: 'dup' });
+    } finally {
+      restore();
+    }
+  });
+
+  test('updateUser replaces matching user', async () => {
+    apiMocks.usersUpdate.mockImplementation((id: string, updates: unknown) =>
+      Promise.resolve({ id, ...(updates as object) }),
+    );
+    const ctx = buildHandlers({ users: [{ id: 'u1', name: 'Old' }] });
+    await ctx.handlers.updateUser('u1', { name: 'New' });
+    expect(ctx.users.get()[0]).toEqual({ id: 'u1', name: 'New' });
+  });
+
+  test('updateUser alerts and swallows on error', async () => {
+    apiMocks.usersUpdate.mockImplementation(() => Promise.reject(new Error('boom')));
+    const ctx = buildHandlers({ users: [{ id: 'u1' }] });
+    const restore = silenceConsole();
+    try {
+      await ctx.handlers.updateUser('u1', { name: 'X' });
+      expect(ctx.users.get()).toEqual([{ id: 'u1' }]);
+    } finally {
+      restore();
+    }
+  });
+
+  test('updateUserRoles flags top-manager and admin-only correctly', async () => {
+    apiMocks.usersUpdateRoles.mockImplementation((_id: string, _ids: string[], primary: string) =>
+      Promise.resolve({ primaryRoleId: primary }),
+    );
+    const ctx = buildHandlers({ users: [{ id: 'u1' }] });
+
+    await ctx.handlers.updateUserRoles('u1', ['top_manager', 'sales'], 'top_manager');
+    expect(ctx.users.get()[0]).toEqual({
+      id: 'u1',
+      role: 'top_manager',
+      hasTopManagerRole: true,
+      isAdminOnly: false,
+    });
+  });
+
+  test('updateUserRoles flags isAdminOnly when only admin role given', async () => {
+    apiMocks.usersUpdateRoles.mockImplementation((_id: string, _ids: string[], primary: string) =>
+      Promise.resolve({ primaryRoleId: primary }),
+    );
+    const ctx = buildHandlers({ users: [{ id: 'u1' }] });
+
+    await ctx.handlers.updateUserRoles('u1', ['admin'], 'admin');
+    expect(ctx.users.get()[0]).toEqual({
+      id: 'u1',
+      role: 'admin',
+      hasTopManagerRole: false,
+      isAdminOnly: true,
+    });
+  });
+
+  test('updateUserRoles alerts and rethrows on error', async () => {
+    apiMocks.usersUpdateRoles.mockImplementation(() => Promise.reject(new Error('boom')));
+    const ctx = buildHandlers({ users: [{ id: 'u1' }] });
+    const restore = silenceConsole();
+    try {
+      await expect(ctx.handlers.updateUserRoles('u1', ['x'], 'x')).rejects.toThrow('boom');
+    } finally {
+      restore();
+    }
+  });
+
+  test('deleteUser removes from list and resets viewingUserId when matched', async () => {
+    apiMocks.usersDelete.mockImplementation(() => Promise.resolve());
+    const ctx = buildHandlers({
+      users: [{ id: 'u1' }, { id: 'u2' }],
+      currentUser: { id: 'u-current' } as never,
+      viewingUserId: 'u1',
+    });
+
+    await ctx.handlers.deleteUser('u1');
+    expect(ctx.users.get()).toEqual([{ id: 'u2' }]);
+    expect(ctx.viewingUserId.get()).toBe('u-current');
+  });
+
+  test('deleteUser falls back to empty viewingUserId when no current user', async () => {
+    apiMocks.usersDelete.mockImplementation(() => Promise.resolve());
+    const ctx = buildHandlers({
+      users: [{ id: 'u1' }],
+      currentUser: null,
+      viewingUserId: 'u1',
+    });
+
+    await ctx.handlers.deleteUser('u1');
+    expect(ctx.viewingUserId.get()).toBe('');
+  });
+
+  test('deleteUser leaves viewingUserId untouched when ids differ', async () => {
+    apiMocks.usersDelete.mockImplementation(() => Promise.resolve());
+    const ctx = buildHandlers({
+      users: [{ id: 'u1' }, { id: 'u2' }],
+      currentUser: { id: 'u-current' } as never,
+      viewingUserId: 'u-other',
+    });
+
+    await ctx.handlers.deleteUser('u1');
+    expect(ctx.viewingUserId.get()).toBe('u-other');
+  });
+
+  test('deleteUser swallows errors', async () => {
+    apiMocks.usersDelete.mockImplementation(() => Promise.reject(new Error('boom')));
+    const ctx = buildHandlers({ users: [{ id: 'u1' }] });
+    const restore = silenceConsole();
+    try {
+      await ctx.handlers.deleteUser('u1');
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe('makeUserHandlers — employees', () => {
+  beforeEach(() => {
+    for (const m of Object.values(apiMocks)) m.mockClear();
+  });
+
+  afterEach(() => {
+    for (const m of Object.values(apiMocks)) m.mockReset();
+  });
+
+  test('addInternalEmployee delegates to employees.create', async () => {
+    apiMocks.employeesCreate.mockImplementation((data: unknown) =>
+      Promise.resolve({ id: 'e-new', ...(data as object) }),
+    );
+    const ctx = buildHandlers();
+    const result = await ctx.handlers.addInternalEmployee('Bob', 75);
+    expect(result).toEqual({ success: true });
+    expect(apiMocks.employeesCreate).toHaveBeenCalledWith({
+      name: 'Bob',
+      employeeType: 'internal',
+      costPerHour: 75,
+    });
+    expect(ctx.users.get()[0].name).toBe('Bob');
+  });
+
+  test('addExternalEmployee delegates to employees.create', async () => {
+    apiMocks.employeesCreate.mockImplementation((data: unknown) =>
+      Promise.resolve({ id: 'e-new', ...(data as object) }),
+    );
+    const ctx = buildHandlers();
+    await ctx.handlers.addExternalEmployee('Eve');
+    expect(apiMocks.employeesCreate).toHaveBeenCalledWith({
+      name: 'Eve',
+      employeeType: 'external',
+      costPerHour: undefined,
+    });
+  });
+
+  test('addInternalEmployee returns failure on api error', async () => {
+    apiMocks.employeesCreate.mockImplementation(() => Promise.reject(new Error('dup')));
+    const ctx = buildHandlers();
+    const restore = silenceConsole();
+    try {
+      const result = await ctx.handlers.addInternalEmployee('Bob');
+      expect(result).toEqual({ success: false, error: 'dup' });
+    } finally {
+      restore();
+    }
+  });
+
+  test('addInternalEmployee handles non-Error rejection', async () => {
+    apiMocks.employeesCreate.mockImplementation(() => Promise.reject('weird'));
+    const ctx = buildHandlers();
+    const restore = silenceConsole();
+    try {
+      const result = await ctx.handlers.addInternalEmployee('Bob');
+      expect(result).toEqual({ success: false, error: 'Failed to create employee' });
+    } finally {
+      restore();
+    }
+  });
+
+  test('updateEmployee replaces matching user', async () => {
+    apiMocks.employeesUpdate.mockImplementation((id: string, updates: unknown) =>
+      Promise.resolve({ id, ...(updates as object) }),
+    );
+    const ctx = buildHandlers({ users: [{ id: 'u1', name: 'Old' }] });
+    await ctx.handlers.updateEmployee('u1', { name: 'New' });
+    expect(ctx.users.get()[0]).toEqual({ id: 'u1', name: 'New' });
+  });
+
+  test('updateEmployee swallows errors', async () => {
+    apiMocks.employeesUpdate.mockImplementation(() => Promise.reject(new Error('boom')));
+    const ctx = buildHandlers({ users: [{ id: 'u1' }] });
+    const restore = silenceConsole();
+    try {
+      await ctx.handlers.updateEmployee('u1', { name: 'X' });
+    } finally {
+      restore();
+    }
+  });
+
+  test('deleteEmployee removes user', async () => {
+    apiMocks.employeesDelete.mockImplementation(() => Promise.resolve());
+    const ctx = buildHandlers({ users: [{ id: 'u1' }, { id: 'u2' }] });
+    await ctx.handlers.deleteEmployee('u1');
+    expect(ctx.users.get()).toEqual([{ id: 'u2' }]);
+  });
+
+  test('deleteEmployee swallows errors', async () => {
+    apiMocks.employeesDelete.mockImplementation(() => Promise.reject(new Error('boom')));
+    const ctx = buildHandlers({ users: [{ id: 'u1' }] });
+    const restore = silenceConsole();
+    try {
+      await ctx.handlers.deleteEmployee('u1');
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe('makeUserHandlers — roles', () => {
+  beforeEach(() => {
+    for (const m of Object.values(apiMocks)) m.mockClear();
+  });
+
+  afterEach(() => {
+    for (const m of Object.values(apiMocks)) m.mockReset();
+  });
+
+  test('createRole appends new role', async () => {
+    apiMocks.rolesCreate.mockImplementation((name: string, permissions: string[]) =>
+      Promise.resolve({ id: 'r-new', name, permissions }),
+    );
+    const ctx = buildHandlers();
+    await ctx.handlers.createRole('Sales', ['sales.view']);
+    expect(ctx.roles.get()).toEqual([{ id: 'r-new', name: 'Sales', permissions: ['sales.view'] }]);
+  });
+
+  test('createRole rethrows api error', async () => {
+    apiMocks.rolesCreate.mockImplementation(() => Promise.reject(new Error('boom')));
+    const ctx = buildHandlers();
+    const restore = silenceConsole();
+    try {
+      await expect(ctx.handlers.createRole('X', [])).rejects.toThrow('boom');
+    } finally {
+      restore();
+    }
+  });
+
+  test('renameRole replaces matching role', async () => {
+    apiMocks.rolesRename.mockImplementation((id: string, name: string) =>
+      Promise.resolve({ id, name }),
+    );
+    const ctx = buildHandlers();
+    ctx.roles.setter([{ id: 'r1', name: 'Old' }] as never);
+    await ctx.handlers.renameRole('r1', 'New');
+    expect(ctx.roles.get()).toEqual([{ id: 'r1', name: 'New' }]);
+  });
+
+  test('renameRole rethrows api error', async () => {
+    apiMocks.rolesRename.mockImplementation(() => Promise.reject(new Error('boom')));
+    const ctx = buildHandlers();
+    const restore = silenceConsole();
+    try {
+      await expect(ctx.handlers.renameRole('r1', 'X')).rejects.toThrow('boom');
+    } finally {
+      restore();
+    }
+  });
+
+  test('updateRolePermissions replaces matching role', async () => {
+    apiMocks.rolesUpdatePermissions.mockImplementation((id: string, perms: string[]) =>
+      Promise.resolve({ id, permissions: perms }),
+    );
+    const ctx = buildHandlers();
+    ctx.roles.setter([{ id: 'r1', permissions: [] }] as never);
+    await ctx.handlers.updateRolePermissions('r1', ['a.view']);
+    expect(ctx.roles.get()).toEqual([{ id: 'r1', permissions: ['a.view'] }]);
+  });
+
+  test('updateRolePermissions rethrows api error', async () => {
+    apiMocks.rolesUpdatePermissions.mockImplementation(() => Promise.reject(new Error('boom')));
+    const ctx = buildHandlers();
+    const restore = silenceConsole();
+    try {
+      await expect(ctx.handlers.updateRolePermissions('r1', [])).rejects.toThrow('boom');
+    } finally {
+      restore();
+    }
+  });
+
+  test('deleteRole removes from list', async () => {
+    apiMocks.rolesDelete.mockImplementation(() => Promise.resolve());
+    const ctx = buildHandlers();
+    ctx.roles.setter([{ id: 'r1' }, { id: 'r2' }] as never);
+    await ctx.handlers.deleteRole('r1');
+    expect(ctx.roles.get()).toEqual([{ id: 'r2' }]);
+  });
+
+  test('deleteRole rethrows api error', async () => {
+    apiMocks.rolesDelete.mockImplementation(() => Promise.reject(new Error('boom')));
+    const ctx = buildHandlers();
+    const restore = silenceConsole();
+    try {
+      await expect(ctx.handlers.deleteRole('r1')).rejects.toThrow('boom');
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe('makeUserHandlers — work units', () => {
+  beforeEach(() => {
+    for (const m of Object.values(apiMocks)) m.mockClear();
+  });
+
+  afterEach(() => {
+    for (const m of Object.values(apiMocks)) m.mockReset();
+  });
+
+  test('addWorkUnit appends new unit', async () => {
+    apiMocks.workUnitsCreate.mockImplementation((data: unknown) =>
+      Promise.resolve({ id: 'wu-new', ...(data as object) }),
+    );
+    const ctx = buildHandlers();
+    await ctx.handlers.addWorkUnit({ name: 'WU' });
+    expect(ctx.workUnits.get()).toEqual([{ id: 'wu-new', name: 'WU' }]);
+  });
+
+  test('addWorkUnit rethrows api error', async () => {
+    apiMocks.workUnitsCreate.mockImplementation(() => Promise.reject(new Error('boom')));
+    const ctx = buildHandlers();
+    const restore = silenceConsole();
+    try {
+      await expect(ctx.handlers.addWorkUnit({})).rejects.toThrow('boom');
+    } finally {
+      restore();
+    }
+  });
+
+  test('updateWorkUnit replaces matching unit', async () => {
+    apiMocks.workUnitsUpdate.mockImplementation((id: string, updates: unknown) =>
+      Promise.resolve({ id, ...(updates as object) }),
+    );
+    const ctx = buildHandlers();
+    ctx.workUnits.setter([{ id: 'wu1', name: 'Old' }] as never);
+    await ctx.handlers.updateWorkUnit('wu1', { name: 'New' });
+    expect(ctx.workUnits.get()).toEqual([{ id: 'wu1', name: 'New' }]);
+  });
+
+  test('updateWorkUnit rethrows api error', async () => {
+    apiMocks.workUnitsUpdate.mockImplementation(() => Promise.reject(new Error('boom')));
+    const ctx = buildHandlers();
+    const restore = silenceConsole();
+    try {
+      await expect(ctx.handlers.updateWorkUnit('wu1', {})).rejects.toThrow('boom');
+    } finally {
+      restore();
+    }
+  });
+
+  test('deleteWorkUnit removes from list', async () => {
+    apiMocks.workUnitsDelete.mockImplementation(() => Promise.resolve());
+    const ctx = buildHandlers();
+    ctx.workUnits.setter([{ id: 'wu1' }, { id: 'wu2' }] as never);
+    await ctx.handlers.deleteWorkUnit('wu1');
+    expect(ctx.workUnits.get()).toEqual([{ id: 'wu2' }]);
+  });
+
+  test('deleteWorkUnit rethrows api error', async () => {
+    apiMocks.workUnitsDelete.mockImplementation(() => Promise.reject(new Error('boom')));
+    const ctx = buildHandlers();
+    const restore = silenceConsole();
+    try {
+      await expect(ctx.handlers.deleteWorkUnit('wu1')).rejects.toThrow('boom');
+    } finally {
+      restore();
+    }
+  });
+
+  test('fetchWorkUnits replaces work units list', async () => {
+    apiMocks.workUnitsList.mockImplementation(() => Promise.resolve([{ id: 'wu-fresh' }]));
+    const ctx = buildHandlers();
+    await ctx.handlers.fetchWorkUnits();
+    expect(ctx.workUnits.get()).toEqual([{ id: 'wu-fresh' }]);
+  });
+
+  test('fetchWorkUnits swallows errors', async () => {
+    apiMocks.workUnitsList.mockImplementation(() => Promise.reject(new Error('boom')));
+    const ctx = buildHandlers();
+    const restore = silenceConsole();
+    try {
+      await ctx.handlers.fetchWorkUnits();
+      expect(ctx.workUnits.get()).toEqual([]);
+    } finally {
+      restore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds unit tests for `entryHandlers`, `invoiceHandlers`, `quoteHandlers`, `supplierHandlers`, `supplierInvoiceHandlers`, `supplierQuoteHandlers`, and `userHandlers` under `test/handlers/`.
- Mirrors the existing pattern used by `clientHandlers.test.ts` / `productHandlers.test.ts`: `mock.module('../../services/api', ...)`, then exercise each factory function and assert the API call, state setter, and error rethrow/swallow semantics.
- Production code is unchanged; tests-only.

## Coverage of the targeted files (line coverage)
- entryHandlers — 100%
- invoiceHandlers — 100%
- quoteHandlers — 100%
- supplierHandlers — 100%
- supplierInvoiceHandlers — 100%
- supplierQuoteHandlers — 100%
- userHandlers — 99.37%

## Test plan
- [x] `bun test test/handlers/` — 128 pass, 0 fail
- [x] `bun run test` — 1098 server + 407 frontend tests pass
- [x] `bun run lint` — Biome + tsc + i18n key check all green

https://claude.ai/code/session_0111c2dFZ99BbKBQtghz8kGJ

---
_Generated by [Claude Code](https://claude.ai/code/session_0111c2dFZ99BbKBQtghz8kGJ)_