### PR TITLE
feat: add light, dark, and auto theme preferences

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -31,7 +31,7 @@ import {
   Users,
 } from 'lucide-react';
 import type React from 'react';
-import { useMemo } from 'react';
+import { useLayoutEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { AppSidebar } from '@/components/app-sidebar';
 import type { SidebarModuleItem, SidebarRouteItem } from '@/components/nav-main';
@@ -39,6 +39,7 @@ import { Separator } from '@/components/ui/separator';
 import { SidebarInset, SidebarProvider, SidebarTrigger } from '@/components/ui/sidebar';
 import type { Notification, User as PraetorUser, Role, View } from '../types';
 import { buildPermission, hasPermission, VIEW_PERMISSION_MAP } from '../utils/permissions';
+import { applyTheme, getTheme } from '../utils/theme';
 import NotificationBell from './shared/NotificationBell';
 
 interface Module {
@@ -108,6 +109,10 @@ const Layout: React.FC<LayoutProps> = ({
   onDeleteNotification,
 }) => {
   const { t, i18n } = useTranslation(['layout', 'hr']);
+
+  useLayoutEffect(() => {
+    applyTheme(getTheme());
+  }, []);
 
   const modules: Module[] = useMemo(
     () => [
@@ -322,6 +327,7 @@ const Layout: React.FC<LayoutProps> = ({
   return (
     <SidebarProvider>
       <AppSidebar
+        data-shadcn-theme-scope
         navItems={navItems}
         currentUser={currentUser}
         roleLabel={roleLabel}

--- a/components/UserSettings.tsx
+++ b/components/UserSettings.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Settings } from '../services/api';
 import { applyLanguagePreference } from '../utils/language';
-import { applyTheme, getTheme, type Theme } from '../utils/theme';
+import { applyTheme, getTheme, THEMES, type Theme } from '../utils/theme';
 
 export interface UserSettingsProps {
   settings: Settings;
@@ -11,6 +11,41 @@ export interface UserSettingsProps {
   onUpdate: (updates: Partial<Settings>) => void;
   onUpdatePassword: (currentPassword: string, newPassword: string) => Promise<void>;
 }
+
+type LanguagePreference = NonNullable<Settings['language']>;
+
+const THEME_OPTION_META: Record<
+  Theme,
+  {
+    activeClassName: string;
+    inactiveClassName: string;
+    swatchClassName: string;
+    inactiveIconClassName: string;
+    activeIconClassName?: string;
+  }
+> = {
+  light: {
+    activeClassName: 'border-praetor bg-zinc-50',
+    inactiveClassName: 'border-zinc-100 hover:border-zinc-200',
+    swatchClassName:
+      'bg-white border border-zinc-200 shrink-0 shadow-sm flex items-center justify-center text-praetor',
+    inactiveIconClassName: 'fa-solid fa-sun text-sm',
+  },
+  dark: {
+    activeClassName: 'border-praetor bg-praetor/5',
+    inactiveClassName: 'border-zinc-100 hover:border-praetor/20',
+    swatchClassName: 'bg-zinc-900 shrink-0 shadow-sm flex items-center justify-center text-white',
+    inactiveIconClassName: 'fa-solid fa-moon text-sm',
+  },
+  auto: {
+    activeClassName: 'border-praetor bg-zinc-50',
+    inactiveClassName: 'border-zinc-100 hover:border-zinc-200',
+    swatchClassName:
+      'bg-gradient-to-br from-white from-50% to-zinc-900 to-50% border border-zinc-200 shrink-0 shadow-sm flex items-center justify-center text-praetor',
+    inactiveIconClassName: 'fa-solid fa-circle-half-stroke text-sm bg-white rounded-full p-1',
+    activeIconClassName: 'fa-solid fa-check text-xs bg-white rounded-full p-1',
+  },
+};
 
 const UserSettings: React.FC<UserSettingsProps> = ({
   settings,
@@ -46,6 +81,7 @@ const UserSettings: React.FC<UserSettingsProps> = ({
   }, [settings]);
 
   const handleThemeChange = (theme: Theme) => {
+    if (theme === currentTheme) return;
     setCurrentTheme(theme);
     applyTheme(theme);
   };
@@ -68,7 +104,7 @@ const UserSettings: React.FC<UserSettingsProps> = ({
     }
   };
 
-  const handleLanguageChange = async (lang: 'en' | 'it' | 'auto') => {
+  const handleLanguageChange = async (lang: LanguagePreference) => {
     applyLanguagePreference(lang);
     setLanguage(lang);
     try {
@@ -248,38 +284,39 @@ const UserSettings: React.FC<UserSettingsProps> = ({
             <h3 className="font-semibold text-zinc-800">{t('appearance.title')}</h3>
           </div>
           <div className="p-6">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-              <button
-                onClick={() => handleThemeChange('default')}
-                className={`relative p-4 rounded-xl border-2 transition-all text-left flex items-start gap-4 group ${currentTheme === 'default' ? 'border-praetor bg-zinc-50' : 'border-zinc-100 hover:border-zinc-200'}`}
-              >
-                <div className="size-10 rounded-full bg-[#20293F] shrink-0 shadow-sm flex items-center justify-center text-white">
-                  {currentTheme === 'default' && <i className="fa-solid fa-check text-xs"></i>}
-                </div>
-                <div>
-                  <h4 className="font-semibold text-zinc-800 mb-1">
-                    {t('appearance.default.name')}
-                  </h4>
-                  <p className="text-xs text-zinc-500 leading-relaxed">
-                    {t('appearance.default.description')}
-                  </p>
-                </div>
-              </button>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+              {THEMES.map((theme) => {
+                const isSelected = currentTheme === theme;
+                const option = THEME_OPTION_META[theme];
 
-              <button
-                onClick={() => handleThemeChange('tempo')}
-                className={`relative p-4 rounded-xl border-2 transition-all text-left flex items-start gap-4 group ${currentTheme === 'tempo' ? 'border-praetor bg-praetor/5' : 'border-zinc-100 hover:border-praetor/20'}`}
-              >
-                <div className="size-10 rounded-full bg-[#4F46E5] shrink-0 shadow-sm flex items-center justify-center text-white">
-                  {currentTheme === 'tempo' && <i className="fa-solid fa-check text-xs"></i>}
-                </div>
-                <div>
-                  <h4 className="font-semibold text-zinc-800 mb-1">{t('appearance.tempo.name')}</h4>
-                  <p className="text-xs text-zinc-500 leading-relaxed">
-                    {t('appearance.tempo.description')}
-                  </p>
-                </div>
-              </button>
+                return (
+                  <button
+                    key={theme}
+                    onClick={() => handleThemeChange(theme)}
+                    className={`relative p-4 rounded-xl border-2 transition-all text-left flex items-start gap-4 group ${
+                      isSelected ? option.activeClassName : option.inactiveClassName
+                    }`}
+                  >
+                    <div className={`size-10 rounded-full ${option.swatchClassName}`}>
+                      <i
+                        className={
+                          isSelected
+                            ? (option.activeIconClassName ?? 'fa-solid fa-check text-xs')
+                            : option.inactiveIconClassName
+                        }
+                      ></i>
+                    </div>
+                    <div>
+                      <h4 className="font-semibold text-zinc-800 mb-1">
+                        {t(`appearance.${theme}.name`)}
+                      </h4>
+                      <p className="text-xs text-zinc-500 leading-relaxed">
+                        {t(`appearance.${theme}.description`)}
+                      </p>
+                    </div>
+                  </button>
+                );
+              })}
             </div>
           </div>
         </section>

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -52,13 +52,16 @@ export function AppSidebar({
       <SidebarHeader>
         <SidebarMenu>
           <SidebarMenuItem>
-            <SidebarMenuButton size="lg" className="cursor-default hover:bg-transparent">
+            <SidebarMenuButton
+              size="lg"
+              className="cursor-default text-sidebar-foreground hover:bg-transparent hover:text-sidebar-foreground"
+            >
               <div className="flex aspect-square size-8 items-center justify-center rounded-lg bg-praetor text-white">
                 <Clock className="size-4" />
               </div>
-              <div className="grid flex-1 text-left text-sm leading-tight">
+              <div className="grid flex-1 text-left text-sm leading-tight text-sidebar-foreground">
                 <span className="truncate font-semibold italic">PRAETOR</span>
-                <span className="truncate text-xs">
+                <span className="truncate text-xs text-sidebar-foreground/80">
                   {roleLabel} {workspaceLabel}
                 </span>
               </div>

--- a/components/nav-main.tsx
+++ b/components/nav-main.tsx
@@ -78,7 +78,7 @@ export function NavMain({ items, label, onViewChange }: NavMainProps) {
                 <SidebarMenuButton
                   tooltip={item.title}
                   isActive={item.isActive}
-                  className="font-normal! text-black hover:text-black data-[active=true]:font-normal! data-[active=true]:text-black [&_span]:font-normal! [&>svg]:text-black/70"
+                  className="font-normal! text-sidebar-foreground hover:text-sidebar-accent-foreground data-[active=true]:font-normal! data-[active=true]:text-sidebar-accent-foreground [&_span]:font-normal! [&>svg]:text-sidebar-foreground/70"
                 >
                   <item.icon />
                   <span>{item.title}</span>
@@ -92,7 +92,7 @@ export function NavMain({ items, label, onViewChange }: NavMainProps) {
                       <SidebarMenuSubButton
                         asChild
                         isActive={subItem.isActive}
-                        className="font-normal! text-black hover:text-black data-[active=true]:font-normal! data-[active=true]:text-black [&_span]:font-normal! [&>svg]:text-black/70"
+                        className="font-normal! text-sidebar-foreground hover:text-sidebar-accent-foreground data-[active=true]:font-normal! data-[active=true]:text-sidebar-accent-foreground [&_span]:font-normal! [&>svg]:text-sidebar-foreground/70"
                       >
                         <button
                           type="button"

--- a/components/nav-user.tsx
+++ b/components/nav-user.tsx
@@ -103,7 +103,7 @@ export function NavUser({
             </SidebarMenuButton>
           </DropdownMenuTrigger>
           <DropdownMenuContent
-            className="w-(--radix-dropdown-menu-trigger-width) min-w-56 rounded-lg border outline-none"
+            className="w-(--radix-dropdown-menu-trigger-width) min-w-56 rounded-lg border border-border outline-none"
             side={isMobile ? 'bottom' : 'right'}
             align="end"
             sideOffset={4}

--- a/components/nav-user.tsx
+++ b/components/nav-user.tsx
@@ -36,9 +36,12 @@ interface NavUserProps {
 interface UserIdentityBlockProps {
   user: User;
   roleLabel: string;
+  context?: 'sidebar' | 'popover';
 }
 
-function UserIdentityBlock({ user, roleLabel }: UserIdentityBlockProps) {
+function UserIdentityBlock({ user, roleLabel, context = 'sidebar' }: UserIdentityBlockProps) {
+  const isPopover = context === 'popover';
+
   return (
     <>
       <Avatar className="h-8 w-8 rounded-lg">
@@ -46,9 +49,21 @@ function UserIdentityBlock({ user, roleLabel }: UserIdentityBlockProps) {
           {user.avatarInitials}
         </AvatarFallback>
       </Avatar>
-      <div className="grid flex-1 text-left text-sm leading-tight text-sidebar-foreground group-data-[state=open]/menu-button:text-sidebar-accent-foreground">
+      <div
+        className={`grid flex-1 text-left text-sm leading-tight ${
+          isPopover
+            ? 'text-popover-foreground'
+            : 'text-sidebar-foreground group-data-[state=open]/menu-button:text-sidebar-accent-foreground'
+        }`}
+      >
         <span className="truncate font-medium">{user.name}</span>
-        <span className="truncate text-xs text-sidebar-foreground/80 group-data-[state=open]/menu-button:text-sidebar-accent-foreground/80">
+        <span
+          className={`truncate text-xs ${
+            isPopover
+              ? 'text-muted-foreground'
+              : 'text-sidebar-foreground/80 group-data-[state=open]/menu-button:text-sidebar-accent-foreground/80'
+          }`}
+        >
           {roleLabel}
         </span>
       </div>
@@ -88,14 +103,14 @@ export function NavUser({
             </SidebarMenuButton>
           </DropdownMenuTrigger>
           <DropdownMenuContent
-            className="w-(--radix-dropdown-menu-trigger-width) min-w-56 rounded-lg border border-zinc-200 outline-none"
+            className="w-(--radix-dropdown-menu-trigger-width) min-w-56 rounded-lg border outline-none"
             side={isMobile ? 'bottom' : 'right'}
             align="end"
             sideOffset={4}
           >
             <DropdownMenuLabel className="p-0 font-normal">
               <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
-                <UserIdentityBlock user={user} roleLabel={roleLabel} />
+                <UserIdentityBlock user={user} roleLabel={roleLabel} context="popover" />
               </div>
             </DropdownMenuLabel>
             <DropdownMenuSeparator />

--- a/components/nav-user.tsx
+++ b/components/nav-user.tsx
@@ -46,9 +46,11 @@ function UserIdentityBlock({ user, roleLabel }: UserIdentityBlockProps) {
           {user.avatarInitials}
         </AvatarFallback>
       </Avatar>
-      <div className="grid flex-1 text-left text-sm leading-tight">
+      <div className="grid flex-1 text-left text-sm leading-tight text-sidebar-foreground group-data-[state=open]/menu-button:text-sidebar-accent-foreground">
         <span className="truncate font-medium">{user.name}</span>
-        <span className="truncate text-xs">{roleLabel}</span>
+        <span className="truncate text-xs text-sidebar-foreground/80 group-data-[state=open]/menu-button:text-sidebar-accent-foreground/80">
+          {roleLabel}
+        </span>
       </div>
     </>
   );
@@ -79,7 +81,7 @@ export function NavUser({
           <DropdownMenuTrigger asChild>
             <SidebarMenuButton
               size="lg"
-              className="focus-visible:ring-0 focus-visible:ring-offset-0 data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+              className="group/menu-button text-sidebar-foreground focus-visible:ring-0 focus-visible:ring-offset-0 data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground [&>svg]:text-sidebar-foreground/70 data-[state=open]:[&>svg]:text-sidebar-accent-foreground/70"
             >
               <UserIdentityBlock user={user} roleLabel={roleLabel} />
               <ChevronsUpDown className="ml-auto size-4" />

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -3,6 +3,13 @@ import { DropdownMenu as DropdownMenuPrimitive } from 'radix-ui';
 import type * as React from 'react';
 
 import { cn } from '@/lib/utils';
+import { getBrowserTheme, getTheme } from '@/utils/theme';
+
+const getInitialShadcnThemeClass = () => {
+  const theme = getTheme();
+  const resolvedTheme = theme === 'auto' ? getBrowserTheme() : theme;
+  return resolvedTheme === 'dark' ? 'dark' : undefined;
+};
 
 function DropdownMenu({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
   return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
@@ -25,13 +32,18 @@ function DropdownMenuContent({
   sideOffset = 4,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  const themeClassName = getInitialShadcnThemeClass();
+
   return (
     <DropdownMenuPrimitive.Portal>
       <DropdownMenuPrimitive.Content
+        data-shadcn-theme-scope
         data-slot="dropdown-menu-content"
+        data-shadcn-theme={themeClassName === 'dark' ? 'dark' : 'light'}
         sideOffset={sideOffset}
         className={cn(
           'z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
+          themeClassName,
           className,
         )}
         {...props}
@@ -195,11 +207,16 @@ function DropdownMenuSubContent({
   className,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  const themeClassName = getInitialShadcnThemeClass();
+
   return (
     <DropdownMenuPrimitive.SubContent
+      data-shadcn-theme-scope
       data-slot="dropdown-menu-sub-content"
+      data-shadcn-theme={themeClassName === 'dark' ? 'dark' : 'light'}
       className={cn(
         'z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
+        themeClassName,
         className,
       )}
       {...props}

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -1,14 +1,28 @@
 import { CheckIcon, ChevronRightIcon, CircleIcon } from 'lucide-react';
 import { DropdownMenu as DropdownMenuPrimitive } from 'radix-ui';
-import type * as React from 'react';
+import * as React from 'react';
 
 import { cn } from '@/lib/utils';
-import { getBrowserTheme, getTheme } from '@/utils/theme';
+import { getResolvedTheme, type ResolvedTheme, THEME_CHANGE_EVENT } from '@/utils/theme';
 
-const getInitialShadcnThemeClass = () => {
-  const theme = getTheme();
-  const resolvedTheme = theme === 'auto' ? getBrowserTheme() : theme;
-  return resolvedTheme === 'dark' ? 'dark' : undefined;
+const getShadcnThemeClassName = (theme: ResolvedTheme) => {
+  return theme === 'dark' ? 'dark' : undefined;
+};
+
+const useResolvedShadcnTheme = () => {
+  const [resolvedTheme, setResolvedTheme] = React.useState<ResolvedTheme>(() => getResolvedTheme());
+
+  React.useEffect(() => {
+    const handleThemeChange = (event: Event) => {
+      const detail = (event as CustomEvent<{ resolvedTheme?: ResolvedTheme }>).detail;
+      setResolvedTheme(detail?.resolvedTheme ?? getResolvedTheme());
+    };
+
+    window.addEventListener(THEME_CHANGE_EVENT, handleThemeChange);
+    return () => window.removeEventListener(THEME_CHANGE_EVENT, handleThemeChange);
+  }, []);
+
+  return resolvedTheme;
 };
 
 function DropdownMenu({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
@@ -32,14 +46,15 @@ function DropdownMenuContent({
   sideOffset = 4,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
-  const themeClassName = getInitialShadcnThemeClass();
+  const resolvedTheme = useResolvedShadcnTheme();
+  const themeClassName = getShadcnThemeClassName(resolvedTheme);
 
   return (
     <DropdownMenuPrimitive.Portal>
       <DropdownMenuPrimitive.Content
         data-shadcn-theme-scope
         data-slot="dropdown-menu-content"
-        data-shadcn-theme={themeClassName === 'dark' ? 'dark' : 'light'}
+        data-shadcn-theme={resolvedTheme}
         sideOffset={sideOffset}
         className={cn(
           'z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
@@ -207,13 +222,14 @@ function DropdownMenuSubContent({
   className,
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
-  const themeClassName = getInitialShadcnThemeClass();
+  const resolvedTheme = useResolvedShadcnTheme();
+  const themeClassName = getShadcnThemeClassName(resolvedTheme);
 
   return (
     <DropdownMenuPrimitive.SubContent
       data-shadcn-theme-scope
       data-slot="dropdown-menu-sub-content"
-      data-shadcn-theme={themeClassName === 'dark' ? 'dark' : 'light'}
+      data-shadcn-theme={resolvedTheme}
       className={cn(
         'z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
         themeClassName,

--- a/locales/en/settings.json
+++ b/locales/en/settings.json
@@ -20,11 +20,11 @@
     "title": "Appearance",
     "light": {
       "name": "Light",
-      "description": "Use the light interface for the application and shadcn components."
+      "description": "Use light mode for shadcn components."
     },
     "dark": {
       "name": "Dark",
-      "description": "Use the dark interface for the application and shadcn components."
+      "description": "Use dark mode for shadcn components."
     },
     "auto": {
       "name": "Auto",

--- a/locales/en/settings.json
+++ b/locales/en/settings.json
@@ -18,13 +18,17 @@
   },
   "appearance": {
     "title": "Appearance",
-    "default": {
-      "name": "Default",
-      "description": "The classic Praetor experience with slate blue branding. Professional and distinct."
+    "light": {
+      "name": "Light",
+      "description": "Use the light interface for the application and shadcn components."
     },
-    "tempo": {
-      "name": "Tempo",
-      "description": "A vibrant indigo theme. Modern, energetic, and clean."
+    "dark": {
+      "name": "Dark",
+      "description": "Use the dark interface for the application and shadcn components."
+    },
+    "auto": {
+      "name": "Auto",
+      "description": "Match your browser or operating system color scheme automatically."
     }
   },
   "password": {

--- a/locales/it/settings.json
+++ b/locales/it/settings.json
@@ -20,11 +20,11 @@
     "title": "Aspetto",
     "light": {
       "name": "Chiaro",
-      "description": "Usa l'interfaccia chiara per l'applicazione e i componenti shadcn."
+      "description": "Usa la modalita chiara per i componenti shadcn."
     },
     "dark": {
       "name": "Scuro",
-      "description": "Usa l'interfaccia scura per l'applicazione e i componenti shadcn."
+      "description": "Usa la modalita scura per i componenti shadcn."
     },
     "auto": {
       "name": "Automatico",

--- a/locales/it/settings.json
+++ b/locales/it/settings.json
@@ -18,13 +18,17 @@
   },
   "appearance": {
     "title": "Aspetto",
-    "default": {
-      "name": "Default",
-      "description": "L'esperienza classica di Praetor con branding blu ardesia. Professionale e distinta."
+    "light": {
+      "name": "Chiaro",
+      "description": "Usa l'interfaccia chiara per l'applicazione e i componenti shadcn."
     },
-    "tempo": {
-      "name": "Tempo",
-      "description": "Un tema indaco vibrante. Moderno, energico e pulito."
+    "dark": {
+      "name": "Scuro",
+      "description": "Usa l'interfaccia scura per l'applicazione e i componenti shadcn."
+    },
+    "auto": {
+      "name": "Automatico",
+      "description": "Segue automaticamente il tema del browser o del sistema operativo."
     }
   },
   "password": {

--- a/src/index.css
+++ b/src/index.css
@@ -20,7 +20,8 @@
   --color-neutral: var(--color-neutral);
 }
 
-:root {
+:root,
+[data-shadcn-theme="light"] {
   --background: oklch(1 0 0);
   --foreground: oklch(0.141 0.005 285.823);
   --card: oklch(1 0 0);
@@ -111,7 +112,8 @@ input[type="number"] {
   display: none !important;
 }
 
-.dark {
+.dark,
+[data-shadcn-theme="dark"] {
   --background: oklch(0.141 0.005 285.823);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.21 0.006 285.885);
@@ -138,6 +140,35 @@ input[type="number"] {
   --sidebar-accent-foreground: hsl(240 4.8% 95.9%);
   --sidebar-border: hsl(240 3.7% 15.9%);
   --sidebar-ring: hsl(217.2 91.2% 59.8%);
+}
+
+[data-shadcn-theme-scope] {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
 }
 
 @theme inline {

--- a/src/index.css
+++ b/src/index.css
@@ -52,6 +52,7 @@
   --sidebar-accent-foreground: hsl(240 5.9% 10%);
   --sidebar-border: hsl(220 13% 91%);
   --sidebar-ring: hsl(217.2 91.2% 59.8%);
+  color-scheme: light;
 }
 
 /* Chrome, Safari, Edge, Opera */
@@ -112,6 +113,7 @@ input[type="number"] {
 }
 
 .dark {
+  color-scheme: dark;
   --background: oklch(0.141 0.005 285.823);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.21 0.006 285.885);

--- a/src/index.css
+++ b/src/index.css
@@ -52,7 +52,6 @@
   --sidebar-accent-foreground: hsl(240 5.9% 10%);
   --sidebar-border: hsl(220 13% 91%);
   --sidebar-ring: hsl(217.2 91.2% 59.8%);
-  color-scheme: light;
 }
 
 /* Chrome, Safari, Edge, Opera */
@@ -113,7 +112,6 @@ input[type="number"] {
 }
 
 .dark {
-  color-scheme: dark;
   --background: oklch(0.141 0.005 285.823);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.21 0.006 285.885);

--- a/test/components/Layout.test.tsx
+++ b/test/components/Layout.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, mock, test } from 'bun:test';
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import { fireEvent, render, screen } from '@testing-library/react';
 import type React from 'react';
 import type { Role, User } from '../../types';
@@ -49,6 +49,12 @@ const renderLayout = (props?: Partial<React.ComponentProps<typeof Layout>>) =>
   );
 
 describe('<Layout />', () => {
+  beforeEach(() => {
+    isMobileViewport = false;
+    localStorage.clear();
+    document.documentElement.classList.remove('dark');
+  });
+
   test('header sits at z-40 so it paints above the table sticky-right cells (z-20)', () => {
     const { container } = renderLayout();
 
@@ -87,6 +93,21 @@ describe('<Layout />', () => {
     expect(activeButton?.className).toContain('text-sidebar-foreground');
     expect(activeButton?.className).toContain('data-[active=true]:text-sidebar-accent-foreground');
     expect(activeButton?.className).not.toContain('text-black');
+  });
+
+  test('account dropdown uses the scoped shadcn dark theme and sidebar text tokens', () => {
+    localStorage.setItem('praetor_theme', 'dark');
+    const { container } = renderLayout();
+
+    const trigger = screen.getByRole('button', { name: 'TU Test User roles.manager' });
+    fireEvent.pointerDown(trigger);
+
+    const dropdownContent = document.body.querySelector('[data-slot="dropdown-menu-content"]');
+
+    expect(trigger.className).toContain('text-sidebar-foreground');
+    expect(dropdownContent?.className).toContain('dark');
+    expect(dropdownContent?.getAttribute('data-shadcn-theme')).toBe('dark');
+    expect(container.ownerDocument.documentElement.classList.contains('dark')).toBe(false);
   });
 
   test('sidebar trigger toggles desktop icon-collapse state', () => {

--- a/test/components/Layout.test.tsx
+++ b/test/components/Layout.test.tsx
@@ -64,15 +64,29 @@ describe('<Layout />', () => {
 
     const wrapper = container.querySelector('[data-slot="sidebar-wrapper"]');
     const sidebar = container.querySelector('[data-slot="sidebar"]');
+    const shadcnThemeScope = container.querySelector('[data-shadcn-theme-scope]');
     const activeButtons = container.querySelectorAll(
       '[data-sidebar="menu-button"][data-active="true"]',
     );
 
     expect(wrapper).not.toBeNull();
     expect(sidebar).not.toBeNull();
+    expect(shadcnThemeScope).not.toBeNull();
     expect(sidebar?.getAttribute('data-state')).toBe('expanded');
     expect(activeButtons.length).toBeGreaterThan(0);
     expect(screen.getAllByText('routes.timeTracker').length).toBeGreaterThan(0);
+  });
+
+  test('sidebar navigation text uses shadcn sidebar color tokens', () => {
+    const { container } = renderLayout();
+
+    const activeButton = container.querySelector(
+      '[data-sidebar="menu-button"][data-active="true"]',
+    );
+
+    expect(activeButton?.className).toContain('text-sidebar-foreground');
+    expect(activeButton?.className).toContain('data-[active=true]:text-sidebar-accent-foreground');
+    expect(activeButton?.className).not.toContain('text-black');
   });
 
   test('sidebar trigger toggles desktop icon-collapse state', () => {

--- a/test/components/Layout.test.tsx
+++ b/test/components/Layout.test.tsx
@@ -91,10 +91,15 @@ describe('<Layout />', () => {
     const activeButton = container.querySelector(
       '[data-sidebar="menu-button"][data-active="true"]',
     );
+    const brandButton = screen.getByText('PRAETOR').closest('[data-sidebar="menu-button"]');
+    const brandSubtitle = screen.getByText('roles.manager workspace');
 
     expect(activeButton?.className).toContain('text-sidebar-foreground');
     expect(activeButton?.className).toContain('data-[active=true]:text-sidebar-accent-foreground');
     expect(activeButton?.className).not.toContain('text-black');
+    expect(brandButton?.className).toContain('text-sidebar-foreground');
+    expect(brandButton?.className).toContain('hover:text-sidebar-foreground');
+    expect(brandSubtitle.className).toContain('text-sidebar-foreground/80');
   });
 
   test('account dropdown uses the scoped shadcn dark theme and sidebar text tokens', async () => {

--- a/test/components/Layout.test.tsx
+++ b/test/components/Layout.test.tsx
@@ -103,10 +103,15 @@ describe('<Layout />', () => {
     fireEvent.pointerDown(trigger);
 
     const dropdownContent = document.body.querySelector('[data-slot="dropdown-menu-content"]');
+    const dropdownIdentity = dropdownContent?.querySelector('.text-popover-foreground');
+    const dropdownRole = dropdownContent?.querySelector('.text-muted-foreground');
 
     expect(trigger.className).toContain('text-sidebar-foreground');
     expect(dropdownContent?.className).toContain('dark');
+    expect(dropdownContent?.className).not.toContain('border-zinc-200');
     expect(dropdownContent?.getAttribute('data-shadcn-theme')).toBe('dark');
+    expect(dropdownIdentity).not.toBeNull();
+    expect(dropdownRole).not.toBeNull();
     expect(container.ownerDocument.documentElement.classList.contains('dark')).toBe(false);
   });
 

--- a/test/components/Layout.test.tsx
+++ b/test/components/Layout.test.tsx
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import type React from 'react';
 import type { Role, User } from '../../types';
+import { applyTheme } from '../../utils/theme';
 import { installI18nMock } from '../helpers/i18n';
 
 installI18nMock();
@@ -95,12 +97,14 @@ describe('<Layout />', () => {
     expect(activeButton?.className).not.toContain('text-black');
   });
 
-  test('account dropdown uses the scoped shadcn dark theme and sidebar text tokens', () => {
+  test('account dropdown uses the scoped shadcn dark theme and sidebar text tokens', async () => {
     localStorage.setItem('praetor_theme', 'dark');
+    const user = userEvent.setup();
     const { container } = renderLayout();
 
     const trigger = screen.getByRole('button', { name: 'TU Test User roles.manager' });
-    fireEvent.pointerDown(trigger);
+    await user.click(trigger);
+    await screen.findByRole('menu');
 
     const dropdownContent = document.body.querySelector('[data-slot="dropdown-menu-content"]');
     const dropdownIdentity = dropdownContent?.querySelector('.text-popover-foreground');
@@ -109,10 +113,32 @@ describe('<Layout />', () => {
     expect(trigger.className).toContain('text-sidebar-foreground');
     expect(dropdownContent?.className).toContain('dark');
     expect(dropdownContent?.className).not.toContain('border-zinc-200');
+    expect(dropdownContent?.className).toContain('border-border');
     expect(dropdownContent?.getAttribute('data-shadcn-theme')).toBe('dark');
     expect(dropdownIdentity).not.toBeNull();
     expect(dropdownRole).not.toBeNull();
     expect(container.ownerDocument.documentElement.classList.contains('dark')).toBe(false);
+  });
+
+  test('open account dropdown updates when shadcn theme changes', async () => {
+    localStorage.setItem('praetor_theme', 'light');
+    const user = userEvent.setup();
+    renderLayout();
+
+    const trigger = screen.getByRole('button', { name: 'TU Test User roles.manager' });
+    await user.click(trigger);
+    await screen.findByRole('menu');
+
+    const dropdownContent = document.body.querySelector('[data-slot="dropdown-menu-content"]');
+    expect(dropdownContent?.getAttribute('data-shadcn-theme')).toBe('light');
+    expect(dropdownContent?.className).not.toContain('dark');
+
+    act(() => {
+      applyTheme('dark');
+    });
+
+    await waitFor(() => expect(dropdownContent?.getAttribute('data-shadcn-theme')).toBe('dark'));
+    expect(dropdownContent?.className).toContain('dark');
   });
 
   test('sidebar trigger toggles desktop icon-collapse state', () => {
@@ -182,16 +208,17 @@ describe('<Layout />', () => {
     isMobileViewport = false;
   });
 
-  test('mobile user menu settings closes the sidebar sheet', () => {
+  test('mobile user menu settings closes the sidebar sheet', async () => {
     isMobileViewport = true;
     const onViewChange = mock(() => {});
+    const user = userEvent.setup();
     renderLayout({ onViewChange });
 
     fireEvent.click(screen.getByRole('button', { name: 'Toggle Sidebar' }));
     expect(screen.getByRole('dialog')).toBeDefined();
 
-    fireEvent.pointerDown(screen.getByRole('button', { name: 'TU Test User roles.manager' }));
-    fireEvent.click(screen.getByRole('menuitem', { name: 'menu.settings' }));
+    await user.click(screen.getByRole('button', { name: 'TU Test User roles.manager' }));
+    await user.click(await screen.findByRole('menuitem', { name: 'menu.settings' }));
 
     expect(onViewChange).toHaveBeenCalledWith('settings');
     expect(screen.queryByRole('dialog')).toBeNull();

--- a/test/utils/theme.test.ts
+++ b/test/utils/theme.test.ts
@@ -4,6 +4,7 @@ import {
   getBrowserTheme,
   getTheme,
   THEME_MEDIA_QUERY,
+  THEME_SCOPE_SELECTOR,
   THEME_STORAGE_KEY,
   THEMES,
   type Theme,
@@ -43,7 +44,18 @@ const resetRootTheme = () => {
   const root = document.documentElement;
   root.classList.remove('dark');
   root.removeAttribute('data-theme');
+  root.removeAttribute('data-shadcn-theme');
   root.style.removeProperty('color-scheme');
+  document.querySelectorAll(THEME_SCOPE_SELECTOR).forEach((element) => {
+    element.remove();
+  });
+};
+
+const appendThemeScope = () => {
+  const scope = document.createElement('div');
+  scope.dataset.shadcnThemeScope = '';
+  document.body.append(scope);
+  return scope;
 };
 
 describe('THEMES constant', () => {
@@ -113,42 +125,51 @@ describe('applyTheme', () => {
     expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark');
   });
 
-  test('applies light mode to the document root', () => {
+  test('applies light mode to shadcn theme scopes only', () => {
+    const scope = appendThemeScope();
     applyTheme('light');
     const root = document.documentElement;
     expect(root.classList.contains('dark')).toBe(false);
-    expect(root.dataset.theme).toBe('light');
-    expect(root.style.colorScheme).toBe('light');
+    expect(root.dataset.theme).toBeUndefined();
+    expect(root.style.colorScheme).toBe('');
+    expect(scope.classList.contains('dark')).toBe(false);
+    expect(scope.dataset.shadcnTheme).toBe('light');
   });
 
-  test('applies dark mode to the document root', () => {
+  test('applies dark mode to shadcn theme scopes only', () => {
+    const scope = appendThemeScope();
     applyTheme('dark');
     const root = document.documentElement;
-    expect(root.classList.contains('dark')).toBe(true);
-    expect(root.dataset.theme).toBe('dark');
-    expect(root.style.colorScheme).toBe('dark');
+    expect(root.classList.contains('dark')).toBe(false);
+    expect(root.dataset.theme).toBeUndefined();
+    expect(scope.classList.contains('dark')).toBe(true);
+    expect(scope.dataset.shadcnTheme).toBe('dark');
   });
 
   test('auto resolves to the browser theme', () => {
+    const scope = appendThemeScope();
     setBrowserDarkMode(true);
     applyTheme('auto');
-    expect(document.documentElement.classList.contains('dark')).toBe(true);
-    expect(document.documentElement.dataset.theme).toBe('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+    expect(scope.classList.contains('dark')).toBe(true);
+    expect(scope.dataset.shadcnTheme).toBe('dark');
   });
 
   test('auto follows browser theme changes after it is applied', () => {
+    const scope = appendThemeScope();
     const mediaQuery = window.matchMedia(THEME_MEDIA_QUERY) as MediaQueryList & {
       triggerChange: (nextMatches: boolean) => void;
     };
 
     applyTheme('auto');
-    expect(document.documentElement.classList.contains('dark')).toBe(false);
+    expect(scope.classList.contains('dark')).toBe(false);
 
     mediaQuery.triggerChange(true);
-    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(scope.classList.contains('dark')).toBe(true);
   });
 
   test('switching to a fixed theme stops following browser theme changes', () => {
+    const scope = appendThemeScope();
     const mediaQuery = window.matchMedia(THEME_MEDIA_QUERY) as MediaQueryList & {
       triggerChange: (nextMatches: boolean) => void;
     };
@@ -157,7 +178,7 @@ describe('applyTheme', () => {
     applyTheme('light');
 
     mediaQuery.triggerChange(true);
-    expect(document.documentElement.classList.contains('dark')).toBe(false);
+    expect(scope.classList.contains('dark')).toBe(false);
     expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('light');
   });
 

--- a/test/utils/theme.test.ts
+++ b/test/utils/theme.test.ts
@@ -1,18 +1,54 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { applyTheme, getTheme, THEMES, type Theme } from '../../utils/theme';
+import {
+  applyTheme,
+  getBrowserTheme,
+  getTheme,
+  THEME_MEDIA_QUERY,
+  THEME_STORAGE_KEY,
+  THEMES,
+  type Theme,
+} from '../../utils/theme';
 
-const STORAGE_KEY = 'praetor_theme';
+const originalMatchMedia = window.matchMedia;
+
+const setBrowserDarkMode = (matches: boolean) => {
+  let listener: ((event: MediaQueryListEvent) => void) | undefined;
+  const mediaQuery = {
+    matches,
+    media: THEME_MEDIA_QUERY,
+    onchange: null,
+    addEventListener: (_type: string, callback: (event: MediaQueryListEvent) => void) => {
+      listener = callback;
+    },
+    removeEventListener: () => {
+      listener = undefined;
+    },
+    addListener: (callback: (event: MediaQueryListEvent) => void) => {
+      listener = callback;
+    },
+    removeListener: () => {
+      listener = undefined;
+    },
+    dispatchEvent: () => true,
+    triggerChange: (nextMatches: boolean) => {
+      mediaQuery.matches = nextMatches;
+      listener?.({ matches: nextMatches } as MediaQueryListEvent);
+    },
+  };
+
+  window.matchMedia = (() => mediaQuery as MediaQueryList) as typeof window.matchMedia;
+};
+
+const resetRootTheme = () => {
+  const root = document.documentElement;
+  root.classList.remove('dark');
+  root.removeAttribute('data-theme');
+  root.style.removeProperty('color-scheme');
+};
 
 describe('THEMES constant', () => {
-  test('exposes both "default" and "tempo" themes', () => {
-    expect(Object.keys(THEMES).sort()).toEqual(['default', 'tempo']);
-  });
-
-  test('every theme defines --color-primary and --color-primary-hover', () => {
-    for (const theme of Object.keys(THEMES) as Theme[]) {
-      expect(THEMES[theme]['--color-primary']).toBeDefined();
-      expect(THEMES[theme]['--color-primary-hover']).toBeDefined();
-    }
+  test('exposes light, dark, and auto themes', () => {
+    expect([...THEMES]).toEqual(['light', 'dark', 'auto']);
   });
 });
 
@@ -21,87 +57,114 @@ describe('getTheme', () => {
     localStorage.clear();
   });
 
-  test('returns "default" when nothing is stored', () => {
-    expect(getTheme()).toBe('default');
+  test('returns "auto" when nothing is stored', () => {
+    expect(getTheme()).toBe('auto');
   });
 
-  test('returns "default" when stored value is unrecognized', () => {
-    localStorage.setItem(STORAGE_KEY, 'unknown-theme');
-    expect(getTheme()).toBe('default');
+  test('returns "auto" when stored value is unrecognized', () => {
+    localStorage.setItem(THEME_STORAGE_KEY, 'unknown-theme');
+    expect(getTheme()).toBe('auto');
   });
 
-  test('returns "tempo" when explicitly stored', () => {
-    localStorage.setItem(STORAGE_KEY, 'tempo');
-    expect(getTheme()).toBe('tempo');
+  test('returns each recognized theme when explicitly stored', () => {
+    for (const theme of THEMES) {
+      localStorage.setItem(THEME_STORAGE_KEY, theme);
+      expect(getTheme()).toBe(theme);
+    }
   });
 
-  test('returns "default" when explicitly stored', () => {
-    localStorage.setItem(STORAGE_KEY, 'default');
-    expect(getTheme()).toBe('default');
+  test('rejects legacy storage values', () => {
+    localStorage.setItem(THEME_STORAGE_KEY, 'tempo');
+    expect(getTheme()).toBe('auto');
+  });
+});
+
+describe('getBrowserTheme', () => {
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
   });
 
-  test('rejects empty-string storage value', () => {
-    localStorage.setItem(STORAGE_KEY, '');
-    expect(getTheme()).toBe('default');
+  test('returns dark when the browser dark media query matches', () => {
+    setBrowserDarkMode(true);
+    expect(getBrowserTheme()).toBe('dark');
+  });
+
+  test('returns light when the browser dark media query does not match', () => {
+    setBrowserDarkMode(false);
+    expect(getBrowserTheme()).toBe('light');
   });
 });
 
 describe('applyTheme', () => {
   beforeEach(() => {
     localStorage.clear();
-    // Clear inline CSS variables that any prior test (or default styles) may have set.
-    const root = document.documentElement;
-    root.style.removeProperty('--color-primary');
-    root.style.removeProperty('--color-primary-hover');
+    resetRootTheme();
+    setBrowserDarkMode(false);
   });
 
   afterEach(() => {
     localStorage.clear();
-    const root = document.documentElement;
-    root.style.removeProperty('--color-primary');
-    root.style.removeProperty('--color-primary-hover');
+    resetRootTheme();
+    window.matchMedia = originalMatchMedia;
   });
 
   test('writes the chosen theme name to localStorage', () => {
-    applyTheme('tempo');
-    expect(localStorage.getItem(STORAGE_KEY)).toBe('tempo');
+    applyTheme('dark');
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark');
   });
 
-  test('writes "default" theme name to localStorage', () => {
-    applyTheme('default');
-    expect(localStorage.getItem(STORAGE_KEY)).toBe('default');
-  });
-
-  test('sets the documented CSS custom properties for the "default" theme', () => {
-    applyTheme('default');
+  test('applies light mode to the document root', () => {
+    applyTheme('light');
     const root = document.documentElement;
-    expect(root.style.getPropertyValue('--color-primary')).toBe(THEMES.default['--color-primary']);
-    expect(root.style.getPropertyValue('--color-primary-hover')).toBe(
-      THEMES.default['--color-primary-hover'],
-    );
+    expect(root.classList.contains('dark')).toBe(false);
+    expect(root.dataset.theme).toBe('light');
+    expect(root.style.colorScheme).toBe('light');
   });
 
-  test('sets the documented CSS custom properties for the "tempo" theme', () => {
-    applyTheme('tempo');
+  test('applies dark mode to the document root', () => {
+    applyTheme('dark');
     const root = document.documentElement;
-    expect(root.style.getPropertyValue('--color-primary')).toBe(THEMES.tempo['--color-primary']);
-    expect(root.style.getPropertyValue('--color-primary-hover')).toBe(
-      THEMES.tempo['--color-primary-hover'],
-    );
+    expect(root.classList.contains('dark')).toBe(true);
+    expect(root.dataset.theme).toBe('dark');
+    expect(root.style.colorScheme).toBe('dark');
   });
 
-  test('switching themes overwrites the previously applied custom properties', () => {
-    applyTheme('default');
-    applyTheme('tempo');
-    const root = document.documentElement;
-    expect(root.style.getPropertyValue('--color-primary')).toBe(THEMES.tempo['--color-primary']);
-    expect(localStorage.getItem(STORAGE_KEY)).toBe('tempo');
+  test('auto resolves to the browser theme', () => {
+    setBrowserDarkMode(true);
+    applyTheme('auto');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(document.documentElement.dataset.theme).toBe('dark');
+  });
+
+  test('auto follows browser theme changes after it is applied', () => {
+    const mediaQuery = window.matchMedia(THEME_MEDIA_QUERY) as MediaQueryList & {
+      triggerChange: (nextMatches: boolean) => void;
+    };
+
+    applyTheme('auto');
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+
+    mediaQuery.triggerChange(true);
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+
+  test('switching to a fixed theme stops following browser theme changes', () => {
+    const mediaQuery = window.matchMedia(THEME_MEDIA_QUERY) as MediaQueryList & {
+      triggerChange: (nextMatches: boolean) => void;
+    };
+
+    applyTheme('auto');
+    applyTheme('light');
+
+    mediaQuery.triggerChange(true);
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('light');
   });
 
   test('round-trips with getTheme', () => {
-    applyTheme('tempo');
-    expect(getTheme()).toBe('tempo');
-    applyTheme('default');
-    expect(getTheme()).toBe('default');
+    for (const theme of THEMES as readonly Theme[]) {
+      applyTheme(theme);
+      expect(getTheme()).toBe(theme);
+    }
   });
 });

--- a/test/utils/theme.test.ts
+++ b/test/utils/theme.test.ts
@@ -138,12 +138,22 @@ describe('applyTheme', () => {
 
   test('applies dark mode to shadcn theme scopes only', () => {
     const scope = appendThemeScope();
+    let eventTheme: string | undefined;
+    window.addEventListener(
+      'praetor-theme-change',
+      (event) => {
+        eventTheme = (event as CustomEvent<{ resolvedTheme: string }>).detail.resolvedTheme;
+      },
+      { once: true },
+    );
+
     applyTheme('dark');
     const root = document.documentElement;
     expect(root.classList.contains('dark')).toBe(false);
     expect(root.dataset.theme).toBeUndefined();
     expect(scope.classList.contains('dark')).toBe(true);
     expect(scope.dataset.shadcnTheme).toBe('dark');
+    expect(eventTheme).toBe('dark');
   });
 
   test('auto resolves to the browser theme', () => {

--- a/utils/theme.ts
+++ b/utils/theme.ts
@@ -6,10 +6,12 @@ export type ResolvedTheme = Exclude<Theme, 'auto'>;
 const STORAGE_KEY = 'praetor_theme';
 const DARK_MODE_QUERY = '(prefers-color-scheme: dark)';
 const SHADCN_THEME_SCOPE_SELECTOR = '[data-shadcn-theme-scope]';
+const THEME_CHANGE_EVENT_NAME = 'praetor-theme-change';
 
 export const THEME_STORAGE_KEY = STORAGE_KEY;
 export const THEME_MEDIA_QUERY = DARK_MODE_QUERY;
 export const THEME_SCOPE_SELECTOR = SHADCN_THEME_SCOPE_SELECTOR;
+export const THEME_CHANGE_EVENT = THEME_CHANGE_EVENT_NAME;
 
 let removeAutoThemeListener: (() => void) | undefined;
 
@@ -31,6 +33,10 @@ const resolveTheme = (theme: Theme): ResolvedTheme => {
   return theme === 'auto' ? getBrowserTheme() : theme;
 };
 
+export const getResolvedTheme = (theme: Theme = getTheme()): ResolvedTheme => {
+  return resolveTheme(theme);
+};
+
 const clearLegacyRootTheme = () => {
   const root = document.documentElement;
   root.classList.remove('dark');
@@ -44,6 +50,11 @@ const applyResolvedTheme = (theme: ResolvedTheme) => {
     scope.classList.toggle('dark', theme === 'dark');
     scope.dataset.shadcnTheme = theme;
   });
+  window.dispatchEvent(
+    new CustomEvent(THEME_CHANGE_EVENT_NAME, {
+      detail: { resolvedTheme: theme },
+    }),
+  );
 };
 
 const unsubscribeAutoTheme = () => {

--- a/utils/theme.ts
+++ b/utils/theme.ts
@@ -1,28 +1,65 @@
-export type Theme = 'default' | 'tempo';
+export const THEMES = ['light', 'dark', 'auto'] as const;
 
-export const THEMES: Record<Theme, Record<string, string>> = {
-  default: {
-    '--color-primary': '#20293F',
-    '--color-primary-hover': '#2d3a55',
-  },
-  tempo: {
-    '--color-primary': '#4F46E5', // Indigo-600
-    '--color-primary-hover': '#4338ca', // Indigo-700
-  },
+export type Theme = (typeof THEMES)[number];
+export type ResolvedTheme = Exclude<Theme, 'auto'>;
+
+const STORAGE_KEY = 'praetor_theme';
+const DARK_MODE_QUERY = '(prefers-color-scheme: dark)';
+
+export const THEME_STORAGE_KEY = STORAGE_KEY;
+export const THEME_MEDIA_QUERY = DARK_MODE_QUERY;
+
+let removeAutoThemeListener: (() => void) | undefined;
+
+const isTheme = (value: string | null): value is Theme => {
+  return value === 'light' || value === 'dark' || value === 'auto';
 };
 
 export const getTheme = (): Theme => {
-  const saved = localStorage.getItem('praetor_theme');
-  return saved === 'tempo' || saved === 'default' ? saved : 'default';
+  const saved = localStorage.getItem(STORAGE_KEY);
+  return isTheme(saved) ? saved : 'auto';
+};
+
+export const getBrowserTheme = (): ResolvedTheme => {
+  if (typeof window.matchMedia !== 'function') return 'light';
+  return window.matchMedia(DARK_MODE_QUERY).matches ? 'dark' : 'light';
+};
+
+const resolveTheme = (theme: Theme): ResolvedTheme => {
+  return theme === 'auto' ? getBrowserTheme() : theme;
+};
+
+const applyResolvedTheme = (theme: ResolvedTheme) => {
+  const root = document.documentElement;
+  root.classList.toggle('dark', theme === 'dark');
+  root.dataset.theme = theme;
+  root.style.colorScheme = theme;
+};
+
+const unsubscribeAutoTheme = () => {
+  removeAutoThemeListener?.();
+  removeAutoThemeListener = undefined;
+};
+
+const subscribeAutoTheme = () => {
+  if (typeof window.matchMedia !== 'function') return;
+
+  const mediaQuery = window.matchMedia(DARK_MODE_QUERY);
+  const handleChange = () => applyResolvedTheme(resolveTheme('auto'));
+
+  if (typeof mediaQuery.addEventListener === 'function') {
+    mediaQuery.addEventListener('change', handleChange);
+    removeAutoThemeListener = () => mediaQuery.removeEventListener('change', handleChange);
+    return;
+  }
+
+  mediaQuery.addListener(handleChange);
+  removeAutoThemeListener = () => mediaQuery.removeListener(handleChange);
 };
 
 export const applyTheme = (theme: Theme) => {
-  const colors = THEMES[theme];
-  const root = document.documentElement;
-
-  Object.entries(colors).forEach(([property, value]) => {
-    root.style.setProperty(property, value);
-  });
-
-  localStorage.setItem('praetor_theme', theme);
+  unsubscribeAutoTheme();
+  applyResolvedTheme(resolveTheme(theme));
+  if (theme === 'auto') subscribeAutoTheme();
+  localStorage.setItem(STORAGE_KEY, theme);
 };

--- a/utils/theme.ts
+++ b/utils/theme.ts
@@ -5,9 +5,11 @@ export type ResolvedTheme = Exclude<Theme, 'auto'>;
 
 const STORAGE_KEY = 'praetor_theme';
 const DARK_MODE_QUERY = '(prefers-color-scheme: dark)';
+const SHADCN_THEME_SCOPE_SELECTOR = '[data-shadcn-theme-scope]';
 
 export const THEME_STORAGE_KEY = STORAGE_KEY;
 export const THEME_MEDIA_QUERY = DARK_MODE_QUERY;
+export const THEME_SCOPE_SELECTOR = SHADCN_THEME_SCOPE_SELECTOR;
 
 let removeAutoThemeListener: (() => void) | undefined;
 
@@ -29,11 +31,19 @@ const resolveTheme = (theme: Theme): ResolvedTheme => {
   return theme === 'auto' ? getBrowserTheme() : theme;
 };
 
-const applyResolvedTheme = (theme: ResolvedTheme) => {
+const clearLegacyRootTheme = () => {
   const root = document.documentElement;
-  root.classList.toggle('dark', theme === 'dark');
-  root.dataset.theme = theme;
-  root.style.colorScheme = theme;
+  root.classList.remove('dark');
+  root.removeAttribute('data-theme');
+  root.style.removeProperty('color-scheme');
+};
+
+const applyResolvedTheme = (theme: ResolvedTheme) => {
+  clearLegacyRootTheme();
+  document.querySelectorAll<HTMLElement>(SHADCN_THEME_SCOPE_SELECTOR).forEach((scope) => {
+    scope.classList.toggle('dark', theme === 'dark');
+    scope.dataset.shadcnTheme = theme;
+  });
 };
 
 const unsubscribeAutoTheme = () => {


### PR DESCRIPTION
## Summary
- Replace the old theme picker with `light`, `dark`, and `auto` options in user preferences.
- Make `auto` follow the browser `prefers-color-scheme` setting and apply the resolved mode to the document root for shadcn/Tailwind dark styles.
- Simplify the settings UI by rendering theme options from shared metadata and reuse the shared language type for preference handling.
- Update translation copy and add coverage for theme resolution, auto-mode updates, and storage behavior.

## Testing
- `bun test ./test/utils/theme.test.ts`
- `bun test ./test`
- `bun run lint`