### PR TITLE
fix: localize settings page header

### DIFF
--- a/locales/en/layout.json
+++ b/locales/en/layout.json
@@ -36,6 +36,7 @@
     "manage": "Manage",
     "invoices": "Invoices",
     "financialReports": "Financial Reports",
+    "settings": "Settings",
     "authentication": "Authentication",
     "general": "General Settings",
     "email": "Email Settings",

--- a/locales/it/layout.json
+++ b/locales/it/layout.json
@@ -36,6 +36,7 @@
     "manage": "Gestisci",
     "invoices": "Fatture",
     "financialReports": "Report Finanziari",
+    "settings": "Impostazioni",
     "authentication": "Autenticazione",
     "general": "Impostazioni Generali",
     "email": "Impostazioni Email",

--- a/test/i18n/layout.test.ts
+++ b/test/i18n/layout.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from 'bun:test';
+import enLayout from '../../locales/en/layout.json';
+import itLayout from '../../locales/it/layout.json';
+
+describe('layout translations', () => {
+  test('standalone settings route has localized page header text', () => {
+    expect(enLayout.routes.settings).toBe('Settings');
+    expect(itLayout.routes.settings).toBe('Impostazioni');
+  });
+});


### PR DESCRIPTION
## Summary
- Add the missing `routes.settings` entries to the English and Italian layout locale files so the settings page header resolves through i18n.
- Add a regression test that asserts the localized settings header text in both locales.

## Testing
- `bun test ./test/i18n/layout.test.ts`
- `bun run i18n:check`