### PR TITLE
 ui(fix): match logs toolbar control sizes

### DIFF
--- a/components/administration/LogsView.tsx
+++ b/components/administration/LogsView.tsx
@@ -16,6 +16,8 @@ const humanizeToken = (value: string) =>
     .trim()
     .toLowerCase();
 
+const tableToolbarButtonClassName = '!h-7 !px-2 !gap-1.5 !rounded-lg !text-[10px] !font-bold';
+
 type TimeRange =
   | 'today'
   | 'yesterday'
@@ -319,6 +321,7 @@ const LogsView: React.FC = () => {
         value={startDate}
         onChange={handleStartDateChange}
         onClear={handleStartDateClear}
+        buttonClassName={tableToolbarButtonClassName}
       />
       <i className="fa-solid fa-arrow-right text-slate-300 text-sm" />
       <DatePickerButton
@@ -326,21 +329,24 @@ const LogsView: React.FC = () => {
         value={endDate}
         onChange={handleEndDateChange}
         onClear={handleEndDateClear}
+        buttonClassName={tableToolbarButtonClassName}
       />
       <CustomSelect
         options={timeRangeOptions}
         value={dropdownValue}
         onChange={handleTimeRangeChange}
         displayValue={dropdownValue ? undefined : t('logs.timeRanges.custom')}
-        buttonClassName="h-10 px-3 text-sm font-semibold !bg-white"
+        buttonClassName={`${tableToolbarButtonClassName} !bg-white`}
       />
       <button
         type="button"
         onClick={handleRefreshLogs}
         disabled={loading || isRefreshing}
-        className="h-10 px-4 inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white text-slate-600 text-sm font-semibold hover:bg-slate-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        className={`${tableToolbarButtonClassName} inline-flex items-center border border-slate-200 bg-white text-slate-600 hover:bg-slate-100 transition-colors disabled:opacity-40 disabled:cursor-not-allowed`}
       >
-        <i className={`fa-solid ${isRefreshing ? 'fa-circle-notch fa-spin' : 'fa-rotate-right'}`} />
+        <i
+          className={`fa-solid ${isRefreshing ? 'fa-circle-notch fa-spin' : 'fa-rotate-right'} text-[10px]`}
+        />
         {t('common:buttons.refresh')}
       </button>
     </div>

--- a/components/administration/LogsView.tsx
+++ b/components/administration/LogsView.tsx
@@ -16,7 +16,7 @@ const humanizeToken = (value: string) =>
     .trim()
     .toLowerCase();
 
-const tableToolbarButtonClassName = '!h-7 !px-2 !gap-1.5 !rounded-lg !text-[10px] !font-bold';
+const tableToolbarButtonClassName = '!h-8 !px-2.5 !gap-1.5 !rounded-lg !text-[11px] !font-bold';
 
 type TimeRange =
   | 'today'
@@ -345,7 +345,7 @@ const LogsView: React.FC = () => {
         className={`${tableToolbarButtonClassName} inline-flex items-center border border-slate-200 bg-white text-slate-600 hover:bg-slate-100 transition-colors disabled:opacity-40 disabled:cursor-not-allowed`}
       >
         <i
-          className={`fa-solid ${isRefreshing ? 'fa-circle-notch fa-spin' : 'fa-rotate-right'} text-[10px]`}
+          className={`fa-solid ${isRefreshing ? 'fa-circle-notch fa-spin' : 'fa-rotate-right'} text-[11px]`}
         />
         {t('common:buttons.refresh')}
       </button>

--- a/components/administration/LogsView.tsx
+++ b/components/administration/LogsView.tsx
@@ -16,7 +16,7 @@ const humanizeToken = (value: string) =>
     .trim()
     .toLowerCase();
 
-const tableToolbarButtonClassName = '!h-8 !px-2.5 !gap-1.5 !rounded-lg !text-[11px] !font-bold';
+const tableToolbarButtonClassName = '!h-7 !px-2 !gap-1.5 !rounded-lg !text-[10px] !font-bold';
 
 type TimeRange =
   | 'today'
@@ -345,7 +345,7 @@ const LogsView: React.FC = () => {
         className={`${tableToolbarButtonClassName} inline-flex items-center border border-slate-200 bg-white text-slate-600 hover:bg-slate-100 transition-colors disabled:opacity-40 disabled:cursor-not-allowed`}
       >
         <i
-          className={`fa-solid ${isRefreshing ? 'fa-circle-notch fa-spin' : 'fa-rotate-right'} text-[11px]`}
+          className={`fa-solid ${isRefreshing ? 'fa-circle-notch fa-spin' : 'fa-rotate-right'} text-[10px]`}
         />
         {t('common:buttons.refresh')}
       </button>

--- a/components/shared/DatePickerButton.tsx
+++ b/components/shared/DatePickerButton.tsx
@@ -69,14 +69,14 @@ const DatePickerButton: React.FC<DatePickerButtonProps> = ({
     const buttonRect = buttonRef.current?.getBoundingClientRect();
     if (!buttonRect) return null;
 
-    const dropdownHeight = 400;
+    const dropdownHeight = 360;
     const spaceBelow = window.innerHeight - buttonRect.bottom;
     const shouldOpenUp = spaceBelow < dropdownHeight && buttonRect.top > dropdownHeight;
 
     return {
       position: 'fixed' as const,
       top: shouldOpenUp ? Math.max(8, buttonRect.top - dropdownHeight - 4) : buttonRect.bottom + 4,
-      left: Math.max(8, Math.min(buttonRect.left, window.innerWidth - 320)),
+      left: Math.max(8, Math.min(buttonRect.left, window.innerWidth - 288)),
       zIndex: 1000,
     };
   }, []);
@@ -181,7 +181,7 @@ const DatePickerButton: React.FC<DatePickerButtonProps> = ({
           <div
             ref={dropdownRef}
             style={dropdownStyles}
-            className="w-80 origin-top-left animate-in fade-in zoom-in-95 duration-100 space-y-3"
+            className="w-72 origin-top-left animate-in fade-in zoom-in-95 duration-100 space-y-2.5"
           >
             <div>
               <Calendar
@@ -189,6 +189,7 @@ const DatePickerButton: React.FC<DatePickerButtonProps> = ({
                 onDateSelect={handleDateSelect}
                 allowWeekendSelection
                 startOfWeek="Monday"
+                size="compact"
               />
             </div>
 
@@ -199,14 +200,14 @@ const DatePickerButton: React.FC<DatePickerButtonProps> = ({
                   aria-label={t('labels.time')}
                   value={formatTimeValue(hours, minutes)}
                   onChange={handleTimeChange}
-                  className="h-10 flex-1 rounded-full border border-slate-200 bg-white px-4 text-sm font-semibold text-slate-700 tabular-nums shadow-sm outline-none transition focus:border-praetor focus:ring-2 focus:ring-praetor/20"
+                  className="h-9 flex-1 rounded-full border border-slate-200 bg-white px-4 text-sm font-semibold text-slate-700 tabular-nums shadow-sm outline-none transition focus:border-praetor focus:ring-2 focus:ring-praetor/20"
                 />
                 <button
                   type="button"
                   onClick={handleApply}
                   aria-label={t('buttons.apply')}
                   title={t('buttons.apply')}
-                  className="grid size-10 shrink-0 place-items-center rounded-full bg-praetor text-white shadow-sm transition-opacity hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-praetor focus:ring-offset-2"
+                  className="grid size-9 shrink-0 place-items-center rounded-full bg-praetor text-white shadow-sm transition-opacity hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-praetor focus:ring-offset-2"
                 >
                   <i className="fa-solid fa-check" />
                 </button>

--- a/components/shared/DatePickerButton.tsx
+++ b/components/shared/DatePickerButton.tsx
@@ -16,6 +16,7 @@ export interface DatePickerButtonProps {
   placeholder?: string;
   disabled?: boolean;
   className?: string;
+  buttonClassName?: string;
 }
 
 const DatePickerButton: React.FC<DatePickerButtonProps> = ({
@@ -25,6 +26,7 @@ const DatePickerButton: React.FC<DatePickerButtonProps> = ({
   placeholder,
   disabled = false,
   className = '',
+  buttonClassName = '',
 }) => {
   const { t } = useTranslation('common');
   const [isOpen, setIsOpen] = useState(false);
@@ -156,7 +158,7 @@ const DatePickerButton: React.FC<DatePickerButtonProps> = ({
         type="button"
         disabled={disabled}
         onClick={handleOpen}
-        className={`h-10 px-4 inline-flex items-center gap-2 rounded-xl border text-sm font-semibold transition-colors
+        className={`h-10 px-4 inline-flex items-center gap-2 rounded-xl border text-sm font-semibold transition-colors ${buttonClassName}
   ${disabled ? 'opacity-50 cursor-not-allowed' : 'hover:bg-slate-50'}
   ${isOpen ? 'border-praetor ring-1 ring-praetor bg-white' : 'border-slate-200 bg-white text-slate-600'}`}
       >

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -750,12 +750,12 @@ const StandardTable = <T extends object>({
               onClick();
             }}
             disabled={disabled}
-            className={`h-8 ${text ? 'px-2.5 gap-1.5' : 'w-8 justify-center'} flex items-center rounded-lg border border-slate-200 transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
+            className={`h-7 ${text ? 'px-2 gap-1.5' : 'w-7 justify-center'} flex items-center rounded-lg border border-slate-200 transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
               active ? 'bg-slate-100 text-praetor' : 'bg-white text-slate-500 hover:bg-slate-100'
             }`}
           >
-            <i className={`fa-solid ${iconClass} text-[11px]`} aria-hidden="true"></i>
-            {text && <span className="text-[11px] font-bold">{text}</span>}
+            <i className={`fa-solid ${iconClass} text-[10px]`} aria-hidden="true"></i>
+            {text && <span className="text-[10px] font-bold">{text}</span>}
           </button>
         )}
       </Tooltip>

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -750,12 +750,12 @@ const StandardTable = <T extends object>({
               onClick();
             }}
             disabled={disabled}
-            className={`h-7 ${text ? 'px-2 gap-1.5' : 'w-7 justify-center'} flex items-center rounded-lg border border-slate-200 transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
+            className={`h-8 ${text ? 'px-2.5 gap-1.5' : 'w-8 justify-center'} flex items-center rounded-lg border border-slate-200 transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
               active ? 'bg-slate-100 text-praetor' : 'bg-white text-slate-500 hover:bg-slate-100'
             }`}
           >
-            <i className={`fa-solid ${iconClass} text-[10px]`} aria-hidden="true"></i>
-            {text && <span className="text-[10px] font-bold">{text}</span>}
+            <i className={`fa-solid ${iconClass} text-[11px]`} aria-hidden="true"></i>
+            {text && <span className="text-[11px] font-bold">{text}</span>}
           </button>
         )}
       </Tooltip>


### PR DESCRIPTION
## Summary
- Aligned the logs time filter, preset selector, and refresh button with the export button’s compact toolbar dimensions.
- Added a `buttonClassName` override to `DatePickerButton` so the shared date picker can reuse the same sizing without extra wrapper styling.

## Testing
- `bunx biome check components/administration/LogsView.tsx components/shared/DatePickerButton.tsx`
- Full repo lint was not reliable in this workspace because backend dependencies are missing, so validation was limited to the touched frontend files.