### PR TITLE
feat(style): replace UserManagement table with StandardTable columns

### DIFF
--- a/components/administration/UserManagement.tsx
+++ b/components/administration/UserManagement.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { usersApi } from '../../services/api';
+import { usersApi } from '../../services/api/users';
 import type { Client, Project, ProjectTask, Role, User } from '../../types';
 import { buildPermission, hasPermission, TOP_MANAGER_ROLE_ID } from '../../utils/permissions';
 import Checkbox from '../shared/Checkbox';

--- a/components/administration/UserManagement.tsx
+++ b/components/administration/UserManagement.tsx
@@ -6,7 +6,7 @@ import { buildPermission, hasPermission, TOP_MANAGER_ROLE_ID } from '../../utils
 import Checkbox from '../shared/Checkbox';
 import CustomSelect from '../shared/CustomSelect';
 import Modal from '../shared/Modal';
-import StandardTable from '../shared/StandardTable';
+import StandardTable, { type Column } from '../shared/StandardTable';
 import StatusBadge from '../shared/StatusBadge';
 import Toggle from '../shared/Toggle';
 import Tooltip from '../shared/Tooltip';
@@ -32,8 +32,6 @@ export interface UserManagementProps {
   roles: Role[];
   currency: string;
 }
-
-const USERS_ROWS_PER_PAGE_STORAGE_KEY = 'praetor_workforce_users_rowsPerPage';
 
 const UserManagement: React.FC<UserManagementProps> = ({
   users,
@@ -156,11 +154,6 @@ const UserManagement: React.FC<UserManagementProps> = ({
   const [editIsDisabled, setEditIsDisabled] = useState(false);
   const [userSearch, setUserSearch] = useState('');
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
-  const [usersCurrentPage, setUsersCurrentPage] = useState(1);
-  const [usersRowsPerPage, setUsersRowsPerPage] = useState(() => {
-    const saved = localStorage.getItem(USERS_ROWS_PER_PAGE_STORAGE_KEY);
-    return saved ? parseInt(saved, 10) : 5;
-  });
 
   const canCreateUsers = hasPermission(
     permissions,
@@ -239,13 +232,6 @@ const UserManagement: React.FC<UserManagementProps> = ({
     setNewRole(roleOptions[0]?.id || '');
     usernameManuallyEdited.current = false;
     setFormErrors({});
-  };
-
-  const handleUsersRowsPerPageChange = (val: string) => {
-    const value = parseInt(val, 10);
-    setUsersRowsPerPage(value);
-    localStorage.setItem(USERS_ROWS_PER_PAGE_STORAGE_KEY, value.toString());
-    setUsersCurrentPage(1);
   };
 
   React.useEffect(() => {
@@ -685,23 +671,6 @@ const UserManagement: React.FC<UserManagementProps> = ({
     .sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }))
     .filter((user) => matchesUserSearch(user, userSearchValue));
 
-  const usersTotalPages = Math.ceil(usersFiltered.length / usersRowsPerPage);
-
-  React.useEffect(() => {
-    if (usersTotalPages === 0) {
-      if (usersCurrentPage !== 1) {
-        setUsersCurrentPage(1);
-      }
-      return;
-    }
-
-    if (usersCurrentPage > usersTotalPages) {
-      setUsersCurrentPage(usersTotalPages);
-    }
-  }, [usersCurrentPage, usersTotalPages]);
-
-  const usersStartIndex = (usersCurrentPage - 1) * usersRowsPerPage;
-  const paginatedUsers = usersFiltered.slice(usersStartIndex, usersStartIndex + usersRowsPerPage);
   const emptyEmailLabel = t('common:common.none');
   const noUsersFoundLabel = t('hr:workforce.noUsers');
   const getUserStatusLabel = (user: User) =>
@@ -732,6 +701,166 @@ const UserManagement: React.FC<UserManagementProps> = ({
       roleName: role?.name || user.role,
     };
   };
+
+  const userColumns: Column<User>[] = [
+    {
+      header: t('hr:workforce.user'),
+      accessorKey: 'name',
+      cell: ({ row }) => (
+        <div className="flex items-center gap-3">
+          <div className="w-8 h-8 rounded-full bg-slate-100 text-praetor flex items-center justify-center text-xs font-bold">
+            {row.avatarInitials}
+          </div>
+          <span className="font-bold text-slate-800">{row.name}</span>
+          {row.id === currentUserId && (
+            <span className="text-[10px] bg-praetor px-2 py-0.5 rounded text-white font-bold uppercase">
+              {t('hr:workforce.you')}
+            </span>
+          )}
+        </div>
+      ),
+    },
+    {
+      header: t('hr:workforce.username'),
+      accessorKey: 'username',
+      cell: ({ row }) => <span className="text-sm text-slate-600 font-mono">{row.username}</span>,
+    },
+    {
+      header: t('common:labels.email'),
+      accessorFn: (user) => user.email || emptyEmailLabel,
+      cell: ({ row }) =>
+        row.email ? (
+          <span className="text-sm font-medium text-slate-600 break-all">{row.email}</span>
+        ) : (
+          <span className="text-sm font-medium text-slate-400">{emptyEmailLabel}</span>
+        ),
+    },
+    {
+      header: t('hr:workforce.role'),
+      accessorFn: (user) => getRolePresentation(user).roleName,
+      cell: ({ row }) => {
+        const { roleBadgeClass, roleIcon, roleName } = getRolePresentation(row);
+        return (
+          <span
+            className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-[10px] font-black uppercase tracking-wider border ${roleBadgeClass}`}
+          >
+            <i className={`fa-solid ${roleIcon}`}></i>
+            {roleName}
+          </span>
+        );
+      },
+    },
+    {
+      header: t('common:labels.status'),
+      accessorFn: (user) => getUserStatusLabel(user),
+      cell: ({ row }) => (
+        <StatusBadge
+          type={row.isDisabled ? 'disabled' : 'active'}
+          label={getUserStatusLabel(row)}
+        />
+      ),
+    },
+    {
+      header: t('hr:workforce.actions'),
+      id: 'actions',
+      align: 'right',
+      sticky: 'right',
+      disableSorting: true,
+      disableFiltering: true,
+      cell: ({ row }) => {
+        const hasManagedTopManagerAssignments =
+          row.hasTopManagerRole || row.role === TOP_MANAGER_ROLE_ID;
+
+        return (
+          <div className="flex items-center justify-end gap-2">
+            {canManageAssignments && !hasManagedTopManagerAssignments && (
+              <Tooltip label={t('hr:workforce.manageAssignments')}>
+                {() => (
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      openAssignments(row.id);
+                    }}
+                    className="text-slate-400 hover:text-praetor transition-colors p-2"
+                  >
+                    <i className="fa-solid fa-link"></i>
+                  </button>
+                )}
+              </Tooltip>
+            )}
+            {canUpdateUsers && (
+              <>
+                <Tooltip label={t('hr:workforce.editUser')}>
+                  {() => (
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleEdit(row);
+                      }}
+                      className="text-slate-400 hover:text-praetor transition-colors p-2"
+                    >
+                      <i className="fa-solid fa-user-pen"></i>
+                    </button>
+                  )}
+                </Tooltip>
+                {row.isDisabled ? (
+                  <Tooltip label={t('hr:workforce.reEnableUser')}>
+                    {() => (
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onUpdateUser(row.id, { isDisabled: false });
+                        }}
+                        className="text-slate-400 hover:text-praetor transition-colors p-2 rounded-lg"
+                      >
+                        <i className="fa-solid fa-rotate-left"></i>
+                      </button>
+                    )}
+                  </Tooltip>
+                ) : (
+                  <Tooltip label={t('hr:workforce.disableUser')}>
+                    {() => (
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onUpdateUser(row.id, { isDisabled: true });
+                        }}
+                        disabled={row.id === currentUserId}
+                        className="text-slate-400 hover:text-amber-600 hover:bg-amber-50 disabled:opacity-0 transition-colors p-2 rounded-lg"
+                      >
+                        <i className="fa-solid fa-ban"></i>
+                      </button>
+                    )}
+                  </Tooltip>
+                )}
+              </>
+            )}
+            {canDeleteUsers && (
+              <Tooltip label={t('hr:workforce.deleteUser')}>
+                {() => (
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      confirmDelete(row);
+                    }}
+                    disabled={row.id === currentUserId}
+                    className="text-slate-400 hover:text-red-500 disabled:opacity-0 transition-colors p-2"
+                  >
+                    <i className="fa-solid fa-trash-can"></i>
+                  </button>
+                )}
+              </Tooltip>
+            )}
+          </div>
+        );
+      },
+    },
+  ];
 
   return (
     <div className="space-y-6 animate-in slide-in-from-bottom-2 duration-500">
@@ -1162,10 +1291,7 @@ const UserManagement: React.FC<UserManagementProps> = ({
             type="text"
             placeholder={t('hr:workforce.searchUsers')}
             value={userSearch}
-            onChange={(e) => {
-              setUserSearch(e.target.value);
-              setUsersCurrentPage(1);
-            }}
+            onChange={(e) => setUserSearch(e.target.value)}
             className="w-full pl-8 pr-3 py-2 bg-white border border-slate-200 rounded-xl text-sm font-semibold focus:ring-2 focus:ring-praetor outline-none shadow-sm"
           />
         </div>
@@ -1179,246 +1305,19 @@ const UserManagement: React.FC<UserManagementProps> = ({
         )}
       </div>
 
-      <StandardTable
+      <StandardTable<User>
         title={t('hr:workforce.title')}
-        totalCount={usersFiltered.length}
-        footerClassName="flex flex-col sm:flex-row justify-between items-center gap-4"
-        footer={
-          <>
-            <div className="flex items-center gap-3">
-              <span className="text-xs font-bold text-slate-500">
-                {t('common:labels.rowsPerPage')}:
-              </span>
-              <CustomSelect
-                options={[
-                  { id: '5', name: '5' },
-                  { id: '10', name: '10' },
-                  { id: '20', name: '20' },
-                  { id: '50', name: '50' },
-                ]}
-                value={usersRowsPerPage.toString()}
-                onChange={(val) => handleUsersRowsPerPageChange(val as string)}
-                className="w-20"
-                buttonClassName="px-2 py-1 bg-white border border-slate-200 text-xs font-bold text-slate-700 rounded-lg"
-                searchable={false}
-              />
-              <span className="text-xs font-bold text-slate-400 ml-2">
-                {t('common:pagination.showing', {
-                  start: paginatedUsers.length > 0 ? usersStartIndex + 1 : 0,
-                  end: Math.min(usersStartIndex + usersRowsPerPage, usersFiltered.length),
-                  total: usersFiltered.length,
-                })}
-              </span>
-            </div>
-
-            <div className="flex items-center gap-2">
-              <button
-                onClick={() => setUsersCurrentPage((prev) => Math.max(1, prev - 1))}
-                disabled={usersCurrentPage === 1}
-                className="w-8 h-8 flex items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-500 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-slate-50 transition-colors"
-              >
-                <i className="fa-solid fa-chevron-left text-xs"></i>
-              </button>
-              <div className="flex items-center gap-1">
-                {Array.from({ length: usersTotalPages }, (_, i) => i + 1).map((page) => (
-                  <button
-                    key={page}
-                    onClick={() => setUsersCurrentPage(page)}
-                    className={`w-8 h-8 flex items-center justify-center rounded-lg text-xs font-bold transition-all ${
-                      usersCurrentPage === page
-                        ? 'bg-praetor text-white shadow-md shadow-slate-200'
-                        : 'text-slate-500 hover:bg-slate-100'
-                    }`}
-                  >
-                    {page}
-                  </button>
-                ))}
-              </div>
-              <button
-                onClick={() => setUsersCurrentPage((prev) => Math.min(usersTotalPages, prev + 1))}
-                disabled={usersCurrentPage === usersTotalPages || usersTotalPages === 0}
-                className="w-8 h-8 flex items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-500 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-slate-50 transition-colors"
-              >
-                <i className="fa-solid fa-chevron-right text-xs"></i>
-              </button>
-            </div>
-          </>
+        data={usersFiltered}
+        columns={userColumns}
+        defaultRowsPerPage={5}
+        emptyState={noUsersFoundLabel}
+        rowClassName={(user) =>
+          user.isDisabled
+            ? 'opacity-60 grayscale hover:opacity-100 hover:grayscale-0 hover:bg-slate-50'
+            : 'hover:bg-slate-50'
         }
-      >
-        <table className="w-full text-left">
-          <thead className="bg-slate-50 border-b border-slate-200">
-            <tr>
-              <th className="px-6 py-3 text-[10px] font-black uppercase text-slate-400 tracking-widest">
-                {t('hr:workforce.user')}
-              </th>
-              <th className="px-6 py-3 text-[10px] font-black uppercase text-slate-400 tracking-widest">
-                {t('hr:workforce.username')}
-              </th>
-              <th className="px-6 py-3 text-[10px] font-black uppercase text-slate-400 tracking-widest">
-                {t('common:labels.email')}
-              </th>
-              <th className="px-6 py-3 text-[10px] font-black uppercase text-slate-400 tracking-widest">
-                {t('hr:workforce.role')}
-              </th>
-              <th className="px-6 py-3 text-[10px] font-black uppercase text-slate-400 tracking-widest">
-                {t('common:labels.status')}
-              </th>
-              <th className="px-6 py-3 text-[10px] font-black uppercase text-slate-400 tracking-widest text-right">
-                {t('hr:workforce.actions')}
-              </th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-slate-100">
-            {paginatedUsers.map((user) => {
-              const canEdit = canUpdateUsers;
-              const { roleBadgeClass, roleIcon, roleName } = getRolePresentation(user);
-              const hasManagedTopManagerAssignments =
-                user.hasTopManagerRole || user.role === TOP_MANAGER_ROLE_ID;
-
-              return (
-                <tr
-                  key={user.id}
-                  onClick={() => canEdit && handleEdit(user)}
-                  className={`group hover:bg-slate-50 transition-colors ${
-                    user.isDisabled
-                      ? 'opacity-60 grayscale hover:opacity-100 hover:grayscale-0'
-                      : ''
-                  } ${canEdit ? 'cursor-pointer' : ''}`}
-                >
-                  <td className="px-6 py-4">
-                    <div className="flex items-center gap-3">
-                      <div className="w-8 h-8 rounded-full bg-slate-100 text-praetor flex items-center justify-center text-xs font-bold">
-                        {user.avatarInitials}
-                      </div>
-                      <span className="font-bold text-slate-800">{user.name}</span>
-                      {user.id === currentUserId && (
-                        <span className="text-[10px] bg-praetor px-2 py-0.5 rounded text-white font-bold uppercase">
-                          {t('hr:workforce.you')}
-                        </span>
-                      )}
-                    </div>
-                  </td>
-                  <td className="px-6 py-4">
-                    <span className="text-sm text-slate-600 font-mono">{user.username}</span>
-                  </td>
-                  <td className="px-6 py-4">
-                    {user.email ? (
-                      <span className="text-sm font-medium text-slate-600 break-all">
-                        {user.email}
-                      </span>
-                    ) : (
-                      <span className="text-sm font-medium text-slate-400">{emptyEmailLabel}</span>
-                    )}
-                  </td>
-                  <td className="px-6 py-4">
-                    <span
-                      className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-[10px] font-black uppercase tracking-wider border ${roleBadgeClass}`}
-                    >
-                      <i className={`fa-solid ${roleIcon}`}></i>
-                      {roleName}
-                    </span>
-                  </td>
-                  <td className="px-6 py-4">
-                    <StatusBadge
-                      type={user.isDisabled ? 'disabled' : 'active'}
-                      label={getUserStatusLabel(user)}
-                    />
-                  </td>
-                  <td className="px-6 py-4 text-right">
-                    <div className="flex items-center justify-end gap-2">
-                      {canManageAssignments && !hasManagedTopManagerAssignments && (
-                        <Tooltip label={t('hr:workforce.manageAssignments')}>
-                          {() => (
-                            <button
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                openAssignments(user.id);
-                              }}
-                              className="text-slate-400 hover:text-praetor transition-colors p-2"
-                            >
-                              <i className="fa-solid fa-link"></i>
-                            </button>
-                          )}
-                        </Tooltip>
-                      )}
-                      {canUpdateUsers && (
-                        <>
-                          <Tooltip label={t('hr:workforce.editUser')}>
-                            {() => (
-                              <button
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  handleEdit(user);
-                                }}
-                                className="text-slate-400 hover:text-praetor transition-colors p-2"
-                              >
-                                <i className="fa-solid fa-user-pen"></i>
-                              </button>
-                            )}
-                          </Tooltip>
-                          {user.isDisabled ? (
-                            <Tooltip label={t('hr:workforce.reEnableUser')}>
-                              {() => (
-                                <button
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    onUpdateUser(user.id, { isDisabled: false });
-                                  }}
-                                  className="text-slate-400 hover:text-praetor transition-colors p-2 rounded-lg"
-                                >
-                                  <i className="fa-solid fa-rotate-left"></i>
-                                </button>
-                              )}
-                            </Tooltip>
-                          ) : (
-                            <Tooltip label={t('hr:workforce.disableUser')}>
-                              {() => (
-                                <button
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    onUpdateUser(user.id, { isDisabled: true });
-                                  }}
-                                  disabled={user.id === currentUserId}
-                                  className="text-slate-400 hover:text-amber-600 hover:bg-amber-50 disabled:opacity-0 transition-colors p-2 rounded-lg"
-                                >
-                                  <i className="fa-solid fa-ban"></i>
-                                </button>
-                              )}
-                            </Tooltip>
-                          )}
-                        </>
-                      )}
-                      {canDeleteUsers && (
-                        <Tooltip label={t('hr:workforce.deleteUser')}>
-                          {() => (
-                            <button
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                confirmDelete(user);
-                              }}
-                              disabled={user.id === currentUserId}
-                              className="text-slate-400 hover:text-red-500 disabled:opacity-0 transition-colors p-2"
-                            >
-                              <i className="fa-solid fa-trash-can"></i>
-                            </button>
-                          )}
-                        </Tooltip>
-                      )}
-                    </div>
-                  </td>
-                </tr>
-              );
-            })}
-            {paginatedUsers.length === 0 && (
-              <tr>
-                <td colSpan={6} className="px-6 py-10 text-center text-sm font-bold text-slate-400">
-                  {noUsersFoundLabel}
-                </td>
-              </tr>
-            )}
-          </tbody>
-        </table>
-      </StandardTable>
+        onRowClick={canUpdateUsers ? handleEdit : undefined}
+      />
 
       {/* Assignment Modal */}
       <Modal

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -471,6 +471,14 @@ const StandardTable = <T extends object>({
   const startIndex = (currentPage - 1) * rowsPerPage;
   const paginatedData = data ? processedData.slice(startIndex, startIndex + rowsPerPage) : [];
 
+  useEffect(() => {
+    if (totalPages === 0) {
+      if (currentPage !== 1) setCurrentPage(1);
+      return;
+    }
+    if (currentPage > totalPages) setCurrentPage(totalPages);
+  }, [currentPage, totalPages]);
+
   // Pre-computed once per data/columns change so each filter popup open is O(1)
   // instead of re-scanning the full dataset on every header re-render.
   const filterOptionsByCol = useMemo(() => {

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -1,5 +1,5 @@
 import { afterAll, afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
-import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { installI18nMock } from '../helpers/i18n';
 
 installI18nMock();
@@ -455,6 +455,39 @@ describe('<StandardTable />', () => {
     const tbody = container.querySelector('tbody') as HTMLElement;
     const bodyRows = tbody.querySelectorAll('tr');
     expect(bodyRows.length).toBe(20);
+  });
+
+  test('clamps current page when data changes reduce the page count', async () => {
+    const many: Row[] = Array.from({ length: 12 }, (_, i) => ({
+      id: String(i + 1),
+      name: `User${i + 1}`,
+      age: 20 + i,
+    }));
+    const { rerender } = render(
+      <StandardTable<Row>
+        title="ClampPage"
+        data={many}
+        columns={sampleColumns}
+        defaultRowsPerPage={5}
+      />,
+    );
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: '3' }));
+    });
+    expect(screen.getByText('User11')).toBeInTheDocument();
+
+    rerender(
+      <StandardTable<Row>
+        title="ClampPage"
+        data={many.slice(0, 4)}
+        columns={sampleColumns}
+        defaultRowsPerPage={5}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText('User1')).toBeInTheDocument());
+    expect(screen.queryByText('table.noResults')).not.toBeInTheDocument();
   });
 
   test('pagination "showing" counter renders and previous-button disables on page 1', () => {

--- a/test/components/administration/UserManagement.test.tsx
+++ b/test/components/administration/UserManagement.test.tsx
@@ -6,6 +6,16 @@ import { installI18nMock } from '../../helpers/i18n';
 
 installI18nMock();
 
+const usersApiMock = {
+  getAssignments: mock(async () => ({ clientIds: [], projectIds: [], taskIds: [] })),
+  getRoles: mock(async () => ({ roleIds: ['user'], primaryRoleId: 'user' })),
+  updateAssignments: mock(async () => {}),
+};
+
+mock.module('../../../services/api/users', () => ({
+  usersApi: usersApiMock,
+}));
+
 const UserManagement = (await import('../../../components/administration/UserManagement')).default;
 
 const updatePermission = 'administration.user_management.update';
@@ -59,6 +69,9 @@ const getRowFor = (text: string) => {
 describe('<UserManagement />', () => {
   beforeEach(() => {
     localStorage.clear();
+    usersApiMock.getAssignments.mockClear();
+    usersApiMock.getRoles.mockClear();
+    usersApiMock.updateAssignments.mockClear();
   });
 
   test('renders user details through StandardTable columns', () => {

--- a/test/components/administration/UserManagement.test.tsx
+++ b/test/components/administration/UserManagement.test.tsx
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import type { User } from '../../../types';
+import { installI18nMock } from '../../helpers/i18n';
+
+installI18nMock();
+
+const UserManagement = (await import('../../../components/administration/UserManagement')).default;
+
+const updatePermission = 'administration.user_management.update';
+const deletePermission = 'administration.user_management.delete';
+
+const users: User[] = [
+  {
+    id: 'u1',
+    name: 'Alice Admin',
+    role: 'admin',
+    avatarInitials: 'AA',
+    username: 'alice.admin',
+    email: 'alice@example.com',
+  },
+  {
+    id: 'u2',
+    name: 'Bob Brown',
+    role: 'manager',
+    avatarInitials: 'BB',
+    username: 'bob.brown',
+  },
+];
+
+const renderUserManagement = (overrides: Partial<ComponentProps<typeof UserManagement>> = {}) => {
+  const props: ComponentProps<typeof UserManagement> = {
+    users,
+    clients: [],
+    projects: [],
+    tasks: [],
+    onAddUser: mock(async () => ({ success: true })),
+    onDeleteUser: mock(() => {}),
+    onUpdateUser: mock(() => {}),
+    onUpdateUserRoles: mock(async () => {}),
+    currentUserId: 'u1',
+    permissions: [updatePermission, deletePermission],
+    roles: [],
+    currency: '$',
+    ...overrides,
+  };
+
+  render(<UserManagement {...props} />);
+  return props;
+};
+
+const getRowFor = (text: string) => {
+  const row = screen.getByText(text).closest('tr');
+  if (!row) throw new Error(`Could not find row for ${text}`);
+  return row;
+};
+
+describe('<UserManagement />', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('renders user details through StandardTable columns', () => {
+    renderUserManagement();
+
+    expect(screen.getByText('Alice Admin')).toBeInTheDocument();
+    expect(screen.getByText('alice.admin')).toBeInTheDocument();
+    expect(screen.getByText('alice@example.com')).toBeInTheDocument();
+    expect(screen.getByText('manager')).toBeInTheDocument();
+    expect(screen.getByText('common:common.none')).toBeInTheDocument();
+    expect(screen.getAllByText('common:common.active')).toHaveLength(2);
+  });
+
+  test('filters users with the external search input', () => {
+    renderUserManagement();
+
+    fireEvent.change(screen.getByPlaceholderText('hr:workforce.searchUsers'), {
+      target: { value: 'alice' },
+    });
+
+    expect(screen.getByText('Alice Admin')).toBeInTheDocument();
+    expect(screen.queryByText('Bob Brown')).not.toBeInTheDocument();
+  });
+
+  test('opens edit modal when an editable row is clicked', () => {
+    renderUserManagement();
+
+    fireEvent.click(screen.getByText('Bob Brown'));
+
+    expect(screen.getByText('hr:workforce.editUser')).toBeInTheDocument();
+  });
+
+  test('action button does not also trigger row edit', () => {
+    const props = renderUserManagement();
+    const bobRow = getRowFor('Bob Brown');
+    const disableButton = bobRow.querySelector('.fa-ban')?.closest('button');
+    if (!disableButton) throw new Error('Could not find disable button');
+
+    fireEvent.click(disableButton);
+
+    expect(props.onUpdateUser).toHaveBeenCalledWith('u2', { isDisabled: true });
+    expect(screen.queryByText('hr:workforce.editUser')).not.toBeInTheDocument();
+  });
+
+  test('shows empty state when no users match the search', () => {
+    renderUserManagement();
+
+    fireEvent.change(screen.getByPlaceholderText('hr:workforce.searchUsers'), {
+      target: { value: 'nobody' },
+    });
+
+    expect(screen.getByText('hr:workforce.noUsers')).toBeInTheDocument();
+    expect(screen.queryByText('Alice Admin')).not.toBeInTheDocument();
+    expect(screen.queryByText('Bob Brown')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Swapped the manual user table in `UserManagement` for `StandardTable<User>` column/data mode.
- Preserved external search, row click-to-edit, assignment/edit/disable/delete actions, permission gates, and disabled-row styling.
- Simplified pagination by letting `StandardTable` own rows-per-page and page state.
- Added a small regression fix in `StandardTable` to clamp the current page when filtered data shrinks.

## Testing
- Added focused unit coverage for `UserManagement` rendering, search filtering, row click behavior, action button propagation, and empty state.
- Added a regression test for `StandardTable` page clamping when the data set shrinks.
- Frontend TypeScript and Biome checks passed; full repo lint was not run locally because backend dependencies were unavailable in this environment.