### PR TITLE
refactor(ui): replace custom toggles with shadcn switch

### DIFF
--- a/components/administration/UserManagement.tsx
+++ b/components/administration/UserManagement.tsx
@@ -1102,7 +1102,7 @@ const UserManagement: React.FC<UserManagementProps> = ({
                   <div>
                     <p className="text-sm font-bold text-zinc-700">{t('hr:workforce.disabled')}</p>
                   </div>
-                  <Toggle checked={editIsDisabled} onChange={setEditIsDisabled} color="red" />
+                  <Toggle checked={editIsDisabled} onChange={setEditIsDisabled} />
                 </div>
               )}
             </div>

--- a/components/projects/ProjectsView.tsx
+++ b/components/projects/ProjectsView.tsx
@@ -955,7 +955,6 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
                               setTempIsDisabled(!tempIsDisabled);
                             }
                           }}
-                          color="red"
                           disabled={isClientDisabled}
                         />
                       </div>

--- a/components/projects/TasksView.tsx
+++ b/components/projects/TasksView.tsx
@@ -659,7 +659,6 @@ const TasksView: React.FC<TasksViewProps> = ({
                           setTempIsDisabled(!tempIsDisabled);
                         }
                       }}
-                      color="red"
                       disabled={isInheritedDisabled}
                     />
                   </div>

--- a/components/shared/Toggle.tsx
+++ b/components/shared/Toggle.tsx
@@ -1,4 +1,5 @@
 import type React from 'react';
+import { useId } from 'react';
 import { Switch } from '@/components/ui/switch';
 
 export interface ToggleProps {
@@ -14,12 +15,24 @@ const Toggle: React.FC<ToggleProps> = ({
   partial = false,
   disabled = false,
 }) => {
+  const partialDescriptionId = useId();
+  const isPartial = partial && !checked;
+
   return (
-    <Switch
-      checked={checked || partial}
-      onCheckedChange={() => onChange(!checked)}
-      disabled={disabled}
-    />
+    <>
+      <Switch
+        checked={checked || partial}
+        onCheckedChange={() => onChange(!checked)}
+        disabled={disabled}
+        aria-describedby={isPartial ? partialDescriptionId : undefined}
+        className={isPartial ? 'data-[state=checked]:bg-primary/50' : undefined}
+      />
+      {isPartial && (
+        <span id={partialDescriptionId} className="sr-only">
+          Partially selected
+        </span>
+      )}
+    </>
   );
 };
 

--- a/components/shared/Toggle.tsx
+++ b/components/shared/Toggle.tsx
@@ -1,10 +1,10 @@
 import type React from 'react';
+import { Switch } from '@/components/ui/switch';
 
 export interface ToggleProps {
   checked: boolean;
   onChange: (checked: boolean) => void;
   partial?: boolean;
-  color?: 'praetor' | 'red';
   disabled?: boolean;
 }
 
@@ -12,32 +12,14 @@ const Toggle: React.FC<ToggleProps> = ({
   checked,
   onChange,
   partial = false,
-  color = 'praetor',
   disabled = false,
 }) => {
-  const bgColor = checked
-    ? color === 'red'
-      ? 'bg-red-500'
-      : 'bg-praetor'
-    : partial
-      ? 'bg-praetor/40'
-      : 'bg-zinc-200';
-
   return (
-    <button
-      type="button"
-      onClick={() => onChange(!checked)}
+    <Switch
+      checked={checked || partial}
+      onCheckedChange={() => onChange(!checked)}
       disabled={disabled}
-      className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-praetor focus:ring-offset-2 ${bgColor} ${disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'}`}
-    >
-      <span
-        className={`pointer-events-none size-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out flex items-center justify-center ${
-          checked || partial ? 'translate-x-5' : 'translate-x-0'
-        }`}
-      >
-        {partial && !checked && <span className="w-2.5 h-0.5 bg-praetor/60 rounded-full" />}
-      </span>
-    </button>
+    />
   );
 };
 

--- a/components/ui/switch.tsx
+++ b/components/ui/switch.tsx
@@ -1,0 +1,33 @@
+import { Switch as SwitchPrimitive } from 'radix-ui';
+import type * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+function Switch({
+  className,
+  size = 'default',
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root> & {
+  size?: 'sm' | 'default';
+}) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      data-size={size}
+      className={cn(
+        'peer group/switch inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-[1.15rem] data-[size=default]:w-8 data-[size=sm]:h-3.5 data-[size=sm]:w-6 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-input/80',
+        className,
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          'pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0 dark:data-[state=checked]:bg-primary-foreground dark:data-[state=unchecked]:bg-foreground',
+        )}
+      />
+    </SwitchPrimitive.Root>
+  );
+}
+
+export { Switch };

--- a/test/components/Toggle.test.tsx
+++ b/test/components/Toggle.test.tsx
@@ -46,6 +46,8 @@ describe('<Toggle />', () => {
     render(<Toggle checked={false} onChange={onChange} partial />);
     const switchControl = screen.getByRole('switch');
     expect(switchControl).toHaveAttribute('aria-checked', 'true');
+    expect(switchControl).toHaveAccessibleDescription('Partially selected');
+    expect(switchControl.className).toContain('data-[state=checked]:bg-primary/50');
     fireEvent.click(switchControl);
     expect(onChange).toHaveBeenCalledWith(true);
   });

--- a/test/components/Toggle.test.tsx
+++ b/test/components/Toggle.test.tsx
@@ -4,65 +4,56 @@ import { fireEvent, render, screen } from '@testing-library/react';
 const Toggle = (await import('../../components/shared/Toggle')).default;
 
 describe('<Toggle />', () => {
-  test('renders a button', () => {
+  test('renders a switch', () => {
     render(<Toggle checked={false} onChange={() => {}} />);
-    expect(screen.getByRole('button')).toBeInTheDocument();
+    expect(screen.getByRole('switch')).toBeInTheDocument();
   });
 
   test('clicking the toggle calls onChange with the inverted value (off -> on)', () => {
     const onChange = mock((_v: boolean) => {});
     render(<Toggle checked={false} onChange={onChange} />);
-    fireEvent.click(screen.getByRole('button'));
+    fireEvent.click(screen.getByRole('switch'));
     expect(onChange).toHaveBeenCalledWith(true);
   });
 
   test('clicking the toggle when checked sends false (on -> off)', () => {
     const onChange = mock((_v: boolean) => {});
     render(<Toggle checked={true} onChange={onChange} />);
-    fireEvent.click(screen.getByRole('button'));
+    fireEvent.click(screen.getByRole('switch'));
     expect(onChange).toHaveBeenCalledWith(false);
   });
 
-  test('disabled prop disables the button and adds disabled styles', () => {
+  test('disabled prop disables the switch and keeps shadcn disabled styles', () => {
     render(<Toggle checked={false} onChange={() => {}} disabled />);
-    const btn = screen.getByRole('button') as HTMLButtonElement;
-    expect(btn.disabled).toBe(true);
-    expect(btn.className).toContain('cursor-not-allowed');
-    expect(btn.className).toContain('opacity-50');
+    const switchControl = screen.getByRole('switch') as HTMLButtonElement;
+    expect(switchControl.disabled).toBe(true);
   });
 
-  test('checked state uses praetor background by default', () => {
+  test('checked state is exposed accessibly', () => {
     render(<Toggle checked={true} onChange={() => {}} />);
-    const btn = screen.getByRole('button');
-    expect(btn.className).toContain('bg-praetor');
+    const switchControl = screen.getByRole('switch');
+    expect(switchControl).toHaveAttribute('aria-checked', 'true');
   });
 
-  test('checked + color="red" uses red background', () => {
-    render(<Toggle checked={true} onChange={() => {}} color="red" />);
-    const btn = screen.getByRole('button');
-    expect(btn.className).toContain('bg-red-500');
-  });
-
-  test('unchecked uses slate background', () => {
+  test('unchecked state is exposed accessibly', () => {
     render(<Toggle checked={false} onChange={() => {}} />);
-    const btn = screen.getByRole('button');
-    expect(btn.className).toContain('bg-zinc-200');
+    const switchControl = screen.getByRole('switch');
+    expect(switchControl).toHaveAttribute('aria-checked', 'false');
   });
 
-  test('partial state renders intermediate background and the partial dash indicator', () => {
-    const { container } = render(<Toggle checked={false} onChange={() => {}} partial />);
-    const btn = screen.getByRole('button');
-    expect(btn.className).toContain('bg-praetor/40');
-    const dash = container.querySelector('span > span');
-    expect(dash).not.toBeNull();
-    const knob = container.querySelector('span');
-    expect(knob?.className).toContain('translate-x-5');
+  test('partial state renders as active while preserving the next checked value', () => {
+    const onChange = mock((_v: boolean) => {});
+    render(<Toggle checked={false} onChange={onChange} partial />);
+    const switchControl = screen.getByRole('switch');
+    expect(switchControl).toHaveAttribute('aria-checked', 'true');
+    fireEvent.click(switchControl);
+    expect(onChange).toHaveBeenCalledWith(true);
   });
 
   test('disabled toggle does not fire onChange on click', () => {
     const onChange = mock((_v: boolean) => {});
     render(<Toggle checked={false} onChange={onChange} disabled />);
-    fireEvent.click(screen.getByRole('button'));
+    fireEvent.click(screen.getByRole('switch'));
     expect(onChange).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Replaced the shared custom toggle implementation with the shadcn `Switch` component.
- Removed stale `color="red"` toggle usage from the remaining call sites so the API matches the native shadcn styling.
- Simplified the toggle tests to focus on switch behavior and accessibility instead of internal CSS utility classes.

## Testing
- `bun test test/components/Toggle.test.tsx`
- `bunx biome check` on the touched files
- `bunx tsc -p tsconfig.json`