### PR TITLE
fix: keep reports module visible and disable AI report route

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2088,7 +2088,7 @@ const App: React.FC = () => {
         onSwitchRole={handleSwitchRole}
         roles={roles}
         isNotFound={!isRouteAccessible}
-        isAiReportingEnabled={!hasLoadedGeneralSettings || generalSettings.enableAiReporting}
+        isAiReportingEnabled={hasLoadedGeneralSettings && generalSettings.enableAiReporting}
         notifications={notifications}
         unreadNotificationCount={unreadNotificationCount}
         onMarkNotificationAsRead={handleMarkNotificationAsRead}

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -101,7 +101,7 @@ const Layout: React.FC<LayoutProps> = ({
   onSwitchRole,
   roles,
   isNotFound,
-  isAiReportingEnabled = true,
+  isAiReportingEnabled = false,
   notifications = [],
   unreadNotificationCount = 0,
   onMarkNotificationAsRead,

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -288,13 +288,16 @@ const Layout: React.FC<LayoutProps> = ({
 
         const permission = VIEW_PERMISSION_MAP[route.view];
         if (!permission || !hasPermission(currentUser.permissions, permission)) continue;
+        const isDisabledAiReporting =
+          route.view === 'reports/ai-reporting' && !isAiReportingEnabled;
 
         routes.push({
           title: route.label,
           view: route.view,
           icon: route.icon,
           isActive: activeView === route.view,
-          disabled: route.view === 'reports/ai-reporting' && !isAiReportingEnabled,
+          disabled: isDisabledAiReporting,
+          disabledTooltip: isDisabledAiReporting ? t('sidebar.aiReportingDisabled') : undefined,
         });
       }
 
@@ -309,7 +312,7 @@ const Layout: React.FC<LayoutProps> = ({
     }
 
     return { activeRoute: matchedRoute, navItems: items };
-  }, [activeModuleId, activeView, currentUser.permissions, isAiReportingEnabled, modules]);
+  }, [activeModuleId, activeView, currentUser.permissions, isAiReportingEnabled, modules, t]);
 
   const canViewNotifications = hasPermission(
     currentUser.permissions,

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -285,7 +285,6 @@ const Layout: React.FC<LayoutProps> = ({
 
       for (const route of module.routes) {
         if (route.view === activeView) matchedRoute = route;
-        if (route.view === 'reports/ai-reporting' && !isAiReportingEnabled) continue;
 
         const permission = VIEW_PERMISSION_MAP[route.view];
         if (!permission || !hasPermission(currentUser.permissions, permission)) continue;
@@ -295,6 +294,7 @@ const Layout: React.FC<LayoutProps> = ({
           view: route.view,
           icon: route.icon,
           isActive: activeView === route.view,
+          disabled: route.view === 'reports/ai-reporting' && !isAiReportingEnabled,
         });
       }
 

--- a/components/nav-main.tsx
+++ b/components/nav-main.tsx
@@ -13,6 +13,7 @@ import {
   SidebarMenuSubItem,
   useSidebar,
 } from '@/components/ui/sidebar';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import type { View } from '@/types';
 
 export interface SidebarRouteItem {
@@ -21,6 +22,7 @@ export interface SidebarRouteItem {
   icon: LucideIcon;
   isActive: boolean;
   disabled?: boolean;
+  disabledTooltip?: string;
 }
 
 export interface SidebarModuleItem {
@@ -88,8 +90,8 @@ export function NavMain({ items, label, onViewChange }: NavMainProps) {
               </CollapsibleTrigger>
               <CollapsibleContent className="sidebar-entry-content">
                 <SidebarMenuSub className="py-1">
-                  {item.items.map((subItem) => (
-                    <SidebarMenuSubItem key={subItem.view}>
+                  {item.items.map((subItem) => {
+                    const routeButton = (
                       <SidebarMenuSubButton
                         asChild
                         isActive={subItem.isActive}
@@ -108,8 +110,23 @@ export function NavMain({ items, label, onViewChange }: NavMainProps) {
                           <span>{subItem.title}</span>
                         </button>
                       </SidebarMenuSubButton>
-                    </SidebarMenuSubItem>
-                  ))}
+                    );
+
+                    return (
+                      <SidebarMenuSubItem key={subItem.view}>
+                        {subItem.disabled && subItem.disabledTooltip ? (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <span className="block">{routeButton}</span>
+                            </TooltipTrigger>
+                            <TooltipContent side="right">{subItem.disabledTooltip}</TooltipContent>
+                          </Tooltip>
+                        ) : (
+                          routeButton
+                        )}
+                      </SidebarMenuSubItem>
+                    );
+                  })}
                 </SidebarMenuSub>
               </CollapsibleContent>
             </SidebarMenuItem>

--- a/components/nav-main.tsx
+++ b/components/nav-main.tsx
@@ -20,6 +20,7 @@ export interface SidebarRouteItem {
   view: View;
   icon: LucideIcon;
   isActive: boolean;
+  disabled?: boolean;
 }
 
 export interface SidebarModuleItem {
@@ -96,6 +97,7 @@ export function NavMain({ items, label, onViewChange }: NavMainProps) {
                       >
                         <button
                           type="button"
+                          disabled={subItem.disabled}
                           onClick={() => {
                             onViewChange(subItem.view);
                             if (isMobile) setOpenMobile(false);

--- a/locales/en/layout.json
+++ b/locales/en/layout.json
@@ -66,7 +66,8 @@
   "sidebar": {
     "toggle": "Toggle Sidebar",
     "expand": "Expand",
-    "collapse": "Collapse"
+    "collapse": "Collapse",
+    "aiReportingDisabled": "AI Reporting is disabled by administration."
   },
   "workspace": "Workspace",
   "module": "Module",

--- a/locales/it/layout.json
+++ b/locales/it/layout.json
@@ -66,7 +66,8 @@
   "sidebar": {
     "toggle": "Attiva/Disattiva Barra Laterale",
     "expand": "Espandi",
-    "collapse": "Comprimi"
+    "collapse": "Comprimi",
+    "aiReportingDisabled": "AI Reporting è disabilitato dall'amministrazione."
   },
   "workspace": "Area di Lavoro",
   "module": "Modulo",

--- a/test/components/Layout.test.tsx
+++ b/test/components/Layout.test.tsx
@@ -201,9 +201,10 @@ describe('<Layout />', () => {
     expect(screen.queryByText('modules.accounting')).toBeNull();
   });
 
-  test('reports module stays visible with disabled AI reporting route when feature is off', () => {
+  test('reports module stays visible with disabled AI reporting route when feature is off', async () => {
     isMobileViewport = false;
     const onViewChange = mock(() => {});
+    const user = userEvent.setup();
     renderLayout({
       onViewChange,
       isAiReportingEnabled: false,
@@ -223,6 +224,10 @@ describe('<Layout />', () => {
     fireEvent.click(aiReportingButton);
 
     expect(onViewChange).not.toHaveBeenCalled();
+
+    await user.hover(aiReportingButton.parentElement as HTMLElement);
+
+    expect(await screen.findAllByText('sidebar.aiReportingDisabled')).toHaveLength(2);
   });
 
   test('AI reporting route remains clickable when feature is on', () => {

--- a/test/components/Layout.test.tsx
+++ b/test/components/Layout.test.tsx
@@ -203,6 +203,7 @@ describe('<Layout />', () => {
 
   test('reports module stays visible with disabled AI reporting route when feature is off', async () => {
     isMobileViewport = false;
+    localStorage.setItem(THEME_STORAGE_KEY, 'dark');
     const onViewChange = mock(() => {});
     const user = userEvent.setup();
     renderLayout({
@@ -228,6 +229,11 @@ describe('<Layout />', () => {
     await user.hover(aiReportingButton.parentElement as HTMLElement);
 
     expect(await screen.findAllByText('sidebar.aiReportingDisabled')).toHaveLength(2);
+    const tooltipContent = document.body.querySelector('[data-slot="tooltip-content"]');
+    expect(tooltipContent?.getAttribute('data-shadcn-theme')).toBe('dark');
+    expect(tooltipContent?.className).toContain('dark');
+    expect(tooltipContent?.className).toContain('bg-primary');
+    expect(tooltipContent?.className).toContain('text-primary-foreground');
   });
 
   test('AI reporting route remains clickable when feature is on', () => {

--- a/test/components/Layout.test.tsx
+++ b/test/components/Layout.test.tsx
@@ -236,6 +236,27 @@ describe('<Layout />', () => {
     expect(tooltipContent?.className).toContain('text-primary-foreground');
   });
 
+  test('AI reporting route is disabled by default while feature settings are unresolved', () => {
+    isMobileViewport = false;
+    const onViewChange = mock(() => {});
+    renderLayout({
+      onViewChange,
+      currentUser: {
+        ...mockUser,
+        permissions: [...(mockUser.permissions ?? []), aiReportingViewPermission],
+      },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'modules.reports' }));
+    const aiReportingButton = screen.getByRole('button', { name: 'routes.aiReporting' });
+
+    expect(aiReportingButton).toBeDisabled();
+
+    fireEvent.click(aiReportingButton);
+
+    expect(onViewChange).not.toHaveBeenCalled();
+  });
+
   test('AI reporting route remains clickable when feature is on', () => {
     isMobileViewport = false;
     const onViewChange = mock(() => {});

--- a/test/components/Layout.test.tsx
+++ b/test/components/Layout.test.tsx
@@ -3,6 +3,7 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event';
 import type React from 'react';
 import type { Role, User } from '../../types';
+import { buildPermission } from '../../utils/permissions';
 import { applyTheme, THEME_STORAGE_KEY } from '../../utils/theme';
 import { installI18nMock } from '../helpers/i18n';
 
@@ -34,6 +35,7 @@ const mockUser: User = {
 };
 
 const mockRoles: Role[] = [];
+const aiReportingViewPermission = buildPermission('reports.ai_reporting', 'view');
 
 const renderLayout = (props?: Partial<React.ComponentProps<typeof Layout>>) =>
   render(
@@ -197,6 +199,52 @@ describe('<Layout />', () => {
     expect(screen.getAllByText('routes.timeTracker').length).toBeGreaterThan(0);
     expect(screen.queryByText('routes.suppliers')).toBeNull();
     expect(screen.queryByText('modules.accounting')).toBeNull();
+  });
+
+  test('reports module stays visible with disabled AI reporting route when feature is off', () => {
+    isMobileViewport = false;
+    const onViewChange = mock(() => {});
+    renderLayout({
+      onViewChange,
+      isAiReportingEnabled: false,
+      currentUser: {
+        ...mockUser,
+        permissions: [...(mockUser.permissions ?? []), aiReportingViewPermission],
+      },
+    });
+
+    expect(screen.getByText('modules.reports')).toBeDefined();
+
+    fireEvent.click(screen.getByRole('button', { name: 'modules.reports' }));
+    const aiReportingButton = screen.getByRole('button', { name: 'routes.aiReporting' });
+
+    expect(aiReportingButton).toBeDisabled();
+
+    fireEvent.click(aiReportingButton);
+
+    expect(onViewChange).not.toHaveBeenCalled();
+  });
+
+  test('AI reporting route remains clickable when feature is on', () => {
+    isMobileViewport = false;
+    const onViewChange = mock(() => {});
+    renderLayout({
+      onViewChange,
+      isAiReportingEnabled: true,
+      currentUser: {
+        ...mockUser,
+        permissions: [...(mockUser.permissions ?? []), aiReportingViewPermission],
+      },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'modules.reports' }));
+    const aiReportingButton = screen.getByRole('button', { name: 'routes.aiReporting' });
+
+    expect(aiReportingButton).not.toBeDisabled();
+
+    fireEvent.click(aiReportingButton);
+
+    expect(onViewChange).toHaveBeenCalledWith('reports/ai-reporting');
   });
 
   test('active module expands when active view changes', () => {


### PR DESCRIPTION
## Summary
- Keep the Reports sidebar module visible even when AI reporting is disabled.
- Mark only the `reports/ai-reporting` sidebar button as disabled instead of removing it from navigation.
- Add coverage for both disabled and enabled AI reporting sidebar behavior.

## Testing
- `bun test test/components/Layout.test.tsx`
- `bun x tsc -p tsconfig.json --noEmit`