### PR TITLE
feat(security): harden runtime secrets and scope assignment-based access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,8 +11,9 @@ POSTGRES_PASSWORD=praetor
 POSTGRES_DB=praetor
 
 # Application Secrets
-JWT_SECRET=praetor-secret-key-change-in-production
-ENCRYPTION_KEY=praetor-encryption-key-change-in-production
+# Generate unique high-entropy values before first startup.
+JWT_SECRET=change-me-long-random-jwt-secret
+ENCRYPTION_KEY=change-me-long-random-encryption-key
 
 # Reverse proxy trust for backend client IP detection.
 # `1` matches the built-in Caddy -> backend topology used by docker-compose.
@@ -29,6 +30,6 @@ LOG_LEVEL=info
 # demo business dataset. Intended for demo/test Docker stacks and reused volumes.
 DEMO_SEEDING=false
 
-# Default password for bootstrap admin user (username: admin)
+# Initial password for bootstrap admin user (username: admin)
 # Used only when the admin user does not already exist.
-ADMIN_DEFAULT_PASSWORD=password
+ADMIN_DEFAULT_PASSWORD=change-me-strong-admin-password

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,7 +296,13 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Prepare environment file
-        run: cp .env.example .env
+        run: |
+          cp .env.example .env
+          sed -i \
+            -e 's/^JWT_SECRET=.*/JWT_SECRET=ci-docker-stack-jwt-secret/' \
+            -e 's/^ENCRYPTION_KEY=.*/ENCRYPTION_KEY=ci-docker-stack-encryption-key/' \
+            -e 's/^ADMIN_DEFAULT_PASSWORD=.*/ADMIN_DEFAULT_PASSWORD=ci-docker-stack-admin-password/' \
+            .env
 
       - name: Build images
         run: docker compose build

--- a/components/Login.tsx
+++ b/components/Login.tsx
@@ -147,13 +147,6 @@ const Login: React.FC<LoginProps> = ({ onLogin, logoutReason, onClearLogoutReaso
             )}
           </button>
         </form>
-
-        <div className="mt-6 pt-4 border-t border-slate-100 text-center">
-          <p className="text-xs text-slate-400">
-            <strong>{t('auth:login.defaultCredentials')}:</strong> &quot;admin&quot; /
-            &quot;password&quot;
-          </p>
-        </div>
       </div>
     </div>
   );

--- a/components/sales/SupplierQuoteAttachmentsSection.tsx
+++ b/components/sales/SupplierQuoteAttachmentsSection.tsx
@@ -7,9 +7,9 @@ import { formatInsertDateTime } from '../../utils/date';
 import DeleteConfirmModal from '../shared/DeleteConfirmModal';
 import FieldTooltip from '../shared/FieldTooltip';
 
-const ALLOWED_EXT = new Set(['xlsx', 'xls', 'csv', 'pdf', 'doc', 'docx']);
+const ALLOWED_EXT = new Set(['xlsx', 'pdf', 'docx']);
 const MAX_FILE_SIZE = 10 * 1024 * 1024;
-const ACCEPT_ATTR = '.xlsx,.xls,.csv,.pdf,.doc,.docx';
+const ACCEPT_ATTR = '.xlsx,.pdf,.docx';
 
 const formatFileSize = (bytes: number): string => {
   if (!Number.isFinite(bytes) || bytes <= 0) return '0 B';
@@ -84,7 +84,7 @@ const SupplierQuoteAttachmentsSection: React.FC<SupplierQuoteAttachmentsSectionP
       const ext = getExtension(file.name);
       if (!ALLOWED_EXT.has(ext)) {
         return t('sales:supplierQuotes.attachments.errors.invalidType', {
-          defaultValue: 'File type not allowed. Use xlsx, xls, csv, pdf, doc, or docx.',
+          defaultValue: 'File type not allowed. Use xlsx, pdf, or docx.',
         });
       }
       return null;
@@ -228,7 +228,7 @@ const SupplierQuoteAttachmentsSection: React.FC<SupplierQuoteAttachmentsSectionP
           </span>
           <span className="text-xs text-slate-400">
             {t('sales:supplierQuotes.attachments.allowedTypes', {
-              defaultValue: 'Allowed: xlsx, xls, csv, pdf, doc, docx · max 10 MB',
+              defaultValue: 'Allowed: xlsx, pdf, docx · max 10 MB',
             })}
           </span>
           <input

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,11 +42,11 @@ services:
     environment:
       <<: *backend-db-env
       PORT: 3001
-      JWT_SECRET: ${JWT_SECRET:-praetor-secret-key-change-in-production}
-      ENCRYPTION_KEY: ${ENCRYPTION_KEY:-praetor-encryption-key-change-in-production}
+      JWT_SECRET: ${JWT_SECRET:?JWT_SECRET is required}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY:?ENCRYPTION_KEY is required}
       TRUST_PROXY: ${TRUST_PROXY:-1}
       DEMO_SEEDING: ${DEMO_SEEDING:-false}
-      ADMIN_DEFAULT_PASSWORD: ${ADMIN_DEFAULT_PASSWORD:-password}
+      ADMIN_DEFAULT_PASSWORD: ${ADMIN_DEFAULT_PASSWORD:?ADMIN_DEFAULT_PASSWORD is required}
       FRONTEND_URL: http://${SERVER_IP:-localhost}:3000
     volumes:
       - ssl_certs:/app/certs

--- a/locales/en/auth.json
+++ b/locales/en/auth.json
@@ -9,7 +9,6 @@
     "signIn": "Sign In",
     "signInButton": "Sign in to your account",
     "signingIn": "Signing in...",
-    "defaultCredentials": "Default credentials",
     "errors": {
       "invalidCredentials": "Invalid username or password",
       "networkError": "Network error. Please try again.",

--- a/locales/en/sales.json
+++ b/locales/en/sales.json
@@ -301,7 +301,7 @@
       "title": "Attachments",
       "uploadButton": "Upload file",
       "dropHere": "Drop a file here or click to upload",
-      "allowedTypes": "Allowed: xlsx, xls, csv, pdf, doc, docx · max 10 MB",
+      "allowedTypes": "Allowed: xlsx, pdf, docx · max 10 MB",
       "empty": "No attachments yet.",
       "uploading": "Uploading...",
       "downloadAction": "Download",
@@ -311,7 +311,7 @@
       "loadFailed": "Failed to load attachments.",
       "errors": {
         "tooLarge": "File exceeds the 10 MB upload limit",
-        "invalidType": "File type not allowed. Use xlsx, xls, csv, pdf, doc, or docx.",
+        "invalidType": "File type not allowed. Use xlsx, pdf, or docx.",
         "uploadFailed": "Upload failed",
         "downloadFailed": "Download failed",
         "deleteFailed": "Delete failed"

--- a/locales/it/auth.json
+++ b/locales/it/auth.json
@@ -9,7 +9,6 @@
     "signIn": "Accedi",
     "signInButton": "Accedi al tuo account",
     "signingIn": "Accesso in corso...",
-    "defaultCredentials": "Credenziali predefinite",
     "errors": {
       "invalidCredentials": "Nome utente o password non validi",
       "networkError": "Errore di rete. Riprova.",

--- a/locales/it/sales.json
+++ b/locales/it/sales.json
@@ -301,7 +301,7 @@
       "title": "Allegati",
       "uploadButton": "Carica file",
       "dropHere": "Trascina un file qui o clicca per caricarlo",
-      "allowedTypes": "Consentiti: xlsx, xls, csv, pdf, doc, docx · max 10 MB",
+      "allowedTypes": "Consentiti: xlsx, pdf, docx · max 10 MB",
       "empty": "Nessun allegato.",
       "uploading": "Caricamento...",
       "downloadAction": "Scarica",
@@ -311,7 +311,7 @@
       "loadFailed": "Caricamento degli allegati non riuscito.",
       "errors": {
         "tooLarge": "Il file supera il limite di 10 MB",
-        "invalidType": "Tipo di file non consentito. Usa xlsx, xls, csv, pdf, doc o docx.",
+        "invalidType": "Tipo di file non consentito. Usa xlsx, pdf o docx.",
         "uploadFailed": "Caricamento non riuscito",
         "downloadFailed": "Download non riuscito",
         "deleteFailed": "Eliminazione non riuscita"

--- a/server/.env.example
+++ b/server/.env.example
@@ -14,21 +14,21 @@ DB_NAME=tempo
 DB_USER=tempo
 DB_PASSWORD=tempo
 
-# JWT Secret (change this in production!)
-JWT_SECRET=tempo-secret-key-change-in-production
+# JWT Secret. Generate a unique high-entropy value before first startup.
+JWT_SECRET=change-me-long-random-jwt-secret
 
 # Optional demo refresh on startup.
 # When true, the backend provisions the demo manager/user credentials plus the canonical
 # demo business dataset. Intended for demo/test environments and reused demo volumes.
 DEMO_SEEDING=false
 
-# Default password for bootstrap admin user (username: admin)
+# Initial password for bootstrap admin user (username: admin)
 # Used only when the admin user does not already exist.
-ADMIN_DEFAULT_PASSWORD=password
+ADMIN_DEFAULT_PASSWORD=change-me-strong-admin-password
 
 # Encryption key for sensitive data (SMTP passwords, etc.)
-# Change this in production! Use a strong random string.
-ENCRYPTION_KEY=praetor-encryption-key-change-in-production
+# Generate a unique high-entropy value before first startup.
+ENCRYPTION_KEY=change-me-long-random-encryption-key
 
 # Filesystem path for uploaded attachments (e.g. supplier quote attachments).
 # Resolved relative to the server working directory; absolute paths are also supported.

--- a/server/db/bootstrapAdmin.ts
+++ b/server/db/bootstrapAdmin.ts
@@ -2,13 +2,22 @@ import bcrypt from 'bcryptjs';
 import * as usersRepo from '../repositories/usersRepo.ts';
 import { createChildLogger } from '../utils/logger.ts';
 import { generatePrefixedId } from '../utils/order-ids.ts';
+import {
+  INSECURE_DEFAULT_ADMIN_PASSWORD,
+  readRequiredNonDefaultEnv,
+} from '../utils/runtimeConfig.ts';
 import { query } from './index.ts';
 
 export const ADMIN_USERNAME = 'admin';
 export const DEFAULT_ADMIN_USER_ID = 'u1';
-export const DEFAULT_ADMIN_PASSWORD = 'password';
 
 const logger = createChildLogger({ module: 'db:bootstrap-admin' });
+
+const resolveBootstrapAdminPassword = () =>
+  readRequiredNonDefaultEnv('ADMIN_DEFAULT_PASSWORD', INSECURE_DEFAULT_ADMIN_PASSWORD, {
+    missing: 'ADMIN_DEFAULT_PASSWORD must be set before creating the bootstrap admin',
+    defaultValue: 'ADMIN_DEFAULT_PASSWORD must not use the default password',
+  });
 
 export const ensureBootstrapAdmin = async () => {
   const existingAdmin = await query('SELECT id FROM users WHERE username = $1 LIMIT 1', [
@@ -25,9 +34,7 @@ export const ensureBootstrapAdmin = async () => {
     ]);
     adminId = defaultIdCheck.rows.length === 0 ? DEFAULT_ADMIN_USER_ID : generatePrefixedId('u');
 
-    const rawPassword = process.env.ADMIN_DEFAULT_PASSWORD?.trim();
-    const adminPassword =
-      rawPassword && rawPassword.length > 0 ? rawPassword : DEFAULT_ADMIN_PASSWORD;
+    const adminPassword = resolveBootstrapAdminPassword();
     const passwordHash = await bcrypt.hash(adminPassword, 12);
 
     await usersRepo.createUser({
@@ -40,8 +47,7 @@ export const ensureBootstrapAdmin = async () => {
     });
     logger.info(
       {
-        passwordSource:
-          rawPassword && rawPassword.length > 0 ? 'ADMIN_DEFAULT_PASSWORD' : 'fallback',
+        passwordSource: 'ADMIN_DEFAULT_PASSWORD',
       },
       'Bootstrap admin created',
     );

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,15 +2,19 @@ import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import buildApp from './app.ts';
-import { DEFAULT_ADMIN_PASSWORD, ensureBootstrapAdmin } from './db/bootstrapAdmin.ts';
+import { ensureBootstrapAdmin } from './db/bootstrapAdmin.ts';
 import { runDemoSeedRefresh } from './db/demoSeed.ts';
 import { query } from './db/index.ts';
 import { runDrizzleMigrations } from './db/migrationsRunner.ts';
 import { createChildLogger, serializeError } from './utils/logger.ts';
+import {
+  INSECURE_DEFAULT_ADMIN_PASSWORD,
+  INSECURE_DEFAULT_ENCRYPTION_KEY,
+  INSECURE_DEFAULT_JWT_SECRET,
+  validateRequiredNonDefaultEnv,
+} from './utils/runtimeConfig.ts';
 
 const PORT = Number(process.env.PORT ?? 3001);
-const DEFAULT_JWT_SECRET = 'praetor-secret-key-change-in-production';
-const DEFAULT_ENCRYPTION_KEY = 'praetor-encryption-key-change-in-production';
 const logger = createChildLogger({ module: 'startup' });
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -34,23 +38,15 @@ const parseBooleanEnv = (value: string | undefined): boolean => {
   return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on';
 };
 
-const warnInsecureRuntimeDefaults = () => {
-  const warnings: string[] = [];
+const assertSecureRuntimeConfig = () => {
+  const errors = [
+    validateRequiredNonDefaultEnv('JWT_SECRET', INSECURE_DEFAULT_JWT_SECRET),
+    validateRequiredNonDefaultEnv('ENCRYPTION_KEY', INSECURE_DEFAULT_ENCRYPTION_KEY),
+    validateRequiredNonDefaultEnv('ADMIN_DEFAULT_PASSWORD', INSECURE_DEFAULT_ADMIN_PASSWORD),
+  ].filter((error): error is string => error !== null);
 
-  if ((process.env.JWT_SECRET || '').trim() === DEFAULT_JWT_SECRET) {
-    warnings.push('JWT_SECRET is using the default placeholder value.');
-  }
-
-  if ((process.env.ENCRYPTION_KEY || '').trim() === DEFAULT_ENCRYPTION_KEY) {
-    warnings.push('ENCRYPTION_KEY is using the default placeholder value.');
-  }
-
-  if ((process.env.ADMIN_DEFAULT_PASSWORD || '').trim() === DEFAULT_ADMIN_PASSWORD) {
-    warnings.push('ADMIN_DEFAULT_PASSWORD is using the default placeholder value.');
-  }
-
-  for (const warning of warnings) {
-    logger.warn({ warning }, 'Security warning');
+  if (errors.length > 0) {
+    throw new Error(errors.join(' '));
   }
 };
 
@@ -101,7 +97,7 @@ process.on('SIGTERM', () => void shutdown('SIGTERM'));
 
 // Start server
 try {
-  warnInsecureRuntimeDefaults();
+  assertSecureRuntimeConfig();
 
   // One-time probe to confirm DB connectivity without logging on every pooled connection.
   // Retry briefly to handle container startup ordering.

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -3,8 +3,24 @@ import jwt, { type JwtPayload } from 'jsonwebtoken';
 import * as rolesRepo from '../repositories/rolesRepo.ts';
 import * as usersRepo from '../repositories/usersRepo.ts';
 import { getRolePermissions } from '../utils/permissions.ts';
+import {
+  INSECURE_DEFAULT_JWT_SECRET,
+  readRequiredNonDefaultEnv,
+  TEST_JWT_SECRET,
+} from '../utils/runtimeConfig.ts';
 
-const JWT_SECRET = process.env.JWT_SECRET || 'praetor-secret-key-change-in-production';
+const resolveJwtSecret = () => {
+  const configured = process.env.JWT_SECRET?.trim();
+  if (
+    process.env.NODE_ENV === 'test' &&
+    (!configured || configured === INSECURE_DEFAULT_JWT_SECRET)
+  ) {
+    return TEST_JWT_SECRET;
+  }
+  return readRequiredNonDefaultEnv('JWT_SECRET', INSECURE_DEFAULT_JWT_SECRET);
+};
+
+const JWT_SECRET = resolveJwtSecret();
 
 type SessionJwtPayload = JwtPayload & {
   userId: string;

--- a/server/repositories/userAssignmentsRepo.ts
+++ b/server/repositories/userAssignmentsRepo.ts
@@ -90,6 +90,77 @@ const assignAllToUserAsTopManager = (
 export const userHasTopManagerRole = (userId: string, exec: DbExecutor = db): Promise<boolean> =>
   rolesRepo.userHasRole(userId, TOP_MANAGER_ROLE_ID, exec);
 
+const isAssignedToUser = async (
+  spec: AssignmentSpec,
+  userId: string,
+  targetId: string,
+  exec: DbExecutor,
+): Promise<boolean> => {
+  const rows = await executeRows<{ exists: boolean }>(
+    exec,
+    sql`SELECT EXISTS (
+      SELECT 1
+      FROM ${sql.identifier(spec.table)}
+      WHERE user_id = ${userId} AND ${sql.identifier(spec.fkColumn)} = ${targetId}
+    ) AS "exists"`,
+  );
+  return rows[0]?.exists === true;
+};
+
+const filterAssignedIds = async (
+  spec: AssignmentSpec,
+  userId: string,
+  targetIds: string[],
+  exec: DbExecutor,
+): Promise<Set<string>> => {
+  if (targetIds.length === 0) return new Set();
+  const uniqueIds = Array.from(new Set(targetIds));
+  const rows = await executeRows<{ id: string }>(
+    exec,
+    sql`SELECT ${sql.identifier(spec.fkColumn)} AS id
+        FROM ${sql.identifier(spec.table)}
+        WHERE user_id = ${userId}
+          AND ${sql.identifier(spec.fkColumn)} = ANY(${sql.param(uniqueIds)}::text[])`,
+  );
+  return new Set(rows.map((row) => row.id));
+};
+
+export const isClientAssignedToUser = (
+  userId: string,
+  clientId: string,
+  exec: DbExecutor = db,
+): Promise<boolean> => isAssignedToUser(ASSIGNMENT_SPECS.clients, userId, clientId, exec);
+
+export const isProjectAssignedToUser = (
+  userId: string,
+  projectId: string,
+  exec: DbExecutor = db,
+): Promise<boolean> => isAssignedToUser(ASSIGNMENT_SPECS.projects, userId, projectId, exec);
+
+export const isTaskAssignedToUser = (
+  userId: string,
+  taskId: string,
+  exec: DbExecutor = db,
+): Promise<boolean> => isAssignedToUser(ASSIGNMENT_SPECS.tasks, userId, taskId, exec);
+
+export const filterAssignedClientIds = (
+  userId: string,
+  clientIds: string[],
+  exec: DbExecutor = db,
+): Promise<Set<string>> => filterAssignedIds(ASSIGNMENT_SPECS.clients, userId, clientIds, exec);
+
+export const filterAssignedProjectIds = (
+  userId: string,
+  projectIds: string[],
+  exec: DbExecutor = db,
+): Promise<Set<string>> => filterAssignedIds(ASSIGNMENT_SPECS.projects, userId, projectIds, exec);
+
+export const filterAssignedTaskIds = (
+  userId: string,
+  taskIds: string[],
+  exec: DbExecutor = db,
+): Promise<Set<string>> => filterAssignedIds(ASSIGNMENT_SPECS.tasks, userId, taskIds, exec);
+
 export const assignClientToUser = async (
   userId: string,
   clientId: string,

--- a/server/routes/clients.ts
+++ b/server/routes/clients.ts
@@ -289,6 +289,13 @@ const buildPrimaryFieldsFromContacts = (contacts: ClientContact[]) => {
   };
 };
 
+const canAccessClient = (request: FastifyRequest, clientId: string) => {
+  if (hasPermission(request, 'crm.clients_all.view')) return Promise.resolve(true);
+  const userId = request.user?.id;
+  if (!userId) return Promise.resolve(false);
+  return userAssignmentsRepo.isClientAssignedToUser(userId, clientId);
+};
+
 export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
@@ -566,6 +573,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
 
+      if (!(await canAccessClient(request, idResult.value))) {
+        return reply.code(403).send({ error: 'Insufficient permissions' });
+      }
+
       const hasName = Object.hasOwn(body, 'name');
       const hasClientCode = Object.hasOwn(body, 'clientCode');
       const hasFiscalCode = Object.hasOwn(body, 'fiscalCode');
@@ -808,6 +819,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const { id } = request.params as { id: string };
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
+
+      if (!(await canAccessClient(request, idResult.value))) {
+        return reply.code(403).send({ error: 'Insufficient permissions' });
+      }
 
       const deleted = await clientsRepo.deleteById(idResult.value);
       if (!deleted) {

--- a/server/routes/entries.ts
+++ b/server/routes/entries.ts
@@ -2,7 +2,9 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { authenticateToken, requireAnyPermission, requirePermission } from '../middleware/auth.ts';
 import * as entriesRepo from '../repositories/entriesRepo.ts';
 import * as generalSettingsRepo from '../repositories/generalSettingsRepo.ts';
+import * as projectsRepo from '../repositories/projectsRepo.ts';
 import * as tasksRepo from '../repositories/tasksRepo.ts';
+import * as userAssignmentsRepo from '../repositories/userAssignmentsRepo.ts';
 import * as usersRepo from '../repositories/usersRepo.ts';
 import * as workUnitsRepo from '../repositories/workUnitsRepo.ts';
 import {
@@ -283,6 +285,28 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         projectIdResult.value,
         taskResult.value,
       );
+      const projectClientId = await projectsRepo.findClientId(projectIdResult.value);
+      if (projectClientId === null) {
+        return badRequest(reply, 'Project not found');
+      }
+      if (projectClientId !== clientIdResult.value) {
+        return badRequest(reply, 'Project does not belong to the selected client');
+      }
+
+      if (!hasPermission(request, 'timesheets.tracker_all.view')) {
+        const [clientAllowed, projectAllowed, taskAllowed] = await Promise.all([
+          userAssignmentsRepo.isClientAssignedToUser(targetUserId, clientIdResult.value),
+          userAssignmentsRepo.isProjectAssignedToUser(targetUserId, projectIdResult.value),
+          resolvedTaskId
+            ? userAssignmentsRepo.isTaskAssignedToUser(targetUserId, resolvedTaskId)
+            : Promise.resolve(true),
+        ]);
+        if (!clientAllowed || !projectAllowed || !taskAllowed) {
+          return reply
+            .code(403)
+            .send({ error: 'Not authorized to create entries for this client, project, or task' });
+        }
+      }
 
       const created = await entriesRepo.create({
         id: generatePrefixedId('te'),

--- a/server/routes/projects.ts
+++ b/server/routes/projects.ts
@@ -75,6 +75,22 @@ const projectUpdateBodySchema = {
   },
 } as const;
 
+class PermissionError extends Error {}
+
+const canAccessClient = (request: FastifyRequest, clientId: string) => {
+  if (hasPermission(request, 'crm.clients_all.view')) return Promise.resolve(true);
+  const userId = request.user?.id;
+  if (!userId) return Promise.resolve(false);
+  return userAssignmentsRepo.isClientAssignedToUser(userId, clientId);
+};
+
+const canAccessProject = (request: FastifyRequest, projectId: string) => {
+  if (hasPermission(request, 'projects.manage_all.view')) return Promise.resolve(true);
+  const userId = request.user?.id;
+  if (!userId) return Promise.resolve(false);
+  return userAssignmentsRepo.isProjectAssignedToUser(userId, projectId);
+};
+
 export default async function (fastify: FastifyInstance, _opts: unknown) {
   // GET / - List all projects
   fastify.get(
@@ -137,6 +153,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
 
       const clientIdResult = requireNonEmptyString(clientId, 'clientId');
       if (!clientIdResult.ok) return badRequest(reply, clientIdResult.message);
+      if (!(await canAccessClient(request, clientIdResult.value))) {
+        return reply.code(403).send({ error: 'Insufficient permissions' });
+      }
 
       const id = generatePrefixedId('p');
       let projectColor = '#3b82f6';
@@ -202,6 +221,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const { id } = request.params as { id: string };
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
+      if (!(await canAccessProject(request, idResult.value))) {
+        return reply.code(403).send({ error: 'Insufficient permissions' });
+      }
 
       let deletedProject: { projectName: string; clientId: string };
 
@@ -271,6 +293,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const { name, clientId, description, color, isDisabled } = body;
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
+      if (!(await canAccessProject(request, idResult.value))) {
+        return reply.code(403).send({ error: 'Insufficient permissions' });
+      }
       let normalizedColor = color;
       if (color !== undefined && color !== null && color !== '') {
         const colorResult = validateHexColor(color, 'color');
@@ -293,6 +318,12 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
 
           const requestedClientId =
             typeof clientId === 'string' && clientId !== '' ? clientId : previousClientId;
+          if (
+            requestedClientId !== previousClientId &&
+            !(await canAccessClient(request, requestedClientId))
+          ) {
+            throw new PermissionError();
+          }
           const clientChanged = requestedClientId !== previousClientId;
           const assignedUserIds = clientChanged
             ? await projectsRepo.findNonTopManagerUserIds(idResult.value, tx)
@@ -339,6 +370,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           return { updated, clientChanged, action };
         });
       } catch (err) {
+        if (err instanceof PermissionError) {
+          return reply.code(403).send({ error: 'Insufficient permissions' });
+        }
         if (err instanceof NotFoundError) {
           return reply.code(404).send({ error: err.message });
         }
@@ -381,6 +415,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const { id } = request.params as { id: string };
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
+      if (!(await canAccessProject(request, idResult.value))) {
+        return reply.code(403).send({ error: 'Insufficient permissions' });
+      }
       return projectsRepo.findAssignedUserIds(idResult.value);
     },
   );
@@ -406,6 +443,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const { userIds } = request.body as { userIds: string[] };
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
+      if (!(await canAccessProject(request, idResult.value))) {
+        return reply.code(403).send({ error: 'Insufficient permissions' });
+      }
 
       const userIdsResult = ensureArrayOfStrings(userIds, 'userIds');
       if (!userIdsResult.ok) return badRequest(reply, userIdsResult.message);

--- a/server/routes/supplier-quotes.ts
+++ b/server/routes/supplier-quotes.ts
@@ -875,9 +875,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
 
         const mimeType = part.mimetype || 'application/octet-stream';
         if (!isAllowedAttachment(mimeType, originalName)) {
-          return reply
-            .code(415)
-            .send({ error: 'File type not allowed. Use xlsx, xls, csv, pdf, doc, or docx.' });
+          return reply.code(415).send({ error: 'File type not allowed. Use xlsx, pdf, or docx.' });
         }
 
         if (buffer.byteLength > ATTACHMENT_MAX_BYTES) {

--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -97,6 +97,20 @@ const userIdsSchema = {
   required: ['userIds'],
 } as const;
 
+const canAccessProject = (request: FastifyRequest, projectId: string) => {
+  if (hasPermission(request, 'projects.manage_all.view')) return Promise.resolve(true);
+  const userId = request.user?.id;
+  if (!userId) return Promise.resolve(false);
+  return userAssignmentsRepo.isProjectAssignedToUser(userId, projectId);
+};
+
+const canAccessTask = (request: FastifyRequest, taskId: string) => {
+  if (hasPermission(request, 'projects.tasks_all.view')) return Promise.resolve(true);
+  const userId = request.user?.id;
+  if (!userId) return Promise.resolve(false);
+  return userAssignmentsRepo.isTaskAssignedToUser(userId, taskId);
+};
+
 export default async function (fastify: FastifyInstance, _opts: unknown) {
   // GET / - List all tasks
   fastify.get(
@@ -173,6 +187,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
 
       const projectIdResult = requireNonEmptyString(projectId, 'projectId');
       if (!projectIdResult.ok) return badRequest(reply, projectIdResult.message);
+      if (!(await canAccessProject(request, projectIdResult.value))) {
+        return reply.code(403).send({ error: 'Insufficient permissions' });
+      }
 
       const durationResult = optionalLocalizedNonNegativeNumber(
         recurrenceDuration,
@@ -395,6 +412,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       } = body;
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
+      if (!(await canAccessTask(request, idResult.value))) {
+        return reply.code(403).send({ error: 'Insufficient permissions' });
+      }
       const durationResult = optionalLocalizedNonNegativeNumber(
         recurrenceDuration,
         'recurrenceDuration',
@@ -486,6 +506,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const { id } = request.params as { id: string };
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
+      if (!(await canAccessTask(request, idResult.value))) {
+        return reply.code(403).send({ error: 'Insufficient permissions' });
+      }
 
       const deleted = await tasksRepo.deleteById(idResult.value);
       if (!deleted) {
@@ -525,6 +548,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const { id } = request.params as { id: string };
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
+      if (!(await canAccessTask(request, idResult.value))) {
+        return reply.code(403).send({ error: 'Insufficient permissions' });
+      }
       return tasksRepo.findAssignedUserIds(idResult.value);
     },
   );
@@ -550,6 +576,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const { userIds } = request.body as { userIds: string[] };
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
+      if (!(await canAccessTask(request, idResult.value))) {
+        return reply.code(403).send({ error: 'Insufficient permissions' });
+      }
 
       const userIdsResult = requireNonEmptyArrayOfStrings(userIds, 'userIds');
       if (!userIdsResult.ok) return badRequest(reply, userIdsResult.message);

--- a/server/routes/users.ts
+++ b/server/routes/users.ts
@@ -169,6 +169,39 @@ const maskUserResponse = (
   costPerHour: canViewCosts ? user.costPerHour : 0,
 });
 
+const ensureSubmittedAssignmentsInScope = async (
+  request: FastifyRequest,
+  {
+    clientIds,
+    projectIds,
+    taskIds,
+  }: {
+    clientIds?: string[];
+    projectIds?: string[];
+    taskIds?: string[];
+  },
+) => {
+  const userId = request.user?.id;
+  if (!userId || hasPermission(request, 'administration.user_management_all.view')) return true;
+
+  if (clientIds && !hasPermission(request, 'crm.clients_all.view')) {
+    const allowed = await userAssignmentsRepo.filterAssignedClientIds(userId, clientIds);
+    if (clientIds.some((id) => !allowed.has(id))) return false;
+  }
+
+  if (projectIds && !hasPermission(request, 'projects.manage_all.view')) {
+    const allowed = await userAssignmentsRepo.filterAssignedProjectIds(userId, projectIds);
+    if (projectIds.some((id) => !allowed.has(id))) return false;
+  }
+
+  if (taskIds && !hasPermission(request, 'projects.tasks_all.view')) {
+    const allowed = await userAssignmentsRepo.filterAssignedTaskIds(userId, taskIds);
+    if (taskIds.some((id) => !allowed.has(id))) return false;
+  }
+
+  return true;
+};
+
 export default async function (fastify: FastifyInstance, _opts: unknown) {
   // GET / - List users
   fastify.get(
@@ -810,6 +843,15 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const taskIdsResult = optionalArrayOfStrings(taskIds, 'taskIds');
       if (!taskIdsResult.ok) return badRequest(reply, taskIdsResult.message);
       const resolvedTaskIds = taskIdsResult.value;
+
+      const assignmentsInScope = await ensureSubmittedAssignmentsInScope(request, {
+        clientIds: resolvedClientIds ?? undefined,
+        projectIds: resolvedProjectIds ?? undefined,
+        taskIds: resolvedTaskIds ?? undefined,
+      });
+      if (!assignmentsInScope) {
+        return reply.code(403).send({ error: 'Insufficient permissions' });
+      }
 
       const [targetUser, isTopManager] = await Promise.all([
         usersRepo.findCoreById(idResult.value),

--- a/server/test/helpers/jwt.ts
+++ b/server/test/helpers/jwt.ts
@@ -1,6 +1,6 @@
 import jwt from 'jsonwebtoken';
 
-const TEST_JWT_SECRET = process.env.JWT_SECRET || 'praetor-secret-key-change-in-production';
+const TEST_JWT_SECRET = process.env.JWT_SECRET || 'praetor-test-jwt-secret';
 
 const SESSION_MAX_DURATION_MS = 8 * 60 * 60 * 1000;
 

--- a/server/test/routes/clients.test.ts
+++ b/server/test/routes/clients.test.ts
@@ -51,6 +51,7 @@ const cpoDeleteByIdMock = mock();
 // userAssignmentsRepo
 const assignClientToUserMock = mock(async () => undefined);
 const assignClientToTopManagersMock = mock(async () => undefined);
+const isClientAssignedToUserMock = mock();
 
 const logAuditMock = mock(async () => undefined);
 const withDbTransactionMock = mock(async (cb: (tx: unknown) => unknown) => cb(undefined));
@@ -97,6 +98,7 @@ beforeAll(async () => {
     ...userAssignmentsRepoSnap,
     assignClientToUser: assignClientToUserMock,
     assignClientToTopManagers: assignClientToTopManagersMock,
+    isClientAssignedToUser: isClientAssignedToUserMock,
   }));
   mock.module('../../utils/audit.ts', () => ({
     ...auditSnap,
@@ -202,6 +204,7 @@ const allMocks = [
   cpoDeleteByIdMock,
   assignClientToUserMock,
   assignClientToTopManagersMock,
+  isClientAssignedToUserMock,
   logAuditMock,
   withDbTransactionMock,
 ];
@@ -217,6 +220,7 @@ beforeEach(async () => {
   logAuditMock.mockImplementation(async () => undefined);
   assignClientToUserMock.mockImplementation(async () => undefined);
   assignClientToTopManagersMock.mockImplementation(async () => undefined);
+  isClientAssignedToUserMock.mockResolvedValue(true);
 
   testApp = await buildRouteTestApp(routePlugin, '/api/clients');
 });
@@ -518,6 +522,22 @@ describe('PUT /api/clients/:id', () => {
     });
     expect(res.statusCode).toBe(403);
   });
+
+  test('403 when scoped updater is not assigned to client', async () => {
+    getRolePermissionsMock.mockResolvedValue(['crm.clients.view', 'crm.clients.update']);
+    isClientAssignedToUserMock.mockResolvedValue(false);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/clients/c-1',
+      headers: authHeader(),
+      payload: { name: 'X' },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(findContactsForUpdateMock).not.toHaveBeenCalled();
+    expect(updateClientMock).not.toHaveBeenCalled();
+  });
 });
 
 describe('DELETE /api/clients/:id', () => {
@@ -563,6 +583,20 @@ describe('DELETE /api/clients/:id', () => {
       headers: authHeader(),
     });
     expect(res.statusCode).toBe(403);
+  });
+
+  test('403 when scoped deleter is not assigned to client', async () => {
+    getRolePermissionsMock.mockResolvedValue(['crm.clients.view', 'crm.clients.delete']);
+    isClientAssignedToUserMock.mockResolvedValue(false);
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/clients/c-1',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(deleteClientByIdMock).not.toHaveBeenCalled();
   });
 });
 

--- a/server/test/routes/entries.test.ts
+++ b/server/test/routes/entries.test.ts
@@ -2,8 +2,10 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, tes
 import type { FastifyInstance, FastifyPluginAsync } from 'fastify';
 import * as realEntriesRepo from '../../repositories/entriesRepo.ts';
 import * as realGeneralSettingsRepo from '../../repositories/generalSettingsRepo.ts';
+import * as realProjectsRepo from '../../repositories/projectsRepo.ts';
 import * as realRolesRepo from '../../repositories/rolesRepo.ts';
 import * as realTasksRepo from '../../repositories/tasksRepo.ts';
+import * as realUserAssignmentsRepo from '../../repositories/userAssignmentsRepo.ts';
 import * as realUsersRepo from '../../repositories/usersRepo.ts';
 import * as realWorkUnitsRepo from '../../repositories/workUnitsRepo.ts';
 import * as realPermissions from '../../utils/permissions.ts';
@@ -20,6 +22,8 @@ const permissionsSnap = { ...realPermissions };
 const entriesRepoSnap = { ...realEntriesRepo };
 const generalSettingsRepoSnap = { ...realGeneralSettingsRepo };
 const tasksRepoSnap = { ...realTasksRepo };
+const projectsRepoSnap = { ...realProjectsRepo };
+const userAssignmentsRepoSnap = { ...realUserAssignmentsRepo };
 const workUnitsRepoSnap = { ...realWorkUnitsRepo };
 
 // Auth-middleware deps (real authenticateToken runs)
@@ -43,6 +47,10 @@ const entriesFindContextMock = mock();
 const entriesFindOwnerMock = mock();
 const entriesDecodeCursorMock = mock();
 const entriesEncodeCursorMock = mock((c: unknown) => `enc:${JSON.stringify(c)}`);
+const projectsFindClientIdMock = mock();
+const isClientAssignedToUserMock = mock();
+const isProjectAssignedToUserMock = mock();
+const isTaskAssignedToUserMock = mock();
 
 let entriesRoutePlugin: FastifyPluginAsync;
 
@@ -83,6 +91,16 @@ beforeAll(async () => {
     ...tasksRepoSnap,
     findIdByProjectAndName: findIdByProjectAndNameMock,
   }));
+  mock.module('../../repositories/projectsRepo.ts', () => ({
+    ...projectsRepoSnap,
+    findClientId: projectsFindClientIdMock,
+  }));
+  mock.module('../../repositories/userAssignmentsRepo.ts', () => ({
+    ...userAssignmentsRepoSnap,
+    isClientAssignedToUser: isClientAssignedToUserMock,
+    isProjectAssignedToUser: isProjectAssignedToUserMock,
+    isTaskAssignedToUser: isTaskAssignedToUserMock,
+  }));
   mock.module('../../repositories/workUnitsRepo.ts', () => ({
     ...workUnitsRepoSnap,
     isUserManagedBy: isUserManagedByMock,
@@ -99,6 +117,8 @@ afterAll(() => {
   mock.module('../../repositories/entriesRepo.ts', () => entriesRepoSnap);
   mock.module('../../repositories/generalSettingsRepo.ts', () => generalSettingsRepoSnap);
   mock.module('../../repositories/tasksRepo.ts', () => tasksRepoSnap);
+  mock.module('../../repositories/projectsRepo.ts', () => projectsRepoSnap);
+  mock.module('../../repositories/userAssignmentsRepo.ts', () => userAssignmentsRepoSnap);
   mock.module('../../repositories/workUnitsRepo.ts', () => workUnitsRepoSnap);
 });
 
@@ -156,6 +176,10 @@ const allMocks = [
   entriesFindContextMock,
   entriesFindOwnerMock,
   entriesDecodeCursorMock,
+  projectsFindClientIdMock,
+  isClientAssignedToUserMock,
+  isProjectAssignedToUserMock,
+  isTaskAssignedToUserMock,
 ];
 
 let testApp: FastifyInstance;
@@ -168,6 +192,10 @@ beforeEach(async () => {
   findAuthUserByIdMock.mockResolvedValue(HAPPY_USER);
   userHasRoleMock.mockResolvedValue(true);
   getRolePermissionsMock.mockResolvedValue(TRACKER_PERMS);
+  projectsFindClientIdMock.mockResolvedValue('c1');
+  isClientAssignedToUserMock.mockResolvedValue(true);
+  isProjectAssignedToUserMock.mockResolvedValue(true);
+  isTaskAssignedToUserMock.mockResolvedValue(true);
 
   testApp = await buildRouteTestApp(entriesRoutePlugin, '/api/entries');
 });
@@ -455,6 +483,55 @@ describe('POST /api/entries', () => {
     expect(res.statusCode).toBe(201);
     expect(findCostPerHourMock).toHaveBeenCalledWith('u2');
     expect(entriesCreateMock).toHaveBeenCalledWith(expect.objectContaining({ userId: 'u2' }));
+  });
+
+  test('400 when project belongs to a different client', async () => {
+    projectsFindClientIdMock.mockResolvedValue('other-client');
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/entries',
+      headers: authHeader(),
+      payload: validBody,
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'Project does not belong to the selected client',
+    });
+    expect(entriesCreateMock).not.toHaveBeenCalled();
+  });
+
+  test('400 when project does not exist', async () => {
+    projectsFindClientIdMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/entries',
+      headers: authHeader(),
+      payload: validBody,
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Project not found' });
+    expect(entriesCreateMock).not.toHaveBeenCalled();
+  });
+
+  test('403 when target user is not assigned to submitted project scope', async () => {
+    isProjectAssignedToUserMock.mockResolvedValue(false);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/entries',
+      headers: authHeader(),
+      payload: validBody,
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'Not authorized to create entries for this client, project, or task',
+    });
+    expect(entriesCreateMock).not.toHaveBeenCalled();
   });
 });
 

--- a/server/test/routes/projects.test.ts
+++ b/server/test/routes/projects.test.ts
@@ -48,6 +48,8 @@ const assignClientToUserMock = mock(async () => undefined);
 const assignProjectToUserMock = mock(async () => undefined);
 const assignClientToTopManagersMock = mock(async () => undefined);
 const assignProjectToTopManagersMock = mock(async () => undefined);
+const isClientAssignedToUserMock = mock();
+const isProjectAssignedToUserMock = mock();
 
 // audit + db
 const logAuditMock = mock(async () => undefined);
@@ -92,6 +94,8 @@ beforeAll(async () => {
     assignProjectToUser: assignProjectToUserMock,
     assignClientToTopManagers: assignClientToTopManagersMock,
     assignProjectToTopManagers: assignProjectToTopManagersMock,
+    isClientAssignedToUser: isClientAssignedToUserMock,
+    isProjectAssignedToUser: isProjectAssignedToUserMock,
   }));
   mock.module('../../utils/audit.ts', () => ({
     ...auditSnap,
@@ -169,6 +173,8 @@ const allMocks = [
   assignProjectToUserMock,
   assignClientToTopManagersMock,
   assignProjectToTopManagersMock,
+  isClientAssignedToUserMock,
+  isProjectAssignedToUserMock,
   logAuditMock,
   withDbTransactionMock,
 ];
@@ -186,6 +192,8 @@ beforeEach(async () => {
   assignProjectToUserMock.mockImplementation(async () => undefined);
   assignClientToTopManagersMock.mockImplementation(async () => undefined);
   assignProjectToTopManagersMock.mockImplementation(async () => undefined);
+  isClientAssignedToUserMock.mockResolvedValue(true);
+  isProjectAssignedToUserMock.mockResolvedValue(true);
 
   testApp = await buildRouteTestApp(routePlugin, '/api/projects');
 });
@@ -370,6 +378,21 @@ describe('POST /api/projects', () => {
 
     expect(res.statusCode).toBe(403);
   });
+
+  test('403: scoped creator cannot create under unassigned client', async () => {
+    getRolePermissionsMock.mockResolvedValue(['projects.manage.create']);
+    isClientAssignedToUserMock.mockResolvedValue(false);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/projects',
+      headers: authHeader(),
+      payload: { name: 'X', clientId: 'c-1' },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(createMock).not.toHaveBeenCalled();
+  });
 });
 
 describe('DELETE /api/projects/:id', () => {
@@ -421,6 +444,21 @@ describe('DELETE /api/projects/:id', () => {
     });
 
     expect(res.statusCode).toBe(403);
+  });
+
+  test('403: scoped deleter cannot delete unassigned project', async () => {
+    getRolePermissionsMock.mockResolvedValue(['projects.manage.delete']);
+    isProjectAssignedToUserMock.mockResolvedValue(false);
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/projects/p-1',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(lockNameAndClientByIdMock).not.toHaveBeenCalled();
+    expect(deleteByIdMock).not.toHaveBeenCalled();
   });
 });
 
@@ -596,6 +634,25 @@ describe('PUT /api/projects/:id', () => {
 
     expect(res.statusCode).toBe(403);
   });
+
+  test('403: scoped updater cannot move project under unassigned client', async () => {
+    getRolePermissionsMock.mockResolvedValue([
+      'projects.manage.update',
+      'projects.manage_all.view',
+    ]);
+    isClientAssignedToUserMock.mockResolvedValue(false);
+    lockClientIdByIdMock.mockResolvedValue('c-old');
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/projects/p-1',
+      headers: authHeader(),
+      payload: { clientId: 'c-new' },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(updateMock).not.toHaveBeenCalled();
+  });
 });
 
 describe('GET /api/projects/:id/users', () => {
@@ -628,6 +685,21 @@ describe('GET /api/projects/:id/users', () => {
     });
 
     expect(res.statusCode).toBe(403);
+  });
+
+  test('403: scoped assignment editor cannot edit unassigned project', async () => {
+    getRolePermissionsMock.mockResolvedValue(['projects.assignments.update']);
+    isProjectAssignedToUserMock.mockResolvedValue(false);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/projects/p-1/users',
+      headers: authHeader(),
+      payload: { userIds: ['u1'] },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(lockNameAndClientByIdMock).not.toHaveBeenCalled();
   });
 });
 

--- a/server/test/routes/supplier-quotes-attachments.test.ts
+++ b/server/test/routes/supplier-quotes-attachments.test.ts
@@ -433,6 +433,30 @@ describe('POST /api/sales/supplier-quotes/:id/attachments', () => {
     expect(saveAttachmentMock).not.toHaveBeenCalled();
   });
 
+  test('415 rejects active Office and CSV attachment formats', async () => {
+    sqFindByIdMock.mockResolvedValue(DRAFT_QUOTE);
+    sqFindLinkedOrderIdMock.mockResolvedValue(null);
+
+    for (const [fileName, mimeType] of [
+      ['formula.csv', 'text/csv'],
+      ['legacy.xls', 'application/vnd.ms-excel'],
+      ['macro.doc', 'application/msword'],
+    ] as const) {
+      const { payload, contentType } = buildMultipartBody(fileName, mimeType, Buffer.from('x'));
+
+      const res = await testApp.inject({
+        method: 'POST',
+        url: '/api/sales/supplier-quotes/sq-1/attachments',
+        headers: { ...authHeader(), 'content-type': contentType },
+        payload,
+      });
+
+      expect(res.statusCode).toBe(415);
+    }
+
+    expect(saveAttachmentMock).not.toHaveBeenCalled();
+  });
+
   test('accepts xlsx with browser-fallback application/octet-stream MIME', async () => {
     sqFindByIdMock.mockResolvedValue(DRAFT_QUOTE);
     sqFindLinkedOrderIdMock.mockResolvedValue(null);

--- a/server/test/routes/tasks.test.ts
+++ b/server/test/routes/tasks.test.ts
@@ -53,6 +53,8 @@ const assignTaskToUserMock = mock(async () => undefined);
 const assignClientToTopManagersMock = mock(async () => undefined);
 const assignProjectToTopManagersMock = mock(async () => undefined);
 const assignTaskToTopManagersMock = mock(async () => undefined);
+const isProjectAssignedToUserMock = mock();
+const isTaskAssignedToUserMock = mock();
 
 // audit + db
 const logAuditMock = mock(async () => undefined);
@@ -100,6 +102,8 @@ beforeAll(async () => {
     assignClientToTopManagers: assignClientToTopManagersMock,
     assignProjectToTopManagers: assignProjectToTopManagersMock,
     assignTaskToTopManagers: assignTaskToTopManagersMock,
+    isProjectAssignedToUser: isProjectAssignedToUserMock,
+    isTaskAssignedToUser: isTaskAssignedToUserMock,
   }));
   mock.module('../../utils/audit.ts', () => ({
     ...auditSnap,
@@ -183,6 +187,8 @@ const allMocks = [
   assignClientToTopManagersMock,
   assignProjectToTopManagersMock,
   assignTaskToTopManagersMock,
+  isProjectAssignedToUserMock,
+  isTaskAssignedToUserMock,
   logAuditMock,
   withDbTransactionMock,
 ];
@@ -202,6 +208,8 @@ beforeEach(async () => {
   assignClientToTopManagersMock.mockImplementation(async () => undefined);
   assignProjectToTopManagersMock.mockImplementation(async () => undefined);
   assignTaskToTopManagersMock.mockImplementation(async () => undefined);
+  isProjectAssignedToUserMock.mockResolvedValue(true);
+  isTaskAssignedToUserMock.mockResolvedValue(true);
 
   testApp = await buildRouteTestApp(routePlugin, '/api/tasks');
 });
@@ -451,6 +459,21 @@ describe('POST /api/tasks', () => {
     });
 
     expect(res.statusCode).toBe(403);
+  });
+
+  test('403: scoped creator cannot create under unassigned project', async () => {
+    getRolePermissionsMock.mockResolvedValue(['projects.tasks.create']);
+    isProjectAssignedToUserMock.mockResolvedValue(false);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/tasks',
+      headers: authHeader(),
+      payload: { name: 'X', projectId: 'p-1' },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(createMock).not.toHaveBeenCalled();
   });
 });
 
@@ -704,6 +727,21 @@ describe('PUT /api/tasks/:id', () => {
     });
 
     expect(res.statusCode).toBe(403);
+  });
+
+  test('403: scoped updater cannot update unassigned task', async () => {
+    getRolePermissionsMock.mockResolvedValue(['projects.tasks.update']);
+    isTaskAssignedToUserMock.mockResolvedValue(false);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/tasks/t-1',
+      headers: authHeader(),
+      payload: { name: 'New' },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(updateMock).not.toHaveBeenCalled();
   });
 });
 

--- a/server/test/routes/users.test.ts
+++ b/server/test/routes/users.test.ts
@@ -58,6 +58,9 @@ const replaceUserProjectsMock = mock();
 const replaceUserTasksMock = mock();
 const clearProjectCascadeAssignmentsMock = mock();
 const applyProjectCascadeToClientsMock = mock();
+const filterAssignedClientIdsMock = mock();
+const filterAssignedProjectIdsMock = mock();
+const filterAssignedTaskIdsMock = mock();
 
 // audit / drizzle
 const logAuditMock = mock(async () => undefined);
@@ -105,6 +108,9 @@ beforeAll(async () => {
     replaceUserTasks: replaceUserTasksMock,
     clearProjectCascadeAssignments: clearProjectCascadeAssignmentsMock,
     applyProjectCascadeToClients: applyProjectCascadeToClientsMock,
+    filterAssignedClientIds: filterAssignedClientIdsMock,
+    filterAssignedProjectIds: filterAssignedProjectIdsMock,
+    filterAssignedTaskIds: filterAssignedTaskIdsMock,
   }));
   mock.module('../../utils/permissions.ts', () => ({
     ...permissionsSnap,
@@ -235,6 +241,9 @@ const allMocks = [
   replaceUserTasksMock,
   clearProjectCascadeAssignmentsMock,
   applyProjectCascadeToClientsMock,
+  filterAssignedClientIdsMock,
+  filterAssignedProjectIdsMock,
+  filterAssignedTaskIdsMock,
   logAuditMock,
   withDbTransactionMock,
 ];
@@ -250,6 +259,9 @@ beforeEach(async () => {
   getRolePermissionsMock.mockResolvedValue(ALL_USER_PERMS);
   withDbTransactionMock.mockImplementation(async (cb) => cb(undefined));
   logAuditMock.mockImplementation(async () => undefined);
+  filterAssignedClientIdsMock.mockResolvedValue(new Set(['c1']));
+  filterAssignedProjectIdsMock.mockResolvedValue(new Set(['p1']));
+  filterAssignedTaskIdsMock.mockResolvedValue(new Set(['t1']));
 
   testApp = await buildRouteTestApp(routePlugin, '/api/users');
 });
@@ -1149,5 +1161,22 @@ describe('POST /api/users/:id/assignments', () => {
     });
 
     expect(res.statusCode).toBe(403);
+  });
+
+  test('403 scoped manager cannot assign clients outside own scope', async () => {
+    findAuthUserByIdMock.mockResolvedValue(MANAGER_USER);
+    getRolePermissionsMock.mockResolvedValue(['hr.employee_assignments.update']);
+    filterAssignedClientIdsMock.mockResolvedValue(new Set());
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: `/api/users/${MANAGER_USER.id}/assignments`,
+      headers: managerAuth(),
+      payload: { clientIds: ['c-out'] },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(replaceUserClientsMock).not.toHaveBeenCalled();
+    expect(filterAssignedClientIdsMock).toHaveBeenCalledWith(MANAGER_USER.id, ['c-out']);
   });
 });

--- a/server/utils/fileStorage.ts
+++ b/server/utils/fileStorage.ts
@@ -7,14 +7,11 @@ export const ATTACHMENT_MAX_BYTES = 10 * 1024 * 1024;
 
 export const ATTACHMENT_ALLOWED_MIME = new Set<string>([
   'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-  'application/vnd.ms-excel',
-  'text/csv',
   'application/pdf',
-  'application/msword',
   'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
 ]);
 
-export const ATTACHMENT_ALLOWED_EXT = new Set<string>(['xlsx', 'xls', 'csv', 'pdf', 'doc', 'docx']);
+export const ATTACHMENT_ALLOWED_EXT = new Set<string>(['xlsx', 'pdf', 'docx']);
 
 const SUPPLIER_QUOTE_ATTACHMENTS_DIR = 'supplier-quote-attachments';
 
@@ -31,7 +28,7 @@ export const isAllowedAttachment = (mimeType: string, fileName: string): boolean
   const ext = getExtensionFromName(fileName);
   if (!ATTACHMENT_ALLOWED_EXT.has(ext)) return false;
   // Some browsers (Safari, some Chrome configs) report `application/octet-stream` for
-  // legitimate xlsx/doc uploads, so accept that as a generic fallback when the extension
+  // legitimate xlsx/docx uploads, so accept that as a generic fallback when the extension
   // itself is allowed. All other MIME types must be on the allowlist.
   if (mimeType === 'application/octet-stream') return true;
   return ATTACHMENT_ALLOWED_MIME.has(mimeType);

--- a/server/utils/runtimeConfig.ts
+++ b/server/utils/runtimeConfig.ts
@@ -1,0 +1,30 @@
+export const INSECURE_DEFAULT_JWT_SECRET = 'praetor-secret-key-change-in-production';
+export const INSECURE_DEFAULT_ENCRYPTION_KEY = 'praetor-encryption-key-change-in-production';
+export const INSECURE_DEFAULT_ADMIN_PASSWORD = 'password';
+export const TEST_JWT_SECRET = 'praetor-test-jwt-secret';
+
+export const validateRequiredNonDefaultEnv = (
+  name: string,
+  insecureDefault: string,
+): string | null => {
+  const value = process.env[name]?.trim() ?? '';
+  return value && value !== insecureDefault ? null : `${name} must be set to a non-default value.`;
+};
+
+export const readRequiredNonDefaultEnv = (
+  name: string,
+  insecureDefault: string,
+  messages?: {
+    missing?: string;
+    defaultValue?: string;
+  },
+): string => {
+  const value = process.env[name]?.trim() ?? '';
+  if (!value) {
+    throw new Error(messages?.missing ?? `${name} must be set to a non-default value.`);
+  }
+  if (value === insecureDefault) {
+    throw new Error(messages?.defaultValue ?? `${name} must be set to a non-default value.`);
+  }
+  return value;
+};

--- a/test/components/SupplierQuoteAttachmentsSection.test.tsx
+++ b/test/components/SupplierQuoteAttachmentsSection.test.tsx
@@ -186,7 +186,7 @@ describe('<SupplierQuoteAttachmentsSection />', () => {
 
     await waitFor(() =>
       expect(
-        screen.getByText('File type not allowed. Use xlsx, xls, csv, pdf, doc, or docx.'),
+        screen.getByText('File type not allowed. Use xlsx, pdf, or docx.'),
       ).toBeInTheDocument(),
     );
     expect(uploadAttachmentMock).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- Remove insecure fallback credentials and require non-default JWT, encryption, and bootstrap admin secrets
- Tighten object-level authorization for client, project, task, and time-entry write paths
- Restrict supplier quote attachments to safe document formats and update the matching UI text and examples
- Add and update focused regression tests for the new security checks

## Testing
- `bun run i18n:check` passed
- `git diff --check` passed
- Lint was attempted, but the workspace is missing installed server dependencies, so full typecheck/lint validation could not complete