### PR TITLE
docs: add secret generation commands to env examples

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,9 @@ POSTGRES_DB=praetor
 
 # Application Secrets
 # Generate unique high-entropy values before first startup.
+# Generate with: openssl rand -base64 32
 JWT_SECRET=change-me-long-random-jwt-secret
+# Generate with: openssl rand -base64 32
 ENCRYPTION_KEY=change-me-long-random-encryption-key
 
 # Reverse proxy trust for backend client IP detection.
@@ -36,4 +38,5 @@ DEMO_SEEDING=false
 
 # Initial password for bootstrap admin user (username: admin)
 # Used only when the admin user does not already exist.
+# Generate with: openssl rand -base64 24
 ADMIN_DEFAULT_PASSWORD=change-me-strong-admin-password

--- a/deploy/.env.customer.example
+++ b/deploy/.env.customer.example
@@ -15,11 +15,14 @@ FRONTEND_PORT=3000
 # Fresh PostgreSQL 18 installs only. Do not reuse a PostgreSQL 17 data volume with this
 # compose file.
 POSTGRES_USER=praetor
+# Generate with: openssl rand -base64 24
 POSTGRES_PASSWORD=change-me-strong-password
 POSTGRES_DB=praetor
 
 # Required app secrets
+# Generate with: openssl rand -base64 32
 JWT_SECRET=change-me-long-random-jwt-secret
+# Generate with: openssl rand -base64 32
 ENCRYPTION_KEY=change-me-long-random-encryption-key
 
 # Reverse proxy trust for backend client IP detection.
@@ -27,6 +30,7 @@ ENCRYPTION_KEY=change-me-long-random-encryption-key
 TRUST_PROXY=1
 
 # Bootstrap admin password (username is always "admin")
+# Generate with: openssl rand -base64 24
 ADMIN_DEFAULT_PASSWORD=change-me-strong-admin-password
 
 # Optional demo data. Keep false for production.

--- a/server/.env.example
+++ b/server/.env.example
@@ -15,6 +15,7 @@ DB_USER=tempo
 DB_PASSWORD=tempo
 
 # JWT Secret. Generate a unique high-entropy value before first startup.
+# Generate with: openssl rand -base64 32
 JWT_SECRET=change-me-long-random-jwt-secret
 
 # Optional demo refresh on startup.
@@ -24,10 +25,12 @@ DEMO_SEEDING=false
 
 # Initial password for bootstrap admin user (username: admin)
 # Used only when the admin user does not already exist.
+# Generate with: openssl rand -base64 24
 ADMIN_DEFAULT_PASSWORD=change-me-strong-admin-password
 
 # Encryption key for sensitive data (SMTP passwords, etc.)
 # Generate a unique high-entropy value before first startup.
+# Generate with: openssl rand -base64 32
 ENCRYPTION_KEY=change-me-long-random-encryption-key
 
 # Filesystem path for uploaded attachments (e.g. supplier quote attachments).


### PR DESCRIPTION
## Summary
- Add concrete `openssl rand` commands next to required secrets in the root, server, and customer env examples
- Clarify which values should be regenerated before first startup or deployment
- Cover `JWT_SECRET`, `ENCRYPTION_KEY`, `POSTGRES_PASSWORD`, and `ADMIN_DEFAULT_PASSWORD` where applicable

## Testing
- Not run (not requested)