### PR TITLE
refactor(ui): replace StandardTable rendering with shadcn table

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,11 @@ SQL belongs in `/server/repositories/<domain>Repo.ts`, not inline in route handl
 - Utilities: camelCase
 - Route files: kebab-case
 
+### Frontend UI
+- Always use shadcn/ui components and primitives for frontend UI work. Prefer existing components under `components/ui/*` and shadcn composition/props over bespoke controls or custom widget implementations.
+- If a needed shadcn/ui component is missing, add it with `bunx --bun shadcn@latest add <component>` and adapt behavior through the component API instead of rebuilding the same behavior manually.
+- Keep shadcn theme tokens (`bg-background`, `text-foreground`, `border-border`, `text-muted-foreground`, etc.) in new UI so the user's selected theme is respected.
+
 ## Important Notes
 
 - **Path aliases**: `@/` maps to project root (Vite + TypeScript config)
@@ -79,4 +84,4 @@ SQL belongs in `/server/repositories/<domain>Repo.ts`, not inline in route handl
 - **Ports**: Frontend 3000, Backend 3001, PostgreSQL 5432
 - **Remote Testing**: The app itself runs on remote Docker containers. Do not run Docker commands locally, but Bun test commands such as `bun test` and `bun run test` may be run locally.
 - **Commit and PR titles**: Always format commit messages and pull request titles as `scope(category): description`.
-- **Docs**: Always use Context7 MCP when I need library/API documentation, code generation, setup or configuration steps without me having to explicitly ask.
+- **Docs**: Always use Context7 MCP for shadcn/ui and any library/API documentation, code generation, setup, configuration, or best-practice checks without me having to explicitly ask.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,11 @@ SQL belongs in `/server/repositories/<domain>Repo.ts`, not inline in route handl
 - Utilities: camelCase
 - Route files: kebab-case
 
+### Frontend UI
+- Always use shadcn/ui components and primitives for frontend UI work. Prefer existing components under `components/ui/*` and shadcn composition/props over bespoke controls or custom widget implementations.
+- If a needed shadcn/ui component is missing, add it with `bunx --bun shadcn@latest add <component>` and adapt behavior through the component API instead of rebuilding the same behavior manually.
+- Keep shadcn theme tokens (`bg-background`, `text-foreground`, `border-border`, `text-muted-foreground`, etc.) in new UI so the user's selected theme is respected.
+
 ## Important Notes
 
 - **Path aliases**: `@/` maps to project root (Vite + TypeScript config)
@@ -78,4 +83,4 @@ SQL belongs in `/server/repositories/<domain>Repo.ts`, not inline in route handl
 - **Tests**: `bun run test` runs both backend (`server/test/`) and frontend (`test/`) suites via the Bun test runner; frontend tests use `@testing-library/react`. **New features and bug fixes must ship with unit tests** that exercise the new behavior — backend tests under `server/test/` mirroring the source layout, frontend under `test/` (e.g. `test/components/Foo.test.tsx`). For bug fixes, the test should fail on the old code and pass on the fix. Manual testing supplements automated tests; it does not replace them.
 - **Ports**: Frontend 3000, Backend 3001, PostgreSQL 5432
 - **Remote Testing**: The app itself runs on remote Docker containers. Do not run Docker commands locally, but Bun test commands such as `bun test` and `bun run test` may be run locally.
-- **Docs**: Always use Context7 MCP when I need library/API documentation, code generation, setup or configuration steps without me having to explicitly ask.
+- **Docs**: Always use Context7 MCP for shadcn/ui and any library/API documentation, code generation, setup, configuration, or best-practice checks without me having to explicitly ask.

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "praetor",
       "dependencies": {
+        "@tanstack/react-table": "^8.21.3",
         "bcryptjs": "^3.0.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -446,6 +447,10 @@
     "@tailwindcss/postcss": ["@tailwindcss/postcss@4.2.4", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.2.4", "@tailwindcss/oxide": "4.2.4", "postcss": "^8.5.6", "tailwindcss": "4.2.4" } }, "sha512-wgAVj6nUWAolAu8YFvzT2cTBIElWHkjZwFYovF+xsqKsW2ADxM/X2opxj5NsF/qVccAOjRNe8X2IdPzMsWyHTg=="],
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.2.4", "", { "dependencies": { "@tailwindcss/node": "4.2.4", "@tailwindcss/oxide": "4.2.4", "tailwindcss": "4.2.4" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw=="],
+
+    "@tanstack/react-table": ["@tanstack/react-table@8.21.3", "", { "dependencies": { "@tanstack/table-core": "8.21.3" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww=="],
+
+    "@tanstack/table-core": ["@tanstack/table-core@8.21.3", "", {}, "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg=="],
 
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
 

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -343,7 +343,7 @@ const Layout: React.FC<LayoutProps> = ({
         onSwitchRole={onSwitchRole}
         className="z-50"
       />
-      <SidebarInset className="h-screen overflow-y-auto">
+      <SidebarInset data-shadcn-theme-scope className="h-screen overflow-y-auto">
         <header className="sticky top-0 z-40 flex items-center justify-between border-b border-zinc-200 bg-white/80 px-4 py-4 backdrop-blur-md md:px-8">
           <div className="flex min-w-0 items-center gap-2">
             <SidebarTrigger className="-ml-1" />

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -345,7 +345,7 @@ const Layout: React.FC<LayoutProps> = ({
       />
       <SidebarInset
         data-shadcn-theme-scope
-        className="shadcn-theme-bridge h-screen overflow-y-auto"
+        className="shadcn-theme-bridge h-screen overflow-y-auto text-foreground"
       >
         <header className="sticky top-0 z-40 flex items-center justify-between border-b border-zinc-200 bg-white/80 px-4 py-4 backdrop-blur-md md:px-8">
           <div className="flex min-w-0 items-center gap-2">

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -343,7 +343,10 @@ const Layout: React.FC<LayoutProps> = ({
         onSwitchRole={onSwitchRole}
         className="z-50"
       />
-      <SidebarInset data-shadcn-theme-scope className="h-screen overflow-y-auto">
+      <SidebarInset
+        data-shadcn-theme-scope
+        className="shadcn-theme-bridge h-screen overflow-y-auto"
+      >
         <header className="sticky top-0 z-40 flex items-center justify-between border-b border-zinc-200 bg-white/80 px-4 py-4 backdrop-blur-md md:px-8">
           <div className="flex min-w-0 items-center gap-2">
             <SidebarTrigger className="-ml-1" />

--- a/components/accounting/ClientsInvoicesView.tsx
+++ b/components/accounting/ClientsInvoicesView.tsx
@@ -409,7 +409,7 @@ const ClientsInvoicesView: React.FC<ClientsInvoicesViewProps> = ({
         ),
       },
       {
-        header: t('common:common.more'),
+        header: t('accounting:clientsInvoices.actionsColumn'),
         id: 'actions',
         className: 'whitespace-nowrap',
         headerClassName: 'min-w-[8rem]',

--- a/components/accounting/ClientsOrdersView.tsx
+++ b/components/accounting/ClientsOrdersView.tsx
@@ -444,10 +444,11 @@ const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
       {
         header: t('sales:clientQuotes.globalDiscount'),
         id: 'globalDiscount',
+        accessorFn: (row: ClientsOrder) =>
+          formatDiscountValue(row.discount, row.discountType, currency),
         className: 'whitespace-nowrap',
         headerClassName: 'min-w-[9rem]',
         disableSorting: true,
-        disableFiltering: true,
         cell: ({ row }: { row: ClientsOrder }) => {
           const history = isHistoryRow(row.status);
           return (
@@ -465,7 +466,6 @@ const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
         accessorFn: (row: ClientsOrder) => orderPricingMap.get(row.id)?.subtotal ?? 0,
         className: 'whitespace-nowrap',
         headerClassName: 'min-w-[8rem]',
-        disableFiltering: true,
         cell: ({ row, value }: { row: ClientsOrder; value: unknown }) => (
           <PricingCell
             value={Number(value)}
@@ -481,7 +481,6 @@ const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
         accessorFn: (row: ClientsOrder) => orderPricingMap.get(row.id)?.discountAmount ?? 0,
         className: 'whitespace-nowrap',
         headerClassName: 'min-w-[8rem]',
-        disableFiltering: true,
         cell: ({ row, value }: { row: ClientsOrder; value: unknown }) => (
           <PricingCell
             value={Number(value)}
@@ -499,7 +498,6 @@ const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
         accessorFn: (row: ClientsOrder) => orderPricingMap.get(row.id)?.margin ?? 0,
         className: 'whitespace-nowrap',
         headerClassName: 'min-w-[8rem]',
-        disableFiltering: true,
         cell: ({ row, value }: { row: ClientsOrder; value: unknown }) => (
           <PricingCell
             value={Number(value)}
@@ -516,7 +514,6 @@ const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
         accessorFn: (row: ClientsOrder) => orderPricingMap.get(row.id)?.totalCost ?? 0,
         className: 'whitespace-nowrap',
         headerClassName: 'min-w-[8rem]',
-        disableFiltering: true,
         cell: ({ row, value }: { row: ClientsOrder; value: unknown }) => (
           <PricingCell
             value={Number(value)}

--- a/components/accounting/ClientsOrdersView.tsx
+++ b/components/accounting/ClientsOrdersView.tsx
@@ -435,9 +435,6 @@ const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
             >
               {row.clientName}
             </div>
-            <div className="text-[10px] font-black uppercase tracking-wider text-zinc-400">
-              {t('accounting:clientsOrders.itemsCount', { count: row.items.length })}
-            </div>
           </div>
         ),
       },
@@ -466,6 +463,7 @@ const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
         accessorFn: (row: ClientsOrder) => orderPricingMap.get(row.id)?.subtotal ?? 0,
         className: 'whitespace-nowrap',
         headerClassName: 'min-w-[8rem]',
+        disableFiltering: true,
         cell: ({ row, value }: { row: ClientsOrder; value: unknown }) => (
           <PricingCell
             value={Number(value)}
@@ -481,6 +479,7 @@ const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
         accessorFn: (row: ClientsOrder) => orderPricingMap.get(row.id)?.discountAmount ?? 0,
         className: 'whitespace-nowrap',
         headerClassName: 'min-w-[8rem]',
+        disableFiltering: true,
         cell: ({ row, value }: { row: ClientsOrder; value: unknown }) => (
           <PricingCell
             value={Number(value)}
@@ -498,6 +497,7 @@ const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
         accessorFn: (row: ClientsOrder) => orderPricingMap.get(row.id)?.margin ?? 0,
         className: 'whitespace-nowrap',
         headerClassName: 'min-w-[8rem]',
+        disableFiltering: true,
         cell: ({ row, value }: { row: ClientsOrder; value: unknown }) => (
           <PricingCell
             value={Number(value)}
@@ -514,6 +514,7 @@ const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
         accessorFn: (row: ClientsOrder) => orderPricingMap.get(row.id)?.totalCost ?? 0,
         className: 'whitespace-nowrap',
         headerClassName: 'min-w-[8rem]',
+        disableFiltering: true,
         cell: ({ row, value }: { row: ClientsOrder; value: unknown }) => (
           <PricingCell
             value={Number(value)}
@@ -528,6 +529,7 @@ const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
         accessorFn: (row: ClientsOrder) => orderPricingMap.get(row.id)?.total ?? 0,
         className: 'whitespace-nowrap',
         headerClassName: 'min-w-[8rem]',
+        disableFiltering: true,
         cell: ({ row, value }: { row: ClientsOrder; value: unknown }) => (
           <PricingCell
             value={Number(value)}

--- a/components/accounting/ClientsOrdersView.tsx
+++ b/components/accounting/ClientsOrdersView.tsx
@@ -571,7 +571,7 @@ const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
         ),
       },
       {
-        header: t('common:common.more'),
+        header: t('accounting:clientsOrders.actionsColumn'),
         id: 'actions',
         className: 'whitespace-nowrap',
         headerClassName: 'min-w-[9rem]',

--- a/components/accounting/SupplierInvoicesView.tsx
+++ b/components/accounting/SupplierInvoicesView.tsx
@@ -276,7 +276,7 @@ const SupplierInvoicesView: React.FC<SupplierInvoicesViewProps> = ({
         ),
       },
       {
-        header: t('common:common.more'),
+        header: t('accounting:supplierInvoices.actionsColumn'),
         id: 'actions',
         className: 'whitespace-nowrap',
         headerClassName: 'min-w-[8rem]',

--- a/components/accounting/SupplierOrdersView.tsx
+++ b/components/accounting/SupplierOrdersView.tsx
@@ -341,7 +341,7 @@ const SupplierOrdersView: React.FC<SupplierOrdersViewProps> = ({
         ),
       },
       {
-        header: t('common:common.more'),
+        header: t('accounting:supplierOrders.actionsColumn'),
         id: 'actions',
         className: 'whitespace-nowrap',
         headerClassName: 'min-w-[9rem]',

--- a/components/administration/UserManagement.tsx
+++ b/components/administration/UserManagement.tsx
@@ -7,7 +7,7 @@ import Checkbox from '../shared/Checkbox';
 import CustomSelect from '../shared/CustomSelect';
 import Modal from '../shared/Modal';
 import StandardTable, { type Column } from '../shared/StandardTable';
-import StatusBadge from '../shared/StatusBadge';
+import StatusBadge, { type StatusType } from '../shared/StatusBadge';
 import Toggle from '../shared/Toggle';
 import Tooltip from '../shared/Tooltip';
 import ValidatedNumberInput from '../shared/ValidatedNumberInput';
@@ -682,22 +682,15 @@ const UserManagement: React.FC<UserManagementProps> = ({
     const isManagerRole = role?.isSystem && !isAdminRole && role?.id === 'manager';
 
     return {
-      roleBadgeClass: isAdminRole
-        ? 'bg-zinc-800 text-white border-zinc-700'
+      roleBadgeType: (isAdminRole
+        ? 'role_admin'
         : isTopManagerRole
-          ? 'bg-amber-50 text-amber-700 border-amber-200'
+          ? 'role_top_manager'
           : isManagerRole
-            ? 'bg-blue-50 text-blue-700 border-blue-200'
+            ? 'role_manager'
             : role?.isSystem
-              ? 'bg-zinc-100 text-zinc-600 border-zinc-200'
-              : 'bg-emerald-50 text-emerald-700 border-emerald-200',
-      roleIcon: isAdminRole
-        ? 'fa-shield-halved'
-        : isTopManagerRole
-          ? 'fa-crown'
-          : isManagerRole
-            ? 'fa-briefcase'
-            : 'fa-user',
+              ? 'role_user'
+              : 'role_custom') as StatusType,
       roleName: role?.name || user.role,
     };
   };
@@ -739,15 +732,8 @@ const UserManagement: React.FC<UserManagementProps> = ({
       header: t('hr:workforce.role'),
       accessorFn: (user) => getRolePresentation(user).roleName,
       cell: ({ row }) => {
-        const { roleBadgeClass, roleIcon, roleName } = getRolePresentation(row);
-        return (
-          <span
-            className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-[10px] font-black uppercase tracking-wider border ${roleBadgeClass}`}
-          >
-            <i className={`fa-solid ${roleIcon}`}></i>
-            {roleName}
-          </span>
-        );
+        const { roleBadgeType, roleName } = getRolePresentation(row);
+        return <StatusBadge type={roleBadgeType} label={roleName} />;
       },
     },
     {

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -59,9 +59,9 @@ export function AppSidebar({
               <div className="flex aspect-square size-8 items-center justify-center rounded-lg border border-sidebar-border bg-transparent text-sidebar-foreground">
                 <Clock className="size-4" />
               </div>
-              <div className="grid flex-1 text-left text-sm leading-tight text-sidebar-foreground">
+              <div className="grid flex-1 text-left text-sm leading-[var(--text-sm--line-height)] text-sidebar-foreground">
                 <span className="truncate font-semibold italic">PRAETOR</span>
-                <span className="truncate text-sm text-sidebar-foreground/80">
+                <span className="truncate text-sm leading-[var(--text-sm--line-height)] text-sidebar-foreground/80">
                   {roleLabel} {workspaceLabel}
                 </span>
               </div>
@@ -73,7 +73,7 @@ export function AppSidebar({
         <NavMain items={navItems} label={navigationLabel} onViewChange={onViewChange} />
       </SidebarContent>
       <SidebarFooter>
-        <div className="px-2 text-sm text-sidebar-foreground/60 group-data-[collapsible=icon]:hidden">
+        <div className="px-2 text-sm leading-[var(--text-sm--line-height)] text-sidebar-foreground/60 group-data-[collapsible=icon]:hidden">
           Praetor v{version}
         </div>
         <NavUser

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -56,12 +56,12 @@ export function AppSidebar({
               size="lg"
               className="cursor-default text-sidebar-foreground hover:bg-transparent hover:text-sidebar-foreground"
             >
-              <div className="flex aspect-square size-8 items-center justify-center rounded-lg bg-praetor text-white">
+              <div className="flex aspect-square size-8 items-center justify-center rounded-lg border border-sidebar-border bg-transparent text-sidebar-foreground">
                 <Clock className="size-4" />
               </div>
               <div className="grid flex-1 text-left text-sm leading-tight text-sidebar-foreground">
                 <span className="truncate font-semibold italic">PRAETOR</span>
-                <span className="truncate text-xs text-sidebar-foreground/80">
+                <span className="truncate text-sm text-sidebar-foreground/80">
                   {roleLabel} {workspaceLabel}
                 </span>
               </div>
@@ -73,7 +73,7 @@ export function AppSidebar({
         <NavMain items={navItems} label={navigationLabel} onViewChange={onViewChange} />
       </SidebarContent>
       <SidebarFooter>
-        <div className="px-2 text-xs text-sidebar-foreground/60 group-data-[collapsible=icon]:hidden">
+        <div className="px-2 text-sm text-sidebar-foreground/60 group-data-[collapsible=icon]:hidden">
           Praetor v{version}
         </div>
         <NavUser

--- a/components/nav-user.tsx
+++ b/components/nav-user.tsx
@@ -45,12 +45,12 @@ function UserIdentityBlock({ user, roleLabel, context = 'sidebar' }: UserIdentit
   return (
     <>
       <Avatar className="h-8 w-8 rounded-lg">
-        <AvatarFallback className="rounded-lg bg-sidebar-accent text-sm font-semibold text-sidebar-foreground">
+        <AvatarFallback className="rounded-lg bg-sidebar-accent text-sm leading-[var(--text-sm--line-height)] font-semibold text-sidebar-foreground">
           {user.avatarInitials}
         </AvatarFallback>
       </Avatar>
       <div
-        className={`grid flex-1 text-left text-sm leading-tight ${
+        className={`grid flex-1 text-left text-sm leading-[var(--text-sm--line-height)] ${
           isPopover
             ? 'text-popover-foreground'
             : 'text-sidebar-foreground group-data-[state=open]/menu-button:text-sidebar-accent-foreground'
@@ -58,7 +58,7 @@ function UserIdentityBlock({ user, roleLabel, context = 'sidebar' }: UserIdentit
       >
         <span className="truncate font-medium">{user.name}</span>
         <span
-          className={`truncate text-sm ${
+          className={`truncate text-sm leading-[var(--text-sm--line-height)] ${
             isPopover
               ? 'text-muted-foreground'
               : 'text-sidebar-foreground/80 group-data-[state=open]/menu-button:text-sidebar-accent-foreground/80'
@@ -109,7 +109,7 @@ export function NavUser({
             sideOffset={4}
           >
             <DropdownMenuLabel className="p-0 font-normal">
-              <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
+              <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm leading-[var(--text-sm--line-height)]">
                 <UserIdentityBlock user={user} roleLabel={roleLabel} context="popover" />
               </div>
             </DropdownMenuLabel>

--- a/components/nav-user.tsx
+++ b/components/nav-user.tsx
@@ -45,7 +45,7 @@ function UserIdentityBlock({ user, roleLabel, context = 'sidebar' }: UserIdentit
   return (
     <>
       <Avatar className="h-8 w-8 rounded-lg">
-        <AvatarFallback className="rounded-lg bg-praetor text-xs font-semibold text-white">
+        <AvatarFallback className="rounded-lg bg-sidebar-accent text-sm font-semibold text-sidebar-foreground">
           {user.avatarInitials}
         </AvatarFallback>
       </Avatar>
@@ -58,7 +58,7 @@ function UserIdentityBlock({ user, roleLabel, context = 'sidebar' }: UserIdentit
       >
         <span className="truncate font-medium">{user.name}</span>
         <span
-          className={`truncate text-xs ${
+          className={`truncate text-sm ${
             isPopover
               ? 'text-muted-foreground'
               : 'text-sidebar-foreground/80 group-data-[state=open]/menu-button:text-sidebar-accent-foreground/80'

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -1,11 +1,39 @@
+import {
+  type ColumnDef,
+  type ColumnFiltersState,
+  flexRender,
+  functionalUpdate,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  type PaginationState,
+  type SortingState,
+  type Updater,
+  useReactTable,
+  type VisibilityState,
+} from '@tanstack/react-table';
 import { type ReactNode, type Ref, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { readTextFromClipboard, writeTextToClipboard } from '../../utils/clipboard';
 import { downloadCsv } from '../../utils/csv';
 import { getLocalDateString } from '../../utils/date';
-import Checkbox from './Checkbox';
-import CustomSelect from './CustomSelect';
+import { Button } from '../ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from '../ui/dropdown-menu';
+import { Input } from '../ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table';
 import CustomViewModal from './CustomViewModal';
 import {
   type CustomView,
@@ -23,7 +51,6 @@ import {
   type SortState,
 } from './customViewHelpers';
 import Modal from './Modal';
-import TableFilter from './TableFilter';
 import Tooltip from './Tooltip';
 
 const STORAGE_SUFFIX = {
@@ -42,48 +69,9 @@ const getStorageKey = (t: string, suffix: StorageSuffix) => `praetor_table_${suf
 const FONT_SIZES = ['xs', 'sm', 'base'] as const;
 type FontSize = (typeof FONT_SIZES)[number];
 
-const VIEWS_HOVER_CLOSE_DELAY_MS = 200;
 const VIEW_ERROR_DURATION_MS = 3000;
 const COPIED_FEEDBACK_DURATION_MS = 1500;
-const FILTER_POPUP_WIDTH_PX = 224;
-const FILTER_POPUP_VIEWPORT_MARGIN_PX = 8;
-
 type ViewModalState = { kind: 'create' } | { kind: 'edit'; view: CustomView } | null;
-
-const getFilterPopupPosition = (rect: DOMRect) => {
-  const scrollX = window.scrollX;
-  const minLeft = scrollX + FILTER_POPUP_VIEWPORT_MARGIN_PX;
-  const maxLeft =
-    scrollX + window.innerWidth - FILTER_POPUP_VIEWPORT_MARGIN_PX - FILTER_POPUP_WIDTH_PX;
-  const preferredLeft = rect.left + scrollX;
-
-  return {
-    top: rect.bottom + window.scrollY + 4,
-    left: Math.max(minLeft, Math.min(preferredLeft, maxLeft)),
-  };
-};
-
-const ViewActionButton = ({
-  icon,
-  title,
-  onClick,
-  className = 'hover:bg-zinc-200 text-zinc-500',
-}: {
-  icon: string;
-  title: string;
-  onClick: (e: React.MouseEvent) => void;
-  className?: string;
-}) => (
-  <button
-    type="button"
-    onClick={onClick}
-    title={title}
-    aria-label={title}
-    className={`size-5 flex items-center justify-center rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-praetor/40 ${className}`}
-  >
-    <i className={`fa-solid ${icon} text-[9px]`} aria-hidden="true"></i>
-  </button>
-);
 
 export type Column<T> = {
   header: string;
@@ -148,10 +136,6 @@ const StandardTable = <T extends object>({
   initialFilterState,
 }: StandardTableProps<T>) => {
   const { t } = useTranslation('common');
-  const filterRef = useRef<HTMLButtonElement>(null);
-  const popupRef = useRef<HTMLDivElement>(null);
-  const gearButtonRef = useRef<HTMLButtonElement>(null);
-  const gearPopupRef = useRef<HTMLDivElement>(null);
   const resizeStartXRef = useRef(0);
   const resizeStartWidthRef = useRef(0);
 
@@ -160,10 +144,9 @@ const StandardTable = <T extends object>({
   const filterStateRef = useRef(filterState);
   filterStateRef.current = filterState;
 
-  const [activeFilterCol, setActiveFilterCol] = useState<string | null>(null);
-  const [filterPos, setFilterPos] = useState<{ top: number; left: number } | null>(null);
   const [currentPage, setCurrentPage] = useState(1);
   const [gearOpen, setGearOpen] = useState(false);
+  const [filtersOpen, setFiltersOpen] = useState(false);
   const [resizingColId, setResizingColId] = useState<string | null>(null);
 
   const [rowsPerPage, setRowsPerPage] = useState(() => {
@@ -218,7 +201,6 @@ const StandardTable = <T extends object>({
   const [pasteModalOpen, setPasteModalOpen] = useState(false);
   const [pasteText, setPasteText] = useState('');
   const [pasteError, setPasteError] = useState<string | null>(null);
-  const viewsHoverTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const copiedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const viewErrorTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const viewsAppliedOnceRef = useRef(false);
@@ -333,7 +315,6 @@ const StandardTable = <T extends object>({
 
   useEffect(
     () => () => {
-      if (viewsHoverTimeoutRef.current) clearTimeout(viewsHoverTimeoutRef.current);
       if (copiedTimeoutRef.current) clearTimeout(copiedTimeoutRef.current);
       if (viewErrorTimeoutRef.current) clearTimeout(viewErrorTimeoutRef.current);
     },
@@ -347,47 +328,6 @@ const StandardTable = <T extends object>({
   };
 
   const fontSizeClass = fontSize === 'xs' ? 'text-xs' : fontSize === 'sm' ? 'text-sm' : 'text-base';
-
-  // Close filter popup when clicking outside
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        filterRef.current &&
-        !filterRef.current.contains(event.target as Node) &&
-        popupRef.current &&
-        !popupRef.current.contains(event.target as Node)
-      ) {
-        setActiveFilterCol(null);
-      }
-    };
-
-    if (activeFilterCol) {
-      document.addEventListener('mousedown', handleClickOutside);
-    }
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [activeFilterCol]);
-
-  // Close gear popup when clicking outside. Suspended while the create/rename
-  // modal is open: the modal portals to document.body (outside gearPopupRef),
-  // so a Save click would otherwise close the gear popup as a side effect.
-  useEffect(() => {
-    if (!gearOpen || modalState !== null) return;
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        gearButtonRef.current &&
-        !gearButtonRef.current.contains(event.target as Node) &&
-        gearPopupRef.current &&
-        !gearPopupRef.current.contains(event.target as Node)
-      ) {
-        setGearOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [gearOpen, modalState]);
 
   useEffect(() => {
     if (!resizingColId) return;
@@ -445,46 +385,192 @@ const StandardTable = <T extends object>({
     return m;
   }, [columns, getColId]);
 
-  const processedData = useMemo(() => {
-    if (!data || !columns) return [];
-    let result = [...data];
+  const tanStackColumns = useMemo<ColumnDef<T, unknown>[]>(
+    () =>
+      (columns ?? []).map((col) => {
+        const colId = getColId(col);
+        return {
+          id: colId,
+          accessorFn: (row) => getValue(row, col),
+          header: col.header,
+          cell: (info) => {
+            const row = info.row.original;
+            const value = info.getValue() as
+              | T[keyof T]
+              | string
+              | number
+              | boolean
+              | null
+              | undefined;
+            return col.cell
+              ? col.cell({ getValue: () => value, row, value })
+              : (value as ReactNode);
+          },
+          enableSorting: !col.disableSorting,
+          enableColumnFilter: !col.disableFiltering,
+          enableHiding: !col.hidden,
+          sortingFn: (rowA, rowB) => {
+            const valA = rowA.getValue(colId);
+            const valB = rowB.getValue(colId);
+            if (typeof valA === 'number' && typeof valB === 'number') {
+              return valA - valB;
+            }
+            const strA = String(valA || '').toLowerCase();
+            const strB = String(valB || '').toLowerCase();
+            if (strA < strB) return -1;
+            if (strA > strB) return 1;
+            return 0;
+          },
+          filterFn: (row, columnId, selectedValues) => {
+            const selected =
+              typeof selectedValues === 'string'
+                ? [selectedValues]
+                : Array.isArray(selectedValues)
+                  ? selectedValues
+                  : [];
+            if (selected.length === 0) return true;
+            const formatted = formatForFilter(row.getValue(columnId), col);
+            return selected.some((value) => formatted.toLowerCase().includes(value.toLowerCase()));
+          },
+        } satisfies ColumnDef<T, unknown>;
+      }),
+    [columns, getColId, getValue, formatForFilter],
+  );
 
-    Object.keys(filterState).forEach((filterColId) => {
-      const selectedValues = filterState[filterColId];
-      if (!selectedValues || selectedValues.length === 0) return;
-      const col = colsById.get(filterColId);
-      if (!col) return;
-      result = result.filter((row) => {
-        const val = formatForFilter(getValue(row, col), col);
-        return selectedValues.includes(val);
-      });
-    });
+  const sorting = useMemo<SortingState>(
+    () => (sortState ? [{ id: sortState.colId, desc: sortState.px === 'desc' }] : []),
+    [sortState],
+  );
 
-    if (sortState) {
-      const col = colsById.get(sortState.colId);
-      if (col) {
-        result.sort((a, b) => {
-          const valA = getValue(a, col);
-          const valB = getValue(b, col);
-          if (typeof valA === 'number' && typeof valB === 'number') {
-            return sortState.px === 'asc' ? valA - valB : valB - valA;
-          }
-          const strA = String(valA || '').toLowerCase();
-          const strB = String(valB || '').toLowerCase();
-          if (strA < strB) return sortState.px === 'asc' ? -1 : 1;
-          if (strA > strB) return sortState.px === 'asc' ? 1 : -1;
-          return 0;
-        });
+  const columnFilters = useMemo<ColumnFiltersState>(
+    () => Object.entries(filterState).map(([id, value]) => ({ id, value })),
+    [filterState],
+  );
+
+  const pagination = useMemo<PaginationState>(
+    () => ({ pageIndex: currentPage - 1, pageSize: rowsPerPage }),
+    [currentPage, rowsPerPage],
+  );
+
+  const columnVisibility = useMemo(
+    () =>
+      Object.fromEntries(
+        (columns ?? []).map((col) => {
+          const colId = getColId(col);
+          return [colId, !col.hidden && !hiddenColIds.has(colId)];
+        }),
+      ) as VisibilityState,
+    [columns, getColId, hiddenColIds],
+  );
+
+  const onSortingChange = useCallback(
+    (updater: Updater<SortingState>) => {
+      const next = functionalUpdate(updater, sorting);
+      const firstSort = next[0];
+      setSortState(firstSort ? { colId: firstSort.id, px: firstSort.desc ? 'desc' : 'asc' } : null);
+      updateActiveViewId(null);
+    },
+    [sorting, updateActiveViewId],
+  );
+
+  const onColumnFiltersChange = useCallback(
+    (updater: Updater<ColumnFiltersState>) => {
+      const next = functionalUpdate(updater, columnFilters);
+      const nextFilterState: FilterState = {};
+      for (const filter of next) {
+        if (Array.isArray(filter.value)) {
+          if (filter.value.length > 0) nextFilterState[filter.id] = filter.value;
+        } else if (typeof filter.value === 'string' && filter.value.trim().length > 0) {
+          nextFilterState[filter.id] = [filter.value];
+        }
       }
-    }
+      setFilterState(nextFilterState);
+      setCurrentPage(1);
+      updateActiveViewId(null);
+    },
+    [columnFilters, updateActiveViewId],
+  );
 
-    return result;
-  }, [data, columns, filterState, sortState, getValue, colsById, formatForFilter]);
+  const onPaginationChange = useCallback(
+    (updater: Updater<PaginationState>) => {
+      const next = functionalUpdate(updater, pagination);
+      setCurrentPage(next.pageIndex + 1);
+      if (next.pageSize !== rowsPerPage) {
+        setRowsPerPage(next.pageSize);
+        if (storageKey) {
+          localStorage.setItem(storageKey, String(next.pageSize));
+        }
+      }
+    },
+    [pagination, rowsPerPage, storageKey],
+  );
 
-  const totalItems = data ? processedData.length : externalTotalCount || 0;
-  const totalPages = Math.ceil(totalItems / rowsPerPage);
+  const onColumnVisibilityChange = useCallback(
+    (updater: Updater<VisibilityState>) => {
+      const next = functionalUpdate(updater, columnVisibility);
+      const nextHiddenColIds = new Set<string>();
+      for (const col of gearColumns) {
+        const colId = getColId(col);
+        if (next[colId] === false) nextHiddenColIds.add(colId);
+      }
+
+      setHiddenColIds(nextHiddenColIds);
+      if (sortState && nextHiddenColIds.has(sortState.colId)) setSortState(null);
+      setFilterState((prev) => {
+        let changed = false;
+        const nextFilters = { ...prev };
+        for (const colId of nextHiddenColIds) {
+          if (nextFilters[colId]) {
+            delete nextFilters[colId];
+            changed = true;
+          }
+        }
+        return changed ? nextFilters : prev;
+      });
+      updateActiveViewId(null);
+    },
+    [columnVisibility, gearColumns, getColId, sortState, updateActiveViewId],
+  );
+
+  const table = useReactTable({
+    data: data ?? [],
+    columns: tanStackColumns,
+    onSortingChange,
+    onColumnFiltersChange,
+    onPaginationChange,
+    onColumnVisibilityChange,
+    state: {
+      sorting,
+      columnFilters,
+      pagination,
+      columnVisibility,
+    },
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+  });
+
+  const processedRows = data ? table.getPrePaginationRowModel().rows : [];
+  const totalItems = data ? processedRows.length : externalTotalCount || 0;
+  const totalPages = data ? table.getPageCount() : Math.ceil(totalItems / rowsPerPage);
   const startIndex = (currentPage - 1) * rowsPerPage;
-  const paginatedData = data ? processedData.slice(startIndex, startIndex + rowsPerPage) : [];
+  const paginatedRows = data ? table.getRowModel().rows : [];
+  const filterableTableColumns = table
+    .getAllLeafColumns()
+    .filter((column) => column.getCanFilter() && colsById.has(column.id));
+  const primaryFilterColumn =
+    filterableTableColumns.find((column) => column.getIsVisible()) ?? filterableTableColumns[0];
+  const primaryFilterSourceColumn = primaryFilterColumn
+    ? colsById.get(primaryFilterColumn.id)
+    : undefined;
+  const primaryFilterValue = primaryFilterColumn?.getFilterValue();
+  const primaryFilterText = Array.isArray(primaryFilterValue)
+    ? primaryFilterValue.join(', ')
+    : typeof primaryFilterValue === 'string'
+      ? primaryFilterValue
+      : '';
+  const hasActiveFilters = table.getState().columnFilters.length > 0;
 
   useEffect(() => {
     if (totalPages === 0) {
@@ -512,23 +598,6 @@ const StandardTable = <T extends object>({
 
   const getFilterOptions = (colId: string) => filterOptionsByCol.get(colId) ?? [];
 
-  const handleSort = (colId: string, dir: 'asc' | 'desc' | null) => {
-    if (!dir) setSortState(null);
-    else setSortState({ colId, px: dir });
-    updateActiveViewId(null);
-  };
-
-  const handleFilter = (colId: string, selected: string[]) => {
-    setFilterState((prev) => {
-      const next = { ...prev };
-      if (selected.length === 0) delete next[colId];
-      else next[colId] = selected;
-      return next;
-    });
-    setCurrentPage(1); // Reset to page 1 on filter
-    updateActiveViewId(null);
-  };
-
   const stepFontSize = (delta: -1 | 1) => {
     setFontSize((prev) => {
       const idx = FONT_SIZES.indexOf(prev);
@@ -550,36 +619,15 @@ const StandardTable = <T extends object>({
     );
     const rows = [
       exportColumns.map((c) => c.header),
-      ...processedData.map((row) =>
-        exportColumns.map((col) => formatForFilter(getValue(row, col), col)),
+      ...processedRows.map((row) =>
+        exportColumns.map((col) => formatForFilter(getValue(row.original, col), col)),
       ),
     ];
     downloadCsv(rows, `${slugify(title)}_${getLocalDateString()}.csv`);
   };
 
-  const toggleColumnVisibility = (colId: string) => {
-    setHiddenColIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(colId)) {
-        next.delete(colId);
-      } else {
-        next.add(colId);
-        if (sortState?.colId === colId) setSortState(null);
-        setFilterState((fs) => {
-          if (!fs[colId]) return fs;
-          const nextFs = { ...fs };
-          delete nextFs[colId];
-          return nextFs;
-        });
-      }
-      return next;
-    });
-    updateActiveViewId(null);
-  };
-
   const resetColumnVisibility = () => {
-    setHiddenColIds(new Set<string>());
-    updateActiveViewId(null);
+    table.setColumnVisibility({});
   };
 
   const applyView = (view: CustomView) => {
@@ -719,19 +767,6 @@ const StandardTable = <T extends object>({
     setPasteError(null);
   };
 
-  const handleViewsMouseEnter = () => {
-    if (viewsHoverTimeoutRef.current) clearTimeout(viewsHoverTimeoutRef.current);
-    setViewsSubmenuOpen(true);
-  };
-
-  const handleViewsMouseLeave = () => {
-    if (viewsHoverTimeoutRef.current) clearTimeout(viewsHoverTimeoutRef.current);
-    viewsHoverTimeoutRef.current = setTimeout(
-      () => setViewsSubmenuOpen(false),
-      VIEWS_HOVER_CLOSE_DELAY_MS,
-    );
-  };
-
   const handleResizeStart = (e: React.MouseEvent<HTMLDivElement>, colId: string) => {
     e.preventDefault();
     e.stopPropagation();
@@ -764,22 +799,22 @@ const StandardTable = <T extends object>({
     return (
       <Tooltip label={label} position="bottom" disabled={tooltipDisabled}>
         {() => (
-          <button
+          <Button
             type="button"
             ref={buttonRef}
             aria-label={label}
+            variant={active ? 'secondary' : 'outline'}
+            size={text ? 'sm' : 'icon-sm'}
             onClick={(e) => {
               e.stopPropagation();
               onClick();
             }}
             disabled={disabled}
-            className={`h-7 ${text ? 'px-2 gap-1.5' : 'w-7 justify-center'} flex items-center rounded-lg border border-zinc-200 transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
-              active ? 'bg-zinc-100 text-praetor' : 'bg-white text-zinc-500 hover:bg-zinc-100'
-            }`}
+            className={text ? 'h-8 px-2 text-xs' : 'size-8'}
           >
             <i className={`fa-solid ${iconClass} text-[10px]`} aria-hidden="true"></i>
             {text && <span className="text-[10px] font-bold">{text}</span>}
-          </button>
+          </Button>
         )}
       </Tooltip>
     );
@@ -787,446 +822,494 @@ const StandardTable = <T extends object>({
 
   const renderInternalFooter = () => (
     <>
-      <div className="flex items-center gap-3">
-        <span className="text-xs font-bold text-zinc-500">{t('pagination.rowsPerPage')}</span>
-        <CustomSelect
-          options={[
-            { id: '5', name: '5' },
-            { id: '10', name: '10' },
-            { id: '20', name: '20' },
-            { id: '50', name: '50' },
-          ]}
-          value={rowsPerPage.toString()}
-          onChange={(val) => {
-            const newValue = Number(val);
-            setRowsPerPage(newValue);
-            setCurrentPage(1);
-            if (storageKey) {
-              localStorage.setItem(storageKey, String(newValue));
-            }
-          }}
-          className="w-20"
-          buttonClassName="px-2 py-1 bg-white border border-zinc-200 text-xs font-bold text-zinc-700 rounded-lg"
-          searchable={false}
-        />
-        <span className="text-xs font-bold text-zinc-400 ml-2">
+      <div className="flex items-center gap-3 text-sm text-muted-foreground">
+        <span>
           {t('pagination.showing')
             .replace('{{start}}', String(totalItems > 0 ? startIndex + 1 : 0))
             .replace('{{end}}', String(Math.min(startIndex + rowsPerPage, totalItems)))
             .replace('{{total}}', String(totalItems))}
         </span>
+        <span className="text-xs font-medium text-muted-foreground">
+          {t('pagination.rowsPerPage')}
+        </span>
+        <Select
+          value={rowsPerPage.toString()}
+          onValueChange={(val) => {
+            const newValue = Number(val);
+            table.setPageIndex(0);
+            table.setPageSize(newValue);
+          }}
+        >
+          <SelectTrigger size="sm" className="h-8 w-[76px] text-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {[5, 10, 20, 50].map((value) => (
+              <SelectItem key={value} value={String(value)}>
+                {value}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
 
       <div className="flex items-center gap-2">
-        <button
+        <Button
           type="button"
+          variant="outline"
+          size="sm"
           onClick={(e) => {
             e.stopPropagation();
-            setCurrentPage((prev) => Math.max(1, prev - 1));
+            table.previousPage();
           }}
-          disabled={currentPage === 1}
-          className="size-8 flex items-center justify-center rounded-lg border border-zinc-200 bg-white text-zinc-500 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-zinc-50 transition-colors"
+          disabled={!table.getCanPreviousPage()}
         >
-          <i className="fa-solid fa-chevron-left text-xs"></i>
-        </button>
-        <div className="flex items-center gap-1">
-          {Array.from({ length: totalPages }, (_, i) => i + 1)
-            .filter(
-              (p) => p === 1 || p === totalPages || (p >= currentPage - 1 && p <= currentPage + 1),
-            )
-            .map((page, i, arr) => (
-              <div key={page} className="flex items-center">
-                {i > 0 && page - arr[i - 1] > 1 && <span className="text-zinc-400 mx-1">...</span>}
-                <button
-                  type="button"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setCurrentPage(page);
-                  }}
-                  className={`size-8 flex items-center justify-center rounded-lg text-xs font-bold transition-all ${
-                    currentPage === page
-                      ? 'bg-praetor text-white shadow-md shadow-zinc-200'
-                      : 'text-zinc-500 hover:bg-zinc-100'
-                  }`}
-                >
-                  {page}
-                </button>
-              </div>
-            ))}
-        </div>
-        <button
+          {t('buttons.previous')}
+        </Button>
+        <span className="text-sm text-muted-foreground">
+          {currentPage} / {Math.max(totalPages, 1)}
+        </span>
+        <Button
           type="button"
+          variant="outline"
+          size="sm"
           onClick={(e) => {
             e.stopPropagation();
-            setCurrentPage((prev) => Math.min(totalPages, prev + 1));
+            table.nextPage();
           }}
-          disabled={currentPage === totalPages || totalPages === 0}
-          className="size-8 flex items-center justify-center rounded-lg border border-zinc-200 bg-white text-zinc-500 disabled:opacity-50 disabled:cursor-not-allowed hover:bg-zinc-50 transition-colors"
+          disabled={!table.getCanNextPage()}
         >
-          <i className="fa-solid fa-chevron-right text-xs"></i>
-        </button>
+          {t('buttons.next')}
+        </Button>
       </div>
     </>
   );
 
   return (
     <div
-      className={`bg-white rounded-3xl border border-zinc-200 shadow-sm ${containerClassName ?? ''}`.trim()}
+      className={`rounded-md border border-border bg-card shadow-sm ${containerClassName ?? ''}`.trim()}
     >
-      <div className="p-3 bg-zinc-50 border-b border-zinc-200 flex justify-between items-center rounded-t-3xl">
-        <div className="flex items-center gap-3">
-          <h4 className="font-semibold text-zinc-400 uppercase text-[10px] tracking-widest">
-            {title}
-          </h4>
-          {typeof totalItems === 'number' && (
-            <span className="bg-zinc-100 text-praetor px-3 py-1 rounded-full text-[10px] font-black uppercase">
-              {totalItems} {totalLabel || t('table.total')}
-            </span>
+      <div className="space-y-4 border-b border-border bg-card p-4">
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <h4 className="text-sm font-medium text-muted-foreground">{title}</h4>
+            {typeof totalItems === 'number' && (
+              <span className="inline-flex items-center rounded-md border border-border bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                {totalItems} {totalLabel || t('table.total')}
+              </span>
+            )}
+          </div>
+          {(headerExtras || headerAction) && (
+            <div className="flex items-center gap-3">
+              {headerExtras}
+              {headerAction}
+            </div>
           )}
         </div>
-        {(data != null && columns != null) || headerExtras != null || headerAction != null ? (
-          <div className="flex items-center gap-3">
-            {data != null && columns != null && (
-              <div className="flex items-center gap-1">
-                {renderToolbarButton({
-                  tooltipKey: 'table.exportToCsv',
-                  iconClass: 'fa-file-export',
-                  onClick: handleExportToCsv,
-                  disabled: processedData.length === 0,
-                  text: t('table.export'),
-                })}
-                {renderToolbarButton({
-                  tooltipKey: 'table.decreaseFont',
-                  iconClass: 'fa-minus',
-                  onClick: () => stepFontSize(-1),
-                  disabled: fontSize === 'xs',
-                })}
-                {renderToolbarButton({
-                  tooltipKey: 'table.increaseFont',
-                  iconClass: 'fa-plus',
-                  onClick: () => stepFontSize(1),
-                  disabled: fontSize === 'base',
-                })}
-                <div className="relative">
-                  {renderToolbarButton({
-                    tooltipKey: 'table.columnSettings',
-                    iconClass: 'fa-gear',
-                    onClick: () => setGearOpen((prev) => !prev),
-                    active: gearOpen,
-                    buttonRef: gearButtonRef,
-                    tooltipDisabled: gearOpen,
+        {data != null && columns != null && (
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <Input
+              placeholder={
+                primaryFilterSourceColumn
+                  ? `${t('table.search')} ${primaryFilterSourceColumn.header}`
+                  : t('table.search')
+              }
+              value={primaryFilterText}
+              onChange={(event) => {
+                primaryFilterColumn?.setFilterValue(event.target.value || undefined);
+                table.setPageIndex(0);
+              }}
+              disabled={!primaryFilterColumn}
+              className="h-8 max-w-sm"
+            />
+            <div className="flex items-center gap-2">
+              <DropdownMenu open={filtersOpen} onOpenChange={setFiltersOpen}>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    type="button"
+                    variant={hasActiveFilters ? 'secondary' : 'outline'}
+                    size="sm"
+                  >
+                    <i className="fa-solid fa-filter text-[10px]" aria-hidden="true"></i>
+                    {t('table.filters')}
+                    <i className="fa-solid fa-chevron-down text-[10px]" aria-hidden="true"></i>
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-64">
+                  <DropdownMenuLabel className="text-xs">{t('table.filters')}</DropdownMenuLabel>
+                  <DropdownMenuSeparator />
+                  {filterableTableColumns.map((column) => {
+                    const sourceColumn = colsById.get(column.id);
+                    if (!sourceColumn) return null;
+                    const selectedValues = Array.isArray(column.getFilterValue())
+                      ? (column.getFilterValue() as string[])
+                      : typeof column.getFilterValue() === 'string'
+                        ? [column.getFilterValue() as string]
+                        : [];
+                    return (
+                      <DropdownMenuSub key={column.id}>
+                        <DropdownMenuSubTrigger className="text-xs">
+                          <span className="truncate">{sourceColumn.header}</span>
+                          {selectedValues.length > 0 && (
+                            <span className="ml-auto text-xs text-muted-foreground">
+                              {selectedValues.length}
+                            </span>
+                          )}
+                        </DropdownMenuSubTrigger>
+                        <DropdownMenuSubContent className="w-64">
+                          <DropdownMenuLabel className="text-xs">
+                            {sourceColumn.header}
+                          </DropdownMenuLabel>
+                          <DropdownMenuSeparator />
+                          <div className="max-h-64 overflow-y-auto">
+                            {getFilterOptions(column.id).map((option) => (
+                              <DropdownMenuCheckboxItem
+                                key={option || '__empty__'}
+                                checked={selectedValues.includes(option)}
+                                onSelect={(event) => {
+                                  event.preventDefault();
+                                  const next = selectedValues.includes(option)
+                                    ? selectedValues.filter((value) => value !== option)
+                                    : [...selectedValues, option];
+                                  column.setFilterValue(next.length > 0 ? next : undefined);
+                                  table.setPageIndex(0);
+                                }}
+                                className="text-xs"
+                              >
+                                <span className="truncate">{option || t('table.empty')}</span>
+                              </DropdownMenuCheckboxItem>
+                            ))}
+                          </div>
+                          {selectedValues.length > 0 && (
+                            <>
+                              <DropdownMenuSeparator />
+                              <DropdownMenuItem
+                                onSelect={(event) => {
+                                  event.preventDefault();
+                                  column.setFilterValue(undefined);
+                                  table.setPageIndex(0);
+                                }}
+                                className="text-xs"
+                              >
+                                {t('table.clearFilter')}
+                              </DropdownMenuItem>
+                            </>
+                          )}
+                        </DropdownMenuSubContent>
+                      </DropdownMenuSub>
+                    );
                   })}
-                  {gearOpen && (
-                    <div
-                      ref={gearPopupRef}
-                      className="absolute right-0 top-full mt-2 w-52 bg-white rounded-2xl shadow-xl border border-zinc-200 z-50 animate-in fade-in zoom-in-95 duration-200 origin-top-right"
-                    >
-                      <div className="px-3 py-2 border-b border-zinc-100 flex items-center justify-between gap-2">
-                        <span
-                          className="text-[10px] font-black text-zinc-400 uppercase tracking-wider truncate"
-                          title={activeView ? activeView.name : undefined}
-                        >
-                          {activeView
-                            ? `${t('table.columns')} · ${activeView.name}`
-                            : t('table.columns')}
+                  {hasActiveFilters && (
+                    <>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem
+                        onSelect={(event) => {
+                          event.preventDefault();
+                          table.resetColumnFilters();
+                          table.setPageIndex(0);
+                        }}
+                        className="text-xs"
+                      >
+                        {t('filters.clearFilters')}
+                      </DropdownMenuItem>
+                    </>
+                  )}
+                </DropdownMenuContent>
+              </DropdownMenu>
+              {renderToolbarButton({
+                tooltipKey: 'table.exportToCsv',
+                iconClass: 'fa-file-export',
+                onClick: handleExportToCsv,
+                disabled: processedRows.length === 0,
+                text: t('table.export'),
+              })}
+              {renderToolbarButton({
+                tooltipKey: 'table.decreaseFont',
+                iconClass: 'fa-minus',
+                onClick: () => stepFontSize(-1),
+                disabled: fontSize === 'xs',
+              })}
+              {renderToolbarButton({
+                tooltipKey: 'table.increaseFont',
+                iconClass: 'fa-plus',
+                onClick: () => stepFontSize(1),
+                disabled: fontSize === 'base',
+              })}
+              <DropdownMenu open={gearOpen} onOpenChange={setGearOpen}>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    type="button"
+                    aria-label={t('table.columnSettings')}
+                    variant={gearOpen ? 'secondary' : 'outline'}
+                    size="sm"
+                  >
+                    {t('table.columns')}
+                    <i className="fa-solid fa-chevron-down text-[10px]" aria-hidden="true"></i>
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-64">
+                  <DropdownMenuLabel
+                    className="truncate text-xs"
+                    title={activeView ? activeView.name : undefined}
+                  >
+                    {activeView ? `${t('table.columns')} · ${activeView.name}` : t('table.columns')}
+                  </DropdownMenuLabel>
+                  <DropdownMenuSeparator />
+                  <div className="max-h-64 overflow-y-auto">
+                    {table
+                      .getAllColumns()
+                      .filter((column) => column.getCanHide() && colsById.has(column.id))
+                      .map((column) => {
+                        const sourceColumn = colsById.get(column.id);
+                        const isVisible = column.getIsVisible();
+                        const isLastVisible =
+                          table
+                            .getVisibleLeafColumns()
+                            .filter((visibleColumn) => visibleColumn.getCanHide()).length === 1 &&
+                          isVisible;
+                        return (
+                          <DropdownMenuCheckboxItem
+                            key={column.id}
+                            checked={isVisible}
+                            disabled={isLastVisible}
+                            onSelect={(event) => {
+                              event.preventDefault();
+                              if (!isLastVisible) column.toggleVisibility(!isVisible);
+                            }}
+                            className="text-xs"
+                          >
+                            <span className="truncate">{sourceColumn?.header ?? column.id}</span>
+                          </DropdownMenuCheckboxItem>
+                        );
+                      })}
+                  </div>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    onSelect={(e) => {
+                      e.preventDefault();
+                      resetColumnVisibility();
+                    }}
+                    className="text-xs"
+                  >
+                    <i className="fa-solid fa-rotate-left text-[10px]" aria-hidden="true"></i>
+                    <span>{t('table.resetColumns')}</span>
+                  </DropdownMenuItem>
+                  <DropdownMenuSub open={viewsSubmenuOpen} onOpenChange={setViewsSubmenuOpen}>
+                    <DropdownMenuSubTrigger className="text-xs">
+                      <i className="fa-solid fa-layer-group text-[10px]" aria-hidden="true"></i>
+                      <span>{t('table.customViews')}</span>
+                      {customViews.length > 0 && (
+                        <span className="ml-auto text-xs text-muted-foreground">
+                          {customViews.length}
                         </span>
-                        <button
-                          type="button"
-                          onClick={(e) => {
-                            e.stopPropagation();
+                      )}
+                    </DropdownMenuSubTrigger>
+                    <DropdownMenuSubContent className="w-72">
+                      <DropdownMenuLabel className="text-xs">
+                        {t('table.customViews')}
+                      </DropdownMenuLabel>
+                      <DropdownMenuSeparator />
+                      {customViews.length > 0 && (
+                        <div className="max-h-64 overflow-y-auto p-1">
+                          {customViews.map((view) => {
+                            const isActive = view.id === activeViewId;
+                            const isCopied = copiedViewId === view.id;
+                            const isDragOver =
+                              dragOverViewId === view.id && draggingViewId !== view.id;
+                            return (
+                              <div
+                                key={view.id}
+                                draggable
+                                onDragStart={(e) => {
+                                  e.stopPropagation();
+                                  e.dataTransfer.effectAllowed = 'move';
+                                  // Firefox aborts the drag unless setData is called.
+                                  e.dataTransfer.setData('text/plain', view.name);
+                                  setDraggingViewId(view.id);
+                                }}
+                                onDragOver={(e) => {
+                                  e.preventDefault();
+                                  e.stopPropagation();
+                                  e.dataTransfer.dropEffect = 'move';
+                                  if (
+                                    draggingViewId &&
+                                    draggingViewId !== view.id &&
+                                    dragOverViewId !== view.id
+                                  ) {
+                                    setDragOverViewId(view.id);
+                                  }
+                                }}
+                                onDragLeave={(e) => {
+                                  e.stopPropagation();
+                                  if (dragOverViewId === view.id) setDragOverViewId(null);
+                                }}
+                                onDrop={(e) => {
+                                  e.preventDefault();
+                                  e.stopPropagation();
+                                  if (draggingViewId) {
+                                    reorderViews(draggingViewId, view.id);
+                                  }
+                                  setDraggingViewId(null);
+                                  setDragOverViewId(null);
+                                }}
+                                onDragEnd={() => {
+                                  setDraggingViewId(null);
+                                  setDragOverViewId(null);
+                                }}
+                                className={`group flex items-center gap-1 rounded-sm border-t-2 px-1 py-1 text-sm outline-hidden transition-colors ${
+                                  isActive
+                                    ? 'bg-accent text-accent-foreground'
+                                    : 'hover:bg-accent hover:text-accent-foreground'
+                                } ${isDragOver ? 'border-primary' : 'border-transparent'} ${
+                                  draggingViewId === view.id ? 'opacity-40' : ''
+                                }`}
+                              >
+                                <button
+                                  type="button"
+                                  title={t('table.reorderViewHandle')}
+                                  aria-label={t('table.reorderViewHandle')}
+                                  onClick={(e) => e.stopPropagation()}
+                                  onKeyDown={(e) => {
+                                    if (e.key === 'ArrowUp') {
+                                      e.preventDefault();
+                                      e.stopPropagation();
+                                      moveViewByDelta(view.id, -1);
+                                    } else if (e.key === 'ArrowDown') {
+                                      e.preventDefault();
+                                      e.stopPropagation();
+                                      moveViewByDelta(view.id, 1);
+                                    }
+                                  }}
+                                  className="flex size-6 shrink-0 cursor-move items-center justify-center rounded-sm text-muted-foreground outline-none hover:bg-background focus-visible:ring-[3px] focus-visible:ring-ring/50"
+                                >
+                                  <i
+                                    className="fa-solid fa-grip-vertical text-[10px]"
+                                    aria-hidden="true"
+                                  ></i>
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    applyView(view);
+                                    setGearOpen(false);
+                                  }}
+                                  className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
+                                  title={view.name}
+                                >
+                                  {isActive && (
+                                    <i
+                                      className="fa-solid fa-check shrink-0 text-[10px]"
+                                      aria-hidden="true"
+                                    ></i>
+                                  )}
+                                  <span className="truncate text-xs font-medium">{view.name}</span>
+                                </button>
+                                <div className="flex shrink-0 items-center gap-0.5 opacity-70 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
+                                  <DropdownMenuItem
+                                    aria-label={t('table.renameView')}
+                                    onSelect={(e) => {
+                                      e.preventDefault();
+                                      setModalState({ kind: 'edit', view });
+                                      setGearOpen(false);
+                                    }}
+                                    className="size-7 justify-center p-0"
+                                  >
+                                    <i
+                                      className="fa-solid fa-pen text-[10px]"
+                                      aria-hidden="true"
+                                    ></i>
+                                  </DropdownMenuItem>
+                                  <DropdownMenuItem
+                                    aria-label={
+                                      isCopied ? t('table.viewCopied') : t('table.exportView')
+                                    }
+                                    onSelect={(e) => {
+                                      e.preventDefault();
+                                      void exportView(view);
+                                    }}
+                                    className="size-7 justify-center p-0"
+                                  >
+                                    <i
+                                      className={`fa-solid ${isCopied ? 'fa-check' : 'fa-copy'} text-[10px]`}
+                                      aria-hidden="true"
+                                    ></i>
+                                  </DropdownMenuItem>
+                                  <DropdownMenuItem
+                                    aria-label={t('table.deleteView')}
+                                    variant="destructive"
+                                    onSelect={(e) => {
+                                      e.preventDefault();
+                                      deleteView(view.id);
+                                    }}
+                                    className="size-7 justify-center p-0"
+                                  >
+                                    <i
+                                      className="fa-solid fa-trash text-[10px]"
+                                      aria-hidden="true"
+                                    ></i>
+                                  </DropdownMenuItem>
+                                </div>
+                              </div>
+                            );
+                          })}
+                        </div>
+                      )}
+                      <DropdownMenuSeparator />
+                      <div className="grid gap-1 p-1">
+                        <DropdownMenuItem
+                          onSelect={(e) => {
+                            e.preventDefault();
+                            setModalState({ kind: 'create' });
                             setGearOpen(false);
                           }}
-                          className="text-zinc-400 hover:text-zinc-600 transition-colors flex-shrink-0"
+                          className="text-xs"
                         >
-                          <i className="fa-solid fa-xmark text-xs"></i>
-                        </button>
-                      </div>
-                      <div className="max-h-60 overflow-y-auto p-1.5 space-y-0.5">
-                        {gearColumns.map((col) => {
-                          const colId = getColId(col);
-                          const isVisible = !hiddenColIds.has(colId);
-                          const isLastVisible = visibleColumns.length === 1 && isVisible;
-                          // Checkbox onChange owns the toggle; the row's
-                          // onClick handles clicks on the text label only.
-                          // Clicks inside the inner <label> bubble twice (the
-                          // visible click + a UA-synthesised click on the
-                          // hidden input), so we ignore those here to avoid a
-                          // double-toggle that cancels itself.
-                          return (
-                            <div
-                              key={colId}
-                              className="flex items-center gap-2 px-1.5 py-1 hover:bg-zinc-50 rounded cursor-pointer"
-                              onClick={(e) => {
-                                if (isLastVisible) return;
-                                if ((e.target as HTMLElement).closest('label')) return;
-                                toggleColumnVisibility(colId);
-                              }}
-                            >
-                              <Checkbox
-                                size="sm"
-                                checked={isVisible}
-                                disabled={isLastVisible}
-                                onChange={() => toggleColumnVisibility(colId)}
-                              />
-                              <span className="text-[11px] text-zinc-600 select-none">
-                                {col.header}
-                              </span>
-                            </div>
-                          );
-                        })}
-                      </div>
-                      <div className="p-2 border-t border-zinc-100">
-                        <button
-                          type="button"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            resetColumnVisibility();
+                          <i className="fa-solid fa-plus text-[10px]" aria-hidden="true"></i>
+                          <span>{t('buttons.add')}</span>
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          onSelect={(e) => {
+                            e.preventDefault();
+                            void importView();
                           }}
-                          className="w-full px-3 py-1.5 text-[11px] font-semibold text-zinc-600 hover:text-white bg-zinc-50 hover:bg-praetor rounded-lg transition-all flex items-center justify-center gap-1.5"
+                          className="text-xs"
                         >
-                          <i className="fa-solid fa-rotate-left text-[10px]"></i>
-                          <span>{t('table.resetColumns')}</span>
-                        </button>
+                          <i className="fa-solid fa-file-import text-[10px]" aria-hidden="true"></i>
+                          <span>{t('buttons.import')}</span>
+                        </DropdownMenuItem>
                       </div>
-                      <div
-                        className="relative border-t border-zinc-100 p-2"
-                        onMouseEnter={handleViewsMouseEnter}
-                        onMouseLeave={handleViewsMouseLeave}
-                      >
-                        <button
-                          type="button"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            setViewsSubmenuOpen(true);
-                          }}
-                          onFocus={() => setViewsSubmenuOpen(true)}
-                          className={`w-full px-3 py-1.5 text-[11px] font-semibold rounded-lg transition-colors flex items-center justify-between ${
-                            viewsSubmenuOpen
-                              ? 'bg-zinc-100 text-praetor'
-                              : 'text-zinc-600 hover:bg-zinc-50'
-                          }`}
+                      {viewError && (
+                        <div
+                          role="alert"
+                          className="px-2 pb-2 text-center text-xs text-destructive"
                         >
-                          <span className="flex items-center gap-1.5">
-                            <i className="fa-solid fa-layer-group text-[10px]"></i>
-                            {t('table.customViews')}
-                            {customViews.length > 0 && (
-                              <span className="text-[9px] font-bold text-zinc-400">
-                                ({customViews.length})
-                              </span>
-                            )}
-                          </span>
-                          <i className="fa-solid fa-chevron-right text-[9px]"></i>
-                        </button>
-                        {viewsSubmenuOpen && (
-                          <div
-                            className="absolute right-full top-0 mr-2 w-64 bg-white rounded-2xl shadow-xl border border-zinc-200 z-50 animate-in fade-in zoom-in-95 duration-150 origin-top-right"
-                            onMouseEnter={handleViewsMouseEnter}
-                            onMouseLeave={handleViewsMouseLeave}
-                          >
-                            <div className="px-3 py-2 border-b border-zinc-100">
-                              <span className="text-[10px] font-black text-zinc-400 uppercase tracking-wider">
-                                {t('table.customViews')}
-                              </span>
-                            </div>
-                            {customViews.length > 0 && (
-                              <div className="max-h-60 overflow-y-auto p-1.5 space-y-0.5">
-                                {customViews.map((view) => {
-                                  const isActive = view.id === activeViewId;
-                                  const isCopied = copiedViewId === view.id;
-                                  const isDragOver =
-                                    dragOverViewId === view.id && draggingViewId !== view.id;
-                                  return (
-                                    <div
-                                      key={view.id}
-                                      draggable
-                                      onDragStart={(e) => {
-                                        e.stopPropagation();
-                                        e.dataTransfer.effectAllowed = 'move';
-                                        // Firefox aborts the drag unless setData is called.
-                                        e.dataTransfer.setData('text/plain', view.name);
-                                        setDraggingViewId(view.id);
-                                      }}
-                                      onDragOver={(e) => {
-                                        e.preventDefault();
-                                        e.stopPropagation();
-                                        e.dataTransfer.dropEffect = 'move';
-                                        if (
-                                          draggingViewId &&
-                                          draggingViewId !== view.id &&
-                                          dragOverViewId !== view.id
-                                        ) {
-                                          setDragOverViewId(view.id);
-                                        }
-                                      }}
-                                      onDragLeave={(e) => {
-                                        e.stopPropagation();
-                                        if (dragOverViewId === view.id) setDragOverViewId(null);
-                                      }}
-                                      onDrop={(e) => {
-                                        e.preventDefault();
-                                        e.stopPropagation();
-                                        if (draggingViewId) {
-                                          reorderViews(draggingViewId, view.id);
-                                        }
-                                        setDraggingViewId(null);
-                                        setDragOverViewId(null);
-                                      }}
-                                      onDragEnd={() => {
-                                        setDraggingViewId(null);
-                                        setDragOverViewId(null);
-                                      }}
-                                      className={`group flex items-center gap-1 px-1.5 py-1 rounded transition-colors border-t-2 ${
-                                        isActive ? 'bg-zinc-100' : 'hover:bg-zinc-50'
-                                      } ${isDragOver ? 'border-praetor' : 'border-transparent'} ${
-                                        draggingViewId === view.id ? 'opacity-40' : ''
-                                      }`}
-                                    >
-                                      <button
-                                        type="button"
-                                        title={t('table.reorderViewHandle')}
-                                        aria-label={t('table.reorderViewHandle')}
-                                        onClick={(e) => e.stopPropagation()}
-                                        onKeyDown={(e) => {
-                                          if (e.key === 'ArrowUp') {
-                                            e.preventDefault();
-                                            e.stopPropagation();
-                                            moveViewByDelta(view.id, -1);
-                                          } else if (e.key === 'ArrowDown') {
-                                            e.preventDefault();
-                                            e.stopPropagation();
-                                            moveViewByDelta(view.id, 1);
-                                          }
-                                        }}
-                                        className="text-zinc-300 group-hover:text-zinc-400 hover:text-zinc-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-praetor/40 rounded cursor-move flex-shrink-0 px-0.5"
-                                      >
-                                        <i
-                                          className="fa-solid fa-grip-vertical text-[10px]"
-                                          aria-hidden="true"
-                                        ></i>
-                                      </button>
-                                      <button
-                                        type="button"
-                                        onClick={(e) => {
-                                          e.stopPropagation();
-                                          applyView(view);
-                                        }}
-                                        className="flex-1 min-w-0 flex items-center gap-1.5 text-left"
-                                        title={view.name}
-                                      >
-                                        {isActive && (
-                                          <i className="fa-solid fa-check text-[10px] text-praetor flex-shrink-0"></i>
-                                        )}
-                                        <span
-                                          className={`text-[11px] truncate ${
-                                            isActive
-                                              ? 'text-praetor font-bold'
-                                              : 'text-zinc-600 font-semibold'
-                                          }`}
-                                        >
-                                          {view.name}
-                                        </span>
-                                      </button>
-                                      <div className="flex items-center gap-0.5 opacity-60 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity flex-shrink-0">
-                                        <ViewActionButton
-                                          icon="fa-pen"
-                                          title={t('table.renameView')}
-                                          onClick={(e) => {
-                                            e.stopPropagation();
-                                            setModalState({ kind: 'edit', view });
-                                            setViewsSubmenuOpen(false);
-                                          }}
-                                        />
-                                        <ViewActionButton
-                                          icon={isCopied ? 'fa-check' : 'fa-copy'}
-                                          title={
-                                            isCopied ? t('table.viewCopied') : t('table.exportView')
-                                          }
-                                          onClick={(e) => {
-                                            e.stopPropagation();
-                                            void exportView(view);
-                                          }}
-                                          className={`hover:bg-zinc-200 ${isCopied ? 'text-praetor' : 'text-zinc-500'}`}
-                                        />
-                                        <ViewActionButton
-                                          icon="fa-trash"
-                                          title={t('table.deleteView')}
-                                          onClick={(e) => {
-                                            e.stopPropagation();
-                                            deleteView(view.id);
-                                          }}
-                                          className="hover:bg-red-100 hover:text-red-600 text-red-600"
-                                        />
-                                      </div>
-                                    </div>
-                                  );
-                                })}
-                              </div>
-                            )}
-                            <div className="p-2 border-t border-zinc-100 space-y-1">
-                              <div className="flex items-center gap-1">
-                                <button
-                                  type="button"
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    setModalState({ kind: 'create' });
-                                    setViewsSubmenuOpen(false);
-                                  }}
-                                  className="flex-1 px-3 py-1.5 text-[11px] font-semibold text-zinc-600 hover:text-white bg-zinc-50 hover:bg-praetor rounded-lg transition-all flex items-center justify-center gap-1.5"
-                                >
-                                  <i className="fa-solid fa-plus text-[10px]"></i>
-                                  <span>{t('buttons.add')}</span>
-                                </button>
-                                <button
-                                  type="button"
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    void importView();
-                                  }}
-                                  className="flex-1 px-3 py-1.5 text-[11px] font-semibold text-zinc-600 hover:bg-zinc-100 rounded-lg transition-colors flex items-center justify-center gap-1.5"
-                                >
-                                  <i className="fa-solid fa-file-import text-[10px]"></i>
-                                  <span>{t('buttons.import')}</span>
-                                </button>
-                              </div>
-                              {viewError && (
-                                <div
-                                  role="alert"
-                                  className="text-[10px] text-red-500 text-center px-1 pt-1"
-                                >
-                                  {viewError}
-                                </div>
-                              )}
-                            </div>
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  )}
-                </div>
-              </div>
-            )}
-            {headerExtras}
-            {headerAction}
+                          {viewError}
+                        </div>
+                      )}
+                    </DropdownMenuSubContent>
+                  </DropdownMenuSub>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
           </div>
-        ) : null}
+        )}
       </div>
 
       <div
         className={`${tableContainerClassName ?? 'overflow-x-auto custom-horizontal-scrollbar'} ${resizingColId ? 'select-none' : ''}`}
       >
         {columns && data ? (
-          <table className="w-full text-left border-separate border-spacing-0">
-            {(paginatedData.length > 0 ||
-              Object.keys(filterState).length > 0 ||
-              sortState !== null) && (
-              <thead className="bg-zinc-50">
-                <tr>
-                  {visibleColumns.map((col, colIdx) => {
+          <Table className="w-full text-left">
+            <TableHeader>
+              {table.getHeaderGroups().map((headerGroup) => (
+                <TableRow key={headerGroup.id} className="hover:bg-transparent">
+                  {headerGroup.headers.map((header, colIdx) => {
+                    const col = colsById.get(header.column.id);
+                    if (!col) return null;
                     const colId = getColId(col);
-                    const isFiltered = filterState[colId] && filterState[colId].length > 0;
-                    const isSorted = sortState?.colId === colId;
                     const isFirstColumn = colIdx === 0;
-                    const isLastColumn = colIdx === visibleColumns.length - 1;
+                    const isLastColumn = colIdx === headerGroup.headers.length - 1;
                     const isStretchColumn = colIdx === stretchColumnIdx;
                     // Force alignment: first column left, last column right, otherwise use col.align
                     const effectiveAlign = isFirstColumn
@@ -1235,10 +1318,11 @@ const StandardTable = <T extends object>({
                         ? 'right'
                         : col.align;
                     const colWidth = columnWidths[colId];
+                    const sorted = header.column.getIsSorted();
 
                     return (
-                      <th
-                        key={colId}
+                      <TableHead
+                        key={header.id}
                         style={
                           colWidth
                             ? { width: colWidth, minWidth: colWidth }
@@ -1246,86 +1330,58 @@ const StandardTable = <T extends object>({
                               ? { minWidth: '40px', width: 'auto' }
                               : undefined
                         }
-                        className={`relative group ${isLastColumn ? 'pl-3 pr-2' : 'px-3'} py-1.5 text-[10px] font-black text-zinc-400 uppercase tracking-widest whitespace-nowrap border-b border-zinc-100 ${isStretchColumn ? 'w-full' : col.sticky === 'right' ? 'w-auto' : 'w-px'} ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''} ${!isLastColumn ? 'border-r border-zinc-100' : ''} ${col.sticky === 'right' ? 'sticky right-0 bg-zinc-50 border-l border-zinc-200 z-20 shadow-[-4px_0_6px_-1px_rgba(0,0,0,0.05)]' : ''} ${col.headerClassName || ''}`}
+                        className={`relative group h-10 ${isLastColumn ? 'pl-3 pr-2' : 'px-3'} whitespace-nowrap ${isStretchColumn ? 'w-full' : col.sticky === 'right' ? 'w-auto' : 'w-px'} ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''} ${col.sticky === 'right' ? 'sticky right-0 bg-card border-l border-border z-20 shadow-[-4px_0_6px_-1px_rgba(0,0,0,0.05)]' : ''} ${col.headerClassName || ''}`}
                       >
-                        <span className="inline-flex items-center gap-1">
-                          <span>{col.header}</span>
-
-                          {!col.disableFiltering && (
-                            <button
-                              type="button"
-                              ref={activeFilterCol === colId ? filterRef : undefined}
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                if (activeFilterCol === colId) {
-                                  setActiveFilterCol(null);
-                                } else {
-                                  const rect = e.currentTarget.getBoundingClientRect();
-                                  setFilterPos(getFilterPopupPosition(rect));
-                                  setActiveFilterCol(colId);
-                                }
-                              }}
-                              className={`p-1 rounded hover:bg-zinc-200 transition-colors ${
-                                isFiltered || isSorted || activeFilterCol === colId
-                                  ? 'text-praetor'
-                                  : 'text-zinc-400'
-                              }`}
-                            >
-                              <i className="fa-solid fa-filter"></i>
-                            </button>
+                        <button
+                          type="button"
+                          disabled={!header.column.getCanSort()}
+                          onClick={header.column.getToggleSortingHandler()}
+                          className={`inline-flex items-center gap-1 rounded-sm text-sm font-medium text-muted-foreground outline-none transition-colors hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-100 ${effectiveAlign === 'right' ? 'justify-end' : effectiveAlign === 'center' ? 'justify-center' : 'justify-start'}`}
+                        >
+                          {header.isPlaceholder
+                            ? null
+                            : flexRender(header.column.columnDef.header, header.getContext())}
+                          {header.column.getCanSort() && (
+                            <i
+                              className={`fa-solid ${
+                                sorted === 'asc'
+                                  ? 'fa-arrow-up'
+                                  : sorted === 'desc'
+                                    ? 'fa-arrow-down'
+                                    : 'fa-arrow-up-arrow-down'
+                              } text-[10px]`}
+                              aria-hidden="true"
+                            ></i>
                           )}
-                        </span>
+                        </button>
 
                         <div
-                          className={`absolute top-0 right-0 w-1 h-full cursor-col-resize z-10 opacity-0 group-hover:opacity-100 hover:bg-praetor/30 ${resizingColId === colId ? 'opacity-100 bg-praetor/50' : ''}`}
+                          className={`absolute top-0 right-0 z-10 h-full w-1 cursor-col-resize opacity-0 hover:bg-primary/30 group-hover:opacity-100 ${resizingColId === colId ? 'bg-primary/50 opacity-100' : ''}`}
                           onMouseDown={(e) => handleResizeStart(e, colId)}
                         />
-
-                        {activeFilterCol === colId &&
-                          filterPos &&
-                          createPortal(
-                            <div
-                              ref={popupRef}
-                              style={{
-                                top: filterPos.top,
-                                left: filterPos.left,
-                                position: 'absolute',
-                                zIndex: 9999,
-                              }}
-                            >
-                              <TableFilter
-                                title={col.header}
-                                options={getFilterOptions(colId)}
-                                selectedValues={filterState[colId] || []}
-                                onFilterChange={(selected) => handleFilter(colId, selected)}
-                                sortDirection={sortState?.colId === colId ? sortState.px : null}
-                                onSortChange={(dir) => handleSort(colId, dir)}
-                                onClose={() => setActiveFilterCol(null)}
-                              />
-                            </div>,
-                            document.body,
-                          )}
-                      </th>
+                      </TableHead>
                     );
                   })}
-                </tr>
-              </thead>
-            )}
-            <tbody>
-              {paginatedData.length > 0 ? (
-                paginatedData.map((row, idx) => {
-                  const isLastRow = idx === paginatedData.length - 1;
+                </TableRow>
+              ))}
+            </TableHeader>
+            <TableBody>
+              {paginatedRows.length > 0 ? (
+                paginatedRows.map((tableRow) => {
+                  const row = tableRow.original;
+                  const visibleCells = tableRow.getVisibleCells();
                   return (
-                    <tr
-                      key={idx}
+                    <TableRow
+                      key={tableRow.id}
                       onClick={() => !disabledRow?.(row) && onRowClick?.(row)}
-                      className={`group transition-colors ${fontSizeClass} ${disabledRow?.(row) ? 'bg-zinc-300 text-zinc-500' : `${onRowClick ? 'cursor-pointer' : ''} ${rowClassName ? rowClassName(row) : 'hover:bg-zinc-50/50'}`}`}
+                      className={`group transition-colors ${fontSizeClass} ${disabledRow?.(row) ? 'bg-muted text-muted-foreground opacity-70' : `${onRowClick ? 'cursor-pointer' : ''} ${rowClassName ? rowClassName(row) : 'hover:bg-muted/50'}`}`}
                     >
-                      {visibleColumns.map((col, colIdx) => {
-                        const colId = getColId(col);
-                        const val = getValue(row, col);
+                      {visibleCells.map((cell, colIdx) => {
+                        const colId = cell.column.id;
+                        const col = colsById.get(colId);
+                        if (!col) return null;
                         const isFirstColumn = colIdx === 0;
-                        const isLastColumn = colIdx === visibleColumns.length - 1;
+                        const isLastColumn = colIdx === visibleCells.length - 1;
                         const isStretchColumn = colIdx === stretchColumnIdx;
                         // Force alignment: first column left, last column right, otherwise use col.align
                         const effectiveAlign = isFirstColumn
@@ -1335,8 +1391,8 @@ const StandardTable = <T extends object>({
                             : col.align;
                         const colWidth = columnWidths[colId];
                         return (
-                          <td
-                            key={colId}
+                          <TableCell
+                            key={cell.id}
                             onDoubleClick={(e) => {
                               e.stopPropagation();
                               col.onCellDoubleClick?.(row);
@@ -1348,37 +1404,33 @@ const StandardTable = <T extends object>({
                                   ? { minWidth: '40px' }
                                   : undefined
                             }
-                            className={`${isLastColumn ? 'pl-3 pr-2' : 'px-3'} py-px whitespace-nowrap ${col.sticky === 'right' ? 'w-auto text-right' : `${isStretchColumn ? 'w-full' : 'w-px'} align-middle ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''}`} ${!isLastColumn ? 'border-r border-zinc-100' : ''} ${!isLastRow ? 'border-b border-zinc-100' : ''} ${col.sticky === 'right' ? 'sticky right-0 bg-white group-hover:bg-zinc-50 transition-all duration-500 border-l border-zinc-200 z-20 shadow-[-4px_0_6px_-1px_rgba(0,0,0,0.05)]' : ''} ${col.className || ''}`}
+                            className={`${isLastColumn ? 'pl-3 pr-2' : 'px-3'} py-2 whitespace-nowrap ${col.sticky === 'right' ? 'w-auto text-right' : `${isStretchColumn ? 'w-full' : 'w-px'} align-middle ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''}`} ${col.sticky === 'right' ? 'sticky right-0 bg-card group-hover:bg-muted/50 transition-colors border-l border-border z-20 shadow-[-4px_0_6px_-1px_rgba(0,0,0,0.05)]' : ''} ${col.className || ''}`}
                           >
                             {col.sticky === 'right' ? (
                               <div className="flex justify-end items-center size-full">
-                                {col.cell
-                                  ? col.cell({ getValue: () => val, row, value: val })
-                                  : (val as ReactNode)}
+                                {flexRender(cell.column.columnDef.cell, cell.getContext())}
                               </div>
-                            ) : col.cell ? (
-                              col.cell({ getValue: () => val, row, value: val })
                             ) : (
-                              (val as ReactNode)
+                              flexRender(cell.column.columnDef.cell, cell.getContext())
                             )}
-                          </td>
+                          </TableCell>
                         );
                       })}
-                    </tr>
+                    </TableRow>
                   );
                 })
               ) : (
-                <tr>
-                  <td
+                <TableRow>
+                  <TableCell
                     colSpan={Math.max(visibleColumns.length, 1)}
-                    className="p-12 text-center text-zinc-400 text-sm font-bold"
+                    className="p-12 text-center text-sm font-medium text-muted-foreground"
                   >
                     {emptyState ?? t('table.noResults')}
-                  </td>
-                </tr>
+                  </TableCell>
+                </TableRow>
               )}
-            </tbody>
-          </table>
+            </TableBody>
+          </Table>
         ) : (
           children
         )}
@@ -1386,7 +1438,7 @@ const StandardTable = <T extends object>({
 
       {(externalFooter || (data && columns)) && (
         <div
-          className={`px-3 py-2 bg-zinc-50 border-t border-zinc-200 rounded-b-3xl ${
+          className={`px-3 py-2 bg-muted/50 border-t border-border rounded-b-md ${
             footerClassName ?? 'flex justify-between items-center flex-wrap gap-4'
           }`}
         >
@@ -1414,22 +1466,22 @@ const StandardTable = <T extends object>({
 
       {data && columns && pasteModalOpen && (
         <Modal isOpen={pasteModalOpen} onClose={closePasteModal}>
-          <div className="bg-white rounded-2xl shadow-2xl w-full max-w-md animate-in zoom-in-95 duration-200">
-            <div className="px-6 py-4 border-b border-zinc-100 bg-zinc-50/50 rounded-t-2xl flex items-center justify-between">
-              <h3 className="text-lg font-semibold text-zinc-800 flex items-center gap-2">
-                <i className="fa-solid fa-file-import text-praetor"></i>
+          <div className="w-full max-w-md rounded-md border border-border bg-card shadow-lg animate-in zoom-in-95 duration-200">
+            <div className="flex items-center justify-between border-b border-border px-6 py-4">
+              <h3 className="flex items-center gap-2 text-lg font-semibold">
+                <i className="fa-solid fa-file-import text-primary"></i>
                 {t('table.pasteViewTitle')}
               </h3>
               <button
                 type="button"
                 onClick={closePasteModal}
-                className="text-zinc-400 hover:text-zinc-600 transition-colors"
+                className="rounded-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none"
               >
                 <i className="fa-solid fa-xmark"></i>
               </button>
             </div>
             <div className="px-6 py-5 space-y-3">
-              <p className="text-xs text-zinc-500">{t('table.pasteViewDescription')}</p>
+              <p className="text-xs text-muted-foreground">{t('table.pasteViewDescription')}</p>
               <textarea
                 value={pasteText}
                 onChange={(e) => {
@@ -1438,7 +1490,7 @@ const StandardTable = <T extends object>({
                 }}
                 placeholder={t('table.pasteViewPlaceholder')}
                 rows={6}
-                className="w-full px-3 py-2 border border-zinc-200 rounded-lg text-xs font-mono focus:outline-none focus:ring-2 focus:ring-praetor/30 focus:border-praetor resize-y"
+                className="w-full resize-y rounded-md border border-input bg-background px-3 py-2 font-mono text-xs shadow-xs outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
               />
               {pasteError && (
                 <div role="alert" className="text-[11px] text-red-500">
@@ -1446,22 +1498,18 @@ const StandardTable = <T extends object>({
                 </div>
               )}
             </div>
-            <div className="px-6 py-3 border-t border-zinc-100 bg-zinc-50/50 rounded-b-2xl flex items-center justify-end gap-2">
-              <button
-                type="button"
-                onClick={closePasteModal}
-                className="px-4 py-2 text-xs font-bold text-zinc-600 hover:bg-zinc-100 rounded-lg transition-colors"
-              >
+            <div className="flex items-center justify-end gap-2 border-t border-border px-6 py-3">
+              <Button type="button" variant="ghost" size="sm" onClick={closePasteModal}>
                 {t('table.cancel')}
-              </button>
-              <button
+              </Button>
+              <Button
                 type="button"
+                size="sm"
                 onClick={submitPasteImport}
                 disabled={pasteText.trim().length === 0}
-                className="px-4 py-2 text-xs font-bold text-white bg-praetor hover:bg-praetor/90 disabled:opacity-50 disabled:cursor-not-allowed rounded-lg transition-colors"
               >
                 {t('table.importView')}
-              </button>
+              </Button>
             </div>
           </div>
         </Modal>

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -15,7 +15,7 @@ import {
   useReactTable,
   type VisibilityState,
 } from '@tanstack/react-table';
-import { ArrowDown, ArrowUp, ArrowUpDown } from 'lucide-react';
+import { ArrowDown, ArrowUp, ArrowUpDown, ZoomIn, ZoomOut } from 'lucide-react';
 import {
   Children,
   Fragment,
@@ -1015,6 +1015,7 @@ const StandardTable = <T extends object>({
   const renderToolbarButton = ({
     tooltipKey,
     iconClass,
+    icon,
     onClick,
     disabled = false,
     active = false,
@@ -1023,7 +1024,8 @@ const StandardTable = <T extends object>({
     text,
   }: {
     tooltipKey: string;
-    iconClass: string;
+    iconClass?: string;
+    icon?: ReactNode;
     onClick: () => void;
     disabled?: boolean;
     active?: boolean;
@@ -1048,7 +1050,7 @@ const StandardTable = <T extends object>({
             }}
             disabled={disabled}
           >
-            <i className={`fa-solid ${iconClass} text-xs`} aria-hidden="true"></i>
+            {icon ?? <i className={`fa-solid ${iconClass} text-xs`} aria-hidden="true"></i>}
             {text && <span>{text}</span>}
           </Button>
         )}
@@ -1255,13 +1257,13 @@ const StandardTable = <T extends object>({
               })}
               {renderToolbarButton({
                 tooltipKey: 'table.decreaseFont',
-                iconClass: 'fa-minus',
+                icon: <ZoomOut className="size-3.5" aria-hidden="true" />,
                 onClick: () => stepFontSize(-1),
                 disabled: fontSize === 'xs',
               })}
               {renderToolbarButton({
                 tooltipKey: 'table.increaseFont',
-                iconClass: 'fa-plus',
+                icon: <ZoomIn className="size-3.5" aria-hidden="true" />,
                 onClick: () => stepFontSize(1),
                 disabled: fontSize === 'base',
               })}

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -9,6 +9,7 @@ import {
   getSortedRowModel,
   type PaginationState,
   type SortingState,
+  type Column as TanStackColumn,
   type Updater,
   useReactTable,
   type VisibilityState,
@@ -31,7 +32,6 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from '../ui/dropdown-menu';
-import { Input } from '../ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table';
 import CustomViewModal from './CustomViewModal';
@@ -146,7 +146,6 @@ const StandardTable = <T extends object>({
 
   const [currentPage, setCurrentPage] = useState(1);
   const [gearOpen, setGearOpen] = useState(false);
-  const [filtersOpen, setFiltersOpen] = useState(false);
   const [resizingColId, setResizingColId] = useState<string | null>(null);
 
   const [rowsPerPage, setRowsPerPage] = useState(() => {
@@ -556,21 +555,6 @@ const StandardTable = <T extends object>({
   const totalPages = data ? table.getPageCount() : Math.ceil(totalItems / rowsPerPage);
   const startIndex = (currentPage - 1) * rowsPerPage;
   const paginatedRows = data ? table.getRowModel().rows : [];
-  const filterableTableColumns = table
-    .getAllLeafColumns()
-    .filter((column) => column.getCanFilter() && colsById.has(column.id));
-  const primaryFilterColumn =
-    filterableTableColumns.find((column) => column.getIsVisible()) ?? filterableTableColumns[0];
-  const primaryFilterSourceColumn = primaryFilterColumn
-    ? colsById.get(primaryFilterColumn.id)
-    : undefined;
-  const primaryFilterValue = primaryFilterColumn?.getFilterValue();
-  const primaryFilterText = Array.isArray(primaryFilterValue)
-    ? primaryFilterValue.join(', ')
-    : typeof primaryFilterValue === 'string'
-      ? primaryFilterValue
-      : '';
-  const hasActiveFilters = table.getState().columnFilters.length > 0;
 
   useEffect(() => {
     if (totalPages === 0) {
@@ -597,6 +581,13 @@ const StandardTable = <T extends object>({
   }, [data, columns, getValue, formatForFilter, getColId]);
 
   const getFilterOptions = (colId: string) => filterOptionsByCol.get(colId) ?? [];
+
+  const getSelectedFilterValues = (column: TanStackColumn<T, unknown>) => {
+    const filterValue = column.getFilterValue();
+    if (Array.isArray(filterValue)) return filterValue as string[];
+    if (typeof filterValue === 'string') return [filterValue];
+    return [];
+  };
 
   const stepFontSize = (delta: -1 | 1) => {
     setFontSize((prev) => {
@@ -820,6 +811,79 @@ const StandardTable = <T extends object>({
     );
   };
 
+  const renderHeaderFilter = (column: TanStackColumn<T, unknown>, sourceColumn: Column<T>) => {
+    if (!column.getCanFilter()) return null;
+    const selectedValues = getSelectedFilterValues(column);
+    const hasFilter = selectedValues.length > 0;
+    const options = getFilterOptions(column.id);
+
+    return (
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant={hasFilter ? 'secondary' : 'ghost'}
+            size="icon-xs"
+            aria-label={`${t('table.filters')} ${sourceColumn.header}`}
+            onClick={(event) => event.stopPropagation()}
+            className="size-6"
+          >
+            <i className="fa-solid fa-filter text-[10px]" aria-hidden="true"></i>
+            {hasFilter && <span className="sr-only">{selectedValues.length}</span>}
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="start"
+          className="w-64"
+          onClick={(event) => event.stopPropagation()}
+        >
+          <DropdownMenuLabel className="text-xs">{sourceColumn.header}</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <div className="max-h-64 overflow-y-auto">
+            {options.length > 0 ? (
+              options.map((option) => (
+                <DropdownMenuCheckboxItem
+                  key={option || '__empty__'}
+                  checked={selectedValues.includes(option)}
+                  onSelect={(event) => {
+                    event.preventDefault();
+                    const next = selectedValues.includes(option)
+                      ? selectedValues.filter((value) => value !== option)
+                      : [...selectedValues, option];
+                    column.setFilterValue(next.length > 0 ? next : undefined);
+                    table.setPageIndex(0);
+                  }}
+                  className="text-xs"
+                >
+                  <span className="truncate">{option || t('table.empty')}</span>
+                </DropdownMenuCheckboxItem>
+              ))
+            ) : (
+              <DropdownMenuItem disabled className="text-xs">
+                {t('table.noResults')}
+              </DropdownMenuItem>
+            )}
+          </div>
+          {hasFilter && (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onSelect={(event) => {
+                  event.preventDefault();
+                  column.setFilterValue(undefined);
+                  table.setPageIndex(0);
+                }}
+                className="text-xs"
+              >
+                {t('table.clearFilter')}
+              </DropdownMenuItem>
+            </>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    );
+  };
+
   const renderInternalFooter = () => (
     <>
       <div className="flex items-center gap-3 text-sm text-muted-foreground">
@@ -886,136 +950,21 @@ const StandardTable = <T extends object>({
   );
 
   return (
-    <div
-      className={`rounded-md border border-border bg-card shadow-sm ${containerClassName ?? ''}`.trim()}
-    >
-      <div className="space-y-4 border-b border-border bg-card p-4">
-        <div className="flex items-center justify-between gap-4">
-          <div className="flex items-center gap-3">
-            <h4 className="text-sm font-medium text-muted-foreground">{title}</h4>
-            {typeof totalItems === 'number' && (
-              <span className="inline-flex items-center rounded-md border border-border bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
-                {totalItems} {totalLabel || t('table.total')}
-              </span>
-            )}
-          </div>
-          {(headerExtras || headerAction) && (
-            <div className="flex items-center gap-3">
-              {headerExtras}
-              {headerAction}
-            </div>
+    <div className={`w-full space-y-3 ${containerClassName ?? ''}`.trim()}>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <h4 className="text-sm font-medium text-muted-foreground">{title}</h4>
+          {typeof totalItems === 'number' && (
+            <span className="inline-flex items-center rounded-md border border-border bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+              {totalItems} {totalLabel || t('table.total')}
+            </span>
           )}
         </div>
-        {data != null && columns != null && (
-          <div className="flex flex-wrap items-center justify-between gap-2">
-            <Input
-              placeholder={
-                primaryFilterSourceColumn
-                  ? `${t('table.search')} ${primaryFilterSourceColumn.header}`
-                  : t('table.search')
-              }
-              value={primaryFilterText}
-              onChange={(event) => {
-                primaryFilterColumn?.setFilterValue(event.target.value || undefined);
-                table.setPageIndex(0);
-              }}
-              disabled={!primaryFilterColumn}
-              className="h-8 max-w-sm"
-            />
-            <div className="flex items-center gap-2">
-              <DropdownMenu open={filtersOpen} onOpenChange={setFiltersOpen}>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    type="button"
-                    variant={hasActiveFilters ? 'secondary' : 'outline'}
-                    size="sm"
-                  >
-                    <i className="fa-solid fa-filter text-[10px]" aria-hidden="true"></i>
-                    {t('table.filters')}
-                    <i className="fa-solid fa-chevron-down text-[10px]" aria-hidden="true"></i>
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="w-64">
-                  <DropdownMenuLabel className="text-xs">{t('table.filters')}</DropdownMenuLabel>
-                  <DropdownMenuSeparator />
-                  {filterableTableColumns.map((column) => {
-                    const sourceColumn = colsById.get(column.id);
-                    if (!sourceColumn) return null;
-                    const selectedValues = Array.isArray(column.getFilterValue())
-                      ? (column.getFilterValue() as string[])
-                      : typeof column.getFilterValue() === 'string'
-                        ? [column.getFilterValue() as string]
-                        : [];
-                    return (
-                      <DropdownMenuSub key={column.id}>
-                        <DropdownMenuSubTrigger className="text-xs">
-                          <span className="truncate">{sourceColumn.header}</span>
-                          {selectedValues.length > 0 && (
-                            <span className="ml-auto text-xs text-muted-foreground">
-                              {selectedValues.length}
-                            </span>
-                          )}
-                        </DropdownMenuSubTrigger>
-                        <DropdownMenuSubContent className="w-64">
-                          <DropdownMenuLabel className="text-xs">
-                            {sourceColumn.header}
-                          </DropdownMenuLabel>
-                          <DropdownMenuSeparator />
-                          <div className="max-h-64 overflow-y-auto">
-                            {getFilterOptions(column.id).map((option) => (
-                              <DropdownMenuCheckboxItem
-                                key={option || '__empty__'}
-                                checked={selectedValues.includes(option)}
-                                onSelect={(event) => {
-                                  event.preventDefault();
-                                  const next = selectedValues.includes(option)
-                                    ? selectedValues.filter((value) => value !== option)
-                                    : [...selectedValues, option];
-                                  column.setFilterValue(next.length > 0 ? next : undefined);
-                                  table.setPageIndex(0);
-                                }}
-                                className="text-xs"
-                              >
-                                <span className="truncate">{option || t('table.empty')}</span>
-                              </DropdownMenuCheckboxItem>
-                            ))}
-                          </div>
-                          {selectedValues.length > 0 && (
-                            <>
-                              <DropdownMenuSeparator />
-                              <DropdownMenuItem
-                                onSelect={(event) => {
-                                  event.preventDefault();
-                                  column.setFilterValue(undefined);
-                                  table.setPageIndex(0);
-                                }}
-                                className="text-xs"
-                              >
-                                {t('table.clearFilter')}
-                              </DropdownMenuItem>
-                            </>
-                          )}
-                        </DropdownMenuSubContent>
-                      </DropdownMenuSub>
-                    );
-                  })}
-                  {hasActiveFilters && (
-                    <>
-                      <DropdownMenuSeparator />
-                      <DropdownMenuItem
-                        onSelect={(event) => {
-                          event.preventDefault();
-                          table.resetColumnFilters();
-                          table.setPageIndex(0);
-                        }}
-                        className="text-xs"
-                      >
-                        {t('filters.clearFilters')}
-                      </DropdownMenuItem>
-                    </>
-                  )}
-                </DropdownMenuContent>
-              </DropdownMenu>
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          {headerExtras}
+          {headerAction}
+          {data != null && columns != null && (
+            <>
               {renderToolbarButton({
                 tooltipKey: 'table.exportToCsv',
                 iconClass: 'fa-file-export',
@@ -1291,23 +1240,24 @@ const StandardTable = <T extends object>({
                   </DropdownMenuSub>
                 </DropdownMenuContent>
               </DropdownMenu>
-            </div>
-          </div>
-        )}
+            </>
+          )}
+        </div>
       </div>
 
       <div
-        className={`${tableContainerClassName ?? 'overflow-x-auto custom-horizontal-scrollbar'} ${resizingColId ? 'select-none' : ''}`}
+        className={`rounded-md border border-border bg-card shadow-sm ${tableContainerClassName ?? 'overflow-x-auto'} ${resizingColId ? 'select-none' : ''}`}
       >
         {columns && data ? (
           <Table className="w-full text-left">
             <TableHeader>
               {table.getHeaderGroups().map((headerGroup) => (
-                <TableRow key={headerGroup.id} className="hover:bg-transparent">
+                <TableRow key={headerGroup.id} className="border-border hover:bg-transparent">
                   {headerGroup.headers.map((header, colIdx) => {
                     const col = colsById.get(header.column.id);
                     if (!col) return null;
                     const colId = getColId(col);
+                    const isActionColumn = col.sticky === 'right';
                     const isFirstColumn = colIdx === 0;
                     const isLastColumn = colIdx === headerGroup.headers.length - 1;
                     const isStretchColumn = colIdx === stretchColumnIdx;
@@ -1326,39 +1276,51 @@ const StandardTable = <T extends object>({
                         style={
                           colWidth
                             ? { width: colWidth, minWidth: colWidth }
-                            : col.sticky === 'right'
+                            : isActionColumn
                               ? { minWidth: '40px', width: 'auto' }
                               : undefined
                         }
-                        className={`relative group h-10 ${isLastColumn ? 'pl-3 pr-2' : 'px-3'} whitespace-nowrap ${isStretchColumn ? 'w-full' : col.sticky === 'right' ? 'w-auto' : 'w-px'} ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''} ${col.sticky === 'right' ? 'sticky right-0 bg-card border-l border-border z-20 shadow-[-4px_0_6px_-1px_rgba(0,0,0,0.05)]' : ''} ${col.headerClassName || ''}`}
+                        aria-label={isActionColumn ? col.header : undefined}
+                        className={`relative group h-10 border-border ${isLastColumn ? 'pl-3 pr-2' : 'px-3'} whitespace-nowrap ${isStretchColumn ? 'w-full' : isActionColumn ? 'w-auto' : 'w-px'} ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''} ${isActionColumn ? 'sticky right-0 z-20 border-l border-border bg-background' : ''} ${col.headerClassName || ''}`}
                       >
-                        <button
-                          type="button"
-                          disabled={!header.column.getCanSort()}
-                          onClick={header.column.getToggleSortingHandler()}
-                          className={`inline-flex items-center gap-1 rounded-sm text-sm font-medium text-muted-foreground outline-none transition-colors hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-100 ${effectiveAlign === 'right' ? 'justify-end' : effectiveAlign === 'center' ? 'justify-center' : 'justify-start'}`}
-                        >
-                          {header.isPlaceholder
-                            ? null
-                            : flexRender(header.column.columnDef.header, header.getContext())}
-                          {header.column.getCanSort() && (
-                            <i
-                              className={`fa-solid ${
-                                sorted === 'asc'
-                                  ? 'fa-arrow-up'
-                                  : sorted === 'desc'
-                                    ? 'fa-arrow-down'
-                                    : 'fa-arrow-up-arrow-down'
-                              } text-[10px]`}
-                              aria-hidden="true"
-                            ></i>
-                          )}
-                        </button>
+                        {!isActionColumn && (
+                          <div
+                            className={`flex items-center gap-1 ${effectiveAlign === 'right' ? 'justify-end' : effectiveAlign === 'center' ? 'justify-center' : 'justify-start'}`}
+                          >
+                            <button
+                              type="button"
+                              disabled={!header.column.getCanSort()}
+                              onClick={header.column.getToggleSortingHandler()}
+                              className="inline-flex min-w-0 items-center gap-1 rounded-sm text-sm font-medium text-muted-foreground outline-none transition-colors hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-100"
+                            >
+                              <span className="truncate">
+                                {header.isPlaceholder
+                                  ? null
+                                  : flexRender(header.column.columnDef.header, header.getContext())}
+                              </span>
+                              {header.column.getCanSort() && (
+                                <i
+                                  className={`fa-solid ${
+                                    sorted === 'asc'
+                                      ? 'fa-arrow-up'
+                                      : sorted === 'desc'
+                                        ? 'fa-arrow-down'
+                                        : 'fa-arrow-up-arrow-down'
+                                  } text-[10px]`}
+                                  aria-hidden="true"
+                                ></i>
+                              )}
+                            </button>
+                            {renderHeaderFilter(header.column, col)}
+                          </div>
+                        )}
 
-                        <div
-                          className={`absolute top-0 right-0 z-10 h-full w-1 cursor-col-resize opacity-0 hover:bg-primary/30 group-hover:opacity-100 ${resizingColId === colId ? 'bg-primary/50 opacity-100' : ''}`}
-                          onMouseDown={(e) => handleResizeStart(e, colId)}
-                        />
+                        {!isActionColumn && (
+                          <div
+                            className={`absolute top-0 right-0 z-10 h-full w-1 cursor-col-resize opacity-0 hover:bg-primary/30 group-hover:opacity-100 ${resizingColId === colId ? 'bg-primary/50 opacity-100' : ''}`}
+                            onMouseDown={(e) => handleResizeStart(e, colId)}
+                          />
+                        )}
                       </TableHead>
                     );
                   })}
@@ -1374,12 +1336,13 @@ const StandardTable = <T extends object>({
                     <TableRow
                       key={tableRow.id}
                       onClick={() => !disabledRow?.(row) && onRowClick?.(row)}
-                      className={`group transition-colors ${fontSizeClass} ${disabledRow?.(row) ? 'bg-muted text-muted-foreground opacity-70' : `${onRowClick ? 'cursor-pointer' : ''} ${rowClassName ? rowClassName(row) : 'hover:bg-muted/50'}`}`}
+                      className={`group border-border transition-colors ${fontSizeClass} ${disabledRow?.(row) ? 'bg-muted text-muted-foreground opacity-70' : `${onRowClick ? 'cursor-pointer' : ''} ${rowClassName ? rowClassName(row) : 'hover:bg-muted/50'}`}`}
                     >
                       {visibleCells.map((cell, colIdx) => {
                         const colId = cell.column.id;
                         const col = colsById.get(colId);
                         if (!col) return null;
+                        const isActionColumn = col.sticky === 'right';
                         const isFirstColumn = colIdx === 0;
                         const isLastColumn = colIdx === visibleCells.length - 1;
                         const isStretchColumn = colIdx === stretchColumnIdx;
@@ -1390,6 +1353,10 @@ const StandardTable = <T extends object>({
                             ? 'right'
                             : col.align;
                         const colWidth = columnWidths[colId];
+                        const cellContent = flexRender(
+                          cell.column.columnDef.cell,
+                          cell.getContext(),
+                        );
                         return (
                           <TableCell
                             key={cell.id}
@@ -1400,18 +1367,41 @@ const StandardTable = <T extends object>({
                             style={
                               colWidth
                                 ? { width: colWidth, minWidth: colWidth }
-                                : col.sticky === 'right'
+                                : isActionColumn
                                   ? { minWidth: '40px' }
                                   : undefined
                             }
-                            className={`${isLastColumn ? 'pl-3 pr-2' : 'px-3'} py-2 whitespace-nowrap ${col.sticky === 'right' ? 'w-auto text-right' : `${isStretchColumn ? 'w-full' : 'w-px'} align-middle ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''}`} ${col.sticky === 'right' ? 'sticky right-0 bg-card group-hover:bg-muted/50 transition-colors border-l border-border z-20 shadow-[-4px_0_6px_-1px_rgba(0,0,0,0.05)]' : ''} ${col.className || ''}`}
+                            className={`${isLastColumn ? 'pl-3 pr-2' : 'px-3'} py-2 whitespace-nowrap ${isActionColumn ? 'w-auto text-right' : `${isStretchColumn ? 'w-full' : 'w-px'} align-middle ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''}`} ${isActionColumn ? 'sticky right-0 z-20 border-l border-border bg-background transition-colors group-hover:bg-muted/50' : ''} ${col.className || ''}`}
                           >
-                            {col.sticky === 'right' ? (
-                              <div className="flex justify-end items-center size-full">
-                                {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                              </div>
+                            {isActionColumn ? (
+                              <DropdownMenu>
+                                <DropdownMenuTrigger asChild>
+                                  <Button
+                                    type="button"
+                                    variant="ghost"
+                                    size="icon-xs"
+                                    aria-label={t('table.rowActions')}
+                                    onClick={(event) => event.stopPropagation()}
+                                  >
+                                    <i
+                                      className="fa-solid fa-ellipsis text-[10px]"
+                                      aria-hidden="true"
+                                    ></i>
+                                  </Button>
+                                </DropdownMenuTrigger>
+                                <DropdownMenuContent
+                                  align="end"
+                                  className="w-auto min-w-10 p-1"
+                                  onClick={(event) => event.stopPropagation()}
+                                  onDoubleClick={(event) => event.stopPropagation()}
+                                >
+                                  <div className="flex items-center justify-end gap-1">
+                                    {cellContent}
+                                  </div>
+                                </DropdownMenuContent>
+                              </DropdownMenu>
                             ) : (
-                              flexRender(cell.column.columnDef.cell, cell.getContext())
+                              cellContent
                             )}
                           </TableCell>
                         );
@@ -1420,7 +1410,7 @@ const StandardTable = <T extends object>({
                   );
                 })
               ) : (
-                <TableRow>
+                <TableRow className="border-border">
                   <TableCell
                     colSpan={Math.max(visibleColumns.length, 1)}
                     className="p-12 text-center text-sm font-medium text-muted-foreground"
@@ -1438,7 +1428,7 @@ const StandardTable = <T extends object>({
 
       {(externalFooter || (data && columns)) && (
         <div
-          className={`px-3 py-2 bg-muted/50 border-t border-border rounded-b-md ${
+          className={`py-1 ${
             footerClassName ?? 'flex justify-between items-center flex-wrap gap-4'
           }`}
         >

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -86,7 +86,8 @@ const sanitizeColumnWidths = (
   if (typeof value !== 'object' || value === null) return {};
   return Object.fromEntries(
     Object.entries(value).filter(
-      ([id, width]) => (!validIds || validIds.has(id)) && typeof width === 'number' && width > 0,
+      ([id, width]) =>
+        (!validIds || validIds.has(id)) && typeof width === 'number' && Number.isFinite(width),
     ),
   );
 };
@@ -102,7 +103,7 @@ type FontSize = (typeof FONT_SIZES)[number];
 
 const VIEW_ERROR_DURATION_MS = 3000;
 const COPIED_FEEDBACK_DURATION_MS = 1500;
-const DEFAULT_MIN_COL_WIDTH = 40;
+const DEFAULT_MIN_COL_WIDTH = 88;
 const HEADER_TEXT_CHAR_WIDTH = 9;
 const HEADER_CELL_HORIZONTAL_PADDING = 24;
 const HEADER_RESIZE_GUTTER_WIDTH = 8;
@@ -111,7 +112,7 @@ const HEADER_SORT_ICON_WIDTH = 12;
 const HEADER_SORT_ICON_GAP = 4;
 const HEADER_FILTER_BUTTON_WIDTH = 24;
 const HEADER_CONTENT_GAP = 4;
-const ACTION_COLUMN_WIDTH = 80;
+const ACTION_COLUMN_WIDTH = 96;
 const TEXT_SM_LINE_HEIGHT_CLASSNAME = 'leading-[var(--text-sm--line-height)]';
 const TABLE_CONTROL_BUTTON_CLASSNAME =
   '!h-7 !gap-1.5 !rounded-lg !px-2 !text-sm !leading-[var(--text-sm--line-height)] !font-medium';
@@ -180,10 +181,6 @@ const StandardTable = <T extends object>({
   initialFilterState,
 }: StandardTableProps<T>) => {
   const { t } = useTranslation('common');
-  const resizeStartXRef = useRef(0);
-  const resizeStartWidthRef = useRef(0);
-  const resizeMinWidthRef = useRef(DEFAULT_MIN_COL_WIDTH);
-  const resizeStartSizingRef = useRef<ColumnSizingState>({});
   const tableContainerRef = useRef<HTMLDivElement | null>(null);
 
   const [sortState, setSortState] = useState<SortState>(null);
@@ -193,8 +190,6 @@ const StandardTable = <T extends object>({
 
   const [currentPage, setCurrentPage] = useState(1);
   const [gearOpen, setGearOpen] = useState(false);
-  const [resizingColId, setResizingColId] = useState<string | null>(null);
-  const [headerMinWidths, setHeaderMinWidths] = useState<Record<string, number>>({});
 
   const [rowsPerPage, setRowsPerPage] = useState(() => {
     if (typeof window === 'undefined') return defaultRowsPerPage;
@@ -314,7 +309,7 @@ const StandardTable = <T extends object>({
     [columns, hiddenColIds, getColId],
   );
 
-  const getStaticColumnMinWidth = useCallback(
+  const getColumnMinWidth = useCallback(
     (col: Column<T>) => {
       const headerTextWidth = String(col.header).length * HEADER_TEXT_CHAR_WIDTH;
       if (isRowActionColumn(col)) {
@@ -343,67 +338,6 @@ const StandardTable = <T extends object>({
     [isRowActionColumn],
   );
 
-  const getMeasuredColumnWidth = useCallback(
-    (col: Column<T>, headerContent: HTMLElement | undefined, includeRenderedWidth = false) => {
-      const minWidth = getStaticColumnMinWidth(col);
-      const headerChromeWidth = isRowActionColumn(col)
-        ? HEADER_CELL_HORIZONTAL_PADDING
-        : HEADER_CELL_HORIZONTAL_PADDING + HEADER_RESIZE_GUTTER_WIDTH;
-      const headerContentWidth = Math.max(
-        headerContent?.scrollWidth ?? 0,
-        headerContent?.getBoundingClientRect().width ?? 0,
-      );
-      const measuredMinWidth = Math.max(
-        minWidth,
-        Math.ceil(headerContentWidth + headerChromeWidth),
-      );
-      if (!includeRenderedWidth) return measuredMinWidth;
-
-      const headerCell = headerContent?.closest('th') as HTMLTableCellElement | null;
-      return Math.max(measuredMinWidth, Math.ceil(headerCell?.getBoundingClientRect().width ?? 0));
-    },
-    [getStaticColumnMinWidth, isRowActionColumn],
-  );
-
-  const measureVisibleColumnWidths = useCallback(
-    (includeRenderedWidth = false) => {
-      const container = tableContainerRef.current;
-      if (!container) return null;
-
-      const contentByColumnId = new Map(
-        Array.from(container.querySelectorAll<HTMLElement>('[data-column-header-content]')).map(
-          (element) => [element.getAttribute('data-column-header-content') ?? '', element],
-        ),
-      );
-      const next: Record<string, number> = {};
-      for (const col of visibleColumns) {
-        const colId = getColId(col);
-        next[colId] = getMeasuredColumnWidth(
-          col,
-          contentByColumnId.get(colId),
-          includeRenderedWidth,
-        );
-      }
-      return next;
-    },
-    [getColId, getMeasuredColumnWidth, visibleColumns],
-  );
-
-  const updateHeaderMinWidths = useCallback(() => {
-    const next = measureVisibleColumnWidths();
-    if (!next) return;
-
-    setHeaderMinWidths((prev) => (numberRecordsEqual(prev, next) ? prev : next));
-  }, [measureVisibleColumnWidths]);
-
-  const getHeaderMinWidth = useCallback(
-    (col: Column<T>) => {
-      const staticMinWidth = getStaticColumnMinWidth(col);
-      return Math.max(headerMinWidths[getColId(col)] ?? 0, staticMinWidth);
-    },
-    [getColId, getStaticColumnMinWidth, headerMinWidths],
-  );
-
   const validColumnSizing = useMemo(() => {
     const validIds = new Set((columns ?? []).map((col) => getColId(col)));
     return sanitizeColumnWidths(columnSizing, validIds);
@@ -416,12 +350,12 @@ const StandardTable = <T extends object>({
       for (const col of columns ?? []) {
         const colId = getColId(col);
         if (next[colId] != null) {
-          next[colId] = Math.max(next[colId], getHeaderMinWidth(col));
+          next[colId] = Math.max(next[colId], getColumnMinWidth(col));
         }
       }
       return next;
     },
-    [columns, getColId, getHeaderMinWidth],
+    [columns, getColId, getColumnMinWidth],
   );
 
   const clampedColumnSizing = useMemo(
@@ -429,15 +363,7 @@ const StandardTable = <T extends object>({
     [clampColumnSizing, validColumnSizing],
   );
 
-  // Rightmost non-sticky column absorbs leftover width. When the last column is
-  // sticky-right, this prevents that sticky column from expanding to fill space.
-  const stretchColumnIdx = useMemo(() => {
-    for (let i = visibleColumns.length - 1; i >= 0; i--) {
-      if (visibleColumns[i].sticky !== 'right') return i;
-    }
-    return -1;
-  }, [visibleColumns]);
-  const usesFixedTableLayout = Object.keys(clampedColumnSizing).length > 0;
+  const usesFixedTableLayout = Boolean(columns && data);
 
   // Excludes statically hidden filter-only columns; sort/filter still target them via colsById.
   const gearColumns = useMemo(() => columns?.filter((col) => !col.hidden) ?? [], [columns]);
@@ -508,59 +434,6 @@ const StandardTable = <T extends object>({
     }
   }, [clampColumnSizing, columnSizing, title]);
 
-  useEffect(() => {
-    if (!resizingColId) return;
-
-    const getClientX = (event: MouseEvent | TouchEvent) => {
-      if ('touches' in event) return event.touches[0]?.clientX ?? event.changedTouches[0]?.clientX;
-      return event.clientX;
-    };
-    const handleResizeMove = (event: MouseEvent | TouchEvent) => {
-      const clientX = getClientX(event);
-      if (typeof clientX !== 'number') return;
-      const delta = clientX - resizeStartXRef.current;
-      if (Math.abs(delta) < 1) return;
-      const newWidth = Math.max(resizeMinWidthRef.current, resizeStartWidthRef.current + delta);
-      setColumnSizing((prev) =>
-        clampColumnSizing({
-          ...resizeStartSizingRef.current,
-          ...prev,
-          [resizingColId]: newWidth,
-        }),
-      );
-    };
-    const handleResizeEnd = () => setResizingColId(null);
-    document.body.style.cursor = 'col-resize';
-    document.addEventListener('mousemove', handleResizeMove);
-    document.addEventListener('touchmove', handleResizeMove);
-    document.addEventListener('mouseup', handleResizeEnd);
-    document.addEventListener('touchend', handleResizeEnd);
-
-    return () => {
-      document.removeEventListener('mousemove', handleResizeMove);
-      document.removeEventListener('touchmove', handleResizeMove);
-      document.removeEventListener('mouseup', handleResizeEnd);
-      document.removeEventListener('touchend', handleResizeEnd);
-      document.body.style.cursor = '';
-    };
-  }, [clampColumnSizing, resizingColId]);
-
-  useEffect(() => {
-    const container = tableContainerRef.current;
-    if (!container) return;
-
-    updateHeaderMinWidths();
-    window.addEventListener('resize', updateHeaderMinWidths);
-
-    const resizeObserver =
-      typeof ResizeObserver !== 'undefined' ? new ResizeObserver(updateHeaderMinWidths) : null;
-    resizeObserver?.observe(container);
-    return () => {
-      window.removeEventListener('resize', updateHeaderMinWidths);
-      resizeObserver?.disconnect();
-    };
-  }, [updateHeaderMinWidths]);
-
   const getValue = useCallback((row: T, col: Column<T>) => {
     if (col.accessorFn) return col.accessorFn(row);
     if (col.accessorKey) return row[col.accessorKey];
@@ -589,7 +462,7 @@ const StandardTable = <T extends object>({
     () =>
       (columns ?? []).map((col) => {
         const colId = getColId(col);
-        const minSize = getHeaderMinWidth(col);
+        const minSize = getColumnMinWidth(col);
         return {
           id: colId,
           accessorFn: (row) => getValue(row, col),
@@ -642,7 +515,7 @@ const StandardTable = <T extends object>({
       clampedColumnSizing,
       columns,
       getColId,
-      getHeaderMinWidth,
+      getColumnMinWidth,
       getValue,
       formatForFilter,
       isRowActionColumn,
@@ -783,7 +656,7 @@ const StandardTable = <T extends object>({
   const paginatedRows = data ? table.getRowModel().rows : [];
   const fixedTableWidth = useMemo(() => {
     if (!usesFixedTableLayout) return undefined;
-    return table.getVisibleLeafColumns().reduce((total, column) => total + column.getSize(), 0);
+    return table.getTotalSize();
   }, [table, usesFixedTableLayout]);
 
   useEffect(() => {
@@ -1634,23 +1507,21 @@ const StandardTable = <T extends object>({
 
       <div
         ref={tableContainerRef}
-        className={`rounded-lg border border-border bg-card shadow-sm ${tableContainerClassName ?? 'overflow-x-auto'} ${resizingColId ? 'select-none' : ''}`}
+        className={`rounded-lg border border-border bg-card shadow-sm ${tableContainerClassName ?? 'overflow-x-auto'}`}
       >
         {columns && data ? (
           <Table
-            className={`text-left ${usesFixedTableLayout ? 'table-fixed' : 'w-full'}`}
+            className="table-fixed text-left"
             style={
               fixedTableWidth ? { width: `${fixedTableWidth}px`, minWidth: '100%' } : undefined
             }
           >
-            {usesFixedTableLayout && (
-              <colgroup>
-                {table.getVisibleLeafColumns().map((column) => {
-                  const colWidth = column.getSize();
-                  return <col key={column.id} style={{ width: colWidth }} />;
-                })}
-              </colgroup>
-            )}
+            <colgroup>
+              {table.getVisibleLeafColumns().map((column) => {
+                const colWidth = column.getSize();
+                return <col key={column.id} style={{ width: colWidth }} />;
+              })}
+            </colgroup>
             <TableHeader>
               {table.getHeaderGroups().map((headerGroup) => (
                 <TableRow key={headerGroup.id} className="border-border hover:bg-transparent">
@@ -1662,35 +1533,26 @@ const StandardTable = <T extends object>({
                     const isActionColumn = isRowActionColumn(col);
                     const isFirstColumn = colIdx === 0;
                     const isLastColumn = colIdx === headerGroup.headers.length - 1;
-                    const isStretchColumn = colIdx === stretchColumnIdx;
                     // Force alignment: first column left, last column right, otherwise use col.align
                     const effectiveAlign = isFirstColumn
                       ? 'left'
                       : isLastColumn
                         ? 'right'
                         : col.align;
-                    const minColumnWidth = getHeaderMinWidth(col);
-                    const colWidth =
-                      usesFixedTableLayout || isActionColumn
-                        ? Math.max(header.getSize(), minColumnWidth)
-                        : undefined;
+                    const minColumnWidth = getColumnMinWidth(col);
+                    const colWidth = Math.max(header.getSize(), minColumnWidth);
                     const sorted = header.column.getIsSorted();
-                    const isResizing = resizingColId === colId || header.column.getIsResizing();
+                    const isResizing = header.column.getIsResizing();
                     const stickyBorderClass =
                       isStickyRightColumn && !isActionColumn ? 'border-l border-border' : '';
+                    const resizeHandler = header.getResizeHandler();
 
                     return (
                       <TableHead
                         key={header.id}
-                        style={
-                          colWidth
-                            ? { width: colWidth, minWidth: colWidth }
-                            : isStickyRightColumn
-                              ? { minWidth: minColumnWidth, width: 'auto' }
-                              : { minWidth: minColumnWidth }
-                        }
+                        style={{ width: colWidth, minWidth: minColumnWidth }}
                         aria-label={isActionColumn ? col.header : undefined}
-                        className={`relative group h-10 border-border ${isLastColumn ? 'pl-3 pr-2' : 'px-3'} whitespace-nowrap ${usesFixedTableLayout ? '' : isStretchColumn ? 'w-full' : isStickyRightColumn ? 'w-auto' : ''} ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''} ${isStickyRightColumn ? `sticky right-0 z-20 bg-card ${stickyBorderClass}` : ''} ${col.headerClassName || ''}`}
+                        className={`relative group h-10 border-border ${isLastColumn ? 'pl-3 pr-2' : 'px-3'} whitespace-nowrap ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''} ${isStickyRightColumn ? `sticky right-0 z-20 bg-card ${stickyBorderClass}` : ''} ${col.headerClassName || ''}`}
                       >
                         {isActionColumn ? (
                           <div
@@ -1743,54 +1605,17 @@ const StandardTable = <T extends object>({
                           </div>
                         )}
 
-                        {!isActionColumn && (
+                        {header.column.getCanResize() && (
                           <div
                             className="absolute top-0 -right-1 z-10 flex h-full w-2 cursor-col-resize items-center justify-center"
                             data-column-resize-handle={colId}
                             onMouseDown={(event) => {
                               event.stopPropagation();
-                              const measuredMinWidths = measureVisibleColumnWidths();
-                              if (measuredMinWidths) {
-                                setHeaderMinWidths((prev) =>
-                                  numberRecordsEqual(prev, measuredMinWidths)
-                                    ? prev
-                                    : measuredMinWidths,
-                                );
-                              }
-                              const measuredWidths = measureVisibleColumnWidths(true);
-                              const minWidth = measuredMinWidths?.[colId] ?? minColumnWidth;
-                              resizeStartXRef.current = event.clientX;
-                              resizeStartWidthRef.current = Math.max(
-                                measuredWidths?.[colId] ?? header.getSize(),
-                                minWidth,
-                              );
-                              resizeMinWidthRef.current = minWidth;
-                              resizeStartSizingRef.current = measuredWidths ?? clampedColumnSizing;
-                              setResizingColId(colId);
-                              header.getResizeHandler(document)(event);
+                              resizeHandler(event);
                             }}
                             onTouchStart={(event) => {
                               event.stopPropagation();
-                              const measuredMinWidths = measureVisibleColumnWidths();
-                              if (measuredMinWidths) {
-                                setHeaderMinWidths((prev) =>
-                                  numberRecordsEqual(prev, measuredMinWidths)
-                                    ? prev
-                                    : measuredMinWidths,
-                                );
-                              }
-                              const measuredWidths = measureVisibleColumnWidths(true);
-                              const minWidth = measuredMinWidths?.[colId] ?? minColumnWidth;
-                              const clientX = event.touches[0]?.clientX ?? 0;
-                              resizeStartXRef.current = clientX;
-                              resizeStartWidthRef.current = Math.max(
-                                measuredWidths?.[colId] ?? header.getSize(),
-                                minWidth,
-                              );
-                              resizeMinWidthRef.current = minWidth;
-                              resizeStartSizingRef.current = measuredWidths ?? clampedColumnSizing;
-                              setResizingColId(colId);
-                              header.getResizeHandler(document)(event);
+                              resizeHandler(event);
                             }}
                           >
                             <span
@@ -1826,18 +1651,14 @@ const StandardTable = <T extends object>({
                         const isActionColumn = isRowActionColumn(col);
                         const isFirstColumn = colIdx === 0;
                         const isLastColumn = colIdx === visibleCells.length - 1;
-                        const isStretchColumn = colIdx === stretchColumnIdx;
                         // Force alignment: first column left, last column right, otherwise use col.align
                         const effectiveAlign = isFirstColumn
                           ? 'left'
                           : isLastColumn
                             ? 'right'
                             : col.align;
-                        const minColumnWidth = getHeaderMinWidth(col);
-                        const colWidth =
-                          usesFixedTableLayout || isActionColumn
-                            ? Math.max(cell.column.getSize(), minColumnWidth)
-                            : undefined;
+                        const minColumnWidth = getColumnMinWidth(col);
+                        const colWidth = Math.max(cell.column.getSize(), minColumnWidth);
                         const stickyBorderClass =
                           isStickyRightColumn && !isActionColumn ? 'border-l border-border' : '';
                         const stickyHoverClass =
@@ -1860,14 +1681,8 @@ const StandardTable = <T extends object>({
                               e.stopPropagation();
                               col.onCellDoubleClick?.(row);
                             }}
-                            style={
-                              colWidth
-                                ? { width: colWidth, minWidth: colWidth }
-                                : isStickyRightColumn
-                                  ? { minWidth: minColumnWidth }
-                                  : { minWidth: minColumnWidth }
-                            }
-                            className={`${isLastColumn ? 'pl-3 pr-2' : 'px-3'} py-2 whitespace-nowrap ${!isActionColumn ? `standard-table-value-cell text-sm ${TEXT_SM_LINE_HEIGHT_CLASSNAME} font-normal` : ''} ${usesFixedTableLayout && !isActionColumn ? 'max-w-0 overflow-hidden text-ellipsis' : ''} ${isStickyRightColumn ? 'w-auto text-right' : `${usesFixedTableLayout ? '' : isStretchColumn ? 'w-full' : ''} align-middle ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''}`} ${isStickyRightColumn ? `sticky right-0 z-20 bg-card transition-colors ${stickyBorderClass} ${stickyHoverClass}` : ''} ${col.className || ''}`}
+                            style={{ width: colWidth, minWidth: minColumnWidth }}
+                            className={`${isLastColumn ? 'pl-3 pr-2' : 'px-3'} py-2 whitespace-nowrap ${!isActionColumn ? `standard-table-value-cell text-sm ${TEXT_SM_LINE_HEIGHT_CLASSNAME} max-w-0 overflow-hidden text-ellipsis font-normal` : ''} ${isStickyRightColumn ? 'w-auto text-right' : `align-middle ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''}`} ${isStickyRightColumn ? `sticky right-0 z-20 bg-card transition-colors ${stickyBorderClass} ${stickyHoverClass}` : ''} ${col.className || ''}`}
                           >
                             {isActionColumn ? (
                               <DropdownMenu>

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -96,6 +96,8 @@ const VIEW_ERROR_DURATION_MS = 3000;
 const COPIED_FEEDBACK_DURATION_MS = 1500;
 const DEFAULT_MIN_COL_WIDTH = 40;
 const HEADER_RESIZE_EXTRA_WIDTH = 64;
+const ACTION_COLUMN_WIDTH = 48;
+const HEADER_CHAR_WIDTH = 8;
 type ViewModalState = { kind: 'create' } | { kind: 'edit'; view: CustomView } | null;
 
 export type Column<T> = {
@@ -659,6 +661,14 @@ const StandardTable = <T extends object>({
 
   const isRowActionColumn = (col: Column<T>) =>
     col.sticky === 'right' && col.accessorKey == null && col.accessorFn == null;
+
+  const getHeaderMinWidth = (col: Column<T>) =>
+    isRowActionColumn(col)
+      ? ACTION_COLUMN_WIDTH
+      : Math.max(
+          DEFAULT_MIN_COL_WIDTH,
+          Math.ceil(col.header.length * HEADER_CHAR_WIDTH + HEADER_RESIZE_EXTRA_WIDTH),
+        );
 
   const getElementLike = (node: ReactNode) => {
     if (isValidElement(node))
@@ -1496,6 +1506,16 @@ const StandardTable = <T extends object>({
       >
         {columns && data ? (
           <Table className={`w-full text-left ${usesFixedTableLayout ? 'table-fixed' : ''}`}>
+            {usesFixedTableLayout && (
+              <colgroup>
+                {table.getVisibleLeafColumns().map((column) => {
+                  const col = colsById.get(column.id);
+                  if (!col) return null;
+                  const colWidth = validColumnWidths[column.id] ?? getHeaderMinWidth(col);
+                  return <col key={column.id} style={{ width: colWidth, minWidth: colWidth }} />;
+                })}
+              </colgroup>
+            )}
             <TableHeader>
               {table.getHeaderGroups().map((headerGroup) => (
                 <TableRow key={headerGroup.id} className="border-border hover:bg-transparent">
@@ -1514,7 +1534,9 @@ const StandardTable = <T extends object>({
                       : isLastColumn
                         ? 'right'
                         : col.align;
-                    const colWidth = validColumnWidths[colId];
+                    const colWidth =
+                      validColumnWidths[colId] ??
+                      (usesFixedTableLayout || isActionColumn ? getHeaderMinWidth(col) : undefined);
                     const sorted = header.column.getIsSorted();
                     const stickyBorderClass =
                       isStickyRightColumn && (!isActionColumn || actionColumnOverlaps)
@@ -1614,7 +1636,11 @@ const StandardTable = <T extends object>({
                           : isLastColumn
                             ? 'right'
                             : col.align;
-                        const colWidth = validColumnWidths[colId];
+                        const colWidth =
+                          validColumnWidths[colId] ??
+                          (usesFixedTableLayout || isActionColumn
+                            ? getHeaderMinWidth(col)
+                            : undefined);
                         const stickyBorderClass =
                           isStickyRightColumn && (!isActionColumn || actionColumnOverlaps)
                             ? 'border-l border-border'

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -14,6 +14,7 @@ import {
   useReactTable,
   type VisibilityState,
 } from '@tanstack/react-table';
+import { ArrowDown, ArrowUp, ArrowUpDown } from 'lucide-react';
 import {
   Children,
   isValidElement,
@@ -97,7 +98,7 @@ const COPIED_FEEDBACK_DURATION_MS = 1500;
 const DEFAULT_MIN_COL_WIDTH = 40;
 const HEADER_RESIZE_EXTRA_WIDTH = 64;
 const ACTION_COLUMN_WIDTH = 80;
-const TABLE_CONTROL_BUTTON_CLASSNAME = '!h-7 !gap-1.5 !rounded-lg !px-2 !text-[10px] !font-bold';
+const TABLE_CONTROL_BUTTON_CLASSNAME = '!h-7 !gap-1.5 !rounded-lg !px-2 !text-sm !font-bold';
 type ViewModalState = { kind: 'create' } | { kind: 'edit'; view: CustomView } | null;
 
 export type Column<T> = {
@@ -365,6 +366,15 @@ const StandardTable = <T extends object>({
       return next;
     });
   }, [measureVisibleColumnWidths]);
+
+  const getHeaderMinWidth = useCallback(
+    (col: Column<T>) =>
+      isRowActionColumn(col)
+        ? ACTION_COLUMN_WIDTH
+        : (headerMinWidths[getColId(col)] ?? DEFAULT_MIN_COL_WIDTH),
+    [getColId, headerMinWidths, isRowActionColumn],
+  );
+
   const validColumnWidths = useMemo(() => {
     const validIds = new Set((columns ?? []).map((col) => getColId(col)));
     return sanitizeColumnWidths(columnWidths, validIds);
@@ -692,6 +702,14 @@ const StandardTable = <T extends object>({
   const totalItems = data ? processedRows.length : externalTotalCount || 0;
   const totalPages = data ? table.getPageCount() : Math.ceil(totalItems / rowsPerPage);
   const paginatedRows = data ? table.getRowModel().rows : [];
+  const fixedTableWidth = useMemo(() => {
+    if (!usesFixedTableLayout) return undefined;
+    return table.getVisibleLeafColumns().reduce((total, column) => {
+      const col = colsById.get(column.id);
+      if (!col) return total;
+      return total + (validColumnWidths[column.id] ?? getHeaderMinWidth(col));
+    }, 0);
+  }, [colsById, getHeaderMinWidth, table, usesFixedTableLayout, validColumnWidths]);
 
   useEffect(() => {
     if (totalPages === 0) {
@@ -725,11 +743,6 @@ const StandardTable = <T extends object>({
     if (typeof filterValue === 'string') return [filterValue];
     return [];
   };
-
-  const getHeaderMinWidth = (col: Column<T>) =>
-    isRowActionColumn(col)
-      ? ACTION_COLUMN_WIDTH
-      : (headerMinWidths[getColId(col)] ?? DEFAULT_MIN_COL_WIDTH);
 
   const getElementLike = (node: ReactNode) => {
     if (isValidElement(node))
@@ -1033,13 +1046,21 @@ const StandardTable = <T extends object>({
     e.stopPropagation();
     const th = e.currentTarget.parentElement as HTMLTableCellElement;
     const headerLabel = th.querySelector<HTMLElement>('[data-column-header-label]');
-    const measuredWidths = measureVisibleColumnWidths(true);
-    if (measuredWidths) {
-      setColumnWidths((prev) => ({ ...prev, ...measuredWidths }));
+    const measuredMinWidths = measureVisibleColumnWidths();
+    if (measuredMinWidths) setHeaderMinWidths(measuredMinWidths);
+    const resizedColumn = colsById.get(colId);
+    const currentWidth = Math.ceil(th.getBoundingClientRect().width);
+    if (resizedColumn && currentWidth > 0) {
+      setColumnWidths((prev) => ({
+        ...prev,
+        [colId]: Math.max(
+          getMeasuredColumnWidth(resizedColumn, headerLabel ?? undefined),
+          currentWidth,
+        ),
+      }));
     }
     resizeStartXRef.current = e.clientX;
-    resizeStartWidthRef.current = th.getBoundingClientRect().width;
-    const resizedColumn = colsById.get(colId);
+    resizeStartWidthRef.current = currentWidth;
     resizeMinWidthRef.current = resizedColumn
       ? getMeasuredColumnWidth(resizedColumn, headerLabel ?? undefined)
       : DEFAULT_MIN_COL_WIDTH;
@@ -1566,7 +1587,12 @@ const StandardTable = <T extends object>({
         className={`rounded-lg border border-border bg-card shadow-sm ${tableContainerClassName ?? 'overflow-x-auto'} ${resizingColId ? 'select-none' : ''}`}
       >
         {columns && data ? (
-          <Table className={`w-full text-left ${usesFixedTableLayout ? 'table-fixed' : ''}`}>
+          <Table
+            className={`text-left ${usesFixedTableLayout ? 'table-fixed' : 'w-full'}`}
+            style={
+              fixedTableWidth ? { width: `${fixedTableWidth}px`, minWidth: '100%' } : undefined
+            }
+          >
             {usesFixedTableLayout && (
               <colgroup>
                 {table.getVisibleLeafColumns().map((column) => {
@@ -1645,16 +1671,22 @@ const StandardTable = <T extends object>({
                                   ? null
                                   : flexRender(header.column.columnDef.header, header.getContext())}
                               </span>
-                              <i
-                                className={`fa-solid ${
-                                  sorted === 'asc'
-                                    ? 'fa-arrow-up'
-                                    : sorted === 'desc'
-                                      ? 'fa-arrow-down'
-                                      : 'fa-arrow-up-arrow-down'
-                                } shrink-0 text-[10px] transition-colors`}
-                                aria-hidden="true"
-                              ></i>
+                              {sorted === 'asc' ? (
+                                <ArrowUp
+                                  className="size-3 shrink-0 transition-colors"
+                                  aria-hidden="true"
+                                />
+                              ) : sorted === 'desc' ? (
+                                <ArrowDown
+                                  className="size-3 shrink-0 transition-colors"
+                                  aria-hidden="true"
+                                />
+                              ) : (
+                                <ArrowUpDown
+                                  className="size-3 shrink-0 transition-colors"
+                                  aria-hidden="true"
+                                />
+                              )}
                             </button>
                             {renderHeaderFilter(header.column, col)}
                           </div>
@@ -1744,7 +1776,7 @@ const StandardTable = <T extends object>({
                                   ? { minWidth: '40px' }
                                   : undefined
                             }
-                            className={`${isLastColumn ? 'pl-3 pr-2' : 'px-3'} py-2 whitespace-nowrap ${!isActionColumn ? 'standard-table-value-cell font-normal' : ''} ${usesFixedTableLayout && !isActionColumn ? 'max-w-0 overflow-hidden text-ellipsis' : ''} ${isStickyRightColumn ? 'w-auto text-right' : `${usesFixedTableLayout ? '' : isStretchColumn ? 'w-full' : 'w-px'} align-middle ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''}`} ${isStickyRightColumn ? `sticky right-0 z-20 bg-card transition-colors ${stickyBorderClass} ${stickyHoverClass}` : ''} ${col.className || ''}`}
+                            className={`${isLastColumn ? 'pl-3 pr-2' : 'px-3'} py-2 whitespace-nowrap ${!isActionColumn ? 'standard-table-value-cell text-sm font-normal' : ''} ${usesFixedTableLayout && !isActionColumn ? 'max-w-0 overflow-hidden text-ellipsis' : ''} ${isStickyRightColumn ? 'w-auto text-right' : `${usesFixedTableLayout ? '' : isStretchColumn ? 'w-full' : 'w-px'} align-middle ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''}`} ${isStickyRightColumn ? `sticky right-0 z-20 bg-card transition-colors ${stickyBorderClass} ${stickyHoverClass}` : ''} ${col.className || ''}`}
                           >
                             {isActionColumn ? (
                               <DropdownMenu>

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -1550,6 +1550,10 @@ const StandardTable = <T extends object>({
                     const isActionColumn = isRowActionColumn(col);
                     const isFirstColumn = colIdx === 0;
                     const isLastColumn = colIdx === headerGroup.headers.length - 1;
+                    const isBeforeActionSpacer =
+                      hasTrailingActionColumn &&
+                      !isActionColumn &&
+                      colIdx === headerGroup.headers.length - 2;
                     // Force alignment: first column left, last column right, otherwise use col.align
                     const effectiveAlign = isFirstColumn
                       ? 'left'
@@ -1653,7 +1657,11 @@ const StandardTable = <T extends object>({
                               <span
                                 data-column-resize-line={colId}
                                 className={`h-5 w-px rounded-full transition-colors ${
-                                  isResizing ? 'bg-primary' : 'bg-border group-hover:bg-primary/40'
+                                  isBeforeActionSpacer
+                                    ? 'bg-transparent'
+                                    : isResizing
+                                      ? 'bg-primary'
+                                      : 'bg-border group-hover:bg-primary/40'
                                 }`}
                               />
                             </div>

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -522,7 +522,7 @@ const StandardTable = <T extends object>({
                   : [];
             if (selected.length === 0) return true;
             const formatted = formatForFilter(row.getValue(columnId), col);
-            return selected.some((value) => formatted.toLowerCase().includes(value.toLowerCase()));
+            return selected.some((value) => formatted.toLowerCase() === value.toLowerCase());
           },
         } satisfies ColumnDef<T, unknown>;
       }),
@@ -841,6 +841,38 @@ const StandardTable = <T extends object>({
 
     visit(node);
     return items.length > 0 ? items : node;
+  };
+
+  const hasActionMenuItems = (node: ReactNode): boolean => {
+    const visit = (current: ReactNode): boolean => {
+      if (current === null || current === undefined || typeof current === 'boolean') return false;
+      if (typeof current === 'string' || typeof current === 'number') return false;
+      if (Array.isArray(current)) return current.some(visit);
+
+      const element = getElementLike(current);
+      if (!element) return false;
+
+      const props = element.props as {
+        children?: ReactNode | (() => ReactNode);
+        label?: ReactNode;
+        onClick?: unknown;
+        type?: unknown;
+      };
+
+      if (props.label !== undefined && typeof props.children === 'function') return true;
+
+      if (
+        (typeof element.type === 'string' && element.type === 'button') ||
+        props.type === 'button' ||
+        typeof props.onClick === 'function'
+      ) {
+        return true;
+      }
+
+      return Children.toArray(props.children as ReactNode).some(visit);
+    };
+
+    return visit(node);
   };
 
   const stepFontSize = (delta: -1 | 1) => {
@@ -1723,6 +1755,9 @@ const StandardTable = <T extends object>({
                         })
                       : flexRender(rowActionCell.column.columnDef.cell, rowActionCell.getContext())
                     : null;
+                  const rowActionMenuItems = hasActionMenuItems(rowActionContent)
+                    ? renderActionMenuItems(rowActionContent)
+                    : null;
                   const rowElement = (
                     <TableRow
                       key={tableRow.id}
@@ -1763,6 +1798,10 @@ const StandardTable = <T extends object>({
                           isActionColumn && col.cell
                             ? col.cell({ getValue: () => rawValue, row, value: rawValue })
                             : flexRender(cell.column.columnDef.cell, cell.getContext());
+                        const actionMenuItems =
+                          isActionColumn && hasActionMenuItems(cellContent)
+                            ? renderActionMenuItems(cellContent)
+                            : null;
                         return (
                           <Fragment key={cell.id}>
                             {shouldAnchorTrailingActionColumn && isActionColumn && (
@@ -1781,34 +1820,36 @@ const StandardTable = <T extends object>({
                               className={`${isLastColumn ? 'pl-3 pr-2' : 'px-3'} py-2 whitespace-nowrap ${!isActionColumn ? `standard-table-value-cell text-sm ${TEXT_SM_LINE_HEIGHT_CLASSNAME} max-w-0 overflow-hidden text-ellipsis font-normal` : ''} ${shouldStickRightColumn ? 'w-auto text-right' : `align-middle ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''}`} ${shouldStickRightColumn ? `sticky right-0 z-20 bg-card transition-colors ${stickyBorderClass} ${stickyHoverClass}` : ''} ${col.className || ''}`}
                             >
                               {isActionColumn ? (
-                                <DropdownMenu>
-                                  <DropdownMenuTrigger asChild>
-                                    <Button
-                                      type="button"
-                                      variant="ghost"
-                                      size="icon-xs"
-                                      aria-label={t('table.rowActions')}
+                                actionMenuItems ? (
+                                  <DropdownMenu>
+                                    <DropdownMenuTrigger asChild>
+                                      <Button
+                                        type="button"
+                                        variant="ghost"
+                                        size="icon-xs"
+                                        aria-label={t('table.rowActions')}
+                                        onClick={(event) => event.stopPropagation()}
+                                        className="rounded-lg"
+                                      >
+                                        <i
+                                          className="fa-solid fa-ellipsis text-[10px]"
+                                          aria-hidden="true"
+                                        ></i>
+                                      </Button>
+                                    </DropdownMenuTrigger>
+                                    <DropdownMenuContent
+                                      align="end"
+                                      data-standard-table-action-menu="true"
+                                      className={ACTION_MENU_CONTENT_CLASSNAME}
                                       onClick={(event) => event.stopPropagation()}
-                                      className="rounded-lg"
+                                      onDoubleClick={(event) => event.stopPropagation()}
                                     >
-                                      <i
-                                        className="fa-solid fa-ellipsis text-[10px]"
-                                        aria-hidden="true"
-                                      ></i>
-                                    </Button>
-                                  </DropdownMenuTrigger>
-                                  <DropdownMenuContent
-                                    align="end"
-                                    data-standard-table-action-menu="true"
-                                    className={ACTION_MENU_CONTENT_CLASSNAME}
-                                    onClick={(event) => event.stopPropagation()}
-                                    onDoubleClick={(event) => event.stopPropagation()}
-                                  >
-                                    <div className={ACTION_MENU_ITEMS_CLASSNAME}>
-                                      {renderActionMenuItems(cellContent)}
-                                    </div>
-                                  </DropdownMenuContent>
-                                </DropdownMenu>
+                                      <div className={ACTION_MENU_ITEMS_CLASSNAME}>
+                                        {actionMenuItems}
+                                      </div>
+                                    </DropdownMenuContent>
+                                  </DropdownMenu>
+                                ) : null
                               ) : (
                                 cellContent
                               )}
@@ -1819,7 +1860,7 @@ const StandardTable = <T extends object>({
                     </TableRow>
                   );
 
-                  return rowActionContent ? (
+                  return rowActionMenuItems ? (
                     <ContextMenu key={tableRow.id}>
                       <ContextMenuTrigger asChild>{rowElement}</ContextMenuTrigger>
                       <ContextMenuContent
@@ -1828,9 +1869,7 @@ const StandardTable = <T extends object>({
                         onClick={(event) => event.stopPropagation()}
                         onDoubleClick={(event) => event.stopPropagation()}
                       >
-                        <div className={ACTION_MENU_ITEMS_CLASSNAME}>
-                          {renderActionMenuItems(rowActionContent)}
-                        </div>
+                        <div className={ACTION_MENU_ITEMS_CLASSNAME}>{rowActionMenuItems}</div>
                       </ContextMenuContent>
                     </ContextMenu>
                   ) : (

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -97,6 +97,7 @@ const VIEW_ERROR_DURATION_MS = 3000;
 const COPIED_FEEDBACK_DURATION_MS = 1500;
 const DEFAULT_MIN_COL_WIDTH = 40;
 const HEADER_RESIZE_EXTRA_WIDTH = 64;
+const HEADER_TEXT_CHAR_WIDTH = 8;
 const ACTION_COLUMN_WIDTH = 80;
 const TEXT_SM_LINE_HEIGHT_CLASSNAME = 'leading-[var(--text-sm--line-height)]';
 const TABLE_CONTROL_BUTTON_CLASSNAME =
@@ -309,24 +310,37 @@ const StandardTable = <T extends object>({
     [columns, hiddenColIds, getColId],
   );
 
+  const getStaticColumnMinWidth = useCallback(
+    (col: Column<T>) => {
+      if (isRowActionColumn(col)) return ACTION_COLUMN_WIDTH;
+      const headerTextWidth = String(col.header).length * HEADER_TEXT_CHAR_WIDTH;
+      return Math.max(
+        DEFAULT_MIN_COL_WIDTH,
+        Math.ceil(headerTextWidth + HEADER_RESIZE_EXTRA_WIDTH),
+      );
+    },
+    [isRowActionColumn],
+  );
+
   const getMeasuredColumnWidth = useCallback(
     (col: Column<T>, label: HTMLElement | undefined, includeRenderedWidth = false) => {
       if (isRowActionColumn(col)) return ACTION_COLUMN_WIDTH;
 
+      const minWidth = getStaticColumnMinWidth(col);
       const labelWidth = Math.max(
         label?.scrollWidth ?? 0,
         label?.getBoundingClientRect().width ?? 0,
       );
-      const minWidth = Math.max(
-        DEFAULT_MIN_COL_WIDTH,
+      const measuredMinWidth = Math.max(
+        minWidth,
         Math.ceil(labelWidth + HEADER_RESIZE_EXTRA_WIDTH),
       );
-      if (!includeRenderedWidth) return minWidth;
+      if (!includeRenderedWidth) return measuredMinWidth;
 
       const headerCell = label?.closest('th') as HTMLTableCellElement | null;
-      return Math.max(minWidth, Math.ceil(headerCell?.getBoundingClientRect().width ?? 0));
+      return Math.max(measuredMinWidth, Math.ceil(headerCell?.getBoundingClientRect().width ?? 0));
     },
-    [isRowActionColumn],
+    [getStaticColumnMinWidth, isRowActionColumn],
   );
 
   const measureVisibleColumnWidths = useCallback(
@@ -385,17 +399,26 @@ const StandardTable = <T extends object>({
   }, []);
 
   const getHeaderMinWidth = useCallback(
-    (col: Column<T>) =>
-      isRowActionColumn(col)
-        ? ACTION_COLUMN_WIDTH
-        : (headerMinWidths[getColId(col)] ?? DEFAULT_MIN_COL_WIDTH),
-    [getColId, headerMinWidths, isRowActionColumn],
+    (col: Column<T>) => {
+      const staticMinWidth = getStaticColumnMinWidth(col);
+      return Math.max(headerMinWidths[getColId(col)] ?? 0, staticMinWidth);
+    },
+    [getColId, getStaticColumnMinWidth, headerMinWidths],
   );
 
   const validColumnWidths = useMemo(() => {
     const validIds = new Set((columns ?? []).map((col) => getColId(col)));
     return sanitizeColumnWidths(columnWidths, validIds);
   }, [columns, columnWidths, getColId]);
+
+  const getColumnWidth = useCallback(
+    (col: Column<T>, colId = getColId(col)) => {
+      const storedWidth = validColumnWidths[colId];
+      const minWidth = getHeaderMinWidth(col);
+      return storedWidth == null ? minWidth : Math.max(storedWidth, minWidth);
+    },
+    [getColId, getHeaderMinWidth, validColumnWidths],
+  );
 
   // Rightmost non-sticky column absorbs leftover width. When the last column is
   // sticky-right, this prevents that sticky column from expanding to fill space.
@@ -726,9 +749,9 @@ const StandardTable = <T extends object>({
     return table.getVisibleLeafColumns().reduce((total, column) => {
       const col = colsById.get(column.id);
       if (!col) return total;
-      return total + (validColumnWidths[column.id] ?? getHeaderMinWidth(col));
+      return total + getColumnWidth(col, column.id);
     }, 0);
-  }, [colsById, getHeaderMinWidth, table, usesFixedTableLayout, validColumnWidths]);
+  }, [colsById, getColumnWidth, table, usesFixedTableLayout]);
 
   useEffect(() => {
     if (totalPages === 0) {
@@ -1610,7 +1633,7 @@ const StandardTable = <T extends object>({
                 {table.getVisibleLeafColumns().map((column) => {
                   const col = colsById.get(column.id);
                   if (!col) return null;
-                  const colWidth = validColumnWidths[column.id] ?? getHeaderMinWidth(col);
+                  const colWidth = getColumnWidth(col, column.id);
                   return <col key={column.id} style={{ width: colWidth, minWidth: colWidth }} />;
                 })}
               </colgroup>
@@ -1633,9 +1656,11 @@ const StandardTable = <T extends object>({
                       : isLastColumn
                         ? 'right'
                         : col.align;
+                    const minColumnWidth = getHeaderMinWidth(col);
                     const colWidth =
-                      validColumnWidths[colId] ??
-                      (usesFixedTableLayout || isActionColumn ? getHeaderMinWidth(col) : undefined);
+                      usesFixedTableLayout || isActionColumn
+                        ? getColumnWidth(col, colId)
+                        : undefined;
                     const sorted = header.column.getIsSorted();
                     const stickyBorderClass =
                       isStickyRightColumn && (!isActionColumn || actionColumnOverlaps)
@@ -1649,8 +1674,8 @@ const StandardTable = <T extends object>({
                           colWidth
                             ? { width: colWidth, minWidth: colWidth }
                             : isStickyRightColumn
-                              ? { minWidth: '40px', width: 'auto' }
-                              : undefined
+                              ? { minWidth: minColumnWidth, width: 'auto' }
+                              : { minWidth: minColumnWidth }
                         }
                         aria-label={isActionColumn ? col.header : undefined}
                         className={`relative group h-10 border-border ${isLastColumn ? 'pl-3 pr-2' : 'px-3'} whitespace-nowrap ${usesFixedTableLayout ? '' : isStretchColumn ? 'w-full' : isStickyRightColumn ? 'w-auto' : 'w-px'} ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''} ${isStickyRightColumn ? `sticky right-0 z-20 bg-card ${stickyBorderClass}` : ''} ${col.headerClassName || ''}`}
@@ -1752,11 +1777,11 @@ const StandardTable = <T extends object>({
                           : isLastColumn
                             ? 'right'
                             : col.align;
+                        const minColumnWidth = getHeaderMinWidth(col);
                         const colWidth =
-                          validColumnWidths[colId] ??
-                          (usesFixedTableLayout || isActionColumn
-                            ? getHeaderMinWidth(col)
-                            : undefined);
+                          usesFixedTableLayout || isActionColumn
+                            ? getColumnWidth(col, colId)
+                            : undefined;
                         const stickyBorderClass =
                           isStickyRightColumn && (!isActionColumn || actionColumnOverlaps)
                             ? 'border-l border-border'
@@ -1785,8 +1810,8 @@ const StandardTable = <T extends object>({
                               colWidth
                                 ? { width: colWidth, minWidth: colWidth }
                                 : isStickyRightColumn
-                                  ? { minWidth: '40px' }
-                                  : undefined
+                                  ? { minWidth: minColumnWidth }
+                                  : { minWidth: minColumnWidth }
                             }
                             className={`${isLastColumn ? 'pl-3 pr-2' : 'px-3'} py-2 whitespace-nowrap ${!isActionColumn ? `standard-table-value-cell text-sm ${TEXT_SM_LINE_HEIGHT_CLASSNAME} font-normal` : ''} ${usesFixedTableLayout && !isActionColumn ? 'max-w-0 overflow-hidden text-ellipsis' : ''} ${isStickyRightColumn ? 'w-auto text-right' : `${usesFixedTableLayout ? '' : isStretchColumn ? 'w-full' : 'w-px'} align-middle ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''}`} ${isStickyRightColumn ? `sticky right-0 z-20 bg-card transition-colors ${stickyBorderClass} ${stickyHoverClass}` : ''} ${col.className || ''}`}
                           >

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -1,6 +1,7 @@
 import {
   type ColumnDef,
   type ColumnFiltersState,
+  type ColumnSizingState,
   flexRender,
   functionalUpdate,
   getCoreRowModel,
@@ -90,14 +91,26 @@ const sanitizeColumnWidths = (
   );
 };
 
+const numberRecordsEqual = (a: Record<string, number>, b: Record<string, number>) => {
+  const aEntries = Object.entries(a);
+  const bEntries = Object.entries(b);
+  return aEntries.length === bEntries.length && aEntries.every(([key, value]) => b[key] === value);
+};
+
 const FONT_SIZES = ['xs', 'sm', 'base'] as const;
 type FontSize = (typeof FONT_SIZES)[number];
 
 const VIEW_ERROR_DURATION_MS = 3000;
 const COPIED_FEEDBACK_DURATION_MS = 1500;
 const DEFAULT_MIN_COL_WIDTH = 40;
-const HEADER_RESIZE_EXTRA_WIDTH = 64;
-const HEADER_TEXT_CHAR_WIDTH = 8;
+const HEADER_TEXT_CHAR_WIDTH = 9;
+const HEADER_CELL_HORIZONTAL_PADDING = 24;
+const HEADER_RESIZE_GUTTER_WIDTH = 8;
+const HEADER_SORT_BUTTON_HORIZONTAL_PADDING = 16;
+const HEADER_SORT_ICON_WIDTH = 12;
+const HEADER_SORT_ICON_GAP = 4;
+const HEADER_FILTER_BUTTON_WIDTH = 24;
+const HEADER_CONTENT_GAP = 4;
 const ACTION_COLUMN_WIDTH = 80;
 const TEXT_SM_LINE_HEIGHT_CLASSNAME = 'leading-[var(--text-sm--line-height)]';
 const TABLE_CONTROL_BUTTON_CLASSNAME =
@@ -170,7 +183,7 @@ const StandardTable = <T extends object>({
   const resizeStartXRef = useRef(0);
   const resizeStartWidthRef = useRef(0);
   const resizeMinWidthRef = useRef(DEFAULT_MIN_COL_WIDTH);
-  const resizeHasMovedRef = useRef(false);
+  const resizeStartSizingRef = useRef<ColumnSizingState>({});
   const tableContainerRef = useRef<HTMLDivElement | null>(null);
 
   const [sortState, setSortState] = useState<SortState>(null);
@@ -207,7 +220,7 @@ const StandardTable = <T extends object>({
   // Session-only: column visibility resets on page reload
   const [hiddenColIds, setHiddenColIds] = useState<Set<string>>(new Set<string>());
 
-  const [columnWidths, setColumnWidths] = useState<Record<string, number>>(() => {
+  const [columnSizing, setColumnSizing] = useState<ColumnSizingState>(() => {
     if (typeof window === 'undefined') return {};
     const saved = localStorage.getItem(getStorageKey(title, STORAGE_SUFFIX.colWidths));
     if (saved) {
@@ -312,32 +325,50 @@ const StandardTable = <T extends object>({
 
   const getStaticColumnMinWidth = useCallback(
     (col: Column<T>) => {
-      if (isRowActionColumn(col)) return ACTION_COLUMN_WIDTH;
       const headerTextWidth = String(col.header).length * HEADER_TEXT_CHAR_WIDTH;
+      if (isRowActionColumn(col)) {
+        return Math.max(
+          ACTION_COLUMN_WIDTH,
+          Math.ceil(headerTextWidth + HEADER_CELL_HORIZONTAL_PADDING),
+        );
+      }
+
+      const filterWidth = col.disableFiltering
+        ? 0
+        : HEADER_CONTENT_GAP + HEADER_FILTER_BUTTON_WIDTH;
       return Math.max(
         DEFAULT_MIN_COL_WIDTH,
-        Math.ceil(headerTextWidth + HEADER_RESIZE_EXTRA_WIDTH),
+        Math.ceil(
+          headerTextWidth +
+            HEADER_SORT_BUTTON_HORIZONTAL_PADDING +
+            HEADER_SORT_ICON_GAP +
+            HEADER_SORT_ICON_WIDTH +
+            filterWidth +
+            HEADER_CELL_HORIZONTAL_PADDING +
+            HEADER_RESIZE_GUTTER_WIDTH,
+        ),
       );
     },
     [isRowActionColumn],
   );
 
   const getMeasuredColumnWidth = useCallback(
-    (col: Column<T>, label: HTMLElement | undefined, includeRenderedWidth = false) => {
-      if (isRowActionColumn(col)) return ACTION_COLUMN_WIDTH;
-
+    (col: Column<T>, headerContent: HTMLElement | undefined, includeRenderedWidth = false) => {
       const minWidth = getStaticColumnMinWidth(col);
-      const labelWidth = Math.max(
-        label?.scrollWidth ?? 0,
-        label?.getBoundingClientRect().width ?? 0,
+      const headerChromeWidth = isRowActionColumn(col)
+        ? HEADER_CELL_HORIZONTAL_PADDING
+        : HEADER_CELL_HORIZONTAL_PADDING + HEADER_RESIZE_GUTTER_WIDTH;
+      const headerContentWidth = Math.max(
+        headerContent?.scrollWidth ?? 0,
+        headerContent?.getBoundingClientRect().width ?? 0,
       );
       const measuredMinWidth = Math.max(
         minWidth,
-        Math.ceil(labelWidth + HEADER_RESIZE_EXTRA_WIDTH),
+        Math.ceil(headerContentWidth + headerChromeWidth),
       );
       if (!includeRenderedWidth) return measuredMinWidth;
 
-      const headerCell = label?.closest('th') as HTMLTableCellElement | null;
+      const headerCell = headerContent?.closest('th') as HTMLTableCellElement | null;
       return Math.max(measuredMinWidth, Math.ceil(headerCell?.getBoundingClientRect().width ?? 0));
     },
     [getStaticColumnMinWidth, isRowActionColumn],
@@ -348,9 +379,9 @@ const StandardTable = <T extends object>({
       const container = tableContainerRef.current;
       if (!container) return null;
 
-      const labelsByColumnId = new Map(
-        Array.from(container.querySelectorAll<HTMLElement>('[data-column-header-label]')).map(
-          (element) => [element.getAttribute('data-column-header-label') ?? '', element],
+      const contentByColumnId = new Map(
+        Array.from(container.querySelectorAll<HTMLElement>('[data-column-header-content]')).map(
+          (element) => [element.getAttribute('data-column-header-content') ?? '', element],
         ),
       );
       const next: Record<string, number> = {};
@@ -358,7 +389,7 @@ const StandardTable = <T extends object>({
         const colId = getColId(col);
         next[colId] = getMeasuredColumnWidth(
           col,
-          labelsByColumnId.get(colId),
+          contentByColumnId.get(colId),
           includeRenderedWidth,
         );
       }
@@ -371,32 +402,8 @@ const StandardTable = <T extends object>({
     const next = measureVisibleColumnWidths();
     if (!next) return;
 
-    setHeaderMinWidths((prev) => {
-      const prevEntries = Object.entries(prev);
-      const nextEntries = Object.entries(next);
-      if (
-        prevEntries.length === nextEntries.length &&
-        nextEntries.every(([id, width]) => prev[id] === width)
-      ) {
-        return prev;
-      }
-      return next;
-    });
+    setHeaderMinWidths((prev) => (numberRecordsEqual(prev, next) ? prev : next));
   }, [measureVisibleColumnWidths]);
-
-  const setHeaderMinWidthsIfChanged = useCallback((next: Record<string, number>) => {
-    setHeaderMinWidths((prev) => {
-      const prevEntries = Object.entries(prev);
-      const nextEntries = Object.entries(next);
-      if (
-        prevEntries.length === nextEntries.length &&
-        nextEntries.every(([id, width]) => prev[id] === width)
-      ) {
-        return prev;
-      }
-      return next;
-    });
-  }, []);
 
   const getHeaderMinWidth = useCallback(
     (col: Column<T>) => {
@@ -406,18 +413,29 @@ const StandardTable = <T extends object>({
     [getColId, getStaticColumnMinWidth, headerMinWidths],
   );
 
-  const validColumnWidths = useMemo(() => {
+  const validColumnSizing = useMemo(() => {
     const validIds = new Set((columns ?? []).map((col) => getColId(col)));
-    return sanitizeColumnWidths(columnWidths, validIds);
-  }, [columns, columnWidths, getColId]);
+    return sanitizeColumnWidths(columnSizing, validIds);
+  }, [columns, columnSizing, getColId]);
 
-  const getColumnWidth = useCallback(
-    (col: Column<T>, colId = getColId(col)) => {
-      const storedWidth = validColumnWidths[colId];
-      const minWidth = getHeaderMinWidth(col);
-      return storedWidth == null ? minWidth : Math.max(storedWidth, minWidth);
+  const clampColumnSizing = useCallback(
+    (value: ColumnSizingState) => {
+      const validIds = new Set((columns ?? []).map((col) => getColId(col)));
+      const next = sanitizeColumnWidths(value, validIds);
+      for (const col of columns ?? []) {
+        const colId = getColId(col);
+        if (next[colId] != null) {
+          next[colId] = Math.max(next[colId], getHeaderMinWidth(col));
+        }
+      }
+      return next;
     },
-    [getColId, getHeaderMinWidth, validColumnWidths],
+    [columns, getColId, getHeaderMinWidth],
+  );
+
+  const clampedColumnSizing = useMemo(
+    () => clampColumnSizing(validColumnSizing),
+    [clampColumnSizing, validColumnSizing],
   );
 
   // Rightmost non-sticky column absorbs leftover width. When the last column is
@@ -428,7 +446,7 @@ const StandardTable = <T extends object>({
     }
     return -1;
   }, [visibleColumns]);
-  const usesFixedTableLayout = Object.keys(validColumnWidths).length > 0;
+  const usesFixedTableLayout = Object.keys(clampedColumnSizing).length > 0;
 
   // Excludes statically hidden filter-only columns; sort/filter still target them via colsById.
   const gearColumns = useMemo(() => columns?.filter((col) => !col.hidden) ?? [], [columns]);
@@ -489,43 +507,52 @@ const StandardTable = <T extends object>({
   const fontSizeClass = fontSize === 'xs' ? 'text-xs' : fontSize === 'sm' ? 'text-sm' : 'text-base';
 
   useEffect(() => {
+    const next = clampColumnSizing(columnSizing);
+    if (!numberRecordsEqual(columnSizing, next)) {
+      setColumnSizing(next);
+      return;
+    }
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(getStorageKey(title, STORAGE_SUFFIX.colWidths), JSON.stringify(next));
+    }
+  }, [clampColumnSizing, columnSizing, title]);
+
+  useEffect(() => {
     if (!resizingColId) return;
 
-    const handleMouseMove = (e: MouseEvent) => {
-      const delta = e.clientX - resizeStartXRef.current;
+    const getClientX = (event: MouseEvent | TouchEvent) => {
+      if ('touches' in event) return event.touches[0]?.clientX ?? event.changedTouches[0]?.clientX;
+      return event.clientX;
+    };
+    const handleResizeMove = (event: MouseEvent | TouchEvent) => {
+      const clientX = getClientX(event);
+      if (typeof clientX !== 'number') return;
+      const delta = clientX - resizeStartXRef.current;
       if (Math.abs(delta) < 1) return;
       const newWidth = Math.max(resizeMinWidthRef.current, resizeStartWidthRef.current + delta);
-      setColumnWidths((prev) => {
-        const seededWidths = resizeHasMovedRef.current
-          ? prev
-          : { ...prev, ...(measureVisibleColumnWidths(true) ?? {}) };
-        resizeHasMovedRef.current = true;
-        if (prev[resizingColId] === newWidth) return prev;
-        return { ...seededWidths, [resizingColId]: newWidth };
-      });
+      setColumnSizing((prev) =>
+        clampColumnSizing({
+          ...resizeStartSizingRef.current,
+          ...prev,
+          [resizingColId]: newWidth,
+        }),
+      );
     };
-
-    const handleMouseUp = () => {
-      setResizingColId(null);
-      document.body.style.cursor = '';
-      setColumnWidths((prev) => {
-        const validIds = new Set((columns ?? []).map((col) => getColId(col)));
-        const next = sanitizeColumnWidths(prev, validIds);
-        localStorage.setItem(getStorageKey(title, STORAGE_SUFFIX.colWidths), JSON.stringify(next));
-        return next;
-      });
-    };
-
+    const handleResizeEnd = () => setResizingColId(null);
     document.body.style.cursor = 'col-resize';
-    document.addEventListener('mousemove', handleMouseMove);
-    document.addEventListener('mouseup', handleMouseUp);
+    document.addEventListener('mousemove', handleResizeMove);
+    document.addEventListener('touchmove', handleResizeMove);
+    document.addEventListener('mouseup', handleResizeEnd);
+    document.addEventListener('touchend', handleResizeEnd);
 
     return () => {
-      document.removeEventListener('mousemove', handleMouseMove);
-      document.removeEventListener('mouseup', handleMouseUp);
+      document.removeEventListener('mousemove', handleResizeMove);
+      document.removeEventListener('touchmove', handleResizeMove);
+      document.removeEventListener('mouseup', handleResizeEnd);
+      document.removeEventListener('touchend', handleResizeEnd);
       document.body.style.cursor = '';
     };
-  }, [columns, getColId, measureVisibleColumnWidths, resizingColId, title]);
+  }, [clampColumnSizing, resizingColId]);
 
   useEffect(() => {
     const container = tableContainerRef.current;
@@ -578,6 +605,7 @@ const StandardTable = <T extends object>({
     () =>
       (columns ?? []).map((col) => {
         const colId = getColId(col);
+        const minSize = getHeaderMinWidth(col);
         return {
           id: colId,
           accessorFn: (row) => getValue(row, col),
@@ -595,6 +623,9 @@ const StandardTable = <T extends object>({
               ? col.cell({ getValue: () => value, row, value })
               : (value as ReactNode);
           },
+          size: Math.max(clampedColumnSizing[colId] ?? minSize, minSize),
+          minSize,
+          enableResizing: !isRowActionColumn(col),
           enableSorting: !col.disableSorting,
           enableColumnFilter: !col.disableFiltering,
           enableHiding: !col.hidden,
@@ -623,7 +654,15 @@ const StandardTable = <T extends object>({
           },
         } satisfies ColumnDef<T, unknown>;
       }),
-    [columns, getColId, getValue, formatForFilter],
+    [
+      clampedColumnSizing,
+      columns,
+      getColId,
+      getHeaderMinWidth,
+      getValue,
+      formatForFilter,
+      isRowActionColumn,
+    ],
   );
 
   const sorting = useMemo<SortingState>(
@@ -721,6 +760,16 @@ const StandardTable = <T extends object>({
     [columnVisibility, gearColumns, getColId, sortState, updateActiveViewId],
   );
 
+  const onColumnSizingChange = useCallback(
+    (updater: Updater<ColumnSizingState>) => {
+      setColumnSizing((prev) => {
+        const next = functionalUpdate(updater, clampColumnSizing(prev));
+        return clampColumnSizing(next);
+      });
+    },
+    [clampColumnSizing],
+  );
+
   const table = useReactTable({
     data: data ?? [],
     columns: tanStackColumns,
@@ -728,11 +777,15 @@ const StandardTable = <T extends object>({
     onColumnFiltersChange,
     onPaginationChange,
     onColumnVisibilityChange,
+    onColumnSizingChange,
+    columnResizeMode: 'onChange',
+    enableColumnResizing: true,
     state: {
       sorting,
       columnFilters,
       pagination,
       columnVisibility,
+      columnSizing: clampedColumnSizing,
     },
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
@@ -746,12 +799,8 @@ const StandardTable = <T extends object>({
   const paginatedRows = data ? table.getRowModel().rows : [];
   const fixedTableWidth = useMemo(() => {
     if (!usesFixedTableLayout) return undefined;
-    return table.getVisibleLeafColumns().reduce((total, column) => {
-      const col = colsById.get(column.id);
-      if (!col) return total;
-      return total + getColumnWidth(col, column.id);
-    }, 0);
-  }, [colsById, getColumnWidth, table, usesFixedTableLayout]);
+    return table.getVisibleLeafColumns().reduce((total, column) => total + column.getSize(), 0);
+  }, [table, usesFixedTableLayout]);
 
   useEffect(() => {
     if (totalPages === 0) {
@@ -839,7 +888,7 @@ const StandardTable = <T extends object>({
       return (
         <div key={key} className="flex min-h-7 items-center gap-2 px-2 py-1 text-xs">
           {node}
-          {labelText && <span className="truncate">{labelText}</span>}
+          {labelText && <span className="whitespace-nowrap">{labelText}</span>}
         </div>
       );
     }
@@ -862,7 +911,7 @@ const StandardTable = <T extends object>({
         aria-label={typeof explicitLabel === 'string' ? explicitLabel : undefined}
         data-testid={testId}
         disabled={props.disabled}
-        className="flex h-7 w-full items-center justify-start gap-2 rounded-sm px-2 text-xs font-medium text-popover-foreground outline-hidden transition-colors hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-50"
+        className="flex h-7 w-full items-center justify-start gap-2 rounded-sm px-2 text-xs font-medium whitespace-nowrap text-popover-foreground outline-hidden transition-colors hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-50"
         onClick={(event) => {
           event.stopPropagation();
           props.onClick?.(event);
@@ -871,7 +920,7 @@ const StandardTable = <T extends object>({
         <span className={`w-3.5 shrink-0 text-center ${getActionIconClassName(props.children)}`}>
           {props.children}
         </span>
-        {text && <span className="truncate">{text}</span>}
+        {text && <span className="whitespace-nowrap">{text}</span>}
       </button>
     );
   };
@@ -1081,24 +1130,6 @@ const StandardTable = <T extends object>({
     setPasteModalOpen(false);
     setPasteText('');
     setPasteError(null);
-  };
-
-  const handleResizeStart = (e: React.MouseEvent<HTMLDivElement>, colId: string) => {
-    e.preventDefault();
-    e.stopPropagation();
-    const th = e.currentTarget.parentElement as HTMLTableCellElement;
-    const headerLabel = th.querySelector<HTMLElement>('[data-column-header-label]');
-    const measuredMinWidths = measureVisibleColumnWidths();
-    if (measuredMinWidths) setHeaderMinWidthsIfChanged(measuredMinWidths);
-    const resizedColumn = colsById.get(colId);
-    const currentWidth = Math.ceil(th.getBoundingClientRect().width);
-    resizeHasMovedRef.current = false;
-    resizeStartXRef.current = e.clientX;
-    resizeStartWidthRef.current = currentWidth;
-    resizeMinWidthRef.current = resizedColumn
-      ? getMeasuredColumnWidth(resizedColumn, headerLabel ?? undefined)
-      : DEFAULT_MIN_COL_WIDTH;
-    setResizingColId(colId);
   };
 
   const renderToolbarButton = ({
@@ -1631,10 +1662,8 @@ const StandardTable = <T extends object>({
             {usesFixedTableLayout && (
               <colgroup>
                 {table.getVisibleLeafColumns().map((column) => {
-                  const col = colsById.get(column.id);
-                  if (!col) return null;
-                  const colWidth = getColumnWidth(col, column.id);
-                  return <col key={column.id} style={{ width: colWidth, minWidth: colWidth }} />;
+                  const colWidth = column.getSize();
+                  return <col key={column.id} style={{ width: colWidth }} />;
                 })}
               </colgroup>
             )}
@@ -1659,9 +1688,10 @@ const StandardTable = <T extends object>({
                     const minColumnWidth = getHeaderMinWidth(col);
                     const colWidth =
                       usesFixedTableLayout || isActionColumn
-                        ? getColumnWidth(col, colId)
+                        ? Math.max(header.getSize(), minColumnWidth)
                         : undefined;
                     const sorted = header.column.getIsSorted();
+                    const isResizing = resizingColId === colId || header.column.getIsResizing();
                     const stickyBorderClass =
                       isStickyRightColumn && (!isActionColumn || actionColumnOverlaps)
                         ? 'border-l border-border'
@@ -1678,14 +1708,15 @@ const StandardTable = <T extends object>({
                               : { minWidth: minColumnWidth }
                         }
                         aria-label={isActionColumn ? col.header : undefined}
-                        className={`relative group h-10 border-border ${isLastColumn ? 'pl-3 pr-2' : 'px-3'} whitespace-nowrap ${usesFixedTableLayout ? '' : isStretchColumn ? 'w-full' : isStickyRightColumn ? 'w-auto' : 'w-px'} ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''} ${isStickyRightColumn ? `sticky right-0 z-20 bg-card ${stickyBorderClass}` : ''} ${col.headerClassName || ''}`}
+                        className={`relative group h-10 border-border ${isLastColumn ? 'pl-3 pr-2' : 'px-3'} whitespace-nowrap ${usesFixedTableLayout ? '' : isStretchColumn ? 'w-full' : isStickyRightColumn ? 'w-auto' : ''} ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''} ${isStickyRightColumn ? `sticky right-0 z-20 bg-card ${stickyBorderClass}` : ''} ${col.headerClassName || ''}`}
                       >
                         {isActionColumn ? (
                           <div
+                            data-column-header-content={colId}
                             className={`flex items-center gap-1 ${effectiveAlign === 'right' ? 'justify-end' : effectiveAlign === 'center' ? 'justify-center' : 'justify-start'}`}
                           >
                             <span
-                              className="truncate text-sm font-semibold text-foreground"
+                              className="whitespace-nowrap text-sm font-semibold text-foreground"
                               data-column-header-label={colId}
                             >
                               {header.isPlaceholder
@@ -1695,15 +1726,16 @@ const StandardTable = <T extends object>({
                           </div>
                         ) : (
                           <div
+                            data-column-header-content={colId}
                             className={`flex items-center gap-1 ${effectiveAlign === 'right' ? 'justify-end' : effectiveAlign === 'center' ? 'justify-center' : 'justify-start'}`}
                           >
                             <button
                               type="button"
                               disabled={!header.column.getCanSort()}
                               onClick={header.column.getToggleSortingHandler()}
-                              className="inline-flex min-w-0 items-center gap-1 rounded-lg px-2 py-1 text-sm font-semibold text-foreground outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-100"
+                              className="inline-flex shrink-0 items-center gap-1 rounded-lg px-2 py-1 text-sm font-semibold text-foreground outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-100"
                             >
-                              <span className="truncate" data-column-header-label={colId}>
+                              <span className="whitespace-nowrap" data-column-header-label={colId}>
                                 {header.isPlaceholder
                                   ? null
                                   : flexRender(header.column.columnDef.header, header.getContext())}
@@ -1733,14 +1765,56 @@ const StandardTable = <T extends object>({
                           <div
                             className="absolute top-0 -right-1 z-10 flex h-full w-2 cursor-col-resize items-center justify-center"
                             data-column-resize-handle={colId}
-                            onMouseDown={(e) => handleResizeStart(e, colId)}
+                            onMouseDown={(event) => {
+                              event.stopPropagation();
+                              const measuredMinWidths = measureVisibleColumnWidths();
+                              if (measuredMinWidths) {
+                                setHeaderMinWidths((prev) =>
+                                  numberRecordsEqual(prev, measuredMinWidths)
+                                    ? prev
+                                    : measuredMinWidths,
+                                );
+                              }
+                              const measuredWidths = measureVisibleColumnWidths(true);
+                              const minWidth = measuredMinWidths?.[colId] ?? minColumnWidth;
+                              resizeStartXRef.current = event.clientX;
+                              resizeStartWidthRef.current = Math.max(
+                                measuredWidths?.[colId] ?? header.getSize(),
+                                minWidth,
+                              );
+                              resizeMinWidthRef.current = minWidth;
+                              resizeStartSizingRef.current = measuredWidths ?? clampedColumnSizing;
+                              setResizingColId(colId);
+                              header.getResizeHandler(document)(event);
+                            }}
+                            onTouchStart={(event) => {
+                              event.stopPropagation();
+                              const measuredMinWidths = measureVisibleColumnWidths();
+                              if (measuredMinWidths) {
+                                setHeaderMinWidths((prev) =>
+                                  numberRecordsEqual(prev, measuredMinWidths)
+                                    ? prev
+                                    : measuredMinWidths,
+                                );
+                              }
+                              const measuredWidths = measureVisibleColumnWidths(true);
+                              const minWidth = measuredMinWidths?.[colId] ?? minColumnWidth;
+                              const clientX = event.touches[0]?.clientX ?? 0;
+                              resizeStartXRef.current = clientX;
+                              resizeStartWidthRef.current = Math.max(
+                                measuredWidths?.[colId] ?? header.getSize(),
+                                minWidth,
+                              );
+                              resizeMinWidthRef.current = minWidth;
+                              resizeStartSizingRef.current = measuredWidths ?? clampedColumnSizing;
+                              setResizingColId(colId);
+                              header.getResizeHandler(document)(event);
+                            }}
                           >
                             <span
                               data-column-resize-line={colId}
                               className={`h-5 w-px rounded-full transition-colors ${
-                                resizingColId === colId
-                                  ? 'bg-primary'
-                                  : 'bg-border group-hover:bg-primary/40'
+                                isResizing ? 'bg-primary' : 'bg-border group-hover:bg-primary/40'
                               }`}
                             />
                           </div>
@@ -1780,7 +1854,7 @@ const StandardTable = <T extends object>({
                         const minColumnWidth = getHeaderMinWidth(col);
                         const colWidth =
                           usesFixedTableLayout || isActionColumn
-                            ? getColumnWidth(col, colId)
+                            ? Math.max(cell.column.getSize(), minColumnWidth)
                             : undefined;
                         const stickyBorderClass =
                           isStickyRightColumn && (!isActionColumn || actionColumnOverlaps)
@@ -1813,7 +1887,7 @@ const StandardTable = <T extends object>({
                                   ? { minWidth: minColumnWidth }
                                   : { minWidth: minColumnWidth }
                             }
-                            className={`${isLastColumn ? 'pl-3 pr-2' : 'px-3'} py-2 whitespace-nowrap ${!isActionColumn ? `standard-table-value-cell text-sm ${TEXT_SM_LINE_HEIGHT_CLASSNAME} font-normal` : ''} ${usesFixedTableLayout && !isActionColumn ? 'max-w-0 overflow-hidden text-ellipsis' : ''} ${isStickyRightColumn ? 'w-auto text-right' : `${usesFixedTableLayout ? '' : isStretchColumn ? 'w-full' : 'w-px'} align-middle ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''}`} ${isStickyRightColumn ? `sticky right-0 z-20 bg-card transition-colors ${stickyBorderClass} ${stickyHoverClass}` : ''} ${col.className || ''}`}
+                            className={`${isLastColumn ? 'pl-3 pr-2' : 'px-3'} py-2 whitespace-nowrap ${!isActionColumn ? `standard-table-value-cell text-sm ${TEXT_SM_LINE_HEIGHT_CLASSNAME} font-normal` : ''} ${usesFixedTableLayout && !isActionColumn ? 'max-w-0 overflow-hidden text-ellipsis' : ''} ${isStickyRightColumn ? 'w-auto text-right' : `${usesFixedTableLayout ? '' : isStretchColumn ? 'w-full' : ''} align-middle ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''}`} ${isStickyRightColumn ? `sticky right-0 z-20 bg-card transition-colors ${stickyBorderClass} ${stickyHoverClass}` : ''} ${col.className || ''}`}
                           >
                             {isActionColumn ? (
                               <DropdownMenu>
@@ -1834,7 +1908,7 @@ const StandardTable = <T extends object>({
                                 </DropdownMenuTrigger>
                                 <DropdownMenuContent
                                   align="end"
-                                  className="w-36 p-1"
+                                  className="w-max min-w-[9rem] max-w-[calc(100vw-2rem)] p-1"
                                   onClick={(event) => event.stopPropagation()}
                                   onDoubleClick={(event) => event.stopPropagation()}
                                 >

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -589,6 +589,9 @@ const StandardTable = <T extends object>({
     return [];
   };
 
+  const isRowActionColumn = (col: Column<T>) =>
+    col.sticky === 'right' && col.accessorKey == null && col.accessorFn == null;
+
   const stepFontSize = (delta: -1 | 1) => {
     setFontSize((prev) => {
       const idx = FONT_SIZES.indexOf(prev);
@@ -1257,7 +1260,8 @@ const StandardTable = <T extends object>({
                     const col = colsById.get(header.column.id);
                     if (!col) return null;
                     const colId = getColId(col);
-                    const isActionColumn = col.sticky === 'right';
+                    const isStickyRightColumn = col.sticky === 'right';
+                    const isActionColumn = isRowActionColumn(col);
                     const isFirstColumn = colIdx === 0;
                     const isLastColumn = colIdx === headerGroup.headers.length - 1;
                     const isStretchColumn = colIdx === stretchColumnIdx;
@@ -1276,12 +1280,12 @@ const StandardTable = <T extends object>({
                         style={
                           colWidth
                             ? { width: colWidth, minWidth: colWidth }
-                            : isActionColumn
+                            : isStickyRightColumn
                               ? { minWidth: '40px', width: 'auto' }
                               : undefined
                         }
                         aria-label={isActionColumn ? col.header : undefined}
-                        className={`relative group h-10 border-border ${isLastColumn ? 'pl-3 pr-2' : 'px-3'} whitespace-nowrap ${isStretchColumn ? 'w-full' : isActionColumn ? 'w-auto' : 'w-px'} ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''} ${isActionColumn ? 'sticky right-0 z-20 border-l border-border bg-background' : ''} ${col.headerClassName || ''}`}
+                        className={`relative group h-10 border-border ${isLastColumn ? 'pl-3 pr-2' : 'px-3'} whitespace-nowrap ${isStretchColumn ? 'w-full' : isStickyRightColumn ? 'w-auto' : 'w-px'} ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''} ${isStickyRightColumn ? 'sticky right-0 z-20 border-l border-border bg-background' : ''} ${col.headerClassName || ''}`}
                       >
                         {!isActionColumn && (
                           <div
@@ -1342,7 +1346,8 @@ const StandardTable = <T extends object>({
                         const colId = cell.column.id;
                         const col = colsById.get(colId);
                         if (!col) return null;
-                        const isActionColumn = col.sticky === 'right';
+                        const isStickyRightColumn = col.sticky === 'right';
+                        const isActionColumn = isRowActionColumn(col);
                         const isFirstColumn = colIdx === 0;
                         const isLastColumn = colIdx === visibleCells.length - 1;
                         const isStretchColumn = colIdx === stretchColumnIdx;
@@ -1367,11 +1372,11 @@ const StandardTable = <T extends object>({
                             style={
                               colWidth
                                 ? { width: colWidth, minWidth: colWidth }
-                                : isActionColumn
+                                : isStickyRightColumn
                                   ? { minWidth: '40px' }
                                   : undefined
                             }
-                            className={`${isLastColumn ? 'pl-3 pr-2' : 'px-3'} py-2 whitespace-nowrap ${isActionColumn ? 'w-auto text-right' : `${isStretchColumn ? 'w-full' : 'w-px'} align-middle ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''}`} ${isActionColumn ? 'sticky right-0 z-20 border-l border-border bg-background transition-colors group-hover:bg-muted/50' : ''} ${col.className || ''}`}
+                            className={`${isLastColumn ? 'pl-3 pr-2' : 'px-3'} py-2 whitespace-nowrap ${isStickyRightColumn ? 'w-auto text-right' : `${isStretchColumn ? 'w-full' : 'w-px'} align-middle ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''}`} ${isStickyRightColumn ? 'sticky right-0 z-20 border-l border-border bg-background transition-colors group-hover:bg-muted/50' : ''} ${col.className || ''}`}
                           >
                             {isActionColumn ? (
                               <DropdownMenu>

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -14,7 +14,17 @@ import {
   useReactTable,
   type VisibilityState,
 } from '@tanstack/react-table';
-import { type ReactNode, type Ref, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Children,
+  isValidElement,
+  type ReactNode,
+  type Ref,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import { readTextFromClipboard, writeTextToClipboard } from '../../utils/clipboard';
 import { downloadCsv } from '../../utils/csv';
@@ -592,6 +602,134 @@ const StandardTable = <T extends object>({
   const isRowActionColumn = (col: Column<T>) =>
     col.sticky === 'right' && col.accessorKey == null && col.accessorFn == null;
 
+  const getElementLike = (node: ReactNode) => {
+    if (isValidElement(node))
+      return { type: node.type, props: node.props as Record<string, unknown> };
+    if (typeof node === 'object' && node !== null && 'props' in node) {
+      return node as { type?: unknown; props: Record<string, unknown> };
+    }
+    return null;
+  };
+
+  const getNodeText = (node: ReactNode): string => {
+    if (node === null || node === undefined || typeof node === 'boolean') return '';
+    if (typeof node === 'string' || typeof node === 'number') return String(node);
+    if (Array.isArray(node)) return node.map(getNodeText).join(' ').trim();
+    const element = getElementLike(node);
+    if (element) return getNodeText(element.props.children as ReactNode);
+    return '';
+  };
+
+  const collectClassNames = (node: ReactNode): string => {
+    if (node === null || node === undefined || typeof node === 'boolean') return '';
+    if (Array.isArray(node)) return node.map(collectClassNames).join(' ');
+    const element = getElementLike(node);
+    if (!element) return '';
+    const props = element.props as { className?: unknown; children?: ReactNode };
+    return [
+      typeof props.className === 'string' ? props.className : '',
+      collectClassNames(props.children),
+    ]
+      .filter(Boolean)
+      .join(' ');
+  };
+
+  const getActionIconClassName = (node: ReactNode) => {
+    const classNames = collectClassNames(node);
+    if (classNames.includes('fa-trash')) return 'text-destructive';
+    if (classNames.includes('fa-ban')) return 'text-amber-600';
+    if (classNames.includes('fa-rotate-left')) return 'text-primary';
+    if (classNames.includes('fa-pen')) return 'text-blue-500';
+    return 'text-muted-foreground';
+  };
+
+  const renderActionMenuButton = (node: ReactNode, label: ReactNode, key: number) => {
+    const labelText = getNodeText(label);
+    const element = getElementLike(node);
+    const isButtonElement =
+      element &&
+      ((typeof element.type === 'string' && element.type === 'button') ||
+        element.props.type === 'button' ||
+        typeof element.props.onClick === 'function');
+    if (!isButtonElement) {
+      return (
+        <div key={key} className="flex min-h-7 items-center gap-2 px-2 py-1 text-xs">
+          {node}
+          {labelText && <span className="truncate">{labelText}</span>}
+        </div>
+      );
+    }
+
+    const props = element.props as React.ButtonHTMLAttributes<HTMLButtonElement> & {
+      children?: ReactNode;
+      'data-testid'?: string;
+    };
+    const explicitLabel = props['aria-label'] ?? props.title;
+    const testId = props['data-testid'];
+    const text =
+      labelText ||
+      (typeof explicitLabel === 'string' ? explicitLabel : getNodeText(explicitLabel)) ||
+      getNodeText(props.children);
+
+    return (
+      <button
+        key={key}
+        type="button"
+        aria-label={typeof explicitLabel === 'string' ? explicitLabel : undefined}
+        data-testid={testId}
+        disabled={props.disabled}
+        className="flex h-7 w-full items-center justify-start gap-2 rounded-sm px-2 text-xs font-medium text-popover-foreground outline-hidden transition-colors hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-50"
+        onClick={(event) => {
+          event.stopPropagation();
+          props.onClick?.(event);
+        }}
+      >
+        <span className={`w-3.5 shrink-0 text-center ${getActionIconClassName(props.children)}`}>
+          {props.children}
+        </span>
+        {text && <span className="truncate">{text}</span>}
+      </button>
+    );
+  };
+
+  const renderActionMenuItems = (node: ReactNode) => {
+    const items: ReactNode[] = [];
+    const visit = (current: ReactNode) => {
+      if (current === null || current === undefined || typeof current === 'boolean') return;
+      if (typeof current === 'string' || typeof current === 'number') return;
+      if (Array.isArray(current)) {
+        current.forEach(visit);
+        return;
+      }
+      const element = getElementLike(current);
+      if (!element) return;
+
+      const props = element.props as {
+        children?: ReactNode | (() => ReactNode);
+        label?: ReactNode;
+      };
+
+      if (props.label !== undefined && typeof props.children === 'function') {
+        items.push(renderActionMenuButton(props.children(), props.label, items.length));
+        return;
+      }
+
+      if (
+        (typeof element.type === 'string' && element.type === 'button') ||
+        (props as { type?: unknown }).type === 'button' ||
+        typeof (props as { onClick?: unknown }).onClick === 'function'
+      ) {
+        items.push(renderActionMenuButton(current, undefined, items.length));
+        return;
+      }
+
+      Children.toArray(props.children as ReactNode).forEach(visit);
+    };
+
+    visit(node);
+    return items.length > 0 ? items : node;
+  };
+
   const stepFontSize = (delta: -1 | 1) => {
     setFontSize((prev) => {
       const idx = FONT_SIZES.indexOf(prev);
@@ -798,16 +936,16 @@ const StandardTable = <T extends object>({
             ref={buttonRef}
             aria-label={label}
             variant={active ? 'secondary' : 'outline'}
-            size={text ? 'sm' : 'icon-sm'}
+            size="sm"
             onClick={(e) => {
               e.stopPropagation();
               onClick();
             }}
             disabled={disabled}
-            className={text ? 'h-8 px-2 text-xs' : 'size-8'}
+            className={text ? 'h-8 px-3 text-sm font-medium' : 'size-8'}
           >
-            <i className={`fa-solid ${iconClass} text-[10px]`} aria-hidden="true"></i>
-            {text && <span className="text-[10px] font-bold">{text}</span>}
+            <i className={`fa-solid ${iconClass} text-xs`} aria-hidden="true"></i>
+            {text && <span>{text}</span>}
           </Button>
         )}
       </Tooltip>
@@ -994,9 +1132,10 @@ const StandardTable = <T extends object>({
                     aria-label={t('table.columnSettings')}
                     variant={gearOpen ? 'secondary' : 'outline'}
                     size="sm"
+                    className="h-8 px-3 text-sm font-medium"
                   >
                     {t('table.columns')}
-                    <i className="fa-solid fa-chevron-down text-[10px]" aria-hidden="true"></i>
+                    <i className="fa-solid fa-chevron-down text-xs" aria-hidden="true"></i>
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end" className="w-64">
@@ -1358,10 +1497,21 @@ const StandardTable = <T extends object>({
                             ? 'right'
                             : col.align;
                         const colWidth = columnWidths[colId];
+                        const rawValue = cell.getValue() as
+                          | T[keyof T]
+                          | string
+                          | number
+                          | boolean
+                          | null
+                          | undefined;
                         const cellContent = flexRender(
                           cell.column.columnDef.cell,
                           cell.getContext(),
                         );
+                        const actionCellContent =
+                          isActionColumn && col.cell
+                            ? col.cell({ getValue: () => rawValue, row, value: rawValue })
+                            : cellContent;
                         return (
                           <TableCell
                             key={cell.id}
@@ -1396,12 +1546,12 @@ const StandardTable = <T extends object>({
                                 </DropdownMenuTrigger>
                                 <DropdownMenuContent
                                   align="end"
-                                  className="w-auto min-w-10 p-1"
+                                  className="w-36 p-1"
                                   onClick={(event) => event.stopPropagation()}
                                   onDoubleClick={(event) => event.stopPropagation()}
                                 >
-                                  <div className="flex items-center justify-end gap-1">
-                                    {cellContent}
+                                  <div className="flex flex-col gap-0.5">
+                                    {renderActionMenuItems(actionCellContent)}
                                   </div>
                                 </DropdownMenuContent>
                               </DropdownMenu>

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -1052,6 +1052,7 @@ const StandardTable = <T extends object>({
             aria-label={label}
             variant={active ? 'secondary' : 'outline'}
             size={text ? 'xs' : 'icon-xs'}
+            className="rounded-lg"
             onClick={(e) => {
               e.stopPropagation();
               onClick();
@@ -1097,7 +1098,7 @@ const StandardTable = <T extends object>({
             size="icon-xs"
             aria-label={`${t('table.filters')} ${sourceColumn.header}`}
             onClick={(event) => event.stopPropagation()}
-            className="size-6"
+            className="size-6 rounded-lg"
           >
             <i className="fa-solid fa-filter text-[10px]" aria-hidden="true"></i>
             {hasFilter && <span className="sr-only">{selectedValues.length}</span>}
@@ -1195,7 +1196,7 @@ const StandardTable = <T extends object>({
               table.setPageSize(newValue);
             }}
           >
-            <SelectTrigger size="sm" className="h-7 w-[68px] text-xs text-foreground">
+            <SelectTrigger size="sm" className="h-7 w-[68px] rounded-lg text-xs text-foreground">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -1213,6 +1214,7 @@ const StandardTable = <T extends object>({
             type="button"
             variant="outline"
             size="xs"
+            className="rounded-lg"
             onClick={(e) => {
               e.stopPropagation();
               table.previousPage();
@@ -1228,6 +1230,7 @@ const StandardTable = <T extends object>({
             type="button"
             variant="outline"
             size="xs"
+            className="rounded-lg"
             onClick={(e) => {
               e.stopPropagation();
               table.nextPage();
@@ -1283,7 +1286,7 @@ const StandardTable = <T extends object>({
                     aria-label={t('table.columnSettings')}
                     variant="outline"
                     size="xs"
-                    className="data-[state=open]:border-border data-[state=open]:bg-accent data-[state=open]:text-accent-foreground focus-visible:ring-0"
+                    className="rounded-lg data-[state=open]:border-border data-[state=open]:bg-accent data-[state=open]:text-accent-foreground focus-visible:ring-0"
                   >
                     {t('table.columns')}
                     <i className="fa-solid fa-chevron-down text-xs" aria-hidden="true"></i>
@@ -1540,7 +1543,7 @@ const StandardTable = <T extends object>({
 
       <div
         ref={tableContainerRef}
-        className={`rounded-md border border-border bg-card shadow-sm ${tableContainerClassName ?? 'overflow-x-auto'} ${resizingColId ? 'select-none' : ''}`}
+        className={`rounded-lg border border-border bg-card shadow-sm ${tableContainerClassName ?? 'overflow-x-auto'} ${resizingColId ? 'select-none' : ''}`}
       >
         {columns && data ? (
           <Table className={`w-full text-left ${usesFixedTableLayout ? 'table-fixed' : ''}`}>
@@ -1615,7 +1618,7 @@ const StandardTable = <T extends object>({
                               type="button"
                               disabled={!header.column.getCanSort()}
                               onClick={header.column.getToggleSortingHandler()}
-                              className="inline-flex min-w-0 items-center gap-1 rounded-md px-2 py-1 text-sm font-semibold text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-100"
+                              className="inline-flex min-w-0 items-center gap-1 rounded-lg px-2 py-1 text-sm font-semibold text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-100"
                             >
                               <span className="truncate" data-column-header-label={colId}>
                                 {header.isPlaceholder
@@ -1732,6 +1735,7 @@ const StandardTable = <T extends object>({
                                     size="icon-xs"
                                     aria-label={t('table.rowActions')}
                                     onClick={(event) => event.stopPropagation()}
+                                    className="rounded-lg"
                                   >
                                     <i
                                       className="fa-solid fa-ellipsis text-[10px]"
@@ -1839,12 +1843,19 @@ const StandardTable = <T extends object>({
               )}
             </div>
             <div className="flex items-center justify-end gap-2 border-t border-border px-6 py-3">
-              <Button type="button" variant="ghost" size="sm" onClick={closePasteModal}>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="rounded-lg"
+                onClick={closePasteModal}
+              >
                 {t('table.cancel')}
               </Button>
               <Button
                 type="button"
                 size="sm"
+                className="rounded-lg"
                 onClick={submitPasteImport}
                 disabled={pasteText.trim().length === 0}
               >

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -194,7 +194,6 @@ const StandardTable = <T extends object>({
   const [currentPage, setCurrentPage] = useState(1);
   const [gearOpen, setGearOpen] = useState(false);
   const [resizingColId, setResizingColId] = useState<string | null>(null);
-  const [actionColumnOverlaps, setActionColumnOverlaps] = useState(false);
   const [headerMinWidths, setHeaderMinWidths] = useState<Record<string, number>>({});
 
   const [rowsPerPage, setRowsPerPage] = useState(() => {
@@ -285,14 +284,6 @@ const StandardTable = <T extends object>({
     },
     [title],
   );
-
-  const updateActionColumnOverlap = useCallback(() => {
-    const container = tableContainerRef.current;
-    if (!container) return;
-    const maxScrollLeft = container.scrollWidth - container.clientWidth;
-    const overlaps = maxScrollLeft > 1 && container.scrollLeft < maxScrollLeft - 1;
-    setActionColumnOverlaps((prev) => (prev === overlaps ? prev : overlaps));
-  }, []);
 
   useEffect(() => {
     const next = initialFilterState ?? {};
@@ -557,25 +548,18 @@ const StandardTable = <T extends object>({
   useEffect(() => {
     const container = tableContainerRef.current;
     if (!container) return;
-    const handleResizeLayout = () => {
-      updateHeaderMinWidths();
-      updateActionColumnOverlap();
-    };
-    const handleScroll = () => updateActionColumnOverlap();
 
-    handleResizeLayout();
-    container.addEventListener('scroll', handleScroll, { passive: true });
-    window.addEventListener('resize', handleResizeLayout);
+    updateHeaderMinWidths();
+    window.addEventListener('resize', updateHeaderMinWidths);
 
     const resizeObserver =
-      typeof ResizeObserver !== 'undefined' ? new ResizeObserver(handleResizeLayout) : null;
+      typeof ResizeObserver !== 'undefined' ? new ResizeObserver(updateHeaderMinWidths) : null;
     resizeObserver?.observe(container);
     return () => {
-      container.removeEventListener('scroll', handleScroll);
-      window.removeEventListener('resize', handleResizeLayout);
+      window.removeEventListener('resize', updateHeaderMinWidths);
       resizeObserver?.disconnect();
     };
-  }, [updateActionColumnOverlap, updateHeaderMinWidths]);
+  }, [updateHeaderMinWidths]);
 
   const getValue = useCallback((row: T, col: Column<T>) => {
     if (col.accessorFn) return col.accessorFn(row);
@@ -1693,9 +1677,7 @@ const StandardTable = <T extends object>({
                     const sorted = header.column.getIsSorted();
                     const isResizing = resizingColId === colId || header.column.getIsResizing();
                     const stickyBorderClass =
-                      isStickyRightColumn && (!isActionColumn || actionColumnOverlaps)
-                        ? 'border-l border-border'
-                        : '';
+                      isStickyRightColumn && !isActionColumn ? 'border-l border-border' : '';
 
                     return (
                       <TableHead
@@ -1857,9 +1839,7 @@ const StandardTable = <T extends object>({
                             ? Math.max(cell.column.getSize(), minColumnWidth)
                             : undefined;
                         const stickyBorderClass =
-                          isStickyRightColumn && (!isActionColumn || actionColumnOverlaps)
-                            ? 'border-l border-border'
-                            : '';
+                          isStickyRightColumn && !isActionColumn ? 'border-l border-border' : '';
                         const stickyHoverClass =
                           isStickyRightColumn && !isActionColumn ? 'group-hover:bg-muted/50' : '';
                         const rawValue = cell.getValue() as

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -1469,7 +1469,7 @@ const StandardTable = <T extends object>({
                               type="button"
                               disabled={!header.column.getCanSort()}
                               onClick={header.column.getToggleSortingHandler()}
-                              className="inline-flex min-w-0 items-center gap-1 rounded-sm text-sm font-medium text-muted-foreground outline-none transition-colors hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-100"
+                              className="inline-flex min-w-0 items-center gap-1 rounded-md px-2 py-1 text-sm font-medium text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-100"
                             >
                               <span className="truncate">
                                 {header.isPlaceholder
@@ -1484,7 +1484,7 @@ const StandardTable = <T extends object>({
                                       : sorted === 'desc'
                                         ? 'fa-arrow-down'
                                         : 'fa-arrow-up-arrow-down'
-                                  } text-[10px]`}
+                                  } shrink-0 text-[10px] transition-colors`}
                                   aria-hidden="true"
                                 ></i>
                               )}

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -938,13 +938,12 @@ const StandardTable = <T extends object>({
             ref={buttonRef}
             aria-label={label}
             variant={active ? 'secondary' : 'outline'}
-            size="sm"
+            size={text ? 'sm' : 'icon-sm'}
             onClick={(e) => {
               e.stopPropagation();
               onClick();
             }}
             disabled={disabled}
-            className={text ? 'h-8 px-3 text-sm font-medium' : 'size-8'}
           >
             <i className={`fa-solid ${iconClass} text-xs`} aria-hidden="true"></i>
             {text && <span>{text}</span>}
@@ -1101,7 +1100,7 @@ const StandardTable = <T extends object>({
             table.previousPage();
           }}
           disabled={!table.getCanPreviousPage()}
-          className="h-8 px-3 text-sm font-medium text-foreground disabled:opacity-100"
+          className="text-foreground disabled:opacity-100"
         >
           {t('buttons.previous')}
         </Button>
@@ -1117,7 +1116,7 @@ const StandardTable = <T extends object>({
             table.nextPage();
           }}
           disabled={!table.getCanNextPage()}
-          className="h-8 px-3 text-sm font-medium text-foreground disabled:opacity-100"
+          className="text-foreground disabled:opacity-100"
         >
           {t('buttons.next')}
         </Button>
@@ -1167,7 +1166,6 @@ const StandardTable = <T extends object>({
                     aria-label={t('table.columnSettings')}
                     variant={gearOpen ? 'secondary' : 'outline'}
                     size="sm"
-                    className="h-8 px-3 text-sm font-medium"
                   >
                     {t('table.columns')}
                     <i className="fa-solid fa-chevron-down text-xs" aria-hidden="true"></i>

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -96,8 +96,7 @@ const VIEW_ERROR_DURATION_MS = 3000;
 const COPIED_FEEDBACK_DURATION_MS = 1500;
 const DEFAULT_MIN_COL_WIDTH = 40;
 const HEADER_RESIZE_EXTRA_WIDTH = 64;
-const ACTION_COLUMN_WIDTH = 48;
-const HEADER_CHAR_WIDTH = 8;
+const ACTION_COLUMN_WIDTH = 80;
 type ViewModalState = { kind: 'create' } | { kind: 'edit'; view: CustomView } | null;
 
 export type Column<T> = {
@@ -177,6 +176,7 @@ const StandardTable = <T extends object>({
   const [gearOpen, setGearOpen] = useState(false);
   const [resizingColId, setResizingColId] = useState<string | null>(null);
   const [actionColumnOverlaps, setActionColumnOverlaps] = useState(false);
+  const [headerMinWidths, setHeaderMinWidths] = useState<Record<string, number>>({});
 
   const [rowsPerPage, setRowsPerPage] = useState(() => {
     if (typeof window === 'undefined') return defaultRowsPerPage;
@@ -297,6 +297,43 @@ const StandardTable = <T extends object>({
       }) ?? [],
     [columns, hiddenColIds, getColId],
   );
+  const updateHeaderMinWidths = useCallback(() => {
+    const container = tableContainerRef.current;
+    if (!container) return;
+
+    const next: Record<string, number> = {};
+    for (const col of visibleColumns) {
+      const colId = getColId(col);
+      if (col.sticky === 'right' && col.accessorKey == null && col.accessorFn == null) {
+        next[colId] = ACTION_COLUMN_WIDTH;
+        continue;
+      }
+
+      const headerLabel = Array.from(
+        container.querySelectorAll<HTMLElement>('[data-column-header-label]'),
+      ).find((element) => element.getAttribute('data-column-header-label') === colId);
+      const labelWidth = Math.max(
+        headerLabel?.scrollWidth ?? 0,
+        headerLabel?.getBoundingClientRect().width ?? 0,
+      );
+      next[colId] = Math.max(
+        DEFAULT_MIN_COL_WIDTH,
+        Math.ceil(labelWidth + HEADER_RESIZE_EXTRA_WIDTH),
+      );
+    }
+
+    setHeaderMinWidths((prev) => {
+      const prevEntries = Object.entries(prev);
+      const nextEntries = Object.entries(next);
+      if (
+        prevEntries.length === nextEntries.length &&
+        nextEntries.every(([id, width]) => prev[id] === width)
+      ) {
+        return prev;
+      }
+      return next;
+    });
+  }, [getColId, visibleColumns]);
   const validColumnWidths = useMemo(() => {
     const validIds = new Set((columns ?? []).map((col) => getColId(col)));
     return sanitizeColumnWidths(columnWidths, validIds);
@@ -407,9 +444,12 @@ const StandardTable = <T extends object>({
   useEffect(() => {
     const container = tableContainerRef.current;
     if (!container) return;
-    const handleLayoutChange = () => updateActionColumnOverlap();
+    const handleLayoutChange = () => {
+      updateHeaderMinWidths();
+      updateActionColumnOverlap();
+    };
 
-    updateActionColumnOverlap();
+    handleLayoutChange();
     container.addEventListener('scroll', handleLayoutChange, { passive: true });
     window.addEventListener('resize', handleLayoutChange);
 
@@ -424,9 +464,10 @@ const StandardTable = <T extends object>({
       window.removeEventListener('resize', handleLayoutChange);
       resizeObserver?.disconnect();
     };
-  }, [updateActionColumnOverlap]);
+  }, [updateActionColumnOverlap, updateHeaderMinWidths]);
 
   useEffect(() => {
+    updateHeaderMinWidths();
     updateActionColumnOverlap();
   });
 
@@ -665,10 +706,7 @@ const StandardTable = <T extends object>({
   const getHeaderMinWidth = (col: Column<T>) =>
     isRowActionColumn(col)
       ? ACTION_COLUMN_WIDTH
-      : Math.max(
-          DEFAULT_MIN_COL_WIDTH,
-          Math.ceil(col.header.length * HEADER_CHAR_WIDTH + HEADER_RESIZE_EXTRA_WIDTH),
-        );
+      : (headerMinWidths[getColId(col)] ?? DEFAULT_MIN_COL_WIDTH);
 
   const getElementLike = (node: ReactNode) => {
     if (isValidElement(node))
@@ -1013,7 +1051,7 @@ const StandardTable = <T extends object>({
             ref={buttonRef}
             aria-label={label}
             variant={active ? 'secondary' : 'outline'}
-            size={text ? 'sm' : 'icon-sm'}
+            size={text ? 'xs' : 'icon-xs'}
             onClick={(e) => {
               e.stopPropagation();
               onClick();
@@ -1157,7 +1195,7 @@ const StandardTable = <T extends object>({
               table.setPageSize(newValue);
             }}
           >
-            <SelectTrigger size="sm" className="h-8 w-[76px] text-xs">
+            <SelectTrigger size="sm" className="h-7 w-[68px] text-xs text-foreground">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -1174,7 +1212,7 @@ const StandardTable = <T extends object>({
           <Button
             type="button"
             variant="outline"
-            size="sm"
+            size="xs"
             onClick={(e) => {
               e.stopPropagation();
               table.previousPage();
@@ -1189,7 +1227,7 @@ const StandardTable = <T extends object>({
           <Button
             type="button"
             variant="outline"
-            size="sm"
+            size="xs"
             onClick={(e) => {
               e.stopPropagation();
               table.nextPage();
@@ -1244,7 +1282,7 @@ const StandardTable = <T extends object>({
                     type="button"
                     aria-label={t('table.columnSettings')}
                     variant="outline"
-                    size="sm"
+                    size="xs"
                     className="data-[state=open]:border-border data-[state=open]:bg-accent data-[state=open]:text-accent-foreground focus-visible:ring-0"
                   >
                     {t('table.columns')}
@@ -1556,7 +1594,20 @@ const StandardTable = <T extends object>({
                         aria-label={isActionColumn ? col.header : undefined}
                         className={`relative group h-10 border-border ${isLastColumn ? 'pl-3 pr-2' : 'px-3'} whitespace-nowrap ${usesFixedTableLayout ? '' : isStretchColumn ? 'w-full' : isStickyRightColumn ? 'w-auto' : 'w-px'} ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''} ${isStickyRightColumn ? `sticky right-0 z-20 bg-card ${stickyBorderClass}` : ''} ${col.headerClassName || ''}`}
                       >
-                        {!isActionColumn && (
+                        {isActionColumn ? (
+                          <div
+                            className={`flex items-center gap-1 ${effectiveAlign === 'right' ? 'justify-end' : effectiveAlign === 'center' ? 'justify-center' : 'justify-start'}`}
+                          >
+                            <span
+                              className="truncate text-sm font-semibold text-muted-foreground"
+                              data-column-header-label={colId}
+                            >
+                              {header.isPlaceholder
+                                ? null
+                                : flexRender(header.column.columnDef.header, header.getContext())}
+                            </span>
+                          </div>
+                        ) : (
                           <div
                             className={`flex items-center gap-1 ${effectiveAlign === 'right' ? 'justify-end' : effectiveAlign === 'center' ? 'justify-center' : 'justify-start'}`}
                           >
@@ -1564,25 +1615,23 @@ const StandardTable = <T extends object>({
                               type="button"
                               disabled={!header.column.getCanSort()}
                               onClick={header.column.getToggleSortingHandler()}
-                              className="inline-flex min-w-0 items-center gap-1 rounded-md px-2 py-1 text-sm font-medium text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-100"
+                              className="inline-flex min-w-0 items-center gap-1 rounded-md px-2 py-1 text-sm font-semibold text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-100"
                             >
                               <span className="truncate" data-column-header-label={colId}>
                                 {header.isPlaceholder
                                   ? null
                                   : flexRender(header.column.columnDef.header, header.getContext())}
                               </span>
-                              {header.column.getCanSort() && (
-                                <i
-                                  className={`fa-solid ${
-                                    sorted === 'asc'
-                                      ? 'fa-arrow-up'
-                                      : sorted === 'desc'
-                                        ? 'fa-arrow-down'
-                                        : 'fa-arrow-up-arrow-down'
-                                  } shrink-0 text-[10px] transition-colors`}
-                                  aria-hidden="true"
-                                ></i>
-                              )}
+                              <i
+                                className={`fa-solid ${
+                                  sorted === 'asc'
+                                    ? 'fa-arrow-up'
+                                    : sorted === 'desc'
+                                      ? 'fa-arrow-down'
+                                      : 'fa-arrow-up-arrow-down'
+                                } shrink-0 text-[10px] transition-colors`}
+                                aria-hidden="true"
+                              ></i>
                             </button>
                             {renderHeaderFilter(header.column, col)}
                           </div>
@@ -1672,7 +1721,7 @@ const StandardTable = <T extends object>({
                                   ? { minWidth: '40px' }
                                   : undefined
                             }
-                            className={`${isLastColumn ? 'pl-3 pr-2' : 'px-3'} py-2 whitespace-nowrap ${usesFixedTableLayout && !isActionColumn ? 'max-w-0 overflow-hidden text-ellipsis' : ''} ${isStickyRightColumn ? 'w-auto text-right' : `${usesFixedTableLayout ? '' : isStretchColumn ? 'w-full' : 'w-px'} align-middle ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''}`} ${isStickyRightColumn ? `sticky right-0 z-20 bg-card transition-colors ${stickyBorderClass} ${stickyHoverClass}` : ''} ${col.className || ''}`}
+                            className={`${isLastColumn ? 'pl-3 pr-2' : 'px-3'} py-2 whitespace-nowrap ${!isActionColumn ? 'standard-table-value-cell font-normal' : ''} ${usesFixedTableLayout && !isActionColumn ? 'max-w-0 overflow-hidden text-ellipsis' : ''} ${isStickyRightColumn ? 'w-auto text-right' : `${usesFixedTableLayout ? '' : isStretchColumn ? 'w-full' : 'w-px'} align-middle ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''}`} ${isStickyRightColumn ? `sticky right-0 z-20 bg-card transition-colors ${stickyBorderClass} ${stickyHoverClass}` : ''} ${col.className || ''}`}
                           >
                             {isActionColumn ? (
                               <DropdownMenu>

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -1659,7 +1659,7 @@ const StandardTable = <T extends object>({
                                 type="button"
                                 disabled={!header.column.getCanSort()}
                                 onClick={header.column.getToggleSortingHandler()}
-                                className="inline-flex shrink-0 items-center gap-1 rounded-lg px-2 py-1 text-sm font-semibold text-foreground outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-100"
+                                className={`inline-flex shrink-0 items-center gap-1 rounded-lg px-2 py-1 text-sm font-semibold text-foreground outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-100 ${effectiveAlign === 'left' ? '-ml-2' : ''}`}
                               >
                                 <span
                                   className="whitespace-nowrap"

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -284,6 +284,7 @@ const StandardTable = <T extends object>({
     }
     return -1;
   }, [visibleColumns]);
+  const usesFixedTableLayout = resizingColId !== null || Object.keys(columnWidths).length > 0;
 
   // Excludes statically hidden filter-only columns; sort/filter still target them via colsById.
   const gearColumns = useMemo(() => columns?.filter((col) => !col.hidden) ?? [], [columns]);
@@ -1441,7 +1442,7 @@ const StandardTable = <T extends object>({
         className={`rounded-md border border-border bg-card shadow-sm ${tableContainerClassName ?? 'overflow-x-auto'} ${resizingColId ? 'select-none' : ''}`}
       >
         {columns && data ? (
-          <Table className="w-full text-left">
+          <Table className={`w-full text-left ${usesFixedTableLayout ? 'table-fixed' : ''}`}>
             <TableHeader>
               {table.getHeaderGroups().map((headerGroup) => (
                 <TableRow key={headerGroup.id} className="border-border hover:bg-transparent">
@@ -1474,7 +1475,7 @@ const StandardTable = <T extends object>({
                               : undefined
                         }
                         aria-label={isActionColumn ? col.header : undefined}
-                        className={`relative group h-10 border-border ${isLastColumn ? 'pl-3 pr-2' : 'px-3'} whitespace-nowrap ${isStretchColumn ? 'w-full' : isStickyRightColumn ? 'w-auto' : 'w-px'} ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''} ${isStickyRightColumn ? 'sticky right-0 z-20 border-l border-border bg-card' : ''} ${col.headerClassName || ''}`}
+                        className={`relative group h-10 border-border ${isLastColumn ? 'pl-3 pr-2' : 'px-3'} whitespace-nowrap ${usesFixedTableLayout ? '' : isStretchColumn ? 'w-full' : isStickyRightColumn ? 'w-auto' : 'w-px'} ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''} ${isStickyRightColumn ? 'sticky right-0 z-20 border-l border-border bg-card' : ''} ${col.headerClassName || ''}`}
                       >
                         {!isActionColumn && (
                           <div
@@ -1586,7 +1587,7 @@ const StandardTable = <T extends object>({
                                   ? { minWidth: '40px' }
                                   : undefined
                             }
-                            className={`${isLastColumn ? 'pl-3 pr-2' : 'px-3'} py-2 whitespace-nowrap ${isStickyRightColumn ? 'w-auto text-right' : `${isStretchColumn ? 'w-full' : 'w-px'} align-middle ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''}`} ${isStickyRightColumn ? 'sticky right-0 z-20 border-l border-border bg-card transition-colors group-hover:bg-muted/50' : ''} ${col.className || ''}`}
+                            className={`${isLastColumn ? 'pl-3 pr-2' : 'px-3'} py-2 whitespace-nowrap ${usesFixedTableLayout && !isActionColumn ? 'max-w-0 overflow-hidden text-ellipsis' : ''} ${isStickyRightColumn ? 'w-auto text-right' : `${usesFixedTableLayout ? '' : isStretchColumn ? 'w-full' : 'w-px'} align-middle ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''}`} ${isStickyRightColumn ? 'sticky right-0 z-20 border-l border-border bg-card transition-colors group-hover:bg-muted/50' : ''} ${col.className || ''}`}
                           >
                             {isActionColumn ? (
                               <DropdownMenu>

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -100,7 +100,7 @@ const HEADER_RESIZE_EXTRA_WIDTH = 64;
 const ACTION_COLUMN_WIDTH = 80;
 const TEXT_SM_LINE_HEIGHT_CLASSNAME = 'leading-[var(--text-sm--line-height)]';
 const TABLE_CONTROL_BUTTON_CLASSNAME =
-  '!h-7 !gap-1.5 !rounded-lg !px-2 !text-sm !leading-[var(--text-sm--line-height)] !font-normal';
+  '!h-7 !gap-1.5 !rounded-lg !px-2 !text-sm !leading-[var(--text-sm--line-height)] !font-medium';
 type ViewModalState = { kind: 'create' } | { kind: 'edit'; view: CustomView } | null;
 
 export type Column<T> = {

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -98,7 +98,9 @@ const COPIED_FEEDBACK_DURATION_MS = 1500;
 const DEFAULT_MIN_COL_WIDTH = 40;
 const HEADER_RESIZE_EXTRA_WIDTH = 64;
 const ACTION_COLUMN_WIDTH = 80;
-const TABLE_CONTROL_BUTTON_CLASSNAME = '!h-7 !gap-1.5 !rounded-lg !px-2 !text-sm !font-bold';
+const TEXT_SM_LINE_HEIGHT_CLASSNAME = 'leading-[var(--text-sm--line-height)]';
+const TABLE_CONTROL_BUTTON_CLASSNAME =
+  '!h-7 !gap-1.5 !rounded-lg !px-2 !text-sm !leading-[var(--text-sm--line-height)] !font-normal';
 type ViewModalState = { kind: 'create' } | { kind: 'edit'; view: CustomView } | null;
 
 export type Column<T> = {
@@ -167,6 +169,7 @@ const StandardTable = <T extends object>({
   const resizeStartXRef = useRef(0);
   const resizeStartWidthRef = useRef(0);
   const resizeMinWidthRef = useRef(DEFAULT_MIN_COL_WIDTH);
+  const resizeHasMovedRef = useRef(false);
   const tableContainerRef = useRef<HTMLDivElement | null>(null);
 
   const [sortState, setSortState] = useState<SortState>(null);
@@ -367,6 +370,20 @@ const StandardTable = <T extends object>({
     });
   }, [measureVisibleColumnWidths]);
 
+  const setHeaderMinWidthsIfChanged = useCallback((next: Record<string, number>) => {
+    setHeaderMinWidths((prev) => {
+      const prevEntries = Object.entries(prev);
+      const nextEntries = Object.entries(next);
+      if (
+        prevEntries.length === nextEntries.length &&
+        nextEntries.every(([id, width]) => prev[id] === width)
+      ) {
+        return prev;
+      }
+      return next;
+    });
+  }, []);
+
   const getHeaderMinWidth = useCallback(
     (col: Column<T>) =>
       isRowActionColumn(col)
@@ -388,7 +405,7 @@ const StandardTable = <T extends object>({
     }
     return -1;
   }, [visibleColumns]);
-  const usesFixedTableLayout = resizingColId !== null || Object.keys(validColumnWidths).length > 0;
+  const usesFixedTableLayout = Object.keys(validColumnWidths).length > 0;
 
   // Excludes statically hidden filter-only columns; sort/filter still target them via colsById.
   const gearColumns = useMemo(() => columns?.filter((col) => !col.hidden) ?? [], [columns]);
@@ -453,10 +470,15 @@ const StandardTable = <T extends object>({
 
     const handleMouseMove = (e: MouseEvent) => {
       const delta = e.clientX - resizeStartXRef.current;
+      if (Math.abs(delta) < 1) return;
       const newWidth = Math.max(resizeMinWidthRef.current, resizeStartWidthRef.current + delta);
       setColumnWidths((prev) => {
+        const seededWidths = resizeHasMovedRef.current
+          ? prev
+          : { ...prev, ...(measureVisibleColumnWidths(true) ?? {}) };
+        resizeHasMovedRef.current = true;
         if (prev[resizingColId] === newWidth) return prev;
-        return { ...prev, [resizingColId]: newWidth };
+        return { ...seededWidths, [resizingColId]: newWidth };
       });
     };
 
@@ -480,7 +502,7 @@ const StandardTable = <T extends object>({
       document.removeEventListener('mouseup', handleMouseUp);
       document.body.style.cursor = '';
     };
-  }, [columns, getColId, resizingColId, title]);
+  }, [columns, getColId, measureVisibleColumnWidths, resizingColId, title]);
 
   useEffect(() => {
     const container = tableContainerRef.current;
@@ -498,9 +520,6 @@ const StandardTable = <T extends object>({
     const resizeObserver =
       typeof ResizeObserver !== 'undefined' ? new ResizeObserver(handleResizeLayout) : null;
     resizeObserver?.observe(container);
-    const tableElement = container.querySelector('table');
-    if (tableElement) resizeObserver?.observe(tableElement);
-
     return () => {
       container.removeEventListener('scroll', handleScroll);
       window.removeEventListener('resize', handleResizeLayout);
@@ -1047,18 +1066,10 @@ const StandardTable = <T extends object>({
     const th = e.currentTarget.parentElement as HTMLTableCellElement;
     const headerLabel = th.querySelector<HTMLElement>('[data-column-header-label]');
     const measuredMinWidths = measureVisibleColumnWidths();
-    if (measuredMinWidths) setHeaderMinWidths(measuredMinWidths);
+    if (measuredMinWidths) setHeaderMinWidthsIfChanged(measuredMinWidths);
     const resizedColumn = colsById.get(colId);
     const currentWidth = Math.ceil(th.getBoundingClientRect().width);
-    if (resizedColumn && currentWidth > 0) {
-      setColumnWidths((prev) => ({
-        ...prev,
-        [colId]: Math.max(
-          getMeasuredColumnWidth(resizedColumn, headerLabel ?? undefined),
-          currentWidth,
-        ),
-      }));
-    }
+    resizeHasMovedRef.current = false;
     resizeStartXRef.current = e.clientX;
     resizeStartWidthRef.current = currentWidth;
     resizeMinWidthRef.current = resizedColumn
@@ -1342,17 +1353,17 @@ const StandardTable = <T extends object>({
                   </DropdownMenuLabel>
                   <DropdownMenuSeparator />
                   <div className="max-h-64 overflow-y-auto">
-                    {table
-                      .getAllColumns()
-                      .filter((column) => column.getCanHide() && colsById.has(column.id))
-                      .map((column) => {
+                    {(() => {
+                      const hideableColumns = table
+                        .getAllColumns()
+                        .filter((column) => column.getCanHide() && colsById.has(column.id));
+                      const visibleHideableColumnCount = table
+                        .getVisibleLeafColumns()
+                        .filter((visibleColumn) => visibleColumn.getCanHide()).length;
+                      return hideableColumns.map((column) => {
                         const sourceColumn = colsById.get(column.id);
                         const isVisible = column.getIsVisible();
-                        const isLastVisible =
-                          table
-                            .getVisibleLeafColumns()
-                            .filter((visibleColumn) => visibleColumn.getCanHide()).length === 1 &&
-                          isVisible;
+                        const isLastVisible = visibleHideableColumnCount === 1 && isVisible;
                         return (
                           <DropdownMenuCheckboxItem
                             key={column.id}
@@ -1367,7 +1378,8 @@ const StandardTable = <T extends object>({
                             <span className="truncate">{sourceColumn?.header ?? column.id}</span>
                           </DropdownMenuCheckboxItem>
                         );
-                      })}
+                      });
+                    })()}
                   </div>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem
@@ -1776,7 +1788,7 @@ const StandardTable = <T extends object>({
                                   ? { minWidth: '40px' }
                                   : undefined
                             }
-                            className={`${isLastColumn ? 'pl-3 pr-2' : 'px-3'} py-2 whitespace-nowrap ${!isActionColumn ? 'standard-table-value-cell text-sm font-normal' : ''} ${usesFixedTableLayout && !isActionColumn ? 'max-w-0 overflow-hidden text-ellipsis' : ''} ${isStickyRightColumn ? 'w-auto text-right' : `${usesFixedTableLayout ? '' : isStretchColumn ? 'w-full' : 'w-px'} align-middle ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''}`} ${isStickyRightColumn ? `sticky right-0 z-20 bg-card transition-colors ${stickyBorderClass} ${stickyHoverClass}` : ''} ${col.className || ''}`}
+                            className={`${isLastColumn ? 'pl-3 pr-2' : 'px-3'} py-2 whitespace-nowrap ${!isActionColumn ? `standard-table-value-cell text-sm ${TEXT_SM_LINE_HEIGHT_CLASSNAME} font-normal` : ''} ${usesFixedTableLayout && !isActionColumn ? 'max-w-0 overflow-hidden text-ellipsis' : ''} ${isStickyRightColumn ? 'w-auto text-right' : `${usesFixedTableLayout ? '' : isStretchColumn ? 'w-full' : 'w-px'} align-middle ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''}`} ${isStickyRightColumn ? `sticky right-0 z-20 bg-card transition-colors ${stickyBorderClass} ${stickyHoverClass}` : ''} ${col.className || ''}`}
                           >
                             {isActionColumn ? (
                               <DropdownMenu>

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -1349,14 +1349,14 @@ const StandardTable = <T extends object>({
                         </div>
                       )}
                       <DropdownMenuSeparator />
-                      <div className="grid gap-1 p-1">
+                      <div className="flex gap-1 p-1">
                         <DropdownMenuItem
                           onSelect={(e) => {
                             e.preventDefault();
                             setModalState({ kind: 'create' });
                             setGearOpen(false);
                           }}
-                          className="text-xs"
+                          className="flex-1 justify-center text-xs"
                         >
                           <i className="fa-solid fa-plus text-[10px]" aria-hidden="true"></i>
                           <span>{t('buttons.add')}</span>
@@ -1366,7 +1366,7 @@ const StandardTable = <T extends object>({
                             e.preventDefault();
                             void importView();
                           }}
-                          className="text-xs"
+                          className="flex-1 justify-center text-xs"
                         >
                           <i className="fa-solid fa-file-import text-[10px]" aria-hidden="true"></i>
                           <span>{t('buttons.import')}</span>

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -119,6 +119,10 @@ const ACTION_COLUMN_WIDTH = 96;
 const TEXT_SM_LINE_HEIGHT_CLASSNAME = 'leading-[var(--text-sm--line-height)]';
 const TABLE_CONTROL_BUTTON_CLASSNAME =
   '!h-7 !gap-1.5 !rounded-lg !px-2 !text-sm !leading-[var(--text-sm--line-height)] !font-medium';
+const ACTION_MENU_CONTENT_CLASSNAME = 'w-max min-w-[9rem] max-w-[calc(100vw-2rem)] p-1';
+const ACTION_MENU_ITEMS_CLASSNAME = 'flex flex-col gap-0.5';
+const ACTION_MENU_BUTTON_CLASSNAME =
+  'flex h-7 w-full items-center justify-start gap-2 rounded-sm px-2 text-xs font-medium whitespace-nowrap text-popover-foreground outline-hidden transition-colors hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-50';
 type ViewModalState = { kind: 'create' } | { kind: 'edit'; view: CustomView } | null;
 
 export type Column<T> = {
@@ -299,17 +303,20 @@ const StandardTable = <T extends object>({
   );
 
   const isRowActionColumn = useCallback(
-    (col: Column<T>) => col.sticky === 'right' && col.accessorKey == null && col.accessorFn == null,
-    [],
+    (col: Column<T>) =>
+      getColId(col) === 'actions' ||
+      (col.sticky === 'right' && col.accessorKey == null && col.accessorFn == null),
+    [getColId],
   );
 
   const visibleColumns = useMemo(
     () =>
       columns?.filter((col) => {
         if (col.hidden) return false;
+        if (isRowActionColumn(col)) return true;
         return !hiddenColIds.has(getColId(col));
       }) ?? [],
-    [columns, hiddenColIds, getColId],
+    [columns, hiddenColIds, getColId, isRowActionColumn],
   );
 
   const getColumnMinWidth = useCallback(
@@ -368,8 +375,12 @@ const StandardTable = <T extends object>({
 
   const usesFixedTableLayout = Boolean(columns && data);
 
-  // Excludes statically hidden filter-only columns; sort/filter still target them via colsById.
-  const gearColumns = useMemo(() => columns?.filter((col) => !col.hidden) ?? [], [columns]);
+  // Excludes statically hidden filter-only columns and row actions; sort/filter
+  // still target hidden filter-only columns via colsById.
+  const gearColumns = useMemo(
+    () => columns?.filter((col) => !col.hidden && !isRowActionColumn(col)) ?? [],
+    [columns, isRowActionColumn],
+  );
 
   const modalColumns = useMemo(
     () => gearColumns.map((col) => ({ id: getColId(col), header: col.header })),
@@ -489,7 +500,7 @@ const StandardTable = <T extends object>({
           enableResizing: !isRowActionColumn(col),
           enableSorting: !col.disableSorting,
           enableColumnFilter: !col.disableFiltering,
-          enableHiding: !col.hidden,
+          enableHiding: !col.hidden && !isRowActionColumn(col),
           sortingFn: (rowA, rowB) => {
             const valA = rowA.getValue(colId);
             const valB = rowB.getValue(colId);
@@ -546,10 +557,11 @@ const StandardTable = <T extends object>({
       Object.fromEntries(
         (columns ?? []).map((col) => {
           const colId = getColId(col);
+          if (isRowActionColumn(col)) return [colId, true];
           return [colId, !col.hidden && !hiddenColIds.has(colId)];
         }),
       ) as VisibilityState,
-    [columns, getColId, hiddenColIds],
+    [columns, getColId, hiddenColIds, isRowActionColumn],
   );
 
   const onSortingChange = useCallback(
@@ -751,7 +763,10 @@ const StandardTable = <T extends object>({
         typeof element.props.onClick === 'function');
     if (!isButtonElement) {
       return (
-        <div key={key} className="flex min-h-7 items-center gap-2 px-2 py-1 text-xs">
+        <div
+          key={key}
+          className="flex min-h-7 items-center gap-2 px-2 py-1 text-xs text-popover-foreground"
+        >
           {node}
           {labelText && <span className="whitespace-nowrap">{labelText}</span>}
         </div>
@@ -776,7 +791,7 @@ const StandardTable = <T extends object>({
         aria-label={typeof explicitLabel === 'string' ? explicitLabel : undefined}
         data-testid={testId}
         disabled={props.disabled}
-        className="flex h-7 w-full items-center justify-start gap-2 rounded-sm px-2 text-xs font-medium whitespace-nowrap text-popover-foreground outline-hidden transition-colors hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-50"
+        className={ACTION_MENU_BUTTON_CLASSNAME}
         onClick={(event) => {
           event.stopPropagation();
           props.onClick?.(event);
@@ -1550,16 +1565,15 @@ const StandardTable = <T extends object>({
                     const col = colsById.get(header.column.id);
                     if (!col) return null;
                     const colId = getColId(col);
-                    const isStickyRightColumn = col.sticky === 'right';
                     const isActionColumn = isRowActionColumn(col);
+                    const isStickyRightColumn = col.sticky === 'right' || isActionColumn;
                     const isFirstColumn = colIdx === 0;
                     const isLastColumn = colIdx === headerGroup.headers.length - 1;
                     const isBeforeActionSpacer =
                       shouldAnchorTrailingActionColumn &&
                       !isActionColumn &&
                       colIdx === headerGroup.headers.length - 2;
-                    const shouldStickRightColumn =
-                      isStickyRightColumn && (!isActionColumn || shouldAnchorTrailingActionColumn);
+                    const shouldStickRightColumn = isStickyRightColumn;
                     // Force alignment: first column left, last column right, otherwise use col.align
                     const effectiveAlign = isFirstColumn
                       ? 'left'
@@ -1688,8 +1702,24 @@ const StandardTable = <T extends object>({
                     const col = colsById.get(cell.column.id);
                     return col ? isRowActionColumn(col) : false;
                   });
+                  const rowActionColumn = rowActionCell
+                    ? colsById.get(rowActionCell.column.id)
+                    : undefined;
+                  const rowActionValue = rowActionCell?.getValue() as
+                    | T[keyof T]
+                    | string
+                    | number
+                    | boolean
+                    | null
+                    | undefined;
                   const rowActionContent = rowActionCell
-                    ? flexRender(rowActionCell.column.columnDef.cell, rowActionCell.getContext())
+                    ? rowActionColumn?.cell
+                      ? rowActionColumn.cell({
+                          getValue: () => rowActionValue,
+                          row,
+                          value: rowActionValue,
+                        })
+                      : flexRender(rowActionCell.column.columnDef.cell, rowActionCell.getContext())
                     : null;
                   const rowElement = (
                     <TableRow
@@ -1701,13 +1731,11 @@ const StandardTable = <T extends object>({
                         const colId = cell.column.id;
                         const col = colsById.get(colId);
                         if (!col) return null;
-                        const isStickyRightColumn = col.sticky === 'right';
                         const isActionColumn = isRowActionColumn(col);
+                        const isStickyRightColumn = col.sticky === 'right' || isActionColumn;
                         const isFirstColumn = colIdx === 0;
                         const isLastColumn = colIdx === visibleCells.length - 1;
-                        const shouldStickRightColumn =
-                          isStickyRightColumn &&
-                          (!isActionColumn || shouldAnchorTrailingActionColumn);
+                        const shouldStickRightColumn = isStickyRightColumn;
                         // Force alignment: first column left, last column right, otherwise use col.align
                         const effectiveAlign = isFirstColumn
                           ? 'left'
@@ -1769,11 +1797,12 @@ const StandardTable = <T extends object>({
                                   </DropdownMenuTrigger>
                                   <DropdownMenuContent
                                     align="end"
-                                    className="w-max min-w-[9rem] max-w-[calc(100vw-2rem)] p-1"
+                                    data-standard-table-action-menu="true"
+                                    className={ACTION_MENU_CONTENT_CLASSNAME}
                                     onClick={(event) => event.stopPropagation()}
                                     onDoubleClick={(event) => event.stopPropagation()}
                                   >
-                                    <div className="flex flex-col gap-0.5">
+                                    <div className={ACTION_MENU_ITEMS_CLASSNAME}>
                                       {renderActionMenuItems(cellContent)}
                                     </div>
                                   </DropdownMenuContent>
@@ -1792,11 +1821,12 @@ const StandardTable = <T extends object>({
                     <ContextMenu key={tableRow.id}>
                       <ContextMenuTrigger asChild>{rowElement}</ContextMenuTrigger>
                       <ContextMenuContent
-                        className="w-max min-w-[9rem] max-w-[calc(100vw-2rem)] p-1"
+                        data-standard-table-action-menu="true"
+                        className={ACTION_MENU_CONTENT_CLASSNAME}
                         onClick={(event) => event.stopPropagation()}
                         onDoubleClick={(event) => event.stopPropagation()}
                       >
-                        <div className="flex flex-col gap-0.5">
+                        <div className={ACTION_MENU_ITEMS_CLASSNAME}>
                           {renderActionMenuItems(rowActionContent)}
                         </div>
                       </ContextMenuContent>

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -115,7 +115,7 @@ const HEADER_SORT_ICON_WIDTH = 12;
 const HEADER_SORT_ICON_GAP = 4;
 const HEADER_FILTER_BUTTON_WIDTH = 24;
 const HEADER_CONTENT_GAP = 4;
-const ACTION_COLUMN_WIDTH = 96;
+const ACTION_COLUMN_WIDTH = 64;
 const TEXT_SM_LINE_HEIGHT_CLASSNAME = 'leading-[var(--text-sm--line-height)]';
 const TABLE_CONTROL_BUTTON_CLASSNAME =
   '!h-7 !gap-1.5 !rounded-lg !px-2 !text-sm !leading-[var(--text-sm--line-height)] !font-medium';

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -291,6 +291,11 @@ const StandardTable = <T extends object>({
     [],
   );
 
+  const isRowActionColumn = useCallback(
+    (col: Column<T>) => col.sticky === 'right' && col.accessorKey == null && col.accessorFn == null,
+    [],
+  );
+
   const visibleColumns = useMemo(
     () =>
       columns?.filter((col) => {
@@ -299,30 +304,54 @@ const StandardTable = <T extends object>({
       }) ?? [],
     [columns, hiddenColIds, getColId],
   );
-  const updateHeaderMinWidths = useCallback(() => {
-    const container = tableContainerRef.current;
-    if (!container) return;
 
-    const next: Record<string, number> = {};
-    for (const col of visibleColumns) {
-      const colId = getColId(col);
-      if (col.sticky === 'right' && col.accessorKey == null && col.accessorFn == null) {
-        next[colId] = ACTION_COLUMN_WIDTH;
-        continue;
-      }
+  const getMeasuredColumnWidth = useCallback(
+    (col: Column<T>, label: HTMLElement | undefined, includeRenderedWidth = false) => {
+      if (isRowActionColumn(col)) return ACTION_COLUMN_WIDTH;
 
-      const headerLabel = Array.from(
-        container.querySelectorAll<HTMLElement>('[data-column-header-label]'),
-      ).find((element) => element.getAttribute('data-column-header-label') === colId);
       const labelWidth = Math.max(
-        headerLabel?.scrollWidth ?? 0,
-        headerLabel?.getBoundingClientRect().width ?? 0,
+        label?.scrollWidth ?? 0,
+        label?.getBoundingClientRect().width ?? 0,
       );
-      next[colId] = Math.max(
+      const minWidth = Math.max(
         DEFAULT_MIN_COL_WIDTH,
         Math.ceil(labelWidth + HEADER_RESIZE_EXTRA_WIDTH),
       );
-    }
+      if (!includeRenderedWidth) return minWidth;
+
+      const headerCell = label?.closest('th') as HTMLTableCellElement | null;
+      return Math.max(minWidth, Math.ceil(headerCell?.getBoundingClientRect().width ?? 0));
+    },
+    [isRowActionColumn],
+  );
+
+  const measureVisibleColumnWidths = useCallback(
+    (includeRenderedWidth = false) => {
+      const container = tableContainerRef.current;
+      if (!container) return null;
+
+      const labelsByColumnId = new Map(
+        Array.from(container.querySelectorAll<HTMLElement>('[data-column-header-label]')).map(
+          (element) => [element.getAttribute('data-column-header-label') ?? '', element],
+        ),
+      );
+      const next: Record<string, number> = {};
+      for (const col of visibleColumns) {
+        const colId = getColId(col);
+        next[colId] = getMeasuredColumnWidth(
+          col,
+          labelsByColumnId.get(colId),
+          includeRenderedWidth,
+        );
+      }
+      return next;
+    },
+    [getColId, getMeasuredColumnWidth, visibleColumns],
+  );
+
+  const updateHeaderMinWidths = useCallback(() => {
+    const next = measureVisibleColumnWidths();
+    if (!next) return;
 
     setHeaderMinWidths((prev) => {
       const prevEntries = Object.entries(prev);
@@ -335,7 +364,7 @@ const StandardTable = <T extends object>({
       }
       return next;
     });
-  }, [getColId, visibleColumns]);
+  }, [measureVisibleColumnWidths]);
   const validColumnWidths = useMemo(() => {
     const validIds = new Set((columns ?? []).map((col) => getColId(col)));
     return sanitizeColumnWidths(columnWidths, validIds);
@@ -446,24 +475,25 @@ const StandardTable = <T extends object>({
   useEffect(() => {
     const container = tableContainerRef.current;
     if (!container) return;
-    const handleLayoutChange = () => {
+    const handleResizeLayout = () => {
       updateHeaderMinWidths();
       updateActionColumnOverlap();
     };
+    const handleScroll = () => updateActionColumnOverlap();
 
-    handleLayoutChange();
-    container.addEventListener('scroll', handleLayoutChange, { passive: true });
-    window.addEventListener('resize', handleLayoutChange);
+    handleResizeLayout();
+    container.addEventListener('scroll', handleScroll, { passive: true });
+    window.addEventListener('resize', handleResizeLayout);
 
     const resizeObserver =
-      typeof ResizeObserver !== 'undefined' ? new ResizeObserver(handleLayoutChange) : null;
+      typeof ResizeObserver !== 'undefined' ? new ResizeObserver(handleResizeLayout) : null;
     resizeObserver?.observe(container);
     const tableElement = container.querySelector('table');
     if (tableElement) resizeObserver?.observe(tableElement);
 
     return () => {
-      container.removeEventListener('scroll', handleLayoutChange);
-      window.removeEventListener('resize', handleLayoutChange);
+      container.removeEventListener('scroll', handleScroll);
+      window.removeEventListener('resize', handleResizeLayout);
       resizeObserver?.disconnect();
     };
   }, [updateActionColumnOverlap, updateHeaderMinWidths]);
@@ -695,9 +725,6 @@ const StandardTable = <T extends object>({
     if (typeof filterValue === 'string') return [filterValue];
     return [];
   };
-
-  const isRowActionColumn = (col: Column<T>) =>
-    col.sticky === 'right' && col.accessorKey == null && col.accessorFn == null;
 
   const getHeaderMinWidth = (col: Column<T>) =>
     isRowActionColumn(col)
@@ -1005,39 +1032,17 @@ const StandardTable = <T extends object>({
     e.preventDefault();
     e.stopPropagation();
     const th = e.currentTarget.parentElement as HTMLTableCellElement;
-    const container = tableContainerRef.current;
     const headerLabel = th.querySelector<HTMLElement>('[data-column-header-label]');
-    const headerTextWidth = Math.max(
-      headerLabel?.scrollWidth ?? 0,
-      headerLabel?.getBoundingClientRect().width ?? 0,
-    );
-    if (container) {
-      const measuredWidths: Record<string, number> = {};
-      for (const col of visibleColumns) {
-        const visibleColId = getColId(col);
-        const label = Array.from(
-          container.querySelectorAll<HTMLElement>('[data-column-header-label]'),
-        ).find((element) => element.getAttribute('data-column-header-label') === visibleColId);
-        const headerCell = label?.closest('th') as HTMLTableCellElement | null;
-        const width = Math.ceil(headerCell?.getBoundingClientRect().width ?? 0);
-        const labelWidth = Math.max(
-          label?.scrollWidth ?? 0,
-          label?.getBoundingClientRect().width ?? 0,
-        );
-        measuredWidths[visibleColId] = Math.max(
-          getHeaderMinWidth(col),
-          Math.ceil(labelWidth + HEADER_RESIZE_EXTRA_WIDTH),
-          width,
-        );
-      }
+    const measuredWidths = measureVisibleColumnWidths(true);
+    if (measuredWidths) {
       setColumnWidths((prev) => ({ ...prev, ...measuredWidths }));
     }
     resizeStartXRef.current = e.clientX;
     resizeStartWidthRef.current = th.getBoundingClientRect().width;
-    resizeMinWidthRef.current = Math.max(
-      DEFAULT_MIN_COL_WIDTH,
-      Math.ceil(headerTextWidth + HEADER_RESIZE_EXTRA_WIDTH),
-    );
+    const resizedColumn = colsById.get(colId);
+    resizeMinWidthRef.current = resizedColumn
+      ? getMeasuredColumnWidth(resizedColumn, headerLabel ?? undefined)
+      : DEFAULT_MIN_COL_WIDTH;
     setResizingColId(colId);
   };
 

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -42,6 +42,7 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from '../ui/dropdown-menu';
+import { Input } from '../ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table';
 import CustomViewModal from './CustomViewModal';
@@ -210,6 +211,7 @@ const StandardTable = <T extends object>({
   const [pasteModalOpen, setPasteModalOpen] = useState(false);
   const [pasteText, setPasteText] = useState('');
   const [pasteError, setPasteError] = useState<string | null>(null);
+  const [filterSearchByColumnId, setFilterSearchByColumnId] = useState<Record<string, string>>({});
   const copiedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const viewErrorTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const viewsAppliedOnceRef = useRef(false);
@@ -957,9 +959,25 @@ const StandardTable = <T extends object>({
     const selectedValues = getSelectedFilterValues(column);
     const hasFilter = selectedValues.length > 0;
     const options = getFilterOptions(column.id);
+    const filterSearch = filterSearchByColumnId[column.id] ?? '';
+    const normalizedFilterSearch = filterSearch.trim().toLocaleLowerCase();
+    const visibleOptions = normalizedFilterSearch
+      ? options.filter((option) =>
+          (option || t('table.empty')).toLocaleLowerCase().includes(normalizedFilterSearch),
+        )
+      : options;
 
     return (
-      <DropdownMenu>
+      <DropdownMenu
+        onOpenChange={(open) => {
+          if (open || !filterSearchByColumnId[column.id]) return;
+          setFilterSearchByColumnId((prev) => {
+            const next = { ...prev };
+            delete next[column.id];
+            return next;
+          });
+        }}
+      >
         <DropdownMenuTrigger asChild>
           <Button
             type="button"
@@ -980,9 +998,24 @@ const StandardTable = <T extends object>({
         >
           <DropdownMenuLabel className="text-xs">{sourceColumn.header}</DropdownMenuLabel>
           <DropdownMenuSeparator />
+          <div className="p-1">
+            <Input
+              type="search"
+              value={filterSearch}
+              onChange={(event) => {
+                const value = event.target.value;
+                setFilterSearchByColumnId((prev) => ({ ...prev, [column.id]: value }));
+              }}
+              onClick={(event) => event.stopPropagation()}
+              onKeyDown={(event) => event.stopPropagation()}
+              placeholder={t('table.search')}
+              aria-label={`${t('table.search')} ${sourceColumn.header}`}
+              className="h-8 text-xs"
+            />
+          </div>
           <div className="max-h-64 overflow-y-auto">
-            {options.length > 0 ? (
-              options.map((option) => (
+            {visibleOptions.length > 0 ? (
+              visibleOptions.map((option) => (
                 <DropdownMenuCheckboxItem
                   key={option || '__empty__'}
                   checked={selectedValues.includes(option)}

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -1069,72 +1069,76 @@ const StandardTable = <T extends object>({
     );
   };
 
-  const renderInternalFooter = () => (
-    <>
-      <div className="flex items-center gap-3 text-sm text-muted-foreground">
-        <span>
-          {t('pagination.showing')
-            .replace('{{start}}', String(totalItems > 0 ? startIndex + 1 : 0))
-            .replace('{{end}}', String(Math.min(startIndex + rowsPerPage, totalItems)))
-            .replace('{{total}}', String(totalItems))}
-        </span>
-        <span className="text-xs font-medium text-muted-foreground">
-          {t('pagination.rowsPerPage')}
-        </span>
-        <Select
-          value={rowsPerPage.toString()}
-          onValueChange={(val) => {
-            const newValue = Number(val);
-            table.setPageIndex(0);
-            table.setPageSize(newValue);
-          }}
-        >
-          <SelectTrigger size="sm" className="h-8 w-[76px] text-xs">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {[5, 10, 20, 50].map((value) => (
-              <SelectItem key={value} value={String(value)}>
-                {value}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
+  const renderInternalFooter = () => {
+    const isSinglePage = Math.max(totalPages, 1) <= 1;
+    const canPreviousPage = !isSinglePage && table.getCanPreviousPage();
+    const canNextPage = !isSinglePage && table.getCanNextPage();
 
-      <div className="flex items-center gap-2">
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={(e) => {
-            e.stopPropagation();
-            table.previousPage();
-          }}
-          disabled={!table.getCanPreviousPage()}
-          className="text-foreground disabled:opacity-100"
-        >
-          {t('buttons.previous')}
-        </Button>
-        <span className="text-sm text-muted-foreground">
-          {currentPage} / {Math.max(totalPages, 1)}
-        </span>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={(e) => {
-            e.stopPropagation();
-            table.nextPage();
-          }}
-          disabled={!table.getCanNextPage()}
-          className="text-foreground disabled:opacity-100"
-        >
-          {t('buttons.next')}
-        </Button>
-      </div>
-    </>
-  );
+    return (
+      <>
+        <div className="flex items-center gap-3 text-sm text-muted-foreground">
+          <span>
+            {t('pagination.showing')
+              .replace('{{start}}', String(totalItems > 0 ? startIndex + 1 : 0))
+              .replace('{{end}}', String(Math.min(startIndex + rowsPerPage, totalItems)))
+              .replace('{{total}}', String(totalItems))}
+          </span>
+          <span className="text-xs font-medium text-muted-foreground">
+            {t('pagination.rowsPerPage')}
+          </span>
+          <Select
+            value={rowsPerPage.toString()}
+            onValueChange={(val) => {
+              const newValue = Number(val);
+              table.setPageIndex(0);
+              table.setPageSize(newValue);
+            }}
+          >
+            <SelectTrigger size="sm" className="h-8 w-[76px] text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {[5, 10, 20, 50].map((value) => (
+                <SelectItem key={value} value={String(value)}>
+                  {value}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={(e) => {
+              e.stopPropagation();
+              table.previousPage();
+            }}
+            disabled={!canPreviousPage}
+          >
+            {t('buttons.previous')}
+          </Button>
+          <span className="text-sm text-muted-foreground">
+            {currentPage} / {Math.max(totalPages, 1)}
+          </span>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={(e) => {
+              e.stopPropagation();
+              table.nextPage();
+            }}
+            disabled={!canNextPage}
+          >
+            {t('buttons.next')}
+          </Button>
+        </div>
+      </>
+    );
+  };
 
   return (
     <div className={`w-full space-y-3 ${containerClassName ?? ''}`.trim()}>
@@ -1176,8 +1180,9 @@ const StandardTable = <T extends object>({
                   <Button
                     type="button"
                     aria-label={t('table.columnSettings')}
-                    variant={gearOpen ? 'secondary' : 'outline'}
+                    variant="outline"
                     size="sm"
+                    className="data-[state=open]:border-border data-[state=open]:bg-accent data-[state=open]:text-accent-foreground focus-visible:ring-0"
                   >
                     {t('table.columns')}
                     <i className="fa-solid fa-chevron-down text-xs" aria-hidden="true"></i>
@@ -1505,10 +1510,19 @@ const StandardTable = <T extends object>({
 
                         {!isActionColumn && (
                           <div
-                            className={`absolute top-0 right-0 z-10 h-full w-1 cursor-col-resize opacity-0 hover:bg-primary/30 group-hover:opacity-100 ${resizingColId === colId ? 'bg-primary/50 opacity-100' : ''}`}
+                            className="absolute top-0 -right-1 z-10 flex h-full w-2 cursor-col-resize items-center justify-center"
                             data-column-resize-handle={colId}
                             onMouseDown={(e) => handleResizeStart(e, colId)}
-                          />
+                          >
+                            <span
+                              data-column-resize-line={colId}
+                              className={`h-5 w-px rounded-full transition-colors ${
+                                resizingColId === colId
+                                  ? 'bg-primary'
+                                  : 'bg-border group-hover:bg-primary/40'
+                              }`}
+                            />
+                          </div>
                         )}
                       </TableHead>
                     );

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -18,6 +18,7 @@ import {
 import { ArrowDown, ArrowUp, ArrowUpDown } from 'lucide-react';
 import {
   Children,
+  Fragment,
   isValidElement,
   type ReactNode,
   type Ref,
@@ -656,6 +657,8 @@ const StandardTable = <T extends object>({
   const totalItems = data ? processedRows.length : externalTotalCount || 0;
   const totalPages = data ? table.getPageCount() : Math.ceil(totalItems / rowsPerPage);
   const paginatedRows = data ? table.getRowModel().rows : [];
+  const hasTrailingActionColumn =
+    visibleColumns.length > 0 && isRowActionColumn(visibleColumns[visibleColumns.length - 1]);
   const fixedTableWidth = useMemo(() => {
     if (!usesFixedTableLayout) return undefined;
     return table.getTotalSize();
@@ -1514,12 +1517,26 @@ const StandardTable = <T extends object>({
         {columns && data ? (
           <Table
             className="table-fixed text-left"
-            style={fixedTableWidth ? { width: `${fixedTableWidth}px` } : undefined}
+            style={
+              fixedTableWidth
+                ? {
+                    width: hasTrailingActionColumn ? '100%' : `${fixedTableWidth}px`,
+                    minWidth: hasTrailingActionColumn ? `${fixedTableWidth}px` : undefined,
+                  }
+                : undefined
+            }
           >
             <colgroup>
               {table.getVisibleLeafColumns().map((column) => {
+                const col = colsById.get(column.id);
                 const colWidth = column.getSize();
-                return <col key={column.id} style={{ width: colWidth }} />;
+                const needsActionSpacer = hasTrailingActionColumn && col && isRowActionColumn(col);
+                return (
+                  <Fragment key={column.id}>
+                    {needsActionSpacer && <col data-action-spacer style={{ width: 'auto' }} />}
+                    <col style={{ width: colWidth }} />
+                  </Fragment>
+                );
               })}
             </colgroup>
             <TableHeader>
@@ -1548,87 +1565,101 @@ const StandardTable = <T extends object>({
                     const resizeHandler = header.getResizeHandler();
 
                     return (
-                      <TableHead
-                        key={header.id}
-                        style={{ width: colWidth, minWidth: minColumnWidth }}
-                        aria-label={isActionColumn ? col.header : undefined}
-                        className={`relative group h-10 border-border ${isLastColumn ? 'pl-3 pr-2' : 'px-3'} whitespace-nowrap ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''} ${isStickyRightColumn ? `sticky right-0 z-20 bg-card ${stickyBorderClass}` : ''} ${col.headerClassName || ''}`}
-                      >
-                        {isActionColumn ? (
-                          <div
-                            data-column-header-content={colId}
-                            className="inline-flex w-max items-center gap-1"
-                          >
-                            <span
-                              className="whitespace-nowrap text-sm font-semibold text-foreground"
-                              data-column-header-label={colId}
+                      <Fragment key={header.id}>
+                        {hasTrailingActionColumn && isActionColumn && (
+                          <TableHead
+                            aria-hidden="true"
+                            style={{ width: 'auto', minWidth: 0 }}
+                            className="h-10 border-border p-0"
+                          />
+                        )}
+                        <TableHead
+                          style={{ width: colWidth, minWidth: minColumnWidth }}
+                          aria-label={isActionColumn ? col.header : undefined}
+                          className={`relative group h-10 border-border ${isLastColumn ? 'pl-3 pr-2' : 'px-3'} whitespace-nowrap ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''} ${isStickyRightColumn ? `sticky right-0 z-20 bg-card ${stickyBorderClass}` : ''} ${col.headerClassName || ''}`}
+                        >
+                          {isActionColumn ? (
+                            <div
+                              data-column-header-content={colId}
+                              className="inline-flex w-max items-center gap-1"
                             >
-                              {header.isPlaceholder
-                                ? null
-                                : flexRender(header.column.columnDef.header, header.getContext())}
-                            </span>
-                          </div>
-                        ) : (
-                          <div
-                            data-column-header-content={colId}
-                            className="inline-flex w-max items-center gap-1"
-                          >
-                            <button
-                              type="button"
-                              disabled={!header.column.getCanSort()}
-                              onClick={header.column.getToggleSortingHandler()}
-                              className="inline-flex shrink-0 items-center gap-1 rounded-lg px-2 py-1 text-sm font-semibold text-foreground outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-100"
-                            >
-                              <span className="whitespace-nowrap" data-column-header-label={colId}>
+                              <span
+                                className="whitespace-nowrap text-sm font-semibold text-foreground"
+                                data-column-header-label={colId}
+                              >
                                 {header.isPlaceholder
                                   ? null
                                   : flexRender(header.column.columnDef.header, header.getContext())}
                               </span>
-                              {sorted === 'asc' ? (
-                                <ArrowUp
-                                  className="size-3 shrink-0 transition-colors"
-                                  aria-hidden="true"
-                                />
-                              ) : sorted === 'desc' ? (
-                                <ArrowDown
-                                  className="size-3 shrink-0 transition-colors"
-                                  aria-hidden="true"
-                                />
-                              ) : (
-                                <ArrowUpDown
-                                  className="size-3 shrink-0 transition-colors"
-                                  aria-hidden="true"
-                                />
-                              )}
-                            </button>
-                            {renderHeaderFilter(header.column, col)}
-                          </div>
-                        )}
+                            </div>
+                          ) : (
+                            <div
+                              data-column-header-content={colId}
+                              className="inline-flex w-max items-center gap-1"
+                            >
+                              <button
+                                type="button"
+                                disabled={!header.column.getCanSort()}
+                                onClick={header.column.getToggleSortingHandler()}
+                                className="inline-flex shrink-0 items-center gap-1 rounded-lg px-2 py-1 text-sm font-semibold text-foreground outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-100"
+                              >
+                                <span
+                                  className="whitespace-nowrap"
+                                  data-column-header-label={colId}
+                                >
+                                  {header.isPlaceholder
+                                    ? null
+                                    : flexRender(
+                                        header.column.columnDef.header,
+                                        header.getContext(),
+                                      )}
+                                </span>
+                                {sorted === 'asc' ? (
+                                  <ArrowUp
+                                    className="size-3 shrink-0 transition-colors"
+                                    aria-hidden="true"
+                                  />
+                                ) : sorted === 'desc' ? (
+                                  <ArrowDown
+                                    className="size-3 shrink-0 transition-colors"
+                                    aria-hidden="true"
+                                  />
+                                ) : (
+                                  <ArrowUpDown
+                                    className="size-3 shrink-0 transition-colors"
+                                    aria-hidden="true"
+                                  />
+                                )}
+                              </button>
+                              {renderHeaderFilter(header.column, col)}
+                            </div>
+                          )}
 
-                        {header.column.getCanResize() && (
-                          <div
-                            className="absolute top-0 right-0 z-30 flex h-full w-2 cursor-col-resize touch-none select-none items-center justify-end"
-                            data-column-resize-handle={colId}
-                            onMouseDown={(event) => {
-                              event.stopPropagation();
-                              resizeHandler(event);
-                            }}
-                            onTouchStart={(event) => {
-                              event.stopPropagation();
-                              resizeHandler(event);
-                            }}
-                            onClick={(event) => event.stopPropagation()}
-                            onDoubleClick={(event) => event.stopPropagation()}
-                          >
-                            <span
-                              data-column-resize-line={colId}
-                              className={`h-5 w-px rounded-full transition-colors ${
-                                isResizing ? 'bg-primary' : 'bg-border group-hover:bg-primary/40'
-                              }`}
-                            />
-                          </div>
-                        )}
-                      </TableHead>
+                          {header.column.getCanResize() && (
+                            <div
+                              className="absolute top-0 right-0 z-30 flex h-full w-2 cursor-col-resize touch-none select-none items-center justify-end"
+                              data-column-resize-handle={colId}
+                              onMouseDown={(event) => {
+                                event.stopPropagation();
+                                resizeHandler(event);
+                              }}
+                              onTouchStart={(event) => {
+                                event.stopPropagation();
+                                resizeHandler(event);
+                              }}
+                              onClick={(event) => event.stopPropagation()}
+                              onDoubleClick={(event) => event.stopPropagation()}
+                            >
+                              <span
+                                data-column-resize-line={colId}
+                                className={`h-5 w-px rounded-full transition-colors ${
+                                  isResizing ? 'bg-primary' : 'bg-border group-hover:bg-primary/40'
+                                }`}
+                              />
+                            </div>
+                          )}
+                        </TableHead>
+                      </Fragment>
                     );
                   })}
                 </TableRow>
@@ -1677,47 +1708,55 @@ const StandardTable = <T extends object>({
                             ? col.cell({ getValue: () => rawValue, row, value: rawValue })
                             : flexRender(cell.column.columnDef.cell, cell.getContext());
                         return (
-                          <TableCell
-                            key={cell.id}
-                            onDoubleClick={(e) => {
-                              e.stopPropagation();
-                              col.onCellDoubleClick?.(row);
-                            }}
-                            style={{ width: colWidth, minWidth: minColumnWidth }}
-                            className={`${isLastColumn ? 'pl-3 pr-2' : 'px-3'} py-2 whitespace-nowrap ${!isActionColumn ? `standard-table-value-cell text-sm ${TEXT_SM_LINE_HEIGHT_CLASSNAME} max-w-0 overflow-hidden text-ellipsis font-normal` : ''} ${isStickyRightColumn ? 'w-auto text-right' : `align-middle ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''}`} ${isStickyRightColumn ? `sticky right-0 z-20 bg-card transition-colors ${stickyBorderClass} ${stickyHoverClass}` : ''} ${col.className || ''}`}
-                          >
-                            {isActionColumn ? (
-                              <DropdownMenu>
-                                <DropdownMenuTrigger asChild>
-                                  <Button
-                                    type="button"
-                                    variant="ghost"
-                                    size="icon-xs"
-                                    aria-label={t('table.rowActions')}
-                                    onClick={(event) => event.stopPropagation()}
-                                    className="rounded-lg"
-                                  >
-                                    <i
-                                      className="fa-solid fa-ellipsis text-[10px]"
-                                      aria-hidden="true"
-                                    ></i>
-                                  </Button>
-                                </DropdownMenuTrigger>
-                                <DropdownMenuContent
-                                  align="end"
-                                  className="w-max min-w-[9rem] max-w-[calc(100vw-2rem)] p-1"
-                                  onClick={(event) => event.stopPropagation()}
-                                  onDoubleClick={(event) => event.stopPropagation()}
-                                >
-                                  <div className="flex flex-col gap-0.5">
-                                    {renderActionMenuItems(cellContent)}
-                                  </div>
-                                </DropdownMenuContent>
-                              </DropdownMenu>
-                            ) : (
-                              cellContent
+                          <Fragment key={cell.id}>
+                            {hasTrailingActionColumn && isActionColumn && (
+                              <TableCell
+                                aria-hidden="true"
+                                style={{ width: 'auto', minWidth: 0 }}
+                                className="border-border p-0"
+                              />
                             )}
-                          </TableCell>
+                            <TableCell
+                              onDoubleClick={(e) => {
+                                e.stopPropagation();
+                                col.onCellDoubleClick?.(row);
+                              }}
+                              style={{ width: colWidth, minWidth: minColumnWidth }}
+                              className={`${isLastColumn ? 'pl-3 pr-2' : 'px-3'} py-2 whitespace-nowrap ${!isActionColumn ? `standard-table-value-cell text-sm ${TEXT_SM_LINE_HEIGHT_CLASSNAME} max-w-0 overflow-hidden text-ellipsis font-normal` : ''} ${isStickyRightColumn ? 'w-auto text-right' : `align-middle ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''}`} ${isStickyRightColumn ? `sticky right-0 z-20 bg-card transition-colors ${stickyBorderClass} ${stickyHoverClass}` : ''} ${col.className || ''}`}
+                            >
+                              {isActionColumn ? (
+                                <DropdownMenu>
+                                  <DropdownMenuTrigger asChild>
+                                    <Button
+                                      type="button"
+                                      variant="ghost"
+                                      size="icon-xs"
+                                      aria-label={t('table.rowActions')}
+                                      onClick={(event) => event.stopPropagation()}
+                                      className="rounded-lg"
+                                    >
+                                      <i
+                                        className="fa-solid fa-ellipsis text-[10px]"
+                                        aria-hidden="true"
+                                      ></i>
+                                    </Button>
+                                  </DropdownMenuTrigger>
+                                  <DropdownMenuContent
+                                    align="end"
+                                    className="w-max min-w-[9rem] max-w-[calc(100vw-2rem)] p-1"
+                                    onClick={(event) => event.stopPropagation()}
+                                    onDoubleClick={(event) => event.stopPropagation()}
+                                  >
+                                    <div className="flex flex-col gap-0.5">
+                                      {renderActionMenuItems(cellContent)}
+                                    </div>
+                                  </DropdownMenuContent>
+                                </DropdownMenu>
+                              ) : (
+                                cellContent
+                              )}
+                            </TableCell>
+                          </Fragment>
                         );
                       })}
                     </TableRow>
@@ -1726,7 +1765,7 @@ const StandardTable = <T extends object>({
               ) : (
                 <TableRow className="border-border">
                   <TableCell
-                    colSpan={Math.max(visibleColumns.length, 1)}
+                    colSpan={Math.max(visibleColumns.length + (hasTrailingActionColumn ? 1 : 0), 1)}
                     className="p-12 text-center text-sm font-medium text-muted-foreground"
                   >
                     {emptyState ?? t('table.noResults')}

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -1068,6 +1068,7 @@ const StandardTable = <T extends object>({
             table.previousPage();
           }}
           disabled={!table.getCanPreviousPage()}
+          className="h-8 px-3 text-sm font-medium text-foreground disabled:opacity-100"
         >
           {t('buttons.previous')}
         </Button>
@@ -1083,6 +1084,7 @@ const StandardTable = <T extends object>({
             table.nextPage();
           }}
           disabled={!table.getCanNextPage()}
+          className="h-8 px-3 text-sm font-medium text-foreground disabled:opacity-100"
         >
           {t('buttons.next')}
         </Button>

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -1659,7 +1659,7 @@ const StandardTable = <T extends object>({
                                 type="button"
                                 disabled={!header.column.getCanSort()}
                                 onClick={header.column.getToggleSortingHandler()}
-                                className={`inline-flex shrink-0 items-center gap-1 rounded-lg px-2 py-1 text-sm font-semibold text-foreground outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-100 ${effectiveAlign === 'left' ? '-ml-2' : ''}`}
+                                className="inline-flex shrink-0 items-center gap-1 rounded-lg px-2 py-1 -ml-2 text-sm font-semibold text-foreground outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-100"
                               >
                                 <span
                                   className="whitespace-nowrap"

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -97,6 +97,7 @@ const COPIED_FEEDBACK_DURATION_MS = 1500;
 const DEFAULT_MIN_COL_WIDTH = 40;
 const HEADER_RESIZE_EXTRA_WIDTH = 64;
 const ACTION_COLUMN_WIDTH = 80;
+const TABLE_CONTROL_BUTTON_CLASSNAME = '!h-7 !gap-1.5 !rounded-lg !px-2 !text-[10px] !font-bold';
 type ViewModalState = { kind: 'create' } | { kind: 'edit'; view: CustomView } | null;
 
 export type Column<T> = {
@@ -271,7 +272,8 @@ const StandardTable = <T extends object>({
     const container = tableContainerRef.current;
     if (!container) return;
     const maxScrollLeft = container.scrollWidth - container.clientWidth;
-    setActionColumnOverlaps(maxScrollLeft > 1 && container.scrollLeft < maxScrollLeft - 1);
+    const overlaps = maxScrollLeft > 1 && container.scrollLeft < maxScrollLeft - 1;
+    setActionColumnOverlaps((prev) => (prev === overlaps ? prev : overlaps));
   }, []);
 
   useEffect(() => {
@@ -466,11 +468,6 @@ const StandardTable = <T extends object>({
     };
   }, [updateActionColumnOverlap, updateHeaderMinWidths]);
 
-  useEffect(() => {
-    updateHeaderMinWidths();
-    updateActionColumnOverlap();
-  });
-
   const getValue = useCallback((row: T, col: Column<T>) => {
     if (col.accessorFn) return col.accessorFn(row);
     if (col.accessorKey) return row[col.accessorKey];
@@ -664,7 +661,6 @@ const StandardTable = <T extends object>({
   const processedRows = data ? table.getPrePaginationRowModel().rows : [];
   const totalItems = data ? processedRows.length : externalTotalCount || 0;
   const totalPages = data ? table.getPageCount() : Math.ceil(totalItems / rowsPerPage);
-  const startIndex = (currentPage - 1) * rowsPerPage;
   const paginatedRows = data ? table.getRowModel().rows : [];
 
   useEffect(() => {
@@ -1009,11 +1005,33 @@ const StandardTable = <T extends object>({
     e.preventDefault();
     e.stopPropagation();
     const th = e.currentTarget.parentElement as HTMLTableCellElement;
+    const container = tableContainerRef.current;
     const headerLabel = th.querySelector<HTMLElement>('[data-column-header-label]');
     const headerTextWidth = Math.max(
       headerLabel?.scrollWidth ?? 0,
       headerLabel?.getBoundingClientRect().width ?? 0,
     );
+    if (container) {
+      const measuredWidths: Record<string, number> = {};
+      for (const col of visibleColumns) {
+        const visibleColId = getColId(col);
+        const label = Array.from(
+          container.querySelectorAll<HTMLElement>('[data-column-header-label]'),
+        ).find((element) => element.getAttribute('data-column-header-label') === visibleColId);
+        const headerCell = label?.closest('th') as HTMLTableCellElement | null;
+        const width = Math.ceil(headerCell?.getBoundingClientRect().width ?? 0);
+        const labelWidth = Math.max(
+          label?.scrollWidth ?? 0,
+          label?.getBoundingClientRect().width ?? 0,
+        );
+        measuredWidths[visibleColId] = Math.max(
+          getHeaderMinWidth(col),
+          Math.ceil(labelWidth + HEADER_RESIZE_EXTRA_WIDTH),
+          width,
+        );
+      }
+      setColumnWidths((prev) => ({ ...prev, ...measuredWidths }));
+    }
     resizeStartXRef.current = e.clientX;
     resizeStartWidthRef.current = th.getBoundingClientRect().width;
     resizeMinWidthRef.current = Math.max(
@@ -1051,8 +1069,8 @@ const StandardTable = <T extends object>({
             ref={buttonRef}
             aria-label={label}
             variant={active ? 'secondary' : 'outline'}
-            size={text ? 'xs' : 'icon-xs'}
-            className="rounded-lg"
+            size="sm"
+            className={TABLE_CONTROL_BUTTON_CLASSNAME}
             onClick={(e) => {
               e.stopPropagation();
               onClick();
@@ -1179,12 +1197,6 @@ const StandardTable = <T extends object>({
     return (
       <>
         <div className="flex items-center gap-3 text-sm text-muted-foreground">
-          <span>
-            {t('pagination.showing')
-              .replace('{{start}}', String(totalItems > 0 ? startIndex + 1 : 0))
-              .replace('{{end}}', String(Math.min(startIndex + rowsPerPage, totalItems)))
-              .replace('{{total}}', String(totalItems))}
-          </span>
           <span className="text-xs font-medium text-muted-foreground">
             {t('pagination.rowsPerPage')}
           </span>
@@ -1196,7 +1208,10 @@ const StandardTable = <T extends object>({
               table.setPageSize(newValue);
             }}
           >
-            <SelectTrigger size="sm" className="h-7 w-[68px] rounded-lg text-xs text-foreground">
+            <SelectTrigger
+              size="sm"
+              className={`${TABLE_CONTROL_BUTTON_CLASSNAME} w-[68px] text-foreground`}
+            >
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -1213,8 +1228,8 @@ const StandardTable = <T extends object>({
           <Button
             type="button"
             variant="outline"
-            size="xs"
-            className="rounded-lg"
+            size="sm"
+            className={TABLE_CONTROL_BUTTON_CLASSNAME}
             onClick={(e) => {
               e.stopPropagation();
               table.previousPage();
@@ -1229,8 +1244,8 @@ const StandardTable = <T extends object>({
           <Button
             type="button"
             variant="outline"
-            size="xs"
-            className="rounded-lg"
+            size="sm"
+            className={TABLE_CONTROL_BUTTON_CLASSNAME}
             onClick={(e) => {
               e.stopPropagation();
               table.nextPage();
@@ -1285,8 +1300,8 @@ const StandardTable = <T extends object>({
                     type="button"
                     aria-label={t('table.columnSettings')}
                     variant="outline"
-                    size="xs"
-                    className="rounded-lg data-[state=open]:border-border data-[state=open]:bg-accent data-[state=open]:text-accent-foreground focus-visible:ring-0"
+                    size="sm"
+                    className={`${TABLE_CONTROL_BUTTON_CLASSNAME} data-[state=open]:border-border data-[state=open]:bg-accent data-[state=open]:text-accent-foreground focus-visible:ring-0`}
                   >
                     {t('table.columns')}
                     <i className="fa-solid fa-chevron-down text-xs" aria-hidden="true"></i>
@@ -1602,7 +1617,7 @@ const StandardTable = <T extends object>({
                             className={`flex items-center gap-1 ${effectiveAlign === 'right' ? 'justify-end' : effectiveAlign === 'center' ? 'justify-center' : 'justify-start'}`}
                           >
                             <span
-                              className="truncate text-sm font-semibold text-muted-foreground"
+                              className="truncate text-sm font-semibold text-foreground"
                               data-column-header-label={colId}
                             >
                               {header.isPlaceholder
@@ -1618,7 +1633,7 @@ const StandardTable = <T extends object>({
                               type="button"
                               disabled={!header.column.getCanSort()}
                               onClick={header.column.getToggleSortingHandler()}
-                              className="inline-flex min-w-0 items-center gap-1 rounded-lg px-2 py-1 text-sm font-semibold text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-100"
+                              className="inline-flex min-w-0 items-center gap-1 rounded-lg px-2 py-1 text-sm font-semibold text-foreground outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-100"
                             >
                               <span className="truncate" data-column-header-label={colId}>
                                 {header.isPlaceholder

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -103,10 +103,11 @@ type FontSize = (typeof FONT_SIZES)[number];
 
 const VIEW_ERROR_DURATION_MS = 3000;
 const COPIED_FEEDBACK_DURATION_MS = 1500;
-const DEFAULT_MIN_COL_WIDTH = 88;
-const HEADER_TEXT_CHAR_WIDTH = 9;
+const DEFAULT_COL_WIDTH = 150;
+const DEFAULT_MIN_COL_WIDTH = 56;
+const HEADER_TEXT_CHAR_WIDTH = 7;
 const HEADER_CELL_HORIZONTAL_PADDING = 24;
-const HEADER_RESIZE_GUTTER_WIDTH = 8;
+const HEADER_RESIZE_GUTTER_WIDTH = 0;
 const HEADER_SORT_BUTTON_HORIZONTAL_PADDING = 16;
 const HEADER_SORT_ICON_WIDTH = 12;
 const HEADER_SORT_ICON_GAP = 4;
@@ -463,6 +464,7 @@ const StandardTable = <T extends object>({
       (columns ?? []).map((col) => {
         const colId = getColId(col);
         const minSize = getColumnMinWidth(col);
+        const defaultSize = isRowActionColumn(col) ? minSize : Math.max(DEFAULT_COL_WIDTH, minSize);
         return {
           id: colId,
           accessorFn: (row) => getValue(row, col),
@@ -480,7 +482,7 @@ const StandardTable = <T extends object>({
               ? col.cell({ getValue: () => value, row, value })
               : (value as ReactNode);
           },
-          size: Math.max(clampedColumnSizing[colId] ?? minSize, minSize),
+          size: Math.max(clampedColumnSizing[colId] ?? defaultSize, minSize),
           minSize,
           enableResizing: !isRowActionColumn(col),
           enableSorting: !col.disableSorting,
@@ -1512,9 +1514,7 @@ const StandardTable = <T extends object>({
         {columns && data ? (
           <Table
             className="table-fixed text-left"
-            style={
-              fixedTableWidth ? { width: `${fixedTableWidth}px`, minWidth: '100%' } : undefined
-            }
+            style={fixedTableWidth ? { width: `${fixedTableWidth}px` } : undefined}
           >
             <colgroup>
               {table.getVisibleLeafColumns().map((column) => {
@@ -1607,7 +1607,7 @@ const StandardTable = <T extends object>({
 
                         {header.column.getCanResize() && (
                           <div
-                            className="absolute top-0 -right-1 z-10 flex h-full w-2 cursor-col-resize items-center justify-center"
+                            className="absolute top-0 right-0 z-30 flex h-full w-2 cursor-col-resize touch-none select-none items-center justify-end"
                             data-column-resize-handle={colId}
                             onMouseDown={(event) => {
                               event.stopPropagation();
@@ -1617,6 +1617,8 @@ const StandardTable = <T extends object>({
                               event.stopPropagation();
                               resizeHandler(event);
                             }}
+                            onClick={(event) => event.stopPropagation()}
+                            onDoubleClick={(event) => event.stopPropagation()}
                           >
                             <span
                               data-column-resize-line={colId}

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -82,6 +82,8 @@ type FontSize = (typeof FONT_SIZES)[number];
 
 const VIEW_ERROR_DURATION_MS = 3000;
 const COPIED_FEEDBACK_DURATION_MS = 1500;
+const DEFAULT_MIN_COL_WIDTH = 40;
+const HEADER_RESIZE_EXTRA_WIDTH = 64;
 type ViewModalState = { kind: 'create' } | { kind: 'edit'; view: CustomView } | null;
 
 export type Column<T> = {
@@ -149,6 +151,7 @@ const StandardTable = <T extends object>({
   const { t } = useTranslation('common');
   const resizeStartXRef = useRef(0);
   const resizeStartWidthRef = useRef(0);
+  const resizeMinWidthRef = useRef(DEFAULT_MIN_COL_WIDTH);
 
   const [sortState, setSortState] = useState<SortState>(null);
   const [filterState, setFilterState] = useState<FilterState>(initialFilterState ?? {});
@@ -345,7 +348,7 @@ const StandardTable = <T extends object>({
 
     const handleMouseMove = (e: MouseEvent) => {
       const delta = e.clientX - resizeStartXRef.current;
-      const newWidth = Math.max(40, resizeStartWidthRef.current + delta);
+      const newWidth = Math.max(resizeMinWidthRef.current, resizeStartWidthRef.current + delta);
       setColumnWidths((prev) => {
         if (prev[resizingColId] === newWidth) return prev;
         return { ...prev, [resizingColId]: newWidth };
@@ -905,8 +908,17 @@ const StandardTable = <T extends object>({
     e.preventDefault();
     e.stopPropagation();
     const th = e.currentTarget.parentElement as HTMLTableCellElement;
+    const headerLabel = th.querySelector<HTMLElement>('[data-column-header-label]');
+    const headerTextWidth = Math.max(
+      headerLabel?.scrollWidth ?? 0,
+      headerLabel?.getBoundingClientRect().width ?? 0,
+    );
     resizeStartXRef.current = e.clientX;
     resizeStartWidthRef.current = th.getBoundingClientRect().width;
+    resizeMinWidthRef.current = Math.max(
+      DEFAULT_MIN_COL_WIDTH,
+      Math.ceil(headerTextWidth + HEADER_RESIZE_EXTRA_WIDTH),
+    );
     setResizingColId(colId);
   };
 
@@ -1469,7 +1481,7 @@ const StandardTable = <T extends object>({
                               onClick={header.column.getToggleSortingHandler()}
                               className="inline-flex min-w-0 items-center gap-1 rounded-md px-2 py-1 text-sm font-medium text-muted-foreground outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-100"
                             >
-                              <span className="truncate">
+                              <span className="truncate" data-column-header-label={colId}>
                                 {header.isPlaceholder
                                   ? null
                                   : flexRender(header.column.columnDef.header, header.getContext())}
@@ -1494,6 +1506,7 @@ const StandardTable = <T extends object>({
                         {!isActionColumn && (
                           <div
                             className={`absolute top-0 right-0 z-10 h-full w-1 cursor-col-resize opacity-0 hover:bg-primary/30 group-hover:opacity-100 ${resizingColId === colId ? 'bg-primary/50 opacity-100' : ''}`}
+                            data-column-resize-handle={colId}
                             onMouseDown={(e) => handleResizeStart(e, colId)}
                           />
                         )}

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -33,6 +33,7 @@ import { readTextFromClipboard, writeTextToClipboard } from '../../utils/clipboa
 import { downloadCsv } from '../../utils/csv';
 import { getLocalDateString } from '../../utils/date';
 import { Button } from '../ui/button';
+import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from '../ui/context-menu';
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -1646,7 +1647,7 @@ const StandardTable = <T extends object>({
 
                           {header.column.getCanResize() && (
                             <div
-                              className="absolute top-0 right-0 z-30 flex h-full w-2 cursor-col-resize touch-none select-none items-center justify-end"
+                              className="absolute top-0 right-0 z-10 flex h-full w-2 cursor-col-resize touch-none select-none items-center justify-end"
                               data-column-resize-handle={colId}
                               onMouseDown={(event) => {
                                 event.stopPropagation();
@@ -1683,7 +1684,14 @@ const StandardTable = <T extends object>({
                 paginatedRows.map((tableRow) => {
                   const row = tableRow.original;
                   const visibleCells = tableRow.getVisibleCells();
-                  return (
+                  const rowActionCell = visibleCells.find((cell) => {
+                    const col = colsById.get(cell.column.id);
+                    return col ? isRowActionColumn(col) : false;
+                  });
+                  const rowActionContent = rowActionCell
+                    ? flexRender(rowActionCell.column.columnDef.cell, rowActionCell.getContext())
+                    : null;
+                  const rowElement = (
                     <TableRow
                       key={tableRow.id}
                       onClick={() => !disabledRow?.(row) && onRowClick?.(row)}
@@ -1778,6 +1786,23 @@ const StandardTable = <T extends object>({
                         );
                       })}
                     </TableRow>
+                  );
+
+                  return rowActionContent ? (
+                    <ContextMenu key={tableRow.id}>
+                      <ContextMenuTrigger asChild>{rowElement}</ContextMenuTrigger>
+                      <ContextMenuContent
+                        className="w-max min-w-[9rem] max-w-[calc(100vw-2rem)] p-1"
+                        onClick={(event) => event.stopPropagation()}
+                        onDoubleClick={(event) => event.stopPropagation()}
+                      >
+                        <div className="flex flex-col gap-0.5">
+                          {renderActionMenuItems(rowActionContent)}
+                        </div>
+                      </ContextMenuContent>
+                    </ContextMenu>
+                  ) : (
+                    rowElement
                   );
                 })
               ) : (

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -1426,7 +1426,7 @@ const StandardTable = <T extends object>({
                               : undefined
                         }
                         aria-label={isActionColumn ? col.header : undefined}
-                        className={`relative group h-10 border-border ${isLastColumn ? 'pl-3 pr-2' : 'px-3'} whitespace-nowrap ${isStretchColumn ? 'w-full' : isStickyRightColumn ? 'w-auto' : 'w-px'} ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''} ${isStickyRightColumn ? 'sticky right-0 z-20 border-l border-border bg-background' : ''} ${col.headerClassName || ''}`}
+                        className={`relative group h-10 border-border ${isLastColumn ? 'pl-3 pr-2' : 'px-3'} whitespace-nowrap ${isStretchColumn ? 'w-full' : isStickyRightColumn ? 'w-auto' : 'w-px'} ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''} ${isStickyRightColumn ? 'sticky right-0 z-20 border-l border-border bg-card' : ''} ${col.headerClassName || ''}`}
                       >
                         {!isActionColumn && (
                           <div
@@ -1528,7 +1528,7 @@ const StandardTable = <T extends object>({
                                   ? { minWidth: '40px' }
                                   : undefined
                             }
-                            className={`${isLastColumn ? 'pl-3 pr-2' : 'px-3'} py-2 whitespace-nowrap ${isStickyRightColumn ? 'w-auto text-right' : `${isStretchColumn ? 'w-full' : 'w-px'} align-middle ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''}`} ${isStickyRightColumn ? 'sticky right-0 z-20 border-l border-border bg-background transition-colors group-hover:bg-muted/50' : ''} ${col.className || ''}`}
+                            className={`${isLastColumn ? 'pl-3 pr-2' : 'px-3'} py-2 whitespace-nowrap ${isStickyRightColumn ? 'w-auto text-right' : `${isStretchColumn ? 'w-full' : 'w-px'} align-middle ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''}`} ${isStickyRightColumn ? 'sticky right-0 z-20 border-l border-border bg-card transition-colors group-hover:bg-muted/50' : ''} ${col.className || ''}`}
                           >
                             {isActionColumn ? (
                               <DropdownMenu>

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -659,6 +659,8 @@ const StandardTable = <T extends object>({
   const paginatedRows = data ? table.getRowModel().rows : [];
   const hasTrailingActionColumn =
     visibleColumns.length > 0 && isRowActionColumn(visibleColumns[visibleColumns.length - 1]);
+  const visibleDataColumnCount = visibleColumns.filter((col) => !isRowActionColumn(col)).length;
+  const shouldAnchorTrailingActionColumn = hasTrailingActionColumn && visibleDataColumnCount > 1;
   const fixedTableWidth = useMemo(() => {
     if (!usesFixedTableLayout) return undefined;
     return table.getTotalSize();
@@ -1520,8 +1522,8 @@ const StandardTable = <T extends object>({
             style={
               fixedTableWidth
                 ? {
-                    width: hasTrailingActionColumn ? '100%' : `${fixedTableWidth}px`,
-                    minWidth: hasTrailingActionColumn ? `${fixedTableWidth}px` : undefined,
+                    width: shouldAnchorTrailingActionColumn ? '100%' : `${fixedTableWidth}px`,
+                    minWidth: shouldAnchorTrailingActionColumn ? `${fixedTableWidth}px` : undefined,
                   }
                 : undefined
             }
@@ -1530,7 +1532,8 @@ const StandardTable = <T extends object>({
               {table.getVisibleLeafColumns().map((column) => {
                 const col = colsById.get(column.id);
                 const colWidth = column.getSize();
-                const needsActionSpacer = hasTrailingActionColumn && col && isRowActionColumn(col);
+                const needsActionSpacer =
+                  shouldAnchorTrailingActionColumn && col && isRowActionColumn(col);
                 return (
                   <Fragment key={column.id}>
                     {needsActionSpacer && <col data-action-spacer style={{ width: 'auto' }} />}
@@ -1551,9 +1554,11 @@ const StandardTable = <T extends object>({
                     const isFirstColumn = colIdx === 0;
                     const isLastColumn = colIdx === headerGroup.headers.length - 1;
                     const isBeforeActionSpacer =
-                      hasTrailingActionColumn &&
+                      shouldAnchorTrailingActionColumn &&
                       !isActionColumn &&
                       colIdx === headerGroup.headers.length - 2;
+                    const shouldStickRightColumn =
+                      isStickyRightColumn && (!isActionColumn || shouldAnchorTrailingActionColumn);
                     // Force alignment: first column left, last column right, otherwise use col.align
                     const effectiveAlign = isFirstColumn
                       ? 'left'
@@ -1565,12 +1570,12 @@ const StandardTable = <T extends object>({
                     const sorted = header.column.getIsSorted();
                     const isResizing = header.column.getIsResizing();
                     const stickyBorderClass =
-                      isStickyRightColumn && !isActionColumn ? 'border-l border-border' : '';
+                      shouldStickRightColumn && !isActionColumn ? 'border-l border-border' : '';
                     const resizeHandler = header.getResizeHandler();
 
                     return (
                       <Fragment key={header.id}>
-                        {hasTrailingActionColumn && isActionColumn && (
+                        {shouldAnchorTrailingActionColumn && isActionColumn && (
                           <TableHead
                             aria-hidden="true"
                             style={{ width: 'auto', minWidth: 0 }}
@@ -1580,7 +1585,7 @@ const StandardTable = <T extends object>({
                         <TableHead
                           style={{ width: colWidth, minWidth: minColumnWidth }}
                           aria-label={isActionColumn ? col.header : undefined}
-                          className={`relative group h-10 border-border ${isLastColumn ? 'pl-3 pr-2' : 'px-3'} whitespace-nowrap ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''} ${isStickyRightColumn ? `sticky right-0 z-20 bg-card ${stickyBorderClass}` : ''} ${col.headerClassName || ''}`}
+                          className={`relative group h-10 border-border ${isLastColumn ? 'pl-3 pr-2' : 'px-3'} whitespace-nowrap ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''} ${shouldStickRightColumn ? `sticky right-0 z-20 bg-card ${stickyBorderClass}` : ''} ${col.headerClassName || ''}`}
                         >
                           {isActionColumn ? (
                             <div
@@ -1692,6 +1697,9 @@ const StandardTable = <T extends object>({
                         const isActionColumn = isRowActionColumn(col);
                         const isFirstColumn = colIdx === 0;
                         const isLastColumn = colIdx === visibleCells.length - 1;
+                        const shouldStickRightColumn =
+                          isStickyRightColumn &&
+                          (!isActionColumn || shouldAnchorTrailingActionColumn);
                         // Force alignment: first column left, last column right, otherwise use col.align
                         const effectiveAlign = isFirstColumn
                           ? 'left'
@@ -1701,9 +1709,11 @@ const StandardTable = <T extends object>({
                         const minColumnWidth = getColumnMinWidth(col);
                         const colWidth = Math.max(cell.column.getSize(), minColumnWidth);
                         const stickyBorderClass =
-                          isStickyRightColumn && !isActionColumn ? 'border-l border-border' : '';
+                          shouldStickRightColumn && !isActionColumn ? 'border-l border-border' : '';
                         const stickyHoverClass =
-                          isStickyRightColumn && !isActionColumn ? 'group-hover:bg-muted/50' : '';
+                          shouldStickRightColumn && !isActionColumn
+                            ? 'group-hover:bg-muted/50'
+                            : '';
                         const rawValue = cell.getValue() as
                           | T[keyof T]
                           | string
@@ -1717,7 +1727,7 @@ const StandardTable = <T extends object>({
                             : flexRender(cell.column.columnDef.cell, cell.getContext());
                         return (
                           <Fragment key={cell.id}>
-                            {hasTrailingActionColumn && isActionColumn && (
+                            {shouldAnchorTrailingActionColumn && isActionColumn && (
                               <TableCell
                                 aria-hidden="true"
                                 style={{ width: 'auto', minWidth: 0 }}
@@ -1730,7 +1740,7 @@ const StandardTable = <T extends object>({
                                 col.onCellDoubleClick?.(row);
                               }}
                               style={{ width: colWidth, minWidth: minColumnWidth }}
-                              className={`${isLastColumn ? 'pl-3 pr-2' : 'px-3'} py-2 whitespace-nowrap ${!isActionColumn ? `standard-table-value-cell text-sm ${TEXT_SM_LINE_HEIGHT_CLASSNAME} max-w-0 overflow-hidden text-ellipsis font-normal` : ''} ${isStickyRightColumn ? 'w-auto text-right' : `align-middle ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''}`} ${isStickyRightColumn ? `sticky right-0 z-20 bg-card transition-colors ${stickyBorderClass} ${stickyHoverClass}` : ''} ${col.className || ''}`}
+                              className={`${isLastColumn ? 'pl-3 pr-2' : 'px-3'} py-2 whitespace-nowrap ${!isActionColumn ? `standard-table-value-cell text-sm ${TEXT_SM_LINE_HEIGHT_CLASSNAME} max-w-0 overflow-hidden text-ellipsis font-normal` : ''} ${shouldStickRightColumn ? 'w-auto text-right' : `align-middle ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''}`} ${shouldStickRightColumn ? `sticky right-0 z-20 bg-card transition-colors ${stickyBorderClass} ${stickyHoverClass}` : ''} ${col.className || ''}`}
                             >
                               {isActionColumn ? (
                                 <DropdownMenu>
@@ -1773,7 +1783,10 @@ const StandardTable = <T extends object>({
               ) : (
                 <TableRow className="border-border">
                   <TableCell
-                    colSpan={Math.max(visibleColumns.length + (hasTrailingActionColumn ? 1 : 0), 1)}
+                    colSpan={Math.max(
+                      visibleColumns.length + (shouldAnchorTrailingActionColumn ? 1 : 0),
+                      1,
+                    )}
                     className="p-12 text-center text-sm font-medium text-muted-foreground"
                   >
                     {emptyState ?? t('table.noResults')}

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -77,6 +77,18 @@ const slugify = (s: string) => s.replace(/[^a-zA-Z0-9]/g, '_').toLowerCase();
 
 const getStorageKey = (t: string, suffix: StorageSuffix) => `praetor_table_${suffix}_${slugify(t)}`;
 
+const sanitizeColumnWidths = (
+  value: unknown,
+  validIds?: ReadonlySet<string>,
+): Record<string, number> => {
+  if (typeof value !== 'object' || value === null) return {};
+  return Object.fromEntries(
+    Object.entries(value).filter(
+      ([id, width]) => (!validIds || validIds.has(id)) && typeof width === 'number' && width > 0,
+    ),
+  );
+};
+
 const FONT_SIZES = ['xs', 'sm', 'base'] as const;
 type FontSize = (typeof FONT_SIZES)[number];
 
@@ -152,6 +164,7 @@ const StandardTable = <T extends object>({
   const resizeStartXRef = useRef(0);
   const resizeStartWidthRef = useRef(0);
   const resizeMinWidthRef = useRef(DEFAULT_MIN_COL_WIDTH);
+  const tableContainerRef = useRef<HTMLDivElement | null>(null);
 
   const [sortState, setSortState] = useState<SortState>(null);
   const [filterState, setFilterState] = useState<FilterState>(initialFilterState ?? {});
@@ -161,6 +174,7 @@ const StandardTable = <T extends object>({
   const [currentPage, setCurrentPage] = useState(1);
   const [gearOpen, setGearOpen] = useState(false);
   const [resizingColId, setResizingColId] = useState<string | null>(null);
+  const [actionColumnOverlaps, setActionColumnOverlaps] = useState(false);
 
   const [rowsPerPage, setRowsPerPage] = useState(() => {
     if (typeof window === 'undefined') return defaultRowsPerPage;
@@ -190,8 +204,7 @@ const StandardTable = <T extends object>({
     const saved = localStorage.getItem(getStorageKey(title, STORAGE_SUFFIX.colWidths));
     if (saved) {
       try {
-        const parsed = JSON.parse(saved);
-        if (typeof parsed === 'object' && parsed !== null) return parsed as Record<string, number>;
+        return sanitizeColumnWidths(JSON.parse(saved));
       } catch {}
     }
     return {};
@@ -252,6 +265,13 @@ const StandardTable = <T extends object>({
     [title],
   );
 
+  const updateActionColumnOverlap = useCallback(() => {
+    const container = tableContainerRef.current;
+    if (!container) return;
+    const maxScrollLeft = container.scrollWidth - container.clientWidth;
+    setActionColumnOverlaps(maxScrollLeft > 1 && container.scrollLeft < maxScrollLeft - 1);
+  }, []);
+
   useEffect(() => {
     const next = initialFilterState ?? {};
     if (filterStatesEqual(filterStateRef.current, next)) return;
@@ -275,6 +295,10 @@ const StandardTable = <T extends object>({
       }) ?? [],
     [columns, hiddenColIds, getColId],
   );
+  const validColumnWidths = useMemo(() => {
+    const validIds = new Set((columns ?? []).map((col) => getColId(col)));
+    return sanitizeColumnWidths(columnWidths, validIds);
+  }, [columns, columnWidths, getColId]);
 
   // Rightmost non-sticky column absorbs leftover width. When the last column is
   // sticky-right, this prevents that sticky column from expanding to fill space.
@@ -284,7 +308,7 @@ const StandardTable = <T extends object>({
     }
     return -1;
   }, [visibleColumns]);
-  const usesFixedTableLayout = resizingColId !== null || Object.keys(columnWidths).length > 0;
+  const usesFixedTableLayout = resizingColId !== null || Object.keys(validColumnWidths).length > 0;
 
   // Excludes statically hidden filter-only columns; sort/filter still target them via colsById.
   const gearColumns = useMemo(() => columns?.filter((col) => !col.hidden) ?? [], [columns]);
@@ -360,8 +384,10 @@ const StandardTable = <T extends object>({
       setResizingColId(null);
       document.body.style.cursor = '';
       setColumnWidths((prev) => {
-        localStorage.setItem(getStorageKey(title, STORAGE_SUFFIX.colWidths), JSON.stringify(prev));
-        return prev;
+        const validIds = new Set((columns ?? []).map((col) => getColId(col)));
+        const next = sanitizeColumnWidths(prev, validIds);
+        localStorage.setItem(getStorageKey(title, STORAGE_SUFFIX.colWidths), JSON.stringify(next));
+        return next;
       });
     };
 
@@ -374,7 +400,33 @@ const StandardTable = <T extends object>({
       document.removeEventListener('mouseup', handleMouseUp);
       document.body.style.cursor = '';
     };
-  }, [resizingColId, title]);
+  }, [columns, getColId, resizingColId, title]);
+
+  useEffect(() => {
+    const container = tableContainerRef.current;
+    if (!container) return;
+    const handleLayoutChange = () => updateActionColumnOverlap();
+
+    updateActionColumnOverlap();
+    container.addEventListener('scroll', handleLayoutChange, { passive: true });
+    window.addEventListener('resize', handleLayoutChange);
+
+    const resizeObserver =
+      typeof ResizeObserver !== 'undefined' ? new ResizeObserver(handleLayoutChange) : null;
+    resizeObserver?.observe(container);
+    const tableElement = container.querySelector('table');
+    if (tableElement) resizeObserver?.observe(tableElement);
+
+    return () => {
+      container.removeEventListener('scroll', handleLayoutChange);
+      window.removeEventListener('resize', handleLayoutChange);
+      resizeObserver?.disconnect();
+    };
+  }, [updateActionColumnOverlap]);
+
+  useEffect(() => {
+    updateActionColumnOverlap();
+  });
 
   const getValue = useCallback((row: T, col: Column<T>) => {
     if (col.accessorFn) return col.accessorFn(row);
@@ -1439,6 +1491,7 @@ const StandardTable = <T extends object>({
       </div>
 
       <div
+        ref={tableContainerRef}
         className={`rounded-md border border-border bg-card shadow-sm ${tableContainerClassName ?? 'overflow-x-auto'} ${resizingColId ? 'select-none' : ''}`}
       >
         {columns && data ? (
@@ -1461,8 +1514,12 @@ const StandardTable = <T extends object>({
                       : isLastColumn
                         ? 'right'
                         : col.align;
-                    const colWidth = columnWidths[colId];
+                    const colWidth = validColumnWidths[colId];
                     const sorted = header.column.getIsSorted();
+                    const stickyBorderClass =
+                      isStickyRightColumn && (!isActionColumn || actionColumnOverlaps)
+                        ? 'border-l border-border'
+                        : '';
 
                     return (
                       <TableHead
@@ -1475,7 +1532,7 @@ const StandardTable = <T extends object>({
                               : undefined
                         }
                         aria-label={isActionColumn ? col.header : undefined}
-                        className={`relative group h-10 border-border ${isLastColumn ? 'pl-3 pr-2' : 'px-3'} whitespace-nowrap ${usesFixedTableLayout ? '' : isStretchColumn ? 'w-full' : isStickyRightColumn ? 'w-auto' : 'w-px'} ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''} ${isStickyRightColumn ? 'sticky right-0 z-20 border-l border-border bg-card' : ''} ${col.headerClassName || ''}`}
+                        className={`relative group h-10 border-border ${isLastColumn ? 'pl-3 pr-2' : 'px-3'} whitespace-nowrap ${usesFixedTableLayout ? '' : isStretchColumn ? 'w-full' : isStickyRightColumn ? 'w-auto' : 'w-px'} ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''} ${isStickyRightColumn ? `sticky right-0 z-20 bg-card ${stickyBorderClass}` : ''} ${col.headerClassName || ''}`}
                       >
                         {!isActionColumn && (
                           <div
@@ -1557,7 +1614,13 @@ const StandardTable = <T extends object>({
                           : isLastColumn
                             ? 'right'
                             : col.align;
-                        const colWidth = columnWidths[colId];
+                        const colWidth = validColumnWidths[colId];
+                        const stickyBorderClass =
+                          isStickyRightColumn && (!isActionColumn || actionColumnOverlaps)
+                            ? 'border-l border-border'
+                            : '';
+                        const stickyHoverClass =
+                          isStickyRightColumn && !isActionColumn ? 'group-hover:bg-muted/50' : '';
                         const rawValue = cell.getValue() as
                           | T[keyof T]
                           | string
@@ -1565,14 +1628,10 @@ const StandardTable = <T extends object>({
                           | boolean
                           | null
                           | undefined;
-                        const cellContent = flexRender(
-                          cell.column.columnDef.cell,
-                          cell.getContext(),
-                        );
-                        const actionCellContent =
+                        const cellContent =
                           isActionColumn && col.cell
                             ? col.cell({ getValue: () => rawValue, row, value: rawValue })
-                            : cellContent;
+                            : flexRender(cell.column.columnDef.cell, cell.getContext());
                         return (
                           <TableCell
                             key={cell.id}
@@ -1587,7 +1646,7 @@ const StandardTable = <T extends object>({
                                   ? { minWidth: '40px' }
                                   : undefined
                             }
-                            className={`${isLastColumn ? 'pl-3 pr-2' : 'px-3'} py-2 whitespace-nowrap ${usesFixedTableLayout && !isActionColumn ? 'max-w-0 overflow-hidden text-ellipsis' : ''} ${isStickyRightColumn ? 'w-auto text-right' : `${usesFixedTableLayout ? '' : isStretchColumn ? 'w-full' : 'w-px'} align-middle ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''}`} ${isStickyRightColumn ? 'sticky right-0 z-20 border-l border-border bg-card transition-colors group-hover:bg-muted/50' : ''} ${col.className || ''}`}
+                            className={`${isLastColumn ? 'pl-3 pr-2' : 'px-3'} py-2 whitespace-nowrap ${usesFixedTableLayout && !isActionColumn ? 'max-w-0 overflow-hidden text-ellipsis' : ''} ${isStickyRightColumn ? 'w-auto text-right' : `${usesFixedTableLayout ? '' : isStretchColumn ? 'w-full' : 'w-px'} align-middle ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''}`} ${isStickyRightColumn ? `sticky right-0 z-20 bg-card transition-colors ${stickyBorderClass} ${stickyHoverClass}` : ''} ${col.className || ''}`}
                           >
                             {isActionColumn ? (
                               <DropdownMenu>
@@ -1612,7 +1671,7 @@ const StandardTable = <T extends object>({
                                   onDoubleClick={(event) => event.stopPropagation()}
                                 >
                                   <div className="flex flex-col gap-0.5">
-                                    {renderActionMenuItems(actionCellContent)}
+                                    {renderActionMenuItems(cellContent)}
                                   </div>
                                 </DropdownMenuContent>
                               </DropdownMenu>

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -1713,7 +1713,7 @@ const StandardTable = <T extends object>({
                         {isActionColumn ? (
                           <div
                             data-column-header-content={colId}
-                            className={`flex items-center gap-1 ${effectiveAlign === 'right' ? 'justify-end' : effectiveAlign === 'center' ? 'justify-center' : 'justify-start'}`}
+                            className="inline-flex w-max items-center gap-1"
                           >
                             <span
                               className="whitespace-nowrap text-sm font-semibold text-foreground"
@@ -1727,7 +1727,7 @@ const StandardTable = <T extends object>({
                         ) : (
                           <div
                             data-column-header-content={colId}
-                            className={`flex items-center gap-1 ${effectiveAlign === 'right' ? 'justify-end' : effectiveAlign === 'center' ? 'justify-center' : 'justify-start'}`}
+                            className="inline-flex w-max items-center gap-1"
                           >
                             <button
                               type="button"

--- a/components/shared/StatusBadge.tsx
+++ b/components/shared/StatusBadge.tsx
@@ -156,6 +156,7 @@ const StatusBadge: React.FC<StatusBadgeProps> = ({ type, label, className = '' }
 
   return (
     <span
+      data-status-badge
       className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg border text-[10px] font-black uppercase tracking-wider transition-all duration-200 ${currentStyle.container} ${className}`}
     >
       <i className={`fa-solid ${currentStyle.icon}`}></i>

--- a/components/shared/StatusBadge.tsx
+++ b/components/shared/StatusBadge.tsx
@@ -28,7 +28,12 @@ export type StatusType =
   | 'customer_premise'
   | 'remote'
   | 'transfer'
-  | 'recurrence';
+  | 'recurrence'
+  | 'role_admin'
+  | 'role_top_manager'
+  | 'role_manager'
+  | 'role_custom'
+  | 'role_user';
 
 export interface StatusBadgeProps {
   type: StatusType;
@@ -149,6 +154,26 @@ const StatusBadge: React.FC<StatusBadgeProps> = ({ type, label, className = '' }
     recurrence: {
       container: 'bg-zinc-50 text-praetor border-zinc-200',
       icon: 'fa-repeat',
+    },
+    role_admin: {
+      container: 'bg-zinc-800 text-white border-zinc-700',
+      icon: 'fa-shield-halved',
+    },
+    role_top_manager: {
+      container: 'bg-amber-50 text-amber-700 border-amber-200',
+      icon: 'fa-crown',
+    },
+    role_manager: {
+      container: 'bg-blue-50 text-blue-700 border-blue-200',
+      icon: 'fa-briefcase',
+    },
+    role_custom: {
+      container: 'bg-emerald-50 text-emerald-700 border-emerald-200',
+      icon: 'fa-user',
+    },
+    role_user: {
+      container: 'bg-zinc-100 text-zinc-600 border-zinc-200',
+      icon: 'fa-user',
     },
   };
 

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -5,7 +5,7 @@ import type * as React from 'react';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -13,7 +13,7 @@ const buttonVariants = cva(
         destructive:
           'bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40',
         outline:
-          'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50',
+          'border border-border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50',
         secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
         ghost: 'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
         link: 'text-primary underline-offset-4 hover:underline',

--- a/components/ui/context-menu.tsx
+++ b/components/ui/context-menu.tsx
@@ -1,0 +1,255 @@
+import { CheckIcon, ChevronRightIcon, CircleIcon } from 'lucide-react';
+import { ContextMenu as ContextMenuPrimitive } from 'radix-ui';
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+import { getResolvedTheme, type ResolvedTheme, THEME_CHANGE_EVENT } from '@/utils/theme';
+
+const getShadcnThemeClassName = (theme: ResolvedTheme) => {
+  return theme === 'dark' ? 'dark' : undefined;
+};
+
+const useResolvedShadcnTheme = () => {
+  const [resolvedTheme, setResolvedTheme] = React.useState<ResolvedTheme>(() => getResolvedTheme());
+
+  React.useEffect(() => {
+    const handleThemeChange = (event: Event) => {
+      const detail = (event as CustomEvent<{ resolvedTheme?: ResolvedTheme }>).detail;
+      setResolvedTheme(detail?.resolvedTheme ?? getResolvedTheme());
+    };
+
+    window.addEventListener(THEME_CHANGE_EVENT, handleThemeChange);
+    return () => window.removeEventListener(THEME_CHANGE_EVENT, handleThemeChange);
+  }, []);
+
+  return resolvedTheme;
+};
+
+function ContextMenu({ ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Root>) {
+  return <ContextMenuPrimitive.Root data-slot="context-menu" {...props} />;
+}
+
+function ContextMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Trigger>) {
+  return <ContextMenuPrimitive.Trigger data-slot="context-menu-trigger" {...props} />;
+}
+
+function ContextMenuGroup({ ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Group>) {
+  return <ContextMenuPrimitive.Group data-slot="context-menu-group" {...props} />;
+}
+
+function ContextMenuPortal({ ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Portal>) {
+  return <ContextMenuPrimitive.Portal data-slot="context-menu-portal" {...props} />;
+}
+
+function ContextMenuSub({ ...props }: React.ComponentProps<typeof ContextMenuPrimitive.Sub>) {
+  return <ContextMenuPrimitive.Sub data-slot="context-menu-sub" {...props} />;
+}
+
+function ContextMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.RadioGroup>) {
+  return <ContextMenuPrimitive.RadioGroup data-slot="context-menu-radio-group" {...props} />;
+}
+
+function ContextMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.SubTrigger> & {
+  inset?: boolean;
+}) {
+  return (
+    <ContextMenuPrimitive.SubTrigger
+      data-slot="context-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[inset]:pl-8 data-[state=open]:bg-accent data-[state=open]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto" />
+    </ContextMenuPrimitive.SubTrigger>
+  );
+}
+
+function ContextMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.SubContent>) {
+  const resolvedTheme = useResolvedShadcnTheme();
+  const themeClassName = getShadcnThemeClassName(resolvedTheme);
+
+  return (
+    <ContextMenuPrimitive.SubContent
+      data-shadcn-theme-scope
+      data-slot="context-menu-sub-content"
+      data-shadcn-theme={resolvedTheme}
+      className={cn(
+        'z-50 min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-lg data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
+        themeClassName,
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function ContextMenuContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Content>) {
+  const resolvedTheme = useResolvedShadcnTheme();
+  const themeClassName = getShadcnThemeClassName(resolvedTheme);
+
+  return (
+    <ContextMenuPrimitive.Portal>
+      <ContextMenuPrimitive.Content
+        data-shadcn-theme-scope
+        data-slot="context-menu-content"
+        data-shadcn-theme={resolvedTheme}
+        className={cn(
+          'z-50 max-h-(--radix-context-menu-content-available-height) min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
+          themeClassName,
+          className,
+        )}
+        {...props}
+      />
+    </ContextMenuPrimitive.Portal>
+  );
+}
+
+function ContextMenuItem({
+  className,
+  inset,
+  variant = 'default',
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Item> & {
+  inset?: boolean;
+  variant?: 'default' | 'destructive';
+}) {
+  return (
+    <ContextMenuPrimitive.Item
+      data-slot="context-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground data-[variant=destructive]:*:[svg]:text-destructive!",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function ContextMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.CheckboxItem>) {
+  return (
+    <ContextMenuPrimitive.CheckboxItem
+      data-slot="context-menu-checkbox-item"
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <ContextMenuPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </ContextMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </ContextMenuPrimitive.CheckboxItem>
+  );
+}
+
+function ContextMenuRadioItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.RadioItem>) {
+  return (
+    <ContextMenuPrimitive.RadioItem
+      data-slot="context-menu-radio-item"
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <ContextMenuPrimitive.ItemIndicator>
+          <CircleIcon className="size-2 fill-current" />
+        </ContextMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </ContextMenuPrimitive.RadioItem>
+  );
+}
+
+function ContextMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Label> & {
+  inset?: boolean;
+}) {
+  return (
+    <ContextMenuPrimitive.Label
+      data-slot="context-menu-label"
+      data-inset={inset}
+      className={cn('px-2 py-1.5 text-sm font-medium text-foreground data-[inset]:pl-8', className)}
+      {...props}
+    />
+  );
+}
+
+function ContextMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Separator>) {
+  return (
+    <ContextMenuPrimitive.Separator
+      data-slot="context-menu-separator"
+      className={cn('-mx-1 my-1 h-px bg-border', className)}
+      {...props}
+    />
+  );
+}
+
+function ContextMenuShortcut({ className, ...props }: React.ComponentProps<'span'>) {
+  return (
+    <span
+      data-slot="context-menu-shortcut"
+      className={cn('ml-auto text-xs tracking-widest text-muted-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  ContextMenu,
+  ContextMenuCheckboxItem,
+  ContextMenuContent,
+  ContextMenuGroup,
+  ContextMenuItem,
+  ContextMenuLabel,
+  ContextMenuPortal,
+  ContextMenuRadioGroup,
+  ContextMenuRadioItem,
+  ContextMenuSeparator,
+  ContextMenuShortcut,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+  ContextMenuTrigger,
+};

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -104,15 +104,18 @@ function DropdownMenuCheckboxItem({
     <DropdownMenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
-        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "group relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       checked={checked}
       {...props}
     >
-      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+      <span
+        data-slot="dropdown-menu-checkbox-indicator"
+        className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center rounded-[3px] border border-input bg-background text-transparent transition-colors group-data-[state=checked]:border-primary group-data-[state=checked]:bg-primary group-data-[state=checked]:text-primary-foreground"
+      >
         <DropdownMenuPrimitive.ItemIndicator>
-          <CheckIcon className="size-4" />
+          <CheckIcon className="size-3" />
         </DropdownMenuPrimitive.ItemIndicator>
       </span>
       {children}

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -57,7 +57,7 @@ function DropdownMenuContent({
         data-shadcn-theme={resolvedTheme}
         sideOffset={sideOffset}
         className={cn(
-          'z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
+          'z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
           themeClassName,
           className,
         )}
@@ -231,7 +231,7 @@ function DropdownMenuSubContent({
       data-slot="dropdown-menu-sub-content"
       data-shadcn-theme={resolvedTheme}
       className={cn(
-        'z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
+        'z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-lg data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=top]:slide-in-from-bottom-2 data-[side=right]:slide-in-from-left-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
         themeClassName,
         className,
       )}

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -104,7 +104,7 @@ function DropdownMenuCheckboxItem({
     <DropdownMenuPrimitive.CheckboxItem
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
-        "group relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       checked={checked}
@@ -112,10 +112,10 @@ function DropdownMenuCheckboxItem({
     >
       <span
         data-slot="dropdown-menu-checkbox-indicator"
-        className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center rounded-[3px] border border-input bg-background text-transparent transition-colors group-data-[state=checked]:border-primary group-data-[state=checked]:bg-primary group-data-[state=checked]:text-primary-foreground"
+        className="pointer-events-none absolute right-2 flex size-3.5 items-center justify-center text-foreground"
       >
         <DropdownMenuPrimitive.ItemIndicator>
-          <CheckIcon className="size-3" />
+          <CheckIcon className="size-4" />
         </DropdownMenuPrimitive.ItemIndicator>
       </span>
       {children}

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -1,0 +1,173 @@
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from 'lucide-react';
+import { Select as SelectPrimitive } from 'radix-ui';
+import type * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+function Select({ ...props }: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />;
+}
+
+function SelectGroup({ ...props }: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />;
+}
+
+function SelectValue({ ...props }: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />;
+}
+
+function SelectTrigger({
+  className,
+  size = 'default',
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: 'sm' | 'default';
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-2 rounded-md border border-input bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[placeholder]:text-muted-foreground data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  );
+}
+
+function SelectContent({
+  className,
+  children,
+  position = 'item-aligned',
+  align = 'center',
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          'relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
+          position === 'popper' &&
+            'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+          className,
+        )}
+        position={position}
+        align={align}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            'p-1',
+            position === 'popper' &&
+              'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1',
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  );
+}
+
+function SelectLabel({ className, ...props }: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn('px-2 py-1.5 text-xs text-muted-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className,
+      )}
+      {...props}
+    >
+      <span
+        data-slot="select-item-indicator"
+        className="absolute right-2 flex size-3.5 items-center justify-center"
+      >
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  );
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn('pointer-events-none -mx-1 my-1 h-px bg-border', className)}
+      {...props}
+    />
+  );
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn('flex cursor-default items-center justify-center py-1', className)}
+      {...props}
+    >
+      <ChevronUpIcon className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  );
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn('flex cursor-default items-center justify-center py-1', className)}
+      {...props}
+    >
+      <ChevronDownIcon className="size-4" />
+    </SelectPrimitive.ScrollDownButton>
+  );
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+};

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -80,7 +80,7 @@ function SelectContent({
         data-slot="select-content"
         data-shadcn-theme={resolvedTheme}
         className={cn(
-          'relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
+          'relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border border-border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
           position === 'popper' &&
             'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
           themeClassName,

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -1,8 +1,29 @@
 import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from 'lucide-react';
 import { Select as SelectPrimitive } from 'radix-ui';
-import type * as React from 'react';
+import * as React from 'react';
 
 import { cn } from '@/lib/utils';
+import { getResolvedTheme, type ResolvedTheme, THEME_CHANGE_EVENT } from '@/utils/theme';
+
+const getShadcnThemeClassName = (theme: ResolvedTheme) => {
+  return theme === 'dark' ? 'dark' : undefined;
+};
+
+const useResolvedShadcnTheme = () => {
+  const [resolvedTheme, setResolvedTheme] = React.useState<ResolvedTheme>(() => getResolvedTheme());
+
+  React.useEffect(() => {
+    const handleThemeChange = (event: Event) => {
+      const detail = (event as CustomEvent<{ resolvedTheme?: ResolvedTheme }>).detail;
+      setResolvedTheme(detail?.resolvedTheme ?? getResolvedTheme());
+    };
+
+    window.addEventListener(THEME_CHANGE_EVENT, handleThemeChange);
+    return () => window.removeEventListener(THEME_CHANGE_EVENT, handleThemeChange);
+  }, []);
+
+  return resolvedTheme;
+};
 
 function Select({ ...props }: React.ComponentProps<typeof SelectPrimitive.Root>) {
   return <SelectPrimitive.Root data-slot="select" {...props} />;
@@ -49,14 +70,20 @@ function SelectContent({
   align = 'center',
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  const resolvedTheme = useResolvedShadcnTheme();
+  const themeClassName = getShadcnThemeClassName(resolvedTheme);
+
   return (
     <SelectPrimitive.Portal>
       <SelectPrimitive.Content
+        data-shadcn-theme-scope
         data-slot="select-content"
+        data-shadcn-theme={resolvedTheme}
         className={cn(
           'relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
           position === 'popper' &&
             'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+          themeClassName,
           className,
         )}
         position={position}

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -387,7 +387,7 @@ function SidebarGroupLabel({
       data-slot="sidebar-group-label"
       data-sidebar="group-label"
       className={cn(
-        'flex h-8 shrink-0 items-center rounded-md px-2 text-sm font-medium text-sidebar-foreground/70 ring-sidebar-ring outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
+        'flex h-8 shrink-0 items-center rounded-md px-2 text-sm leading-[var(--text-sm--line-height)] font-medium text-sidebar-foreground/70 ring-sidebar-ring outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
         'group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0',
         className,
       )}
@@ -424,7 +424,7 @@ function SidebarGroupContent({ className, ...props }: React.ComponentProps<'div'
     <div
       data-slot="sidebar-group-content"
       data-sidebar="group-content"
-      className={cn('w-full text-sm', className)}
+      className={cn('w-full text-sm leading-[var(--text-sm--line-height)]', className)}
       {...props}
     />
   );
@@ -453,7 +453,7 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<'li'>) {
 }
 
 const sidebarMenuButtonVariants = cva(
-  'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
+  'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm leading-[var(--text-sm--line-height)] ring-sidebar-ring outline-hidden transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
   {
     variants: {
       variant: {
@@ -462,9 +462,9 @@ const sidebarMenuButtonVariants = cva(
           'bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]',
       },
       size: {
-        default: 'h-8 text-sm',
-        sm: 'h-7 text-sm',
-        lg: 'h-12 text-sm group-data-[collapsible=icon]:p-0!',
+        default: 'h-8 text-sm leading-[var(--text-sm--line-height)]',
+        sm: 'h-7 text-sm leading-[var(--text-sm--line-height)]',
+        lg: 'h-12 text-sm leading-[var(--text-sm--line-height)] group-data-[collapsible=icon]:p-0!',
       },
     },
     defaultVariants: {
@@ -562,7 +562,7 @@ function SidebarMenuBadge({ className, ...props }: React.ComponentProps<'div'>) 
       data-slot="sidebar-menu-badge"
       data-sidebar="menu-badge"
       className={cn(
-        'pointer-events-none absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-sm font-medium text-sidebar-foreground tabular-nums select-none',
+        'pointer-events-none absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-sm leading-[var(--text-sm--line-height)] font-medium text-sidebar-foreground tabular-nums select-none',
         'peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[active=true]/menu-button:text-sidebar-accent-foreground',
         'peer-data-[size=sm]/menu-button:top-1',
         'peer-data-[size=default]/menu-button:top-1.5',
@@ -656,8 +656,8 @@ function SidebarMenuSubButton({
       className={cn(
         'flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground ring-sidebar-ring outline-hidden hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground',
         'data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground',
-        size === 'sm' && 'text-sm',
-        size === 'md' && 'text-sm',
+        size === 'sm' && 'text-sm leading-[var(--text-sm--line-height)]',
+        size === 'md' && 'text-sm leading-[var(--text-sm--line-height)]',
         'group-data-[collapsible=icon]:hidden',
         className,
       )}

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -228,7 +228,7 @@ function Sidebar({
           // Adjust the padding for floating and inset variants.
           variant === 'floating' || variant === 'inset'
             ? 'p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]'
-            : 'group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l border-zinc-200',
+            : 'group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l border-sidebar-border',
           className,
         )}
         {...props}

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -387,7 +387,7 @@ function SidebarGroupLabel({
       data-slot="sidebar-group-label"
       data-sidebar="group-label"
       className={cn(
-        'flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 ring-sidebar-ring outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
+        'flex h-8 shrink-0 items-center rounded-md px-2 text-sm font-medium text-sidebar-foreground/70 ring-sidebar-ring outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
         'group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0',
         className,
       )}
@@ -463,7 +463,7 @@ const sidebarMenuButtonVariants = cva(
       },
       size: {
         default: 'h-8 text-sm',
-        sm: 'h-7 text-xs',
+        sm: 'h-7 text-sm',
         lg: 'h-12 text-sm group-data-[collapsible=icon]:p-0!',
       },
     },
@@ -562,7 +562,7 @@ function SidebarMenuBadge({ className, ...props }: React.ComponentProps<'div'>) 
       data-slot="sidebar-menu-badge"
       data-sidebar="menu-badge"
       className={cn(
-        'pointer-events-none absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-xs font-medium text-sidebar-foreground tabular-nums select-none',
+        'pointer-events-none absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-sm font-medium text-sidebar-foreground tabular-nums select-none',
         'peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[active=true]/menu-button:text-sidebar-accent-foreground',
         'peer-data-[size=sm]/menu-button:top-1',
         'peer-data-[size=default]/menu-button:top-1.5',
@@ -656,7 +656,7 @@ function SidebarMenuSubButton({
       className={cn(
         'flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground ring-sidebar-ring outline-hidden hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground',
         'data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground',
-        size === 'sm' && 'text-xs',
+        size === 'sm' && 'text-sm',
         size === 'md' && 'text-sm',
         'group-data-[collapsible=icon]:hidden',
         className,

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -1,0 +1,88 @@
+import type * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+function Table({ className, ...props }: React.ComponentProps<'table'>) {
+  return (
+    <table
+      data-slot="table"
+      className={cn('w-full caption-bottom text-sm', className)}
+      {...props}
+    />
+  );
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<'thead'>) {
+  return <thead data-slot="table-header" className={cn('[&_tr]:border-b', className)} {...props} />;
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<'tbody'>) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn('[&_tr:last-child]:border-0', className)}
+      {...props}
+    />
+  );
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<'tfoot'>) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn('border-t bg-muted/50 font-medium [&>tr]:last:border-b-0', className)}
+      {...props}
+    />
+  );
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<'tr'>) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        'border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<'th'>) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        'h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<'td'>) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        'p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCaption({ className, ...props }: React.ComponentProps<'caption'>) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn('mt-4 text-sm text-muted-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+export { Table, TableBody, TableCaption, TableCell, TableFooter, TableHead, TableHeader, TableRow };

--- a/locales/en/accounting.json
+++ b/locales/en/accounting.json
@@ -86,6 +86,7 @@
     "amountPaidInvalid": "Enter a valid paid amount.",
     "amountPaidExceedsTotal": "Amount paid cannot exceed the invoice total.",
     "status": "Status",
+    "actionsColumn": "Actions",
     "statusDraft": "Draft",
     "statusSent": "Sent",
     "statusPaid": "Paid",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -249,6 +249,7 @@
     "columnSettings": "Column settings",
     "columns": "Columns",
     "filters": "Filters",
+    "rowActions": "Row actions",
     "resetColumns": "Reset columns",
     "export": "Export",
     "exportToCsv": "Export to CSV",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -248,6 +248,7 @@
     "decreaseFont": "Decrease font size",
     "columnSettings": "Column settings",
     "columns": "Columns",
+    "filters": "Filters",
     "resetColumns": "Reset columns",
     "export": "Export",
     "exportToCsv": "Export to CSV",

--- a/locales/en/hr.json
+++ b/locales/en/hr.json
@@ -29,7 +29,7 @@
     "selectTasks": "Select Tasks",
     "assignmentsSaved": "Assignments saved successfully",
     "deleteConfirm": "Are you sure you want to delete this user? All associated data will be affected.",
-    "deleteUser": "Delete User?",
+    "deleteUser": "Delete User",
     "createNewUser": "Create New User",
     "manageAccess": "Manage Access: {{name}}",
     "disabled": "Disabled",

--- a/locales/it/accounting.json
+++ b/locales/it/accounting.json
@@ -86,6 +86,7 @@
     "amountPaidInvalid": "Inserisci un importo pagato valido.",
     "amountPaidExceedsTotal": "L'importo pagato non puo' superare il totale della fattura.",
     "status": "Stato",
+    "actionsColumn": "Azioni",
     "statusDraft": "Bozza",
     "statusSent": "Inviata",
     "statusPaid": "Pagata",

--- a/locales/it/common.json
+++ b/locales/it/common.json
@@ -249,6 +249,7 @@
     "columnSettings": "Impostazioni colonne",
     "columns": "Colonne",
     "filters": "Filtri",
+    "rowActions": "Azioni riga",
     "resetColumns": "Ripristina colonne",
     "export": "Esporta",
     "exportToCsv": "Esporta in CSV",

--- a/locales/it/common.json
+++ b/locales/it/common.json
@@ -248,6 +248,7 @@
     "decreaseFont": "Riduci dimensione testo",
     "columnSettings": "Impostazioni colonne",
     "columns": "Colonne",
+    "filters": "Filtri",
     "resetColumns": "Ripristina colonne",
     "export": "Esporta",
     "exportToCsv": "Esporta in CSV",

--- a/locales/it/hr.json
+++ b/locales/it/hr.json
@@ -29,7 +29,7 @@
     "selectTasks": "Seleziona Attività",
     "assignmentsSaved": "Assegnazioni salvate con successo",
     "deleteConfirm": "Sei sicuro di voler eliminare questo utente? Tutti i dati associati saranno interessati.",
-    "deleteUser": "Elimina Utente?",
+    "deleteUser": "Elimina Utente",
     "createNewUser": "Crea Nuovo Utente",
     "manageAccess": "Gestisci Accesso: {{name}}",
     "disabled": "Disabilitato",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     ]
   },
   "dependencies": {
+    "@tanstack/react-table": "^8.21.3",
     "bcryptjs": "^3.0.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/index.css
+++ b/src/index.css
@@ -347,3 +347,23 @@ input[type="number"] {
 .sidebar-entry-content[data-state="closed"] {
   animation: sidebar-entry-up 100ms ease-in;
 }
+
+.standard-table-value-cell :where(:not([data-status-badge], [data-status-badge] *)) {
+  background-color: transparent !important;
+  border-color: transparent !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
+  color: inherit !important;
+  font: inherit !important;
+  letter-spacing: normal !important;
+  padding: 0 !important;
+  text-transform: none !important;
+}
+
+.standard-table-value-cell i {
+  display: none !important;
+}
+
+.standard-table-value-cell [data-status-badge] i {
+  display: inline-block !important;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -177,6 +177,85 @@ input[type="number"] {
   --color-sidebar-ring: var(--sidebar-ring);
 }
 
+@layer components {
+  [data-shadcn-theme="dark"].shadcn-theme-bridge
+    :where(
+      .text-black,
+      .text-zinc-950,
+      .text-zinc-900,
+      .text-zinc-800,
+      .text-zinc-700,
+      .text-gray-950,
+      .text-gray-900,
+      .text-gray-800,
+      .text-gray-700,
+      .text-slate-950,
+      .text-slate-900,
+      .text-slate-800,
+      .text-slate-700
+    ) {
+    color: var(--foreground);
+  }
+
+  [data-shadcn-theme="dark"].shadcn-theme-bridge
+    :where(
+      .text-zinc-600,
+      .text-zinc-500,
+      .text-zinc-400,
+      .text-zinc-300,
+      .text-gray-600,
+      .text-gray-500,
+      .text-gray-400,
+      .text-gray-300,
+      .text-slate-600,
+      .text-slate-500,
+      .text-slate-400,
+      .text-slate-300
+    ) {
+    color: var(--muted-foreground);
+  }
+
+  [data-shadcn-theme="dark"].shadcn-theme-bridge
+    :where(.bg-white, .bg-white\/80, .bg-zinc-50, .bg-gray-50, .bg-slate-50) {
+    background-color: var(--card);
+  }
+
+  [data-shadcn-theme="dark"].shadcn-theme-bridge
+    :where(.bg-zinc-100, .bg-gray-100, .bg-slate-100, .bg-zinc-200, .bg-gray-200, .bg-slate-200) {
+    background-color: var(--muted);
+  }
+
+  [data-shadcn-theme="dark"].shadcn-theme-bridge
+    :where(
+      .hover\:bg-zinc-50:hover,
+      .hover\:bg-gray-50:hover,
+      .hover\:bg-slate-50:hover,
+      .hover\:bg-zinc-100:hover,
+      .hover\:bg-gray-100:hover,
+      .hover\:bg-slate-100:hover,
+      .hover\:bg-zinc-200:hover,
+      .hover\:bg-gray-200:hover,
+      .hover\:bg-slate-200:hover
+    ) {
+    background-color: var(--accent);
+  }
+
+  [data-shadcn-theme="dark"].shadcn-theme-bridge
+    :where(
+      .border-zinc-100,
+      .border-zinc-200,
+      .border-zinc-300,
+      .border-gray-100,
+      .border-gray-200,
+      .border-gray-300,
+      .border-slate-100,
+      .border-slate-200,
+      .border-slate-300
+    ) {
+    border-color: var(--border);
+  }
+}
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);

--- a/src/index.css
+++ b/src/index.css
@@ -177,83 +177,108 @@ input[type="number"] {
   --color-sidebar-ring: var(--sidebar-ring);
 }
 
-@layer components {
-  [data-shadcn-theme="dark"].shadcn-theme-bridge
-    :where(
-      .text-black,
-      .text-zinc-950,
-      .text-zinc-900,
-      .text-zinc-800,
-      .text-zinc-700,
-      .text-gray-950,
-      .text-gray-900,
-      .text-gray-800,
-      .text-gray-700,
-      .text-slate-950,
-      .text-slate-900,
-      .text-slate-800,
-      .text-slate-700
-    ) {
-    color: var(--foreground);
-  }
+/* Legacy pages still use neutral Tailwind utilities. Keep them readable inside the
+   scoped shadcn dark theme until those views are migrated to semantic tokens. */
+[data-shadcn-theme="dark"].shadcn-theme-bridge
+  :where(
+    .text-black,
+    .text-zinc-950,
+    .text-zinc-900,
+    .text-zinc-800,
+    .text-zinc-700,
+    .text-gray-950,
+    .text-gray-900,
+    .text-gray-800,
+    .text-gray-700,
+    .text-slate-950,
+    .text-slate-900,
+    .text-slate-800,
+    .text-slate-700
+  ) {
+  color: var(--foreground);
+}
 
-  [data-shadcn-theme="dark"].shadcn-theme-bridge
-    :where(
-      .text-zinc-600,
-      .text-zinc-500,
-      .text-zinc-400,
-      .text-zinc-300,
-      .text-gray-600,
-      .text-gray-500,
-      .text-gray-400,
-      .text-gray-300,
-      .text-slate-600,
-      .text-slate-500,
-      .text-slate-400,
-      .text-slate-300
-    ) {
-    color: var(--muted-foreground);
-  }
+[data-shadcn-theme="dark"].shadcn-theme-bridge
+  :where(
+    .text-zinc-600,
+    .text-zinc-500,
+    .text-zinc-400,
+    .text-zinc-300,
+    .text-gray-600,
+    .text-gray-500,
+    .text-gray-400,
+    .text-gray-300,
+    .text-slate-600,
+    .text-slate-500,
+    .text-slate-400,
+    .text-slate-300
+  ) {
+  color: var(--muted-foreground);
+}
 
-  [data-shadcn-theme="dark"].shadcn-theme-bridge
-    :where(.bg-white, .bg-white\/80, .bg-zinc-50, .bg-gray-50, .bg-slate-50) {
-    background-color: var(--card);
-  }
+[data-shadcn-theme="dark"].shadcn-theme-bridge
+  :where(
+    .bg-white,
+    .bg-white\/80,
+    .bg-zinc-50,
+    .bg-zinc-50\/50,
+    .bg-gray-50,
+    .bg-gray-50\/50,
+    .bg-slate-50,
+    .bg-slate-50\/50
+  ) {
+  background-color: var(--card);
+}
 
-  [data-shadcn-theme="dark"].shadcn-theme-bridge
-    :where(.bg-zinc-100, .bg-gray-100, .bg-slate-100, .bg-zinc-200, .bg-gray-200, .bg-slate-200) {
-    background-color: var(--muted);
-  }
+[data-shadcn-theme="dark"].shadcn-theme-bridge
+  :where(
+    .bg-zinc-100,
+    .bg-zinc-100\/30,
+    .bg-gray-100,
+    .bg-gray-100\/30,
+    .bg-slate-100,
+    .bg-slate-100\/30,
+    .bg-zinc-200,
+    .bg-gray-200,
+    .bg-slate-200
+  ) {
+  background-color: var(--muted);
+}
 
-  [data-shadcn-theme="dark"].shadcn-theme-bridge
-    :where(
-      .hover\:bg-zinc-50:hover,
-      .hover\:bg-gray-50:hover,
-      .hover\:bg-slate-50:hover,
-      .hover\:bg-zinc-100:hover,
-      .hover\:bg-gray-100:hover,
-      .hover\:bg-slate-100:hover,
-      .hover\:bg-zinc-200:hover,
-      .hover\:bg-gray-200:hover,
-      .hover\:bg-slate-200:hover
-    ) {
-    background-color: var(--accent);
-  }
+[data-shadcn-theme="dark"].shadcn-theme-bridge
+  :where(
+    .hover\:bg-zinc-50:hover,
+    .hover\:bg-zinc-50\/50:hover,
+    .hover\:bg-gray-50:hover,
+    .hover\:bg-gray-50\/50:hover,
+    .hover\:bg-slate-50:hover,
+    .hover\:bg-slate-50\/50:hover,
+    .hover\:bg-zinc-100:hover,
+    .hover\:bg-gray-100:hover,
+    .hover\:bg-slate-100:hover,
+    .hover\:bg-zinc-200:hover,
+    .hover\:bg-zinc-200\/50:hover,
+    .hover\:bg-gray-200:hover,
+    .hover\:bg-gray-200\/50:hover,
+    .hover\:bg-slate-200:hover,
+    .hover\:bg-slate-200\/50:hover
+  ) {
+  background-color: var(--accent);
+}
 
-  [data-shadcn-theme="dark"].shadcn-theme-bridge
-    :where(
-      .border-zinc-100,
-      .border-zinc-200,
-      .border-zinc-300,
-      .border-gray-100,
-      .border-gray-200,
-      .border-gray-300,
-      .border-slate-100,
-      .border-slate-200,
-      .border-slate-300
-    ) {
-    border-color: var(--border);
-  }
+[data-shadcn-theme="dark"].shadcn-theme-bridge
+  :where(
+    .border-zinc-100,
+    .border-zinc-200,
+    .border-zinc-300,
+    .border-gray-100,
+    .border-gray-200,
+    .border-gray-300,
+    .border-slate-100,
+    .border-slate-200,
+    .border-slate-300
+  ) {
+  border-color: var(--border);
 }
 
 @theme inline {

--- a/src/index.css
+++ b/src/index.css
@@ -47,11 +47,11 @@
   --color-accent: #9a2222;
   --color-neutral: #b8b5b3;
   --sidebar: hsl(0 0% 98%);
-  --sidebar-foreground: hsl(240 5.3% 26.1%);
+  --sidebar-foreground: var(--foreground);
   --sidebar-primary: hsl(240 5.9% 10%);
   --sidebar-primary-foreground: hsl(0 0% 98%);
   --sidebar-accent: hsl(240 4.8% 95.9%);
-  --sidebar-accent-foreground: hsl(240 5.9% 10%);
+  --sidebar-accent-foreground: var(--foreground);
   --sidebar-border: hsl(220 13% 91%);
   --sidebar-ring: hsl(217.2 91.2% 59.8%);
 }
@@ -139,11 +139,11 @@ input[type="number"] {
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.552 0.016 285.938);
   --sidebar: hsl(240 5.9% 10%);
-  --sidebar-foreground: hsl(240 4.8% 95.9%);
+  --sidebar-foreground: var(--foreground);
   --sidebar-primary: hsl(224.3 76.3% 48%);
   --sidebar-primary-foreground: hsl(0 0% 100%);
   --sidebar-accent: hsl(240 3.7% 15.9%);
-  --sidebar-accent-foreground: hsl(240 4.8% 95.9%);
+  --sidebar-accent-foreground: var(--foreground);
   --sidebar-border: hsl(240 3.7% 15.9%);
   --sidebar-ring: hsl(217.2 91.2% 59.8%);
 }

--- a/test/components/Layout.test.tsx
+++ b/test/components/Layout.test.tsx
@@ -104,7 +104,9 @@ describe('<Layout />', () => {
       '[data-sidebar="menu-button"][data-active="true"]',
     );
     const brandButton = screen.getByText('PRAETOR').closest('[data-sidebar="menu-button"]');
+    const brandLogo = brandButton?.querySelector('svg')?.parentElement;
     const brandSubtitle = screen.getByText('roles.manager workspace');
+    const avatarFallback = screen.getByText('TU');
 
     expect(sidebarContainer?.className).toContain('border-sidebar-border');
     expect(sidebarContainer?.className).not.toContain('border-zinc-200');
@@ -113,7 +115,14 @@ describe('<Layout />', () => {
     expect(activeButton?.className).not.toContain('text-black');
     expect(brandButton?.className).toContain('text-sidebar-foreground');
     expect(brandButton?.className).toContain('hover:text-sidebar-foreground');
+    expect(brandLogo?.className).toContain('text-sidebar-foreground');
+    expect(brandLogo?.className).not.toContain('text-white');
+    expect(brandLogo?.className).not.toContain('bg-praetor');
+    expect(brandSubtitle.className).toContain('text-sm');
     expect(brandSubtitle.className).toContain('text-sidebar-foreground/80');
+    expect(avatarFallback.className).toContain('text-sm');
+    expect(avatarFallback.className).toContain('text-sidebar-foreground');
+    expect(avatarFallback.className).not.toContain('text-white');
   });
 
   test('account dropdown uses the scoped shadcn dark theme and sidebar text tokens', async () => {

--- a/test/components/Layout.test.tsx
+++ b/test/components/Layout.test.tsx
@@ -91,6 +91,7 @@ describe('<Layout />', () => {
 
     const main = container.querySelector('[data-slot="sidebar-inset"]');
     expect(main?.hasAttribute('data-shadcn-theme-scope')).toBe(true);
+    expect(main?.className).toContain('shadcn-theme-bridge');
     await waitFor(() => expect(main?.getAttribute('data-shadcn-theme')).toBe('dark'));
   });
 

--- a/test/components/Layout.test.tsx
+++ b/test/components/Layout.test.tsx
@@ -99,12 +99,15 @@ describe('<Layout />', () => {
   test('sidebar navigation text uses shadcn sidebar color tokens', () => {
     const { container } = renderLayout();
 
+    const sidebarContainer = container.querySelector('[data-slot="sidebar-container"]');
     const activeButton = container.querySelector(
       '[data-sidebar="menu-button"][data-active="true"]',
     );
     const brandButton = screen.getByText('PRAETOR').closest('[data-sidebar="menu-button"]');
     const brandSubtitle = screen.getByText('roles.manager workspace');
 
+    expect(sidebarContainer?.className).toContain('border-sidebar-border');
+    expect(sidebarContainer?.className).not.toContain('border-zinc-200');
     expect(activeButton?.className).toContain('text-sidebar-foreground');
     expect(activeButton?.className).toContain('data-[active=true]:text-sidebar-accent-foreground');
     expect(activeButton?.className).not.toContain('text-black');

--- a/test/components/Layout.test.tsx
+++ b/test/components/Layout.test.tsx
@@ -92,6 +92,7 @@ describe('<Layout />', () => {
     const main = container.querySelector('[data-slot="sidebar-inset"]');
     expect(main?.hasAttribute('data-shadcn-theme-scope')).toBe(true);
     expect(main?.className).toContain('shadcn-theme-bridge');
+    expect(main?.className).toContain('text-foreground');
     await waitFor(() => expect(main?.getAttribute('data-shadcn-theme')).toBe('dark'));
   });
 

--- a/test/components/Layout.test.tsx
+++ b/test/components/Layout.test.tsx
@@ -85,6 +85,15 @@ describe('<Layout />', () => {
     expect(screen.getAllByText('routes.timeTracker').length).toBeGreaterThan(0);
   });
 
+  test('main content is scoped to the selected shadcn theme', async () => {
+    localStorage.setItem('praetor_theme', 'dark');
+    const { container } = renderLayout();
+
+    const main = container.querySelector('[data-slot="sidebar-inset"]');
+    expect(main?.hasAttribute('data-shadcn-theme-scope')).toBe(true);
+    await waitFor(() => expect(main?.getAttribute('data-shadcn-theme')).toBe('dark'));
+  });
+
   test('sidebar navigation text uses shadcn sidebar color tokens', () => {
     const { container } = renderLayout();
 

--- a/test/components/Layout.test.tsx
+++ b/test/components/Layout.test.tsx
@@ -3,7 +3,7 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event';
 import type React from 'react';
 import type { Role, User } from '../../types';
-import { applyTheme } from '../../utils/theme';
+import { applyTheme, THEME_STORAGE_KEY } from '../../utils/theme';
 import { installI18nMock } from '../helpers/i18n';
 
 installI18nMock();
@@ -86,7 +86,7 @@ describe('<Layout />', () => {
   });
 
   test('main content is scoped to the selected shadcn theme', async () => {
-    localStorage.setItem('praetor_theme', 'dark');
+    localStorage.setItem(THEME_STORAGE_KEY, 'dark');
     const { container } = renderLayout();
 
     const main = container.querySelector('[data-slot="sidebar-inset"]');
@@ -119,14 +119,16 @@ describe('<Layout />', () => {
     expect(brandLogo?.className).not.toContain('text-white');
     expect(brandLogo?.className).not.toContain('bg-praetor');
     expect(brandSubtitle.className).toContain('text-sm');
+    expect(brandSubtitle.className).toContain('leading-[var(--text-sm--line-height)]');
     expect(brandSubtitle.className).toContain('text-sidebar-foreground/80');
     expect(avatarFallback.className).toContain('text-sm');
+    expect(avatarFallback.className).toContain('leading-[var(--text-sm--line-height)]');
     expect(avatarFallback.className).toContain('text-sidebar-foreground');
     expect(avatarFallback.className).not.toContain('text-white');
   });
 
   test('account dropdown uses the scoped shadcn dark theme and sidebar text tokens', async () => {
-    localStorage.setItem('praetor_theme', 'dark');
+    localStorage.setItem(THEME_STORAGE_KEY, 'dark');
     const user = userEvent.setup();
     const { container } = renderLayout();
 
@@ -149,7 +151,7 @@ describe('<Layout />', () => {
   });
 
   test('open account dropdown updates when shadcn theme changes', async () => {
-    localStorage.setItem('praetor_theme', 'light');
+    localStorage.setItem(THEME_STORAGE_KEY, 'light');
     const user = userEvent.setup();
     renderLayout();
 

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -355,6 +355,18 @@ describe('<StandardTable />', () => {
     expect(sortIcon?.className).toContain('transition-colors');
   });
 
+  test('all sortable header buttons align with cell padding', () => {
+    render(<StandardTable<Row> title="People" data={sampleRows} columns={sampleColumns} />);
+
+    for (const headerText of ['Name', 'Age']) {
+      const headerCell = screen.getByText(headerText).closest('th') as HTMLTableCellElement;
+      const sortButton = within(headerCell)
+        .getAllByRole('button')
+        .find((button) => button.textContent?.trim().startsWith(headerText)) as HTMLButtonElement;
+      expect(sortButton.className).toContain('-ml-2');
+    }
+  });
+
   test('every non-action header shows a sort icon affordance', () => {
     const columns = [
       { header: 'Name', accessorKey: 'name' as const, id: 'name' },

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -620,8 +620,28 @@ describe('<StandardTable />', () => {
 
     const previousButton = screen.getByRole('button', { name: 'buttons.previous' });
     expect(previousButton).toBeDisabled();
+    expect(previousButton.getAttribute('data-size')).toBe('sm');
+    expect(previousButton.className).toContain('border-border');
     expect(previousButton.className).toContain('text-foreground');
     expect(previousButton.className).toContain('disabled:opacity-100');
+  });
+
+  test('toolbar outline buttons use the same shadcn border token as pagination', () => {
+    render(<StandardTable<Row> title="People" data={sampleRows} columns={sampleColumns} />);
+
+    const exportButton = screen.getByRole('button', { name: 'table.exportToCsv' });
+    const decreaseFontButton = screen.getByRole('button', { name: 'table.decreaseFont' });
+    const increaseFontButton = screen.getByRole('button', { name: 'table.increaseFont' });
+    const columnsButton = screen.getByRole('button', { name: 'table.columnSettings' });
+
+    expect(exportButton.getAttribute('data-size')).toBe('sm');
+    expect(columnsButton.getAttribute('data-size')).toBe('sm');
+    expect(decreaseFontButton.getAttribute('data-size')).toBe('icon-sm');
+    expect(increaseFontButton.getAttribute('data-size')).toBe('icon-sm');
+
+    for (const button of [exportButton, decreaseFontButton, increaseFontButton, columnsButton]) {
+      expect(button.className).toContain('border-border');
+    }
   });
 
   // ---------------------------------------------------------------------------

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -1,6 +1,7 @@
 import { afterAll, afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { THEME_STORAGE_KEY } from '../../utils/theme';
 import { installI18nMock } from '../helpers/i18n';
 
 installI18nMock();
@@ -170,7 +171,7 @@ describe('<StandardTable />', () => {
   });
 
   test('rows-per-page select menu uses the scoped shadcn dark theme', async () => {
-    localStorage.setItem('praetor_theme', 'dark');
+    localStorage.setItem(THEME_STORAGE_KEY, 'dark');
     const user = userEvent.setup();
     render(<StandardTable<Row> title="People" data={sampleRows} columns={sampleColumns} />);
 
@@ -367,6 +368,8 @@ describe('<StandardTable />', () => {
     });
 
     await waitFor(() => expect(document.body.style.cursor).toBe('col-resize'));
+    expect(headerCell.style.width).toBe('');
+    expect(headerCell.closest('table')?.className).not.toContain('table-fixed');
 
     act(() => {
       fireEvent.mouseMove(document, { clientX: 0 });
@@ -566,6 +569,9 @@ describe('<StandardTable />', () => {
       'standard-table-value-cell',
     );
     expect(screen.getByText('Alice').closest('td')?.className).toContain('text-sm');
+    expect(screen.getByText('Alice').closest('td')?.className).toContain(
+      'leading-[var(--text-sm--line-height)]',
+    );
     expect(screen.getByText('Active')).toHaveAttribute('data-status-badge');
   });
 
@@ -818,6 +824,8 @@ describe('<StandardTable />', () => {
     expect(previousButton.className).toContain('rounded-lg');
     expect(previousButton.className).toContain('!h-7');
     expect(previousButton.className).toContain('!text-sm');
+    expect(previousButton.className).toContain('!leading-[var(--text-sm--line-height)]');
+    expect(previousButton.className).toContain('!font-normal');
     expect(previousButton.className).toContain('disabled:opacity-50');
     expect(previousButton.className).not.toContain('disabled:opacity-100');
   });
@@ -857,6 +865,8 @@ describe('<StandardTable />', () => {
       expect(button.className).toContain('rounded-lg');
       expect(button.className).toContain('!h-7');
       expect(button.className).toContain('!text-sm');
+      expect(button.className).toContain('!leading-[var(--text-sm--line-height)]');
+      expect(button.className).toContain('!font-normal');
       expect(button.className).not.toContain('focus-visible:border-ring');
     }
 

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -158,6 +158,7 @@ describe('<StandardTable />', () => {
     // The rows-per-page shadcn Select trigger shows the current value (default 10).
     const trigger = screen.getByRole('combobox');
     expect(trigger.textContent).toContain('10');
+    expect(trigger.className).toContain('rounded-lg');
     await user.click(trigger);
 
     // Pick "20" from the dropdown - fail loudly if the option isn't rendered.
@@ -184,6 +185,7 @@ describe('<StandardTable />', () => {
 
   test('CSV export click invokes downloadCsv with rows and filename', () => {
     render(<StandardTable<Row> title="People" data={sampleRows} columns={sampleColumns} />);
+    expect(screen.getByRole('table').parentElement?.className).toContain('rounded-lg');
     const exportButton = screen.getByText('table.export');
     fireEvent.click(exportButton);
 
@@ -299,7 +301,7 @@ describe('<StandardTable />', () => {
       .find((button) => button.textContent?.trim().startsWith('Name')) as HTMLButtonElement;
     const sortIcon = sortButton.querySelector('i.fa-arrow-up-arrow-down');
 
-    expect(sortButton.className).toContain('rounded-md');
+    expect(sortButton.className).toContain('rounded-lg');
     expect(sortButton.className).toContain('font-semibold');
     expect(sortButton.className).toContain('hover:bg-accent');
     expect(sortButton.className).toContain('hover:text-accent-foreground');
@@ -791,6 +793,7 @@ describe('<StandardTable />', () => {
     expect(previousButton).toBeDisabled();
     expect(previousButton.getAttribute('data-size')).toBe('xs');
     expect(previousButton.className).toContain('border-border');
+    expect(previousButton.className).toContain('rounded-lg');
     expect(previousButton.className).toContain('disabled:opacity-50');
     expect(previousButton.className).not.toContain('disabled:opacity-100');
   });
@@ -803,6 +806,8 @@ describe('<StandardTable />', () => {
 
     expect(previousButton).toBeDisabled();
     expect(nextButton).toBeDisabled();
+    expect(previousButton.className).toContain('rounded-lg');
+    expect(nextButton.className).toContain('rounded-lg');
     expect(previousButton.className).toContain('disabled:opacity-50');
     expect(nextButton.className).toContain('disabled:opacity-50');
     expect(previousButton.className).not.toContain('disabled:opacity-100');
@@ -825,6 +830,7 @@ describe('<StandardTable />', () => {
 
     for (const button of [exportButton, decreaseFontButton, increaseFontButton, columnsButton]) {
       expect(button.className).toContain('border-border');
+      expect(button.className).toContain('rounded-lg');
       expect(button.className).not.toContain('focus-visible:border-ring');
     }
 

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -412,6 +412,16 @@ describe('<StandardTable />', () => {
     await waitFor(() => expect(longHeaderCell.style.minWidth).toBe('200px'));
   });
 
+  test('stored column widths are clamped to the full header label width', async () => {
+    localStorage.setItem('praetor_table_colwidths_role_width', JSON.stringify({ role: 32 }));
+    const columns = [{ header: 'Ruolo', accessorKey: 'name' as const, id: 'role' }];
+
+    render(<StandardTable<Row> title="Role Width" data={sampleRows} columns={columns} />);
+
+    const headerCell = screen.getByText('Ruolo').closest('th') as HTMLElement;
+    await waitFor(() => expect(Number.parseInt(headerCell.style.minWidth, 10)).toBeGreaterThan(80));
+  });
+
   test('stale stored column widths do not force fixed table layout', () => {
     localStorage.setItem('praetor_table_colwidths_stale_widths', JSON.stringify({ missing: 160 }));
 

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -299,13 +299,31 @@ describe('<StandardTable />', () => {
     const sortButton = within(headerCell)
       .getAllByRole('button')
       .find((button) => button.textContent?.trim().startsWith('Name')) as HTMLButtonElement;
-    const sortIcon = sortButton.querySelector('i.fa-arrow-up-arrow-down');
+    const sortIcon = sortButton.querySelector('svg.lucide-arrow-up-down');
 
     expect(sortButton.className).toContain('rounded-lg');
     expect(sortButton.className).toContain('font-semibold');
     expect(sortButton.className).toContain('hover:bg-accent');
     expect(sortButton.className).toContain('hover:text-accent-foreground');
     expect(sortIcon?.className).toContain('transition-colors');
+  });
+
+  test('every non-action header shows a sort icon affordance', () => {
+    const columns = [
+      { header: 'Name', accessorKey: 'name' as const, id: 'name' },
+      { header: 'Age', accessorKey: 'age' as const, id: 'age', disableSorting: true },
+      {
+        id: 'actions',
+        header: 'Actions',
+        sticky: 'right' as const,
+        cell: () => <span>X</span>,
+      },
+    ];
+    render(<StandardTable<Row> title="People" data={sampleRows} columns={columns} />);
+
+    expect(screen.getByText('Name').closest('th')?.querySelector('svg')).toBeInTheDocument();
+    expect(screen.getByText('Age').closest('th')?.querySelector('svg')).toBeInTheDocument();
+    expect(screen.getByText('Actions').closest('th')?.querySelector('svg')).toBeNull();
   });
 
   test('column resize clamps to the measured header label width', async () => {
@@ -356,7 +374,10 @@ describe('<StandardTable />', () => {
 
     await waitFor(() => expect(headerCell.style.width).toBe('160px'));
     expect(headerCell.style.minWidth).toBe('160px');
-    await waitFor(() => expect(headerCell.closest('table')?.className).toContain('table-fixed'));
+    const table = headerCell.closest('table') as HTMLTableElement;
+    await waitFor(() => expect(table.className).toContain('table-fixed'));
+    expect(table.style.width).toBe('248px');
+    expect(table.style.minWidth).toBe('100%');
     expect(screen.getByText('Age').closest('th')?.style.minWidth).toBe('88px');
     expect(screen.getByText('Alice').closest('td')?.className).toContain('overflow-hidden');
     expect(screen.getByText('Alice').closest('td')?.className).toContain('text-ellipsis');
@@ -518,7 +539,7 @@ describe('<StandardTable />', () => {
     expect(actionsHeader.className).not.toContain('bg-background');
     expect(actionsHeader.textContent?.trim()).toBe('Actions');
     expect(within(actionsHeader).queryByRole('button')).not.toBeInTheDocument();
-    expect(actionsHeader.querySelector('i.fa-arrow-up-arrow-down')).toBeNull();
+    expect(actionsHeader.querySelector('svg')).toBeNull();
   });
 
   test('value cells reset custom value styling while preserving status badges', () => {
@@ -544,6 +565,7 @@ describe('<StandardTable />', () => {
     expect(screen.getByText('Alice').closest('td')?.className).toContain(
       'standard-table-value-cell',
     );
+    expect(screen.getByText('Alice').closest('td')?.className).toContain('text-sm');
     expect(screen.getByText('Active')).toHaveAttribute('data-status-badge');
   });
 
@@ -795,7 +817,7 @@ describe('<StandardTable />', () => {
     expect(previousButton.className).toContain('border-border');
     expect(previousButton.className).toContain('rounded-lg');
     expect(previousButton.className).toContain('!h-7');
-    expect(previousButton.className).toContain('!text-[10px]');
+    expect(previousButton.className).toContain('!text-sm');
     expect(previousButton.className).toContain('disabled:opacity-50');
     expect(previousButton.className).not.toContain('disabled:opacity-100');
   });
@@ -834,7 +856,7 @@ describe('<StandardTable />', () => {
       expect(button.className).toContain('border-border');
       expect(button.className).toContain('rounded-lg');
       expect(button.className).toContain('!h-7');
-      expect(button.className).toContain('!text-[10px]');
+      expect(button.className).toContain('!text-sm');
       expect(button.className).not.toContain('focus-visible:border-ring');
     }
 

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -652,7 +652,7 @@ describe('<StandardTable />', () => {
     expect(actionsHeader.className).toContain('sticky');
     expect(actionsHeader.className).toContain('right-0');
     expect(actionsHeader.className).toContain('bg-card');
-    expect(Number.parseInt(actionsHeader.style.minWidth, 10)).toBeGreaterThanOrEqual(96);
+    expect(Number.parseInt(actionsHeader.style.minWidth, 10)).toBeGreaterThanOrEqual(64);
     expect(actionsHeader.className).not.toContain('bg-background');
     expect(actionsHeader.textContent?.trim()).toBe('Actions');
     expect(within(actionsHeader).queryByRole('button')).not.toBeInTheDocument();
@@ -722,7 +722,7 @@ describe('<StandardTable />', () => {
     expect(screen.queryByTestId('action-1')).not.toBeInTheDocument();
     const firstActionCell = screen.getAllByLabelText('table.rowActions')[0].closest('td');
     expect(firstActionCell?.className).toContain('bg-card');
-    expect(Number.parseInt(firstActionCell?.style.minWidth ?? '0', 10)).toBeGreaterThanOrEqual(96);
+    expect(Number.parseInt(firstActionCell?.style.minWidth ?? '0', 10)).toBeGreaterThanOrEqual(64);
     expect(firstActionCell?.className).not.toContain('bg-background');
     expect(firstActionCell?.className).not.toContain('border-l');
     expect(firstActionCell?.className).not.toContain('group-hover:bg-muted/50');

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -348,6 +348,7 @@ describe('<StandardTable />', () => {
     const sortIcon = sortButton.querySelector('svg.lucide-arrow-up-down');
 
     expect(sortButton.className).toContain('rounded-lg');
+    expect(sortButton.className).toContain('-ml-2');
     expect(sortButton.className).toContain('font-semibold');
     expect(sortButton.className).toContain('hover:bg-accent');
     expect(sortButton.className).toContain('hover:text-accent-foreground');

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -303,6 +303,51 @@ describe('<StandardTable />', () => {
     expect(sortIcon?.className).toContain('transition-colors');
   });
 
+  test('column resize clamps to the measured header label width', async () => {
+    render(<StandardTable<Row> title="People" data={sampleRows} columns={sampleColumns} />);
+
+    const headerCell = screen.getByText('Name').closest('th') as HTMLTableCellElement;
+    const headerLabel = headerCell.querySelector(
+      '[data-column-header-label="name"]',
+    ) as HTMLElement;
+    const resizeHandle = headerCell.querySelector(
+      '[data-column-resize-handle="name"]',
+    ) as HTMLElement;
+
+    Object.defineProperty(headerLabel, 'scrollWidth', { configurable: true, value: 96 });
+    Object.defineProperty(headerCell, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({
+        bottom: 0,
+        height: 40,
+        left: 0,
+        right: 220,
+        top: 0,
+        width: 220,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }),
+    });
+
+    act(() => {
+      fireEvent.mouseDown(resizeHandle, { clientX: 220 });
+    });
+
+    await waitFor(() => expect(document.body.style.cursor).toBe('col-resize'));
+
+    act(() => {
+      fireEvent.mouseMove(document, { clientX: 0 });
+    });
+
+    await waitFor(() => expect(headerCell.style.width).toBe('160px'));
+    expect(headerCell.style.minWidth).toBe('160px');
+
+    act(() => {
+      fireEvent.mouseUp(document);
+    });
+  });
+
   test('sorting descending by age reorders numerically (largest first)', () => {
     render(<StandardTable<Row> title="People" data={sampleRows} columns={sampleColumns} />);
     clickSortHeader('Age');
@@ -641,6 +686,7 @@ describe('<StandardTable />', () => {
 
     for (const button of [exportButton, decreaseFontButton, increaseFontButton, columnsButton]) {
       expect(button.className).toContain('border-border');
+      expect(button.className).not.toContain('focus-visible:border-ring');
     }
   });
 

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -274,6 +274,12 @@ describe('<StandardTable />', () => {
     expect(cells[3].className).not.toMatch(/\bw-full\b/);
     expect(screen.getByRole('table').style.width).toBe('100%');
     expect(screen.getByRole('table').style.minWidth).not.toBe('');
+    const ageResizeLine = screen
+      .getByText('Age')
+      .closest('th')
+      ?.querySelector('[data-column-resize-line="age"]');
+    expect(ageResizeLine?.className).toContain('bg-transparent');
+    expect(ageResizeLine?.className).not.toContain('bg-border');
   });
 
   // ---------------------------------------------------------------------------

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -1,5 +1,6 @@
 import { afterAll, afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { installI18nMock } from '../helpers/i18n';
 
 installI18nMock();
@@ -29,22 +30,52 @@ const sampleColumns = [
   { header: 'Age', accessorKey: 'age' as const, id: 'age' },
 ];
 
-// Each header's filter trigger is an icon-only button with no accessible name,
-// so scope the lookup to the matching <th> and grab its single button.
-const openFilterFor = (headerText: string) => {
+const clickSortHeader = (headerText: string) => {
   const headerCell = screen.getByText(headerText).closest('th') as HTMLTableCellElement;
-  const btn = headerCell.querySelector('button') as HTMLButtonElement;
+  const btn = within(headerCell).getByRole('button');
   act(() => {
     fireEvent.click(btn);
   });
 };
 
-const findPositionedFilterPopup = () => {
-  let el = screen.getByText('table.sortAsc').parentElement;
-  while (el && el.style.position !== 'absolute') {
-    el = el.parentElement;
-  }
-  return el as HTMLDivElement | null;
+const openFiltersMenu = async () => {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole('button', { name: /table\.filters/ }));
+  return user;
+};
+
+const selectFilterValue = async (columnHeader: string, value: string) => {
+  const user = await openFiltersMenu();
+  const columnItem = screen
+    .getAllByText(columnHeader)
+    .find((element) => element.closest('[role="menuitem"]'));
+  expect(columnItem).toBeDefined();
+  await user.click(columnItem as HTMLElement);
+  act(() => {
+    fireEvent.click(screen.getByRole('menuitemcheckbox', { name: value }));
+  });
+  return user;
+};
+
+const openColumnSettings = async () => {
+  const user = userEvent.setup();
+  await user.click(screen.getByLabelText('table.columnSettings'));
+  return user;
+};
+
+const openCustomViews = async () => {
+  const user = await openColumnSettings();
+  await user.click(screen.getByText('table.customViews'));
+  return user;
+};
+
+const clickMenuItemByText = (text: string) => {
+  const item = screen.getByText(text).closest('[role="menuitem"]') as HTMLElement;
+  act(() => fireEvent.click(item));
+};
+
+const clickMenuAction = (element: HTMLElement) => {
+  act(() => fireEvent.click(element.closest('[role="menuitem"]') ?? element));
 };
 
 describe('<StandardTable />', () => {
@@ -120,18 +151,19 @@ describe('<StandardTable />', () => {
     expect(onRowClick).toHaveBeenCalledWith(sampleRows[1]);
   });
 
-  test('rowsPerPage persists to localStorage', () => {
+  test('rowsPerPage persists to localStorage', async () => {
+    const user = userEvent.setup();
     const { unmount } = render(
       <StandardTable<Row> title="People" data={sampleRows} columns={sampleColumns} />,
     );
 
-    // The rows-per-page CustomSelect's trigger shows the current value (default 10).
-    const triggers = screen.getAllByRole('button').filter((b) => b.textContent === '10');
-    expect(triggers.length).toBeGreaterThan(0);
-    fireEvent.click(triggers[0]);
+    // The rows-per-page shadcn Select trigger shows the current value (default 10).
+    const trigger = screen.getByRole('combobox');
+    expect(trigger.textContent).toContain('10');
+    await user.click(trigger);
 
     // Pick "20" from the dropdown - fail loudly if the option isn't rendered.
-    fireEvent.click(screen.getByText('20'));
+    await user.click(screen.getByRole('option', { name: '20' }));
     unmount();
 
     // localStorage should hold the newly-selected value, not just any value.
@@ -226,7 +258,7 @@ describe('<StandardTable />', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Sorting (ascending / descending via the per-column filter popup)
+  // Sorting (via TanStack header sort handlers)
   // ---------------------------------------------------------------------------
   test('sorting ascending by name reorders the rendered rows', () => {
     // Render with intentionally unsorted data so a no-op sort would fail.
@@ -236,10 +268,7 @@ describe('<StandardTable />', () => {
       { id: '2', name: 'Bob', age: 25 },
     ];
     render(<StandardTable<Row> title="People" data={unsortedRows} columns={sampleColumns} />);
-    openFilterFor('Name');
-    act(() => {
-      fireEvent.click(screen.getByText('table.sortAsc'));
-    });
+    clickSortHeader('Name');
     const rows = screen
       .getAllByRole('row')
       .slice(1)
@@ -251,10 +280,7 @@ describe('<StandardTable />', () => {
 
   test('sorting descending by age reorders numerically (largest first)', () => {
     render(<StandardTable<Row> title="People" data={sampleRows} columns={sampleColumns} />);
-    openFilterFor('Age');
-    act(() => {
-      fireEvent.click(screen.getByText('table.sortDesc'));
-    });
+    clickSortHeader('Age');
     const rows = screen
       .getAllByRole('row')
       .slice(1)
@@ -266,24 +292,20 @@ describe('<StandardTable />', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Filters: dropdown filter (the only filter UI on the per-column popup)
+  // Filters: toolbar input and shadcn dropdown bound to TanStack column filters
   // ---------------------------------------------------------------------------
-  test('selecting a single filter value narrows the visible rows', () => {
+  test('selecting a single filter value narrows the visible rows', async () => {
     const { container } = render(
       <StandardTable<Row> title="People" data={sampleRows} columns={sampleColumns} />,
     );
-    openFilterFor('Name');
-    // Click the "Alice" filter option (under a <label>; table cells aren't).
-    act(() => {
-      const aliceLabels = screen.getAllByText('Alice');
-      const optionLabel = aliceLabels.find((el) => el.closest('label'));
-      fireEvent.click(optionLabel ?? aliceLabels[0]);
-    });
+    await selectFilterValue('Name', 'Alice');
     const tbody = container.querySelector('tbody') as HTMLElement;
-    const bodyText = tbody.textContent ?? '';
-    expect(bodyText).toContain('Alice');
-    expect(bodyText).not.toContain('Bob');
-    expect(bodyText).not.toContain('Charlie');
+    await waitFor(() => {
+      const bodyText = tbody.textContent ?? '';
+      expect(bodyText).toContain('Alice');
+      expect(bodyText).not.toContain('Bob');
+      expect(bodyText).not.toContain('Charlie');
+    });
   });
 
   test('multi-column filters intersect (Name + Age)', () => {
@@ -307,7 +329,7 @@ describe('<StandardTable />', () => {
     expect(bodyRows[0].textContent).toContain('30');
   });
 
-  test('clearing a filter via the popup restores all rows', () => {
+  test('clearing a filter via the dropdown restores all rows', async () => {
     const { container } = render(
       <StandardTable<Row>
         title="People"
@@ -318,51 +340,26 @@ describe('<StandardTable />', () => {
     );
     const tbody = container.querySelector('tbody') as HTMLElement;
     expect(tbody.textContent).not.toContain('Bob');
-    openFilterFor('Name');
-    act(() => {
-      fireEvent.click(screen.getByText('table.clearFilter'));
-    });
+    const user = await openFiltersMenu();
+    const nameItem = screen
+      .getAllByText('Name')
+      .find((element) => element.closest('[role="menuitem"]'));
+    expect(nameItem).toBeDefined();
+    await user.click(nameItem as HTMLElement);
+    clickMenuItemByText('table.clearFilter');
     expect(tbody.textContent).toContain('Bob');
     expect(tbody.textContent).toContain('Charlie');
   });
 
-  test('filter popup stays within the viewport near the right edge', () => {
-    const originalInnerWidth = window.innerWidth;
-    Object.defineProperty(window, 'innerWidth', {
-      configurable: true,
-      value: 400,
+  test('toolbar search input filters the primary column', () => {
+    render(<StandardTable<Row> title="People" data={sampleRows} columns={sampleColumns} />);
+    const search = screen.getByPlaceholderText('table.search Name');
+    act(() => {
+      fireEvent.change(search, { target: { value: 'Ali' } });
     });
-    try {
-      render(<StandardTable<Row> title="People" data={sampleRows} columns={sampleColumns} />);
-
-      const ageHeader = screen.getByText('Age').closest('th') as HTMLTableCellElement;
-      const filterButton = ageHeader.querySelector('button') as HTMLButtonElement;
-      filterButton.getBoundingClientRect = () =>
-        ({
-          bottom: 20,
-          height: 16,
-          left: 380,
-          right: 396,
-          top: 4,
-          width: 16,
-          x: 380,
-          y: 4,
-          toJSON: () => ({}),
-        }) as DOMRect;
-
-      act(() => {
-        fireEvent.click(filterButton);
-      });
-
-      const popup = findPositionedFilterPopup();
-      expect(popup).not.toBeNull();
-      expect(popup?.style.left).toBe('168px');
-    } finally {
-      Object.defineProperty(window, 'innerWidth', {
-        configurable: true,
-        value: originalInnerWidth,
-      });
-    }
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.queryByText('Bob')).not.toBeInTheDocument();
+    expect(screen.queryByText('Charlie')).not.toBeInTheDocument();
   });
 
   // ---------------------------------------------------------------------------
@@ -450,7 +447,7 @@ describe('<StandardTable />', () => {
   // ---------------------------------------------------------------------------
   // Pagination
   // ---------------------------------------------------------------------------
-  test('pagination renders multiple pages and navigates with the page buttons', () => {
+  test('pagination navigates with the shadcn previous and next buttons', () => {
     const many: Row[] = Array.from({ length: 12 }, (_, i) => ({
       id: String(i + 1),
       name: `User${i + 1}`,
@@ -469,16 +466,22 @@ describe('<StandardTable />', () => {
     expect(screen.getByText('User5')).toBeInTheDocument();
     expect(screen.queryByText('User6')).not.toBeInTheDocument();
 
-    // Click page button "2".
+    // Click next to move to page 2.
     act(() => {
-      fireEvent.click(screen.getByRole('button', { name: '2' }));
+      fireEvent.click(screen.getByRole('button', { name: 'buttons.next' }));
     });
     expect(screen.queryByText('User1')).not.toBeInTheDocument();
     expect(screen.getByText('User6')).toBeInTheDocument();
     expect(screen.getByText('User10')).toBeInTheDocument();
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'buttons.previous' }));
+    });
+    expect(screen.getByText('User1')).toBeInTheDocument();
   });
 
-  test('changing rowsPerPage produces the new slice on page 1', () => {
+  test('changing rowsPerPage produces the new slice on page 1', async () => {
+    const user = userEvent.setup();
     const many: Row[] = Array.from({ length: 30 }, (_, i) => ({
       id: String(i + 1),
       name: `User${i + 1}`,
@@ -492,10 +495,10 @@ describe('<StandardTable />', () => {
         defaultRowsPerPage={5}
       />,
     );
-    const triggers = screen.getAllByRole('button').filter((b) => b.textContent === '5');
-    expect(triggers.length).toBeGreaterThan(0);
-    act(() => fireEvent.click(triggers[0]));
-    act(() => fireEvent.click(screen.getByText('20')));
+    const trigger = screen.getByRole('combobox');
+    expect(trigger.textContent).toContain('5');
+    await user.click(trigger);
+    await user.click(screen.getByRole('option', { name: '20' }));
 
     // Now 20 rows fit on page 1. Count rows directly to avoid substring
     // collisions like "User21" matching "User2107".
@@ -520,7 +523,10 @@ describe('<StandardTable />', () => {
     );
 
     act(() => {
-      fireEvent.click(screen.getByRole('button', { name: '3' }));
+      fireEvent.click(screen.getByRole('button', { name: 'buttons.next' }));
+    });
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'buttons.next' }));
     });
     expect(screen.getByText('User11')).toBeInTheDocument();
 
@@ -543,7 +549,7 @@ describe('<StandardTable />', () => {
       name: `User${i + 1}`,
       age: 100 + i,
     }));
-    const { container } = render(
+    render(
       <StandardTable<Row>
         title="ShowingTest"
         data={many}
@@ -553,42 +559,31 @@ describe('<StandardTable />', () => {
     );
     expect(screen.getByText(/pagination\.showing/)).toBeInTheDocument();
 
-    // The chevron-left button should be disabled on page 1.
-    const prevBtn = container.querySelector('.fa-chevron-left')
-      ?.parentElement as HTMLButtonElement | null;
-    expect(prevBtn?.disabled).toBe(true);
+    expect(screen.getByRole('button', { name: 'buttons.previous' })).toBeDisabled();
   });
 
   // ---------------------------------------------------------------------------
   // Custom views: gear menu, column visibility, save / load / delete / export
   // ---------------------------------------------------------------------------
-  test('gear menu opens, toggles a column, and reset restores all', () => {
+  test('gear menu opens, toggles a column, and reset restores all', async () => {
     render(<StandardTable<Row> title="People" data={sampleRows} columns={sampleColumns} />);
-    const gearBtn = screen.getByLabelText('table.columnSettings');
-    act(() => fireEvent.click(gearBtn));
+    const user = await openColumnSettings();
 
     expect(screen.getAllByText('Name').length).toBeGreaterThan(0);
 
-    // Click the Age row inside the popup. There are multiple "Age" texts on
-    // screen (header + popup); pick the popup entry by its select-none class.
-    const ageEntries = screen.getAllByText('Age');
-    const popupAge = ageEntries.find((el) => el.className.includes('select-none'));
-    expect(popupAge).toBeDefined();
-    act(() => fireEvent.click(popupAge as HTMLElement));
+    await user.click(screen.getByRole('menuitemcheckbox', { name: 'Age' }));
 
     const remainingAge = screen.queryAllByText('Age');
     expect(remainingAge.length).toBe(1);
 
-    act(() => fireEvent.click(screen.getByText('table.resetColumns')));
+    await user.click(screen.getByText('table.resetColumns'));
     expect(screen.getAllByText('Age').length).toBe(2);
   });
 
-  test('saving a custom view persists it to localStorage and marks it active', () => {
+  test('saving a custom view persists it to localStorage and marks it active', async () => {
     render(<StandardTable<Row> title="People" data={sampleRows} columns={sampleColumns} />);
-    act(() => fireEvent.click(screen.getByLabelText('table.columnSettings')));
-    const viewsBtn = screen.getByText('table.customViews').closest('button') as HTMLElement;
-    act(() => fireEvent.click(viewsBtn));
-    act(() => fireEvent.click(screen.getByText('buttons.add')));
+    await openCustomViews();
+    clickMenuItemByText('buttons.add');
 
     const input = screen.getByPlaceholderText('table.viewNamePlaceholder') as HTMLInputElement;
     act(() => fireEvent.change(input, { target: { value: 'My View' } }));
@@ -627,7 +622,7 @@ describe('<StandardTable />', () => {
     expect(rows[2]).toContain('Bob');
   });
 
-  test('deleting a saved view removes it from localStorage', () => {
+  test('deleting a saved view removes it from localStorage', async () => {
     const seeded = [
       { id: 'v1', name: 'View 1', hiddenColIds: [], sortState: null, filterState: {} },
       { id: 'v2', name: 'View 2', hiddenColIds: [], sortState: null, filterState: {} },
@@ -637,13 +632,11 @@ describe('<StandardTable />', () => {
 
     render(<StandardTable<Row> title="DelTest" data={sampleRows} columns={sampleColumns} />);
 
-    act(() => fireEvent.click(screen.getByLabelText('table.columnSettings')));
-    const viewsBtn = screen.getByText('table.customViews').closest('button') as HTMLElement;
-    act(() => fireEvent.click(viewsBtn));
+    await openCustomViews();
 
     const deleteBtns = screen.getAllByLabelText('table.deleteView');
     expect(deleteBtns.length).toBe(2);
-    act(() => fireEvent.click(deleteBtns[1]));
+    clickMenuAction(deleteBtns[1]);
 
     const stored = JSON.parse(localStorage.getItem('praetor_table_customviews_deltest') as string);
     expect(stored.length).toBe(1);
@@ -664,13 +657,11 @@ describe('<StandardTable />', () => {
     localStorage.setItem('praetor_table_customviews_exporttest', JSON.stringify(seeded));
 
     render(<StandardTable<Row> title="ExportTest" data={sampleRows} columns={sampleColumns} />);
-    act(() => fireEvent.click(screen.getByLabelText('table.columnSettings')));
-    const viewsBtn = screen.getByText('table.customViews').closest('button') as HTMLElement;
-    act(() => fireEvent.click(viewsBtn));
+    await openCustomViews();
 
     const exportBtns = screen.getAllByLabelText('table.exportView');
     await act(async () => {
-      fireEvent.click(exportBtns[0]);
+      fireEvent.click(exportBtns[0].closest('[role="menuitem"]') ?? exportBtns[0]);
       await Promise.resolve();
     });
     expect(writeClipboardSpy).toHaveBeenCalled();
@@ -683,13 +674,13 @@ describe('<StandardTable />', () => {
 
   test('importing via paste modal adds a new view to localStorage', async () => {
     render(<StandardTable<Row> title="ImportTest" data={sampleRows} columns={sampleColumns} />);
-    act(() => fireEvent.click(screen.getByLabelText('table.columnSettings')));
-    const viewsBtn = screen.getByText('table.customViews').closest('button') as HTMLElement;
-    act(() => fireEvent.click(viewsBtn));
+    await openCustomViews();
 
     // Clipboard read returns 'unavailable' → the paste modal opens.
     await act(async () => {
-      fireEvent.click(screen.getByText('buttons.import'));
+      fireEvent.click(
+        screen.getByText('buttons.import').closest('[role="menuitem"]') as HTMLElement,
+      );
       await Promise.resolve();
     });
     const textarea = screen.getByPlaceholderText(
@@ -713,12 +704,12 @@ describe('<StandardTable />', () => {
 
   test('paste import surfaces an error for invalid JSON', async () => {
     render(<StandardTable<Row> title="BadImport" data={sampleRows} columns={sampleColumns} />);
-    act(() => fireEvent.click(screen.getByLabelText('table.columnSettings')));
-    const viewsBtn = screen.getByText('table.customViews').closest('button') as HTMLElement;
-    act(() => fireEvent.click(viewsBtn));
+    await openCustomViews();
 
     await act(async () => {
-      fireEvent.click(screen.getByText('buttons.import'));
+      fireEvent.click(
+        screen.getByText('buttons.import').closest('[role="menuitem"]') as HTMLElement,
+      );
       await Promise.resolve();
     });
     const textarea = screen.getByPlaceholderText(

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -348,6 +348,9 @@ describe('<StandardTable />', () => {
 
     await waitFor(() => expect(headerCell.style.width).toBe('160px'));
     expect(headerCell.style.minWidth).toBe('160px');
+    await waitFor(() => expect(headerCell.closest('table')?.className).toContain('table-fixed'));
+    expect(screen.getByText('Alice').closest('td')?.className).toContain('overflow-hidden');
+    expect(screen.getByText('Alice').closest('td')?.className).toContain('text-ellipsis');
 
     act(() => {
       fireEvent.mouseUp(document);

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -773,7 +773,7 @@ describe('<StandardTable />', () => {
     expect(screen.queryByText('table.noResults')).not.toBeInTheDocument();
   });
 
-  test('pagination "showing" counter renders and previous-button disables on page 1', () => {
+  test('pagination omits the range counter and previous-button disables on page 1', () => {
     const many: Row[] = Array.from({ length: 7 }, (_, i) => ({
       id: String(i + 1),
       name: `User${i + 1}`,
@@ -787,13 +787,15 @@ describe('<StandardTable />', () => {
         defaultRowsPerPage={5}
       />,
     );
-    expect(screen.getByText(/pagination\.showing/)).toBeInTheDocument();
+    expect(screen.queryByText(/pagination\.showing/)).not.toBeInTheDocument();
 
     const previousButton = screen.getByRole('button', { name: 'buttons.previous' });
     expect(previousButton).toBeDisabled();
-    expect(previousButton.getAttribute('data-size')).toBe('xs');
+    expect(previousButton.getAttribute('data-size')).toBe('sm');
     expect(previousButton.className).toContain('border-border');
     expect(previousButton.className).toContain('rounded-lg');
+    expect(previousButton.className).toContain('!h-7');
+    expect(previousButton.className).toContain('!text-[10px]');
     expect(previousButton.className).toContain('disabled:opacity-50');
     expect(previousButton.className).not.toContain('disabled:opacity-100');
   });
@@ -823,14 +825,16 @@ describe('<StandardTable />', () => {
     const increaseFontButton = screen.getByRole('button', { name: 'table.increaseFont' });
     const columnsButton = screen.getByRole('button', { name: 'table.columnSettings' });
 
-    expect(exportButton.getAttribute('data-size')).toBe('xs');
-    expect(columnsButton.getAttribute('data-size')).toBe('xs');
-    expect(decreaseFontButton.getAttribute('data-size')).toBe('icon-xs');
-    expect(increaseFontButton.getAttribute('data-size')).toBe('icon-xs');
+    expect(exportButton.getAttribute('data-size')).toBe('sm');
+    expect(columnsButton.getAttribute('data-size')).toBe('sm');
+    expect(decreaseFontButton.getAttribute('data-size')).toBe('sm');
+    expect(increaseFontButton.getAttribute('data-size')).toBe('sm');
 
     for (const button of [exportButton, decreaseFontButton, increaseFontButton, columnsButton]) {
       expect(button.className).toContain('border-border');
       expect(button.className).toContain('rounded-lg');
+      expect(button.className).toContain('!h-7');
+      expect(button.className).toContain('!text-[10px]');
       expect(button.className).not.toContain('focus-visible:border-ring');
     }
 

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -565,6 +565,28 @@ describe('<StandardTable />', () => {
     });
   });
 
+  test('selected filter values match exact options instead of substrings', () => {
+    type PaymentRow = { id: string; status: string };
+    const rows: PaymentRow[] = [
+      { id: '1', status: 'Paid' },
+      { id: '2', status: 'Unpaid' },
+    ];
+
+    render(
+      <StandardTable<PaymentRow>
+        title="Payments"
+        data={rows}
+        columns={[{ header: 'Status', accessorKey: 'status', id: 'status' }]}
+        initialFilterState={{ status: ['Paid'] }}
+      />,
+    );
+
+    const bodyRows = screen.getAllByRole('row').slice(1);
+    expect(bodyRows).toHaveLength(1);
+    expect(bodyRows[0].textContent).toContain('Paid');
+    expect(bodyRows[0].textContent).not.toContain('Unpaid');
+  });
+
   test('multi-column filters intersect (Name + Age)', () => {
     const rows: Row[] = [
       { id: '1', name: 'Alice', age: 30 },
@@ -737,6 +759,35 @@ describe('<StandardTable />', () => {
     expect(actionMenu.className).toContain('w-max');
     expect(actionMenu.className).toContain('min-w-[9rem]');
     expect(screen.getByTestId('action-1').className).toContain('text-popover-foreground');
+  });
+
+  test('row action trigger is hidden when the action cell has no items', async () => {
+    const user = userEvent.setup();
+    const actionCell = mock(({ row }: { row: Row }) =>
+      row.id === '1' ? null : (
+        <button type="button" aria-label={`Edit ${row.name}`} data-testid={`action-${row.id}`}>
+          <i className="fa-solid fa-pencil" aria-hidden="true"></i>
+        </button>
+      ),
+    );
+    const cols = [
+      ...sampleColumns,
+      {
+        id: 'actions',
+        header: 'Actions',
+        sticky: 'right' as const,
+        cell: actionCell,
+      },
+    ];
+
+    render(<StandardTable<Row> title="People" data={sampleRows.slice(0, 2)} columns={cols} />);
+
+    expect(screen.getAllByLabelText('table.rowActions')).toHaveLength(1);
+    fireEvent.contextMenu(screen.getByText('Alice').closest('tr') as HTMLElement);
+    expect(screen.queryByTestId('action-1')).not.toBeInTheDocument();
+
+    await user.click(screen.getByLabelText('table.rowActions'));
+    expect(screen.getByTestId('action-2')).toBeInTheDocument();
   });
 
   test('action column stays borderless even while sticky over scrollable content', () => {

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -379,6 +379,8 @@ describe('<StandardTable />', () => {
     const actionsHeader = within(headerRow).getAllByRole('columnheader')[2];
     expect(actionsHeader.className).toContain('sticky');
     expect(actionsHeader.className).toContain('right-0');
+    expect(actionsHeader.className).toContain('bg-card');
+    expect(actionsHeader.className).not.toContain('bg-background');
     expect(actionsHeader.textContent?.trim()).toBe('');
     expect(screen.queryByText('Actions')).not.toBeInTheDocument();
   });
@@ -412,6 +414,9 @@ describe('<StandardTable />', () => {
     ];
     render(<StandardTable<Row> title="People" data={sampleRows} columns={cols} />);
     expect(screen.queryByTestId('action-1')).not.toBeInTheDocument();
+    const firstActionCell = screen.getAllByLabelText('table.rowActions')[0].closest('td');
+    expect(firstActionCell?.className).toContain('bg-card');
+    expect(firstActionCell?.className).not.toContain('bg-background');
 
     await user.click(screen.getAllByLabelText('table.rowActions')[0]);
     expect(screen.getByTestId('action-1')).toBeInTheDocument();

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -426,6 +426,21 @@ describe('<StandardTable />', () => {
     expect(screen.getByText('Ruolo').className).not.toContain('truncate');
   });
 
+  test('header measurement content stays intrinsic instead of filling stretched cells', () => {
+    render(
+      <StandardTable<Row> title="Intrinsic Headers" data={sampleRows} columns={sampleColumns} />,
+    );
+
+    const headerContent = screen
+      .getByText('Name')
+      .closest('th')
+      ?.querySelector('[data-column-header-content="name"]') as HTMLElement;
+
+    expect(headerContent.className).toContain('inline-flex');
+    expect(headerContent.className).toContain('w-max');
+    expect(Array.from(headerContent.classList)).not.toContain('flex');
+  });
+
   test('stale stored column widths do not force fixed table layout', () => {
     localStorage.setItem('praetor_table_colwidths_stale_widths', JSON.stringify({ missing: 160 }));
 

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -357,6 +357,15 @@ describe('<StandardTable />', () => {
     });
   });
 
+  test('stale stored column widths do not force fixed table layout', () => {
+    localStorage.setItem('praetor_table_colwidths_stale_widths', JSON.stringify({ missing: 160 }));
+
+    render(<StandardTable<Row> title="Stale Widths" data={sampleRows} columns={sampleColumns} />);
+
+    expect(screen.getByRole('table').className).not.toContain('table-fixed');
+    expect(screen.getByText('Alice').closest('td')?.className).not.toContain('overflow-hidden');
+  });
+
   test('sorting descending by age reorders numerically (largest first)', () => {
     render(<StandardTable<Row> title="People" data={sampleRows} columns={sampleColumns} />);
     clickSortHeader('Age');
@@ -493,17 +502,18 @@ describe('<StandardTable />', () => {
 
   test('sticky-right body cell collapses actions behind an ellipsis menu', async () => {
     const user = userEvent.setup();
+    const actionCell = mock(({ row }: { row: Row }) => (
+      <button type="button" aria-label={`Edit ${row.name}`} data-testid={`action-${row.id}`}>
+        X
+      </button>
+    ));
     const cols = [
       ...sampleColumns,
       {
         id: 'actions',
         header: 'Actions',
         sticky: 'right' as const,
-        cell: ({ row }: { row: Row }) => (
-          <button type="button" aria-label={`Edit ${row.name}`} data-testid={`action-${row.id}`}>
-            X
-          </button>
-        ),
+        cell: actionCell,
       },
     ];
     render(<StandardTable<Row> title="People" data={sampleRows} columns={cols} />);
@@ -511,10 +521,53 @@ describe('<StandardTable />', () => {
     const firstActionCell = screen.getAllByLabelText('table.rowActions')[0].closest('td');
     expect(firstActionCell?.className).toContain('bg-card');
     expect(firstActionCell?.className).not.toContain('bg-background');
+    expect(firstActionCell?.className).not.toContain('border-l');
+    expect(firstActionCell?.className).not.toContain('group-hover:bg-muted/50');
 
     await user.click(screen.getAllByLabelText('table.rowActions')[0]);
     expect(screen.getByTestId('action-1')).toBeInTheDocument();
     expect(screen.getByText('Edit Alice')).toBeInTheDocument();
+  });
+
+  test('action column border appears only while the sticky column overlaps content', async () => {
+    const cols = [
+      ...sampleColumns,
+      {
+        id: 'actions',
+        header: 'Actions',
+        sticky: 'right' as const,
+        cell: () => <button type="button">Edit</button>,
+      },
+    ];
+    render(<StandardTable<Row> title="People" data={sampleRows} columns={cols} />);
+
+    const tableContainer = screen.getByRole('table').parentElement as HTMLDivElement;
+    const headerRow = screen.getAllByRole('row')[0];
+    const actionHeader = within(headerRow).getAllByRole('columnheader')[2];
+    const actionCell = screen.getAllByLabelText('table.rowActions')[0].closest('td') as HTMLElement;
+
+    Object.defineProperty(tableContainer, 'scrollWidth', { configurable: true, value: 600 });
+    Object.defineProperty(tableContainer, 'clientWidth', { configurable: true, value: 300 });
+    Object.defineProperty(tableContainer, 'scrollLeft', {
+      configurable: true,
+      value: 0,
+      writable: true,
+    });
+
+    act(() => {
+      fireEvent.scroll(tableContainer);
+    });
+
+    await waitFor(() => expect(actionHeader.className).toContain('border-l'));
+    expect(actionCell.className).toContain('border-l');
+
+    tableContainer.scrollLeft = 300;
+    act(() => {
+      fireEvent.scroll(tableContainer);
+    });
+
+    await waitFor(() => expect(actionHeader.className).not.toContain('border-l'));
+    expect(actionCell.className).not.toContain('border-l');
   });
 
   // ---------------------------------------------------------------------------

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -646,7 +646,7 @@ describe('<StandardTable />', () => {
     expect(screen.getByText('Edit Alice')).toBeInTheDocument();
   });
 
-  test('action column border appears only while the sticky column overlaps content', async () => {
+  test('action column stays borderless even while sticky over scrollable content', () => {
     const cols = [
       ...sampleColumns,
       {
@@ -675,15 +675,15 @@ describe('<StandardTable />', () => {
       fireEvent.scroll(tableContainer);
     });
 
-    await waitFor(() => expect(actionHeader.className).toContain('border-l'));
-    expect(actionCell.className).toContain('border-l');
+    expect(actionHeader.className).not.toContain('border-l');
+    expect(actionCell.className).not.toContain('border-l');
 
     tableContainer.scrollLeft = 300;
     act(() => {
       fireEvent.scroll(tableContainer);
     });
 
-    await waitFor(() => expect(actionHeader.className).not.toContain('border-l'));
+    expect(actionHeader.className).not.toContain('border-l');
     expect(actionCell.className).not.toContain('border-l');
   });
 

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -282,6 +282,35 @@ describe('<StandardTable />', () => {
     expect(ageResizeLine?.className).not.toContain('bg-border');
   });
 
+  test('sparse action-only custom views do not insert an action spacer', () => {
+    const columns = [
+      { header: 'Name', accessorKey: 'name' as const, id: 'name' },
+      {
+        id: 'actions',
+        header: 'Actions',
+        sticky: 'right' as const,
+        cell: () => <button type="button">x</button>,
+      },
+    ];
+    render(<StandardTable<Row> title="People" data={sampleRows} columns={columns} />);
+
+    const headerRow = screen.getAllByRole('row')[0];
+    const headers = within(headerRow).getAllByRole('columnheader');
+    const aliceRow = screen.getAllByRole('row')[1];
+    const cells = aliceRow.querySelectorAll('td');
+
+    expect(headers).toHaveLength(2);
+    expect(cells).toHaveLength(2);
+    expect(headers[1].className).not.toContain('sticky');
+    expect(cells[1].className).not.toContain('sticky');
+    expect(screen.getByRole('table').style.width).not.toBe('100%');
+    expect(screen.getByRole('table').querySelector('[data-action-spacer]')).toBeNull();
+    expect(
+      screen.getByText('Name').closest('th')?.querySelector('[data-column-resize-line="name"]')
+        ?.className,
+    ).toContain('bg-border');
+  });
+
   // ---------------------------------------------------------------------------
   // Sorting (via TanStack header sort handlers)
   // ---------------------------------------------------------------------------

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -251,7 +251,6 @@ describe('<StandardTable />', () => {
       {
         id: 'actions',
         header: 'Actions',
-        sticky: 'right' as const,
         cell: () => <button type="button">x</button>,
       },
     ];
@@ -288,13 +287,12 @@ describe('<StandardTable />', () => {
     expect(ageResizeHandle?.className).not.toContain('z-30');
   });
 
-  test('sparse action-only custom views do not insert an action spacer', () => {
+  test('sparse action-only custom views keep actions sticky without inserting a spacer', () => {
     const columns = [
       { header: 'Name', accessorKey: 'name' as const, id: 'name' },
       {
         id: 'actions',
         header: 'Actions',
-        sticky: 'right' as const,
         cell: () => <button type="button">x</button>,
       },
     ];
@@ -307,8 +305,10 @@ describe('<StandardTable />', () => {
 
     expect(headers).toHaveLength(2);
     expect(cells).toHaveLength(2);
-    expect(headers[1].className).not.toContain('sticky');
-    expect(cells[1].className).not.toContain('sticky');
+    expect(headers[1].className).toContain('sticky');
+    expect(headers[1].className).toContain('right-0');
+    expect(cells[1].className).toContain('sticky');
+    expect(cells[1].className).toContain('right-0');
     expect(screen.getByRole('table').style.width).not.toBe('100%');
     expect(screen.getByRole('table').querySelector('[data-action-spacer]')).toBeNull();
     expect(
@@ -730,6 +730,13 @@ describe('<StandardTable />', () => {
     await user.click(screen.getAllByLabelText('table.rowActions')[0]);
     expect(screen.getByTestId('action-1')).toBeInTheDocument();
     expect(screen.getByText('Edit Alice')).toBeInTheDocument();
+    const actionMenu = screen
+      .getByTestId('action-1')
+      .closest('[data-standard-table-action-menu="true"]') as HTMLElement;
+    expect(actionMenu).toHaveAttribute('data-slot', 'dropdown-menu-content');
+    expect(actionMenu.className).toContain('w-max');
+    expect(actionMenu.className).toContain('min-w-[9rem]');
+    expect(screen.getByTestId('action-1').className).toContain('text-popover-foreground');
   });
 
   test('action column stays borderless even while sticky over scrollable content', () => {
@@ -846,10 +853,67 @@ describe('<StandardTable />', () => {
     });
 
     const action = await screen.findByTestId('context-action-2');
-    expect(action.closest('[data-slot="context-menu-content"]')).toBeInTheDocument();
+    const actionMenu = action.closest('[data-standard-table-action-menu="true"]') as HTMLElement;
+    expect(actionMenu).toHaveAttribute('data-slot', 'context-menu-content');
+    expect(actionMenu.className).toContain('w-max');
+    expect(actionMenu.className).toContain('min-w-[9rem]');
+    expect(action.className).toContain('text-popover-foreground');
 
     await userEvent.click(action);
     expect(onAction).toHaveBeenCalledWith('2');
+  });
+
+  test('saved views cannot hide the actions column or disable row context actions', async () => {
+    const onAction = mock((id: string) => id);
+    localStorage.setItem(
+      'praetor_table_customviews_action_persist',
+      JSON.stringify([
+        {
+          id: 'hide-actions',
+          name: 'Hide actions',
+          hiddenColIds: ['actions'],
+          sortState: null,
+          filterState: {},
+        },
+      ]),
+    );
+    localStorage.setItem('praetor_table_activeview_action_persist', 'hide-actions');
+    const cols = [
+      { header: 'Name', accessorKey: 'name' as const, id: 'name' },
+      {
+        id: 'actions',
+        header: 'Actions',
+        cell: ({ row }: { row: Row }) => (
+          <button
+            type="button"
+            data-testid={`persisted-action-${row.id}`}
+            onClick={(e) => {
+              e.stopPropagation();
+              onAction(row.id);
+            }}
+          >
+            Edit {row.name}
+          </button>
+        ),
+      },
+    ];
+    render(<StandardTable<Row> title="Action Persist" data={sampleRows} columns={cols} />);
+
+    expect(screen.getByText('Actions')).toBeInTheDocument();
+    expect(screen.getAllByLabelText('table.rowActions')).toHaveLength(sampleRows.length);
+
+    await openColumnSettings();
+    expect(screen.queryByRole('menuitemcheckbox', { name: 'Actions' })).toBeNull();
+    act(() => {
+      fireEvent.keyDown(document, { key: 'Escape' });
+    });
+    act(() => {
+      fireEvent.contextMenu(screen.getAllByRole('row')[1], { clientX: 12, clientY: 24 });
+    });
+
+    const action = await screen.findByTestId('persisted-action-1');
+    await userEvent.click(action);
+    expect(onAction).toHaveBeenCalledWith('1');
   });
 
   // ---------------------------------------------------------------------------

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -825,7 +825,7 @@ describe('<StandardTable />', () => {
     expect(previousButton.className).toContain('!h-7');
     expect(previousButton.className).toContain('!text-sm');
     expect(previousButton.className).toContain('!leading-[var(--text-sm--line-height)]');
-    expect(previousButton.className).toContain('!font-normal');
+    expect(previousButton.className).toContain('!font-medium');
     expect(previousButton.className).toContain('disabled:opacity-50');
     expect(previousButton.className).not.toContain('disabled:opacity-100');
   });
@@ -866,7 +866,7 @@ describe('<StandardTable />', () => {
       expect(button.className).toContain('!h-7');
       expect(button.className).toContain('!text-sm');
       expect(button.className).toContain('!leading-[var(--text-sm--line-height)]');
-      expect(button.className).toContain('!font-normal');
+      expect(button.className).toContain('!font-medium');
       expect(button.className).not.toContain('focus-visible:border-ring');
     }
 

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -370,6 +370,18 @@ describe('<StandardTable />', () => {
     expect(screen.queryByText('Actions')).not.toBeInTheDocument();
   });
 
+  test('sticky-right data columns stay inline instead of becoming row actions', () => {
+    const cols = [
+      { header: 'Name', accessorKey: 'name' as const, id: 'name' },
+      { header: 'Age', accessorKey: 'age' as const, id: 'age', sticky: 'right' as const },
+    ];
+    render(<StandardTable<Row> title="People" data={sampleRows} columns={cols} />);
+
+    expect(screen.getByText('Age')).toBeInTheDocument();
+    expect(screen.getByText('30')).toBeInTheDocument();
+    expect(screen.queryByLabelText('table.rowActions')).not.toBeInTheDocument();
+  });
+
   test('sticky-right body cell collapses actions behind an ellipsis menu', async () => {
     const user = userEvent.setup();
     const cols = [

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -16,6 +16,7 @@ const readClipboardSpy = spyOn(clipboardModule, 'readTextFromClipboard').mockRes
 });
 
 const StandardTable = (await import('../../components/shared/StandardTable')).default;
+const StatusBadge = (await import('../../components/shared/StatusBadge')).default;
 
 type Row = { id: string; name: string; age: number };
 
@@ -299,6 +300,7 @@ describe('<StandardTable />', () => {
     const sortIcon = sortButton.querySelector('i.fa-arrow-up-arrow-down');
 
     expect(sortButton.className).toContain('rounded-md');
+    expect(sortButton.className).toContain('font-semibold');
     expect(sortButton.className).toContain('hover:bg-accent');
     expect(sortButton.className).toContain('hover:text-accent-foreground');
     expect(sortIcon?.className).toContain('transition-colors');
@@ -311,12 +313,16 @@ describe('<StandardTable />', () => {
     const headerLabel = headerCell.querySelector(
       '[data-column-header-label="name"]',
     ) as HTMLElement;
+    const ageHeaderLabel = screen
+      .getByText('Age')
+      .closest('[data-column-header-label="age"]') as HTMLElement;
     const resizeHandle = headerCell.querySelector(
       '[data-column-resize-handle="name"]',
     ) as HTMLElement;
     const resizeLine = headerCell.querySelector('[data-column-resize-line="name"]') as HTMLElement;
 
     Object.defineProperty(headerLabel, 'scrollWidth', { configurable: true, value: 96 });
+    Object.defineProperty(ageHeaderLabel, 'scrollWidth', { configurable: true, value: 24 });
     Object.defineProperty(headerCell, 'getBoundingClientRect', {
       configurable: true,
       value: () => ({
@@ -356,6 +362,28 @@ describe('<StandardTable />', () => {
     act(() => {
       fireEvent.mouseUp(document);
     });
+  });
+
+  test('fixed table fallback widths use measured full header text', async () => {
+    localStorage.setItem('praetor_table_colwidths_measured_headers', JSON.stringify({ name: 160 }));
+    const columns = [
+      { header: 'Name', accessorKey: 'name' as const, id: 'name' },
+      { header: 'Very Long Header', accessorKey: 'age' as const, id: 'age' },
+    ];
+
+    render(<StandardTable<Row> title="Measured Headers" data={sampleRows} columns={columns} />);
+
+    const longHeaderCell = screen.getByText('Very Long Header').closest('th') as HTMLElement;
+    const longHeaderLabel = longHeaderCell.querySelector(
+      '[data-column-header-label="age"]',
+    ) as HTMLElement;
+    Object.defineProperty(longHeaderLabel, 'scrollWidth', { configurable: true, value: 136 });
+
+    act(() => {
+      fireEvent.resize(window);
+    });
+
+    await waitFor(() => expect(longHeaderCell.style.minWidth).toBe('200px'));
   });
 
   test('stale stored column widths do not force fixed table layout', () => {
@@ -468,7 +496,7 @@ describe('<StandardTable />', () => {
   // ---------------------------------------------------------------------------
   // Sticky-right action column: classes on header and body cells
   // ---------------------------------------------------------------------------
-  test('sticky-right action header is sticky but visually empty', () => {
+  test('sticky-right action header is sticky and keeps its label without sort controls', () => {
     const cols = [
       ...sampleColumns,
       {
@@ -484,10 +512,37 @@ describe('<StandardTable />', () => {
     expect(actionsHeader.className).toContain('sticky');
     expect(actionsHeader.className).toContain('right-0');
     expect(actionsHeader.className).toContain('bg-card');
-    expect(actionsHeader.style.minWidth).toBe('48px');
+    expect(actionsHeader.style.minWidth).toBe('80px');
     expect(actionsHeader.className).not.toContain('bg-background');
-    expect(actionsHeader.textContent?.trim()).toBe('');
-    expect(screen.queryByText('Actions')).not.toBeInTheDocument();
+    expect(actionsHeader.textContent?.trim()).toBe('Actions');
+    expect(within(actionsHeader).queryByRole('button')).not.toBeInTheDocument();
+    expect(actionsHeader.querySelector('i.fa-arrow-up-arrow-down')).toBeNull();
+  });
+
+  test('value cells reset custom value styling while preserving status badges', () => {
+    const cols = [
+      {
+        header: 'Name',
+        accessorKey: 'name' as const,
+        id: 'name',
+        cell: ({ row }: { row: Row }) => (
+          <span className="rounded-lg bg-red-500 px-2 font-bold text-red-900">{row.name}</span>
+        ),
+      },
+      {
+        header: 'Status',
+        accessorKey: 'age' as const,
+        id: 'status',
+        cell: () => <StatusBadge type="active" label="Active" />,
+      },
+    ];
+
+    render(<StandardTable<Row> title="People" data={sampleRows.slice(0, 1)} columns={cols} />);
+
+    expect(screen.getByText('Alice').closest('td')?.className).toContain(
+      'standard-table-value-cell',
+    );
+    expect(screen.getByText('Active')).toHaveAttribute('data-status-badge');
   });
 
   test('sticky-right data columns stay inline instead of becoming row actions', () => {
@@ -522,7 +577,7 @@ describe('<StandardTable />', () => {
     expect(screen.queryByTestId('action-1')).not.toBeInTheDocument();
     const firstActionCell = screen.getAllByLabelText('table.rowActions')[0].closest('td');
     expect(firstActionCell?.className).toContain('bg-card');
-    expect(firstActionCell?.style.minWidth).toBe('48px');
+    expect(firstActionCell?.style.minWidth).toBe('80px');
     expect(firstActionCell?.className).not.toContain('bg-background');
     expect(firstActionCell?.className).not.toContain('border-l');
     expect(firstActionCell?.className).not.toContain('group-hover:bg-muted/50');
@@ -668,6 +723,8 @@ describe('<StandardTable />', () => {
     );
     const trigger = screen.getByRole('combobox');
     expect(trigger.textContent).toContain('5');
+    expect(trigger.className).toContain('h-7');
+    expect(trigger.className).toContain('text-foreground');
     await user.click(trigger);
     await user.click(screen.getByRole('option', { name: '20' }));
 
@@ -732,7 +789,7 @@ describe('<StandardTable />', () => {
 
     const previousButton = screen.getByRole('button', { name: 'buttons.previous' });
     expect(previousButton).toBeDisabled();
-    expect(previousButton.getAttribute('data-size')).toBe('sm');
+    expect(previousButton.getAttribute('data-size')).toBe('xs');
     expect(previousButton.className).toContain('border-border');
     expect(previousButton.className).toContain('disabled:opacity-50');
     expect(previousButton.className).not.toContain('disabled:opacity-100');
@@ -761,10 +818,10 @@ describe('<StandardTable />', () => {
     const increaseFontButton = screen.getByRole('button', { name: 'table.increaseFont' });
     const columnsButton = screen.getByRole('button', { name: 'table.columnSettings' });
 
-    expect(exportButton.getAttribute('data-size')).toBe('sm');
-    expect(columnsButton.getAttribute('data-size')).toBe('sm');
-    expect(decreaseFontButton.getAttribute('data-size')).toBe('icon-sm');
-    expect(increaseFontButton.getAttribute('data-size')).toBe('icon-sm');
+    expect(exportButton.getAttribute('data-size')).toBe('xs');
+    expect(columnsButton.getAttribute('data-size')).toBe('xs');
+    expect(decreaseFontButton.getAttribute('data-size')).toBe('icon-xs');
+    expect(increaseFontButton.getAttribute('data-size')).toBe('icon-xs');
 
     for (const button of [exportButton, decreaseFontButton, increaseFontButton, columnsButton]) {
       expect(button.className).toContain('border-border');

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -562,7 +562,10 @@ describe('<StandardTable />', () => {
     );
     expect(screen.getByText(/pagination\.showing/)).toBeInTheDocument();
 
-    expect(screen.getByRole('button', { name: 'buttons.previous' })).toBeDisabled();
+    const previousButton = screen.getByRole('button', { name: 'buttons.previous' });
+    expect(previousButton).toBeDisabled();
+    expect(previousButton.className).toContain('text-foreground');
+    expect(previousButton.className).toContain('disabled:opacity-100');
   });
 
   // ---------------------------------------------------------------------------

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -260,16 +260,20 @@ describe('<StandardTable />', () => {
     // rows[0] is the header; rows[1] is Alice's data row.
     const aliceRow = screen.getAllByRole('row')[1];
     const cells = aliceRow.querySelectorAll('td');
-    expect(cells.length).toBe(3);
+    expect(cells.length).toBe(4);
 
     // Fixed-layout cells keep their alignment without relying on a stretch column.
     expect(cells[1].className).toContain('align-middle');
     expect(cells[1].className).toContain('text-right');
     expect(cells[1].className).toContain('overflow-hidden');
 
-    // Sticky-right action column: stays w-auto, never w-full.
-    expect(cells[2].className).toContain('w-auto');
-    expect(cells[2].className).not.toMatch(/\bw-full\b/);
+    // Spacer absorbs spare container width so the sticky action column remains on the right.
+    expect(cells[2]).toHaveAttribute('aria-hidden', 'true');
+    expect(cells[2].style.width).toBe('auto');
+    expect(cells[3].className).toContain('w-auto');
+    expect(cells[3].className).not.toMatch(/\bw-full\b/);
+    expect(screen.getByRole('table').style.width).toBe('100%');
+    expect(screen.getByRole('table').style.minWidth).not.toBe('');
   });
 
   // ---------------------------------------------------------------------------

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -262,10 +262,10 @@ describe('<StandardTable />', () => {
     const cells = aliceRow.querySelectorAll('td');
     expect(cells.length).toBe(3);
 
-    // Stretch column (Age): absorbs leftover width AND keeps its right alignment.
-    expect(cells[1].className).toContain('w-full');
+    // Fixed-layout cells keep their alignment without relying on a stretch column.
+    expect(cells[1].className).toContain('align-middle');
     expect(cells[1].className).toContain('text-right');
-    expect(cells[1].className).not.toMatch(/\bw-px\b/);
+    expect(cells[1].className).toContain('overflow-hidden');
 
     // Sticky-right action column: stays w-auto, never w-full.
     expect(cells[2].className).toContain('w-auto');
@@ -327,90 +327,119 @@ describe('<StandardTable />', () => {
     expect(screen.getByText('Actions').closest('th')?.querySelector('svg')).toBeNull();
   });
 
-  test('column resize clamps to the measured header label width', async () => {
+  test('simple resize handle click does not change or persist the column width', async () => {
     render(<StandardTable<Row> title="People" data={sampleRows} columns={sampleColumns} />);
 
     const headerCell = screen.getByText('Name').closest('th') as HTMLTableCellElement;
-    const headerContent = headerCell.querySelector(
-      '[data-column-header-content="name"]',
-    ) as HTMLElement;
-    const ageHeaderContent = screen
-      .getByText('Age')
-      .closest('th')
-      ?.querySelector('[data-column-header-content="age"]') as HTMLElement;
     const resizeHandle = headerCell.querySelector(
       '[data-column-resize-handle="name"]',
     ) as HTMLElement;
     const resizeLine = headerCell.querySelector('[data-column-resize-line="name"]') as HTMLElement;
-
-    Object.defineProperty(headerContent, 'scrollWidth', { configurable: true, value: 128 });
-    Object.defineProperty(ageHeaderContent, 'scrollWidth', { configurable: true, value: 87 });
-    Object.defineProperty(headerCell, 'getBoundingClientRect', {
-      configurable: true,
-      value: () => ({
-        bottom: 0,
-        height: 40,
-        left: 0,
-        right: 220,
-        top: 0,
-        width: 220,
-        x: 0,
-        y: 0,
-        toJSON: () => ({}),
-      }),
-    });
+    const initialWidth = headerCell.style.width;
 
     expect(resizeHandle.className).toContain('w-2');
     expect(resizeLine.className).toContain('w-px');
     expect(resizeLine.className).toContain('bg-border');
 
     act(() => {
+      fireEvent.mouseDown(resizeHandle, { clientX: 128 });
+      fireEvent.mouseUp(document);
+    });
+
+    await waitFor(() => expect(headerCell.style.width).toBe(initialWidth));
+    const saved = JSON.parse(localStorage.getItem('praetor_table_colwidths_people') ?? '{}');
+    expect(saved.name).toBeUndefined();
+  });
+
+  test('dragging a resize handle increases only the target column', async () => {
+    render(<StandardTable<Row> title="Drag Widths" data={sampleRows} columns={sampleColumns} />);
+
+    const nameHeader = screen.getByText('Name').closest('th') as HTMLTableCellElement;
+    const ageHeader = screen.getByText('Age').closest('th') as HTMLTableCellElement;
+    const resizeHandle = nameHeader.querySelector(
+      '[data-column-resize-handle="name"]',
+    ) as HTMLElement;
+    const initialNameWidth = Number.parseInt(nameHeader.style.width, 10);
+    const initialAgeWidth = Number.parseInt(ageHeader.style.width, 10);
+
+    act(() => {
+      fireEvent.mouseDown(resizeHandle, { clientX: initialNameWidth });
+    });
+
+    await waitFor(() =>
+      expect(nameHeader.querySelector('[data-column-resize-line="name"]')?.className).toContain(
+        'bg-primary',
+      ),
+    );
+
+    act(() => {
+      fireEvent.mouseMove(document, { clientX: initialNameWidth + 60 });
+      fireEvent.mouseUp(document);
+    });
+
+    await waitFor(() =>
+      expect(Number.parseInt(nameHeader.style.width, 10)).toBeGreaterThan(initialNameWidth),
+    );
+    expect(Number.parseInt(nameHeader.style.width, 10)).toBe(initialNameWidth + 60);
+    expect(Number.parseInt(ageHeader.style.width, 10)).toBe(initialAgeWidth);
+    const table = nameHeader.closest('table') as HTMLTableElement;
+    expect(table.className).toContain('table-fixed');
+    expect(table.style.minWidth).toBe('100%');
+    expect(screen.getByText('Alice').closest('td')?.className).toContain('overflow-hidden');
+    expect(screen.getByText('Alice').closest('td')?.className).toContain('text-ellipsis');
+  });
+
+  test('dragging far left clamps to the deterministic header-control minimum', async () => {
+    localStorage.setItem('praetor_table_colwidths_clamped_drag', JSON.stringify({ name: 220 }));
+    render(<StandardTable<Row> title="Clamped Drag" data={sampleRows} columns={sampleColumns} />);
+
+    const nameHeader = screen.getByText('Name').closest('th') as HTMLTableCellElement;
+    const resizeHandle = nameHeader.querySelector(
+      '[data-column-resize-handle="name"]',
+    ) as HTMLElement;
+
+    await waitFor(() => expect(Number.parseInt(nameHeader.style.width, 10)).toBe(220));
+
+    act(() => {
       fireEvent.mouseDown(resizeHandle, { clientX: 220 });
     });
 
-    await waitFor(() => expect(document.body.style.cursor).toBe('col-resize'));
-    expect(headerCell.style.width).toBe('');
-    expect(headerCell.closest('table')?.className).not.toContain('table-fixed');
+    await waitFor(() =>
+      expect(nameHeader.querySelector('[data-column-resize-line="name"]')?.className).toContain(
+        'bg-primary',
+      ),
+    );
 
     act(() => {
-      fireEvent.mouseMove(document, { clientX: 0 });
+      fireEvent.mouseMove(document, { clientX: -500 });
+      fireEvent.mouseUp(document);
     });
 
-    await waitFor(() => expect(headerCell.style.width).toBe('160px'));
-    expect(headerCell.style.minWidth).toBe('160px');
-    const table = headerCell.closest('table') as HTMLTableElement;
-    await waitFor(() => expect(table.className).toContain('table-fixed'));
-    expect(table.style.width).toBe('279px');
-    expect(table.style.minWidth).toBe('100%');
-    expect(screen.getByText('Age').closest('th')?.style.minWidth).toBe('119px');
-    expect(screen.getByText('Alice').closest('td')?.className).toContain('overflow-hidden');
-    expect(screen.getByText('Alice').closest('td')?.className).toContain('text-ellipsis');
-
-    act(() => {
-      fireEvent.mouseUp(document);
+    await waitFor(() => expect(Number.parseInt(nameHeader.style.width, 10)).toBe(128));
+    await waitFor(() => {
+      const saved = JSON.parse(
+        localStorage.getItem('praetor_table_colwidths_clamped_drag') ?? '{}',
+      );
+      expect(saved.name).toBe(128);
     });
   });
 
-  test('fixed table fallback widths use measured full header text', async () => {
-    localStorage.setItem('praetor_table_colwidths_measured_headers', JSON.stringify({ name: 160 }));
+  test('fixed table fallback widths use deterministic full header text', () => {
+    localStorage.setItem(
+      'praetor_table_colwidths_deterministic_headers',
+      JSON.stringify({ name: 160 }),
+    );
     const columns = [
       { header: 'Name', accessorKey: 'name' as const, id: 'name' },
       { header: 'Very Long Header', accessorKey: 'age' as const, id: 'age' },
     ];
 
-    render(<StandardTable<Row> title="Measured Headers" data={sampleRows} columns={columns} />);
+    render(
+      <StandardTable<Row> title="Deterministic Headers" data={sampleRows} columns={columns} />,
+    );
 
     const longHeaderCell = screen.getByText('Very Long Header').closest('th') as HTMLElement;
-    const longHeaderContent = longHeaderCell.querySelector(
-      '[data-column-header-content="age"]',
-    ) as HTMLElement;
-    Object.defineProperty(longHeaderContent, 'scrollWidth', { configurable: true, value: 204 });
-
-    act(() => {
-      fireEvent.resize(window);
-    });
-
-    await waitFor(() => expect(longHeaderCell.style.minWidth).toBe('236px'));
+    expect(Number.parseInt(longHeaderCell.style.minWidth, 10)).toBeGreaterThan(200);
   });
 
   test('stored column widths are clamped to the full header label width', async () => {
@@ -426,28 +455,37 @@ describe('<StandardTable />', () => {
     expect(screen.getByText('Ruolo').className).not.toContain('truncate');
   });
 
-  test('header measurement content stays intrinsic instead of filling stretched cells', () => {
-    render(
-      <StandardTable<Row> title="Intrinsic Headers" data={sampleRows} columns={sampleColumns} />,
+  test('stored widths below minimum are clamped once and do not widen on remount', async () => {
+    localStorage.setItem('praetor_table_colwidths_remount_width', JSON.stringify({ role: 32 }));
+    const columns = [{ header: 'Ruolo', accessorKey: 'name' as const, id: 'role' }];
+    const { unmount } = render(
+      <StandardTable<Row> title="Remount Width" data={sampleRows} columns={columns} />,
     );
 
-    const headerContent = screen
-      .getByText('Name')
-      .closest('th')
-      ?.querySelector('[data-column-header-content="name"]') as HTMLElement;
+    const firstHeader = screen.getByText('Ruolo').closest('th') as HTMLElement;
+    await waitFor(() => expect(Number.parseInt(firstHeader.style.width, 10)).toBe(137));
+    const savedAfterFirstRender = localStorage.getItem('praetor_table_colwidths_remount_width');
 
-    expect(headerContent.className).toContain('inline-flex');
-    expect(headerContent.className).toContain('w-max');
-    expect(Array.from(headerContent.classList)).not.toContain('flex');
+    unmount();
+    render(<StandardTable<Row> title="Remount Width" data={sampleRows} columns={columns} />);
+
+    const secondHeader = screen.getByText('Ruolo').closest('th') as HTMLElement;
+    await waitFor(() => expect(Number.parseInt(secondHeader.style.width, 10)).toBe(137));
+    expect(localStorage.getItem('praetor_table_colwidths_remount_width')).toBe(
+      savedAfterFirstRender,
+    );
   });
 
-  test('stale stored column widths do not force fixed table layout', () => {
+  test('stale stored column widths are ignored while fixed layout remains deterministic', async () => {
     localStorage.setItem('praetor_table_colwidths_stale_widths', JSON.stringify({ missing: 160 }));
 
     render(<StandardTable<Row> title="Stale Widths" data={sampleRows} columns={sampleColumns} />);
 
-    expect(screen.getByRole('table').className).not.toContain('table-fixed');
-    expect(screen.getByText('Alice').closest('td')?.className).not.toContain('overflow-hidden');
+    expect(screen.getByRole('table').className).toContain('table-fixed');
+    expect(screen.getByText('Alice').closest('td')?.className).toContain('overflow-hidden');
+    await waitFor(() =>
+      expect(localStorage.getItem('praetor_table_colwidths_stale_widths')).toBe('{}'),
+    );
   });
 
   test('sorting descending by age reorders numerically (largest first)', () => {
@@ -567,10 +605,11 @@ describe('<StandardTable />', () => {
     expect(actionsHeader.className).toContain('sticky');
     expect(actionsHeader.className).toContain('right-0');
     expect(actionsHeader.className).toContain('bg-card');
-    expect(Number.parseInt(actionsHeader.style.minWidth, 10)).toBeGreaterThanOrEqual(80);
+    expect(Number.parseInt(actionsHeader.style.minWidth, 10)).toBeGreaterThanOrEqual(96);
     expect(actionsHeader.className).not.toContain('bg-background');
     expect(actionsHeader.textContent?.trim()).toBe('Actions');
     expect(within(actionsHeader).queryByRole('button')).not.toBeInTheDocument();
+    expect(actionsHeader.querySelector('[data-column-resize-handle="actions"]')).toBeNull();
     expect(actionsHeader.querySelector('svg')).toBeNull();
   });
 
@@ -636,7 +675,7 @@ describe('<StandardTable />', () => {
     expect(screen.queryByTestId('action-1')).not.toBeInTheDocument();
     const firstActionCell = screen.getAllByLabelText('table.rowActions')[0].closest('td');
     expect(firstActionCell?.className).toContain('bg-card');
-    expect(Number.parseInt(firstActionCell?.style.minWidth ?? '0', 10)).toBeGreaterThanOrEqual(80);
+    expect(Number.parseInt(firstActionCell?.style.minWidth ?? '0', 10)).toBeGreaterThanOrEqual(96);
     expect(firstActionCell?.className).not.toContain('bg-background');
     expect(firstActionCell?.className).not.toContain('border-l');
     expect(firstActionCell?.className).not.toContain('group-hover:bg-muted/50');

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -331,19 +331,20 @@ describe('<StandardTable />', () => {
     render(<StandardTable<Row> title="People" data={sampleRows} columns={sampleColumns} />);
 
     const headerCell = screen.getByText('Name').closest('th') as HTMLTableCellElement;
-    const headerLabel = headerCell.querySelector(
-      '[data-column-header-label="name"]',
+    const headerContent = headerCell.querySelector(
+      '[data-column-header-content="name"]',
     ) as HTMLElement;
-    const ageHeaderLabel = screen
+    const ageHeaderContent = screen
       .getByText('Age')
-      .closest('[data-column-header-label="age"]') as HTMLElement;
+      .closest('th')
+      ?.querySelector('[data-column-header-content="age"]') as HTMLElement;
     const resizeHandle = headerCell.querySelector(
       '[data-column-resize-handle="name"]',
     ) as HTMLElement;
     const resizeLine = headerCell.querySelector('[data-column-resize-line="name"]') as HTMLElement;
 
-    Object.defineProperty(headerLabel, 'scrollWidth', { configurable: true, value: 96 });
-    Object.defineProperty(ageHeaderLabel, 'scrollWidth', { configurable: true, value: 24 });
+    Object.defineProperty(headerContent, 'scrollWidth', { configurable: true, value: 128 });
+    Object.defineProperty(ageHeaderContent, 'scrollWidth', { configurable: true, value: 87 });
     Object.defineProperty(headerCell, 'getBoundingClientRect', {
       configurable: true,
       value: () => ({
@@ -379,9 +380,9 @@ describe('<StandardTable />', () => {
     expect(headerCell.style.minWidth).toBe('160px');
     const table = headerCell.closest('table') as HTMLTableElement;
     await waitFor(() => expect(table.className).toContain('table-fixed'));
-    expect(table.style.width).toBe('248px');
+    expect(table.style.width).toBe('279px');
     expect(table.style.minWidth).toBe('100%');
-    expect(screen.getByText('Age').closest('th')?.style.minWidth).toBe('88px');
+    expect(screen.getByText('Age').closest('th')?.style.minWidth).toBe('119px');
     expect(screen.getByText('Alice').closest('td')?.className).toContain('overflow-hidden');
     expect(screen.getByText('Alice').closest('td')?.className).toContain('text-ellipsis');
 
@@ -400,16 +401,16 @@ describe('<StandardTable />', () => {
     render(<StandardTable<Row> title="Measured Headers" data={sampleRows} columns={columns} />);
 
     const longHeaderCell = screen.getByText('Very Long Header').closest('th') as HTMLElement;
-    const longHeaderLabel = longHeaderCell.querySelector(
-      '[data-column-header-label="age"]',
+    const longHeaderContent = longHeaderCell.querySelector(
+      '[data-column-header-content="age"]',
     ) as HTMLElement;
-    Object.defineProperty(longHeaderLabel, 'scrollWidth', { configurable: true, value: 136 });
+    Object.defineProperty(longHeaderContent, 'scrollWidth', { configurable: true, value: 204 });
 
     act(() => {
       fireEvent.resize(window);
     });
 
-    await waitFor(() => expect(longHeaderCell.style.minWidth).toBe('200px'));
+    await waitFor(() => expect(longHeaderCell.style.minWidth).toBe('236px'));
   });
 
   test('stored column widths are clamped to the full header label width', async () => {
@@ -419,7 +420,10 @@ describe('<StandardTable />', () => {
     render(<StandardTable<Row> title="Role Width" data={sampleRows} columns={columns} />);
 
     const headerCell = screen.getByText('Ruolo').closest('th') as HTMLElement;
-    await waitFor(() => expect(Number.parseInt(headerCell.style.minWidth, 10)).toBeGreaterThan(80));
+    await waitFor(() =>
+      expect(Number.parseInt(headerCell.style.minWidth, 10)).toBeGreaterThan(120),
+    );
+    expect(screen.getByText('Ruolo').className).not.toContain('truncate');
   });
 
   test('stale stored column widths do not force fixed table layout', () => {
@@ -548,7 +552,7 @@ describe('<StandardTable />', () => {
     expect(actionsHeader.className).toContain('sticky');
     expect(actionsHeader.className).toContain('right-0');
     expect(actionsHeader.className).toContain('bg-card');
-    expect(actionsHeader.style.minWidth).toBe('80px');
+    expect(Number.parseInt(actionsHeader.style.minWidth, 10)).toBeGreaterThanOrEqual(80);
     expect(actionsHeader.className).not.toContain('bg-background');
     expect(actionsHeader.textContent?.trim()).toBe('Actions');
     expect(within(actionsHeader).queryByRole('button')).not.toBeInTheDocument();
@@ -617,7 +621,7 @@ describe('<StandardTable />', () => {
     expect(screen.queryByTestId('action-1')).not.toBeInTheDocument();
     const firstActionCell = screen.getAllByLabelText('table.rowActions')[0].closest('td');
     expect(firstActionCell?.className).toContain('bg-card');
-    expect(firstActionCell?.style.minWidth).toBe('80px');
+    expect(Number.parseInt(firstActionCell?.style.minWidth ?? '0', 10)).toBeGreaterThanOrEqual(80);
     expect(firstActionCell?.className).not.toContain('bg-background');
     expect(firstActionCell?.className).not.toContain('border-l');
     expect(firstActionCell?.className).not.toContain('group-hover:bg-muted/50');

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -32,25 +32,22 @@ const sampleColumns = [
 
 const clickSortHeader = (headerText: string) => {
   const headerCell = screen.getByText(headerText).closest('th') as HTMLTableCellElement;
-  const btn = within(headerCell).getByRole('button');
+  const btn = within(headerCell)
+    .getAllByRole('button')
+    .find((button) => button.textContent?.trim().startsWith(headerText)) as HTMLButtonElement;
   act(() => {
     fireEvent.click(btn);
   });
 };
 
-const openFiltersMenu = async () => {
+const openHeaderFilter = async (columnHeader: string) => {
   const user = userEvent.setup();
-  await user.click(screen.getByRole('button', { name: /table\.filters/ }));
+  await user.click(screen.getByRole('button', { name: `table.filters ${columnHeader}` }));
   return user;
 };
 
 const selectFilterValue = async (columnHeader: string, value: string) => {
-  const user = await openFiltersMenu();
-  const columnItem = screen
-    .getAllByText(columnHeader)
-    .find((element) => element.closest('[role="menuitem"]'));
-  expect(columnItem).toBeDefined();
-  await user.click(columnItem as HTMLElement);
+  const user = await openHeaderFilter(columnHeader);
   act(() => {
     fireEvent.click(screen.getByRole('menuitemcheckbox', { name: value }));
   });
@@ -292,7 +289,7 @@ describe('<StandardTable />', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Filters: toolbar input and shadcn dropdown bound to TanStack column filters
+  // Filters: shadcn header dropdowns bound to TanStack column filters
   // ---------------------------------------------------------------------------
   test('selecting a single filter value narrows the visible rows', async () => {
     const { container } = render(
@@ -340,32 +337,21 @@ describe('<StandardTable />', () => {
     );
     const tbody = container.querySelector('tbody') as HTMLElement;
     expect(tbody.textContent).not.toContain('Bob');
-    const user = await openFiltersMenu();
-    const nameItem = screen
-      .getAllByText('Name')
-      .find((element) => element.closest('[role="menuitem"]'));
-    expect(nameItem).toBeDefined();
-    await user.click(nameItem as HTMLElement);
+    await openHeaderFilter('Name');
     clickMenuItemByText('table.clearFilter');
     expect(tbody.textContent).toContain('Bob');
     expect(tbody.textContent).toContain('Charlie');
   });
 
-  test('toolbar search input filters the primary column', () => {
+  test('does not render the unsolicited toolbar search input', () => {
     render(<StandardTable<Row> title="People" data={sampleRows} columns={sampleColumns} />);
-    const search = screen.getByPlaceholderText('table.search Name');
-    act(() => {
-      fireEvent.change(search, { target: { value: 'Ali' } });
-    });
-    expect(screen.getByText('Alice')).toBeInTheDocument();
-    expect(screen.queryByText('Bob')).not.toBeInTheDocument();
-    expect(screen.queryByText('Charlie')).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('table.search Name')).not.toBeInTheDocument();
   });
 
   // ---------------------------------------------------------------------------
   // Sticky-right action column: classes on header and body cells
   // ---------------------------------------------------------------------------
-  test('sticky-right header has sticky positioning classes', () => {
+  test('sticky-right action header is sticky but visually empty', () => {
     const cols = [
       ...sampleColumns,
       {
@@ -376,12 +362,16 @@ describe('<StandardTable />', () => {
       },
     ];
     render(<StandardTable<Row> title="People" data={sampleRows} columns={cols} />);
-    const actionsHeader = screen.getByText('Actions').closest('th') as HTMLTableCellElement;
+    const headerRow = screen.getAllByRole('row')[0];
+    const actionsHeader = within(headerRow).getAllByRole('columnheader')[2];
     expect(actionsHeader.className).toContain('sticky');
     expect(actionsHeader.className).toContain('right-0');
+    expect(actionsHeader.textContent?.trim()).toBe('');
+    expect(screen.queryByText('Actions')).not.toBeInTheDocument();
   });
 
-  test('sticky-right body cell wraps content in a flex container', () => {
+  test('sticky-right body cell collapses actions behind an ellipsis menu', async () => {
+    const user = userEvent.setup();
     const cols = [
       ...sampleColumns,
       {
@@ -396,16 +386,17 @@ describe('<StandardTable />', () => {
       },
     ];
     render(<StandardTable<Row> title="People" data={sampleRows} columns={cols} />);
-    const actionBtn = screen.getByTestId('action-1');
-    const wrapper = actionBtn.parentElement as HTMLElement;
-    expect(wrapper.className).toContain('flex');
-    expect(wrapper.className).toContain('justify-end');
+    expect(screen.queryByTestId('action-1')).not.toBeInTheDocument();
+
+    await user.click(screen.getAllByLabelText('table.rowActions')[0]);
+    expect(screen.getByTestId('action-1')).toBeInTheDocument();
   });
 
   // ---------------------------------------------------------------------------
   // Row-action menu: click handler + stopPropagation prevents row click
   // ---------------------------------------------------------------------------
-  test('row action button fires its handler without bubbling to row click', () => {
+  test('row action menu item fires its handler without bubbling to row click', async () => {
+    const user = userEvent.setup();
     const onAction = mock(() => {});
     const onRowClick = mock(() => {});
     const cols = [
@@ -436,9 +427,8 @@ describe('<StandardTable />', () => {
         onRowClick={onRowClick}
       />,
     );
-    act(() => {
-      fireEvent.click(screen.getByTestId('row-action-2'));
-    });
+    await user.click(screen.getAllByLabelText('table.rowActions')[1]);
+    await user.click(screen.getByTestId('row-action-2'));
     expect(onAction).toHaveBeenCalledTimes(1);
     // stopPropagation in the action button keeps the row's onClick silent.
     expect(onRowClick).not.toHaveBeenCalled();

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -278,8 +278,14 @@ describe('<StandardTable />', () => {
       .getByText('Age')
       .closest('th')
       ?.querySelector('[data-column-resize-line="age"]');
+    const ageResizeHandle = screen
+      .getByText('Age')
+      .closest('th')
+      ?.querySelector('[data-column-resize-handle="age"]');
     expect(ageResizeLine?.className).toContain('bg-transparent');
     expect(ageResizeLine?.className).not.toContain('bg-border');
+    expect(ageResizeHandle?.className).toContain('z-10');
+    expect(ageResizeHandle?.className).not.toContain('z-30');
   });
 
   test('sparse action-only custom views do not insert an action spacer', () => {
@@ -807,6 +813,43 @@ describe('<StandardTable />', () => {
     expect(onAction).toHaveBeenCalledTimes(1);
     // stopPropagation in the action button keeps the row's onClick silent.
     expect(onRowClick).not.toHaveBeenCalled();
+  });
+
+  test('right-clicking a row opens its shadcn context menu actions', async () => {
+    const onAction = mock((id: string) => id);
+    const cols = [
+      ...sampleColumns,
+      {
+        id: 'actions',
+        header: 'Actions',
+        sticky: 'right' as const,
+        cell: ({ row }: { row: Row }) => (
+          <button
+            type="button"
+            data-testid={`context-action-${row.id}`}
+            onClick={(e) => {
+              e.stopPropagation();
+              onAction(row.id);
+            }}
+          >
+            Edit {row.name}
+          </button>
+        ),
+      },
+    ];
+    render(<StandardTable<Row> title="People" data={sampleRows} columns={cols} />);
+
+    expect(screen.queryByTestId('context-action-2')).not.toBeInTheDocument();
+
+    act(() => {
+      fireEvent.contextMenu(screen.getAllByRole('row')[2], { clientX: 12, clientY: 24 });
+    });
+
+    const action = await screen.findByTestId('context-action-2');
+    expect(action.closest('[data-slot="context-menu-content"]')).toBeInTheDocument();
+
+    await userEvent.click(action);
+    expect(onAction).toHaveBeenCalledWith('2');
   });
 
   // ---------------------------------------------------------------------------

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -167,6 +167,19 @@ describe('<StandardTable />', () => {
     expect(localStorage.getItem('praetor_table_rows_people')).toBe('20');
   });
 
+  test('rows-per-page select menu uses the scoped shadcn dark theme', async () => {
+    localStorage.setItem('praetor_theme', 'dark');
+    const user = userEvent.setup();
+    render(<StandardTable<Row> title="People" data={sampleRows} columns={sampleColumns} />);
+
+    await user.click(screen.getByRole('combobox'));
+
+    const content = document.body.querySelector('[data-slot="select-content"]');
+    expect(content?.hasAttribute('data-shadcn-theme-scope')).toBe(true);
+    expect(content?.getAttribute('data-shadcn-theme')).toBe('dark');
+    expect(content?.className).toContain('dark');
+  });
+
   test('CSV export click invokes downloadCsv with rows and filename', () => {
     render(<StandardTable<Row> title="People" data={sampleRows} columns={sampleColumns} />);
     const exportButton = screen.getByText('table.export');

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -356,6 +356,22 @@ describe('<StandardTable />', () => {
     expect(tbody.textContent).toContain('Charlie');
   });
 
+  test('header filter menu uses shadcn border tokens and searches filter options', async () => {
+    render(<StandardTable<Row> title="People" data={sampleRows} columns={sampleColumns} />);
+    const user = await openHeaderFilter('Name');
+
+    const content = document.body.querySelector('[data-slot="dropdown-menu-content"]');
+    expect(content?.className).toContain('border-border');
+
+    const search = screen.getByRole('searchbox', { name: 'table.search Name' });
+    expect(search).toHaveAttribute('placeholder', 'table.search');
+    await user.type(search, 'ali');
+
+    expect(screen.getByRole('menuitemcheckbox', { name: 'Alice' })).toBeInTheDocument();
+    expect(screen.queryByRole('menuitemcheckbox', { name: 'Bob' })).toBeNull();
+    expect(screen.queryByRole('menuitemcheckbox', { name: 'Charlie' })).toBeNull();
+  });
+
   test('does not render the unsolicited toolbar search input', () => {
     render(<StandardTable<Row> title="People" data={sampleRows} columns={sampleColumns} />);
     expect(screen.queryByPlaceholderText('table.search Name')).not.toBeInTheDocument();

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -605,6 +605,22 @@ describe('<StandardTable />', () => {
     expect(activeId).toBe(parsed[0].id);
   });
 
+  test('custom view add and import actions render side by side', async () => {
+    render(<StandardTable<Row> title="People" data={sampleRows} columns={sampleColumns} />);
+    await openCustomViews();
+
+    const addItem = screen.getByText('buttons.add').closest('[role="menuitem"]') as HTMLElement;
+    const importItem = screen
+      .getByText('buttons.import')
+      .closest('[role="menuitem"]') as HTMLElement;
+    const actionsRow = addItem.parentElement as HTMLElement;
+
+    expect(actionsRow.className).toContain('flex');
+    expect(actionsRow.className).not.toContain('grid');
+    expect(addItem.className).toContain('flex-1');
+    expect(importItem.className).toContain('flex-1');
+  });
+
   test('loading a stored view at mount applies sortState to the table', () => {
     const stored = [
       {

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -349,6 +349,7 @@ describe('<StandardTable />', () => {
     await waitFor(() => expect(headerCell.style.width).toBe('160px'));
     expect(headerCell.style.minWidth).toBe('160px');
     await waitFor(() => expect(headerCell.closest('table')?.className).toContain('table-fixed'));
+    expect(screen.getByText('Age').closest('th')?.style.minWidth).toBe('88px');
     expect(screen.getByText('Alice').closest('td')?.className).toContain('overflow-hidden');
     expect(screen.getByText('Alice').closest('td')?.className).toContain('text-ellipsis');
 
@@ -483,6 +484,7 @@ describe('<StandardTable />', () => {
     expect(actionsHeader.className).toContain('sticky');
     expect(actionsHeader.className).toContain('right-0');
     expect(actionsHeader.className).toContain('bg-card');
+    expect(actionsHeader.style.minWidth).toBe('48px');
     expect(actionsHeader.className).not.toContain('bg-background');
     expect(actionsHeader.textContent?.trim()).toBe('');
     expect(screen.queryByText('Actions')).not.toBeInTheDocument();
@@ -520,6 +522,7 @@ describe('<StandardTable />', () => {
     expect(screen.queryByTestId('action-1')).not.toBeInTheDocument();
     const firstActionCell = screen.getAllByLabelText('table.rowActions')[0].closest('td');
     expect(firstActionCell?.className).toContain('bg-card');
+    expect(firstActionCell?.style.minWidth).toBe('48px');
     expect(firstActionCell?.className).not.toContain('bg-background');
     expect(firstActionCell?.className).not.toContain('border-l');
     expect(firstActionCell?.className).not.toContain('group-hover:bg-muted/50');

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -391,7 +391,7 @@ describe('<StandardTable />', () => {
         header: 'Actions',
         sticky: 'right' as const,
         cell: ({ row }: { row: Row }) => (
-          <button type="button" data-testid={`action-${row.id}`}>
+          <button type="button" aria-label={`Edit ${row.name}`} data-testid={`action-${row.id}`}>
             X
           </button>
         ),
@@ -402,6 +402,7 @@ describe('<StandardTable />', () => {
 
     await user.click(screen.getAllByLabelText('table.rowActions')[0]);
     expect(screen.getByTestId('action-1')).toBeInTheDocument();
+    expect(screen.getByText('Edit Alice')).toBeInTheDocument();
   });
 
   // ---------------------------------------------------------------------------

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -338,6 +338,8 @@ describe('<StandardTable />', () => {
     const initialWidth = headerCell.style.width;
 
     expect(resizeHandle.className).toContain('w-2');
+    expect(resizeHandle.className).toContain('right-0');
+    expect(resizeHandle.className).toContain('touch-none');
     expect(resizeLine.className).toContain('w-px');
     expect(resizeLine.className).toContain('bg-border');
 
@@ -384,7 +386,7 @@ describe('<StandardTable />', () => {
     expect(Number.parseInt(ageHeader.style.width, 10)).toBe(initialAgeWidth);
     const table = nameHeader.closest('table') as HTMLTableElement;
     expect(table.className).toContain('table-fixed');
-    expect(table.style.minWidth).toBe('100%');
+    expect(table.style.minWidth).toBe('');
     expect(screen.getByText('Alice').closest('td')?.className).toContain('overflow-hidden');
     expect(screen.getByText('Alice').closest('td')?.className).toContain('text-ellipsis');
   });
@@ -415,12 +417,12 @@ describe('<StandardTable />', () => {
       fireEvent.mouseUp(document);
     });
 
-    await waitFor(() => expect(Number.parseInt(nameHeader.style.width, 10)).toBe(128));
+    await waitFor(() => expect(Number.parseInt(nameHeader.style.width, 10)).toBe(112));
     await waitFor(() => {
       const saved = JSON.parse(
         localStorage.getItem('praetor_table_colwidths_clamped_drag') ?? '{}',
       );
-      expect(saved.name).toBe(128);
+      expect(saved.name).toBe(112);
     });
   });
 
@@ -439,7 +441,7 @@ describe('<StandardTable />', () => {
     );
 
     const longHeaderCell = screen.getByText('Very Long Header').closest('th') as HTMLElement;
-    expect(Number.parseInt(longHeaderCell.style.minWidth, 10)).toBeGreaterThan(200);
+    expect(Number.parseInt(longHeaderCell.style.minWidth, 10)).toBeGreaterThan(190);
   });
 
   test('stored column widths are clamped to the full header label width', async () => {
@@ -450,7 +452,7 @@ describe('<StandardTable />', () => {
 
     const headerCell = screen.getByText('Ruolo').closest('th') as HTMLElement;
     await waitFor(() =>
-      expect(Number.parseInt(headerCell.style.minWidth, 10)).toBeGreaterThan(120),
+      expect(Number.parseInt(headerCell.style.minWidth, 10)).toBeGreaterThan(110),
     );
     expect(screen.getByText('Ruolo').className).not.toContain('truncate');
   });
@@ -463,14 +465,14 @@ describe('<StandardTable />', () => {
     );
 
     const firstHeader = screen.getByText('Ruolo').closest('th') as HTMLElement;
-    await waitFor(() => expect(Number.parseInt(firstHeader.style.width, 10)).toBe(137));
+    await waitFor(() => expect(Number.parseInt(firstHeader.style.width, 10)).toBe(119));
     const savedAfterFirstRender = localStorage.getItem('praetor_table_colwidths_remount_width');
 
     unmount();
     render(<StandardTable<Row> title="Remount Width" data={sampleRows} columns={columns} />);
 
     const secondHeader = screen.getByText('Ruolo').closest('th') as HTMLElement;
-    await waitFor(() => expect(Number.parseInt(secondHeader.style.width, 10)).toBe(137));
+    await waitFor(() => expect(Number.parseInt(secondHeader.style.width, 10)).toBe(119));
     expect(localStorage.getItem('praetor_table_colwidths_remount_width')).toBe(
       savedAfterFirstRender,
     );

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -382,7 +382,14 @@ describe('<StandardTable />', () => {
     expect(search).toHaveAttribute('placeholder', 'table.search');
     await user.type(search, 'ali');
 
-    expect(screen.getByRole('menuitemcheckbox', { name: 'Alice' })).toBeInTheDocument();
+    const aliceOption = screen.getByRole('menuitemcheckbox', { name: 'Alice' });
+    const checkboxIndicator = aliceOption.querySelector(
+      '[data-slot="dropdown-menu-checkbox-indicator"]',
+    );
+
+    expect(aliceOption).toBeInTheDocument();
+    expect(checkboxIndicator?.className).toContain('border-input');
+    expect(checkboxIndicator?.className).toContain('group-data-[state=checked]:bg-primary');
     expect(screen.queryByRole('menuitemcheckbox', { name: 'Bob' })).toBeNull();
     expect(screen.queryByRole('menuitemcheckbox', { name: 'Charlie' })).toBeNull();
   });

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -178,6 +178,7 @@ describe('<StandardTable />', () => {
     expect(content?.hasAttribute('data-shadcn-theme-scope')).toBe(true);
     expect(content?.getAttribute('data-shadcn-theme')).toBe('dark');
     expect(content?.className).toContain('dark');
+    expect(content?.className).toContain('border-border');
   });
 
   test('CSV export click invokes downloadCsv with rows and filename', () => {

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -314,6 +314,7 @@ describe('<StandardTable />', () => {
     const resizeHandle = headerCell.querySelector(
       '[data-column-resize-handle="name"]',
     ) as HTMLElement;
+    const resizeLine = headerCell.querySelector('[data-column-resize-line="name"]') as HTMLElement;
 
     Object.defineProperty(headerLabel, 'scrollWidth', { configurable: true, value: 96 });
     Object.defineProperty(headerCell, 'getBoundingClientRect', {
@@ -330,6 +331,10 @@ describe('<StandardTable />', () => {
         toJSON: () => ({}),
       }),
     });
+
+    expect(resizeHandle.className).toContain('w-2');
+    expect(resizeLine.className).toContain('w-px');
+    expect(resizeLine.className).toContain('bg-border');
 
     act(() => {
       fireEvent.mouseDown(resizeHandle, { clientX: 220 });
@@ -434,8 +439,10 @@ describe('<StandardTable />', () => {
     );
 
     expect(aliceOption).toBeInTheDocument();
-    expect(checkboxIndicator?.className).toContain('border-input');
-    expect(checkboxIndicator?.className).toContain('group-data-[state=checked]:bg-primary');
+    expect(checkboxIndicator?.className).toContain('right-2');
+    expect(checkboxIndicator?.className).toContain('text-foreground');
+    expect(checkboxIndicator?.className).not.toContain('border-input');
+    expect(checkboxIndicator?.className).not.toContain('bg-primary');
     expect(screen.queryByRole('menuitemcheckbox', { name: 'Bob' })).toBeNull();
     expect(screen.queryByRole('menuitemcheckbox', { name: 'Charlie' })).toBeNull();
   });
@@ -668,11 +675,26 @@ describe('<StandardTable />', () => {
     expect(previousButton).toBeDisabled();
     expect(previousButton.getAttribute('data-size')).toBe('sm');
     expect(previousButton.className).toContain('border-border');
-    expect(previousButton.className).toContain('text-foreground');
-    expect(previousButton.className).toContain('disabled:opacity-100');
+    expect(previousButton.className).toContain('disabled:opacity-50');
+    expect(previousButton.className).not.toContain('disabled:opacity-100');
   });
 
-  test('toolbar outline buttons use the same shadcn border token as pagination', () => {
+  test('pagination uses native disabled states when there is only one page', () => {
+    render(<StandardTable<Row> title="People" data={sampleRows} columns={sampleColumns} />);
+
+    const previousButton = screen.getByRole('button', { name: 'buttons.previous' });
+    const nextButton = screen.getByRole('button', { name: 'buttons.next' });
+
+    expect(previousButton).toBeDisabled();
+    expect(nextButton).toBeDisabled();
+    expect(previousButton.className).toContain('disabled:opacity-50');
+    expect(nextButton.className).toContain('disabled:opacity-50');
+    expect(previousButton.className).not.toContain('disabled:opacity-100');
+    expect(nextButton.className).not.toContain('disabled:opacity-100');
+  });
+
+  test('toolbar outline buttons use the same shadcn border token as pagination', async () => {
+    const user = userEvent.setup();
     render(<StandardTable<Row> title="People" data={sampleRows} columns={sampleColumns} />);
 
     const exportButton = screen.getByRole('button', { name: 'table.exportToCsv' });
@@ -689,6 +711,14 @@ describe('<StandardTable />', () => {
       expect(button.className).toContain('border-border');
       expect(button.className).not.toContain('focus-visible:border-ring');
     }
+
+    expect(columnsButton.getAttribute('data-variant')).toBe('outline');
+    await user.click(columnsButton);
+    await waitFor(() => expect(columnsButton.getAttribute('data-state')).toBe('open'));
+    expect(columnsButton.getAttribute('data-variant')).toBe('outline');
+    expect(columnsButton.className).toContain('data-[state=open]:border-border');
+    expect(columnsButton.className).toContain('data-[state=open]:bg-accent');
+    expect(columnsButton.className).toContain('focus-visible:ring-0');
   });
 
   // ---------------------------------------------------------------------------

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -288,6 +288,21 @@ describe('<StandardTable />', () => {
     expect(rows[2]).toContain('Charlie');
   });
 
+  test('sortable column header uses shadcn hover background and sort icon styling', () => {
+    render(<StandardTable<Row> title="People" data={sampleRows} columns={sampleColumns} />);
+
+    const headerCell = screen.getByText('Name').closest('th') as HTMLTableCellElement;
+    const sortButton = within(headerCell)
+      .getAllByRole('button')
+      .find((button) => button.textContent?.trim().startsWith('Name')) as HTMLButtonElement;
+    const sortIcon = sortButton.querySelector('i.fa-arrow-up-arrow-down');
+
+    expect(sortButton.className).toContain('rounded-md');
+    expect(sortButton.className).toContain('hover:bg-accent');
+    expect(sortButton.className).toContain('hover:text-accent-foreground');
+    expect(sortIcon?.className).toContain('transition-colors');
+  });
+
   test('sorting descending by age reorders numerically (largest first)', () => {
     render(<StandardTable<Row> title="People" data={sampleRows} columns={sampleColumns} />);
     clickSortHeader('Age');

--- a/test/components/SupplierQuotesView.test.tsx
+++ b/test/components/SupplierQuotesView.test.tsx
@@ -1,22 +1,9 @@
-import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, describe, expect, test } from 'bun:test';
 import { fireEvent, render, screen } from '@testing-library/react';
-import type { ReactNode } from 'react';
 import type { Product, Supplier, SupplierQuote } from '../../types';
 import { installI18nMock } from '../helpers/i18n';
 
 installI18nMock();
-
-// Modal renders via createPortal, which doesn't reliably surface in screen
-// queries with happy-dom + React 19. Replace createPortal with a passthrough
-// so the real Modal source still runs but its children render inline. This
-// also avoids globally mocking '../../components/shared/Modal', which would
-// leak across test files in the same Bun process.
-const reactDom = await import('react-dom');
-mock.module('react-dom', () => ({
-  ...reactDom,
-  default: reactDom.default,
-  createPortal: (children: ReactNode) => <div data-testid="modal">{children}</div>,
-}));
 
 const SupplierQuotesView = (await import('../../components/sales/SupplierQuotesView')).default;
 
@@ -78,7 +65,6 @@ describe('<SupplierQuotesView /> read-only gating', () => {
   test('clicking a draft row opens the modal in editable mode', () => {
     render(<SupplierQuotesView {...baseProps} />);
     fireEvent.click(screen.getByText('SQ-DRAFT'));
-    expect(screen.getByTestId('modal')).toBeInTheDocument();
     // Edit modal title and Update submit button are rendered.
     expect(screen.getByText('sales:supplierQuotes.editQuote')).toBeInTheDocument();
     expect(screen.getByText('common:buttons.update')).toBeInTheDocument();
@@ -90,7 +76,6 @@ describe('<SupplierQuotesView /> read-only gating', () => {
   test('clicking a sent row opens the modal in read-only mode', () => {
     render(<SupplierQuotesView {...baseProps} />);
     fireEvent.click(screen.getByText('SQ-SENT'));
-    expect(screen.getByTestId('modal')).toBeInTheDocument();
     expect(screen.getByText('sales:supplierQuotes.viewQuote')).toBeInTheDocument();
     expect(screen.queryByText('common:buttons.update')).not.toBeInTheDocument();
     expect(screen.getByText('sales:supplierQuotes.readOnlyStatus')).toBeInTheDocument();
@@ -99,7 +84,6 @@ describe('<SupplierQuotesView /> read-only gating', () => {
   test('clicking an accepted row (without linked order) opens the modal in read-only mode', () => {
     render(<SupplierQuotesView {...baseProps} />);
     fireEvent.click(screen.getByText('SQ-ACCEPTED'));
-    expect(screen.getByTestId('modal')).toBeInTheDocument();
     expect(screen.getByText('sales:supplierQuotes.viewQuote')).toBeInTheDocument();
     expect(screen.queryByText('common:buttons.update')).not.toBeInTheDocument();
     expect(screen.getByText('sales:supplierQuotes.readOnlyStatus')).toBeInTheDocument();
@@ -108,7 +92,6 @@ describe('<SupplierQuotesView /> read-only gating', () => {
   test('clicking a denied row opens the modal in read-only mode', () => {
     render(<SupplierQuotesView {...baseProps} />);
     fireEvent.click(screen.getByText('SQ-DENIED'));
-    expect(screen.getByTestId('modal')).toBeInTheDocument();
     expect(screen.getByText('sales:supplierQuotes.viewQuote')).toBeInTheDocument();
     expect(screen.queryByText('common:buttons.update')).not.toBeInTheDocument();
     expect(screen.getByText('sales:supplierQuotes.readOnlyStatus')).toBeInTheDocument();
@@ -117,7 +100,6 @@ describe('<SupplierQuotesView /> read-only gating', () => {
   test('clicking an accepted row with a linked order shows the linked-order banner', () => {
     render(<SupplierQuotesView {...baseProps} />);
     fireEvent.click(screen.getByText('SQ-ACCEPTED-ORDER'));
-    expect(screen.getByTestId('modal')).toBeInTheDocument();
     expect(screen.getByText('sales:supplierQuotes.viewQuote')).toBeInTheDocument();
     expect(screen.queryByText('common:buttons.update')).not.toBeInTheDocument();
     // Linked-order copy wins over the generic non-draft copy.

--- a/test/components/accounting/ClientsOrdersView.test.tsx
+++ b/test/components/accounting/ClientsOrdersView.test.tsx
@@ -1,0 +1,62 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { render, screen } from '@testing-library/react';
+import type { Client, ClientsOrder } from '../../../types';
+import { installI18nMock } from '../../helpers/i18n';
+
+installI18nMock();
+
+const ClientsOrdersView = (await import('../../../components/accounting/ClientsOrdersView'))
+  .default;
+
+const clients: Client[] = [{ id: 'client-1', name: 'Helios Energy Services' }];
+
+const orders: ClientsOrder[] = [
+  {
+    id: 'dm_so_01',
+    clientId: 'client-1',
+    clientName: 'Helios Energy Services',
+    items: [
+      {
+        id: 'item-1',
+        orderId: 'dm_so_01',
+        productId: 'product-1',
+        productName: 'Consulting',
+        quantity: 2,
+        unitPrice: 2000,
+        productCost: 1200,
+        productMolPercentage: 40,
+      },
+    ],
+    paymentTerms: '30gg',
+    discount: 5,
+    discountType: 'percentage',
+    status: 'draft',
+    createdAt: Date.UTC(2026, 3, 24),
+    updatedAt: Date.UTC(2026, 3, 24),
+  },
+];
+
+describe('<ClientsOrdersView />', () => {
+  test('pricing columns expose StandardTable header filters', () => {
+    render(
+      <ClientsOrdersView
+        orders={orders}
+        clients={clients}
+        products={[]}
+        currency="EUR"
+        onUpdateClientsOrder={mock(() => {})}
+        onDeleteClientsOrder={mock(() => {})}
+      />,
+    );
+
+    for (const header of [
+      'sales:clientQuotes.globalDiscount',
+      'accounting:clientsOrders.subtotal',
+      'common:labels.discount',
+      'accounting:clientsOrders.margin',
+      'sales:clientQuotes.totalCost',
+    ]) {
+      expect(screen.getByRole('button', { name: `table.filters ${header}` })).toBeInTheDocument();
+    }
+  });
+});

--- a/test/components/accounting/ClientsOrdersView.test.tsx
+++ b/test/components/accounting/ClientsOrdersView.test.tsx
@@ -37,7 +37,7 @@ const orders: ClientsOrder[] = [
 ];
 
 describe('<ClientsOrdersView />', () => {
-  test('pricing columns expose StandardTable header filters', () => {
+  test('pricing amount columns keep sorting but hide StandardTable header filters', () => {
     render(
       <ClientsOrdersView
         orders={orders}
@@ -49,14 +49,35 @@ describe('<ClientsOrdersView />', () => {
       />,
     );
 
+    expect(
+      screen.getByRole('button', { name: 'table.filters sales:clientQuotes.globalDiscount' }),
+    ).toBeInTheDocument();
+
     for (const header of [
-      'sales:clientQuotes.globalDiscount',
       'accounting:clientsOrders.subtotal',
       'common:labels.discount',
       'accounting:clientsOrders.margin',
       'sales:clientQuotes.totalCost',
+      'accounting:clientsOrders.totalColumn',
     ]) {
-      expect(screen.getByRole('button', { name: `table.filters ${header}` })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: `table.filters ${header}` })).toBeNull();
+      expect(screen.getByText(header).closest('th')?.querySelector('svg')).toBeInTheDocument();
     }
+  });
+
+  test('client column does not render item count below the client name', () => {
+    render(
+      <ClientsOrdersView
+        orders={orders}
+        clients={clients}
+        products={[]}
+        currency="EUR"
+        onUpdateClientsOrder={mock(() => {})}
+        onDeleteClientsOrder={mock(() => {})}
+      />,
+    );
+
+    expect(screen.getByText('Helios Energy Services')).toBeInTheDocument();
+    expect(screen.queryByText('accounting:clientsOrders.itemsCount')).toBeNull();
   });
 });

--- a/test/components/administration/UserManagement.test.tsx
+++ b/test/components/administration/UserManagement.test.tsx
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import type { ComponentProps } from 'react';
 import type { User } from '../../../types';
 import { installI18nMock } from '../../helpers/i18n';
@@ -81,6 +82,7 @@ describe('<UserManagement />', () => {
     expect(screen.getByText('alice.admin')).toBeInTheDocument();
     expect(screen.getByText('alice@example.com')).toBeInTheDocument();
     expect(screen.getByText('manager')).toBeInTheDocument();
+    expect(screen.getByText('manager').closest('[data-status-badge]')).not.toBeNull();
     expect(screen.getByText('common:common.none')).toBeInTheDocument();
     expect(screen.getAllByText('common:common.active')).toHaveLength(2);
   });
@@ -104,16 +106,20 @@ describe('<UserManagement />', () => {
     expect(screen.getByText('hr:workforce.editUser')).toBeInTheDocument();
   });
 
-  test('action button does not also trigger row edit', () => {
+  test('action button does not also trigger row edit', async () => {
+    const user = userEvent.setup();
     const props = renderUserManagement();
     const bobRow = getRowFor('Bob Brown');
-    const disableButton = bobRow.querySelector('.fa-ban')?.closest('button');
-    if (!disableButton) throw new Error('Could not find disable button');
+    const actionButton = bobRow.querySelector('[aria-label="table.rowActions"]');
+    if (!actionButton) throw new Error('Could not find row actions button');
 
-    fireEvent.click(disableButton);
+    await user.click(actionButton);
+    const disableButton = await screen.findByRole('button', { name: 'hr:workforce.disableUser' });
+
+    await user.click(disableButton);
 
     expect(props.onUpdateUser).toHaveBeenCalledWith('u2', { isDisabled: true });
-    expect(screen.queryByText('hr:workforce.editUser')).not.toBeInTheDocument();
+    expect(usersApiMock.getRoles).not.toHaveBeenCalled();
   });
 
   test('shows empty state when no users match the search', () => {


### PR DESCRIPTION
## Summary
- add the shadcn table primitive and TanStack Table dependency
- move StandardTable row modeling for sorting, filtering, pagination, and visibility onto TanStack Table
- preserve the existing StandardTable API, saved views, CSV export, row actions, column resizing, and pagination behavior
- keep scrolling ownership in StandardTable to avoid nested horizontal scroll containers

## Validation
- `bun test ./test/components/StandardTable.test.tsx`
- `bun test ./test`
- `bun x tsc -p tsconfig.json`
- `bunx biome check --write components/shared/StandardTable.tsx components/ui/table.tsx`

## Notes
- `bun run typecheck` is still blocked in this workspace by missing server-side dependencies such as Fastify and Drizzle before the frontend check runs.