### PR TITLE
fix(crm): allow creating clients without contacts

### DIFF
--- a/components/CRM/ClientsView.tsx
+++ b/components/CRM/ClientsView.tsx
@@ -441,10 +441,6 @@ const ClientsView: React.FC<ClientsViewProps> = ({
       newErrors.fiscalCode = t('common:validation.required');
     }
 
-    if (normalizedContacts.length === 0 || !primaryContact) {
-      newErrors.contacts = t('common:validation.required');
-    }
-
     if (Object.keys(newErrors).length > 0) {
       setErrors(newErrors);
       return;
@@ -454,10 +450,10 @@ const ClientsView: React.FC<ClientsViewProps> = ({
       name: trimmedName,
       type: formData.type,
       contacts: normalizedContacts,
-      contactName: primaryContact.fullName,
+      contactName: primaryContact?.fullName,
       clientCode: trimmedClientCode,
-      email: primaryContact.email?.trim() || undefined,
-      phone: primaryContact.phone?.trim() || '',
+      email: primaryContact?.email?.trim() || undefined,
+      phone: primaryContact?.phone?.trim() || undefined,
       addressCountry: formData.addressCountry?.trim() || '',
       addressState: formData.addressState?.trim() || '',
       addressCap: formData.addressCap?.trim() || '',

--- a/test/components/crm/ClientsView.test.tsx
+++ b/test/components/crm/ClientsView.test.tsx
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ComponentProps } from 'react';
+import type { ClientProfileOption, ClientProfileOptionsByCategory } from '../../../types';
+import { installI18nMock } from '../../helpers/i18n';
+import { render } from '../../helpers/render';
+
+installI18nMock();
+
+const emptyProfileOptions: ClientProfileOptionsByCategory = {
+  sector: [],
+  numberOfEmployees: [],
+  revenue: [],
+  officeCountRange: [],
+};
+
+const listAllProfileOptions = mock(async () => emptyProfileOptions);
+
+const profileOption: ClientProfileOption = {
+  id: 'option-1',
+  category: 'sector',
+  value: 'Manufacturing',
+  sortOrder: 0,
+  usageCount: 0,
+};
+
+mock.module('../../../services/api', () => ({
+  default: {
+    clients: {
+      listAllProfileOptions,
+    },
+  },
+}));
+
+const ClientsView = (await import('../../../components/CRM/ClientsView')).default;
+
+const renderClientsView = (overrides: Partial<ComponentProps<typeof ClientsView>> = {}) => {
+  const props: ComponentProps<typeof ClientsView> = {
+    clients: [],
+    onAddClient: mock(async () => {}),
+    onUpdateClient: mock(async () => {}),
+    onDeleteClient: mock(async () => {}),
+    onCreateClientProfileOption: mock(async () => profileOption),
+    onUpdateClientProfileOption: mock(async () => profileOption),
+    onDeleteClientProfileOption: mock(async () => {}),
+    permissions: ['crm.clients.view', 'crm.clients.create', 'crm.clients.update'],
+    ...overrides,
+  };
+
+  render(<ClientsView {...props} />);
+  return props;
+};
+
+const openAddClientModal = async () => {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole('button', { name: 'crm:clients.addClient' }));
+  await screen.findByText('crm:clients.identifyingData');
+  return user;
+};
+
+const fillRequiredClientFields = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.type(screen.getByPlaceholderText('crm:clients.clientCodePlaceholder'), 'ACME');
+  await user.type(screen.getByPlaceholderText('crm:clients.namePlaceholder'), 'Acme Srl');
+  await user.type(
+    screen.getByPlaceholderText('crm:clients.fiscalCodePlaceholder'),
+    'IT12345678901',
+  );
+};
+
+const submitClientForm = async (user: ReturnType<typeof userEvent.setup>) => {
+  const submitButton = document.querySelector('button[type="submit"]');
+  if (!(submitButton instanceof HTMLElement)) {
+    throw new Error('Could not find client form submit button');
+  }
+  await user.click(submitButton);
+};
+
+describe('<ClientsView /> contact validation', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    listAllProfileOptions.mockClear();
+  });
+
+  test('creates a client without requiring a contact', async () => {
+    const props = renderClientsView();
+    const user = await openAddClientModal();
+    await fillRequiredClientFields(user);
+
+    await submitClientForm(user);
+
+    await waitFor(() => expect(props.onAddClient).toHaveBeenCalledTimes(1));
+    expect(props.onAddClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Acme Srl',
+        clientCode: 'ACME',
+        fiscalCode: 'IT12345678901',
+        contacts: [],
+        contactName: undefined,
+        email: undefined,
+        phone: undefined,
+      }),
+    );
+    expect(screen.queryByText('common:validation.required')).not.toBeInTheDocument();
+  });
+
+  test('requires a contact name when submitting a partially filled contact draft', async () => {
+    const props = renderClientsView();
+    const user = await openAddClientModal();
+    await fillRequiredClientFields(user);
+
+    await user.click(screen.getByRole('button', { name: 'crm:clients.addContact' }));
+    await user.type(screen.getByPlaceholderText('crm:clients.rolePlaceholder'), 'Buyer');
+    await submitClientForm(user);
+
+    expect(props.onAddClient).not.toHaveBeenCalled();
+    expect(screen.getByText('common:validation.required')).toBeInTheDocument();
+  });
+
+  test('requires a contact name when saving a contact draft', async () => {
+    const props = renderClientsView();
+    const user = await openAddClientModal();
+
+    await user.click(screen.getByRole('button', { name: 'crm:clients.addContact' }));
+    await user.click(screen.getAllByRole('button', { name: 'common:buttons.save' })[0]);
+
+    expect(props.onAddClient).not.toHaveBeenCalled();
+    expect(screen.getByText('common:validation.required')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Remove the submit-time requirement that forced every client to have at least one contact.
- Keep contact `fullName` required only when a contact draft is actually being added or saved.
- Preserve client creation/editing when no contact is provided by sending an empty contacts array.

## Testing
- Added CRM component regression coverage for creating a client without contacts.
- Added coverage for the contact draft flow to ensure `fullName` is still required when a contact is being added.
- `bun test ./test/components/crm`
- `bun x biome check components/CRM/ClientsView.tsx test/components/crm/ClientsView.test.tsx`