### PR TITLE
fix: route 404 return button to admin authentication settings

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -85,6 +85,8 @@ import { getErrorMessage } from './utils/errors';
 import { isItalianHoliday } from './utils/holidays';
 import {
   buildPermission,
+  getDefaultViewForPermissions,
+  getNotFoundReturnView,
   hasAnyPermission,
   hasPermission,
   VIEW_PERMISSION_MAP,
@@ -774,7 +776,7 @@ const App: React.FC = () => {
     onLogin: (user) => {
       clearAuthScopedAppState();
       setViewingUserId(user.id);
-      const defaultView = getDefaultViewForPermissions(user.permissions || []);
+      const defaultView = getDefaultViewForPermissions(user.permissions || [], VALID_VIEWS);
       const activePermission =
         activeView !== '404' ? VIEW_PERMISSION_MAP[activeView as View] : undefined;
       const canAccessActive = activePermission
@@ -1949,12 +1951,8 @@ const App: React.FC = () => {
     }
   };
 
-  const getDefaultViewForPermissions = (permissions: string[]): View => {
-    const allowedView = VALID_VIEWS.find((view) => {
-      const permission = VIEW_PERMISSION_MAP[view];
-      return permission ? hasPermission(permissions, permission) : false;
-    });
-    return allowedView || 'timesheets/tracker';
+  const handleNotFoundReturn = () => {
+    setActiveView(getNotFoundReturnView(currentUser?.permissions || [], VALID_VIEWS));
   };
 
   const handleSaveLdapConfig = async (config: LdapConfig) => {
@@ -2096,7 +2094,7 @@ const App: React.FC = () => {
         onDeleteNotification={handleDeleteNotification}
       >
         {!isRouteAccessible ? (
-          <NotFound onReturn={() => setActiveView('timesheets/tracker')} />
+          <NotFound onReturn={handleNotFoundReturn} />
         ) : (
           <>
             {activeModuleLoadFailures.length > 0 && (

--- a/test/App.notfound.test.ts
+++ b/test/App.notfound.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'bun:test';
+import type { View } from '../types';
+import { buildPermission, getNotFoundReturnView } from '../utils/permissions';
+
+const validViews: View[] = ['timesheets/tracker', 'administration/authentication', 'crm/clients'];
+
+describe('getNotFoundReturnView', () => {
+  test('returns authentication settings when the user can access admin auth settings', () => {
+    const permissions = [
+      buildPermission('timesheets.tracker', 'view'),
+      buildPermission('administration.authentication', 'view'),
+    ];
+
+    expect(getNotFoundReturnView(permissions, validViews)).toBe('administration/authentication');
+  });
+
+  test('falls back to the first accessible default view without auth settings permission', () => {
+    const permissions = [buildPermission('crm.clients', 'view')];
+
+    expect(getNotFoundReturnView(permissions, validViews)).toBe('crm/clients');
+  });
+});

--- a/utils/permissions.ts
+++ b/utils/permissions.ts
@@ -156,3 +156,28 @@ export const VIEW_PERMISSION_MAP: Record<View, Permission> = {
   'docs/api': buildPermission('docs.api', 'view'),
   'docs/frontend': buildPermission('docs.frontend', 'view'),
 };
+
+export const getDefaultViewForPermissions = (
+  permissions: Permission[] | undefined,
+  validViews: View[],
+): View => {
+  const allowedView = validViews.find((view) =>
+    hasPermission(permissions, VIEW_PERMISSION_MAP[view]),
+  );
+
+  return allowedView || 'timesheets/tracker';
+};
+
+export const getNotFoundReturnView = (
+  permissions: Permission[] | undefined,
+  validViews: View[],
+): View => {
+  const authSettingsView: View = 'administration/authentication';
+  const authSettingsPermission = VIEW_PERMISSION_MAP[authSettingsView];
+
+  if (hasPermission(permissions, authSettingsPermission)) {
+    return authSettingsView;
+  }
+
+  return getDefaultViewForPermissions(permissions, validViews);
+};


### PR DESCRIPTION
## Summary
- Updated the 404 return action so admin users with authentication settings access are sent to `administration/authentication`.
- Kept the existing default-view fallback for users who cannot access admin settings.
- Consolidated the shared permission-based default view lookup in `utils/permissions.ts`.
- Added a focused regression test for the new 404 return routing behavior.

## Testing
- `bun test ./test/App.notfound.test.ts`
- `bun x tsc -p tsconfig.json --noEmit`
- `bun x biome check App.tsx utils/permissions.ts test/App.notfound.test.ts`