### PR TITLE
ci(actions): add react doctor check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,12 +60,35 @@ jobs:
     name: React Doctor
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
+      - name: Detect changed frontend files
+        id: frontend-changes
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            changed_files=$(git diff --name-only "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}")
+          else
+            git fetch origin main
+            changed_files=$(git diff --name-only origin/main...HEAD)
+          fi
+
+          if printf '%s\n' "$changed_files" | grep -Eq '^(App|index|i18n|types)\.tsx?$|^(components|hooks|locales|public|services|src|utils)/|^(package|bun\.lock|vite\.config|tsconfig).*'; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No frontend source changes detected; skipping React Doctor."
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run React Doctor
+        if: steps.frontend-changes.outputs.has_changes == 'true'
         uses: millionco/react-doctor@main
         with:
           diff: main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,22 @@ jobs:
           fi
         working-directory: server
 
+
+  react-doctor:
+    name: React Doctor
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run React Doctor
+        uses: millionco/react-doctor@main
+        with:
+          diff: main
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
   test:
     name: Tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Motivation
- Run the React Doctor GitHub Action on PRs to surface React-specific diagnostics and linting issues early in CI for frontend changes.

### Description
- Add a new `react-doctor` job to `.github/workflows/ci.yml` that uses `actions/checkout@v4` with `fetch-depth: 0` and runs `millionco/react-doctor@main` with `diff: main` and `github-token: ${{ secrets.GITHUB_TOKEN }}`.

### Testing
- No automated tests were run locally; this is a workflow-only change and will be validated when GitHub Actions executes the workflow on the next push or pull request.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff0b0abb688325b0782cdf3a3d1d31)