### PR TITLE
fix: simplify bootstrap admin defaults and add password warning

### DIFF
--- a/components/shared/NotificationBell.tsx
+++ b/components/shared/NotificationBell.tsx
@@ -12,6 +12,9 @@ export interface NotificationBellProps {
   onDelete: (id: string) => void;
 }
 
+const getNotificationIconClass = (type: string) =>
+  type === 'admin_password_warning' ? 'fa-triangle-exclamation' : 'fa-folder-tree';
+
 const NotificationBell: React.FC<NotificationBellProps> = ({
   notifications,
   unreadCount,
@@ -153,7 +156,9 @@ const NotificationBell: React.FC<NotificationBellProps> = ({
                           : 'bg-praetor/10 text-praetor'
                       }`}
                     >
-                      <i className="fa-solid fa-folder-tree text-sm"></i>
+                      <i
+                        className={`fa-solid ${getNotificationIconClass(notification.type)} text-sm`}
+                      ></i>
                     </div>
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-2">

--- a/deploy/.env.customer.example
+++ b/deploy/.env.customer.example
@@ -29,9 +29,5 @@ ENCRYPTION_KEY=change-me-long-random-encryption-key
 # `1` matches the built-in frontend proxy -> backend hop in this deployment.
 TRUST_PROXY=1
 
-# Bootstrap admin password (username is always "admin")
-# Generate with: openssl rand -base64 24
-ADMIN_DEFAULT_PASSWORD=change-me-strong-admin-password
-
 # Optional demo data. Keep false for production.
 DEMO_SEEDING=false

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -17,8 +17,10 @@ Set at least:
 - `POSTGRES_PASSWORD`
 - `JWT_SECRET`
 - `ENCRYPTION_KEY`
-- `ADMIN_DEFAULT_PASSWORD`
 - `FRONTEND_URL`
+
+Fresh installs create the bootstrap admin as `admin` / `password`. Change that password after
+the first login.
 
 ## 2) Authenticate to Registry (if private)
 

--- a/deploy/docker-compose.customer.yml
+++ b/deploy/docker-compose.customer.yml
@@ -32,7 +32,6 @@ services:
       ENCRYPTION_KEY: ${ENCRYPTION_KEY:?ENCRYPTION_KEY is required}
       TRUST_PROXY: ${TRUST_PROXY:-1}
       DEMO_SEEDING: ${DEMO_SEEDING:-false}
-      ADMIN_DEFAULT_PASSWORD: ${ADMIN_DEFAULT_PASSWORD:?ADMIN_DEFAULT_PASSWORD is required}
       FRONTEND_URL: ${FRONTEND_URL:?FRONTEND_URL is required}
     volumes:
       - ssl_certs:/app/certs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,6 @@ services:
       ENCRYPTION_KEY: ${ENCRYPTION_KEY:?ENCRYPTION_KEY is required}
       TRUST_PROXY: ${TRUST_PROXY:-1}
       DEMO_SEEDING: ${DEMO_SEEDING:-false}
-      ADMIN_DEFAULT_PASSWORD: ${ADMIN_DEFAULT_PASSWORD:?ADMIN_DEFAULT_PASSWORD is required}
       FRONTEND_URL: http://${SERVER_IP:-localhost}:3000
     volumes:
       - ssl_certs:/app/certs

--- a/server/db/bootstrapAdmin.ts
+++ b/server/db/bootstrapAdmin.ts
@@ -1,32 +1,42 @@
 import bcrypt from 'bcryptjs';
+import * as notificationsRepo from '../repositories/notificationsRepo.ts';
 import * as usersRepo from '../repositories/usersRepo.ts';
 import { createChildLogger } from '../utils/logger.ts';
 import { generatePrefixedId } from '../utils/order-ids.ts';
-import {
-  INSECURE_DEFAULT_ADMIN_PASSWORDS,
-  readRequiredNonDefaultEnv,
-} from '../utils/runtimeConfig.ts';
 import { query } from './index.ts';
 
 export const ADMIN_USERNAME = 'admin';
 export const DEFAULT_ADMIN_USER_ID = 'u1';
+export const DEFAULT_BOOTSTRAP_ADMIN_PASSWORD = 'password';
 
 const logger = createChildLogger({ module: 'db:bootstrap-admin' });
 
-const resolveBootstrapAdminPassword = () =>
-  readRequiredNonDefaultEnv('ADMIN_DEFAULT_PASSWORD', INSECURE_DEFAULT_ADMIN_PASSWORDS, {
-    missing: 'ADMIN_DEFAULT_PASSWORD must be set before creating the bootstrap admin',
-    defaultValue: 'ADMIN_DEFAULT_PASSWORD must not use the default password',
-  });
+export const syncDefaultAdminPasswordWarning = async (
+  adminId: string,
+  passwordHash: string | null | undefined,
+) => {
+  const usesDefaultPassword =
+    typeof passwordHash === 'string' &&
+    (await bcrypt.compare(DEFAULT_BOOTSTRAP_ADMIN_PASSWORD, passwordHash));
+
+  if (usesDefaultPassword) {
+    await notificationsRepo.upsertAdminPasswordWarning(adminId);
+  } else {
+    await notificationsRepo.deleteAdminPasswordWarning();
+  }
+};
 
 export const ensureBootstrapAdmin = async () => {
-  const existingAdmin = await query('SELECT id FROM users WHERE username = $1 LIMIT 1', [
-    ADMIN_USERNAME,
-  ]);
+  const existingAdmin = await query(
+    'SELECT id, password_hash FROM users WHERE username = $1 LIMIT 1',
+    [ADMIN_USERNAME],
+  );
 
   let adminId: string;
+  let adminPasswordHash: string | null | undefined;
   if (existingAdmin.rows.length > 0) {
     adminId = existingAdmin.rows[0].id as string;
+    adminPasswordHash = existingAdmin.rows[0].password_hash as string | null | undefined;
     logger.info('Bootstrap admin already exists. Skipping admin creation');
   } else {
     const defaultIdCheck = await query('SELECT 1 FROM users WHERE id = $1 LIMIT 1', [
@@ -34,29 +44,25 @@ export const ensureBootstrapAdmin = async () => {
     ]);
     adminId = defaultIdCheck.rows.length === 0 ? DEFAULT_ADMIN_USER_ID : generatePrefixedId('u');
 
-    const adminPassword = resolveBootstrapAdminPassword();
-    const passwordHash = await bcrypt.hash(adminPassword, 12);
+    adminPasswordHash = await bcrypt.hash(DEFAULT_BOOTSTRAP_ADMIN_PASSWORD, 12);
 
     await usersRepo.createUser({
       id: adminId,
       name: 'Admin User',
       username: ADMIN_USERNAME,
-      passwordHash,
+      passwordHash: adminPasswordHash,
       role: 'admin',
       avatarInitials: 'AD',
     });
-    logger.info(
-      {
-        passwordSource: 'ADMIN_DEFAULT_PASSWORD',
-      },
-      'Bootstrap admin created',
-    );
+    logger.info('Bootstrap admin created');
   }
 
   await query('INSERT INTO user_roles (user_id, role_id) VALUES ($1, $2) ON CONFLICT DO NOTHING', [
     adminId,
     'admin',
   ]);
+
+  await syncDefaultAdminPasswordWarning(adminId, adminPasswordHash);
 
   return adminId;
 };

--- a/server/index.ts
+++ b/server/index.ts
@@ -9,7 +9,6 @@ import { runDrizzleMigrations } from './db/migrationsRunner.ts';
 import { verifyDbReadiness } from './db/readiness.ts';
 import { createChildLogger, serializeError } from './utils/logger.ts';
 import {
-  INSECURE_DEFAULT_ADMIN_PASSWORDS,
   INSECURE_DEFAULT_ENCRYPTION_KEYS,
   INSECURE_DEFAULT_JWT_SECRETS,
   validateRequiredNonDefaultEnv,
@@ -34,7 +33,6 @@ const assertSecureRuntimeConfig = () => {
   const errors = [
     validateRequiredNonDefaultEnv('JWT_SECRET', INSECURE_DEFAULT_JWT_SECRETS),
     validateRequiredNonDefaultEnv('ENCRYPTION_KEY', INSECURE_DEFAULT_ENCRYPTION_KEYS),
-    validateRequiredNonDefaultEnv('ADMIN_DEFAULT_PASSWORD', INSECURE_DEFAULT_ADMIN_PASSWORDS),
   ].filter((error): error is string => error !== null);
 
   if (errors.length > 0) {

--- a/server/repositories/notificationsRepo.ts
+++ b/server/repositories/notificationsRepo.ts
@@ -20,6 +20,14 @@ export type Notification = {
   createdAt: number;
 };
 
+export const ADMIN_PASSWORD_WARNING_NOTIFICATION_ID = 'admin-default-password-warning';
+export const ADMIN_PASSWORD_WARNING_TYPE = 'admin_password_warning';
+
+const ADMIN_PASSWORD_WARNING_TITLE = 'Change the default admin password';
+const ADMIN_PASSWORD_WARNING_MESSAGE =
+  'The admin account is still using the default password. Change it from Settings as soon as possible.';
+const adminPasswordWarningData = { reason: 'default_admin_password' };
+
 const mapRow = (row: typeof notifications.$inferSelect): Notification => ({
   id: row.id,
   userId: row.userId,
@@ -86,4 +94,38 @@ export const deleteForUser = async (
     .delete(notifications)
     .where(and(eq(notifications.id, id), eq(notifications.userId, userId)));
   return (result.rowCount ?? 0) > 0;
+};
+
+export const upsertAdminPasswordWarning = async (
+  userId: string,
+  exec: DbExecutor = db,
+): Promise<void> => {
+  const warning = {
+    userId,
+    type: ADMIN_PASSWORD_WARNING_TYPE,
+    title: ADMIN_PASSWORD_WARNING_TITLE,
+    message: ADMIN_PASSWORD_WARNING_MESSAGE,
+    data: adminPasswordWarningData,
+    isRead: false,
+  };
+
+  await exec
+    .insert(notifications)
+    .values({
+      id: ADMIN_PASSWORD_WARNING_NOTIFICATION_ID,
+      ...warning,
+    })
+    .onConflictDoUpdate({
+      target: notifications.id,
+      set: {
+        ...warning,
+        createdAt: sql`CURRENT_TIMESTAMP`,
+      },
+    });
+};
+
+export const deleteAdminPasswordWarning = async (exec: DbExecutor = db): Promise<void> => {
+  await exec
+    .delete(notifications)
+    .where(eq(notifications.id, ADMIN_PASSWORD_WARNING_NOTIFICATION_ID));
 };

--- a/server/routes/settings.ts
+++ b/server/routes/settings.ts
@@ -1,6 +1,7 @@
 import bcrypt from 'bcryptjs';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { authenticateToken } from '../middleware/auth.ts';
+import * as notificationsRepo from '../repositories/notificationsRepo.ts';
 import * as settingsRepo from '../repositories/settingsRepo.ts';
 import * as usersRepo from '../repositories/usersRepo.ts';
 import {
@@ -17,6 +18,9 @@ import {
   optionalNonEmptyString,
   requireNonEmptyString,
 } from '../utils/validation.ts';
+
+const ADMIN_USERNAME = 'admin';
+const DEFAULT_ADMIN_PASSWORD = 'password';
 
 const settingsSchema = {
   type: 'object',
@@ -156,6 +160,13 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const newHash = await bcrypt.hash(newPasswordResult.value, 12);
 
       await usersRepo.updatePasswordHash(request.user.id, newHash);
+      if (request.user.username === ADMIN_USERNAME) {
+        if (newPasswordResult.value === DEFAULT_ADMIN_PASSWORD) {
+          await notificationsRepo.upsertAdminPasswordWarning(request.user.id);
+        } else {
+          await notificationsRepo.deleteAdminPasswordWarning();
+        }
+      }
 
       return { message: 'Password updated successfully' };
     },

--- a/server/test/db/bootstrapAdmin.test.ts
+++ b/server/test/db/bootstrapAdmin.test.ts
@@ -1,0 +1,122 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as realBcrypt from 'bcryptjs';
+import * as realDbIndex from '../../db/index.ts';
+import * as realNotificationsRepo from '../../repositories/notificationsRepo.ts';
+import * as realUsersRepo from '../../repositories/usersRepo.ts';
+
+type BootstrapAdminModule = typeof import('../../db/bootstrapAdmin.ts');
+
+const dbIndexSnap = { ...realDbIndex };
+const usersRepoSnap = { ...realUsersRepo };
+const notificationsRepoSnap = { ...realNotificationsRepo };
+const bcryptSnap = { ...(realBcrypt as Record<string, unknown>) };
+
+const queryMock = mock();
+const createUserMock = mock();
+const upsertAdminPasswordWarningMock = mock();
+const deleteAdminPasswordWarningMock = mock();
+const bcryptHashMock = mock();
+const bcryptCompareMock = mock();
+
+let bootstrapAdmin: BootstrapAdminModule;
+
+beforeAll(async () => {
+  mock.module('../../db/index.ts', () => ({
+    ...dbIndexSnap,
+    query: queryMock,
+  }));
+  mock.module('../../repositories/usersRepo.ts', () => ({
+    ...usersRepoSnap,
+    createUser: createUserMock,
+  }));
+  mock.module('../../repositories/notificationsRepo.ts', () => ({
+    ...notificationsRepoSnap,
+    upsertAdminPasswordWarning: upsertAdminPasswordWarningMock,
+    deleteAdminPasswordWarning: deleteAdminPasswordWarningMock,
+  }));
+  mock.module('bcryptjs', () => ({
+    default: { hash: bcryptHashMock, compare: bcryptCompareMock },
+    hash: bcryptHashMock,
+    compare: bcryptCompareMock,
+  }));
+
+  bootstrapAdmin = await import('../../db/bootstrapAdmin.ts');
+});
+
+afterAll(() => {
+  mock.module('../../db/index.ts', () => dbIndexSnap);
+  mock.module('../../repositories/usersRepo.ts', () => usersRepoSnap);
+  mock.module('../../repositories/notificationsRepo.ts', () => notificationsRepoSnap);
+  mock.module('bcryptjs', () => bcryptSnap);
+});
+
+const allMocks = [
+  queryMock,
+  createUserMock,
+  upsertAdminPasswordWarningMock,
+  deleteAdminPasswordWarningMock,
+  bcryptHashMock,
+  bcryptCompareMock,
+];
+
+beforeEach(() => {
+  for (const mockedFn of allMocks) mockedFn.mockReset();
+  createUserMock.mockResolvedValue(undefined);
+  upsertAdminPasswordWarningMock.mockResolvedValue(undefined);
+  deleteAdminPasswordWarningMock.mockResolvedValue(undefined);
+});
+
+describe('ensureBootstrapAdmin', () => {
+  test('creates a fresh admin with the literal default password', async () => {
+    queryMock
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 });
+    bcryptHashMock.mockResolvedValue('$2a$password-hash');
+    bcryptCompareMock.mockResolvedValue(true);
+
+    const adminId = await bootstrapAdmin.ensureBootstrapAdmin();
+
+    expect(adminId).toBe('u1');
+    expect(bcryptHashMock).toHaveBeenCalledWith('password', 12);
+    expect(createUserMock).toHaveBeenCalledWith({
+      id: 'u1',
+      name: 'Admin User',
+      username: 'admin',
+      passwordHash: '$2a$password-hash',
+      role: 'admin',
+      avatarInitials: 'AD',
+    });
+    expect(upsertAdminPasswordWarningMock).toHaveBeenCalledWith('u1');
+  });
+
+  test('existing admin with default password gets the warning', async () => {
+    queryMock
+      .mockResolvedValueOnce({ rows: [{ id: 'u1', password_hash: '$2a$existing' }] })
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 });
+    bcryptCompareMock.mockResolvedValue(true);
+
+    const adminId = await bootstrapAdmin.ensureBootstrapAdmin();
+
+    expect(adminId).toBe('u1');
+    expect(createUserMock).not.toHaveBeenCalled();
+    expect(bcryptCompareMock).toHaveBeenCalledWith('password', '$2a$existing');
+    expect(upsertAdminPasswordWarningMock).toHaveBeenCalledWith('u1');
+    expect(deleteAdminPasswordWarningMock).not.toHaveBeenCalled();
+  });
+
+  test('existing admin with changed password removes the warning', async () => {
+    queryMock
+      .mockResolvedValueOnce({ rows: [{ id: 'u1', password_hash: '$2a$changed' }] })
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 });
+    bcryptCompareMock.mockResolvedValue(false);
+
+    const adminId = await bootstrapAdmin.ensureBootstrapAdmin();
+
+    expect(adminId).toBe('u1');
+    expect(createUserMock).not.toHaveBeenCalled();
+    expect(bcryptCompareMock).toHaveBeenCalledWith('password', '$2a$changed');
+    expect(upsertAdminPasswordWarningMock).not.toHaveBeenCalled();
+    expect(deleteAdminPasswordWarningMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/test/repositories/notificationsRepo.test.ts
+++ b/server/test/repositories/notificationsRepo.test.ts
@@ -109,3 +109,31 @@ describe('markAllReadForUser', () => {
     expect(exec.calls[0].params).toContain('user-1');
   });
 });
+
+describe('admin password warning helpers', () => {
+  test('upsertAdminPasswordWarning inserts a deterministic unread warning', async () => {
+    exec.enqueue({ rows: [], rowCount: 1 });
+
+    const result = await notificationsRepo.upsertAdminPasswordWarning('admin-1', testDb);
+
+    expect(result).toBeUndefined();
+    expect(exec.calls[0].sql.toLowerCase()).toContain('on conflict');
+    expect(exec.calls[0].params).toContain(
+      notificationsRepo.ADMIN_PASSWORD_WARNING_NOTIFICATION_ID,
+    );
+    expect(exec.calls[0].params).toContain(notificationsRepo.ADMIN_PASSWORD_WARNING_TYPE);
+    expect(exec.calls[0].params).toContain('admin-1');
+    expect(exec.calls[0].params).toContain(false);
+  });
+
+  test('deleteAdminPasswordWarning deletes by deterministic id', async () => {
+    exec.enqueue({ rows: [], rowCount: 1 });
+
+    const result = await notificationsRepo.deleteAdminPasswordWarning(testDb);
+
+    expect(result).toBeUndefined();
+    expect(exec.calls[0].params).toContain(
+      notificationsRepo.ADMIN_PASSWORD_WARNING_NOTIFICATION_ID,
+    );
+  });
+});

--- a/server/test/routes/settings.test.ts
+++ b/server/test/routes/settings.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
 import * as realBcrypt from 'bcryptjs';
 import type { FastifyInstance, FastifyPluginAsync } from 'fastify';
+import * as realNotificationsRepo from '../../repositories/notificationsRepo.ts';
 import * as realRolesRepo from '../../repositories/rolesRepo.ts';
 import * as realSettingsRepo from '../../repositories/settingsRepo.ts';
 import * as realUsersRepo from '../../repositories/usersRepo.ts';
@@ -16,6 +17,7 @@ const usersRepoSnap = { ...realUsersRepo };
 const rolesRepoSnap = { ...realRolesRepo };
 const permissionsSnap = { ...realPermissions };
 const settingsRepoSnap = { ...realSettingsRepo };
+const notificationsRepoSnap = { ...realNotificationsRepo };
 const bcryptSnap = { ...(realBcrypt as Record<string, unknown>) };
 
 const findAuthUserByIdMock = mock();
@@ -25,6 +27,8 @@ const getOrCreateForUserMock = mock();
 const upsertForUserMock = mock();
 const getPasswordHashMock = mock();
 const updatePasswordHashMock = mock();
+const upsertAdminPasswordWarningMock = mock();
+const deleteAdminPasswordWarningMock = mock();
 const bcryptCompareMock = mock();
 const bcryptHashMock = mock();
 
@@ -52,6 +56,11 @@ beforeAll(async () => {
     getOrCreateForUser: getOrCreateForUserMock,
     upsertForUser: upsertForUserMock,
   }));
+  mock.module('../../repositories/notificationsRepo.ts', () => ({
+    ...notificationsRepoSnap,
+    upsertAdminPasswordWarning: upsertAdminPasswordWarningMock,
+    deleteAdminPasswordWarning: deleteAdminPasswordWarningMock,
+  }));
   mock.module('bcryptjs', () => ({
     default: { compare: bcryptCompareMock, hash: bcryptHashMock },
     compare: bcryptCompareMock,
@@ -67,6 +76,7 @@ afterAll(() => {
   mock.module('../../repositories/rolesRepo.ts', () => rolesRepoSnap);
   mock.module('../../utils/permissions.ts', () => permissionsSnap);
   mock.module('../../repositories/settingsRepo.ts', () => settingsRepoSnap);
+  mock.module('../../repositories/notificationsRepo.ts', () => notificationsRepoSnap);
   mock.module('bcryptjs', () => bcryptSnap);
 });
 
@@ -93,6 +103,8 @@ const allMocks = [
   upsertForUserMock,
   getPasswordHashMock,
   updatePasswordHashMock,
+  upsertAdminPasswordWarningMock,
+  deleteAdminPasswordWarningMock,
   bcryptCompareMock,
   bcryptHashMock,
 ];
@@ -104,6 +116,8 @@ beforeEach(async () => {
   findAuthUserByIdMock.mockResolvedValue(HAPPY_USER);
   userHasRoleMock.mockResolvedValue(true);
   getRolePermissionsMock.mockResolvedValue([]);
+  upsertAdminPasswordWarningMock.mockResolvedValue(undefined);
+  deleteAdminPasswordWarningMock.mockResolvedValue(undefined);
 
   testApp = await buildRouteTestApp(routePlugin, '/api/settings');
 });
@@ -240,6 +254,46 @@ describe('PUT /api/settings/password', () => {
     expect(bcryptCompareMock).toHaveBeenCalledWith('old-pw1', '$2a$existing');
     expect(bcryptHashMock).toHaveBeenCalledWith('new-secure-pw', 12);
     expect(updatePasswordHashMock).toHaveBeenCalledWith('u1', '$2a$newhash');
+    expect(upsertAdminPasswordWarningMock).not.toHaveBeenCalled();
+    expect(deleteAdminPasswordWarningMock).not.toHaveBeenCalled();
+  });
+
+  test('200 admin changing away from default password removes warning', async () => {
+    findAuthUserByIdMock.mockResolvedValue({ ...HAPPY_USER, username: 'admin' });
+    getPasswordHashMock.mockResolvedValue('$2a$existing');
+    bcryptCompareMock.mockResolvedValue(true);
+    bcryptHashMock.mockResolvedValue('$2a$newhash');
+    updatePasswordHashMock.mockResolvedValue(undefined);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/settings/password',
+      headers: authHeader(),
+      payload: { currentPassword: 'password', newPassword: 'new-secure-pw' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(deleteAdminPasswordWarningMock).toHaveBeenCalledTimes(1);
+    expect(upsertAdminPasswordWarningMock).not.toHaveBeenCalled();
+  });
+
+  test('200 admin setting password back to default recreates warning', async () => {
+    findAuthUserByIdMock.mockResolvedValue({ ...HAPPY_USER, username: 'admin' });
+    getPasswordHashMock.mockResolvedValue('$2a$existing');
+    bcryptCompareMock.mockResolvedValue(true);
+    bcryptHashMock.mockResolvedValue('$2a$newhash');
+    updatePasswordHashMock.mockResolvedValue(undefined);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/settings/password',
+      headers: authHeader(),
+      payload: { currentPassword: 'new-secure-pw', newPassword: 'password' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(upsertAdminPasswordWarningMock).toHaveBeenCalledWith('u1');
+    expect(deleteAdminPasswordWarningMock).not.toHaveBeenCalled();
   });
 
   test('400 missing currentPassword', async () => {

--- a/server/test/utils/runtimeConfig.test.ts
+++ b/server/test/utils/runtimeConfig.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from 'bun:test';
+import * as runtimeConfig from '../../utils/runtimeConfig.ts';
 import {
   INSECURE_DEFAULT_JWT_SECRETS,
   readRequiredNonDefaultEnv,
@@ -30,5 +31,9 @@ describe('runtimeConfig', () => {
     expect(readRequiredNonDefaultEnv(ENV_NAME, INSECURE_DEFAULT_JWT_SECRETS)).toBe(
       'unique-secret-value',
     );
+  });
+
+  test('does not maintain a separate admin default password denylist', () => {
+    expect('INSECURE_DEFAULT_ADMIN_PASSWORDS' in runtimeConfig).toBe(false);
   });
 });

--- a/server/utils/runtimeConfig.ts
+++ b/server/utils/runtimeConfig.ts
@@ -7,10 +7,6 @@ export const INSECURE_DEFAULT_ENCRYPTION_KEYS = [
   'praetor-encryption-key-change-in-production',
   'change-me-long-random-encryption-key',
 ] as const;
-export const INSECURE_DEFAULT_ADMIN_PASSWORDS = [
-  'password',
-  'change-me-strong-admin-password',
-] as const;
 export const TEST_JWT_SECRET = 'praetor-test-jwt-secret';
 
 type InsecureDefaults = string | readonly string[];

--- a/test/components/NotificationBell.test.tsx
+++ b/test/components/NotificationBell.test.tsx
@@ -87,6 +87,25 @@ describe('<NotificationBell />', () => {
     expect(screen.getByText('A generic notification')).toBeInTheDocument();
   });
 
+  test('admin password warning notifications use the warning icon', () => {
+    const warning: Notification = {
+      id: 'admin-default-password-warning',
+      userId: 'u1',
+      type: 'admin_password_warning',
+      title: 'Change the default admin password',
+      isRead: false,
+      createdAt: NOW,
+    };
+
+    const { container } = render(<NotificationBell {...baseProps} notifications={[warning]} />);
+
+    openDropdown();
+
+    expect(screen.getByText('Change the default admin password')).toBeInTheDocument();
+    expect(container.querySelector('i.fa-triangle-exclamation')).not.toBeNull();
+    expect(container.querySelector('i.fa-folder-tree')).toBeNull();
+  });
+
   test('clicking a single-project notification uses the singular translation key', () => {
     const single: Notification = {
       id: 'n3',


### PR DESCRIPTION
## Summary
- Make bootstrap admin credentials always start as `admin` / `password`.
- Remove `ADMIN_DEFAULT_PASSWORD` from startup validation and deployment env requirements.
- Add a deterministic admin notification warning while that default password is still in use.
- Keep the warning in sync when the admin changes their password.

## Testing
- Added unit coverage for bootstrap admin creation and warning sync.
- Added repository tests for the admin password warning helpers.
- Added settings route tests for removing and recreating the warning on password changes.
- Updated runtime config tests to reflect the removed admin-password denylist.
- `bun test ./test/db ./test/repositories/notificationsRepo.test.ts ./test/routes/settings.test.ts ./test/utils/runtimeConfig.test.ts`
- `bun run lint`