### PR TITLE
feat: animate copy buttons into success checkmarks

### DIFF
--- a/components/UserSettings.tsx
+++ b/components/UserSettings.tsx
@@ -1,4 +1,4 @@
-import { Check, Contrast, Copy, type LucideIcon, Moon, Sun, SunMoon, Trash2 } from 'lucide-react';
+import { Check, Contrast, type LucideIcon, Moon, Sun, SunMoon, Trash2 } from 'lucide-react';
 import type React from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -22,6 +22,7 @@ import type { CreatedMcpToken, McpToken, Settings } from '../services/api';
 import { writeTextToClipboard } from '../utils/clipboard';
 import { applyLanguagePreference } from '../utils/language';
 import { applyTheme, getTheme, THEMES, type Theme } from '../utils/theme';
+import { AnimatedCopyIcon } from './shared/AnimatedCopyIcon';
 
 export interface UserSettingsProps {
   settings: Settings;
@@ -35,6 +36,9 @@ export interface UserSettingsProps {
 
 type LanguagePreference = NonNullable<Settings['language']>;
 type ThemeSwatchVariant = 'default' | 'praetor';
+type McpCopyTarget = 'endpoint-url' | 'setup-prompt' | 'raw-token';
+
+const COPIED_FEEDBACK_DURATION_MS = 1500;
 
 const THEME_OPTION_META: Record<
   Theme,
@@ -159,6 +163,8 @@ const UserSettings: React.FC<UserSettingsProps> = ({
   const [isLoadingMcpTokens, setIsLoadingMcpTokens] = useState(false);
   const [isCreatingMcpToken, setIsCreatingMcpToken] = useState(false);
   const [revokingMcpTokenId, setRevokingMcpTokenId] = useState<string | null>(null);
+  const [copiedMcpTarget, setCopiedMcpTarget] = useState<McpCopyTarget | null>(null);
+  const copiedMcpTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const mcpEndpointUrl = useMemo(getMcpEndpointUrl, []);
   const mcpSetupPrompt = useMemo(
     () =>
@@ -185,6 +191,13 @@ const UserSettings: React.FC<UserSettingsProps> = ({
   useEffect(() => {
     tRef.current = t;
   }, [t]);
+
+  useEffect(
+    () => () => {
+      if (copiedMcpTimeoutRef.current) clearTimeout(copiedMcpTimeoutRef.current);
+    },
+    [],
+  );
 
   const handleThemeChange = (theme: Theme) => {
     if (theme === currentTheme) return;
@@ -302,17 +315,16 @@ const UserSettings: React.FC<UserSettingsProps> = ({
     }
   };
 
-  const copyRawMcpToken = async () => {
-    if (!rawMcpToken) return;
-    await writeTextToClipboard(rawMcpToken);
-  };
+  const copyMcpValue = async (target: McpCopyTarget, value: string) => {
+    if (!value) return;
+    const didCopy = await writeTextToClipboard(value);
+    if (!didCopy) return;
 
-  const copyMcpEndpointUrl = async () => {
-    await writeTextToClipboard(mcpEndpointUrl);
-  };
-
-  const copyMcpSetupPrompt = async () => {
-    await writeTextToClipboard(mcpSetupPrompt);
+    setCopiedMcpTarget(target);
+    if (copiedMcpTimeoutRef.current) clearTimeout(copiedMcpTimeoutRef.current);
+    copiedMcpTimeoutRef.current = setTimeout(() => {
+      setCopiedMcpTarget((currentTarget) => (currentTarget === target ? null : currentTarget));
+    }, COPIED_FEEDBACK_DURATION_MS);
   };
 
   const hasChanges =
@@ -687,8 +699,12 @@ const UserSettings: React.FC<UserSettingsProps> = ({
               <FieldLabel htmlFor="mcp-endpoint-url">{t('mcp.urlLabel')}</FieldLabel>
               <div className="grid grid-cols-1 gap-2 sm:grid-cols-[1fr_auto]">
                 <Input id="mcp-endpoint-url" readOnly value={mcpEndpointUrl} />
-                <Button type="button" variant="outline" onClick={copyMcpEndpointUrl}>
-                  <Copy aria-hidden="true" className="size-4" />
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => void copyMcpValue('endpoint-url', mcpEndpointUrl)}
+                >
+                  <AnimatedCopyIcon copied={copiedMcpTarget === 'endpoint-url'} />
                   {t('mcp.copyUrl')}
                 </Button>
               </div>
@@ -704,8 +720,12 @@ const UserSettings: React.FC<UserSettingsProps> = ({
                 className="min-h-44 resize-y font-mono text-xs"
               />
               <div className="flex justify-end">
-                <Button type="button" variant="outline" onClick={copyMcpSetupPrompt}>
-                  <Copy aria-hidden="true" className="size-4" />
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => void copyMcpValue('setup-prompt', mcpSetupPrompt)}
+                >
+                  <AnimatedCopyIcon copied={copiedMcpTarget === 'setup-prompt'} />
                   {t('mcp.copyPrompt')}
                 </Button>
               </div>
@@ -754,12 +774,15 @@ const UserSettings: React.FC<UserSettingsProps> = ({
                   </div>
                   <Button
                     type="button"
-                    onClick={copyRawMcpToken}
+                    onClick={() => void copyMcpValue('raw-token', rawMcpToken)}
                     variant="outline"
                     size="sm"
                     className="shrink-0"
                   >
-                    <Copy aria-hidden="true" className="size-3.5" />
+                    <AnimatedCopyIcon
+                      copied={copiedMcpTarget === 'raw-token'}
+                      className="size-3.5"
+                    />
                     {t('mcp.copy')}
                   </Button>
                 </div>

--- a/components/reports/AiReportingView.tsx
+++ b/components/reports/AiReportingView.tsx
@@ -9,6 +9,7 @@ import api from '../../services/api';
 import type { ReportChatMessage, ReportChatSessionSummary } from '../../types';
 import { writeTextToClipboard } from '../../utils/clipboard';
 import { buildPermission, hasPermission } from '../../utils/permissions';
+import { AnimatedCopyIcon } from '../shared/AnimatedCopyIcon';
 import Modal from '../shared/Modal';
 import SelectControl from '../shared/SelectControl';
 import StatusBadge from '../shared/StatusBadge';
@@ -1455,12 +1456,10 @@ const AiReportingView: React.FC<AiReportingViewProps> = ({
                                         }
                                         className="p-1.5 rounded-lg text-zinc-400 hover:text-zinc-600 hover:bg-zinc-100 transition-all"
                                       >
-                                        <i
-                                          className={
-                                            copiedMessageId === userMessage.id
-                                              ? 'fa-solid fa-check text-green-500'
-                                              : 'fa-regular fa-copy'
-                                          }
+                                        <AnimatedCopyIcon
+                                          copied={copiedMessageId === userMessage.id}
+                                          className="size-4"
+                                          copiedClassName="text-green-500"
                                         />
                                       </button>
                                     </span>
@@ -1643,12 +1642,10 @@ const AiReportingView: React.FC<AiReportingViewProps> = ({
                                             defaultValue: 'Copy table',
                                           })}
                                         >
-                                          <i
-                                            className={
-                                              copied
-                                                ? 'fa-solid fa-check text-green-500'
-                                                : 'fa-regular fa-copy'
-                                            }
+                                          <AnimatedCopyIcon
+                                            copied={copied}
+                                            className="size-3.5"
+                                            copiedClassName="text-green-500"
                                           />
                                         </button>
                                       </div>
@@ -1737,12 +1734,10 @@ const AiReportingView: React.FC<AiReportingViewProps> = ({
                                         defaultValue: 'Copy',
                                       })}
                                     >
-                                      <i
-                                        className={
-                                          copiedMessageId === assistantMessage.id
-                                            ? 'fa-solid fa-check text-green-500'
-                                            : 'fa-regular fa-copy'
-                                        }
+                                      <AnimatedCopyIcon
+                                        copied={copiedMessageId === assistantMessage.id}
+                                        className="size-4"
+                                        copiedClassName="text-green-500"
                                       />
                                     </button>
                                   </span>

--- a/components/shared/AnimatedCopyIcon.tsx
+++ b/components/shared/AnimatedCopyIcon.tsx
@@ -1,0 +1,31 @@
+import { Check, Copy } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+interface AnimatedCopyIconProps {
+  copied: boolean;
+  className?: string;
+  copiedClassName?: string;
+}
+
+const iconTransition =
+  'absolute inset-0 h-full w-full transition-[opacity,transform] duration-200 ease-out';
+
+const visibleState = 'scale-100 rotate-0 opacity-100';
+const hiddenCopyState = 'scale-75 -rotate-12 opacity-0';
+const hiddenCheckState = 'scale-75 rotate-12 opacity-0';
+
+export const AnimatedCopyIcon = ({ copied, className, copiedClassName }: AnimatedCopyIconProps) => (
+  <span className={cn('relative inline-flex size-4 shrink-0', className)} aria-hidden="true">
+    <Copy
+      data-copy-feedback-icon="copy"
+      data-visible={!copied}
+      className={cn(iconTransition, copied ? hiddenCopyState : visibleState)}
+    />
+    <Check
+      data-copy-feedback-icon="check"
+      data-visible={copied}
+      className={cn(iconTransition, copied ? visibleState : hiddenCheckState, copiedClassName)}
+    />
+  </span>
+);

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -52,6 +52,7 @@ import { Input } from '../ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table';
 import { Textarea } from '../ui/textarea';
+import { AnimatedCopyIcon } from './AnimatedCopyIcon';
 import CustomViewModal from './CustomViewModal';
 import {
   type CustomView,
@@ -1567,10 +1568,11 @@ const StandardTable = <T extends object>({
                                     }}
                                     className="size-7 justify-center p-0"
                                   >
-                                    <i
-                                      className={`fa-solid ${isCopied ? 'fa-check' : 'fa-copy'} text-[10px]`}
-                                      aria-hidden="true"
-                                    ></i>
+                                    <AnimatedCopyIcon
+                                      copied={isCopied}
+                                      className="size-3"
+                                      copiedClassName="text-emerald-600"
+                                    />
                                   </DropdownMenuItem>
                                   <DropdownMenuItem
                                     aria-label={t('table.deleteView')}

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -1419,6 +1419,39 @@ describe('<StandardTable />', () => {
     expect(payload.hiddenColIds).toEqual(['age']);
     expect(payload.sortState).toEqual({ colId: 'name', px: 'asc' });
     expect(payload.filterState).toEqual({ name: ['Alice'] });
+    expect(screen.getByLabelText('table.viewCopied')).toBeInTheDocument();
+    expect(
+      screen
+        .getByLabelText('table.viewCopied')
+        .querySelector('[data-copy-feedback-icon="check"][data-visible="true"]'),
+    ).toBeTruthy();
+  });
+
+  test('does not show saved view copy feedback when clipboard export fails', async () => {
+    writeClipboardSpy.mockResolvedValueOnce(false);
+    const seeded = [
+      {
+        id: 'vexp-fail',
+        name: 'Exportable',
+        hiddenColIds: ['age'],
+        sortState: { colId: 'name', px: 'asc' },
+        filterState: { name: ['Alice'] },
+      },
+    ];
+    localStorage.setItem('praetor_table_customviews_exportfailtest', JSON.stringify(seeded));
+
+    render(<StandardTable<Row> title="ExportFailTest" data={sampleRows} columns={sampleColumns} />);
+    await openCustomViews();
+
+    const exportBtns = screen.getAllByLabelText('table.exportView');
+    await act(async () => {
+      fireEvent.click(exportBtns[0].closest('[role="menuitem"]') ?? exportBtns[0]);
+      await Promise.resolve();
+    });
+
+    expect(writeClipboardSpy).toHaveBeenCalled();
+    expect(screen.queryByLabelText('table.viewCopied')).not.toBeInTheDocument();
+    expect(screen.getByText('table.viewCopyFailed')).toBeInTheDocument();
   });
 
   test('importing via paste modal adds a new view to localStorage', async () => {

--- a/test/components/UserSettings.test.tsx
+++ b/test/components/UserSettings.test.tsx
@@ -54,6 +54,26 @@ const renderSettings = () =>
     />,
   );
 
+const installUnavailableClipboard = (execCommand: () => boolean) => {
+  const originalClipboard = navigator.clipboard;
+  const originalExecCommand = Object.getOwnPropertyDescriptor(document, 'execCommand');
+
+  Object.defineProperty(navigator, 'clipboard', { configurable: true, value: undefined });
+  Object.defineProperty(document, 'execCommand', { configurable: true, value: execCommand });
+
+  return () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: originalClipboard,
+    });
+    if (originalExecCommand) {
+      Object.defineProperty(document, 'execCommand', originalExecCommand);
+    } else {
+      Reflect.deleteProperty(document, 'execCommand');
+    }
+  };
+};
+
 describe('<UserSettings /> MCP tokens', () => {
   beforeEach(() => {
     for (const m of [
@@ -109,29 +129,43 @@ describe('<UserSettings /> MCP tokens', () => {
     );
   });
 
-  test('copies MCP values when navigator.clipboard is unavailable', async () => {
-    const originalClipboard = navigator.clipboard;
-    const originalExecCommand = Object.getOwnPropertyDescriptor(document, 'execCommand');
+  test('copies MCP values when navigator.clipboard is unavailable and shows success feedback', async () => {
     const execCommand = mock(() => true);
-    Object.defineProperty(navigator, 'clipboard', { configurable: true, value: undefined });
-    Object.defineProperty(document, 'execCommand', { configurable: true, value: execCommand });
+    const restoreClipboard = installUnavailableClipboard(execCommand);
 
     try {
       renderSettings();
       fireEvent.click(screen.getByRole('button', { name: /mcp.title/ }));
-      fireEvent.click(await screen.findByRole('button', { name: /mcp.copyUrl/ }));
+      const copyButton = await screen.findByRole('button', { name: /mcp.copyUrl/ });
+      fireEvent.click(copyButton);
 
       expect(execCommand).toHaveBeenCalledWith('copy');
+      await waitFor(() =>
+        expect(
+          copyButton.querySelector('[data-copy-feedback-icon="check"][data-visible="true"]'),
+        ).toBeTruthy(),
+      );
     } finally {
-      Object.defineProperty(navigator, 'clipboard', {
-        configurable: true,
-        value: originalClipboard,
-      });
-      if (originalExecCommand) {
-        Object.defineProperty(document, 'execCommand', originalExecCommand);
-      } else {
-        Reflect.deleteProperty(document, 'execCommand');
-      }
+      restoreClipboard();
+    }
+  });
+
+  test('does not show MCP copy success feedback when copying fails', async () => {
+    const execCommand = mock(() => false);
+    const restoreClipboard = installUnavailableClipboard(execCommand);
+
+    try {
+      renderSettings();
+      fireEvent.click(screen.getByRole('button', { name: /mcp.title/ }));
+      const copyButton = await screen.findByRole('button', { name: /mcp.copyUrl/ });
+      fireEvent.click(copyButton);
+
+      expect(execCommand).toHaveBeenCalledWith('copy');
+      expect(
+        copyButton.querySelector('[data-copy-feedback-icon="check"][data-visible="true"]'),
+      ).toBeNull();
+    } finally {
+      restoreClipboard();
     }
   });
 


### PR DESCRIPTION
## Summary
- Added a reusable `AnimatedCopyIcon` for copy actions that transitions from copy to checkmark on successful clipboard writes.
- Applied the shared animated feedback to AI reporting, MCP/settings copy buttons, and saved view export in the shared table.
- Tightened MCP copy handling so failed clipboard writes no longer trigger copied state.
- Added focused unit coverage for success and failure copy behavior.

## Testing
- `bun test test/components/UserSettings.test.tsx`
- `bun test test/components/StandardTable.test.tsx`
- `bunx biome check` on the changed frontend files
- `bunx tsc -p tsconfig.json --noEmit`
- `bun run lint` was not fully runnable in this worktree because backend dependencies are not resolved in the local environment