### PR TITLE
fix(table): clamp filter popup within the viewport

### DIFF
--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -45,8 +45,23 @@ type FontSize = (typeof FONT_SIZES)[number];
 const VIEWS_HOVER_CLOSE_DELAY_MS = 200;
 const VIEW_ERROR_DURATION_MS = 3000;
 const COPIED_FEEDBACK_DURATION_MS = 1500;
+const FILTER_POPUP_WIDTH_PX = 224;
+const FILTER_POPUP_VIEWPORT_MARGIN_PX = 8;
 
 type ViewModalState = { kind: 'create' } | { kind: 'edit'; view: CustomView } | null;
+
+const getFilterPopupPosition = (rect: DOMRect) => {
+  const scrollX = window.scrollX;
+  const minLeft = scrollX + FILTER_POPUP_VIEWPORT_MARGIN_PX;
+  const maxLeft =
+    scrollX + window.innerWidth - FILTER_POPUP_VIEWPORT_MARGIN_PX - FILTER_POPUP_WIDTH_PX;
+  const preferredLeft = rect.left + scrollX;
+
+  return {
+    top: rect.bottom + window.scrollY + 4,
+    left: Math.max(minLeft, Math.min(preferredLeft, maxLeft)),
+  };
+};
 
 const ViewActionButton = ({
   icon,
@@ -1238,10 +1253,7 @@ const StandardTable = <T extends object>({
                                   setActiveFilterCol(null);
                                 } else {
                                   const rect = e.currentTarget.getBoundingClientRect();
-                                  setFilterPos({
-                                    top: rect.bottom + window.scrollY + 4,
-                                    left: rect.left + window.scrollX,
-                                  });
+                                  setFilterPos(getFilterPopupPosition(rect));
                                   setActiveFilterCol(colId);
                                 }
                               }}

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -39,6 +39,14 @@ const openFilterFor = (headerText: string) => {
   });
 };
 
+const findPositionedFilterPopup = () => {
+  let el = screen.getByText('table.sortAsc').parentElement;
+  while (el && el.style.position !== 'absolute') {
+    el = el.parentElement;
+  }
+  return el as HTMLDivElement | null;
+};
+
 describe('<StandardTable />', () => {
   beforeEach(() => {
     localStorage.clear();
@@ -316,6 +324,45 @@ describe('<StandardTable />', () => {
     });
     expect(tbody.textContent).toContain('Bob');
     expect(tbody.textContent).toContain('Charlie');
+  });
+
+  test('filter popup stays within the viewport near the right edge', () => {
+    const originalInnerWidth = window.innerWidth;
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: 400,
+    });
+    try {
+      render(<StandardTable<Row> title="People" data={sampleRows} columns={sampleColumns} />);
+
+      const ageHeader = screen.getByText('Age').closest('th') as HTMLTableCellElement;
+      const filterButton = ageHeader.querySelector('button') as HTMLButtonElement;
+      filterButton.getBoundingClientRect = () =>
+        ({
+          bottom: 20,
+          height: 16,
+          left: 380,
+          right: 396,
+          top: 4,
+          width: 16,
+          x: 380,
+          y: 4,
+          toJSON: () => ({}),
+        }) as DOMRect;
+
+      act(() => {
+        fireEvent.click(filterButton);
+      });
+
+      const popup = findPositionedFilterPopup();
+      expect(popup).not.toBeNull();
+      expect(popup?.style.left).toBe('168px');
+    } finally {
+      Object.defineProperty(window, 'innerWidth', {
+        configurable: true,
+        value: originalInnerWidth,
+      });
+    }
   });
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Clamp the StandardTable filter popup position so it stays inside the viewport when opened from right-edge columns.
- Add a regression test that simulates a narrow viewport and verifies the popup is repositioned instead of overflowing off-screen.

## Testing
- `bun test ./test/components/StandardTable.test.tsx`
- `bunx biome check components/shared/StandardTable.tsx test/components/StandardTable.test.tsx`