### PR TITLE
fix(db): guard historical bootstrap behind Drizzle ledger

### DIFF
--- a/server/db/README.md
+++ b/server/db/README.md
@@ -61,9 +61,12 @@ Use the same pattern for indexes (`CREATE INDEX IF NOT EXISTS`) and tables that 
 ## Applying migrations
 
 The backend applies pending migrations automatically during startup, after it
-has verified PostgreSQL readiness and applied the historical `schema.sql`
-bootstrap. Migration failures are fatal: the backend exits instead of starting
-against a partially upgraded schema.
+has verified PostgreSQL readiness. The historical `schema.sql` bootstrap is
+one-time compatibility support for databases that predate Drizzle tracking:
+startup runs it only when `drizzle.__drizzle_migrations` does not exist yet.
+Once Drizzle's migration ledger exists, startup skips `schema.sql` entirely and
+only applies pending Drizzle migrations. Migration failures are fatal: the
+backend exits instead of starting against a partially upgraded schema.
 
 For a non-Compose local DB, apply migrations manually:
 
@@ -78,12 +81,17 @@ Idempotent: re-running is a no-op if everything's applied. The runner is `db/mig
 
 Bootstrap order for a fresh local DB:
 
-1. Apply `schema.sql` (`psql -f db/schema.sql` or let the backend startup bootstrap do it).
+1. Apply `schema.sql` (`psql -f db/schema.sql` or let the backend startup bootstrap do it before Drizzle's migration ledger exists).
 2. Apply Drizzle migrations. If using Docker Compose, the backend runs them automatically
    before it starts serving requests. Otherwise, from `server/`, run `bun run db:migrate`.
    The migrations are written with `IF NOT EXISTS` guards so they're no-ops on a DB that
    already matches; their rows still land in `__drizzle_migrations` so subsequent migrations
    apply normally.
+
+After the first successful Drizzle migration run, do not re-run `schema.sql` as
+part of upgrades. It contains frozen historical cleanup statements that are safe
+only for the pre-Drizzle bootstrap path; Drizzle migration files are the upgrade
+path from that point forward.
 
 For a Drizzle-only fresh DB (skipping `schema.sql`): every existing migration uses `CREATE TABLE IF NOT EXISTS` and friends, so applying them in order produces a fully-formed schema. This path isn't the production bootstrap, but it's how `db:check` and CI verify the migrations.
 

--- a/server/db/migrationsRunner.ts
+++ b/server/db/migrationsRunner.ts
@@ -47,7 +47,14 @@ const acquireMigrationLock = async (client: PoolClient): Promise<void> => {
   }
 };
 
-export const runDrizzleMigrations = async (): Promise<void> => {
+export const runDrizzleMigrationsWithClient = async (client: PoolClient): Promise<void> => {
+  const db = drizzle(client);
+  await migrate(db, { migrationsFolder });
+};
+
+export const withMigrationLock = async <T>(
+  callback: (client: PoolClient) => Promise<T>,
+): Promise<T> => {
   const pool = new pg.Pool(createDbPoolConfig({ max: 1 }));
   let client: PoolClient | undefined;
   let hasMigrationLock = false;
@@ -73,10 +80,7 @@ export const runDrizzleMigrations = async (): Promise<void> => {
     await acquireMigrationLock(client);
     hasMigrationLock = true;
 
-    const db = drizzle(client);
-    await migrate(db, { migrationsFolder });
-
-    logger.info('Drizzle migrations applied or already up to date');
+    return await callback(client);
   } finally {
     if (client) {
       if (hasMigrationLock) {
@@ -99,4 +103,11 @@ export const runDrizzleMigrations = async (): Promise<void> => {
       logger.warn({ err: serializeError(err) }, 'Failed to close migration database pool');
     }
   }
+};
+
+export const runDrizzleMigrations = async (): Promise<void> => {
+  await withMigrationLock(async (client) => {
+    await runDrizzleMigrationsWithClient(client);
+    logger.info('Drizzle migrations applied or already up to date');
+  });
 };

--- a/server/db/startup.ts
+++ b/server/db/startup.ts
@@ -1,0 +1,82 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { PoolClient, QueryResult, QueryResultRow } from 'pg';
+import { createChildLogger } from '../utils/logger.ts';
+import { runDrizzleMigrationsWithClient, withMigrationLock } from './migrationsRunner.ts';
+import { type DbReadinessResult, verifyDbReadiness } from './readiness.ts';
+
+const logger = createChildLogger({ module: 'db-startup' });
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const defaultSchemaPath = join(__dirname, 'schema.sql');
+const DRIZZLE_MIGRATION_LEDGER = 'drizzle.__drizzle_migrations';
+
+type QueryableClient = {
+  query: <T extends QueryResultRow = QueryResultRow>(
+    text: string,
+    params?: unknown[],
+  ) => Promise<QueryResult<T>>;
+};
+
+type StartupLogger = {
+  info: (message: string) => void;
+};
+
+export type PrepareDatabaseForStartupOptions = {
+  schemaPath?: string;
+  logger?: StartupLogger;
+  withLock?: <T>(callback: (client: PoolClient) => Promise<T>) => Promise<T>;
+  runMigrations?: (client: PoolClient) => Promise<void>;
+  verifyReadiness?: () => Promise<DbReadinessResult>;
+  readSchemaSql?: (path: string) => string;
+};
+
+type LedgerExistsRow = {
+  exists: boolean;
+};
+
+export const hasDrizzleMigrationLedger = async (client: QueryableClient): Promise<boolean> => {
+  const result = await client.query<LedgerExistsRow>(
+    'SELECT to_regclass($1) IS NOT NULL AS "exists"',
+    [DRIZZLE_MIGRATION_LEDGER],
+  );
+
+  return result.rows[0]?.exists === true;
+};
+
+const readHistoricalSchemaSql = (schemaPath: string): string => {
+  if (!existsSync(schemaPath)) {
+    throw new Error(`Schema file not found at ${schemaPath}`);
+  }
+
+  return readFileSync(schemaPath, 'utf8');
+};
+
+export const prepareDatabaseForStartup = async (
+  options: PrepareDatabaseForStartupOptions = {},
+): Promise<DbReadinessResult> => {
+  const schemaPath = options.schemaPath ?? defaultSchemaPath;
+  const startupLogger = options.logger ?? logger;
+  const runWithLock = options.withLock ?? withMigrationLock;
+  const runMigrations = options.runMigrations ?? runDrizzleMigrationsWithClient;
+  const checkReadiness = options.verifyReadiness ?? verifyDbReadiness;
+  const readSchemaSql = options.readSchemaSql ?? readHistoricalSchemaSql;
+
+  return runWithLock(async (client) => {
+    const ledgerExists = await hasDrizzleMigrationLedger(client);
+
+    if (ledgerExists) {
+      startupLogger.info('Historical schema bootstrap skipped; Drizzle migration ledger exists');
+    } else {
+      const schemaSql = readSchemaSql(schemaPath);
+      await client.query(schemaSql);
+      startupLogger.info('Historical schema bootstrap applied');
+    }
+
+    await runMigrations(client);
+    startupLogger.info('Drizzle migrations applied or already up to date');
+
+    return checkReadiness();
+  });
+};

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,12 +1,8 @@
-import { existsSync, readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import buildApp from './app.ts';
 import { ensureBootstrapAdmin } from './db/bootstrapAdmin.ts';
 import { runDemoSeedRefresh } from './db/demoSeed.ts';
 import { query } from './db/index.ts';
-import { runDrizzleMigrations } from './db/migrationsRunner.ts';
-import { verifyDbReadiness } from './db/readiness.ts';
+import { prepareDatabaseForStartup } from './db/startup.ts';
 import { createChildLogger, serializeError } from './utils/logger.ts';
 import {
   INSECURE_DEFAULT_ENCRYPTION_KEYS,
@@ -16,9 +12,6 @@ import {
 
 const PORT = Number(process.env.PORT ?? 3001);
 const logger = createChildLogger({ module: 'startup' });
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-const schemaPath = join(__dirname, 'db', 'schema.sql');
 
 const fastify = await buildApp();
 
@@ -38,16 +31,6 @@ const assertSecureRuntimeConfig = () => {
   if (errors.length > 0) {
     throw new Error(errors.join(' '));
   }
-};
-
-const applyHistoricalSchemaBootstrap = async () => {
-  if (!existsSync(schemaPath)) {
-    throw new Error(`Schema file not found at ${schemaPath}`);
-  }
-
-  const schemaSql = readFileSync(schemaPath, 'utf8');
-  await query(schemaSql);
-  logger.info('Historical schema bootstrap applied');
 };
 
 const shutdown = async (signal: string) => {
@@ -87,9 +70,7 @@ try {
   }
   if (dbReady) logger.info('PostgreSQL ready');
 
-  await applyHistoricalSchemaBootstrap();
-  await runDrizzleMigrations();
-  const readiness = await verifyDbReadiness();
+  const readiness = await prepareDatabaseForStartup();
   logger.info(
     {
       appliedMigrations: readiness.appliedMigrations,

--- a/server/package.json
+++ b/server/package.json
@@ -2,11 +2,11 @@
   "name": "praetor-server",
   "version": "0.6.0",
   "description": "Praetor API Server",
-  "main": "dist/index.ts",
+  "main": "index.ts",
   "type": "module",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "start": "bun run dist/index.js",
+    "start": "bun run index.ts",
     "dev": "bun --watch index.ts",
     "test:integration": "bun test ./test/integration",
     "seed:demo": "bun run scripts/seed-demo.ts",

--- a/server/test/db/startup.test.ts
+++ b/server/test/db/startup.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, test } from 'bun:test';
+import type { PoolClient, QueryResult, QueryResultRow } from 'pg';
+import { hasDrizzleMigrationLedger, prepareDatabaseForStartup } from '../../db/startup.ts';
+
+type FakeClient = {
+  calls: string[];
+  query: <T extends QueryResultRow = QueryResultRow>(
+    text: string,
+    params?: unknown[],
+  ) => Promise<QueryResult<T>>;
+};
+
+const makeQueryResult = <T extends QueryResultRow>(rows: T[]): QueryResult<T> => ({
+  rows,
+  rowCount: rows.length,
+  command: '',
+  oid: 0,
+  fields: [],
+});
+
+const makeClient = (ledgerExists: boolean): FakeClient => {
+  const calls: string[] = [];
+
+  return {
+    calls,
+    async query<T extends QueryResultRow = QueryResultRow>(
+      text: string,
+      params: unknown[] = [],
+    ): Promise<QueryResult<T>> {
+      calls.push(`${text} ${JSON.stringify(params)}`);
+
+      if (text.includes('to_regclass')) {
+        return makeQueryResult([{ exists: ledgerExists } as unknown as T]);
+      }
+
+      return makeQueryResult<T>([]);
+    },
+  };
+};
+
+describe('hasDrizzleMigrationLedger', () => {
+  test('checks for the Drizzle ledger table by regclass', async () => {
+    const client = makeClient(true);
+
+    await expect(hasDrizzleMigrationLedger(client)).resolves.toBe(true);
+
+    expect(client.calls).toEqual([
+      'SELECT to_regclass($1) IS NOT NULL AS "exists" ["drizzle.__drizzle_migrations"]',
+    ]);
+  });
+});
+
+describe('prepareDatabaseForStartup', () => {
+  test('skips historical schema bootstrap when the Drizzle ledger exists', async () => {
+    const events: string[] = [];
+    const client = makeClient(true);
+
+    const result = await prepareDatabaseForStartup({
+      withLock: async (callback) => {
+        events.push('lock');
+        try {
+          return await callback(client as unknown as PoolClient);
+        } finally {
+          events.push('unlock');
+        }
+      },
+      readSchemaSql: () => {
+        events.push('read-schema');
+        return 'schema sql';
+      },
+      runMigrations: async () => {
+        events.push('migrate');
+      },
+      verifyReadiness: async () => {
+        events.push('readiness');
+        return { appliedMigrations: 1, expectedMigrations: 1, probedTables: ['users'] };
+      },
+      logger: {
+        info: (message: string) => events.push(`log:${message}`),
+      },
+    });
+
+    expect(result).toEqual({
+      appliedMigrations: 1,
+      expectedMigrations: 1,
+      probedTables: ['users'],
+    });
+    expect(events).toEqual([
+      'lock',
+      'log:Historical schema bootstrap skipped; Drizzle migration ledger exists',
+      'migrate',
+      'log:Drizzle migrations applied or already up to date',
+      'readiness',
+      'unlock',
+    ]);
+    expect(client.calls).toEqual([
+      'SELECT to_regclass($1) IS NOT NULL AS "exists" ["drizzle.__drizzle_migrations"]',
+    ]);
+  });
+
+  test('applies historical schema before migrations when the Drizzle ledger is missing', async () => {
+    const events: string[] = [];
+    const client = makeClient(false);
+
+    await prepareDatabaseForStartup({
+      withLock: async (callback) => {
+        events.push('lock');
+        try {
+          return await callback(client as unknown as PoolClient);
+        } finally {
+          events.push('unlock');
+        }
+      },
+      readSchemaSql: () => {
+        events.push('read-schema');
+        return 'CREATE TABLE historical();';
+      },
+      runMigrations: async () => {
+        events.push('migrate');
+      },
+      verifyReadiness: async () => {
+        events.push('readiness');
+        return { appliedMigrations: 1, expectedMigrations: 1, probedTables: [] };
+      },
+      logger: {
+        info: (message: string) => events.push(`log:${message}`),
+      },
+    });
+
+    expect(events).toEqual([
+      'lock',
+      'read-schema',
+      'log:Historical schema bootstrap applied',
+      'migrate',
+      'log:Drizzle migrations applied or already up to date',
+      'readiness',
+      'unlock',
+    ]);
+    expect(client.calls).toEqual([
+      'SELECT to_regclass($1) IS NOT NULL AS "exists" ["drizzle.__drizzle_migrations"]',
+      'CREATE TABLE historical(); []',
+    ]);
+  });
+
+  test('keeps bootstrap and migrations inside the advisory lock boundary', async () => {
+    const events: string[] = [];
+    const client = makeClient(false);
+
+    await prepareDatabaseForStartup({
+      withLock: async (callback) => {
+        events.push('lock');
+        const result = await callback(client as unknown as PoolClient);
+        events.push('unlock');
+        return result;
+      },
+      readSchemaSql: () => {
+        events.push('read-schema');
+        return 'schema sql';
+      },
+      runMigrations: async () => {
+        events.push('migrate');
+      },
+      verifyReadiness: async () => {
+        events.push('readiness');
+        return { appliedMigrations: 1, expectedMigrations: 1, probedTables: [] };
+      },
+      logger: { info: () => undefined },
+    });
+
+    expect(events).toEqual(['lock', 'read-schema', 'migrate', 'readiness', 'unlock']);
+  });
+
+  test('releases the lock when startup preparation fails', async () => {
+    const events: string[] = [];
+    const client = makeClient(true);
+
+    await expect(
+      prepareDatabaseForStartup({
+        withLock: async (callback) => {
+          events.push('lock');
+          try {
+            return await callback(client as unknown as PoolClient);
+          } finally {
+            events.push('unlock');
+          }
+        },
+        runMigrations: async () => {
+          events.push('migrate');
+          throw new Error('migration failed');
+        },
+        verifyReadiness: async () => {
+          events.push('readiness');
+          return { appliedMigrations: 1, expectedMigrations: 1, probedTables: [] };
+        },
+        logger: { info: () => undefined },
+      }),
+    ).rejects.toThrow('migration failed');
+
+    expect(events).toEqual(['lock', 'migrate', 'unlock']);
+  });
+});


### PR DESCRIPTION
## Summary
- Move startup DB preparation into a testable helper that checks for `drizzle.__drizzle_migrations` before running `schema.sql`
- Keep the advisory lock around both historical bootstrap and Drizzle migration execution
- Align server startup scripts with Bun runtime output and document the new bootstrap behavior

## Testing
- Added unit tests for ledger detection, bootstrap ordering, lock scope, and lock release on failure
- `bun test ./test/db` passed
- `bun test ./test` passed
- `bun run db:check` passed
- `bun run lint` passed