### PR TITLE
feat: add Drizzle-based database readiness checks

### DIFF
--- a/server/db/readiness.ts
+++ b/server/db/readiness.ts
@@ -1,0 +1,144 @@
+import { readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { sql } from 'drizzle-orm';
+import type { PgTable } from 'drizzle-orm/pg-core';
+import { type DbExecutor, db, executeRows } from './drizzle.ts';
+import * as schema from './schema/index.ts';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const migrationsFolder = join(__dirname, 'migrations');
+
+type MigrationCountRow = {
+  appliedCount: string | number | bigint;
+};
+
+export type DbReadinessProbe = {
+  name: string;
+  run: (exec: DbExecutor) => Promise<unknown>;
+};
+
+export type DbReadinessResult = {
+  appliedMigrations: number;
+  expectedMigrations: number;
+  probedTables: string[];
+};
+
+type VerifyDbReadinessOptions = {
+  exec?: DbExecutor;
+  migrationsDir?: string;
+  probes?: readonly DbReadinessProbe[];
+};
+
+const schemaReadinessTables = [
+  ['audit_logs', schema.auditLogs],
+  ['client_profile_options', schema.clientProfileOptions],
+  ['clients', schema.clients],
+  ['customer_offer_items', schema.customerOfferItems],
+  ['customer_offers', schema.customerOffers],
+  ['email_config', schema.emailConfig],
+  ['external_identities', schema.externalIdentities],
+  ['general_settings', schema.generalSettings],
+  ['invoice_items', schema.invoiceItems],
+  ['invoices', schema.invoices],
+  ['ldap_config', schema.ldapConfig],
+  ['notifications', schema.notifications],
+  ['offer_versions', schema.offerVersions],
+  ['order_versions', schema.orderVersions],
+  ['product_categories', schema.productCategories],
+  ['product_subcategories', schema.productSubcategories],
+  ['products', schema.products],
+  ['product_types', schema.productTypes],
+  ['projects', schema.projects],
+  ['quote_items', schema.quoteItems],
+  ['quotes', schema.quotes],
+  ['quote_versions', schema.quoteVersions],
+  ['report_chat_messages', schema.reportChatMessages],
+  ['report_chat_sessions', schema.reportChatSessions],
+  ['role_permissions', schema.rolePermissions],
+  ['roles', schema.roles],
+  ['sale_items', schema.saleItems],
+  ['sales', schema.sales],
+  ['settings', schema.settings],
+  ['sso_login_tickets', schema.ssoLoginTickets],
+  ['sso_providers', schema.ssoProviders],
+  ['sso_states', schema.ssoStates],
+  ['supplier_invoice_items', schema.supplierInvoiceItems],
+  ['supplier_invoices', schema.supplierInvoices],
+  ['supplier_order_versions', schema.supplierOrderVersions],
+  ['supplier_quote_attachments', schema.supplierQuoteAttachments],
+  ['supplier_quote_items', schema.supplierQuoteItems],
+  ['supplier_quotes', schema.supplierQuotes],
+  ['supplier_quote_versions', schema.supplierQuoteVersions],
+  ['supplier_sale_items', schema.supplierSaleItems],
+  ['supplier_sales', schema.supplierSales],
+  ['suppliers', schema.suppliers],
+  ['tasks', schema.tasks],
+  ['time_entries', schema.timeEntries],
+  ['user_clients', schema.userClients],
+  ['user_projects', schema.userProjects],
+  ['user_roles', schema.userRoles],
+  ['user_tasks', schema.userTasks],
+  ['users', schema.users],
+  ['user_work_units', schema.userWorkUnits],
+  ['work_unit_managers', schema.workUnitManagers],
+  ['work_units', schema.workUnits],
+] satisfies readonly (readonly [string, PgTable])[];
+
+export const schemaReadinessProbes = schemaReadinessTables.map(
+  ([name, table]): DbReadinessProbe => ({
+    name,
+    run: (exec) => exec.select().from(table).limit(0),
+  }),
+);
+
+const countMigrationFiles = (dir: string): number =>
+  readdirSync(dir).filter((fileName) => /^\d+_.+\.sql$/.test(fileName)).length;
+
+const parseMigrationCount = (value: string | number | bigint | undefined): number => {
+  if (typeof value === 'number') return value;
+  if (typeof value === 'bigint') return Number(value);
+  if (typeof value === 'string') {
+    const parsed = Number.parseInt(value, 10);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  throw new Error(`Unexpected Drizzle migration count value: ${String(value)}`);
+};
+
+export const verifyDbReadiness = async (
+  options: VerifyDbReadinessOptions = {},
+): Promise<DbReadinessResult> => {
+  const exec = options.exec ?? db;
+  const expectedMigrations = countMigrationFiles(options.migrationsDir ?? migrationsFolder);
+  const probes = options.probes ?? schemaReadinessProbes;
+
+  await executeRows(exec, sql`SELECT 1 AS ok`);
+
+  const migrationRows = await executeRows<MigrationCountRow>(
+    exec,
+    sql`SELECT COUNT(*) AS "appliedCount" FROM drizzle.__drizzle_migrations`,
+  );
+  const appliedMigrations = parseMigrationCount(migrationRows[0]?.appliedCount);
+
+  if (appliedMigrations < expectedMigrations) {
+    throw new Error(
+      `Database migrations incomplete. Applied ${appliedMigrations} of ${expectedMigrations} migration files.`,
+    );
+  }
+
+  const probedTables: string[] = [];
+  for (const probe of probes) {
+    try {
+      await probe.run(exec);
+      probedTables.push(probe.name);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`Database schema probe failed for ${probe.name}: ${message}`, {
+        cause: err,
+      });
+    }
+  }
+
+  return { appliedMigrations, expectedMigrations, probedTables };
+};

--- a/server/index.ts
+++ b/server/index.ts
@@ -6,6 +6,7 @@ import { ensureBootstrapAdmin } from './db/bootstrapAdmin.ts';
 import { runDemoSeedRefresh } from './db/demoSeed.ts';
 import { query } from './db/index.ts';
 import { runDrizzleMigrations } from './db/migrationsRunner.ts';
+import { verifyDbReadiness } from './db/readiness.ts';
 import { createChildLogger, serializeError } from './utils/logger.ts';
 import {
   INSECURE_DEFAULT_ADMIN_PASSWORDS,
@@ -19,15 +20,6 @@ const logger = createChildLogger({ module: 'startup' });
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const schemaPath = join(__dirname, 'db', 'schema.sql');
-const REQUIRED_BOOTSTRAP_TABLES = [
-  'roles',
-  'users',
-  'user_roles',
-  'settings',
-  'user_clients',
-  'user_projects',
-  'user_tasks',
-] as const;
 
 const fastify = await buildApp();
 
@@ -50,35 +42,14 @@ const assertSecureRuntimeConfig = () => {
   }
 };
 
-const bootstrapDatabase = async () => {
+const applyHistoricalSchemaBootstrap = async () => {
   if (!existsSync(schemaPath)) {
     throw new Error(`Schema file not found at ${schemaPath}`);
   }
 
   const schemaSql = readFileSync(schemaPath, 'utf8');
   await query(schemaSql);
-
-  const tableCheck = await query(
-    `
-      SELECT table_name
-      FROM information_schema.tables
-      WHERE table_schema = 'public'
-        AND table_name = ANY($1::text[])
-      ORDER BY table_name
-    `,
-    [REQUIRED_BOOTSTRAP_TABLES],
-  );
-
-  const foundTables = tableCheck.rows.map((row) => String(row.table_name));
-  const missingTables = REQUIRED_BOOTSTRAP_TABLES.filter(
-    (tableName) => !foundTables.includes(tableName),
-  );
-
-  logger.info({ foundTables }, 'Database schema verified');
-
-  if (missingTables.length > 0) {
-    throw new Error(`Database bootstrap incomplete. Missing tables: ${missingTables.join(', ')}`);
-  }
+  logger.info('Historical schema bootstrap applied');
 };
 
 const shutdown = async (signal: string) => {
@@ -118,8 +89,17 @@ try {
   }
   if (dbReady) logger.info('PostgreSQL ready');
 
-  await bootstrapDatabase();
+  await applyHistoricalSchemaBootstrap();
   await runDrizzleMigrations();
+  const readiness = await verifyDbReadiness();
+  logger.info(
+    {
+      appliedMigrations: readiness.appliedMigrations,
+      expectedMigrations: readiness.expectedMigrations,
+      probedTableCount: readiness.probedTables.length,
+    },
+    'Database schema verified',
+  );
 
   // Ensure required bootstrap user data always exists.
   await ensureBootstrapAdmin();

--- a/server/package.json
+++ b/server/package.json
@@ -13,6 +13,7 @@
     "db:generate": "drizzle-kit generate",
     "db:generate:custom": "drizzle-kit generate --custom",
     "db:migrate": "bun run scripts/run-migrations.ts",
+    "db:ready": "bun run scripts/check-db-ready.ts",
     "db:check": "drizzle-kit check",
     "db:studio": "drizzle-kit studio"
   },

--- a/server/scripts/check-db-ready.ts
+++ b/server/scripts/check-db-ready.ts
@@ -1,0 +1,17 @@
+#!/usr/bin/env bun
+import 'dotenv/config';
+import pool from '../db/index.ts';
+import { verifyDbReadiness } from '../db/readiness.ts';
+
+try {
+  const result = await verifyDbReadiness();
+  console.info(
+    `Database ready: ${result.appliedMigrations}/${result.expectedMigrations} migrations applied; ${result.probedTables.length} tables probed.`,
+  );
+} catch (err) {
+  console.error('Database readiness check failed:');
+  console.error(err);
+  process.exitCode = 1;
+} finally {
+  await pool.end();
+}

--- a/server/test/db/readiness.test.ts
+++ b/server/test/db/readiness.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { sql } from 'drizzle-orm';
+import type { DbReadinessProbe } from '../../db/readiness.ts';
+import { verifyDbReadiness } from '../../db/readiness.ts';
+import { setupTestDb } from '../helpers/fakeExecutor.ts';
+
+const makeMigrationsDir = (count: number): string => {
+  const dir = mkdtempSync(join(tmpdir(), 'praetor-readiness-'));
+  for (let i = 0; i < count; i += 1) {
+    writeFileSync(join(dir, `${String(i).padStart(4, '0')}_test.sql`), '-- test\n');
+  }
+  return dir;
+};
+
+const removeMigrationsDir = (dir: string) => {
+  rmSync(dir, { recursive: true, force: true });
+};
+
+describe('verifyDbReadiness', () => {
+  test('succeeds when migrations are complete and probes pass', async () => {
+    const { exec, testDb } = setupTestDb();
+    const probe: DbReadinessProbe = {
+      name: 'users',
+      run: async (db) => db.execute(sql`SELECT * FROM users LIMIT 0`),
+    };
+
+    exec.enqueue({ rows: [{ ok: 1 }] });
+    exec.enqueue({ rows: [{ appliedCount: '2' }] });
+    exec.enqueue({ rows: [] });
+    const migrationsDir = makeMigrationsDir(2);
+
+    try {
+      const result = await verifyDbReadiness({
+        exec: testDb,
+        migrationsDir,
+        probes: [probe],
+      });
+
+      expect(result).toEqual({
+        appliedMigrations: 2,
+        expectedMigrations: 2,
+        probedTables: ['users'],
+      });
+    } finally {
+      removeMigrationsDir(migrationsDir);
+    }
+  });
+
+  test('fails when the database is missing applied migration rows', async () => {
+    const { exec, testDb } = setupTestDb();
+
+    exec.enqueue({ rows: [{ ok: 1 }] });
+    exec.enqueue({ rows: [{ appliedCount: '1' }] });
+    const migrationsDir = makeMigrationsDir(2);
+
+    try {
+      await expect(
+        verifyDbReadiness({
+          exec: testDb,
+          migrationsDir,
+          probes: [],
+        }),
+      ).rejects.toThrow('Database migrations incomplete. Applied 1 of 2 migration files.');
+    } finally {
+      removeMigrationsDir(migrationsDir);
+    }
+  });
+
+  test('fails with the probe name when a table probe throws', async () => {
+    const { exec, testDb } = setupTestDb();
+    const probe: DbReadinessProbe = {
+      name: 'users',
+      run: async () => {
+        throw new Error('relation "users" does not exist');
+      },
+    };
+
+    exec.enqueue({ rows: [{ ok: 1 }] });
+    exec.enqueue({ rows: [{ appliedCount: '1' }] });
+    const migrationsDir = makeMigrationsDir(1);
+
+    try {
+      await expect(
+        verifyDbReadiness({
+          exec: testDb,
+          migrationsDir,
+          probes: [probe],
+        }),
+      ).rejects.toThrow('Database schema probe failed for users');
+    } finally {
+      removeMigrationsDir(migrationsDir);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add a deploy-time DB readiness check that verifies connectivity, applied Drizzle migrations, and table-level ORM probes before startup continues.
- Keep the historical `schema.sql` bootstrap apply, but move the schema verification signal to the new Drizzle-backed readiness flow.
- Add a `db:ready` script for standalone deploy checks and cover the new behavior with unit tests.

## Testing
- `bun test server/test/db/readiness.test.ts`
- `bun run lint`
- `bun run typecheck`
- `bun run test:server`