### PR TITLE
fix: Ease Fastify rate limiting defaults

### DIFF
--- a/server/test/utils/rate-limit.test.ts
+++ b/server/test/utils/rate-limit.test.ts
@@ -7,21 +7,21 @@ import {
 
 describe('GLOBAL_RATE_LIMIT', () => {
   test('has the documented max and timeWindow', () => {
-    expect(GLOBAL_RATE_LIMIT.max).toBe(1000);
+    expect(GLOBAL_RATE_LIMIT.max).toBe(3000);
     expect(GLOBAL_RATE_LIMIT.timeWindow).toBe('1 minute');
   });
 });
 
 describe('STANDARD_ROUTE_RATE_LIMIT', () => {
   test('has the documented max and timeWindow', () => {
-    expect(STANDARD_ROUTE_RATE_LIMIT.max).toBe(120);
+    expect(STANDARD_ROUTE_RATE_LIMIT.max).toBe(600);
     expect(STANDARD_ROUTE_RATE_LIMIT.timeWindow).toBe('1 minute');
   });
 });
 
 describe('LOGIN_RATE_LIMIT', () => {
   test('has the documented max and timeWindow', () => {
-    expect(LOGIN_RATE_LIMIT.max).toBe(10);
+    expect(LOGIN_RATE_LIMIT.max).toBe(30);
     expect(LOGIN_RATE_LIMIT.timeWindow).toBe('15 minutes');
   });
 });

--- a/server/utils/rate-limit.ts
+++ b/server/utils/rate-limit.ts
@@ -1,14 +1,14 @@
 export const GLOBAL_RATE_LIMIT = {
-  max: 1000,
+  max: 3000,
   timeWindow: '1 minute',
 } as const;
 
 export const STANDARD_ROUTE_RATE_LIMIT = {
-  max: 120,
+  max: 600,
   timeWindow: '1 minute',
 } as const;
 
 export const LOGIN_RATE_LIMIT = {
-  max: 10,
+  max: 30,
   timeWindow: '15 minutes',
 } as const;


### PR DESCRIPTION
## Summary
- Relaxed the centralized Fastify rate-limit thresholds so normal ERP usage is less likely to hit `429 Too many requests`.
- Updated the shared constants for global traffic, standard authenticated routes, and login/SSO attempts.
- Kept the existing rate-limit architecture unchanged.

## Testing
- Updated the rate-limit unit tests to assert the new limits.
- Verified the focused Bun test suite for `server/test/utils/rate-limit.test.ts` passes.