### PR TITLE
Bump app version to 0.6.0

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Praetor API",
     "description": "Praetor API documentation",
-    "version": "0.5.0"
+    "version": "0.6.0"
   },
   "components": {
     "securitySchemes": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praetor",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server/app.ts
+++ b/server/app.ts
@@ -91,7 +91,7 @@ export const buildApp = async () => {
       info: {
         title: 'Praetor API',
         description: 'Praetor API documentation',
-        version: '0.5.0',
+        version: '0.6.0',
       },
       components: {
         securitySchemes: {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "praetor-server",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Praetor API Server",
   "main": "dist/index.ts",
   "type": "module",


### PR DESCRIPTION
## Summary
- Updated the frontend and server package versions to `0.6.0`
- Synced the backend Swagger/OpenAPI metadata to report `0.6.0`
- Regenerated the checked-in OpenAPI document version header

## Testing
- Not run (not requested)