### PR TITLE
fix: align notification header with popover theme

### DIFF
--- a/components/shared/NotificationBell.tsx
+++ b/components/shared/NotificationBell.tsx
@@ -116,7 +116,7 @@ const NotificationBell: React.FC<NotificationBellProps> = ({
       {isOpen && (
         <div className="absolute right-0 z-50 mt-3 w-80 origin-top-right overflow-hidden rounded-2xl border border-border bg-popover text-popover-foreground shadow-xl animate-in fade-in zoom-in-95 duration-200">
           {/* Header */}
-          <div className="flex items-center justify-between border-b border-border bg-muted/50 px-4 py-3">
+          <div className="flex items-center justify-between border-b border-border bg-popover px-4 py-3">
             <h3 className="text-sm font-semibold text-popover-foreground">
               {t('notifications.title', 'Notifications')}
             </h3>

--- a/test/components/NotificationBell.test.tsx
+++ b/test/components/NotificationBell.test.tsx
@@ -92,6 +92,11 @@ describe('<NotificationBell />', () => {
 
     openDropdown();
 
+    const header = screen.getByText('notifications.title').closest('div');
+    expect(header).not.toBeNull();
+    expect(header).toHaveClass('bg-popover', 'border-border');
+    expect(header?.className).not.toContain('bg-muted/50');
+
     const unreadTitle = screen.getByText('notifications.newProjects');
     const unreadRow = unreadTitle.closest('.group');
     expect(unreadRow).not.toBeNull();


### PR DESCRIPTION
## Summary
- Changed the notification dropdown header to use `bg-popover` so it matches the app’s dark themed surface.
- Added a regression test to ensure the header stays on theme and does not fall back to `bg-muted/50`.

## Testing
- `bun test test/components/NotificationBell.test.tsx`
- `bun run lint` was not fully runnable in this worktree because backend dependencies are missing