### PR TITLE
test(api): cover client/auth/notifications service modules

### DIFF
--- a/test/helpers/fetchMock.ts
+++ b/test/helpers/fetchMock.ts
@@ -1,0 +1,36 @@
+/**
+ * Builds a Response-like object for use with `fetchMock.mockImplementation(...)`.
+ *
+ * Matches the surface area of `globalThis.fetch`'s Response that
+ * `services/api/client.ts` consumes: `ok`, `status`, `headers.get(name)` and
+ * `json()`. Headers are matched case-insensitively to mirror real Headers.
+ */
+export type FetchResponseInit = {
+  status?: number;
+  ok?: boolean;
+  headers?: Record<string, string>;
+  /** Sync or async producer for the JSON body. */
+  json?: () => unknown | Promise<unknown>;
+};
+
+export const buildResponse = ({ status = 200, ok, headers = {}, json }: FetchResponseInit = {}) => {
+  const lowerHeaders = Object.fromEntries(
+    Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v]),
+  );
+  return {
+    ok: ok ?? (status >= 200 && status < 300),
+    status,
+    headers: {
+      get: (name: string) => lowerHeaders[name.toLowerCase()] ?? null,
+    },
+    json: json
+      ? () => {
+          try {
+            return Promise.resolve(json());
+          } catch (err) {
+            return Promise.reject(err);
+          }
+        }
+      : () => Promise.reject(new Error('json not implemented')),
+  };
+};

--- a/test/services/auth.test.ts
+++ b/test/services/auth.test.ts
@@ -1,0 +1,170 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { buildResponse } from '../helpers/fetchMock';
+
+// Stub fetch globally; the real client.ts will call it under the hood.
+const respondWith = (body: unknown, status = 200) => buildResponse({ status, json: () => body });
+
+const originalFetch = globalThis.fetch;
+const fetchMock = mock(
+  async (_input: unknown, _init?: unknown): Promise<unknown> => respondWith({}),
+);
+globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+// Load the real auth module — it pulls in the real client.ts, which calls our fetch mock.
+const { authApi } = await import('../../services/api/auth');
+const { getAuthToken, setAuthToken } = await import('../../services/api/client');
+
+// Canonical user shape that passes every guard inside `normalizeAuthUser`.
+const canonicalUser = {
+  id: 'u-1',
+  name: 'Canonical User',
+  username: 'canonical',
+  role: 'admin',
+  avatarInitials: 'CU',
+  availableRoles: [{ id: 'admin', name: 'Admin', isAdmin: true, permissions: [] }],
+  permissions: ['*'],
+  costPerHour: 0,
+  hasTopManagerRole: false,
+  isAdminOnly: false,
+};
+
+// Routes fetch by URL substring so each test can program just the responses it cares about.
+const programRoutes = (routes: Record<string, unknown | (() => unknown)>) => {
+  fetchMock.mockImplementation(async (input: unknown) => {
+    const url = String(input);
+    for (const [pattern, response] of Object.entries(routes)) {
+      if (url.endsWith(pattern)) {
+        const body = typeof response === 'function' ? (response as () => unknown)() : response;
+        return respondWith(body);
+      }
+    }
+    throw new Error(`unexpected fetch URL: ${url}`);
+  });
+};
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  setAuthToken(null);
+});
+
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('authApi', () => {
+  describe('login', () => {
+    test('POSTs to /auth/login, persists token, fetches /auth/me, returns canonical response', async () => {
+      programRoutes({
+        '/auth/login': { token: 'login-token', user: { id: 'ignored' } },
+        '/auth/me': { ...canonicalUser },
+      });
+
+      const result = await authApi.login('alice', 'secret');
+
+      // First call sends credentials.
+      const loginCall = fetchMock.mock.calls[0];
+      expect(String(loginCall[0])).toContain('/auth/login');
+      expect((loginCall[1] as { method: string }).method).toBe('POST');
+      expect((loginCall[1] as { body: string }).body).toBe(
+        JSON.stringify({ username: 'alice', password: 'secret' }),
+      );
+
+      // Second call fetches the canonical user.
+      expect(String(fetchMock.mock.calls[1][0])).toContain('/auth/me');
+
+      // Token was persisted via setAuthToken (visible through getAuthToken).
+      expect(getAuthToken()).toBe('login-token');
+      expect(result.token).toBe('login-token');
+      expect(result.user.id).toBe('u-1');
+      expect(result.user.username).toBe('canonical');
+    });
+
+    test('rejects when login response has a blank token, restores previous token', async () => {
+      setAuthToken('old-token');
+      programRoutes({ '/auth/login': { token: '   ', user: {} } });
+
+      await expect(authApi.login('a', 'b')).rejects.toThrow('Invalid authentication response');
+      expect(getAuthToken()).toBe('old-token');
+    });
+
+    test('restores previous token if /auth/me fails after login succeeds', async () => {
+      setAuthToken('old-token');
+      fetchMock.mockImplementation(async (input: unknown) => {
+        const url = String(input);
+        if (url.endsWith('/auth/login')) return respondWith({ token: 'new-token', user: {} });
+        // /auth/me returns an HTTP error → fetchApi throws.
+        return respondWith({ message: 'me failed' }, 500);
+      });
+
+      await expect(authApi.login('a', 'b')).rejects.toThrow('me failed');
+      // Previous token restored on error.
+      expect(getAuthToken()).toBe('old-token');
+    });
+
+    test('rejects when canonical user fails normalization (missing username)', async () => {
+      programRoutes({
+        '/auth/login': { token: 't', user: {} },
+        '/auth/me': { ...canonicalUser, username: '' },
+      });
+
+      await expect(authApi.login('a', 'b')).rejects.toThrow('Invalid authentication response');
+    });
+
+    test('rejects when active role is not in availableRoles', async () => {
+      programRoutes({
+        '/auth/login': { token: 't', user: {} },
+        '/auth/me': {
+          ...canonicalUser,
+          role: 'manager',
+          availableRoles: [{ id: 'admin', name: 'Admin', isAdmin: true, permissions: [] }],
+        },
+      });
+
+      await expect(authApi.login('a', 'b')).rejects.toThrow('Invalid authentication response');
+    });
+  });
+
+  describe('me', () => {
+    test('fetches /auth/me and returns the normalized canonical user', async () => {
+      programRoutes({ '/auth/me': { ...canonicalUser } });
+
+      const user = await authApi.me();
+      expect(user.id).toBe('u-1');
+      expect(user.username).toBe('canonical');
+      expect(String(fetchMock.mock.calls[0][0])).toContain('/auth/me');
+    });
+
+    test('throws when /auth/me responds with an empty available roles list', async () => {
+      programRoutes({ '/auth/me': { ...canonicalUser, availableRoles: [] } });
+      await expect(authApi.me()).rejects.toThrow('Invalid authentication response');
+    });
+  });
+
+  describe('switchRole', () => {
+    test('POSTs to /auth/switch-role with the requested roleId and returns canonical response', async () => {
+      programRoutes({
+        '/auth/switch-role': { token: 'role-token', user: {} },
+        '/auth/me': { ...canonicalUser, role: 'admin' },
+      });
+
+      const result = await authApi.switchRole('admin');
+
+      const switchCall = fetchMock.mock.calls[0];
+      expect(String(switchCall[0])).toContain('/auth/switch-role');
+      expect((switchCall[1] as { method: string }).method).toBe('POST');
+      expect((switchCall[1] as { body: string }).body).toBe(JSON.stringify({ roleId: 'admin' }));
+
+      expect(getAuthToken()).toBe('role-token');
+      expect(result.token).toBe('role-token');
+      expect(result.user.role).toBe('admin');
+    });
+
+    test('restores previous token if switch fails', async () => {
+      setAuthToken('prev');
+      fetchMock.mockImplementation(async () => respondWith({ message: 'switch failed' }, 500));
+
+      await expect(authApi.switchRole('admin')).rejects.toThrow('switch failed');
+      expect(getAuthToken()).toBe('prev');
+    });
+  });
+});

--- a/test/services/client.test.ts
+++ b/test/services/client.test.ts
@@ -1,0 +1,224 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { buildResponse } from '../helpers/fetchMock';
+
+const originalFetch = globalThis.fetch;
+const fetchMock = mock(
+  async (_input: unknown, _init?: unknown): Promise<unknown> => buildResponse({ status: 204 }),
+);
+globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+const { fetchApi, fetchApiStream, getAuthToken, setAuthToken } = await import(
+  '../../services/api/client'
+);
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  setAuthToken(null);
+});
+
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('services/api/client', () => {
+  describe('setAuthToken / getAuthToken', () => {
+    test('setAuthToken with a string persists it in localStorage and getAuthToken returns it', () => {
+      setAuthToken('my-token');
+      expect(localStorage.getItem('praetor_auth_token')).toBe('my-token');
+      expect(getAuthToken()).toBe('my-token');
+    });
+
+    test('setAuthToken(null) clears localStorage and getAuthToken returns null', () => {
+      setAuthToken('temp');
+      setAuthToken(null);
+      expect(localStorage.getItem('praetor_auth_token')).toBeNull();
+      expect(getAuthToken()).toBeNull();
+    });
+  });
+
+  describe('fetchApi', () => {
+    test('successful JSON response is parsed and returned', async () => {
+      fetchMock.mockImplementationOnce(async () =>
+        buildResponse({ status: 200, json: () => ({ hello: 'world' }) }),
+      );
+
+      const result = await fetchApi<{ hello: string }>('/things');
+      expect(result).toEqual({ hello: 'world' });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    test('returns empty object for 204 responses without parsing JSON', async () => {
+      fetchMock.mockImplementationOnce(async () => buildResponse({ status: 204 }));
+
+      const result = await fetchApi<Record<string, unknown>>('/empty');
+      expect(result).toEqual({});
+    });
+
+    test('rotates the auth token when response includes x-auth-token header', async () => {
+      fetchMock.mockImplementationOnce(async () =>
+        buildResponse({
+          status: 200,
+          headers: { 'x-auth-token': 'rotated-token' },
+          json: () => ({ ok: true }),
+        }),
+      );
+
+      await fetchApi('/anything');
+      expect(getAuthToken()).toBe('rotated-token');
+      expect(localStorage.getItem('praetor_auth_token')).toBe('rotated-token');
+    });
+
+    test('does not change token when response omits x-auth-token header', async () => {
+      setAuthToken('pre-existing');
+      fetchMock.mockImplementationOnce(async () =>
+        buildResponse({ status: 200, json: () => ({}) }),
+      );
+
+      await fetchApi('/x');
+      expect(getAuthToken()).toBe('pre-existing');
+    });
+
+    test('attaches Authorization header when a token is present', async () => {
+      setAuthToken('bearer-token');
+      fetchMock.mockImplementationOnce(async (_input: unknown, init: unknown) => {
+        const headers = (init as { headers: Record<string, string> }).headers;
+        expect(headers.Authorization).toBe('Bearer bearer-token');
+        return buildResponse({ status: 200, json: () => ({}) });
+      });
+      await fetchApi('/secure');
+    });
+
+    test('omits Authorization header when no token is set', async () => {
+      fetchMock.mockImplementationOnce(async (_input: unknown, init: unknown) => {
+        const headers = (init as { headers: Record<string, string> }).headers;
+        expect(headers.Authorization).toBeUndefined();
+        return buildResponse({ status: 200, json: () => ({}) });
+      });
+      await fetchApi('/public');
+    });
+
+    test('sets Content-Type=application/json automatically when a body is present', async () => {
+      fetchMock.mockImplementationOnce(async (_input: unknown, init: unknown) => {
+        const headers = (init as { headers: Record<string, string> }).headers;
+        expect(headers['Content-Type']).toBe('application/json');
+        return buildResponse({ status: 200, json: () => ({}) });
+      });
+      await fetchApi('/post', { method: 'POST', body: JSON.stringify({ a: 1 }) });
+    });
+
+    test('does not set Content-Type when no body is provided', async () => {
+      fetchMock.mockImplementationOnce(async (_input: unknown, init: unknown) => {
+        const headers = (init as { headers: Record<string, string> }).headers;
+        expect(headers['Content-Type']).toBeUndefined();
+        return buildResponse({ status: 200, json: () => ({}) });
+      });
+      await fetchApi('/get');
+    });
+
+    test('error response with body.message throws Error with that message', async () => {
+      fetchMock.mockImplementationOnce(async () =>
+        buildResponse({ status: 400, json: () => ({ message: 'Bad input' }) }),
+      );
+      await expect(fetchApi('/bad')).rejects.toThrow('Bad input');
+    });
+
+    test('error response with body.error throws Error with that message', async () => {
+      fetchMock.mockImplementationOnce(async () =>
+        buildResponse({ status: 422, json: () => ({ error: 'validation failed' }) }),
+      );
+      await expect(fetchApi('/v')).rejects.toThrow('validation failed');
+    });
+
+    test('error response with unparseable JSON falls back to "Request failed"', async () => {
+      // When response.json() rejects, the implementation defaults the parsed
+      // payload to `{ error: 'Request failed' }`.
+      fetchMock.mockImplementationOnce(async () =>
+        buildResponse({
+          status: 500,
+          json: () => Promise.reject(new Error('not json')),
+        }),
+      );
+      await expect(fetchApi('/crash')).rejects.toThrow('Request failed');
+    });
+
+    test('error response with empty body falls back to "HTTP <status>"', async () => {
+      // When the parsed body has neither `message` nor `error`, the implementation
+      // throws `HTTP <status>`.
+      fetchMock.mockImplementationOnce(async () =>
+        buildResponse({ status: 503, json: () => ({}) }),
+      );
+      await expect(fetchApi('/crash')).rejects.toThrow('HTTP 503');
+    });
+
+    test('401 response throws and still rotates the token if header present', async () => {
+      fetchMock.mockImplementationOnce(async () =>
+        buildResponse({
+          status: 401,
+          headers: { 'x-auth-token': 'rotated-on-401' },
+          json: () => ({ message: 'Unauthorized' }),
+        }),
+      );
+      await expect(fetchApi('/me')).rejects.toThrow('Unauthorized');
+      // The current implementation rotates the token whenever the header is set,
+      // regardless of status code.
+      expect(getAuthToken()).toBe('rotated-on-401');
+    });
+
+    test('network error from fetch propagates to caller', async () => {
+      fetchMock.mockImplementationOnce(async () => {
+        throw new TypeError('Failed to fetch');
+      });
+      await expect(fetchApi('/down')).rejects.toThrow('Failed to fetch');
+    });
+
+    test('caller can override headers via options.headers', async () => {
+      fetchMock.mockImplementationOnce(async (_input: unknown, init: unknown) => {
+        const headers = (init as { headers: Record<string, string> }).headers;
+        expect(headers['X-Custom']).toBe('yes');
+        return buildResponse({ status: 200, json: () => ({}) });
+      });
+      await fetchApi('/custom', { headers: { 'X-Custom': 'yes' } });
+    });
+  });
+
+  describe('fetchApiStream', () => {
+    test('returns the raw Response without parsing the body', async () => {
+      const fakeResponse = buildResponse({ status: 200, json: () => ({ wont: 'parse' }) });
+      fetchMock.mockImplementationOnce(async () => fakeResponse);
+
+      const result = await fetchApiStream('/stream');
+      expect(result).toBe(fakeResponse as never);
+    });
+
+    test('rotates token from x-auth-token on stream responses too', async () => {
+      fetchMock.mockImplementationOnce(async () =>
+        buildResponse({
+          status: 200,
+          headers: { 'x-auth-token': 'stream-rotated' },
+          json: () => ({}),
+        }),
+      );
+      await fetchApiStream('/stream');
+      expect(getAuthToken()).toBe('stream-rotated');
+    });
+
+    test('attaches Authorization header but not Content-Type by default', async () => {
+      setAuthToken('stream-token');
+      fetchMock.mockImplementationOnce(async (_input: unknown, init: unknown) => {
+        const headers = (init as { headers: Record<string, string> }).headers;
+        expect(headers.Authorization).toBe('Bearer stream-token');
+        expect(headers['Content-Type']).toBeUndefined();
+        return buildResponse({ status: 200, json: () => ({}) });
+      });
+      await fetchApiStream('/stream');
+    });
+
+    test('does not throw on non-ok stream responses; caller handles them', async () => {
+      fetchMock.mockImplementationOnce(async () =>
+        buildResponse({ status: 500, json: () => ({}) }),
+      );
+      const response = await fetchApiStream('/bad-stream');
+      expect((response as { status: number }).status).toBe(500);
+    });
+  });
+});

--- a/test/services/notifications.test.ts
+++ b/test/services/notifications.test.ts
@@ -1,0 +1,97 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { buildResponse } from '../helpers/fetchMock';
+
+const respondWith = (body: unknown, status = 200) => buildResponse({ status, json: () => body });
+
+const originalFetch = globalThis.fetch;
+const fetchMock = mock(
+  async (_input: unknown, _init?: unknown): Promise<unknown> => respondWith({}),
+);
+globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+// Load the real notifications module — it pulls the real client.ts which calls our fetch mock.
+const { notificationsApi } = await import('../../services/api/notifications');
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  fetchMock.mockImplementation(async () => respondWith({}));
+});
+
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('notificationsApi', () => {
+  test('list() GETs /notifications and returns the response payload', async () => {
+    const payload = {
+      notifications: [
+        { id: 'n1', message: 'hello', read: false },
+        { id: 'n2', message: 'world', read: true },
+      ],
+      unreadCount: 1,
+    };
+    fetchMock.mockImplementation(async () => respondWith(payload));
+
+    const result = await notificationsApi.list();
+
+    const call = fetchMock.mock.calls[0];
+    expect(String(call[0])).toContain('/notifications');
+    expect(result).toEqual(payload as never);
+  });
+
+  test('markAsRead() PUTs to /notifications/:id/read', async () => {
+    fetchMock.mockImplementation(async () => respondWith({ success: true }));
+
+    const result = await notificationsApi.markAsRead('abc-123');
+
+    const call = fetchMock.mock.calls[0];
+    expect(String(call[0])).toContain('/notifications/abc-123/read');
+    expect((call[1] as { method: string }).method).toBe('PUT');
+    expect(result).toEqual({ success: true } as never);
+  });
+
+  test('markAllAsRead() PUTs to /notifications/read-all', async () => {
+    fetchMock.mockImplementation(async () => respondWith({ success: true }));
+
+    const result = await notificationsApi.markAllAsRead();
+
+    const call = fetchMock.mock.calls[0];
+    expect(String(call[0])).toContain('/notifications/read-all');
+    expect((call[1] as { method: string }).method).toBe('PUT');
+    expect(result).toEqual({ success: true } as never);
+  });
+
+  test('delete() DELETEs to /notifications/:id', async () => {
+    // 204 → fetchApi returns {} without parsing body.
+    fetchMock.mockImplementation(async () => respondWith({}, 204));
+
+    await notificationsApi.delete('xyz-789');
+
+    const call = fetchMock.mock.calls[0];
+    expect(String(call[0])).toContain('/notifications/xyz-789');
+    expect((call[1] as { method: string }).method).toBe('DELETE');
+  });
+
+  test('errors thrown by the underlying client propagate to the caller', async () => {
+    fetchMock.mockImplementation(async () => {
+      throw new Error('network down');
+    });
+
+    await expect(notificationsApi.list()).rejects.toThrow('network down');
+    await expect(notificationsApi.markAsRead('1')).rejects.toThrow('network down');
+    await expect(notificationsApi.markAllAsRead()).rejects.toThrow('network down');
+    await expect(notificationsApi.delete('1')).rejects.toThrow('network down');
+  });
+
+  test('id segments are interpolated literally (no URL encoding)', async () => {
+    // The current implementation embeds the id directly; this test pins that
+    // behaviour so future refactors are intentional.
+    fetchMock.mockImplementation(async () => respondWith({ success: true }));
+
+    await notificationsApi.markAsRead('id with spaces');
+    await notificationsApi.delete('id/with/slashes');
+
+    expect(String(fetchMock.mock.calls[0][0])).toContain('/notifications/id with spaces/read');
+    expect(String(fetchMock.mock.calls[1][0])).toContain('/notifications/id/with/slashes');
+  });
+});


### PR DESCRIPTION
## Summary
- Add unit tests for `services/api/client.ts` covering token rotation via `x-auth-token`, error body parsing (message/error/fallbacks), 204 handling, header injection, and the `fetchApiStream` helper.
- Add smoke tests for `services/api/auth.ts` and `services/api/notifications.ts` that exercise every exported method by stubbing `globalThis.fetch`.
- Extract a shared `buildResponse` helper into `test/helpers/fetchMock.ts` for reuse across the new test files.

After this change `services/api/client.ts`, `services/api/auth.ts`, and `services/api/notifications.ts` each report 100% line coverage.

## Test plan
- [x] `bun test ./test/services/` — 36/36 pass
- [x] `bun run test` — 1098 server + 338 frontend tests pass
- [x] `bun run lint` — exits 0 (warnings only, all pre-existing)
- [x] `bun test ./test --coverage` confirms 100% line coverage on the three target modules

https://claude.ai/code/session_0111c2dFZ99BbKBQtghz8kGJ

---
_Generated by [Claude Code](https://claude.ai/code/session_0111c2dFZ99BbKBQtghz8kGJ)_