### PR TITLE
feat: switch app typography to Satoshi

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>Praetor</title>
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <link
-      href="https://api.fontshare.com/v2/css?f[]=satoshi@300&display=swap"
+      href="https://api.fontshare.com/v2/css?f[]=satoshi@300,400,500,700,900&display=swap"
       rel="stylesheet"
     />
     <link
@@ -25,7 +25,7 @@
     </script>
   </head>
 
-  <body class="bg-slate-50 text-slate-900 font-sans">
+  <body class="bg-slate-50 text-zinc-950 font-sans">
     <div id="root"></div>
     <script type="module" src="/index.tsx"></script>
   </body>

--- a/index.html
+++ b/index.html
@@ -6,6 +6,10 @@
     <title>Praetor</title>
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <link
+      href="https://api.fontshare.com/v2/css?f[]=satoshi@300&display=swap"
+      rel="stylesheet"
+    />
+    <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
     />

--- a/src/index.css
+++ b/src/index.css
@@ -14,6 +14,7 @@
 }
 
 @theme {
+  --font-sans: "Satoshi", sans-serif;
   --color-praetor: var(--color-primary);
   --color-secondary: var(--color-secondary);
   --color-accent: var(--color-accent);
@@ -52,6 +53,11 @@
   --sidebar-accent-foreground: hsl(240 5.9% 10%);
   --sidebar-border: hsl(220 13% 91%);
   --sidebar-ring: hsl(217.2 91.2% 59.8%);
+}
+
+html,
+body {
+  font-family: "Satoshi", sans-serif;
 }
 
 /* Chrome, Safari, Edge, Opera */


### PR DESCRIPTION
## Summary
- Load Satoshi from Fontshare in the app shell.
- Set Satoshi as the default `font-sans` stack and base `html, body` font family.
- Leave monospace usage and non-app rendered artifacts unchanged.

## Testing
- `bunx biome check index.html src/index.css` passed.
- `bun run build` passed.
- `bun run lint` could not complete in this environment because the local backend dependency install is incomplete, so TypeScript fails before Biome.