### PR TITLE
feat: add docs entry to the account menu

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -335,6 +335,7 @@ const Layout: React.FC<LayoutProps> = ({
         navigationLabel={t('workspace')}
         workspaceLabel={t('workspace')}
         settingsLabel={t('menu.settings')}
+        documentationLabel={t('menu.documentation')}
         logoutLabel={t('menu.logout')}
         switchRoleLabel={t('menu.switchRole')}
         version={import.meta.env.VITE_APP_VERSION ?? ''}

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -23,6 +23,7 @@ interface AppSidebarProps extends React.ComponentProps<typeof Sidebar> {
   navigationLabel: string;
   workspaceLabel: string;
   settingsLabel: string;
+  documentationLabel: string;
   logoutLabel: string;
   switchRoleLabel: string;
   version: string;
@@ -39,6 +40,7 @@ export function AppSidebar({
   navigationLabel,
   workspaceLabel,
   settingsLabel,
+  documentationLabel,
   logoutLabel,
   switchRoleLabel,
   version,
@@ -81,9 +83,11 @@ export function AppSidebar({
           roleLabel={roleLabel}
           roles={roles}
           settingsLabel={settingsLabel}
+          documentationLabel={documentationLabel}
           logoutLabel={logoutLabel}
           switchRoleLabel={switchRoleLabel}
           onSettings={() => onViewChange('settings')}
+          onDocumentation={() => onViewChange('docs/frontend')}
           onLogout={onLogout}
           onSwitchRole={onSwitchRole}
         />

--- a/components/nav-user.tsx
+++ b/components/nav-user.tsx
@@ -1,4 +1,4 @@
-import { Check, ChevronsUpDown, LogOut, Settings, ShieldCheck } from 'lucide-react';
+import { BookOpen, Check, ChevronsUpDown, LogOut, Settings, ShieldCheck } from 'lucide-react';
 
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import {
@@ -26,9 +26,11 @@ interface NavUserProps {
   roleLabel: string;
   roles: Role[];
   settingsLabel: string;
+  documentationLabel: string;
   logoutLabel: string;
   switchRoleLabel: string;
   onSettings: () => void;
+  onDocumentation: () => void;
   onLogout: () => void;
   onSwitchRole: (roleId: string) => void;
 }
@@ -76,9 +78,11 @@ export function NavUser({
   roleLabel,
   roles,
   settingsLabel,
+  documentationLabel,
   logoutLabel,
   switchRoleLabel,
   onSettings,
+  onDocumentation,
   onLogout,
   onSwitchRole,
 }: NavUserProps) {
@@ -150,6 +154,15 @@ export function NavUser({
               >
                 <Settings />
                 <span>{settingsLabel}</span>
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onSelect={() => {
+                  onDocumentation();
+                  closeMobileSidebar();
+                }}
+              >
+                <BookOpen />
+                <span>{documentationLabel}</span>
               </DropdownMenuItem>
             </DropdownMenuGroup>
             <DropdownMenuSeparator />

--- a/test/components/Layout.test.tsx
+++ b/test/components/Layout.test.tsx
@@ -254,4 +254,15 @@ describe('<Layout />', () => {
     expect(screen.queryByRole('dialog')).toBeNull();
     isMobileViewport = false;
   });
+
+  test('account dropdown documentation item navigates to frontend docs', async () => {
+    const onViewChange = mock(() => {});
+    const user = userEvent.setup();
+    renderLayout({ onViewChange });
+
+    await user.click(screen.getByRole('button', { name: 'TU Test User roles.manager' }));
+    await user.click(await screen.findByRole('menuitem', { name: 'menu.documentation' }));
+
+    expect(onViewChange).toHaveBeenCalledWith('docs/frontend');
+  });
 });


### PR DESCRIPTION
## Summary
- Adds a Documentation item to the account popup menu in the sidebar
- Routes the action to the frontend docs view (`docs/frontend`)
- Passes the docs label through the layout/sidebar props chain
- Adds a regression test for the new menu action

## Testing
- `bun test test/components/Layout.test.tsx`
- `bun x biome check components/nav-user.tsx components/app-sidebar.tsx components/Layout.tsx test/components/Layout.test.tsx`