### PR TITLE
fix(modal): restore focus when opening shared modals from shadcn menus

### DIFF
--- a/components/shared/CustomViewModal.tsx
+++ b/components/shared/CustomViewModal.tsx
@@ -93,6 +93,7 @@ const CustomViewModal: React.FC<CustomViewModalProps> = ({
             <input
               id="custom-view-name"
               type="text"
+              data-autofocus
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder={t('table.viewNamePlaceholder')}

--- a/components/shared/Modal.tsx
+++ b/components/shared/Modal.tsx
@@ -1,6 +1,7 @@
+import { Dialog as DialogPrimitive } from 'radix-ui';
 import type React from 'react';
-import { useCallback, useEffect } from 'react';
-import { createPortal } from 'react-dom';
+import { useCallback, useEffect, useRef } from 'react';
+import { Dialog, DialogOverlay, DialogPortal, DialogTitle } from '@/components/ui/dialog';
 
 export interface ModalProps {
   isOpen: boolean;
@@ -12,6 +13,18 @@ export interface ModalProps {
   backdropClass?: string;
 }
 
+const AUTOFOCUS_SELECTOR = '[data-autofocus]:not([disabled])';
+
+const FOCUSABLE_SELECTOR = [
+  AUTOFOCUS_SELECTOR,
+  'button:not([disabled])',
+  '[href]',
+  'input:not([disabled]):not([type="hidden"])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
 const Modal: React.FC<ModalProps> = ({
   isOpen,
   onClose,
@@ -21,28 +34,47 @@ const Modal: React.FC<ModalProps> = ({
   closeOnEsc = true,
   backdropClass = 'bg-black/60 backdrop-blur-sm',
 }) => {
-  const handleEscKey = useCallback(
-    (e: KeyboardEvent) => {
-      if (closeOnEsc && e.key === 'Escape') {
-        onClose();
-      }
-    },
-    [onClose, closeOnEsc],
-  );
+  const contentRef = useRef<HTMLDivElement>(null);
+  const focusRunIdRef = useRef(0);
 
   useEffect(() => {
     if (isOpen) {
-      document.addEventListener('keydown', handleEscKey);
       document.body.style.overflow = 'hidden';
     }
 
     return () => {
-      document.removeEventListener('keydown', handleEscKey);
+      focusRunIdRef.current += 1;
       document.body.style.overflow = '';
     };
-  }, [isOpen, handleEscKey]);
+  }, [isOpen]);
 
-  if (!isOpen) return null;
+  const focusModalContentNow = useCallback(() => {
+    const content = contentRef.current;
+    if (!content) return;
+
+    const focusTarget =
+      content.querySelector<HTMLElement>(AUTOFOCUS_SELECTOR) ??
+      content.querySelector<HTMLElement>(FOCUSABLE_SELECTOR) ??
+      content;
+    focusTarget.focus();
+  }, []);
+
+  const focusModalContent = useCallback(() => {
+    const focusRunId = focusRunIdRef.current + 1;
+    focusRunIdRef.current = focusRunId;
+    focusModalContentNow();
+
+    queueMicrotask(() => {
+      if (focusRunId !== focusRunIdRef.current) return;
+      focusModalContentNow();
+    });
+  }, [focusModalContentNow]);
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open) {
+      onClose();
+    }
+  };
 
   const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
     if (closeOnBackdrop && e.target === e.currentTarget) {
@@ -50,15 +82,39 @@ const Modal: React.FC<ModalProps> = ({
     }
   };
 
-  return createPortal(
-    <div
-      className={`fixed inset-0 flex items-center justify-center p-4 ${backdropClass}`}
-      style={{ zIndex }}
-      onClick={handleBackdropClick}
-    >
-      {children}
-    </div>,
-    document.body,
+  return (
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+      <DialogPortal>
+        <DialogOverlay className={backdropClass} style={{ zIndex }} />
+        <DialogPrimitive.Content
+          ref={contentRef}
+          aria-label="Dialog"
+          aria-modal="true"
+          aria-describedby={undefined}
+          className="fixed inset-0 flex items-center justify-center p-4 outline-none"
+          style={{ zIndex: zIndex + 1 }}
+          tabIndex={-1}
+          onClick={handleBackdropClick}
+          onEscapeKeyDown={(e) => {
+            if (!closeOnEsc) {
+              e.preventDefault();
+            }
+          }}
+          onInteractOutside={(e) => {
+            if (!closeOnBackdrop) {
+              e.preventDefault();
+            }
+          }}
+          onOpenAutoFocus={(e) => {
+            e.preventDefault();
+            focusModalContent();
+          }}
+        >
+          <DialogTitle className="sr-only">Dialog</DialogTitle>
+          {children}
+        </DialogPrimitive.Content>
+      </DialogPortal>
+    </Dialog>
   );
 };
 

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,141 @@
+import { XIcon } from 'lucide-react';
+import { Dialog as DialogPrimitive } from 'radix-ui';
+import type * as React from 'react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+}
+
+function DialogTrigger({ ...props }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+}
+
+function DialogPortal({ ...props }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+}
+
+function DialogClose({ ...props }: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        'fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean;
+}) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          'fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  );
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
+      {...props}
+    />
+  );
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<'div'> & {
+  showCloseButton?: boolean;
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close asChild>
+          <Button variant="outline">Close</Button>
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  );
+}
+
+function DialogTitle({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn('text-lg leading-none font-semibold', className)}
+      {...props}
+    />
+  );
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn('text-sm text-muted-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+};

--- a/test/components/Modal.test.tsx
+++ b/test/components/Modal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, mock, test } from 'bun:test';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 const Modal = (await import('../../components/shared/Modal')).default;
 
@@ -20,7 +20,34 @@ describe('<Modal />', () => {
       </Modal>,
     );
     expect(screen.getByTestId('modal-content')).toBeInTheDocument();
+    const dialog = screen.getByRole('dialog');
+    expect(dialog.getAttribute('aria-modal')).toBe('true');
     expect(document.body.style.overflow).toBe('hidden');
+  });
+
+  test('focuses the first focusable child when opened', async () => {
+    render(
+      <Modal isOpen={true} onClose={() => {}}>
+        <div data-testid="modal-content">
+          <input aria-label="Name" />
+        </div>
+      </Modal>,
+    );
+
+    await waitFor(() => expect(screen.getByLabelText('Name')).toHaveFocus());
+  });
+
+  test('prefers data-autofocus over the first focusable child', async () => {
+    render(
+      <Modal isOpen={true} onClose={() => {}}>
+        <div data-testid="modal-content">
+          <button type="button">First</button>
+          <input aria-label="Preferred" data-autofocus />
+        </div>
+      </Modal>,
+    );
+
+    await waitFor(() => expect(screen.getByLabelText('Preferred')).toHaveFocus());
   });
 
   test('clicking the backdrop calls onClose', () => {
@@ -30,7 +57,7 @@ describe('<Modal />', () => {
         <div data-testid="modal-content">Hi</div>
       </Modal>,
     );
-    const backdrop = screen.getByTestId('modal-content').parentElement as HTMLElement;
+    const backdrop = screen.getByRole('dialog');
     fireEvent.click(backdrop);
     expect(onClose).toHaveBeenCalledTimes(1);
   });
@@ -53,7 +80,7 @@ describe('<Modal />', () => {
         <div data-testid="modal-content">Hi</div>
       </Modal>,
     );
-    const backdrop = screen.getByTestId('modal-content').parentElement as HTMLElement;
+    const backdrop = screen.getByRole('dialog');
     fireEvent.click(backdrop);
     expect(onClose).not.toHaveBeenCalled();
   });
@@ -98,7 +125,7 @@ describe('<Modal />', () => {
         <div data-testid="modal-content">Hi</div>
       </Modal>,
     );
-    const backdrop = screen.getByTestId('modal-content').parentElement as HTMLElement;
+    const backdrop = document.body.querySelector('[data-slot="dialog-overlay"]') as HTMLElement;
     expect(backdrop.style.zIndex).toBe('999');
   });
 
@@ -108,7 +135,7 @@ describe('<Modal />', () => {
         <div data-testid="modal-content">Hi</div>
       </Modal>,
     );
-    const backdrop = screen.getByTestId('modal-content').parentElement as HTMLElement;
+    const backdrop = document.body.querySelector('[data-slot="dialog-overlay"]') as HTMLElement;
     expect(backdrop.className).toContain('custom-backdrop');
   });
 

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -1231,6 +1231,18 @@ describe('<StandardTable />', () => {
     expect(activeId).toBe(parsed[0].id);
   });
 
+  test('custom view modal opened from the shadcn columns menu is immediately keyboard-ready', async () => {
+    render(<StandardTable<Row> title="People" data={sampleRows} columns={sampleColumns} />);
+    const user = await openCustomViews();
+    clickMenuItemByText('buttons.add');
+
+    const input = screen.getByPlaceholderText('table.viewNamePlaceholder') as HTMLInputElement;
+    await waitFor(() => expect(input).toHaveFocus());
+
+    await user.keyboard('Keyboard View');
+    expect(input.value).toBe('Keyboard View');
+  });
+
   test('custom view add and import actions render side by side', async () => {
     render(<StandardTable<Row> title="People" data={sampleRows} columns={sampleColumns} />);
     await openCustomViews();


### PR DESCRIPTION
## Summary
- Migrate the shared modal shell to shadcn/Radix Dialog semantics so focus trapping and dismissal behavior work correctly when opened from dropdown menus.
- Add autofocus support for modal content and mark the custom view name field as the intended initial focus target.
- Add regression coverage for modal focus behavior and the StandardTable custom view flow.

## Testing
- `bun test test/components/Modal.test.tsx test/components/StandardTable.test.tsx`
- `bun run test:frontend`
- `bun x tsc -p tsconfig.json --noEmit`
- `bun x biome check` on the touched files