### PR TITLE
feat(supplier-quotes): add file attachments to draft quotes

### DIFF
--- a/components/sales/SupplierQuoteAttachmentsSection.tsx
+++ b/components/sales/SupplierQuoteAttachmentsSection.tsx
@@ -193,8 +193,7 @@ const SupplierQuoteAttachmentsSection: React.FC<SupplierQuoteAttachmentsSectionP
         {t('sales:supplierQuotes.attachments.title', { defaultValue: 'Attachments' })}
         <FieldTooltip
           description={t('sales:fieldInfo.attachments', {
-            defaultValue:
-              'Files received from the supplier (xlsx, pdf, doc...). Editable on draft quotes only.',
+            defaultValue: 'Files received from the supplier',
           })}
           status={readOnlyStatus}
           statusLabel={statusLabel}

--- a/components/sales/SupplierQuoteAttachmentsSection.tsx
+++ b/components/sales/SupplierQuoteAttachmentsSection.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { supplierQuotesApi } from '../../services/api/supplierQuotes';
 import type { SupplierQuoteAttachment } from '../../types';
@@ -52,7 +52,6 @@ const SupplierQuoteAttachmentsSection: React.FC<SupplierQuoteAttachmentsSectionP
   const [isUploading, setIsUploading] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
   const [pendingDelete, setPendingDelete] = useState<SupplierQuoteAttachment | null>(null);
-  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const reload = useCallback(async () => {
     setIsLoading(true);
@@ -233,7 +232,6 @@ const SupplierQuoteAttachmentsSection: React.FC<SupplierQuoteAttachmentsSectionP
             })}
           </span>
           <input
-            ref={fileInputRef}
             type="file"
             accept={ACCEPT_ATTR}
             disabled={isUploading}

--- a/components/sales/SupplierQuoteAttachmentsSection.tsx
+++ b/components/sales/SupplierQuoteAttachmentsSection.tsx
@@ -180,7 +180,7 @@ const SupplierQuoteAttachmentsSection: React.FC<SupplierQuoteAttachmentsSectionP
   }, [pendingDelete, quoteId, t]);
 
   return (
-    <div className="space-y-3">
+    <div className="space-y-3 border-t border-slate-100 pt-4">
       <h4 className="flex items-center gap-2 text-xs font-black uppercase tracking-widest text-praetor">
         <span className="h-1.5 w-1.5 rounded-full bg-praetor"></span>
         {t('sales:supplierQuotes.attachments.title', { defaultValue: 'Attachments' })}

--- a/components/sales/SupplierQuoteAttachmentsSection.tsx
+++ b/components/sales/SupplierQuoteAttachmentsSection.tsx
@@ -5,6 +5,7 @@ import { supplierQuotesApi } from '../../services/api/supplierQuotes';
 import type { SupplierQuoteAttachment } from '../../types';
 import { formatInsertDateTime } from '../../utils/date';
 import DeleteConfirmModal from '../shared/DeleteConfirmModal';
+import FieldTooltip from '../shared/FieldTooltip';
 
 const ALLOWED_EXT = new Set(['xlsx', 'xls', 'csv', 'pdf', 'doc', 'docx']);
 const MAX_FILE_SIZE = 10 * 1024 * 1024;
@@ -32,11 +33,17 @@ const getExtension = (name: string): string => {
 interface SupplierQuoteAttachmentsSectionProps {
   quoteId: string;
   isReadOnly: boolean;
+  /** Resolved string for the FieldTooltip status row (e.g. "Editable" or the read-only reason). */
+  readOnlyStatus: string;
+  /** Localized "Status:" label prefix; mirrors the other sections in SupplierQuotesView. */
+  statusLabel: string;
 }
 
 const SupplierQuoteAttachmentsSection: React.FC<SupplierQuoteAttachmentsSectionProps> = ({
   quoteId,
   isReadOnly,
+  readOnlyStatus,
+  statusLabel,
 }) => {
   const { t, i18n } = useTranslation(['sales', 'common']);
   const [attachments, setAttachments] = useState<SupplierQuoteAttachment[]>([]);
@@ -184,13 +191,15 @@ const SupplierQuoteAttachmentsSection: React.FC<SupplierQuoteAttachmentsSectionP
       <h4 className="flex items-center gap-2 text-xs font-black uppercase tracking-widest text-praetor">
         <span className="h-1.5 w-1.5 rounded-full bg-praetor"></span>
         {t('sales:supplierQuotes.attachments.title', { defaultValue: 'Attachments' })}
+        <FieldTooltip
+          description={t('sales:fieldInfo.attachments', {
+            defaultValue:
+              'Files received from the supplier (xlsx, pdf, doc...). Editable on draft quotes only.',
+          })}
+          status={readOnlyStatus}
+          statusLabel={statusLabel}
+        />
       </h4>
-      <p className="text-xs text-slate-500">
-        {t('sales:supplierQuotes.attachments.description', {
-          defaultValue:
-            'Files received from the supplier (xlsx, pdf, doc...). Available on draft quotes only.',
-        })}
-      </p>
 
       {!isReadOnly && (
         // <label> + hidden <input type="file"> gets us native click-to-open and keyboard focus

--- a/components/sales/SupplierQuoteAttachmentsSection.tsx
+++ b/components/sales/SupplierQuoteAttachmentsSection.tsx
@@ -1,0 +1,308 @@
+import type React from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { supplierQuotesApi } from '../../services/api/supplierQuotes';
+import type { SupplierQuoteAttachment } from '../../types';
+import { formatInsertDateTime } from '../../utils/date';
+import DeleteConfirmModal from '../shared/DeleteConfirmModal';
+
+const ALLOWED_EXT = new Set(['xlsx', 'xls', 'csv', 'pdf', 'doc', 'docx']);
+const MAX_FILE_SIZE = 10 * 1024 * 1024;
+const ACCEPT_ATTR = '.xlsx,.xls,.csv,.pdf,.doc,.docx';
+
+const formatFileSize = (bytes: number): string => {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB'];
+  let value = bytes;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  const decimals = unitIndex === 0 ? 0 : 1;
+  return `${value.toFixed(decimals)} ${units[unitIndex]}`;
+};
+
+const getExtension = (name: string): string => {
+  const dot = name.lastIndexOf('.');
+  if (dot < 0 || dot === name.length - 1) return '';
+  return name.slice(dot + 1).toLowerCase();
+};
+
+interface SupplierQuoteAttachmentsSectionProps {
+  quoteId: string;
+  isReadOnly: boolean;
+}
+
+const SupplierQuoteAttachmentsSection: React.FC<SupplierQuoteAttachmentsSectionProps> = ({
+  quoteId,
+  isReadOnly,
+}) => {
+  const { t, i18n } = useTranslation(['sales', 'common']);
+  const [attachments, setAttachments] = useState<SupplierQuoteAttachment[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isUploading, setIsUploading] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
+  const [pendingDelete, setPendingDelete] = useState<SupplierQuoteAttachment | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const reload = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const data = await supplierQuotesApi.listAttachments(quoteId);
+      setAttachments(data);
+      setError(null);
+    } catch {
+      setError(
+        t('sales:supplierQuotes.attachments.loadFailed', {
+          defaultValue: 'Failed to load attachments.',
+        }),
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [quoteId, t]);
+
+  useEffect(() => {
+    reload();
+  }, [reload]);
+
+  const validateFile = useCallback(
+    (file: File): string | null => {
+      if (file.size > MAX_FILE_SIZE) {
+        return t('sales:supplierQuotes.attachments.errors.tooLarge', {
+          defaultValue: 'File exceeds the 10 MB upload limit',
+        });
+      }
+      const ext = getExtension(file.name);
+      if (!ALLOWED_EXT.has(ext)) {
+        return t('sales:supplierQuotes.attachments.errors.invalidType', {
+          defaultValue: 'File type not allowed. Use xlsx, xls, csv, pdf, doc, or docx.',
+        });
+      }
+      return null;
+    },
+    [t],
+  );
+
+  const handleUpload = useCallback(
+    async (file: File) => {
+      const validationError = validateFile(file);
+      if (validationError) {
+        setError(validationError);
+        return;
+      }
+      setIsUploading(true);
+      setError(null);
+      try {
+        const created = await supplierQuotesApi.uploadAttachment(quoteId, file);
+        setAttachments((prev) => [created, ...prev]);
+      } catch (e) {
+        setError(
+          e instanceof Error && e.message
+            ? e.message
+            : t('sales:supplierQuotes.attachments.errors.uploadFailed', {
+                defaultValue: 'Upload failed',
+              }),
+        );
+      } finally {
+        setIsUploading(false);
+      }
+    },
+    [quoteId, t, validateFile],
+  );
+
+  const handleFileInputChange = useCallback(
+    async (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      // Reset the input so selecting the same file again still triggers a change event.
+      event.target.value = '';
+      if (file) await handleUpload(file);
+    },
+    [handleUpload],
+  );
+
+  const handleDrop = useCallback(
+    async (event: React.DragEvent<HTMLLabelElement>) => {
+      event.preventDefault();
+      setIsDragging(false);
+      if (isReadOnly || isUploading) return;
+      const file = event.dataTransfer.files?.[0];
+      if (file) await handleUpload(file);
+    },
+    [handleUpload, isReadOnly, isUploading],
+  );
+
+  const handleDownload = useCallback(
+    async (attachment: SupplierQuoteAttachment) => {
+      try {
+        const blob = await supplierQuotesApi.downloadAttachment(quoteId, attachment.id);
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = attachment.fileName;
+        document.body.appendChild(link);
+        link.click();
+        link.remove();
+        URL.revokeObjectURL(url);
+        setError(null);
+      } catch (e) {
+        setError(
+          e instanceof Error && e.message
+            ? e.message
+            : t('sales:supplierQuotes.attachments.errors.downloadFailed', {
+                defaultValue: 'Download failed',
+              }),
+        );
+      }
+    },
+    [quoteId, t],
+  );
+
+  const handleDeleteConfirmed = useCallback(async () => {
+    if (!pendingDelete) return;
+    try {
+      await supplierQuotesApi.deleteAttachment(quoteId, pendingDelete.id);
+      setAttachments((prev) => prev.filter((a) => a.id !== pendingDelete.id));
+      setError(null);
+    } catch (e) {
+      setError(
+        e instanceof Error && e.message
+          ? e.message
+          : t('sales:supplierQuotes.attachments.errors.deleteFailed', {
+              defaultValue: 'Delete failed',
+            }),
+      );
+    } finally {
+      setPendingDelete(null);
+    }
+  }, [pendingDelete, quoteId, t]);
+
+  return (
+    <div className="space-y-3">
+      <h4 className="flex items-center gap-2 text-xs font-black uppercase tracking-widest text-praetor">
+        <span className="h-1.5 w-1.5 rounded-full bg-praetor"></span>
+        {t('sales:supplierQuotes.attachments.title', { defaultValue: 'Attachments' })}
+      </h4>
+      <p className="text-xs text-slate-500">
+        {t('sales:supplierQuotes.attachments.description', {
+          defaultValue:
+            'Files received from the supplier (xlsx, pdf, doc...). Available on draft quotes only.',
+        })}
+      </p>
+
+      {!isReadOnly && (
+        // <label> + hidden <input type="file"> gets us native click-to-open and keyboard focus
+        // without needing role="button" on a div. Drag handlers stay on the label.
+        <label
+          onDragOver={(event) => {
+            event.preventDefault();
+            if (!isDragging) setIsDragging(true);
+          }}
+          onDragLeave={() => setIsDragging(false)}
+          onDrop={handleDrop}
+          aria-label={t('sales:supplierQuotes.attachments.uploadButton', {
+            defaultValue: 'Upload file',
+          })}
+          className={`flex flex-col items-center justify-center gap-1 rounded-xl border-2 border-dashed px-4 py-6 text-sm transition-all cursor-pointer ${
+            isDragging
+              ? 'border-praetor bg-praetor/5'
+              : 'border-slate-200 bg-slate-50 hover:border-slate-300'
+          } ${isUploading ? 'opacity-60 pointer-events-none' : ''}`}
+        >
+          <i className="fa-solid fa-cloud-arrow-up text-2xl text-slate-400"></i>
+          <span className="font-bold text-slate-600">
+            {isUploading
+              ? t('sales:supplierQuotes.attachments.uploading', { defaultValue: 'Uploading...' })
+              : t('sales:supplierQuotes.attachments.dropHere', {
+                  defaultValue: 'Drop a file here or click to upload',
+                })}
+          </span>
+          <span className="text-xs text-slate-400">
+            {t('sales:supplierQuotes.attachments.allowedTypes', {
+              defaultValue: 'Allowed: xlsx, xls, csv, pdf, doc, docx · max 10 MB',
+            })}
+          </span>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept={ACCEPT_ATTR}
+            disabled={isUploading}
+            className="hidden"
+            onChange={handleFileInputChange}
+          />
+        </label>
+      )}
+
+      {error && (
+        <div className="rounded-xl border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">
+          {error}
+        </div>
+      )}
+
+      {isLoading ? (
+        <div className="text-center py-4 text-slate-400 text-sm">
+          <i className="fa-solid fa-spinner fa-spin"></i>
+        </div>
+      ) : attachments.length === 0 ? (
+        <div className="text-center py-4 text-slate-400 text-sm">
+          {t('sales:supplierQuotes.attachments.empty', { defaultValue: 'No attachments yet.' })}
+        </div>
+      ) : (
+        <ul className="divide-y divide-slate-100 rounded-xl border border-slate-200 bg-white">
+          {attachments.map((attachment) => (
+            <li key={attachment.id} className="flex items-center gap-3 px-3 py-2.5">
+              <i className="fa-solid fa-file-lines text-slate-400"></i>
+              <div className="flex-1 min-w-0">
+                <div className="text-sm font-bold text-slate-700 truncate">
+                  {attachment.fileName}
+                </div>
+                <div className="text-xs text-slate-400">
+                  {formatFileSize(attachment.fileSize)}
+                  {attachment.createdAt
+                    ? ` · ${formatInsertDateTime(attachment.createdAt, i18n.language)}`
+                    : ''}
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => handleDownload(attachment)}
+                className="p-2 rounded-lg transition-all text-slate-400 hover:text-praetor hover:bg-slate-100"
+                aria-label={t('sales:supplierQuotes.attachments.downloadAction', {
+                  defaultValue: 'Download',
+                })}
+              >
+                <i className="fa-solid fa-download"></i>
+              </button>
+              {!isReadOnly && (
+                <button
+                  type="button"
+                  onClick={() => setPendingDelete(attachment)}
+                  className="p-2 rounded-lg transition-all text-slate-400 hover:text-red-600 hover:bg-red-50"
+                  aria-label={t('sales:supplierQuotes.attachments.deleteAction', {
+                    defaultValue: 'Delete',
+                  })}
+                >
+                  <i className="fa-solid fa-trash-can"></i>
+                </button>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <DeleteConfirmModal
+        isOpen={pendingDelete !== null}
+        onClose={() => setPendingDelete(null)}
+        onConfirm={handleDeleteConfirmed}
+        title={t('sales:supplierQuotes.attachments.deleteConfirm', {
+          defaultValue: 'Remove this attachment?',
+        })}
+        description={pendingDelete?.fileName}
+      />
+    </div>
+  );
+};
+
+export default SupplierQuoteAttachmentsSection;

--- a/components/sales/SupplierQuotesView.tsx
+++ b/components/sales/SupplierQuotesView.tsx
@@ -1065,23 +1065,21 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
                 )}
               </div>
 
-              <div className="border-t border-slate-100 pt-4">
-                {editingQuote?.id && previewVersion === null ? (
-                  <SupplierQuoteAttachmentsSection
-                    quoteId={editingQuote.id}
-                    isReadOnly={baseReadOnly}
-                  />
-                ) : (
-                  !editingQuote && (
-                    <p className="rounded-xl border border-dashed border-slate-200 bg-slate-50 px-4 py-3 text-xs text-slate-500">
-                      <i className="fa-solid fa-paperclip mr-2"></i>
-                      {t('sales:supplierQuotes.attachments.saveQuoteFirst', {
-                        defaultValue: 'Save the quote first to add attachments.',
-                      })}
-                    </p>
-                  )
-                )}
-              </div>
+              {editingQuote?.id && previewVersion === null ? (
+                <SupplierQuoteAttachmentsSection
+                  quoteId={editingQuote.id}
+                  isReadOnly={baseReadOnly}
+                />
+              ) : (
+                !editingQuote && (
+                  <p className="rounded-xl border border-dashed border-slate-200 bg-slate-50 px-4 py-3 text-xs text-slate-500">
+                    <i className="fa-solid fa-paperclip mr-2"></i>
+                    {t('sales:supplierQuotes.attachments.saveQuoteFirst', {
+                      defaultValue: 'Save the quote first to add attachments.',
+                    })}
+                  </p>
+                )
+              )}
 
               <div className="flex flex-col gap-4 border-t border-slate-100 pt-4 md:flex-row">
                 <div className="w-full space-y-4 md:w-2/3">

--- a/components/sales/SupplierQuotesView.tsx
+++ b/components/sales/SupplierQuotesView.tsx
@@ -1069,6 +1069,8 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
                 <SupplierQuoteAttachmentsSection
                   quoteId={editingQuote.id}
                   isReadOnly={baseReadOnly}
+                  readOnlyStatus={readOnlyStatus}
+                  statusLabel={statusLabel}
                 />
               ) : (
                 !editingQuote && (

--- a/components/sales/SupplierQuotesView.tsx
+++ b/components/sales/SupplierQuotesView.tsx
@@ -1072,12 +1072,14 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
                 />
               ) : (
                 !editingQuote && (
-                  <p className="rounded-xl border border-dashed border-slate-200 bg-slate-50 px-4 py-3 text-xs text-slate-500">
-                    <i className="fa-solid fa-paperclip mr-2"></i>
-                    {t('sales:supplierQuotes.attachments.saveQuoteFirst', {
-                      defaultValue: 'Save the quote first to add attachments.',
-                    })}
-                  </p>
+                  <div className="border-t border-slate-100 pt-4">
+                    <p className="rounded-xl border border-dashed border-slate-200 bg-slate-50 px-4 py-3 text-xs text-slate-500">
+                      <i className="fa-solid fa-paperclip mr-2"></i>
+                      {t('sales:supplierQuotes.attachments.saveQuoteFirst', {
+                        defaultValue: 'Save the quote first to add attachments.',
+                      })}
+                    </p>
+                  </div>
                 )
               )}
 

--- a/components/sales/SupplierQuotesView.tsx
+++ b/components/sales/SupplierQuotesView.tsx
@@ -28,6 +28,7 @@ import StatusBadge, { type StatusType } from '../shared/StatusBadge';
 import Tooltip from '../shared/Tooltip';
 import UnitTypeSelector from '../shared/UnitTypeSelector';
 import ValidatedNumberInput from '../shared/ValidatedNumberInput';
+import SupplierQuoteAttachmentsSection from './SupplierQuoteAttachmentsSection';
 import SupplierQuoteVersionsPanel from './SupplierQuoteVersionsPanel';
 
 interface TotalsBreakdown {
@@ -1061,6 +1062,24 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
                       defaultValue: 'No items added yet',
                     })}
                   </div>
+                )}
+              </div>
+
+              <div className="border-t border-slate-100 pt-4">
+                {editingQuote?.id && previewVersion === null ? (
+                  <SupplierQuoteAttachmentsSection
+                    quoteId={editingQuote.id}
+                    isReadOnly={baseReadOnly}
+                  />
+                ) : (
+                  !editingQuote && (
+                    <p className="rounded-xl border border-dashed border-slate-200 bg-slate-50 px-4 py-3 text-xs text-slate-500">
+                      <i className="fa-solid fa-paperclip mr-2"></i>
+                      {t('sales:supplierQuotes.attachments.saveQuoteFirst', {
+                        defaultValue: 'Save the quote first to add attachments.',
+                      })}
+                    </p>
+                  )
                 )}
               </div>
 

--- a/locales/en/sales.json
+++ b/locales/en/sales.json
@@ -12,6 +12,7 @@
     "items": "Line items for this offer",
     "supplierInformation": "Supplier and document details",
     "supplierItems": "Line items for this quote",
+    "attachments": "Files received from the supplier (xlsx, pdf, doc...). Editable on draft quotes only.",
     "statusLabel": "Status:",
     "fieldLockedBySupplierQuote": "Locked due to linked supplier quote"
   },
@@ -298,7 +299,6 @@
     },
     "attachments": {
       "title": "Attachments",
-      "description": "Files received from the supplier (xlsx, pdf, doc...). Available on draft quotes only.",
       "uploadButton": "Upload file",
       "dropHere": "Drop a file here or click to upload",
       "allowedTypes": "Allowed: xlsx, xls, csv, pdf, doc, docx · max 10 MB",

--- a/locales/en/sales.json
+++ b/locales/en/sales.json
@@ -295,6 +295,27 @@
       "reasonUpdate": "Save",
       "reasonRestore": "Restored",
       "loadFailed": "Failed to load version history."
+    },
+    "attachments": {
+      "title": "Attachments",
+      "description": "Files received from the supplier (xlsx, pdf, doc...). Available on draft quotes only.",
+      "uploadButton": "Upload file",
+      "dropHere": "Drop a file here or click to upload",
+      "allowedTypes": "Allowed: xlsx, xls, csv, pdf, doc, docx · max 10 MB",
+      "empty": "No attachments yet.",
+      "uploading": "Uploading...",
+      "downloadAction": "Download",
+      "deleteAction": "Delete",
+      "deleteConfirm": "Remove this attachment?",
+      "saveQuoteFirst": "Save the quote first to add attachments.",
+      "loadFailed": "Failed to load attachments.",
+      "errors": {
+        "tooLarge": "File exceeds the 10 MB upload limit",
+        "invalidType": "File type not allowed. Use xlsx, xls, csv, pdf, doc, or docx.",
+        "uploadFailed": "Upload failed",
+        "downloadFailed": "Download failed",
+        "deleteFailed": "Delete failed"
+      }
     }
   }
 }

--- a/locales/en/sales.json
+++ b/locales/en/sales.json
@@ -12,7 +12,7 @@
     "items": "Line items for this offer",
     "supplierInformation": "Supplier and document details",
     "supplierItems": "Line items for this quote",
-    "attachments": "Files received from the supplier (xlsx, pdf, doc...). Editable on draft quotes only.",
+    "attachments": "Files received from the supplier",
     "statusLabel": "Status:",
     "fieldLockedBySupplierQuote": "Locked due to linked supplier quote"
   },

--- a/locales/it/sales.json
+++ b/locales/it/sales.json
@@ -295,6 +295,27 @@
       "reasonUpdate": "Salvataggio",
       "reasonRestore": "Ripristino",
       "loadFailed": "Caricamento della cronologia non riuscito."
+    },
+    "attachments": {
+      "title": "Allegati",
+      "description": "File ricevuti dal fornitore (xlsx, pdf, doc...). Disponibile solo per i preventivi in bozza.",
+      "uploadButton": "Carica file",
+      "dropHere": "Trascina un file qui o clicca per caricarlo",
+      "allowedTypes": "Consentiti: xlsx, xls, csv, pdf, doc, docx · max 10 MB",
+      "empty": "Nessun allegato.",
+      "uploading": "Caricamento...",
+      "downloadAction": "Scarica",
+      "deleteAction": "Elimina",
+      "deleteConfirm": "Rimuovere questo allegato?",
+      "saveQuoteFirst": "Salva prima il preventivo per poter aggiungere allegati.",
+      "loadFailed": "Caricamento degli allegati non riuscito.",
+      "errors": {
+        "tooLarge": "Il file supera il limite di 10 MB",
+        "invalidType": "Tipo di file non consentito. Usa xlsx, xls, csv, pdf, doc o docx.",
+        "uploadFailed": "Caricamento non riuscito",
+        "downloadFailed": "Download non riuscito",
+        "deleteFailed": "Eliminazione non riuscita"
+      }
     }
   }
 }

--- a/locales/it/sales.json
+++ b/locales/it/sales.json
@@ -12,6 +12,7 @@
     "items": "Voci per questa offerta",
     "supplierInformation": "Dettagli fornitore e documento",
     "supplierItems": "Voci di questo preventivo",
+    "attachments": "File ricevuti dal fornitore (xlsx, pdf, doc...). Modificabili solo per i preventivi in bozza.",
     "statusLabel": "Stato:",
     "fieldLockedBySupplierQuote": "Bloccato per preventivo fornitore collegato"
   },
@@ -298,7 +299,6 @@
     },
     "attachments": {
       "title": "Allegati",
-      "description": "File ricevuti dal fornitore (xlsx, pdf, doc...). Disponibile solo per i preventivi in bozza.",
       "uploadButton": "Carica file",
       "dropHere": "Trascina un file qui o clicca per caricarlo",
       "allowedTypes": "Consentiti: xlsx, xls, csv, pdf, doc, docx · max 10 MB",

--- a/locales/it/sales.json
+++ b/locales/it/sales.json
@@ -12,7 +12,7 @@
     "items": "Voci per questa offerta",
     "supplierInformation": "Dettagli fornitore e documento",
     "supplierItems": "Voci di questo preventivo",
-    "attachments": "File ricevuti dal fornitore (xlsx, pdf, doc...). Modificabili solo per i preventivi in bozza.",
+    "attachments": "File ricevuti dal fornitore",
     "statusLabel": "Stato:",
     "fieldLockedBySupplierQuote": "Bloccato per preventivo fornitore collegato"
   },

--- a/server/.env.example
+++ b/server/.env.example
@@ -30,6 +30,10 @@ ADMIN_DEFAULT_PASSWORD=password
 # Change this in production! Use a strong random string.
 ENCRYPTION_KEY=praetor-encryption-key-change-in-production
 
+# Filesystem path for uploaded attachments (e.g. supplier quote attachments).
+# Resolved relative to the server working directory; absolute paths are also supported.
+UPLOAD_PATH=./uploads
+
 # Logging
 # LOG_LEVEL supports: trace, debug, info, warn, error, fatal
 LOG_LEVEL=info

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,4 +1,5 @@
 import cors from '@fastify/cors';
+import multipart from '@fastify/multipart';
 import swagger from '@fastify/swagger';
 import dotenv from 'dotenv';
 import Fastify from 'fastify';
@@ -73,6 +74,14 @@ export const buildApp = async () => {
     errorResponseBuilder: () => ({
       error: 'Too many requests',
     }),
+  });
+
+  await fastify.register(multipart, {
+    limits: {
+      fileSize: 10 * 1024 * 1024,
+      files: 1,
+      fields: 0,
+    },
   });
 
   await fastify.register(swagger, {

--- a/server/bun.lock
+++ b/server/bun.lock
@@ -6,6 +6,7 @@
       "name": "praetor-server",
       "dependencies": {
         "@fastify/cors": "^11.2.0",
+        "@fastify/multipart": "^10.0.0",
         "@fastify/swagger": "^9.7.0",
         "bcryptjs": "^3.0.3",
         "dotenv": "^17.4.2",
@@ -92,7 +93,11 @@
 
     "@fastify/ajv-compiler": ["@fastify/ajv-compiler@4.0.5", "", { "dependencies": { "ajv": "^8.12.0", "ajv-formats": "^3.0.1", "fast-uri": "^3.0.0" } }, "sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A=="],
 
+    "@fastify/busboy": ["@fastify/busboy@3.2.0", "", {}, "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA=="],
+
     "@fastify/cors": ["@fastify/cors@11.2.0", "", { "dependencies": { "fastify-plugin": "^5.0.0", "toad-cache": "^3.7.0" } }, "sha512-LbLHBuSAdGdSFZYTLVA3+Ch2t+sA6nq3Ejc6XLAKiQ6ViS2qFnvicpj0htsx03FyYeLs04HfRNBsz/a8SvbcUw=="],
+
+    "@fastify/deepmerge": ["@fastify/deepmerge@3.2.1", "", {}, "sha512-N5Oqvltoa2r9z1tbx4xjky0oRR60v+T47Ic4J1ukoVQcptLOrIdRnCSdTGmOmajZuHVKlTnfcmrjyqsGEW1ztA=="],
 
     "@fastify/error": ["@fastify/error@4.2.0", "", {}, "sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ=="],
 
@@ -101,6 +106,8 @@
     "@fastify/forwarded": ["@fastify/forwarded@3.0.1", "", {}, "sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw=="],
 
     "@fastify/merge-json-schemas": ["@fastify/merge-json-schemas@0.2.1", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A=="],
+
+    "@fastify/multipart": ["@fastify/multipart@10.0.0", "", { "dependencies": { "@fastify/busboy": "^3.0.0", "@fastify/deepmerge": "^3.0.0", "@fastify/error": "^4.0.0", "fastify-plugin": "^5.0.0", "secure-json-parse": "^4.0.0" } }, "sha512-pUx3Z1QStY7E7kwvDTIvB6P+rF5lzP+iqPgZyJyG3yBJVPvQaZxzDHYbQD89rbY0ciXrMOyGi8ezHDVexLvJDA=="],
 
     "@fastify/proxy-addr": ["@fastify/proxy-addr@5.1.0", "", { "dependencies": { "@fastify/forwarded": "^3.0.0", "ipaddr.js": "^2.1.0" } }, "sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw=="],
 

--- a/server/db/migrations/0025_add_supplier_quote_attachments.sql
+++ b/server/db/migrations/0025_add_supplier_quote_attachments.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "supplier_quote_attachments" (
+	"id" varchar(50) PRIMARY KEY NOT NULL,
+	"quote_id" varchar(100) NOT NULL,
+	"file_name" varchar(255) NOT NULL,
+	"stored_name" varchar(255) NOT NULL,
+	"mime_type" varchar(100) NOT NULL,
+	"file_size" integer NOT NULL,
+	"uploaded_by_user_id" varchar(50),
+	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP
+);
+--> statement-breakpoint
+ALTER TABLE "supplier_quote_attachments" ADD CONSTRAINT "supplier_quote_attachments_quote_id_supplier_quotes_id_fk" FOREIGN KEY ("quote_id") REFERENCES "public"."supplier_quotes"("id") ON DELETE cascade ON UPDATE cascade;--> statement-breakpoint
+ALTER TABLE "supplier_quote_attachments" ADD CONSTRAINT "supplier_quote_attachments_uploaded_by_user_id_users_id_fk" FOREIGN KEY ("uploaded_by_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_supplier_quote_attachments_quote_id" ON "supplier_quote_attachments" USING btree ("quote_id");

--- a/server/db/migrations/meta/0025_snapshot.json
+++ b/server/db/migrations/meta/0025_snapshot.json
@@ -1,0 +1,5505 @@
+{
+  "id": "ba006aa1-1b01-4a93-9b34-413968cf0cea",
+  "prevId": "d34d9bbf-3331-4ee4-b2af-16dc385fcb65",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user.login'"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_audit_logs_created_at": {
+          "name": "idx_audit_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_user_id": {
+          "name": "idx_audit_logs_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_action": {
+          "name": "idx_audit_logs_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.client_profile_options": {
+      "name": "client_profile_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_client_profile_options_category_value_unique": {
+          "name": "idx_client_profile_options_category_value_unique",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "LOWER(\"value\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_client_profile_options_category_sort": {
+          "name": "idx_client_profile_options_category_sort",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_client_profile_options_category": {
+          "name": "chk_client_profile_options_category",
+          "value": "\"client_profile_options\".\"category\" IN ('sector', 'numberOfEmployees', 'revenue', 'officeCountRange')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'company'"
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_code": {
+          "name": "client_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ateco_code": {
+          "name": "ateco_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sector": {
+          "name": "sector",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_of_employees": {
+          "name": "number_of_employees",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revenue": {
+          "name": "revenue",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fiscal_code": {
+          "name": "fiscal_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "office_count_range": {
+          "name": "office_count_range",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "address_country": {
+          "name": "address_country",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_state": {
+          "name": "address_state",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_cap": {
+          "name": "address_cap",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_province": {
+          "name": "address_province",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_civic_number": {
+          "name": "address_civic_number",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line": {
+          "name": "address_line",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_clients_fiscal_code_unique": {
+          "name": "idx_clients_fiscal_code_unique",
+          "columns": [
+            {
+              "expression": "LOWER(\"fiscal_code\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"fiscal_code\" IS NOT NULL AND \"clients\".\"fiscal_code\" <> ''",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_clients_client_code_unique": {
+          "name": "idx_clients_client_code_unique",
+          "columns": [
+            {
+              "expression": "client_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"client_code\" IS NOT NULL AND \"clients\".\"client_code\" <> ''",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_clients": {
+      "name": "user_clients",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_source": {
+          "name": "assignment_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_clients_user_id_users_id_fk": {
+          "name": "user_clients_user_id_users_id_fk",
+          "tableFrom": "user_clients",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_clients_client_id_clients_id_fk": {
+          "name": "user_clients_client_id_clients_id_fk",
+          "tableFrom": "user_clients",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_clients_user_id_client_id_pk": {
+          "name": "user_clients_user_id_client_id_pk",
+          "columns": ["user_id", "client_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_clients_assignment_source_check": {
+          "name": "user_clients_assignment_source_check",
+          "value": "\"user_clients\".\"assignment_source\" IN ('manual', 'top_manager_auto', 'project_cascade')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.customer_offer_items": {
+      "name": "customer_offer_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "offer_id": {
+          "name": "offer_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_cost": {
+          "name": "product_cost",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_mol_percentage": {
+          "name": "product_mol_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "unit_type": {
+          "name": "unit_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'hours'"
+        },
+        "supplier_quote_id": {
+          "name": "supplier_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_item_id": {
+          "name": "supplier_quote_item_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_supplier_name": {
+          "name": "supplier_quote_supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_unit_price": {
+          "name": "supplier_quote_unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_customer_offer_items_offer_id": {
+          "name": "idx_customer_offer_items_offer_id",
+          "columns": [
+            {
+              "expression": "offer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_offer_items_offer_id_customer_offers_id_fk": {
+          "name": "customer_offer_items_offer_id_customer_offers_id_fk",
+          "tableFrom": "customer_offer_items",
+          "tableTo": "customer_offers",
+          "columnsFrom": ["offer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "customer_offer_items_product_id_products_id_fk": {
+          "name": "customer_offer_items_product_id_products_id_fk",
+          "tableFrom": "customer_offer_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_customer_offer_items_unit_type": {
+          "name": "chk_customer_offer_items_unit_type",
+          "value": "\"customer_offer_items\".\"unit_type\" IN ('hours', 'days', 'unit')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.customer_offers": {
+      "name": "customer_offers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_quote_id": {
+          "name": "linked_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_customer_offers_linked_quote_id": {
+          "name": "idx_customer_offers_linked_quote_id",
+          "columns": [
+            {
+              "expression": "linked_quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_offers_client_id": {
+          "name": "idx_customer_offers_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_offers_status": {
+          "name": "idx_customer_offers_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_offers_created_at": {
+          "name": "idx_customer_offers_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_offers_linked_quote_id_quotes_id_fk": {
+          "name": "customer_offers_linked_quote_id_quotes_id_fk",
+          "tableFrom": "customer_offers",
+          "tableTo": "quotes",
+          "columnsFrom": ["linked_quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "customer_offers_client_id_clients_id_fk": {
+          "name": "customer_offers_client_id_clients_id_fk",
+          "tableFrom": "customer_offers",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "customer_offers_status_check": {
+          "name": "customer_offers_status_check",
+          "value": "\"customer_offers\".\"status\" IN ('draft', 'sent', 'accepted', 'denied')"
+        },
+        "chk_customer_offers_discount_type": {
+          "name": "chk_customer_offers_discount_type",
+          "value": "\"customer_offers\".\"discount_type\" IN ('percentage', 'currency')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.email_config": {
+      "name": "email_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "smtp_host": {
+          "name": "smtp_host",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "smtp_port": {
+          "name": "smtp_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 587
+        },
+        "smtp_encryption": {
+          "name": "smtp_encryption",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'tls'"
+        },
+        "smtp_reject_unauthorized": {
+          "name": "smtp_reject_unauthorized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "smtp_user": {
+          "name": "smtp_user",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "smtp_password": {
+          "name": "smtp_password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "from_email": {
+          "name": "from_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Praetor'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "email_config_id_check": {
+          "name": "email_config_id_check",
+          "value": "\"email_config\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.general_settings": {
+      "name": "general_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'€'"
+        },
+        "daily_limit": {
+          "name": "daily_limit",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'8.00'"
+        },
+        "start_of_week": {
+          "name": "start_of_week",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Monday'"
+        },
+        "treat_saturday_as_holiday": {
+          "name": "treat_saturday_as_holiday",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "enable_ai_reporting": {
+          "name": "enable_ai_reporting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "gemini_api_key": {
+          "name": "gemini_api_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_provider": {
+          "name": "ai_provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'gemini'"
+        },
+        "openrouter_api_key": {
+          "name": "openrouter_api_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gemini_model_id": {
+          "name": "gemini_model_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "openrouter_model_id": {
+          "name": "openrouter_model_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_weekend_selection": {
+          "name": "allow_weekend_selection",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "default_location": {
+          "name": "default_location",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'remote'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "general_settings_id_check": {
+          "name": "general_settings_id_check",
+          "value": "\"general_settings\".\"id\" = 1"
+        },
+        "general_settings_start_of_week_check": {
+          "name": "general_settings_start_of_week_check",
+          "value": "\"general_settings\".\"start_of_week\" IN ('Monday', 'Sunday')"
+        },
+        "general_settings_ai_provider_check": {
+          "name": "general_settings_ai_provider_check",
+          "value": "\"general_settings\".\"ai_provider\" IN ('gemini', 'openrouter')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invoice_items": {
+      "name": "invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_of_measure": {
+          "name": "unit_of_measure",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unit'"
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_invoice_items_invoice_id": {
+          "name": "idx_invoice_items_invoice_id",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "invoices",
+          "columnsFrom": ["invoice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "invoice_items_product_id_products_id_fk": {
+          "name": "invoice_items_product_id_products_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_sale_id": {
+          "name": "linked_sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_date": {
+          "name": "issue_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "amount_paid": {
+          "name": "amount_paid",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_invoices_client_id": {
+          "name": "idx_invoices_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_status": {
+          "name": "idx_invoices_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_issue_date": {
+          "name": "idx_invoices_issue_date",
+          "columns": [
+            {
+              "expression": "issue_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_linked_sale_id_sales_id_fk": {
+          "name": "invoices_linked_sale_id_sales_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "sales",
+          "columnsFrom": ["linked_sale_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "invoices_client_id_clients_id_fk": {
+          "name": "invoices_client_id_clients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invoices_status_check": {
+          "name": "invoices_status_check",
+          "value": "\"invoices\".\"status\" IN ('draft', 'sent', 'paid', 'overdue', 'cancelled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ldap_config": {
+      "name": "ldap_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "server_url": {
+          "name": "server_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ldap://ldap.example.com:389'"
+        },
+        "base_dn": {
+          "name": "base_dn",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'dc=example,dc=com'"
+        },
+        "bind_dn": {
+          "name": "bind_dn",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'cn=read-only-admin,dc=example,dc=com'"
+        },
+        "bind_password": {
+          "name": "bind_password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "user_filter": {
+          "name": "user_filter",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'(uid={0})'"
+        },
+        "group_base_dn": {
+          "name": "group_base_dn",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ou=groups,dc=example,dc=com'"
+        },
+        "group_filter": {
+          "name": "group_filter",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'(member={0})'"
+        },
+        "role_mappings": {
+          "name": "role_mappings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "tls_ca_certificate": {
+          "name": "tls_ca_certificate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ldap_config_id_check": {
+          "name": "ldap_config_id_check",
+          "value": "\"ldap_config\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_notifications_user_id": {
+          "name": "idx_notifications_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_user_unread": {
+          "name": "idx_notifications_user_unread",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notifications\".\"is_read\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.offer_versions": {
+      "name": "offer_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "offer_id": {
+          "name": "offer_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'update'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_offer_versions_offer_id_created_at": {
+          "name": "idx_offer_versions_offer_id_created_at",
+          "columns": [
+            {
+              "expression": "offer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "offer_versions_offer_id_customer_offers_id_fk": {
+          "name": "offer_versions_offer_id_customer_offers_id_fk",
+          "tableFrom": "offer_versions",
+          "tableTo": "customer_offers",
+          "columnsFrom": ["offer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "offer_versions_created_by_user_id_users_id_fk": {
+          "name": "offer_versions_created_by_user_id_users_id_fk",
+          "tableFrom": "offer_versions",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_offer_versions_reason": {
+          "name": "chk_offer_versions_reason",
+          "value": "\"offer_versions\".\"reason\" IN ('update', 'restore')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_versions": {
+      "name": "order_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'update'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_order_versions_order_id_created_at": {
+          "name": "idx_order_versions_order_id_created_at",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_versions_order_id_sales_id_fk": {
+          "name": "order_versions_order_id_sales_id_fk",
+          "tableFrom": "order_versions",
+          "tableTo": "sales",
+          "columnsFrom": ["order_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "order_versions_created_by_user_id_users_id_fk": {
+          "name": "order_versions_created_by_user_id_users_id_fk",
+          "tableFrom": "order_versions",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_order_versions_reason": {
+          "name": "chk_order_versions_reason",
+          "value": "\"order_versions\".\"reason\" IN ('update', 'restore')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.internal_product_categories": {
+      "name": "internal_product_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_unit": {
+          "name": "cost_unit",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unit'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_internal_product_categories_type": {
+          "name": "idx_internal_product_categories_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "internal_product_categories_name_type_key": {
+          "name": "internal_product_categories_name_type_key",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "internal_product_categories_cost_unit_check": {
+          "name": "internal_product_categories_cost_unit_check",
+          "value": "\"internal_product_categories\".\"cost_unit\" IN ('unit', 'hours')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.internal_product_subcategories": {
+      "name": "internal_product_subcategories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_internal_product_subcategories_category_id": {
+          "name": "idx_internal_product_subcategories_category_id",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "internal_product_subcategories_category_id_name_key": {
+          "name": "internal_product_subcategories_category_id_name_key",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "internal_product_subcategories_category_id_internal_product_categories_id_fk": {
+          "name": "internal_product_subcategories_category_id_internal_product_categories_id_fk",
+          "tableFrom": "internal_product_subcategories",
+          "tableTo": "internal_product_categories",
+          "columnsFrom": ["category_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_code": {
+          "name": "product_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "costo": {
+          "name": "costo",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "mol_percentage": {
+          "name": "mol_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "cost_unit": {
+          "name": "cost_unit",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unit'"
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'item'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subcategory": {
+          "name": "subcategory",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_products_name": {
+          "name": "idx_products_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_name_unique": {
+          "name": "idx_products_name_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_product_code_unique": {
+          "name": "idx_products_product_code_unique",
+          "columns": [
+            {
+              "expression": "product_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_supplier_id": {
+          "name": "idx_products_supplier_id",
+          "columns": [
+            {
+              "expression": "supplier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_type": {
+          "name": "idx_products_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "products_supplier_id_suppliers_id_fk": {
+          "name": "products_supplier_id_suppliers_id_fk",
+          "tableFrom": "products",
+          "tableTo": "suppliers",
+          "columnsFrom": ["supplier_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_types": {
+      "name": "product_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_unit": {
+          "name": "cost_unit",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unit'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_product_types_name": {
+          "name": "idx_product_types_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "product_types_name_unique": {
+          "name": "product_types_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "product_types_cost_unit_check": {
+          "name": "product_types_cost_unit_check",
+          "value": "\"product_types\".\"cost_unit\" IN ('unit', 'hours')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#3b82f6'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_projects_client_id": {
+          "name": "idx_projects_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_client_id_clients_id_fk": {
+          "name": "projects_client_id_clients_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_projects": {
+      "name": "user_projects",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_source": {
+          "name": "assignment_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_projects_user_id_users_id_fk": {
+          "name": "user_projects_user_id_users_id_fk",
+          "tableFrom": "user_projects",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_projects_project_id_projects_id_fk": {
+          "name": "user_projects_project_id_projects_id_fk",
+          "tableFrom": "user_projects",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_projects_user_id_project_id_pk": {
+          "name": "user_projects_user_id_project_id_pk",
+          "columns": ["user_id", "project_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_projects_assignment_source_check": {
+          "name": "user_projects_assignment_source_check",
+          "value": "\"user_projects\".\"assignment_source\" IN ('manual', 'top_manager_auto', 'project_cascade')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.quote_items": {
+      "name": "quote_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_cost": {
+          "name": "product_cost",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_mol_percentage": {
+          "name": "product_mol_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_id": {
+          "name": "supplier_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_item_id": {
+          "name": "supplier_quote_item_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_supplier_name": {
+          "name": "supplier_quote_supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_unit_price": {
+          "name": "supplier_quote_unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_type": {
+          "name": "unit_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'hours'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_quote_items_quote_id": {
+          "name": "idx_quote_items_quote_id",
+          "columns": [
+            {
+              "expression": "quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quote_items_quote_id_quotes_id_fk": {
+          "name": "quote_items_quote_id_quotes_id_fk",
+          "tableFrom": "quote_items",
+          "tableTo": "quotes",
+          "columnsFrom": ["quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "quote_items_product_id_products_id_fk": {
+          "name": "quote_items_product_id_products_id_fk",
+          "tableFrom": "quote_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_quote_items_unit_type": {
+          "name": "chk_quote_items_unit_type",
+          "value": "\"quote_items\".\"unit_type\" IN ('hours', 'days', 'unit')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.quotes": {
+      "name": "quotes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_quotes_client_id": {
+          "name": "idx_quotes_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quotes_status": {
+          "name": "idx_quotes_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quotes_created_at": {
+          "name": "idx_quotes_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quotes_client_id_clients_id_fk": {
+          "name": "quotes_client_id_clients_id_fk",
+          "tableFrom": "quotes",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "quotes_status_check": {
+          "name": "quotes_status_check",
+          "value": "\"quotes\".\"status\" IN ('quoted', 'confirmed', 'draft', 'sent', 'accepted', 'denied')"
+        },
+        "chk_quotes_discount_type": {
+          "name": "chk_quotes_discount_type",
+          "value": "\"quotes\".\"discount_type\" IN ('percentage', 'currency')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.quote_versions": {
+      "name": "quote_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'update'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_quote_versions_quote_id_created_at": {
+          "name": "idx_quote_versions_quote_id_created_at",
+          "columns": [
+            {
+              "expression": "quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quote_versions_quote_id_quotes_id_fk": {
+          "name": "quote_versions_quote_id_quotes_id_fk",
+          "tableFrom": "quote_versions",
+          "tableTo": "quotes",
+          "columnsFrom": ["quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "quote_versions_created_by_user_id_users_id_fk": {
+          "name": "quote_versions_created_by_user_id_users_id_fk",
+          "tableFrom": "quote_versions",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_quote_versions_reason": {
+          "name": "chk_quote_versions_reason",
+          "value": "\"quote_versions\".\"reason\" IN ('update', 'restore')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.report_chat_messages": {
+      "name": "report_chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thought_content": {
+          "name": "thought_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_report_chat_messages_session_created": {
+          "name": "idx_report_chat_messages_session_created",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_chat_messages_session_id_report_chat_sessions_id_fk": {
+          "name": "report_chat_messages_session_id_report_chat_sessions_id_fk",
+          "tableFrom": "report_chat_messages",
+          "tableTo": "report_chat_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "report_chat_messages_role_check": {
+          "name": "report_chat_messages_role_check",
+          "value": "\"report_chat_messages\".\"role\" IN ('user', 'assistant')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.report_chat_sessions": {
+      "name": "report_chat_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'AI Reporting'"
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_report_chat_sessions_user_updated": {
+          "name": "idx_report_chat_sessions_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_report_chat_sessions_user_archived": {
+          "name": "idx_report_chat_sessions_user_archived",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_chat_sessions_user_id_users_id_fk": {
+          "name": "report_chat_sessions_user_id_users_id_fk",
+          "tableFrom": "report_chat_sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_permissions": {
+      "name": "role_permissions",
+      "schema": "",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_permissions_role_id_roles_id_fk": {
+          "name": "role_permissions_role_id_roles_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "roles",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "role_permissions_role_id_permission_pk": {
+          "name": "role_permissions_role_id_permission_pk",
+          "columns": ["role_id", "permission"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roles": {
+      "name": "roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_roles": {
+      "name": "user_roles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_roles_user_id_users_id_fk": {
+          "name": "user_roles_user_id_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_role_id_roles_id_fk": {
+          "name": "user_roles_role_id_roles_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "roles",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_roles_user_id_role_id_pk": {
+          "name": "user_roles_user_id_role_id_pk",
+          "columns": ["user_id", "role_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sale_items": {
+      "name": "sale_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sale_id": {
+          "name": "sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_cost": {
+          "name": "product_cost",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_mol_percentage": {
+          "name": "product_mol_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "unit_type": {
+          "name": "unit_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'hours'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_id": {
+          "name": "supplier_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_item_id": {
+          "name": "supplier_quote_item_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_supplier_name": {
+          "name": "supplier_quote_supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_unit_price": {
+          "name": "supplier_quote_unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_sale_id": {
+          "name": "supplier_sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_sale_item_id": {
+          "name": "supplier_sale_item_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_sale_supplier_name": {
+          "name": "supplier_sale_supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_sale_items_sale_id": {
+          "name": "idx_sale_items_sale_id",
+          "columns": [
+            {
+              "expression": "sale_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sale_items_supplier_sale_id": {
+          "name": "idx_sale_items_supplier_sale_id",
+          "columns": [
+            {
+              "expression": "supplier_sale_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sale_items_sale_id_sales_id_fk": {
+          "name": "sale_items_sale_id_sales_id_fk",
+          "tableFrom": "sale_items",
+          "tableTo": "sales",
+          "columnsFrom": ["sale_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "sale_items_product_id_products_id_fk": {
+          "name": "sale_items_product_id_products_id_fk",
+          "tableFrom": "sale_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_sale_items_unit_type": {
+          "name": "chk_sale_items_unit_type",
+          "value": "\"sale_items\".\"unit_type\" IN ('hours', 'days', 'unit')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sales": {
+      "name": "sales",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_quote_id": {
+          "name": "linked_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_offer_id": {
+          "name": "linked_offer_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_sales_client_id": {
+          "name": "idx_sales_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_status": {
+          "name": "idx_sales_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_linked_quote_id": {
+          "name": "idx_sales_linked_quote_id",
+          "columns": [
+            {
+              "expression": "linked_quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_linked_offer_id": {
+          "name": "idx_sales_linked_offer_id",
+          "columns": [
+            {
+              "expression": "linked_offer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_linked_offer_id_unique": {
+          "name": "idx_sales_linked_offer_id_unique",
+          "columns": [
+            {
+              "expression": "linked_offer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sales\".\"linked_offer_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_created_at": {
+          "name": "idx_sales_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sales_linked_quote_id_quotes_id_fk": {
+          "name": "sales_linked_quote_id_quotes_id_fk",
+          "tableFrom": "sales",
+          "tableTo": "quotes",
+          "columnsFrom": ["linked_quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "sales_linked_offer_id_customer_offers_id_fk": {
+          "name": "sales_linked_offer_id_customer_offers_id_fk",
+          "tableFrom": "sales",
+          "tableTo": "customer_offers",
+          "columnsFrom": ["linked_offer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "sales_client_id_clients_id_fk": {
+          "name": "sales_client_id_clients_id_fk",
+          "tableFrom": "sales",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sales_status_check": {
+          "name": "sales_status_check",
+          "value": "\"sales\".\"status\" IN ('draft', 'confirmed', 'denied')"
+        },
+        "chk_sales_discount_type": {
+          "name": "chk_sales_discount_type",
+          "value": "\"sales\".\"discount_type\" IN ('percentage', 'currency')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "daily_goal": {
+          "name": "daily_goal",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'8.00'"
+        },
+        "start_of_week": {
+          "name": "start_of_week",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Monday'"
+        },
+        "compact_view": {
+          "name": "compact_view",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "treat_saturday_as_holiday": {
+          "name": "treat_saturday_as_holiday",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "settings_user_id_users_id_fk": {
+          "name": "settings_user_id_users_id_fk",
+          "tableFrom": "settings",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "settings_user_id_unique": {
+          "name": "settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "settings_language_check": {
+          "name": "settings_language_check",
+          "value": "\"settings\".\"language\" IN ('en', 'it', 'auto')"
+        },
+        "settings_start_of_week_check": {
+          "name": "settings_start_of_week_check",
+          "value": "\"settings\".\"start_of_week\" IN ('Monday', 'Sunday')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier_invoice_items": {
+      "name": "supplier_invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_invoice_items_invoice_id": {
+          "name": "idx_supplier_invoice_items_invoice_id",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_invoice_items_invoice_id_supplier_invoices_id_fk": {
+          "name": "supplier_invoice_items_invoice_id_supplier_invoices_id_fk",
+          "tableFrom": "supplier_invoice_items",
+          "tableTo": "supplier_invoices",
+          "columnsFrom": ["invoice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "supplier_invoice_items_product_id_products_id_fk": {
+          "name": "supplier_invoice_items_product_id_products_id_fk",
+          "tableFrom": "supplier_invoice_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_invoices": {
+      "name": "supplier_invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_sale_id": {
+          "name": "linked_sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_name": {
+          "name": "supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_date": {
+          "name": "issue_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "amount_paid": {
+          "name": "amount_paid",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_invoices_supplier_id": {
+          "name": "idx_supplier_invoices_supplier_id",
+          "columns": [
+            {
+              "expression": "supplier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_invoices_status": {
+          "name": "idx_supplier_invoices_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_invoices_issue_date": {
+          "name": "idx_supplier_invoices_issue_date",
+          "columns": [
+            {
+              "expression": "issue_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_invoices_linked_sale_id": {
+          "name": "idx_supplier_invoices_linked_sale_id",
+          "columns": [
+            {
+              "expression": "linked_sale_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_invoices_linked_sale_id_unique": {
+          "name": "idx_supplier_invoices_linked_sale_id_unique",
+          "columns": [
+            {
+              "expression": "linked_sale_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"supplier_invoices\".\"linked_sale_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_invoices_linked_sale_id_supplier_sales_id_fk": {
+          "name": "supplier_invoices_linked_sale_id_supplier_sales_id_fk",
+          "tableFrom": "supplier_invoices",
+          "tableTo": "supplier_sales",
+          "columnsFrom": ["linked_sale_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "supplier_invoices_supplier_id_suppliers_id_fk": {
+          "name": "supplier_invoices_supplier_id_suppliers_id_fk",
+          "tableFrom": "supplier_invoices",
+          "tableTo": "suppliers",
+          "columnsFrom": ["supplier_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "supplier_invoices_status_check": {
+          "name": "supplier_invoices_status_check",
+          "value": "\"supplier_invoices\".\"status\" IN ('draft', 'sent', 'paid', 'overdue', 'cancelled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier_order_versions": {
+      "name": "supplier_order_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'update'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_order_versions_order_id_created_at": {
+          "name": "idx_supplier_order_versions_order_id_created_at",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_order_versions_order_id_supplier_sales_id_fk": {
+          "name": "supplier_order_versions_order_id_supplier_sales_id_fk",
+          "tableFrom": "supplier_order_versions",
+          "tableTo": "supplier_sales",
+          "columnsFrom": ["order_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "supplier_order_versions_created_by_user_id_users_id_fk": {
+          "name": "supplier_order_versions_created_by_user_id_users_id_fk",
+          "tableFrom": "supplier_order_versions",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_supplier_order_versions_reason": {
+          "name": "chk_supplier_order_versions_reason",
+          "value": "\"supplier_order_versions\".\"reason\" IN ('update', 'restore')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier_quote_attachments": {
+      "name": "supplier_quote_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stored_name": {
+          "name": "stored_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by_user_id": {
+          "name": "uploaded_by_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_quote_attachments_quote_id": {
+          "name": "idx_supplier_quote_attachments_quote_id",
+          "columns": [
+            {
+              "expression": "quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_quote_attachments_quote_id_supplier_quotes_id_fk": {
+          "name": "supplier_quote_attachments_quote_id_supplier_quotes_id_fk",
+          "tableFrom": "supplier_quote_attachments",
+          "tableTo": "supplier_quotes",
+          "columnsFrom": ["quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "supplier_quote_attachments_uploaded_by_user_id_users_id_fk": {
+          "name": "supplier_quote_attachments_uploaded_by_user_id_users_id_fk",
+          "tableFrom": "supplier_quote_attachments",
+          "tableTo": "users",
+          "columnsFrom": ["uploaded_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_quote_items": {
+      "name": "supplier_quote_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "unit_type": {
+          "name": "unit_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'hours'"
+        }
+      },
+      "indexes": {
+        "idx_supplier_quote_items_quote_id": {
+          "name": "idx_supplier_quote_items_quote_id",
+          "columns": [
+            {
+              "expression": "quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_quote_items_quote_id_supplier_quotes_id_fk": {
+          "name": "supplier_quote_items_quote_id_supplier_quotes_id_fk",
+          "tableFrom": "supplier_quote_items",
+          "tableTo": "supplier_quotes",
+          "columnsFrom": ["quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "supplier_quote_items_product_id_products_id_fk": {
+          "name": "supplier_quote_items_product_id_products_id_fk",
+          "tableFrom": "supplier_quote_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_supplier_quote_items_unit_type": {
+          "name": "chk_supplier_quote_items_unit_type",
+          "value": "\"supplier_quote_items\".\"unit_type\" IN ('hours', 'days', 'unit')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier_quotes": {
+      "name": "supplier_quotes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_name": {
+          "name": "supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_quotes_supplier_id": {
+          "name": "idx_supplier_quotes_supplier_id",
+          "columns": [
+            {
+              "expression": "supplier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_quotes_status": {
+          "name": "idx_supplier_quotes_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_quotes_created_at": {
+          "name": "idx_supplier_quotes_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_quotes_supplier_id_suppliers_id_fk": {
+          "name": "supplier_quotes_supplier_id_suppliers_id_fk",
+          "tableFrom": "supplier_quotes",
+          "tableTo": "suppliers",
+          "columnsFrom": ["supplier_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "supplier_quotes_status_check": {
+          "name": "supplier_quotes_status_check",
+          "value": "\"supplier_quotes\".\"status\" IN ('received', 'approved', 'rejected', 'draft', 'sent', 'accepted', 'denied')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier_quote_versions": {
+      "name": "supplier_quote_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'update'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_quote_versions_quote_id_created_at": {
+          "name": "idx_supplier_quote_versions_quote_id_created_at",
+          "columns": [
+            {
+              "expression": "quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_quote_versions_quote_id_supplier_quotes_id_fk": {
+          "name": "supplier_quote_versions_quote_id_supplier_quotes_id_fk",
+          "tableFrom": "supplier_quote_versions",
+          "tableTo": "supplier_quotes",
+          "columnsFrom": ["quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "supplier_quote_versions_created_by_user_id_users_id_fk": {
+          "name": "supplier_quote_versions_created_by_user_id_users_id_fk",
+          "tableFrom": "supplier_quote_versions",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_supplier_quote_versions_reason": {
+          "name": "chk_supplier_quote_versions_reason",
+          "value": "\"supplier_quote_versions\".\"reason\" IN ('update', 'restore')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier_sale_items": {
+      "name": "supplier_sale_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sale_id": {
+          "name": "sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_sale_items_sale_id": {
+          "name": "idx_supplier_sale_items_sale_id",
+          "columns": [
+            {
+              "expression": "sale_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_sale_items_sale_id_supplier_sales_id_fk": {
+          "name": "supplier_sale_items_sale_id_supplier_sales_id_fk",
+          "tableFrom": "supplier_sale_items",
+          "tableTo": "supplier_sales",
+          "columnsFrom": ["sale_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "supplier_sale_items_product_id_products_id_fk": {
+          "name": "supplier_sale_items_product_id_products_id_fk",
+          "tableFrom": "supplier_sale_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_sales": {
+      "name": "supplier_sales",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_quote_id": {
+          "name": "linked_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_name": {
+          "name": "supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_sales_supplier_id": {
+          "name": "idx_supplier_sales_supplier_id",
+          "columns": [
+            {
+              "expression": "supplier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_sales_status": {
+          "name": "idx_supplier_sales_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_sales_linked_quote_id": {
+          "name": "idx_supplier_sales_linked_quote_id",
+          "columns": [
+            {
+              "expression": "linked_quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_sales_linked_quote_id_supplier_quotes_id_fk": {
+          "name": "supplier_sales_linked_quote_id_supplier_quotes_id_fk",
+          "tableFrom": "supplier_sales",
+          "tableTo": "supplier_quotes",
+          "columnsFrom": ["linked_quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "supplier_sales_supplier_id_suppliers_id_fk": {
+          "name": "supplier_sales_supplier_id_suppliers_id_fk",
+          "tableFrom": "supplier_sales",
+          "tableTo": "suppliers",
+          "columnsFrom": ["supplier_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "supplier_sales_status_check": {
+          "name": "supplier_sales_status_check",
+          "value": "\"supplier_sales\".\"status\" IN ('draft', 'sent')"
+        },
+        "chk_supplier_sales_discount_type": {
+          "name": "chk_supplier_sales_discount_type",
+          "value": "\"supplier_sales\".\"discount_type\" IN ('percentage', 'currency')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.suppliers": {
+      "name": "suppliers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "supplier_code": {
+          "name": "supplier_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_code": {
+          "name": "tax_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_suppliers_name": {
+          "name": "idx_suppliers_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "recurrence_pattern": {
+          "name": "recurrence_pattern",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_start": {
+          "name": "recurrence_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_end": {
+          "name": "recurrence_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_duration": {
+          "name": "recurrence_duration",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "expected_effort": {
+          "name": "expected_effort",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "revenue": {
+          "name": "revenue",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tasks_project_id_projects_id_fk": {
+          "name": "tasks_project_id_projects_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_tasks": {
+      "name": "user_tasks",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_source": {
+          "name": "assignment_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_tasks_user_id_users_id_fk": {
+          "name": "user_tasks_user_id_users_id_fk",
+          "tableFrom": "user_tasks",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_tasks_task_id_tasks_id_fk": {
+          "name": "user_tasks_task_id_tasks_id_fk",
+          "tableFrom": "user_tasks",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_tasks_user_id_task_id_pk": {
+          "name": "user_tasks_user_id_task_id_pk",
+          "columns": ["user_id", "task_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_tasks_assignment_source_check": {
+          "name": "user_tasks_assignment_source_check",
+          "value": "\"user_tasks\".\"assignment_source\" IN ('manual', 'top_manager_auto', 'project_cascade')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.time_entries": {
+      "name": "time_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_name": {
+          "name": "project_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task": {
+          "name": "task",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "hourly_cost": {
+          "name": "hourly_cost",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "is_placeholder": {
+          "name": "is_placeholder",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'remote'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_time_entries_user_id": {
+          "name": "idx_time_entries_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_time_entries_date": {
+          "name": "idx_time_entries_date",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_time_entries_project_id": {
+          "name": "idx_time_entries_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_time_entries_task_id": {
+          "name": "idx_time_entries_task_id",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_time_entries_created_at_id": {
+          "name": "idx_time_entries_created_at_id",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_time_entries_user_id_created_at_id": {
+          "name": "idx_time_entries_user_id_created_at_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "time_entries_user_id_users_id_fk": {
+          "name": "time_entries_user_id_users_id_fk",
+          "tableFrom": "time_entries",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "time_entries_client_id_clients_id_fk": {
+          "name": "time_entries_client_id_clients_id_fk",
+          "tableFrom": "time_entries",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "time_entries_project_id_projects_id_fk": {
+          "name": "time_entries_project_id_projects_id_fk",
+          "tableFrom": "time_entries",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "time_entries_task_id_tasks_id_fk": {
+          "name": "time_entries_task_id_tasks_id_fk",
+          "tableFrom": "time_entries",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "time_entries_location_check": {
+          "name": "time_entries_location_check",
+          "value": "\"time_entries\".\"location\" IN ('remote', 'office', 'customer_premise', 'transfer')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_initials": {
+          "name": "avatar_initials",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_per_hour": {
+          "name": "cost_per_hour",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "employee_type": {
+          "name": "employee_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'app_user'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_role_roles_id_fk": {
+          "name": "users_role_roles_id_fk",
+          "tableFrom": "users",
+          "tableTo": "roles",
+          "columnsFrom": ["role"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": ["username"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_employee_type_check": {
+          "name": "users_employee_type_check",
+          "value": "\"users\".\"employee_type\" IN ('app_user', 'internal', 'external')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_work_units": {
+      "name": "user_work_units",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "work_unit_id": {
+          "name": "work_unit_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_work_units_user_id_users_id_fk": {
+          "name": "user_work_units_user_id_users_id_fk",
+          "tableFrom": "user_work_units",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_work_units_work_unit_id_work_units_id_fk": {
+          "name": "user_work_units_work_unit_id_work_units_id_fk",
+          "tableFrom": "user_work_units",
+          "tableTo": "work_units",
+          "columnsFrom": ["work_unit_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_work_units_user_id_work_unit_id_pk": {
+          "name": "user_work_units_user_id_work_unit_id_pk",
+          "columns": ["user_id", "work_unit_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.work_unit_managers": {
+      "name": "work_unit_managers",
+      "schema": "",
+      "columns": {
+        "work_unit_id": {
+          "name": "work_unit_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "work_unit_managers_work_unit_id_work_units_id_fk": {
+          "name": "work_unit_managers_work_unit_id_work_units_id_fk",
+          "tableFrom": "work_unit_managers",
+          "tableTo": "work_units",
+          "columnsFrom": ["work_unit_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "work_unit_managers_user_id_users_id_fk": {
+          "name": "work_unit_managers_user_id_users_id_fk",
+          "tableFrom": "work_unit_managers",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "work_unit_managers_work_unit_id_user_id_pk": {
+          "name": "work_unit_managers_work_unit_id_user_id_pk",
+          "columns": ["work_unit_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.work_units": {
+      "name": "work_units",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1778106233320,
       "tag": "0024_add_ldap_ca_certificate",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1778196941020,
+      "tag": "0025_add_supplier_quote_attachments",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/schema/index.ts
+++ b/server/db/schema/index.ts
@@ -24,6 +24,7 @@ export * from './sales.ts';
 export * from './settings.ts';
 export * from './supplierInvoices.ts';
 export * from './supplierOrderVersions.ts';
+export * from './supplierQuoteAttachments.ts';
 export * from './supplierQuotes.ts';
 export * from './supplierQuoteVersions.ts';
 export * from './supplierSales.ts';

--- a/server/db/schema/supplierQuoteAttachments.ts
+++ b/server/db/schema/supplierQuoteAttachments.ts
@@ -1,0 +1,23 @@
+import { sql } from 'drizzle-orm';
+import { index, integer, pgTable, timestamp, varchar } from 'drizzle-orm/pg-core';
+import { supplierQuotes } from './supplierQuotes.ts';
+import { users } from './users.ts';
+
+export const supplierQuoteAttachments = pgTable(
+  'supplier_quote_attachments',
+  {
+    id: varchar('id', { length: 50 }).primaryKey(),
+    quoteId: varchar('quote_id', { length: 100 })
+      .notNull()
+      .references(() => supplierQuotes.id, { onDelete: 'cascade', onUpdate: 'cascade' }),
+    fileName: varchar('file_name', { length: 255 }).notNull(),
+    storedName: varchar('stored_name', { length: 255 }).notNull(),
+    mimeType: varchar('mime_type', { length: 100 }).notNull(),
+    fileSize: integer('file_size').notNull(),
+    uploadedByUserId: varchar('uploaded_by_user_id', { length: 50 }).references(() => users.id, {
+      onDelete: 'set null',
+    }),
+    createdAt: timestamp('created_at').default(sql`CURRENT_TIMESTAMP`),
+  },
+  (table) => [index('idx_supplier_quote_attachments_quote_id').on(table.quoteId)],
+);

--- a/server/package.json
+++ b/server/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@fastify/cors": "^11.2.0",
+    "@fastify/multipart": "^10.0.0",
     "@fastify/swagger": "^9.7.0",
     "bcryptjs": "^3.0.3",
     "dotenv": "^17.4.2",

--- a/server/repositories/supplierQuoteAttachmentsRepo.ts
+++ b/server/repositories/supplierQuoteAttachmentsRepo.ts
@@ -1,4 +1,4 @@
-import { desc, eq } from 'drizzle-orm';
+import { and, desc, eq } from 'drizzle-orm';
 import { type DbExecutor, db } from '../db/drizzle.ts';
 import { supplierQuoteAttachments } from '../db/schema/supplierQuoteAttachments.ts';
 
@@ -77,13 +77,21 @@ export const insert = async (
   return mapRow(row);
 };
 
+// Scoped on BOTH attachmentId and quoteId so an attachment-id from another quote can't be
+// deleted via the wrong route — same defense-in-depth pattern as `supplierQuoteVersionsRepo.findById`.
 export const deleteById = async (
   attachmentId: string,
+  quoteId: string,
   exec: DbExecutor = db,
 ): Promise<SupplierQuoteAttachment | null> => {
   const rows = await exec
     .delete(supplierQuoteAttachments)
-    .where(eq(supplierQuoteAttachments.id, attachmentId))
+    .where(
+      and(
+        eq(supplierQuoteAttachments.id, attachmentId),
+        eq(supplierQuoteAttachments.quoteId, quoteId),
+      ),
+    )
     .returning();
   return rows[0] ? mapRow(rows[0]) : null;
 };

--- a/server/repositories/supplierQuoteAttachmentsRepo.ts
+++ b/server/repositories/supplierQuoteAttachmentsRepo.ts
@@ -1,0 +1,89 @@
+import { desc, eq } from 'drizzle-orm';
+import { type DbExecutor, db } from '../db/drizzle.ts';
+import { supplierQuoteAttachments } from '../db/schema/supplierQuoteAttachments.ts';
+
+export type SupplierQuoteAttachment = {
+  id: string;
+  quoteId: string;
+  fileName: string;
+  storedName: string;
+  mimeType: string;
+  fileSize: number;
+  uploadedByUserId: string | null;
+  createdAt: number;
+};
+
+const mapRow = (row: typeof supplierQuoteAttachments.$inferSelect): SupplierQuoteAttachment => ({
+  id: row.id,
+  quoteId: row.quoteId,
+  fileName: row.fileName,
+  storedName: row.storedName,
+  mimeType: row.mimeType,
+  fileSize: row.fileSize,
+  uploadedByUserId: row.uploadedByUserId,
+  createdAt: row.createdAt?.getTime() ?? 0,
+});
+
+export const listForQuote = async (
+  quoteId: string,
+  exec: DbExecutor = db,
+): Promise<SupplierQuoteAttachment[]> => {
+  const rows = await exec
+    .select()
+    .from(supplierQuoteAttachments)
+    .where(eq(supplierQuoteAttachments.quoteId, quoteId))
+    .orderBy(desc(supplierQuoteAttachments.createdAt));
+  return rows.map(mapRow);
+};
+
+export const findById = async (
+  attachmentId: string,
+  exec: DbExecutor = db,
+): Promise<SupplierQuoteAttachment | null> => {
+  const rows = await exec
+    .select()
+    .from(supplierQuoteAttachments)
+    .where(eq(supplierQuoteAttachments.id, attachmentId))
+    .limit(1);
+  return rows[0] ? mapRow(rows[0]) : null;
+};
+
+export type NewSupplierQuoteAttachment = {
+  id: string;
+  quoteId: string;
+  fileName: string;
+  storedName: string;
+  mimeType: string;
+  fileSize: number;
+  uploadedByUserId: string | null;
+};
+
+export const insert = async (
+  input: NewSupplierQuoteAttachment,
+  exec: DbExecutor = db,
+): Promise<SupplierQuoteAttachment> => {
+  const [row] = await exec
+    .insert(supplierQuoteAttachments)
+    .values({
+      id: input.id,
+      quoteId: input.quoteId,
+      fileName: input.fileName,
+      storedName: input.storedName,
+      mimeType: input.mimeType,
+      fileSize: input.fileSize,
+      uploadedByUserId: input.uploadedByUserId,
+    })
+    .returning();
+  return mapRow(row);
+};
+
+export const deleteById = async (
+  attachmentId: string,
+  exec: DbExecutor = db,
+): Promise<SupplierQuoteAttachment | null> => {
+  const rows = await exec
+    .delete(supplierQuoteAttachments)
+    .where(eq(supplierQuoteAttachments.id, attachmentId))
+    .returning();
+  return rows[0] ? mapRow(rows[0]) : null;
+};

--- a/server/routes/supplier-quotes.ts
+++ b/server/routes/supplier-quotes.ts
@@ -969,8 +969,14 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       // RFC 6266: provide an ASCII-safe `filename` for legacy clients plus an RFC 5987
       // `filename*` with UTF-8 encoding for Unicode filenames. Strip CR/LF/quote/backslash
       // from the legacy form to prevent header injection through user-controlled filenames.
+      // `encodeURIComponent` already emits valid `%XX%XX` UTF-8 byte pairs; we only need to
+      // additionally encode `'`, `(`, `)` per RFC 5987 (the legacy global `escape()` would
+      // emit invalid `%uXXXX` for non-BMP codepoints, hence explicit replacements here).
       const asciiFallback = attachment.fileName.replace(/[\r\n"\\]/g, '');
-      const utf8EncodedName = encodeURIComponent(attachment.fileName).replace(/['()]/g, escape);
+      const utf8EncodedName = encodeURIComponent(attachment.fileName)
+        .replace(/'/g, '%27')
+        .replace(/\(/g, '%28')
+        .replace(/\)/g, '%29');
       reply.header('Content-Type', attachment.mimeType || 'application/octet-stream');
       reply.header('Content-Length', String(opened.size));
       reply.header(

--- a/server/routes/supplier-quotes.ts
+++ b/server/routes/supplier-quotes.ts
@@ -2,13 +2,22 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { type DbExecutor, withDbTransaction } from '../db/drizzle.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
 import * as productsRepo from '../repositories/productsRepo.ts';
+import * as supplierQuoteAttachmentsRepo from '../repositories/supplierQuoteAttachmentsRepo.ts';
 import * as supplierQuotesRepo from '../repositories/supplierQuotesRepo.ts';
 import * as supplierQuoteVersionsRepo from '../repositories/supplierQuoteVersionsRepo.ts';
 import * as suppliersRepo from '../repositories/suppliersRepo.ts';
 import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
 import { logAudit } from '../utils/audit.ts';
 import { getUniqueViolation } from '../utils/db-errors.ts';
-import { generateItemId } from '../utils/order-ids.ts';
+import {
+  ATTACHMENT_MAX_BYTES,
+  deleteSupplierQuoteAttachment,
+  isAllowedAttachment,
+  openSupplierQuoteAttachment,
+  saveSupplierQuoteAttachment,
+} from '../utils/fileStorage.ts';
+import { createChildLogger } from '../utils/logger.ts';
+import { generateItemId, generatePrefixedId } from '../utils/order-ids.ts';
 import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
@@ -713,6 +722,307 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
     },
   );
 
+  // ---------------------------------------------------------------------------------------
+  // Attachments
+  // ---------------------------------------------------------------------------------------
+
+  const attachmentsLogger = createChildLogger({ module: 'supplier-quote-attachments' });
+
+  const attachmentParamSchema = {
+    type: 'object',
+    properties: {
+      id: { type: 'string' },
+      attachmentId: { type: 'string' },
+    },
+    required: ['id', 'attachmentId'],
+  } as const;
+
+  const supplierQuoteAttachmentSchema = {
+    type: 'object',
+    properties: {
+      id: { type: 'string' },
+      quoteId: { type: 'string' },
+      fileName: { type: 'string' },
+      mimeType: { type: 'string' },
+      fileSize: { type: 'number' },
+      uploadedByUserId: { type: ['string', 'null'] },
+      createdAt: { type: 'number' },
+    },
+    required: ['id', 'quoteId', 'fileName', 'mimeType', 'fileSize', 'createdAt'],
+  } as const;
+
+  const projectAttachment = (attachment: supplierQuoteAttachmentsRepo.SupplierQuoteAttachment) => ({
+    id: attachment.id,
+    quoteId: attachment.quoteId,
+    fileName: attachment.fileName,
+    mimeType: attachment.mimeType,
+    fileSize: attachment.fileSize,
+    uploadedByUserId: attachment.uploadedByUserId,
+    createdAt: attachment.createdAt,
+  });
+
+  // Mutation guard mirrors the existing supplier-quote edit rules: only `draft` quotes that
+  // are not yet linked to an order may be modified. Returns the quote on success, or sends
+  // the appropriate error response and returns null.
+  const assertQuoteEditableForAttachments = async (
+    id: string,
+    reply: FastifyReply,
+  ): Promise<supplierQuotesRepo.SupplierQuote | null> => {
+    const quote = await supplierQuotesRepo.findById(id);
+    if (!quote) {
+      reply.code(404).send({ error: 'Supplier quote not found' });
+      return null;
+    }
+    const status = normalizeSupplierQuoteStatus(quote.status);
+    if (status !== 'draft') {
+      reply.code(409).send({ error: 'Attachments can only be modified on draft supplier quotes' });
+      return null;
+    }
+    const linkedOrderId = await supplierQuotesRepo.findLinkedOrderId(id);
+    if (linkedOrderId) {
+      reply.code(409).send({ error: 'Quotes become read-only once an order exists' });
+      return null;
+    }
+    return quote;
+  };
+
+  fastify.get(
+    '/:id/attachments',
+    {
+      onRequest: [
+        fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
+        requirePermission('sales.supplier_quotes.view'),
+      ],
+      schema: {
+        tags: ['supplier-quotes'],
+        summary: 'List attachments for a supplier quote',
+        params: idParamSchema,
+        response: {
+          200: { type: 'array', items: supplierQuoteAttachmentSchema },
+          ...standardRateLimitedErrorResponses,
+        },
+      },
+    },
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      const { id } = request.params as { id: string };
+      const idResult = requireNonEmptyString(id, 'id');
+      if (!idResult.ok) return badRequest(reply, idResult.message);
+
+      const exists = await supplierQuotesRepo.existsById(idResult.value);
+      if (!exists) {
+        return reply.code(404).send({ error: 'Supplier quote not found' });
+      }
+      const attachments = await supplierQuoteAttachmentsRepo.listForQuote(idResult.value);
+      return attachments.map(projectAttachment);
+    },
+  );
+
+  fastify.post(
+    '/:id/attachments',
+    {
+      onRequest: [requirePermission('sales.supplier_quotes.update')],
+      schema: {
+        tags: ['supplier-quotes'],
+        summary: 'Upload an attachment to a supplier quote',
+        params: idParamSchema,
+        consumes: ['multipart/form-data'],
+        response: {
+          201: supplierQuoteAttachmentSchema,
+          ...standardErrorResponses,
+          413: { type: 'object', properties: { error: { type: 'string' } }, required: ['error'] },
+          415: { type: 'object', properties: { error: { type: 'string' } }, required: ['error'] },
+        },
+      },
+    },
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      const { id } = request.params as { id: string };
+      const idResult = requireNonEmptyString(id, 'id');
+      if (!idResult.ok) return badRequest(reply, idResult.message);
+
+      if (!request.isMultipart()) {
+        return reply.code(400).send({ error: 'Request must be multipart/form-data' });
+      }
+
+      const quote = await assertQuoteEditableForAttachments(idResult.value, reply);
+      if (!quote) return;
+
+      let uploaded: { storedName: string; size: number } | null = null;
+      try {
+        const part = await request.file();
+        if (!part) {
+          return reply.code(400).send({ error: 'A file is required' });
+        }
+
+        const originalName = part.filename?.trim();
+        if (!originalName) {
+          return reply.code(400).send({ error: 'Uploaded file is missing a filename' });
+        }
+
+        const mimeType = part.mimetype || 'application/octet-stream';
+        if (!isAllowedAttachment(mimeType, originalName)) {
+          return reply
+            .code(415)
+            .send({ error: 'File type not allowed. Use xlsx, xls, csv, pdf, doc, or docx.' });
+        }
+
+        let buffer: Buffer;
+        try {
+          buffer = await part.toBuffer();
+        } catch (err) {
+          if ((err as { code?: string }).code === 'FST_REQ_FILE_TOO_LARGE') {
+            return reply.code(413).send({ error: 'File exceeds the 10 MB upload limit' });
+          }
+          throw err;
+        }
+
+        if (buffer.byteLength > ATTACHMENT_MAX_BYTES) {
+          return reply.code(413).send({ error: 'File exceeds the 10 MB upload limit' });
+        }
+        if (buffer.byteLength === 0) {
+          return reply.code(400).send({ error: 'Uploaded file is empty' });
+        }
+
+        uploaded = await saveSupplierQuoteAttachment(buffer, originalName);
+
+        const attachment = await supplierQuoteAttachmentsRepo.insert({
+          id: generatePrefixedId('sqa'),
+          quoteId: idResult.value,
+          fileName: originalName,
+          storedName: uploaded.storedName,
+          mimeType,
+          fileSize: uploaded.size,
+          uploadedByUserId: request.user?.id ?? null,
+        });
+
+        await logAudit({
+          request,
+          action: 'supplier_quote_attachment.uploaded',
+          entityType: 'supplier_quote',
+          entityId: idResult.value,
+          details: {
+            targetLabel: attachment.fileName,
+            secondaryLabel: quote.supplierName,
+          },
+        });
+
+        uploaded = null;
+        return reply.code(201).send(projectAttachment(attachment));
+      } finally {
+        if (uploaded) {
+          // DB insert failed after file landed on disk — clean up so we don't leave orphans.
+          await deleteSupplierQuoteAttachment(uploaded.storedName).catch((err) => {
+            attachmentsLogger.warn(
+              { err, storedName: uploaded?.storedName },
+              'Failed to clean up orphaned upload after error',
+            );
+          });
+        }
+      }
+    },
+  );
+
+  fastify.get(
+    '/:id/attachments/:attachmentId/download',
+    {
+      onRequest: [
+        fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
+        requirePermission('sales.supplier_quotes.view'),
+      ],
+      schema: {
+        tags: ['supplier-quotes'],
+        summary: 'Download a supplier-quote attachment',
+        params: attachmentParamSchema,
+        response: {
+          ...standardRateLimitedErrorResponses,
+        },
+      },
+    },
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      const { id, attachmentId } = request.params as { id: string; attachmentId: string };
+      const idResult = requireNonEmptyString(id, 'id');
+      if (!idResult.ok) return badRequest(reply, idResult.message);
+      const attachmentIdResult = requireNonEmptyString(attachmentId, 'attachmentId');
+      if (!attachmentIdResult.ok) return badRequest(reply, attachmentIdResult.message);
+
+      const attachment = await supplierQuoteAttachmentsRepo.findById(attachmentIdResult.value);
+      if (!attachment || attachment.quoteId !== idResult.value) {
+        return reply.code(404).send({ error: 'Attachment not found' });
+      }
+
+      let opened;
+      try {
+        opened = await openSupplierQuoteAttachment(attachment.storedName);
+      } catch (err) {
+        attachmentsLogger.warn(
+          { err, attachmentId: attachment.id },
+          'Stored attachment file is missing or unreadable',
+        );
+        return reply.code(404).send({ error: 'Attachment file is no longer available' });
+      }
+
+      const safeName = attachment.fileName.replace(/"/g, '');
+      reply.header('Content-Type', attachment.mimeType || 'application/octet-stream');
+      reply.header('Content-Length', String(opened.size));
+      reply.header('Content-Disposition', `attachment; filename="${safeName}"`);
+      return reply.send(opened.stream);
+    },
+  );
+
+  fastify.delete(
+    '/:id/attachments/:attachmentId',
+    {
+      onRequest: [requirePermission('sales.supplier_quotes.update')],
+      schema: {
+        tags: ['supplier-quotes'],
+        summary: 'Delete a supplier-quote attachment',
+        params: attachmentParamSchema,
+        response: {
+          204: { type: 'null' },
+          ...standardErrorResponses,
+        },
+      },
+    },
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      const { id, attachmentId } = request.params as { id: string; attachmentId: string };
+      const idResult = requireNonEmptyString(id, 'id');
+      if (!idResult.ok) return badRequest(reply, idResult.message);
+      const attachmentIdResult = requireNonEmptyString(attachmentId, 'attachmentId');
+      if (!attachmentIdResult.ok) return badRequest(reply, attachmentIdResult.message);
+
+      const quote = await assertQuoteEditableForAttachments(idResult.value, reply);
+      if (!quote) return;
+
+      const existing = await supplierQuoteAttachmentsRepo.findById(attachmentIdResult.value);
+      if (!existing || existing.quoteId !== idResult.value) {
+        return reply.code(404).send({ error: 'Attachment not found' });
+      }
+
+      const deleted = await supplierQuoteAttachmentsRepo.deleteById(attachmentIdResult.value);
+      if (!deleted) {
+        return reply.code(404).send({ error: 'Attachment not found' });
+      }
+
+      await deleteSupplierQuoteAttachment(deleted.storedName).catch((err) => {
+        attachmentsLogger.warn(
+          { err, storedName: deleted.storedName },
+          'Failed to remove attachment file from disk',
+        );
+      });
+
+      await logAudit({
+        request,
+        action: 'supplier_quote_attachment.deleted',
+        entityType: 'supplier_quote',
+        entityId: idResult.value,
+        details: {
+          targetLabel: deleted.fileName,
+          secondaryLabel: quote.supplierName,
+        },
+      });
+      return reply.code(204).send();
+    },
+  );
+
   fastify.delete(
     '/:id',
     {
@@ -739,9 +1049,22 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           .send({ error: 'Cannot delete a quote once an order has been created from it' });
       }
 
+      // Fetch attachment metadata BEFORE deleting the quote — the FK cascade will drop the
+      // rows, leaving us no way to learn which files to clean off disk.
+      const attachmentsToCleanup = await supplierQuoteAttachmentsRepo.listForQuote(idResult.value);
+
       const deleted = await supplierQuotesRepo.deleteById(idResult.value);
       if (!deleted) {
         return reply.code(404).send({ error: 'Supplier quote not found' });
+      }
+
+      for (const attachment of attachmentsToCleanup) {
+        await deleteSupplierQuoteAttachment(attachment.storedName).catch((err) => {
+          attachmentsLogger.warn(
+            { err, storedName: attachment.storedName },
+            'Failed to remove attachment file during quote delete',
+          );
+        });
       }
 
       await logAudit({

--- a/server/routes/supplier-quotes.ts
+++ b/server/routes/supplier-quotes.ts
@@ -855,6 +855,20 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         }
 
         const originalName = part.filename?.trim();
+
+        // Drain the multipart stream up front, before any validation early-returns. If we
+        // bail on filename/MIME without consuming `part.file`, fastify-multipart leaves the
+        // request body un-drained which can stall the connection until the parser times out.
+        let buffer: Buffer;
+        try {
+          buffer = await part.toBuffer();
+        } catch (err) {
+          if ((err as { code?: string }).code === 'FST_REQ_FILE_TOO_LARGE') {
+            return reply.code(413).send({ error: 'File exceeds the 10 MB upload limit' });
+          }
+          throw err;
+        }
+
         if (!originalName) {
           return reply.code(400).send({ error: 'Uploaded file is missing a filename' });
         }
@@ -864,16 +878,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           return reply
             .code(415)
             .send({ error: 'File type not allowed. Use xlsx, xls, csv, pdf, doc, or docx.' });
-        }
-
-        let buffer: Buffer;
-        try {
-          buffer = await part.toBuffer();
-        } catch (err) {
-          if ((err as { code?: string }).code === 'FST_REQ_FILE_TOO_LARGE') {
-            return reply.code(413).send({ error: 'File exceeds the 10 MB upload limit' });
-          }
-          throw err;
         }
 
         if (buffer.byteLength > ATTACHMENT_MAX_BYTES) {
@@ -894,6 +898,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           fileSize: uploaded.size,
           uploadedByUserId: request.user?.id ?? null,
         });
+        // DB row is now the source of truth — clear the cleanup token before audit so a
+        // failing audit log doesn't unlink the file under a live row.
+        uploaded = null;
 
         await logAudit({
           request,
@@ -906,11 +913,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           },
         });
 
-        uploaded = null;
         return reply.code(201).send(projectAttachment(attachment));
       } finally {
         if (uploaded) {
-          // DB insert failed after file landed on disk — clean up so we don't leave orphans.
           await deleteSupplierQuoteAttachment(uploaded.storedName).catch((err) => {
             attachmentsLogger.warn(
               { err, storedName: uploaded?.storedName },
@@ -961,10 +966,17 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         return reply.code(404).send({ error: 'Attachment file is no longer available' });
       }
 
-      const safeName = attachment.fileName.replace(/"/g, '');
+      // RFC 6266: provide an ASCII-safe `filename` for legacy clients plus an RFC 5987
+      // `filename*` with UTF-8 encoding for Unicode filenames. Strip CR/LF/quote/backslash
+      // from the legacy form to prevent header injection through user-controlled filenames.
+      const asciiFallback = attachment.fileName.replace(/[\r\n"\\]/g, '');
+      const utf8EncodedName = encodeURIComponent(attachment.fileName).replace(/['()]/g, escape);
       reply.header('Content-Type', attachment.mimeType || 'application/octet-stream');
       reply.header('Content-Length', String(opened.size));
-      reply.header('Content-Disposition', `attachment; filename="${safeName}"`);
+      reply.header(
+        'Content-Disposition',
+        `attachment; filename="${asciiFallback}"; filename*=UTF-8''${utf8EncodedName}`,
+      );
       return reply.send(opened.stream);
     },
   );

--- a/server/routes/supplier-quotes.ts
+++ b/server/routes/supplier-quotes.ts
@@ -768,19 +768,20 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
     id: string,
     reply: FastifyReply,
   ): Promise<supplierQuotesRepo.SupplierQuote | null> => {
-    const quote = await supplierQuotesRepo.findById(id);
+    const [quote, linkedOrderId] = await Promise.all([
+      supplierQuotesRepo.findById(id),
+      supplierQuotesRepo.findLinkedOrderId(id),
+    ]);
     if (!quote) {
       reply.code(404).send({ error: 'Supplier quote not found' });
       return null;
     }
-    const status = normalizeSupplierQuoteStatus(quote.status);
-    if (status !== 'draft') {
-      reply.code(409).send({ error: 'Attachments can only be modified on draft supplier quotes' });
-      return null;
-    }
-    const linkedOrderId = await supplierQuotesRepo.findLinkedOrderId(id);
     if (linkedOrderId) {
       reply.code(409).send({ error: 'Quotes become read-only once an order exists' });
+      return null;
+    }
+    if (normalizeSupplierQuoteStatus(quote.status) !== 'draft') {
+      reply.code(409).send({ error: 'Attachments can only be modified on draft supplier quotes' });
       return null;
     }
     return quote;
@@ -992,12 +993,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const quote = await assertQuoteEditableForAttachments(idResult.value, reply);
       if (!quote) return;
 
-      const existing = await supplierQuoteAttachmentsRepo.findById(attachmentIdResult.value);
-      if (!existing || existing.quoteId !== idResult.value) {
-        return reply.code(404).send({ error: 'Attachment not found' });
-      }
-
-      const deleted = await supplierQuoteAttachmentsRepo.deleteById(attachmentIdResult.value);
+      const deleted = await supplierQuoteAttachmentsRepo.deleteById(
+        attachmentIdResult.value,
+        idResult.value,
+      );
       if (!deleted) {
         return reply.code(404).send({ error: 'Attachment not found' });
       }
@@ -1058,14 +1057,16 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         return reply.code(404).send({ error: 'Supplier quote not found' });
       }
 
-      for (const attachment of attachmentsToCleanup) {
-        await deleteSupplierQuoteAttachment(attachment.storedName).catch((err) => {
-          attachmentsLogger.warn(
-            { err, storedName: attachment.storedName },
-            'Failed to remove attachment file during quote delete',
-          );
-        });
-      }
+      await Promise.all(
+        attachmentsToCleanup.map((attachment) =>
+          deleteSupplierQuoteAttachment(attachment.storedName).catch((err) => {
+            attachmentsLogger.warn(
+              { err, storedName: attachment.storedName },
+              'Failed to remove attachment file during quote delete',
+            );
+          }),
+        ),
+      );
 
       await logAudit({
         request,

--- a/server/test/repositories/supplierQuoteAttachmentsRepo.test.ts
+++ b/server/test/repositories/supplierQuoteAttachmentsRepo.test.ts
@@ -96,19 +96,20 @@ describe('insert', () => {
 });
 
 describe('deleteById', () => {
-  test('returns the deleted row including storedName for cleanup', async () => {
+  test('scopes deletion by attachmentId AND quoteId so cross-quote ids 404 cleanly', async () => {
     exec.enqueue({ rows: [attachmentRow()] });
-    const result = await supplierQuoteAttachmentsRepo.deleteById('sqa-1', testDb);
+    const result = await supplierQuoteAttachmentsRepo.deleteById('sqa-1', 'q-1', testDb);
     const sql = exec.calls[0].sql;
     expect(sql).toContain('delete from "supplier_quote_attachments"');
     expect(sql).toContain('"id" = $1');
+    expect(sql).toContain('"quote_id" = $2');
     expect(sql).toContain('returning');
-    expect(exec.calls[0].params).toEqual(['sqa-1']);
+    expect(exec.calls[0].params).toEqual(['sqa-1', 'q-1']);
     expect(result?.storedName).toBe('abc-123.xlsx');
   });
 
-  test('returns null when no row deleted', async () => {
+  test('returns null when no row deleted (id mismatch or wrong quote)', async () => {
     exec.enqueue({ rows: [] });
-    expect(await supplierQuoteAttachmentsRepo.deleteById('missing', testDb)).toBeNull();
+    expect(await supplierQuoteAttachmentsRepo.deleteById('missing', 'q-1', testDb)).toBeNull();
   });
 });

--- a/server/test/repositories/supplierQuoteAttachmentsRepo.test.ts
+++ b/server/test/repositories/supplierQuoteAttachmentsRepo.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import type { DbExecutor } from '../../db/drizzle.ts';
+import * as supplierQuoteAttachmentsRepo from '../../repositories/supplierQuoteAttachmentsRepo.ts';
+import { type FakeExecutor, makeRow, setupTestDb } from '../helpers/fakeExecutor.ts';
+
+let exec: FakeExecutor;
+let testDb: DbExecutor;
+
+beforeEach(() => {
+  ({ exec, testDb } = setupTestDb());
+});
+
+// Column order matches db/schema/supplierQuoteAttachments.ts:
+//   [id, quoteId, fileName, storedName, mimeType, fileSize, uploadedByUserId, createdAt]
+const ATTACHMENT_BASE: readonly unknown[] = [
+  'sqa-1',
+  'q-1',
+  'order.xlsx',
+  'abc-123.xlsx',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  2048,
+  'u-1',
+  new Date(1735689600000),
+];
+
+const attachmentRow = (overrides: Record<number, unknown> = {}) =>
+  makeRow(ATTACHMENT_BASE, overrides);
+
+describe('listForQuote', () => {
+  test('orders by created_at DESC and filters by quoteId', async () => {
+    exec.enqueue({ rows: [attachmentRow()] });
+    const result = await supplierQuoteAttachmentsRepo.listForQuote('q-1', testDb);
+    const sql = exec.calls[0].sql;
+    expect(sql).toContain('from "supplier_quote_attachments"');
+    expect(sql).toContain('"quote_id" = $1');
+    expect(sql).toContain('order by "supplier_quote_attachments"."created_at" desc');
+    expect(exec.calls[0].params).toEqual(['q-1']);
+    expect(result[0].id).toBe('sqa-1');
+    expect(result[0].fileName).toBe('order.xlsx');
+    expect(result[0].fileSize).toBe(2048);
+    expect(result[0].createdAt).toBe(1735689600000);
+  });
+
+  test('returns empty array when no rows', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await supplierQuoteAttachmentsRepo.listForQuote('q-x', testDb)).toEqual([]);
+  });
+});
+
+describe('findById', () => {
+  test('binds id and limits to 1', async () => {
+    exec.enqueue({ rows: [attachmentRow()] });
+    const result = await supplierQuoteAttachmentsRepo.findById('sqa-1', testDb);
+    const sql = exec.calls[0].sql;
+    expect(sql).toContain('"id" = $1');
+    expect(sql).toContain('limit $2');
+    expect(exec.calls[0].params).toEqual(['sqa-1', 1]);
+    expect(result?.storedName).toBe('abc-123.xlsx');
+  });
+
+  test('returns null when no row', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await supplierQuoteAttachmentsRepo.findById('missing', testDb)).toBeNull();
+  });
+});
+
+describe('insert', () => {
+  test('inserts the supplied values and returns mapped row', async () => {
+    exec.enqueue({ rows: [attachmentRow()] });
+    const result = await supplierQuoteAttachmentsRepo.insert(
+      {
+        id: 'sqa-1',
+        quoteId: 'q-1',
+        fileName: 'order.xlsx',
+        storedName: 'abc-123.xlsx',
+        mimeType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        fileSize: 2048,
+        uploadedByUserId: 'u-1',
+      },
+      testDb,
+    );
+    const sql = exec.calls[0].sql;
+    expect(sql).toContain('insert into "supplier_quote_attachments"');
+    expect(sql).toContain('returning');
+    expect(exec.calls[0].params).toEqual([
+      'sqa-1',
+      'q-1',
+      'order.xlsx',
+      'abc-123.xlsx',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      2048,
+      'u-1',
+    ]);
+    expect(result.id).toBe('sqa-1');
+  });
+});
+
+describe('deleteById', () => {
+  test('returns the deleted row including storedName for cleanup', async () => {
+    exec.enqueue({ rows: [attachmentRow()] });
+    const result = await supplierQuoteAttachmentsRepo.deleteById('sqa-1', testDb);
+    const sql = exec.calls[0].sql;
+    expect(sql).toContain('delete from "supplier_quote_attachments"');
+    expect(sql).toContain('"id" = $1');
+    expect(sql).toContain('returning');
+    expect(exec.calls[0].params).toEqual(['sqa-1']);
+    expect(result?.storedName).toBe('abc-123.xlsx');
+  });
+
+  test('returns null when no row deleted', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await supplierQuoteAttachmentsRepo.deleteById('missing', testDb)).toBeNull();
+  });
+});

--- a/server/test/routes/supplier-quotes-attachments.test.ts
+++ b/server/test/routes/supplier-quotes-attachments.test.ts
@@ -410,6 +410,52 @@ describe('POST /api/sales/supplier-quotes/:id/attachments', () => {
     expect(saveAttachmentMock).not.toHaveBeenCalled();
   });
 
+  test('415 when extension is disallowed even if MIME claims an allowed type', async () => {
+    sqFindByIdMock.mockResolvedValue(DRAFT_QUOTE);
+    sqFindLinkedOrderIdMock.mockResolvedValue(null);
+
+    // Attacker uploads payload.exe but lies that it's a PDF — extension allowlist must
+    // gate this regardless of the client-supplied MIME type.
+    const { payload, contentType } = buildMultipartBody(
+      'payload.exe',
+      'application/pdf',
+      Buffer.from('MZ\x90\x00binary'),
+    );
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/sales/supplier-quotes/sq-1/attachments',
+      headers: { ...authHeader(), 'content-type': contentType },
+      payload,
+    });
+
+    expect(res.statusCode).toBe(415);
+    expect(saveAttachmentMock).not.toHaveBeenCalled();
+  });
+
+  test('accepts xlsx with browser-fallback application/octet-stream MIME', async () => {
+    sqFindByIdMock.mockResolvedValue(DRAFT_QUOTE);
+    sqFindLinkedOrderIdMock.mockResolvedValue(null);
+    saveAttachmentMock.mockResolvedValue({ storedName: 'abc-123.xlsx', size: 11 });
+    sqaInsertMock.mockResolvedValue(SAMPLE_ATTACHMENT);
+
+    const { payload, contentType } = buildMultipartBody(
+      'order.xlsx',
+      'application/octet-stream',
+      Buffer.from('xlsx-bytes-'),
+    );
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/sales/supplier-quotes/sq-1/attachments',
+      headers: { ...authHeader(), 'content-type': contentType },
+      payload,
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(saveAttachmentMock).toHaveBeenCalledTimes(1);
+  });
+
   test('cleans up file when DB insert fails', async () => {
     sqFindByIdMock.mockResolvedValue(DRAFT_QUOTE);
     sqFindLinkedOrderIdMock.mockResolvedValue(null);

--- a/server/test/routes/supplier-quotes-attachments.test.ts
+++ b/server/test/routes/supplier-quotes-attachments.test.ts
@@ -1,0 +1,572 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import multipart from '@fastify/multipart';
+import Fastify, { type FastifyInstance, type FastifyPluginAsync } from 'fastify';
+import * as realDrizzle from '../../db/drizzle.ts';
+import * as realProductsRepo from '../../repositories/productsRepo.ts';
+import * as realRolesRepo from '../../repositories/rolesRepo.ts';
+import * as realSupplierQuoteAttachmentsRepo from '../../repositories/supplierQuoteAttachmentsRepo.ts';
+import * as realSupplierQuotesRepo from '../../repositories/supplierQuotesRepo.ts';
+import * as realSupplierQuoteVersionsRepo from '../../repositories/supplierQuoteVersionsRepo.ts';
+import * as realSuppliersRepo from '../../repositories/suppliersRepo.ts';
+import * as realUsersRepo from '../../repositories/usersRepo.ts';
+import * as realAudit from '../../utils/audit.ts';
+import * as realFileStorage from '../../utils/fileStorage.ts';
+import * as realPermissions from '../../utils/permissions.ts';
+import {
+  installAuthMiddlewareMock,
+  restoreAuthMiddlewareMock,
+} from '../helpers/authMiddlewareMock.ts';
+import { signToken } from '../helpers/jwt.ts';
+
+const usersRepoSnap = { ...realUsersRepo };
+const rolesRepoSnap = { ...realRolesRepo };
+const permissionsSnap = { ...realPermissions };
+const suppliersRepoSnap = { ...realSuppliersRepo };
+const supplierQuotesRepoSnap = { ...realSupplierQuotesRepo };
+const supplierQuoteVersionsRepoSnap = { ...realSupplierQuoteVersionsRepo };
+const supplierQuoteAttachmentsRepoSnap = { ...realSupplierQuoteAttachmentsRepo };
+const productsRepoSnap = { ...realProductsRepo };
+const auditSnap = { ...realAudit };
+const drizzleSnap = { ...realDrizzle };
+const fileStorageSnap = { ...realFileStorage };
+
+const findAuthUserByIdMock = mock();
+const userHasRoleMock = mock();
+const getRolePermissionsMock = mock();
+
+const sqFindByIdMock = mock();
+const sqExistsByIdMock = mock();
+const sqFindLinkedOrderIdMock = mock();
+const sqDeleteByIdMock = mock();
+
+const sqaListForQuoteMock = mock();
+const sqaFindByIdMock = mock();
+const sqaInsertMock = mock();
+const sqaDeleteByIdMock = mock();
+
+const saveAttachmentMock = mock();
+const openAttachmentMock = mock();
+const deleteAttachmentMock = mock();
+
+const logAuditMock = mock(async () => undefined);
+const withDbTransactionMock = mock(async (cb: (tx: unknown) => unknown) => cb(undefined));
+
+let routePlugin: FastifyPluginAsync;
+
+beforeAll(async () => {
+  installAuthMiddlewareMock();
+
+  mock.module('../../repositories/usersRepo.ts', () => ({
+    ...usersRepoSnap,
+    findAuthUserById: findAuthUserByIdMock,
+  }));
+  mock.module('../../repositories/rolesRepo.ts', () => ({
+    ...rolesRepoSnap,
+    userHasRole: userHasRoleMock,
+  }));
+  mock.module('../../utils/permissions.ts', () => ({
+    ...permissionsSnap,
+    getRolePermissions: getRolePermissionsMock,
+  }));
+  mock.module('../../repositories/suppliersRepo.ts', () => suppliersRepoSnap);
+  mock.module('../../repositories/supplierQuotesRepo.ts', () => ({
+    ...supplierQuotesRepoSnap,
+    findById: sqFindByIdMock,
+    existsById: sqExistsByIdMock,
+    findLinkedOrderId: sqFindLinkedOrderIdMock,
+    deleteById: sqDeleteByIdMock,
+  }));
+  mock.module(
+    '../../repositories/supplierQuoteVersionsRepo.ts',
+    () => supplierQuoteVersionsRepoSnap,
+  );
+  mock.module('../../repositories/supplierQuoteAttachmentsRepo.ts', () => ({
+    ...supplierQuoteAttachmentsRepoSnap,
+    listForQuote: sqaListForQuoteMock,
+    findById: sqaFindByIdMock,
+    insert: sqaInsertMock,
+    deleteById: sqaDeleteByIdMock,
+  }));
+  mock.module('../../repositories/productsRepo.ts', () => productsRepoSnap);
+  mock.module('../../utils/fileStorage.ts', () => ({
+    ...fileStorageSnap,
+    saveSupplierQuoteAttachment: saveAttachmentMock,
+    openSupplierQuoteAttachment: openAttachmentMock,
+    deleteSupplierQuoteAttachment: deleteAttachmentMock,
+  }));
+  mock.module('../../utils/audit.ts', () => ({
+    ...auditSnap,
+    logAudit: logAuditMock,
+  }));
+  mock.module('../../db/drizzle.ts', () => ({
+    ...drizzleSnap,
+    withDbTransaction: withDbTransactionMock,
+  }));
+
+  routePlugin = (await import('../../routes/supplier-quotes.ts')).default as FastifyPluginAsync;
+});
+
+afterAll(() => {
+  restoreAuthMiddlewareMock();
+  mock.module('../../repositories/usersRepo.ts', () => usersRepoSnap);
+  mock.module('../../repositories/rolesRepo.ts', () => rolesRepoSnap);
+  mock.module('../../utils/permissions.ts', () => permissionsSnap);
+  mock.module('../../repositories/suppliersRepo.ts', () => suppliersRepoSnap);
+  mock.module('../../repositories/supplierQuotesRepo.ts', () => supplierQuotesRepoSnap);
+  mock.module(
+    '../../repositories/supplierQuoteVersionsRepo.ts',
+    () => supplierQuoteVersionsRepoSnap,
+  );
+  mock.module(
+    '../../repositories/supplierQuoteAttachmentsRepo.ts',
+    () => supplierQuoteAttachmentsRepoSnap,
+  );
+  mock.module('../../repositories/productsRepo.ts', () => productsRepoSnap);
+  mock.module('../../utils/fileStorage.ts', () => fileStorageSnap);
+  mock.module('../../utils/audit.ts', () => auditSnap);
+  mock.module('../../db/drizzle.ts', () => drizzleSnap);
+});
+
+const HAPPY_USER = {
+  id: 'u1',
+  name: 'Alice',
+  username: 'alice',
+  role: 'manager',
+  avatarInitials: 'AL',
+  isDisabled: false,
+};
+
+const FULL_PERMS = [
+  'sales.supplier_quotes.view',
+  'sales.supplier_quotes.update',
+  'sales.supplier_quotes.delete',
+];
+
+const DRAFT_QUOTE = {
+  id: 'sq-1',
+  supplierId: 's1',
+  supplierName: 'Acme',
+  paymentTerms: 'immediate',
+  status: 'draft',
+  expirationDate: '2026-12-31',
+  linkedOrderId: null,
+  notes: null,
+  createdAt: 1_700_000_000_000,
+  updatedAt: 1_700_000_000_000,
+};
+
+const SAMPLE_ATTACHMENT = {
+  id: 'sqa-1',
+  quoteId: 'sq-1',
+  fileName: 'order.xlsx',
+  storedName: 'abc-123.xlsx',
+  mimeType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  fileSize: 1024,
+  uploadedByUserId: 'u1',
+  createdAt: 1_700_000_000_000,
+};
+
+const allMocks = [
+  findAuthUserByIdMock,
+  userHasRoleMock,
+  getRolePermissionsMock,
+  sqFindByIdMock,
+  sqExistsByIdMock,
+  sqFindLinkedOrderIdMock,
+  sqDeleteByIdMock,
+  sqaListForQuoteMock,
+  sqaFindByIdMock,
+  sqaInsertMock,
+  sqaDeleteByIdMock,
+  saveAttachmentMock,
+  openAttachmentMock,
+  deleteAttachmentMock,
+  logAuditMock,
+  withDbTransactionMock,
+];
+
+let testApp: FastifyInstance;
+
+// Custom builder so the multipart plugin is actually registered for the upload tests.
+// `buildRouteTestApp` skips it because most route tests don't need multipart.
+const buildAttachmentsTestApp = async (): Promise<FastifyInstance> => {
+  const app = Fastify({ logger: false });
+  app.decorate('rateLimit', () => async () => {});
+  await app.register(multipart, {
+    limits: {
+      fileSize: 10 * 1024 * 1024,
+      files: 1,
+      fields: 0,
+    },
+  });
+  await app.register(routePlugin, { prefix: '/api/sales/supplier-quotes' });
+  await app.ready();
+  return app;
+};
+
+beforeEach(async () => {
+  for (const m of allMocks) m.mockReset();
+  findAuthUserByIdMock.mockResolvedValue(HAPPY_USER);
+  userHasRoleMock.mockResolvedValue(true);
+  getRolePermissionsMock.mockResolvedValue(FULL_PERMS);
+  withDbTransactionMock.mockImplementation(async (cb) => cb(undefined));
+  logAuditMock.mockImplementation(async () => undefined);
+  // Defaults to a resolved promise so the route's `.catch(...)` chain has something callable
+  // when individual tests don't override the mock.
+  deleteAttachmentMock.mockResolvedValue(undefined);
+
+  testApp = await buildAttachmentsTestApp();
+});
+
+afterEach(async () => {
+  await testApp.close();
+});
+
+const authHeader = () => ({ authorization: `Bearer ${signToken({ userId: 'u1' })}` });
+
+const buildMultipartBody = (
+  fileName: string,
+  contentType: string,
+  body: Buffer,
+): { payload: Buffer; contentType: string } => {
+  const boundary = '----TestBoundary123';
+  const parts = Buffer.concat([
+    Buffer.from(
+      `--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="${fileName}"\r\n` +
+        `Content-Type: ${contentType}\r\n\r\n`,
+    ),
+    body,
+    Buffer.from(`\r\n--${boundary}--\r\n`),
+  ]);
+  return { payload: parts, contentType: `multipart/form-data; boundary=${boundary}` };
+};
+
+describe('GET /api/sales/supplier-quotes/:id/attachments', () => {
+  test('200 returns attachments without exposing storedName', async () => {
+    sqExistsByIdMock.mockResolvedValue(true);
+    sqaListForQuoteMock.mockResolvedValue([SAMPLE_ATTACHMENT]);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/sales/supplier-quotes/sq-1/attachments',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body).toHaveLength(1);
+    expect(body[0].id).toBe('sqa-1');
+    expect(body[0].fileName).toBe('order.xlsx');
+    expect(body[0].storedName).toBeUndefined();
+    expect(sqaListForQuoteMock).toHaveBeenCalledWith('sq-1');
+  });
+
+  test('404 when quote does not exist', async () => {
+    sqExistsByIdMock.mockResolvedValue(false);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/sales/supplier-quotes/missing/attachments',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  test('403 missing view permission', async () => {
+    getRolePermissionsMock.mockResolvedValue([]);
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/sales/supplier-quotes/sq-1/attachments',
+      headers: authHeader(),
+    });
+    expect(res.statusCode).toBe(403);
+  });
+});
+
+describe('POST /api/sales/supplier-quotes/:id/attachments', () => {
+  test('201 happy path saves file, inserts row, audits', async () => {
+    sqFindByIdMock.mockResolvedValue(DRAFT_QUOTE);
+    sqFindLinkedOrderIdMock.mockResolvedValue(null);
+    saveAttachmentMock.mockResolvedValue({ storedName: 'abc-123.xlsx', size: 11 });
+    sqaInsertMock.mockResolvedValue(SAMPLE_ATTACHMENT);
+
+    const { payload, contentType } = buildMultipartBody(
+      'order.xlsx',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      Buffer.from('hello world'),
+    );
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/sales/supplier-quotes/sq-1/attachments',
+      headers: { ...authHeader(), 'content-type': contentType },
+      payload,
+    });
+
+    expect(res.statusCode).toBe(201);
+    const body = JSON.parse(res.body);
+    expect(body.id).toBe('sqa-1');
+    expect(body.fileName).toBe('order.xlsx');
+    expect(saveAttachmentMock).toHaveBeenCalledTimes(1);
+    expect(sqaInsertMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        quoteId: 'sq-1',
+        fileName: 'order.xlsx',
+        storedName: 'abc-123.xlsx',
+        uploadedByUserId: 'u1',
+      }),
+    );
+    expect(deleteAttachmentMock).not.toHaveBeenCalled();
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'supplier_quote_attachment.uploaded',
+        entityType: 'supplier_quote',
+        entityId: 'sq-1',
+      }),
+    );
+  });
+
+  test('404 when quote does not exist', async () => {
+    sqFindByIdMock.mockResolvedValue(null);
+
+    const { payload, contentType } = buildMultipartBody(
+      'order.xlsx',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      Buffer.from('hi'),
+    );
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/sales/supplier-quotes/missing/attachments',
+      headers: { ...authHeader(), 'content-type': contentType },
+      payload,
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(saveAttachmentMock).not.toHaveBeenCalled();
+  });
+
+  test('409 when quote status is not draft', async () => {
+    sqFindByIdMock.mockResolvedValue({ ...DRAFT_QUOTE, status: 'sent' });
+    sqFindLinkedOrderIdMock.mockResolvedValue(null);
+
+    const { payload, contentType } = buildMultipartBody(
+      'order.xlsx',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      Buffer.from('hi'),
+    );
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/sales/supplier-quotes/sq-1/attachments',
+      headers: { ...authHeader(), 'content-type': contentType },
+      payload,
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(saveAttachmentMock).not.toHaveBeenCalled();
+  });
+
+  test('409 when quote is linked to an order', async () => {
+    sqFindByIdMock.mockResolvedValue(DRAFT_QUOTE);
+    sqFindLinkedOrderIdMock.mockResolvedValue('sord-1');
+
+    const { payload, contentType } = buildMultipartBody(
+      'order.xlsx',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      Buffer.from('hi'),
+    );
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/sales/supplier-quotes/sq-1/attachments',
+      headers: { ...authHeader(), 'content-type': contentType },
+      payload,
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(saveAttachmentMock).not.toHaveBeenCalled();
+  });
+
+  test('415 when file type is not in allowlist', async () => {
+    sqFindByIdMock.mockResolvedValue(DRAFT_QUOTE);
+    sqFindLinkedOrderIdMock.mockResolvedValue(null);
+
+    const { payload, contentType } = buildMultipartBody(
+      'malware.exe',
+      'application/octet-stream',
+      Buffer.from('binary'),
+    );
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/sales/supplier-quotes/sq-1/attachments',
+      headers: { ...authHeader(), 'content-type': contentType },
+      payload,
+    });
+
+    expect(res.statusCode).toBe(415);
+    expect(saveAttachmentMock).not.toHaveBeenCalled();
+  });
+
+  test('cleans up file when DB insert fails', async () => {
+    sqFindByIdMock.mockResolvedValue(DRAFT_QUOTE);
+    sqFindLinkedOrderIdMock.mockResolvedValue(null);
+    saveAttachmentMock.mockResolvedValue({ storedName: 'abc-123.xlsx', size: 11 });
+    sqaInsertMock.mockRejectedValue(new Error('DB exploded'));
+
+    const { payload, contentType } = buildMultipartBody(
+      'order.xlsx',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      Buffer.from('hello world'),
+    );
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/sales/supplier-quotes/sq-1/attachments',
+      headers: { ...authHeader(), 'content-type': contentType },
+      payload,
+    });
+
+    expect(res.statusCode).toBe(500);
+    expect(deleteAttachmentMock).toHaveBeenCalledWith('abc-123.xlsx');
+  });
+
+  test('400 on non-multipart body', async () => {
+    sqFindByIdMock.mockResolvedValue(DRAFT_QUOTE);
+    sqFindLinkedOrderIdMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/sales/supplier-quotes/sq-1/attachments',
+      headers: { ...authHeader(), 'content-type': 'application/json' },
+      payload: '{}',
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe('GET /api/sales/supplier-quotes/:id/attachments/:attachmentId/download', () => {
+  test('200 streams file with Content-Disposition', async () => {
+    sqaFindByIdMock.mockResolvedValue(SAMPLE_ATTACHMENT);
+    const { Readable } = await import('node:stream');
+    openAttachmentMock.mockResolvedValue({
+      stream: Readable.from(Buffer.from('hello world')),
+      size: 11,
+    });
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/sales/supplier-quotes/sq-1/attachments/sqa-1/download',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-disposition']).toBe('attachment; filename="order.xlsx"');
+    expect(res.headers['content-type']).toBe(
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    );
+    expect(res.body).toBe('hello world');
+  });
+
+  test('404 when attachment id belongs to a different quote', async () => {
+    sqaFindByIdMock.mockResolvedValue({ ...SAMPLE_ATTACHMENT, quoteId: 'sq-other' });
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/sales/supplier-quotes/sq-1/attachments/sqa-1/download',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(openAttachmentMock).not.toHaveBeenCalled();
+  });
+
+  test('404 when stored file is missing', async () => {
+    sqaFindByIdMock.mockResolvedValue(SAMPLE_ATTACHMENT);
+    openAttachmentMock.mockRejectedValue(new Error('ENOENT'));
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/sales/supplier-quotes/sq-1/attachments/sqa-1/download',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe('DELETE /api/sales/supplier-quotes/:id/attachments/:attachmentId', () => {
+  test('204 removes row, file, and audits', async () => {
+    sqFindByIdMock.mockResolvedValue(DRAFT_QUOTE);
+    sqFindLinkedOrderIdMock.mockResolvedValue(null);
+    sqaFindByIdMock.mockResolvedValue(SAMPLE_ATTACHMENT);
+    sqaDeleteByIdMock.mockResolvedValue(SAMPLE_ATTACHMENT);
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/sales/supplier-quotes/sq-1/attachments/sqa-1',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(204);
+    expect(sqaDeleteByIdMock).toHaveBeenCalledWith('sqa-1');
+    expect(deleteAttachmentMock).toHaveBeenCalledWith('abc-123.xlsx');
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'supplier_quote_attachment.deleted' }),
+    );
+  });
+
+  test('409 when quote is not draft', async () => {
+    sqFindByIdMock.mockResolvedValue({ ...DRAFT_QUOTE, status: 'sent' });
+    sqFindLinkedOrderIdMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/sales/supplier-quotes/sq-1/attachments/sqa-1',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(sqaDeleteByIdMock).not.toHaveBeenCalled();
+  });
+
+  test('404 when attachment belongs to another quote', async () => {
+    sqFindByIdMock.mockResolvedValue(DRAFT_QUOTE);
+    sqFindLinkedOrderIdMock.mockResolvedValue(null);
+    sqaFindByIdMock.mockResolvedValue({ ...SAMPLE_ATTACHMENT, quoteId: 'sq-other' });
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/sales/supplier-quotes/sq-1/attachments/sqa-1',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(sqaDeleteByIdMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('DELETE /api/sales/supplier-quotes/:id cleans up attachment files', () => {
+  test('removes files for each attachment after the quote is deleted', async () => {
+    sqFindLinkedOrderIdMock.mockResolvedValue(null);
+    sqaListForQuoteMock.mockResolvedValue([
+      SAMPLE_ATTACHMENT,
+      { ...SAMPLE_ATTACHMENT, id: 'sqa-2', storedName: 'def-456.pdf' },
+    ]);
+    sqDeleteByIdMock.mockResolvedValue({ supplierName: 'Acme' });
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/sales/supplier-quotes/sq-1',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(204);
+    expect(deleteAttachmentMock).toHaveBeenCalledTimes(2);
+    expect(deleteAttachmentMock).toHaveBeenCalledWith('abc-123.xlsx');
+    expect(deleteAttachmentMock).toHaveBeenCalledWith('def-456.pdf');
+  });
+});

--- a/server/test/routes/supplier-quotes-attachments.test.ts
+++ b/server/test/routes/supplier-quotes-attachments.test.ts
@@ -449,7 +449,7 @@ describe('POST /api/sales/supplier-quotes/:id/attachments', () => {
 });
 
 describe('GET /api/sales/supplier-quotes/:id/attachments/:attachmentId/download', () => {
-  test('200 streams file with Content-Disposition', async () => {
+  test('200 streams file with RFC 6266 Content-Disposition (ASCII + UTF-8)', async () => {
     sqaFindByIdMock.mockResolvedValue(SAMPLE_ATTACHMENT);
     const { Readable } = await import('node:stream');
     openAttachmentMock.mockResolvedValue({
@@ -464,11 +464,42 @@ describe('GET /api/sales/supplier-quotes/:id/attachments/:attachmentId/download'
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.headers['content-disposition']).toBe('attachment; filename="order.xlsx"');
+    expect(res.headers['content-disposition']).toBe(
+      `attachment; filename="order.xlsx"; filename*=UTF-8''order.xlsx`,
+    );
     expect(res.headers['content-type']).toBe(
       'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
     );
     expect(res.body).toBe('hello world');
+  });
+
+  test('strips CR/LF/quote from Content-Disposition filename to prevent header injection', async () => {
+    sqaFindByIdMock.mockResolvedValue({
+      ...SAMPLE_ATTACHMENT,
+      fileName: 'evil"\r\nSet-Cookie: pwn=1.xlsx',
+    });
+    const { Readable } = await import('node:stream');
+    openAttachmentMock.mockResolvedValue({
+      stream: Readable.from(Buffer.from('x')),
+      size: 1,
+    });
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/sales/supplier-quotes/sq-1/attachments/sqa-1/download',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const disposition = res.headers['content-disposition'] as string;
+    expect(disposition).not.toContain('\r');
+    expect(disposition).not.toContain('\n');
+    // Quote stripped from the legacy `filename=` parameter; filename* preserves the original
+    // (URL-encoded) so non-ASCII filenames still round-trip on RFC-5987-aware clients.
+    expect(disposition).toMatch(
+      /^attachment; filename="evilSet-Cookie: pwn=1\.xlsx"; filename\*=UTF-8''/,
+    );
+    expect(res.headers['set-cookie']).toBeUndefined();
   });
 
   test('404 when attachment id belongs to a different quote', async () => {

--- a/server/test/routes/supplier-quotes-attachments.test.ts
+++ b/server/test/routes/supplier-quotes-attachments.test.ts
@@ -502,7 +502,6 @@ describe('DELETE /api/sales/supplier-quotes/:id/attachments/:attachmentId', () =
   test('204 removes row, file, and audits', async () => {
     sqFindByIdMock.mockResolvedValue(DRAFT_QUOTE);
     sqFindLinkedOrderIdMock.mockResolvedValue(null);
-    sqaFindByIdMock.mockResolvedValue(SAMPLE_ATTACHMENT);
     sqaDeleteByIdMock.mockResolvedValue(SAMPLE_ATTACHMENT);
 
     const res = await testApp.inject({
@@ -512,7 +511,7 @@ describe('DELETE /api/sales/supplier-quotes/:id/attachments/:attachmentId', () =
     });
 
     expect(res.statusCode).toBe(204);
-    expect(sqaDeleteByIdMock).toHaveBeenCalledWith('sqa-1');
+    expect(sqaDeleteByIdMock).toHaveBeenCalledWith('sqa-1', 'sq-1');
     expect(deleteAttachmentMock).toHaveBeenCalledWith('abc-123.xlsx');
     expect(logAuditMock).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'supplier_quote_attachment.deleted' }),
@@ -536,7 +535,8 @@ describe('DELETE /api/sales/supplier-quotes/:id/attachments/:attachmentId', () =
   test('404 when attachment belongs to another quote', async () => {
     sqFindByIdMock.mockResolvedValue(DRAFT_QUOTE);
     sqFindLinkedOrderIdMock.mockResolvedValue(null);
-    sqaFindByIdMock.mockResolvedValue({ ...SAMPLE_ATTACHMENT, quoteId: 'sq-other' });
+    // deleteById is scoped on (id, quoteId) so a mismatched quoteId yields no row.
+    sqaDeleteByIdMock.mockResolvedValue(null);
 
     const res = await testApp.inject({
       method: 'DELETE',
@@ -545,7 +545,7 @@ describe('DELETE /api/sales/supplier-quotes/:id/attachments/:attachmentId', () =
     });
 
     expect(res.statusCode).toBe(404);
-    expect(sqaDeleteByIdMock).not.toHaveBeenCalled();
+    expect(deleteAttachmentMock).not.toHaveBeenCalled();
   });
 });
 

--- a/server/utils/fileStorage.ts
+++ b/server/utils/fileStorage.ts
@@ -1,0 +1,90 @@
+import { randomUUID } from 'node:crypto';
+import { createReadStream, type ReadStream } from 'node:fs';
+import { mkdir, stat, unlink, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+export const ATTACHMENT_MAX_BYTES = 10 * 1024 * 1024;
+
+export const ATTACHMENT_ALLOWED_MIME = new Set<string>([
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'application/vnd.ms-excel',
+  'text/csv',
+  'application/pdf',
+  'application/msword',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+]);
+
+export const ATTACHMENT_ALLOWED_EXT = new Set<string>(['xlsx', 'xls', 'csv', 'pdf', 'doc', 'docx']);
+
+const SUPPLIER_QUOTE_ATTACHMENTS_DIR = 'supplier-quote-attachments';
+
+export const getExtensionFromName = (name: string): string => {
+  const dot = name.lastIndexOf('.');
+  if (dot < 0 || dot === name.length - 1) return '';
+  return name.slice(dot + 1).toLowerCase();
+};
+
+export const isAllowedAttachment = (mimeType: string, fileName: string): boolean => {
+  const ext = getExtensionFromName(fileName);
+  if (ATTACHMENT_ALLOWED_MIME.has(mimeType)) return true;
+  if (ATTACHMENT_ALLOWED_EXT.has(ext)) return true;
+  return false;
+};
+
+const getUploadRoot = (): string => {
+  const configured = process.env.UPLOAD_PATH?.trim();
+  return configured && configured.length > 0 ? path.resolve(configured) : path.resolve('./uploads');
+};
+
+const getSupplierQuoteAttachmentsDir = (): string =>
+  path.join(getUploadRoot(), SUPPLIER_QUOTE_ATTACHMENTS_DIR);
+
+const ensureSafeBasename = (storedName: string): void => {
+  if (!storedName || storedName !== path.basename(storedName) || storedName.includes('..')) {
+    throw new Error('Invalid stored attachment name');
+  }
+};
+
+export interface SavedAttachment {
+  storedName: string;
+  size: number;
+}
+
+export const saveSupplierQuoteAttachment = async (
+  buffer: Buffer,
+  originalName: string,
+): Promise<SavedAttachment> => {
+  const ext = getExtensionFromName(originalName);
+  const sanitizedExt = ext && /^[a-z0-9]+$/i.test(ext) ? ext.toLowerCase() : '';
+  const storedName = sanitizedExt ? `${randomUUID()}.${sanitizedExt}` : randomUUID();
+  const dir = getSupplierQuoteAttachmentsDir();
+  await mkdir(dir, { recursive: true });
+  const fullPath = path.join(dir, storedName);
+  await writeFile(fullPath, buffer, { flag: 'wx' });
+  return { storedName, size: buffer.byteLength };
+};
+
+export interface OpenedAttachment {
+  stream: ReadStream;
+  size: number;
+}
+
+export const openSupplierQuoteAttachment = async (
+  storedName: string,
+): Promise<OpenedAttachment> => {
+  ensureSafeBasename(storedName);
+  const fullPath = path.join(getSupplierQuoteAttachmentsDir(), storedName);
+  const info = await stat(fullPath);
+  if (!info.isFile()) throw new Error('Attachment is not a regular file');
+  return { stream: createReadStream(fullPath), size: info.size };
+};
+
+export const deleteSupplierQuoteAttachment = async (storedName: string): Promise<void> => {
+  ensureSafeBasename(storedName);
+  const fullPath = path.join(getSupplierQuoteAttachmentsDir(), storedName);
+  try {
+    await unlink(fullPath);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+  }
+};

--- a/server/utils/fileStorage.ts
+++ b/server/utils/fileStorage.ts
@@ -25,10 +25,16 @@ export const getExtensionFromName = (name: string): string => {
 };
 
 export const isAllowedAttachment = (mimeType: string, fileName: string): boolean => {
+  // Extension is the firm gate: a file with an extension outside the allowlist is rejected
+  // regardless of the client-supplied MIME type, otherwise an attacker could upload e.g.
+  // `payload.exe` by claiming `application/pdf`.
   const ext = getExtensionFromName(fileName);
-  if (ATTACHMENT_ALLOWED_MIME.has(mimeType)) return true;
-  if (ATTACHMENT_ALLOWED_EXT.has(ext)) return true;
-  return false;
+  if (!ATTACHMENT_ALLOWED_EXT.has(ext)) return false;
+  // Some browsers (Safari, some Chrome configs) report `application/octet-stream` for
+  // legitimate xlsx/doc uploads, so accept that as a generic fallback when the extension
+  // itself is allowed. All other MIME types must be on the allowlist.
+  if (mimeType === 'application/octet-stream') return true;
+  return ATTACHMENT_ALLOWED_MIME.has(mimeType);
 };
 
 const getUploadRoot = (): string => {

--- a/services/api/supplierQuotes.ts
+++ b/services/api/supplierQuotes.ts
@@ -1,5 +1,10 @@
-import type { SupplierQuote, SupplierQuoteVersion, SupplierQuoteVersionRow } from '../../types';
-import { fetchApi } from './client';
+import type {
+  SupplierQuote,
+  SupplierQuoteAttachment,
+  SupplierQuoteVersion,
+  SupplierQuoteVersionRow,
+} from '../../types';
+import { fetchApi, fetchApiStream } from './client';
 import { normalizeSupplierQuote } from './normalizers';
 
 export const supplierQuotesApi = {
@@ -33,4 +38,37 @@ export const supplierQuotesApi = {
     fetchApi<SupplierQuote>(`/sales/supplier-quotes/${id}/versions/${versionId}/restore`, {
       method: 'POST',
     }).then(normalizeSupplierQuote),
+
+  listAttachments: (id: string): Promise<SupplierQuoteAttachment[]> =>
+    fetchApi<SupplierQuoteAttachment[]>(`/sales/supplier-quotes/${id}/attachments`),
+
+  uploadAttachment: async (id: string, file: File): Promise<SupplierQuoteAttachment> => {
+    const formData = new FormData();
+    formData.append('file', file, file.name);
+    // fetchApiStream avoids the auto Content-Type: application/json that fetchApi adds when a
+    // body is present — we need fetch to set the multipart boundary itself.
+    const response = await fetchApiStream(`/sales/supplier-quotes/${id}/attachments`, {
+      method: 'POST',
+      body: formData,
+    });
+    if (!response.ok) {
+      const errorBody = await response.json().catch(() => ({ error: 'Upload failed' }));
+      throw new Error(errorBody.error || `HTTP ${response.status}`);
+    }
+    return (await response.json()) as SupplierQuoteAttachment;
+  },
+
+  downloadAttachment: async (id: string, attachmentId: string): Promise<Blob> => {
+    const response = await fetchApiStream(
+      `/sales/supplier-quotes/${id}/attachments/${attachmentId}/download`,
+    );
+    if (!response.ok) {
+      const errorBody = await response.json().catch(() => ({ error: 'Download failed' }));
+      throw new Error(errorBody.error || `HTTP ${response.status}`);
+    }
+    return await response.blob();
+  },
+
+  deleteAttachment: (id: string, attachmentId: string): Promise<void> =>
+    fetchApi(`/sales/supplier-quotes/${id}/attachments/${attachmentId}`, { method: 'DELETE' }),
 };

--- a/test/components/SupplierQuoteAttachmentsSection.test.tsx
+++ b/test/components/SupplierQuoteAttachmentsSection.test.tsx
@@ -95,7 +95,14 @@ afterEach(() => {
 
 describe('<SupplierQuoteAttachmentsSection />', () => {
   test('renders empty state and the upload zone when editable', async () => {
-    render(<SupplierQuoteAttachmentsSection quoteId="sq-1" isReadOnly={false} />);
+    render(
+      <SupplierQuoteAttachmentsSection
+        quoteId="sq-1"
+        isReadOnly={false}
+        readOnlyStatus="Editable"
+        statusLabel="Status:"
+      />,
+    );
     await waitFor(() => expect(listAttachmentsMock).toHaveBeenCalledWith('sq-1'));
     expect(screen.getByText('No attachments yet.')).toBeInTheDocument();
     expect(screen.getByText('Drop a file here or click to upload')).toBeInTheDocument();
@@ -103,7 +110,14 @@ describe('<SupplierQuoteAttachmentsSection />', () => {
 
   test('renders attachments newest-first and shows formatted size', async () => {
     listAttachmentsMock.mockImplementation(() => Promise.resolve([ATTACHMENT_B, ATTACHMENT_A]));
-    render(<SupplierQuoteAttachmentsSection quoteId="sq-1" isReadOnly={false} />);
+    render(
+      <SupplierQuoteAttachmentsSection
+        quoteId="sq-1"
+        isReadOnly={false}
+        readOnlyStatus="Editable"
+        statusLabel="Status:"
+      />,
+    );
     await waitFor(() => expect(screen.getByText('first.xlsx')).toBeInTheDocument());
     expect(screen.getByText('second.pdf')).toBeInTheDocument();
     // 2048 bytes => 2.0 KB; 5242880 bytes => 5.0 MB
@@ -113,7 +127,14 @@ describe('<SupplierQuoteAttachmentsSection />', () => {
 
   test('hides upload zone and delete buttons when read-only', async () => {
     listAttachmentsMock.mockImplementation(() => Promise.resolve([ATTACHMENT_A]));
-    render(<SupplierQuoteAttachmentsSection quoteId="sq-1" isReadOnly={true} />);
+    render(
+      <SupplierQuoteAttachmentsSection
+        quoteId="sq-1"
+        isReadOnly={true}
+        readOnlyStatus="Read-only"
+        statusLabel="Status:"
+      />,
+    );
     await waitFor(() => expect(screen.getByText('first.xlsx')).toBeInTheDocument());
     expect(screen.queryByText('Drop a file here or click to upload')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Delete')).not.toBeInTheDocument();
@@ -128,7 +149,14 @@ describe('<SupplierQuoteAttachmentsSection />', () => {
       fileName: 'new.xlsx',
     };
     uploadAttachmentMock.mockImplementation(() => Promise.resolve(created));
-    render(<SupplierQuoteAttachmentsSection quoteId="sq-1" isReadOnly={false} />);
+    render(
+      <SupplierQuoteAttachmentsSection
+        quoteId="sq-1"
+        isReadOnly={false}
+        readOnlyStatus="Editable"
+        statusLabel="Status:"
+      />,
+    );
     await waitFor(() => expect(listAttachmentsMock).toHaveBeenCalled());
 
     const file = new File(['contents'], 'new.xlsx', {
@@ -142,7 +170,14 @@ describe('<SupplierQuoteAttachmentsSection />', () => {
   });
 
   test('rejects disallowed file types client-side without calling the API', async () => {
-    render(<SupplierQuoteAttachmentsSection quoteId="sq-1" isReadOnly={false} />);
+    render(
+      <SupplierQuoteAttachmentsSection
+        quoteId="sq-1"
+        isReadOnly={false}
+        readOnlyStatus="Editable"
+        statusLabel="Status:"
+      />,
+    );
     await waitFor(() => expect(listAttachmentsMock).toHaveBeenCalled());
 
     const exe = new File(['x'], 'malware.exe', { type: 'application/octet-stream' });
@@ -158,7 +193,14 @@ describe('<SupplierQuoteAttachmentsSection />', () => {
   });
 
   test('rejects oversized files client-side', async () => {
-    render(<SupplierQuoteAttachmentsSection quoteId="sq-1" isReadOnly={false} />);
+    render(
+      <SupplierQuoteAttachmentsSection
+        quoteId="sq-1"
+        isReadOnly={false}
+        readOnlyStatus="Editable"
+        statusLabel="Status:"
+      />,
+    );
     await waitFor(() => expect(listAttachmentsMock).toHaveBeenCalled());
 
     // Forge a File whose `size` property reports >10 MB without actually allocating that much.
@@ -178,7 +220,14 @@ describe('<SupplierQuoteAttachmentsSection />', () => {
   test('confirms before deleting and removes the row on success', async () => {
     listAttachmentsMock.mockImplementation(() => Promise.resolve([ATTACHMENT_A]));
     deleteAttachmentMock.mockImplementation(() => Promise.resolve());
-    render(<SupplierQuoteAttachmentsSection quoteId="sq-1" isReadOnly={false} />);
+    render(
+      <SupplierQuoteAttachmentsSection
+        quoteId="sq-1"
+        isReadOnly={false}
+        readOnlyStatus="Editable"
+        statusLabel="Status:"
+      />,
+    );
     await waitFor(() => expect(screen.getByText('first.xlsx')).toBeInTheDocument());
 
     fireEvent.click(screen.getByLabelText('Delete'));
@@ -193,7 +242,14 @@ describe('<SupplierQuoteAttachmentsSection />', () => {
     uploadAttachmentMock.mockImplementation(() =>
       Promise.reject(new Error('Quotes become read-only once an order exists')),
     );
-    render(<SupplierQuoteAttachmentsSection quoteId="sq-1" isReadOnly={false} />);
+    render(
+      <SupplierQuoteAttachmentsSection
+        quoteId="sq-1"
+        isReadOnly={false}
+        readOnlyStatus="Editable"
+        statusLabel="Status:"
+      />,
+    );
     await waitFor(() => expect(listAttachmentsMock).toHaveBeenCalled());
 
     const file = new File(['x'], 'order.xlsx', {

--- a/test/components/SupplierQuoteAttachmentsSection.test.tsx
+++ b/test/components/SupplierQuoteAttachmentsSection.test.tsx
@@ -1,0 +1,209 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import type { SupplierQuoteAttachment } from '../../types';
+
+// Stable t/i18n references — components that put `t` in useEffect dep arrays would otherwise
+// loop forever in tests because every render produces a fresh `t` identity.
+const t = (key: string, opts?: { defaultValue?: string }) => opts?.defaultValue ?? key;
+const i18n = { language: 'en', changeLanguage: () => {} };
+mock.module('react-i18next', () => ({
+  useTranslation: () => ({ t, i18n }),
+  Trans: ({ children }: { children: ReactNode }) => children,
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}));
+
+const listAttachmentsMock = mock<(id: string) => Promise<SupplierQuoteAttachment[]>>(() =>
+  Promise.resolve([]),
+);
+const uploadAttachmentMock = mock<(id: string, file: File) => Promise<SupplierQuoteAttachment>>();
+const downloadAttachmentMock = mock<(id: string, attachmentId: string) => Promise<Blob>>();
+const deleteAttachmentMock = mock<(id: string, attachmentId: string) => Promise<void>>();
+
+mock.module('../../services/api/supplierQuotes', () => ({
+  supplierQuotesApi: {
+    listAttachments: (id: string) => listAttachmentsMock(id),
+    uploadAttachment: (id: string, file: File) => uploadAttachmentMock(id, file),
+    downloadAttachment: (id: string, aid: string) => downloadAttachmentMock(id, aid),
+    deleteAttachment: (id: string, aid: string) => deleteAttachmentMock(id, aid),
+  },
+}));
+
+const realDate = await import('../../utils/date');
+mock.module('../../utils/date', () => ({
+  ...realDate,
+  formatInsertDateTime: (ts: number) => `at-${ts}`,
+}));
+
+mock.module('../../components/shared/DeleteConfirmModal', () => ({
+  default: ({
+    isOpen,
+    onConfirm,
+    onClose,
+  }: {
+    isOpen: boolean;
+    onConfirm: () => void;
+    onClose: () => void;
+  }) =>
+    isOpen ? (
+      <div data-testid="confirm-modal">
+        <button type="button" onClick={onClose}>
+          confirm-cancel
+        </button>
+        <button type="button" onClick={onConfirm}>
+          confirm-yes
+        </button>
+      </div>
+    ) : null,
+}));
+
+const SupplierQuoteAttachmentsSection = (
+  await import('../../components/sales/SupplierQuoteAttachmentsSection')
+).default;
+
+const ATTACHMENT_A: SupplierQuoteAttachment = {
+  id: 'sqa-1',
+  quoteId: 'sq-1',
+  fileName: 'first.xlsx',
+  mimeType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  fileSize: 2048,
+  uploadedByUserId: 'u-1',
+  createdAt: 1_700_000_000_000,
+};
+
+const ATTACHMENT_B: SupplierQuoteAttachment = {
+  id: 'sqa-2',
+  quoteId: 'sq-1',
+  fileName: 'second.pdf',
+  mimeType: 'application/pdf',
+  fileSize: 5_242_880,
+  uploadedByUserId: null,
+  createdAt: 1_700_000_001_000,
+};
+
+beforeEach(() => {
+  listAttachmentsMock.mockReset();
+  uploadAttachmentMock.mockReset();
+  downloadAttachmentMock.mockReset();
+  deleteAttachmentMock.mockReset();
+  listAttachmentsMock.mockImplementation(() => Promise.resolve([]));
+});
+
+afterEach(() => {
+  document.body.style.overflow = '';
+});
+
+describe('<SupplierQuoteAttachmentsSection />', () => {
+  test('renders empty state and the upload zone when editable', async () => {
+    render(<SupplierQuoteAttachmentsSection quoteId="sq-1" isReadOnly={false} />);
+    await waitFor(() => expect(listAttachmentsMock).toHaveBeenCalledWith('sq-1'));
+    expect(screen.getByText('No attachments yet.')).toBeInTheDocument();
+    expect(screen.getByText('Drop a file here or click to upload')).toBeInTheDocument();
+  });
+
+  test('renders attachments newest-first and shows formatted size', async () => {
+    listAttachmentsMock.mockImplementation(() => Promise.resolve([ATTACHMENT_B, ATTACHMENT_A]));
+    render(<SupplierQuoteAttachmentsSection quoteId="sq-1" isReadOnly={false} />);
+    await waitFor(() => expect(screen.getByText('first.xlsx')).toBeInTheDocument());
+    expect(screen.getByText('second.pdf')).toBeInTheDocument();
+    // 2048 bytes => 2.0 KB; 5242880 bytes => 5.0 MB
+    expect(screen.getByText(/2\.0 KB/)).toBeInTheDocument();
+    expect(screen.getByText(/5\.0 MB/)).toBeInTheDocument();
+  });
+
+  test('hides upload zone and delete buttons when read-only', async () => {
+    listAttachmentsMock.mockImplementation(() => Promise.resolve([ATTACHMENT_A]));
+    render(<SupplierQuoteAttachmentsSection quoteId="sq-1" isReadOnly={true} />);
+    await waitFor(() => expect(screen.getByText('first.xlsx')).toBeInTheDocument());
+    expect(screen.queryByText('Drop a file here or click to upload')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Delete')).not.toBeInTheDocument();
+    // Download stays visible — view-only users can still grab the file.
+    expect(screen.getByLabelText('Download')).toBeInTheDocument();
+  });
+
+  test('uploads a valid file and prepends it to the list', async () => {
+    const created: SupplierQuoteAttachment = {
+      ...ATTACHMENT_A,
+      id: 'sqa-new',
+      fileName: 'new.xlsx',
+    };
+    uploadAttachmentMock.mockImplementation(() => Promise.resolve(created));
+    render(<SupplierQuoteAttachmentsSection quoteId="sq-1" isReadOnly={false} />);
+    await waitFor(() => expect(listAttachmentsMock).toHaveBeenCalled());
+
+    const file = new File(['contents'], 'new.xlsx', {
+      type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    });
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => expect(uploadAttachmentMock).toHaveBeenCalledWith('sq-1', file));
+    await waitFor(() => expect(screen.getByText('new.xlsx')).toBeInTheDocument());
+  });
+
+  test('rejects disallowed file types client-side without calling the API', async () => {
+    render(<SupplierQuoteAttachmentsSection quoteId="sq-1" isReadOnly={false} />);
+    await waitFor(() => expect(listAttachmentsMock).toHaveBeenCalled());
+
+    const exe = new File(['x'], 'malware.exe', { type: 'application/octet-stream' });
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [exe] } });
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('File type not allowed. Use xlsx, xls, csv, pdf, doc, or docx.'),
+      ).toBeInTheDocument(),
+    );
+    expect(uploadAttachmentMock).not.toHaveBeenCalled();
+  });
+
+  test('rejects oversized files client-side', async () => {
+    render(<SupplierQuoteAttachmentsSection quoteId="sq-1" isReadOnly={false} />);
+    await waitFor(() => expect(listAttachmentsMock).toHaveBeenCalled());
+
+    // Forge a File whose `size` property reports >10 MB without actually allocating that much.
+    const big = new File(['x'], 'big.xlsx', {
+      type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    });
+    Object.defineProperty(big, 'size', { value: 11 * 1024 * 1024 });
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [big] } });
+
+    await waitFor(() =>
+      expect(screen.getByText('File exceeds the 10 MB upload limit')).toBeInTheDocument(),
+    );
+    expect(uploadAttachmentMock).not.toHaveBeenCalled();
+  });
+
+  test('confirms before deleting and removes the row on success', async () => {
+    listAttachmentsMock.mockImplementation(() => Promise.resolve([ATTACHMENT_A]));
+    deleteAttachmentMock.mockImplementation(() => Promise.resolve());
+    render(<SupplierQuoteAttachmentsSection quoteId="sq-1" isReadOnly={false} />);
+    await waitFor(() => expect(screen.getByText('first.xlsx')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByLabelText('Delete'));
+    expect(screen.getByTestId('confirm-modal')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('confirm-yes'));
+    await waitFor(() => expect(deleteAttachmentMock).toHaveBeenCalledWith('sq-1', 'sqa-1'));
+    await waitFor(() => expect(screen.queryByText('first.xlsx')).not.toBeInTheDocument());
+  });
+
+  test('surfaces server upload error message', async () => {
+    uploadAttachmentMock.mockImplementation(() =>
+      Promise.reject(new Error('Quotes become read-only once an order exists')),
+    );
+    render(<SupplierQuoteAttachmentsSection quoteId="sq-1" isReadOnly={false} />);
+    await waitFor(() => expect(listAttachmentsMock).toHaveBeenCalled());
+
+    const file = new File(['x'], 'order.xlsx', {
+      type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    });
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() =>
+      expect(screen.getByText('Quotes become read-only once an order exists')).toBeInTheDocument(),
+    );
+  });
+});

--- a/types.ts
+++ b/types.ts
@@ -625,6 +625,16 @@ export interface SupplierQuoteVersion extends SupplierQuoteVersionRow {
   snapshot: SupplierQuoteVersionSnapshot;
 }
 
+export interface SupplierQuoteAttachment {
+  id: string;
+  quoteId: string;
+  fileName: string;
+  mimeType: string;
+  fileSize: number;
+  uploadedByUserId: string | null;
+  createdAt: number;
+}
+
 export interface SupplierSaleOrderItem {
   id: string;
   orderId: string;


### PR DESCRIPTION
Add an attachments section to supplier quotes so users can keep the source
files (xlsx, pdf, doc, etc.) received from suppliers alongside the digitized
quote. Files are uploaded to a configurable filesystem path (UPLOAD_PATH),
limited to 10 MB and the xlsx/xls/csv/pdf/doc/docx allowlist, and only
mutable while the quote is still draft and not yet linked to an order.
Cleanup of orphaned files happens on insert failure and on quote delete.

https://claude.ai/code/session_01VUor1Vd9FRzNEb4Hi9gQUA