### PR TITLE
fix(style): clear disabled tooltips when the gear menu opens

### DIFF
--- a/components/shared/Tooltip.tsx
+++ b/components/shared/Tooltip.tsx
@@ -47,6 +47,13 @@ const Tooltip: React.FC<TooltipProps> = ({
   const [coords, setCoords] = useState<{ top: number; left: number } | null>(null);
   const [effectivePosition, setEffectivePosition] = useState<TooltipPosition>(position);
   const [arrowOffset, setArrowOffset] = useState<{ x: number; y: number }>({ x: 0, y: 0 });
+  const hasLabel = label !== null && label !== undefined && label !== '';
+
+  useEffect(() => {
+    if (disabled || !hasLabel) {
+      setIsVisible(false);
+    }
+  }, [disabled, hasLabel]);
 
   const calcCoords = useCallback((pos: TooltipPosition) => {
     if (!wrapperRef.current) return null;
@@ -183,7 +190,7 @@ const Tooltip: React.FC<TooltipProps> = ({
     setIsVisible(false);
   };
 
-  if (disabled || label === null || label === undefined || label === '') {
+  if (disabled || !hasLabel) {
     return <>{children()}</>;
   }
 

--- a/test/components/Tooltip.test.tsx
+++ b/test/components/Tooltip.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
 
 const Tooltip = (await import('../../components/shared/Tooltip')).default;
 
@@ -138,5 +139,36 @@ describe('<Tooltip />', () => {
     expect(screen.getByText('Tip text')).toBeInTheDocument();
     fireEvent.mouseDown(screen.getByTestId('outside'));
     expect(screen.queryByText('Tip text')).toBeNull();
+  });
+
+  test('disabling a visible tooltip clears it before re-enabling', () => {
+    const Harness = () => {
+      const [disabled, setDisabled] = useState(false);
+      return (
+        <div>
+          <div data-testid="outside" onMouseDown={() => setDisabled(false)}>
+            outside
+          </div>
+          <Tooltip label="Gear tip" disabled={disabled}>
+            {() => (
+              <button type="button" onClick={() => setDisabled(true)}>
+                gear
+              </button>
+            )}
+          </Tooltip>
+        </div>
+      );
+    };
+
+    const { container } = render(<Harness />);
+    const wrapper = container.querySelector('span') as HTMLElement;
+    fireEvent.mouseEnter(wrapper);
+    expect(screen.getByText('Gear tip')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'gear' }));
+    expect(screen.queryByText('Gear tip')).toBeNull();
+
+    fireEvent.mouseDown(screen.getByTestId('outside'));
+    expect(screen.queryByText('Gear tip')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- Hide tooltip state immediately when a `Tooltip` becomes disabled or loses its label
- Prevent the gear button tooltip in `StandardTable` from lingering after the menu is opened and dismissed
- Add a regression test covering the disable/re-enable flow

## Testing
- `bun test test/components/Tooltip.test.tsx`
- `bun test test/components/StandardTable.test.tsx`