### PR TITLE
feat(theme): add zebra and praetor variants

### DIFF
--- a/components/UserSettings.tsx
+++ b/components/UserSettings.tsx
@@ -68,7 +68,7 @@ const THEME_OPTION_META: Record<
 
 const renderThemeSwatchContent = (option: (typeof THEME_OPTION_META)[Theme]) => {
   if (option.swatchVariant === 'praetor') {
-    return <img src={praetorFaviconUrl} alt="" className="size-7 object-contain" />;
+    return <img src={praetorFaviconUrl} alt="" className="size-12 max-w-none object-cover" />;
   }
 
   const Icon = option.Icon;

--- a/components/UserSettings.tsx
+++ b/components/UserSettings.tsx
@@ -32,10 +32,24 @@ const THEME_OPTION_META: Record<
     inactiveIconClassName: 'fa-solid fa-sun text-sm',
   },
   dark: {
-    activeClassName: 'border-praetor bg-praetor/5',
-    inactiveClassName: 'border-zinc-100 hover:border-praetor/20',
+    activeClassName: 'border-secondary bg-secondary',
+    inactiveClassName: 'border-zinc-100 hover:border-secondary',
     swatchClassName: 'bg-zinc-900 shrink-0 shadow-sm flex items-center justify-center text-white',
     inactiveIconClassName: 'fa-solid fa-moon text-sm',
+  },
+  zebra: {
+    activeClassName: 'border-praetor bg-zinc-50',
+    inactiveClassName: 'border-zinc-100 hover:border-zinc-200',
+    swatchClassName:
+      'bg-gradient-to-r from-zinc-950 from-50% to-white to-50% border border-zinc-200 shrink-0 shadow-sm flex items-center justify-center text-praetor',
+    inactiveIconClassName: 'fa-solid fa-table-columns text-sm bg-white rounded-full p-1',
+  },
+  praetor: {
+    activeClassName: 'border-praetor bg-praetor/5',
+    inactiveClassName: 'border-zinc-100 hover:border-praetor/20',
+    swatchClassName:
+      'bg-gradient-to-r from-[#20293f] from-50% to-white to-50% border border-zinc-200 shrink-0 shadow-sm flex items-center justify-center text-praetor',
+    inactiveIconClassName: 'fa-solid fa-shield-halved text-sm bg-white rounded-full p-1',
   },
   auto: {
     activeClassName: 'border-praetor bg-zinc-50',
@@ -284,7 +298,7 @@ const UserSettings: React.FC<UserSettingsProps> = ({
             <h3 className="font-semibold text-zinc-800">{t('appearance.title')}</h3>
           </div>
           <div className="p-6">
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
               {THEMES.map((theme) => {
                 const isSelected = currentTheme === theme;
                 const option = THEME_OPTION_META[theme];

--- a/components/UserSettings.tsx
+++ b/components/UserSettings.tsx
@@ -13,6 +13,7 @@ export interface UserSettingsProps {
 }
 
 type LanguagePreference = NonNullable<Settings['language']>;
+type ThemeSwatchVariant = 'auto' | 'praetor' | 'splitSidebar';
 
 const THEME_OPTION_META: Record<
   Theme,
@@ -20,8 +21,8 @@ const THEME_OPTION_META: Record<
     activeClassName: string;
     inactiveClassName: string;
     swatchClassName: string;
-    inactiveIconClassName: string;
-    activeIconClassName?: string;
+    iconClassName?: string;
+    swatchVariant?: ThemeSwatchVariant;
   }
 > = {
   light: {
@@ -29,36 +30,63 @@ const THEME_OPTION_META: Record<
     inactiveClassName: 'border-zinc-100 hover:border-zinc-200',
     swatchClassName:
       'bg-white border border-zinc-200 shrink-0 shadow-sm flex items-center justify-center text-praetor',
-    inactiveIconClassName: 'fa-solid fa-sun text-sm',
+    iconClassName: 'fa-solid fa-sun text-sm',
   },
   dark: {
     activeClassName: 'border-secondary bg-secondary',
     inactiveClassName: 'border-zinc-100 hover:border-secondary',
     swatchClassName: 'bg-zinc-900 shrink-0 shadow-sm flex items-center justify-center text-white',
-    inactiveIconClassName: 'fa-solid fa-moon text-sm',
+    iconClassName: 'fa-solid fa-moon text-sm',
   },
   zebra: {
     activeClassName: 'border-praetor bg-zinc-50',
     inactiveClassName: 'border-zinc-100 hover:border-zinc-200',
     swatchClassName:
-      'bg-gradient-to-r from-zinc-950 from-50% to-white to-50% border border-zinc-200 shrink-0 shadow-sm flex items-center justify-center text-praetor',
-    inactiveIconClassName: 'fa-solid fa-table-columns text-sm bg-white rounded-full p-1',
+      'relative overflow-hidden bg-white border border-zinc-200 shrink-0 shadow-sm flex items-center justify-center',
+    swatchVariant: 'splitSidebar',
   },
   praetor: {
-    activeClassName: 'border-praetor bg-praetor/5',
-    inactiveClassName: 'border-zinc-100 hover:border-praetor/20',
+    activeClassName: 'border-praetor bg-zinc-50',
+    inactiveClassName: 'border-zinc-100 hover:border-zinc-200',
     swatchClassName:
-      'bg-gradient-to-r from-[#20293f] from-50% to-white to-50% border border-zinc-200 shrink-0 shadow-sm flex items-center justify-center text-praetor',
-    inactiveIconClassName: 'fa-solid fa-shield-halved text-sm bg-white rounded-full p-1',
+      'bg-white border border-zinc-200 shrink-0 shadow-sm flex items-center justify-center',
+    swatchVariant: 'praetor',
   },
   auto: {
     activeClassName: 'border-praetor bg-zinc-50',
     inactiveClassName: 'border-zinc-100 hover:border-zinc-200',
     swatchClassName:
-      'bg-gradient-to-br from-white from-50% to-zinc-900 to-50% border border-zinc-200 shrink-0 shadow-sm flex items-center justify-center text-praetor',
-    inactiveIconClassName: 'fa-solid fa-circle-half-stroke text-sm bg-white rounded-full p-1',
-    activeIconClassName: 'fa-solid fa-check text-xs bg-white rounded-full p-1',
+      'relative overflow-hidden bg-white border border-zinc-200 shrink-0 shadow-sm flex items-center justify-center',
+    swatchVariant: 'auto',
   },
+};
+
+const renderThemeSwatchContent = (option: (typeof THEME_OPTION_META)[Theme]) => {
+  if (option.swatchVariant === 'splitSidebar') {
+    return (
+      <>
+        <span className="absolute inset-y-0 left-0 w-[38%] bg-zinc-950" />
+        <span className="absolute top-3 left-[48%] h-1 w-4 rounded-full bg-zinc-300" />
+        <span className="absolute top-5 left-[48%] h-1 w-3 rounded-full bg-zinc-200" />
+      </>
+    );
+  }
+
+  if (option.swatchVariant === 'auto') {
+    return (
+      <>
+        <span className="absolute inset-y-0 left-0 w-1/2 bg-white" />
+        <span className="absolute inset-y-0 right-0 w-1/2 bg-zinc-950" />
+        <span className="absolute inset-2 rounded-full border border-zinc-300" />
+      </>
+    );
+  }
+
+  if (option.swatchVariant === 'praetor') {
+    return <img src="/praetor-favicon.png" alt="" className="size-7 object-contain" />;
+  }
+
+  return <i className={option.iconClassName}></i>;
 };
 
 const UserSettings: React.FC<UserSettingsProps> = ({
@@ -311,14 +339,13 @@ const UserSettings: React.FC<UserSettingsProps> = ({
                       isSelected ? option.activeClassName : option.inactiveClassName
                     }`}
                   >
-                    <div className={`size-10 rounded-full ${option.swatchClassName}`}>
-                      <i
-                        className={
-                          isSelected
-                            ? (option.activeIconClassName ?? 'fa-solid fa-check text-xs')
-                            : option.inactiveIconClassName
-                        }
-                      ></i>
+                    <div className={`relative size-10 rounded-full ${option.swatchClassName}`}>
+                      {renderThemeSwatchContent(option)}
+                      {isSelected && (
+                        <span className="absolute -top-1 -right-1 flex size-4 items-center justify-center rounded-full border-2 border-background bg-secondary text-[8px] text-secondary-foreground shadow-sm">
+                          <i className="fa-solid fa-check"></i>
+                        </span>
+                      )}
                     </div>
                     <div>
                       <h4 className="font-semibold text-zinc-800 mb-1">

--- a/components/UserSettings.tsx
+++ b/components/UserSettings.tsx
@@ -1,6 +1,8 @@
+import { Check, Contrast, type LucideIcon, Moon, Sun, SunMoon } from 'lucide-react';
 import type React from 'react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import praetorFaviconUrl from '../praetor-favicon.png';
 import type { Settings } from '../services/api';
 import { applyLanguagePreference } from '../utils/language';
 import { applyTheme, getTheme, THEMES, type Theme } from '../utils/theme';
@@ -13,7 +15,7 @@ export interface UserSettingsProps {
 }
 
 type LanguagePreference = NonNullable<Settings['language']>;
-type ThemeSwatchVariant = 'auto' | 'praetor' | 'splitSidebar';
+type ThemeSwatchVariant = 'default' | 'praetor';
 
 const THEME_OPTION_META: Record<
   Theme,
@@ -21,72 +23,56 @@ const THEME_OPTION_META: Record<
     activeClassName: string;
     inactiveClassName: string;
     swatchClassName: string;
-    iconClassName?: string;
-    swatchVariant?: ThemeSwatchVariant;
+    Icon?: LucideIcon;
+    swatchVariant: ThemeSwatchVariant;
   }
 > = {
   light: {
     activeClassName: 'border-praetor bg-zinc-50',
     inactiveClassName: 'border-zinc-100 hover:border-zinc-200',
     swatchClassName:
-      'bg-white border border-zinc-200 shrink-0 shadow-sm flex items-center justify-center text-praetor',
-    iconClassName: 'fa-solid fa-sun text-sm',
+      'bg-white border border-zinc-200 shadow-sm flex items-center justify-center text-praetor',
+    Icon: Sun,
+    swatchVariant: 'default',
   },
   dark: {
     activeClassName: 'border-secondary bg-secondary',
     inactiveClassName: 'border-zinc-100 hover:border-secondary',
-    swatchClassName: 'bg-zinc-900 shrink-0 shadow-sm flex items-center justify-center text-white',
-    iconClassName: 'fa-solid fa-moon text-sm',
+    swatchClassName: 'bg-zinc-900 shadow-sm flex items-center justify-center text-white',
+    Icon: Moon,
+    swatchVariant: 'default',
   },
   zebra: {
     activeClassName: 'border-praetor bg-zinc-50',
     inactiveClassName: 'border-zinc-100 hover:border-zinc-200',
     swatchClassName:
-      'relative overflow-hidden bg-white border border-zinc-200 shrink-0 shadow-sm flex items-center justify-center',
-    swatchVariant: 'splitSidebar',
+      'bg-white border border-zinc-200 shadow-sm flex items-center justify-center text-praetor',
+    Icon: Contrast,
+    swatchVariant: 'default',
   },
   praetor: {
     activeClassName: 'border-praetor bg-zinc-50',
     inactiveClassName: 'border-zinc-100 hover:border-zinc-200',
-    swatchClassName:
-      'bg-white border border-zinc-200 shrink-0 shadow-sm flex items-center justify-center',
+    swatchClassName: 'bg-white border border-zinc-200 shadow-sm flex items-center justify-center',
     swatchVariant: 'praetor',
   },
   auto: {
     activeClassName: 'border-praetor bg-zinc-50',
     inactiveClassName: 'border-zinc-100 hover:border-zinc-200',
     swatchClassName:
-      'relative overflow-hidden bg-white border border-zinc-200 shrink-0 shadow-sm flex items-center justify-center',
-    swatchVariant: 'auto',
+      'bg-white border border-zinc-200 shadow-sm flex items-center justify-center text-praetor',
+    Icon: SunMoon,
+    swatchVariant: 'default',
   },
 };
 
 const renderThemeSwatchContent = (option: (typeof THEME_OPTION_META)[Theme]) => {
-  if (option.swatchVariant === 'splitSidebar') {
-    return (
-      <>
-        <span className="absolute inset-y-0 left-0 w-[38%] bg-zinc-950" />
-        <span className="absolute top-3 left-[48%] h-1 w-4 rounded-full bg-zinc-300" />
-        <span className="absolute top-5 left-[48%] h-1 w-3 rounded-full bg-zinc-200" />
-      </>
-    );
-  }
-
-  if (option.swatchVariant === 'auto') {
-    return (
-      <>
-        <span className="absolute inset-y-0 left-0 w-1/2 bg-white" />
-        <span className="absolute inset-y-0 right-0 w-1/2 bg-zinc-950" />
-        <span className="absolute inset-2 rounded-full border border-zinc-300" />
-      </>
-    );
-  }
-
   if (option.swatchVariant === 'praetor') {
-    return <img src="/praetor-favicon.png" alt="" className="size-7 object-contain" />;
+    return <img src={praetorFaviconUrl} alt="" className="size-7 object-contain" />;
   }
 
-  return <i className={option.iconClassName}></i>;
+  const Icon = option.Icon;
+  return Icon ? <Icon aria-hidden="true" className="size-4" strokeWidth={2.25} /> : null;
 };
 
 const UserSettings: React.FC<UserSettingsProps> = ({
@@ -339,11 +325,15 @@ const UserSettings: React.FC<UserSettingsProps> = ({
                       isSelected ? option.activeClassName : option.inactiveClassName
                     }`}
                   >
-                    <div className={`relative size-10 rounded-full ${option.swatchClassName}`}>
-                      {renderThemeSwatchContent(option)}
+                    <div className="relative size-10 shrink-0">
+                      <div
+                        className={`size-10 overflow-hidden rounded-full ${option.swatchClassName}`}
+                      >
+                        {renderThemeSwatchContent(option)}
+                      </div>
                       {isSelected && (
-                        <span className="absolute -top-1 -right-1 flex size-4 items-center justify-center rounded-full border-2 border-background bg-secondary text-[8px] text-secondary-foreground shadow-sm">
-                          <i className="fa-solid fa-check"></i>
+                        <span className="absolute -top-1 -right-1 z-10 flex size-4 items-center justify-center rounded-full border-2 border-background bg-secondary text-secondary-foreground shadow-sm">
+                          <Check aria-hidden="true" className="size-2.5" strokeWidth={3} />
                         </span>
                       )}
                     </div>

--- a/locales/en/settings.json
+++ b/locales/en/settings.json
@@ -26,6 +26,14 @@
       "name": "Dark",
       "description": "Use dark mode for shadcn components."
     },
+    "zebra": {
+      "name": "Zebra",
+      "description": "Use light mode with a dark sidebar."
+    },
+    "praetor": {
+      "name": "Praetor",
+      "description": "Use light mode with a Praetor-colored dark sidebar."
+    },
     "auto": {
       "name": "Auto",
       "description": "Match your browser or operating system color scheme automatically."

--- a/locales/it/settings.json
+++ b/locales/it/settings.json
@@ -26,6 +26,14 @@
       "name": "Scuro",
       "description": "Usa la modalita scura per i componenti shadcn."
     },
+    "zebra": {
+      "name": "Zebra",
+      "description": "Usa la modalita chiara con una barra laterale scura."
+    },
+    "praetor": {
+      "name": "Praetor",
+      "description": "Usa la modalita chiara con una barra laterale scura color Praetor."
+    },
     "auto": {
       "name": "Automatico",
       "description": "Segue automaticamente il tema del browser o del sistema operativo."

--- a/src/index.css
+++ b/src/index.css
@@ -22,7 +22,9 @@
 }
 
 :root,
-[data-shadcn-theme="light"] {
+[data-shadcn-theme="light"],
+[data-shadcn-theme="zebra"],
+[data-shadcn-theme="praetor"] {
   --background: oklch(1 0 0);
   --foreground: oklch(0.141 0.005 285.823);
   --card: oklch(1 0 0);
@@ -145,6 +147,28 @@ input[type="number"] {
   --sidebar-accent: hsl(240 3.7% 15.9%);
   --sidebar-accent-foreground: var(--foreground);
   --sidebar-border: hsl(240 3.7% 15.9%);
+  --sidebar-ring: hsl(217.2 91.2% 59.8%);
+}
+
+[data-shadcn-theme="zebra"] {
+  --sidebar: hsl(240 5.9% 10%);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-primary: hsl(224.3 76.3% 48%);
+  --sidebar-primary-foreground: hsl(0 0% 100%);
+  --sidebar-accent: hsl(240 3.7% 15.9%);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: hsl(240 3.7% 15.9%);
+  --sidebar-ring: hsl(217.2 91.2% 59.8%);
+}
+
+[data-shadcn-theme="praetor"] {
+  --sidebar: #20293f;
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.92 0.004 286.32);
+  --sidebar-primary-foreground: #20293f;
+  --sidebar-accent: #2d3a55;
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: rgb(255 255 255 / 10%);
   --sidebar-ring: hsl(217.2 91.2% 59.8%);
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -305,6 +305,23 @@ input[type="number"] {
   border-color: var(--border);
 }
 
+[data-shadcn-theme="dark"].shadcn-theme-bridge :where(.text-praetor, .hover\:text-praetor:hover) {
+  color: var(--secondary-foreground);
+}
+
+[data-shadcn-theme="dark"].shadcn-theme-bridge :where(.bg-praetor, .hover\:bg-praetor:hover) {
+  background-color: var(--secondary);
+}
+
+[data-shadcn-theme="dark"].shadcn-theme-bridge
+  :where(.border-praetor, .focus\:border-praetor:focus) {
+  border-color: var(--secondary);
+}
+
+[data-shadcn-theme="dark"].shadcn-theme-bridge :where(.focus\:ring-praetor:focus) {
+  --tw-ring-color: var(--secondary);
+}
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);

--- a/test/utils/theme.test.ts
+++ b/test/utils/theme.test.ts
@@ -3,6 +3,7 @@ import {
   applyTheme,
   getBrowserTheme,
   getTheme,
+  THEME_CHANGE_EVENT,
   THEME_MEDIA_QUERY,
   THEME_SCOPE_SELECTOR,
   THEME_STORAGE_KEY,
@@ -59,8 +60,8 @@ const appendThemeScope = () => {
 };
 
 describe('THEMES constant', () => {
-  test('exposes light, dark, and auto themes', () => {
-    expect([...THEMES]).toEqual(['light', 'dark', 'auto']);
+  test('exposes available theme options', () => {
+    expect([...THEMES]).toEqual(['light', 'dark', 'zebra', 'praetor', 'auto']);
   });
 });
 
@@ -140,7 +141,7 @@ describe('applyTheme', () => {
     const scope = appendThemeScope();
     let eventTheme: string | undefined;
     window.addEventListener(
-      'praetor-theme-change',
+      THEME_CHANGE_EVENT,
       (event) => {
         eventTheme = (event as CustomEvent<{ resolvedTheme: string }>).detail.resolvedTheme;
       },
@@ -154,6 +155,24 @@ describe('applyTheme', () => {
     expect(scope.classList.contains('dark')).toBe(true);
     expect(scope.dataset.shadcnTheme).toBe('dark');
     expect(eventTheme).toBe('dark');
+  });
+
+  test('applies zebra as light mode with a dedicated theme token', () => {
+    const scope = appendThemeScope();
+    applyTheme('zebra');
+
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+    expect(scope.classList.contains('dark')).toBe(false);
+    expect(scope.dataset.shadcnTheme).toBe('zebra');
+  });
+
+  test('applies praetor as light mode with a dedicated theme token', () => {
+    const scope = appendThemeScope();
+    applyTheme('praetor');
+
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+    expect(scope.classList.contains('dark')).toBe(false);
+    expect(scope.dataset.shadcnTheme).toBe('praetor');
   });
 
   test('auto resolves to the browser theme', () => {

--- a/utils/theme.ts
+++ b/utils/theme.ts
@@ -1,4 +1,4 @@
-export const THEMES = ['light', 'dark', 'auto'] as const;
+export const THEMES = ['light', 'dark', 'zebra', 'praetor', 'auto'] as const;
 
 export type Theme = (typeof THEMES)[number];
 export type ResolvedTheme = Exclude<Theme, 'auto'>;
@@ -16,7 +16,7 @@ export const THEME_CHANGE_EVENT = THEME_CHANGE_EVENT_NAME;
 let removeAutoThemeListener: (() => void) | undefined;
 
 const isTheme = (value: string | null): value is Theme => {
-  return value === 'light' || value === 'dark' || value === 'auto';
+  return THEMES.includes(value as Theme);
 };
 
 export const getTheme = (): Theme => {


### PR DESCRIPTION
## Summary
- Added two new appearance options: `Zebra` and `Praetor`
- Kept both variants light overall while overriding only sidebar theme tokens
- Updated the settings UI, translations, and theme tests to cover the new options
- Switched dark theme selection styling to the shadcn `secondary` tokens

## Testing
- `bun test test/utils/theme.test.ts`
- `bunx biome check` on the touched files
- `bunx tsc -p tsconfig.json --noEmit`