### PR TITLE
fix: use praetor favicon in browser tab and sidebar

### DIFF
--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -1,4 +1,3 @@
-import { Clock } from 'lucide-react';
 import type React from 'react';
 
 import { NavMain, type SidebarModuleItem } from '@/components/nav-main';
@@ -13,6 +12,7 @@ import {
   SidebarMenuItem,
   SidebarRail,
 } from '@/components/ui/sidebar';
+import praetorFaviconUrl from '@/praetor-favicon.png';
 import type { Role, User, View } from '@/types';
 
 interface AppSidebarProps extends React.ComponentProps<typeof Sidebar> {
@@ -56,8 +56,13 @@ export function AppSidebar({
               size="lg"
               className="cursor-default text-sidebar-foreground hover:bg-transparent hover:text-sidebar-foreground"
             >
-              <div className="flex aspect-square size-8 items-center justify-center rounded-lg border border-sidebar-border bg-transparent text-sidebar-foreground">
-                <Clock className="size-4" />
+              <div className="flex aspect-square size-8 items-center justify-center rounded-lg border border-sidebar-border bg-background">
+                <img
+                  src={praetorFaviconUrl}
+                  alt=""
+                  className="size-5 object-contain"
+                  aria-hidden="true"
+                />
               </div>
               <div className="grid flex-1 text-left text-sm leading-[var(--text-sm--line-height)] text-sidebar-foreground">
                 <span className="truncate font-semibold italic">PRAETOR</span>

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -60,7 +60,7 @@ export function AppSidebar({
                 <img
                   src={praetorFaviconUrl}
                   alt=""
-                  className="size-5 object-contain"
+                  className="size-full rounded-lg object-cover"
                   aria-hidden="true"
                 />
               </div>

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -56,7 +56,7 @@ export function AppSidebar({
               size="lg"
               className="cursor-default text-sidebar-foreground hover:bg-transparent hover:text-sidebar-foreground"
             >
-              <div className="flex aspect-square size-8 items-center justify-center rounded-lg border border-sidebar-border bg-background">
+              <div className="flex aspect-square size-8 items-center justify-center rounded-lg border border-sidebar-border bg-background text-sidebar-foreground">
                 <img
                   src={praetorFaviconUrl}
                   alt=""

--- a/index.html
+++ b/index.html
@@ -4,8 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Praetor</title>
-    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/png" href="./praetor-favicon.png" />
     <link
       href="https://api.fontshare.com/v2/css?f[]=satoshi@300,400,500,700,900&display=swap"
       rel="stylesheet"

--- a/test/components/Layout.test.tsx
+++ b/test/components/Layout.test.tsx
@@ -106,7 +106,8 @@ describe('<Layout />', () => {
       '[data-sidebar="menu-button"][data-active="true"]',
     );
     const brandButton = screen.getByText('PRAETOR').closest('[data-sidebar="menu-button"]');
-    const brandLogo = brandButton?.querySelector('svg')?.parentElement;
+    const brandLogoImage = brandButton?.querySelector('img');
+    const brandLogo = brandLogoImage?.parentElement;
     const brandSubtitle = screen.getByText('roles.manager workspace');
     const avatarFallback = screen.getByText('TU');
 
@@ -120,6 +121,8 @@ describe('<Layout />', () => {
     expect(brandLogo?.className).toContain('text-sidebar-foreground');
     expect(brandLogo?.className).not.toContain('text-white');
     expect(brandLogo?.className).not.toContain('bg-praetor');
+    expect(brandLogoImage?.className).toContain('size-full');
+    expect(brandLogoImage?.className).toContain('object-cover');
     expect(brandSubtitle.className).toContain('text-sm');
     expect(brandSubtitle.className).toContain('leading-[var(--text-sm--line-height)]');
     expect(brandSubtitle.className).toContain('text-sidebar-foreground/80');


### PR DESCRIPTION
## Summary
- Point the document favicon at `praetor-favicon.png` in `index.html`.
- Replace the sidebar clock glyph with the same PNG asset for consistent branding.

## Testing
- `bun x tsc -p tsconfig.json`
- `bun x biome check index.html components\app-sidebar.tsx`