### PR TITLE
fix(rbac): allow all-scope permissions for CRUD and view checks

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -87,10 +87,12 @@ import { getErrorMessage } from './utils/errors';
 import { isItalianHoliday } from './utils/holidays';
 import {
   buildPermission,
+  equivalentPermissionsFor,
   getDefaultViewForPermissions,
   getNotFoundReturnView,
   hasAnyPermission,
   hasPermission,
+  hasViewAccess,
   VIEW_PERMISSION_MAP,
 } from './utils/permissions';
 import { applyTheme, getTheme } from './utils/theme';
@@ -777,11 +779,8 @@ const App: React.FC = () => {
       clearAuthScopedAppState();
       setViewingUserId(user.id);
       const defaultView = getDefaultViewForPermissions(user.permissions || [], VALID_VIEWS);
-      const activePermission =
-        activeView !== '404' ? VIEW_PERMISSION_MAP[activeView as View] : undefined;
-      const canAccessActive = activePermission
-        ? hasPermission(user.permissions || [], activePermission)
-        : false;
+      const canAccessActive =
+        activeView !== '404' ? hasViewAccess(user.permissions || [], activeView as View) : false;
       if (activeView === '404' || !canAccessActive) {
         setActiveView(defaultView);
       }
@@ -949,8 +948,7 @@ const App: React.FC = () => {
       if (hasLoadedGeneralSettings && !generalSettings.enableAiReporting) return false;
     }
 
-    const permission = VIEW_PERMISSION_MAP[activeView as View];
-    return permission ? hasPermission(currentUser.permissions, permission) : false;
+    return hasViewAccess(currentUser.permissions, activeView as View);
   }, [activeView, currentUser, hasLoadedGeneralSettings, generalSettings.enableAiReporting]);
 
   // Redirect to 404 if route is not accessible
@@ -1119,14 +1117,13 @@ const App: React.FC = () => {
       try {
         const permissions = currentUser.permissions || [];
         const canViewTimesheets = hasAnyPermission(permissions, [
-          buildPermission('timesheets.tracker', 'view'),
+          ...equivalentPermissionsFor('timesheets.tracker', 'view'),
           buildPermission('timesheets.recurring', 'view'),
         ]);
         const canViewHr = hasAnyPermission(permissions, [
           buildPermission('hr.internal', 'view'),
           buildPermission('hr.external', 'view'),
-          buildPermission('hr.work_units', 'view'),
-          buildPermission('hr.work_units_all', 'view'),
+          ...equivalentPermissionsFor('hr.work_units', 'view'),
         ]);
         const canViewConfiguration = hasAnyPermission(permissions, [
           buildPermission('administration.user_management', 'view'),
@@ -1138,10 +1135,8 @@ const App: React.FC = () => {
           buildPermission('administration.email', 'view'),
         ]);
         const canViewCrm = hasAnyPermission(permissions, [
-          buildPermission('crm.clients', 'view'),
-          buildPermission('crm.clients_all', 'view'),
-          buildPermission('crm.suppliers', 'view'),
-          buildPermission('crm.suppliers_all', 'view'),
+          ...equivalentPermissionsFor('crm.clients', 'view'),
+          ...equivalentPermissionsFor('crm.suppliers', 'view'),
         ]);
         const canViewSales = hasAnyPermission(permissions, [
           buildPermission('sales.client_quotes', 'view'),
@@ -1159,8 +1154,8 @@ const App: React.FC = () => {
           buildPermission('accounting.supplier_invoices', 'view'),
         ]);
         const canViewProjects = hasAnyPermission(permissions, [
-          buildPermission('projects.manage', 'view'),
-          buildPermission('projects.tasks', 'view'),
+          ...equivalentPermissionsFor('projects.manage', 'view'),
+          ...equivalentPermissionsFor('projects.tasks', 'view'),
         ]);
         const canViewSuppliersModule = hasPermission(
           permissions,
@@ -1168,12 +1163,11 @@ const App: React.FC = () => {
         );
 
         const canListClients = hasAnyPermission(permissions, [
-          buildPermission('crm.clients', 'view'),
-          buildPermission('crm.clients_all', 'view'),
-          buildPermission('timesheets.tracker', 'view'),
+          ...equivalentPermissionsFor('crm.clients', 'view'),
+          ...equivalentPermissionsFor('timesheets.tracker', 'view'),
           buildPermission('timesheets.recurring', 'view'),
-          buildPermission('projects.manage', 'view'),
-          buildPermission('projects.tasks', 'view'),
+          ...equivalentPermissionsFor('projects.manage', 'view'),
+          ...equivalentPermissionsFor('projects.tasks', 'view'),
           buildPermission('sales.client_quotes', 'view'),
           buildPermission('sales.client_offers', 'view'),
           buildPermission('accounting.clients_orders', 'view'),
@@ -1183,15 +1177,15 @@ const App: React.FC = () => {
           buildPermission('administration.user_management', 'update'),
         ]);
         const canListProjects = hasAnyPermission(permissions, [
-          buildPermission('projects.manage', 'view'),
-          buildPermission('projects.tasks', 'view'),
-          buildPermission('timesheets.tracker', 'view'),
+          ...equivalentPermissionsFor('projects.manage', 'view'),
+          ...equivalentPermissionsFor('projects.tasks', 'view'),
+          ...equivalentPermissionsFor('timesheets.tracker', 'view'),
           buildPermission('timesheets.recurring', 'view'),
         ]);
         const canListTasks = hasAnyPermission(permissions, [
-          buildPermission('projects.tasks', 'view'),
-          buildPermission('projects.manage', 'view'),
-          buildPermission('timesheets.tracker', 'view'),
+          ...equivalentPermissionsFor('projects.tasks', 'view'),
+          ...equivalentPermissionsFor('projects.manage', 'view'),
+          ...equivalentPermissionsFor('timesheets.tracker', 'view'),
           buildPermission('timesheets.recurring', 'view'),
         ]);
         const canListUsers = hasAnyPermission(permissions, [
@@ -1200,10 +1194,10 @@ const App: React.FC = () => {
           buildPermission('administration.user_management', 'update'),
           buildPermission('hr.internal', 'view'),
           buildPermission('hr.external', 'view'),
-          buildPermission('timesheets.tracker', 'view'),
-          buildPermission('projects.manage', 'view'),
-          buildPermission('projects.tasks', 'view'),
-          buildPermission('hr.work_units', 'view'),
+          ...equivalentPermissionsFor('timesheets.tracker', 'view'),
+          ...equivalentPermissionsFor('projects.manage', 'view'),
+          ...equivalentPermissionsFor('projects.tasks', 'view'),
+          ...equivalentPermissionsFor('hr.work_units', 'view'),
         ]);
         const canListQuotes = hasPermission(
           permissions,
@@ -1221,8 +1215,7 @@ const App: React.FC = () => {
           buildPermission('accounting.supplier_invoices', 'view'),
         ]);
         const canListSuppliers = hasAnyPermission(permissions, [
-          buildPermission('crm.suppliers', 'view'),
-          buildPermission('crm.suppliers_all', 'view'),
+          ...equivalentPermissionsFor('crm.suppliers', 'view'),
           buildPermission('sales.supplier_quotes', 'view'),
           buildPermission('accounting.supplier_orders', 'view'),
           buildPermission('accounting.supplier_invoices', 'view'),
@@ -1247,10 +1240,7 @@ const App: React.FC = () => {
           permissions,
           buildPermission('accounting.supplier_invoices', 'view'),
         );
-        const canListWorkUnits = hasAnyPermission(permissions, [
-          buildPermission('hr.work_units', 'view'),
-          buildPermission('hr.work_units_all', 'view'),
-        ]);
+        const canListWorkUnits = hasViewAccess(permissions, 'hr/work-units');
         const canManageEmployeeAssignments = hasPermission(
           permissions,
           buildPermission('hr.employee_assignments', 'update'),
@@ -1273,14 +1263,8 @@ const App: React.FC = () => {
           permissions,
           buildPermission('administration.email', 'view'),
         );
-        const canViewCrmClients = hasAnyPermission(permissions, [
-          buildPermission('crm.clients', 'view'),
-          buildPermission('crm.clients_all', 'view'),
-        ]);
-        const canViewCrmSuppliers = hasAnyPermission(permissions, [
-          buildPermission('crm.suppliers', 'view'),
-          buildPermission('crm.suppliers_all', 'view'),
-        ]);
+        const canViewCrmClients = hasViewAccess(permissions, 'crm/clients');
+        const canViewCrmSuppliers = hasViewAccess(permissions, 'crm/suppliers');
         const canViewCatalogInternal = hasPermission(
           permissions,
           buildPermission('catalog.internal_listing', 'view'),
@@ -2163,7 +2147,7 @@ const App: React.FC = () => {
                 defaultLocation={generalSettings.defaultLocation}
               />
             )}
-            {hasPermission(currentUser.permissions, VIEW_PERMISSION_MAP['crm/clients']) &&
+            {hasViewAccess(currentUser.permissions, 'crm/clients') &&
               activeView === 'crm/clients' && (
                 <ClientsView
                   clients={clients}
@@ -2375,7 +2359,7 @@ const App: React.FC = () => {
                 />
               )}
 
-            {hasPermission(currentUser.permissions, VIEW_PERMISSION_MAP['crm/suppliers']) &&
+            {hasViewAccess(currentUser.permissions, 'crm/suppliers') &&
               activeView === 'crm/suppliers' && (
                 <SuppliersView
                   suppliers={suppliers}
@@ -2418,62 +2402,64 @@ const App: React.FC = () => {
                 />
               )}
 
-            {activeView === 'projects/manage' && (
-              <ProjectsView
-                projects={projects}
-                clients={clients}
-                orders={clientsOrders}
-                currency={generalSettings.currency}
-                permissions={currentUser.permissions || []}
-                users={availableUsers}
-                roles={roles}
-                tasks={projectTasks}
-                onAddProject={addProject}
-                onUpdateProject={handleUpdateProject}
-                onDeleteProject={handleDeleteProject}
-                onAddTask={addProjectTask}
-                onUpdateTask={handleUpdateTask}
-                onDeleteTask={async (id) => {
-                  try {
-                    await api.tasks.delete(id);
-                    setProjectTasks((prev) => prev.filter((t) => t.id !== id));
-                  } catch (err) {
-                    console.error('Failed to delete task:', err);
-                  }
-                }}
-                onViewOrder={(orderId) => {
-                  setClientsOrderFilterId(orderId);
-                  setActiveView('accounting/clients-orders');
-                }}
-              />
-            )}
+            {hasViewAccess(currentUser.permissions, 'projects/manage') &&
+              activeView === 'projects/manage' && (
+                <ProjectsView
+                  projects={projects}
+                  clients={clients}
+                  orders={clientsOrders}
+                  currency={generalSettings.currency}
+                  permissions={currentUser.permissions || []}
+                  users={availableUsers}
+                  roles={roles}
+                  tasks={projectTasks}
+                  onAddProject={addProject}
+                  onUpdateProject={handleUpdateProject}
+                  onDeleteProject={handleDeleteProject}
+                  onAddTask={addProjectTask}
+                  onUpdateTask={handleUpdateTask}
+                  onDeleteTask={async (id) => {
+                    try {
+                      await api.tasks.delete(id);
+                      setProjectTasks((prev) => prev.filter((t) => t.id !== id));
+                    } catch (err) {
+                      console.error('Failed to delete task:', err);
+                    }
+                  }}
+                  onViewOrder={(orderId) => {
+                    setClientsOrderFilterId(orderId);
+                    setActiveView('accounting/clients-orders');
+                  }}
+                />
+              )}
 
-            {activeView === 'projects/tasks' && (
-              <TasksView
-                tasks={projectTasks}
-                projects={projects}
-                clients={clients}
-                permissions={currentUser.permissions || []}
-                users={availableUsers}
-                roles={roles}
-                currency={generalSettings.currency}
-                onAddTask={addProjectTask}
-                onUpdateTask={handleUpdateTask}
-                onDeleteTask={async (id) => {
-                  try {
-                    await api.tasks.delete(id);
-                    setProjectTasks((prev) => prev.filter((t) => t.id !== id));
-                  } catch (err) {
-                    console.error('Failed to delete task:', err);
-                    alert('Failed to delete task');
-                  }
-                }}
-                onViewOrder={(orderId) => {
-                  setClientsOrderFilterId(orderId);
-                  setActiveView('accounting/clients-orders');
-                }}
-              />
-            )}
+            {hasViewAccess(currentUser.permissions, 'projects/tasks') &&
+              activeView === 'projects/tasks' && (
+                <TasksView
+                  tasks={projectTasks}
+                  projects={projects}
+                  clients={clients}
+                  permissions={currentUser.permissions || []}
+                  users={availableUsers}
+                  roles={roles}
+                  currency={generalSettings.currency}
+                  onAddTask={addProjectTask}
+                  onUpdateTask={handleUpdateTask}
+                  onDeleteTask={async (id) => {
+                    try {
+                      await api.tasks.delete(id);
+                      setProjectTasks((prev) => prev.filter((t) => t.id !== id));
+                    } catch (err) {
+                      console.error('Failed to delete task:', err);
+                      alert('Failed to delete task');
+                    }
+                  }}
+                  onViewOrder={(orderId) => {
+                    setClientsOrderFilterId(orderId);
+                    setActiveView('accounting/clients-orders');
+                  }}
+                />
+              )}
 
             {hasPermission(
               currentUser.permissions,
@@ -2498,7 +2484,7 @@ const App: React.FC = () => {
                 />
               )}
 
-            {hasPermission(currentUser.permissions, VIEW_PERMISSION_MAP['hr/work-units']) &&
+            {hasViewAccess(currentUser.permissions, 'hr/work-units') &&
               activeView === 'hr/work-units' && (
                 <WorkUnitsView
                   workUnits={workUnits}

--- a/components/CRM/ClientsView.tsx
+++ b/components/CRM/ClientsView.tsx
@@ -15,7 +15,7 @@ import type {
   ClientProfileOptionsByCategory,
 } from '../../types';
 import { formatInsertDate } from '../../utils/date';
-import { buildPermission, hasPermission } from '../../utils/permissions';
+import { hasScopedActionPermission } from '../../utils/permissions';
 import DeleteConfirmModal from '../shared/DeleteConfirmModal';
 import HeaderAddButton from '../shared/HeaderAddButton';
 import Modal from '../shared/Modal';
@@ -183,9 +183,9 @@ const ClientsView: React.FC<ClientsViewProps> = ({
   permissions,
 }) => {
   const { t, i18n } = useTranslation(['crm', 'common']);
-  const canCreateClients = hasPermission(permissions, buildPermission('crm.clients', 'create'));
-  const canUpdateClients = hasPermission(permissions, buildPermission('crm.clients', 'update'));
-  const canDeleteClients = hasPermission(permissions, buildPermission('crm.clients', 'delete'));
+  const canCreateClients = hasScopedActionPermission(permissions, 'crm.clients', 'create');
+  const canUpdateClients = hasScopedActionPermission(permissions, 'crm.clients', 'update');
+  const canDeleteClients = hasScopedActionPermission(permissions, 'crm.clients', 'delete');
 
   const { language } = i18n;
 

--- a/components/CRM/SuppliersView.tsx
+++ b/components/CRM/SuppliersView.tsx
@@ -8,7 +8,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import type { Supplier, SupplierSaleOrder, SupplierSaleOrderItem } from '../../types';
 import { formatInsertDate } from '../../utils/date';
-import { buildPermission, hasPermission } from '../../utils/permissions';
+import { hasScopedActionPermission } from '../../utils/permissions';
 import DeleteConfirmModal from '../shared/DeleteConfirmModal';
 import HeaderAddButton from '../shared/HeaderAddButton';
 import Modal from '../shared/Modal';
@@ -55,9 +55,9 @@ const SuppliersView: React.FC<SuppliersViewProps> = ({
   permissions,
 }) => {
   const { t } = useTranslation(['crm', 'common']);
-  const canCreateSuppliers = hasPermission(permissions, buildPermission('crm.suppliers', 'create'));
-  const canUpdateSuppliers = hasPermission(permissions, buildPermission('crm.suppliers', 'update'));
-  const canDeleteSuppliers = hasPermission(permissions, buildPermission('crm.suppliers', 'delete'));
+  const canCreateSuppliers = hasScopedActionPermission(permissions, 'crm.suppliers', 'create');
+  const canUpdateSuppliers = hasScopedActionPermission(permissions, 'crm.suppliers', 'update');
+  const canDeleteSuppliers = hasScopedActionPermission(permissions, 'crm.suppliers', 'delete');
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingSupplier, setEditingSupplier] = useState<Supplier | null>(null);
   const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -40,7 +40,7 @@ import { SidebarInset, SidebarProvider, SidebarTrigger } from '@/components/ui/s
 import { getShadcnThemeClassName, useResolvedShadcnTheme } from '@/components/ui/use-shadcn-theme';
 import { cn } from '@/lib/utils';
 import type { Notification, User as PraetorUser, Role, View } from '../types';
-import { buildPermission, hasPermission, VIEW_PERMISSION_MAP } from '../utils/permissions';
+import { buildPermission, hasPermission, hasViewAccess } from '../utils/permissions';
 import { applyTheme, getTheme } from '../utils/theme';
 import NotificationBell from './shared/NotificationBell';
 
@@ -291,8 +291,7 @@ const Layout: React.FC<LayoutProps> = ({
       for (const route of module.routes) {
         if (route.view === activeView) matchedRoute = route;
 
-        const permission = VIEW_PERMISSION_MAP[route.view];
-        if (!permission || !hasPermission(currentUser.permissions, permission)) continue;
+        if (!hasViewAccess(currentUser.permissions, route.view)) continue;
         const isDisabledAiReporting =
           route.view === 'reports/ai-reporting' && !isAiReportingEnabled;
 

--- a/components/WorkUnitsView.tsx
+++ b/components/WorkUnitsView.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { workUnitsApi } from '../services/api';
 import type { User, WorkUnit } from '../types';
-import { buildPermission, hasPermission } from '../utils/permissions';
+import { hasScopedActionPermission } from '../utils/permissions';
 import Checkbox from './shared/Checkbox';
 import HeaderAddButton from './shared/HeaderAddButton';
 import Modal from './shared/Modal';
@@ -175,9 +175,9 @@ const WorkUnitsView: React.FC<WorkUnitsViewProps> = ({
 
   const managerOptions = users.map((u) => ({ id: u.id, name: u.name }));
 
-  const canCreateWorkUnits = hasPermission(permissions, buildPermission('hr.work_units', 'create'));
-  const canUpdateWorkUnits = hasPermission(permissions, buildPermission('hr.work_units', 'update'));
-  const canDeleteWorkUnits = hasPermission(permissions, buildPermission('hr.work_units', 'delete'));
+  const canCreateWorkUnits = hasScopedActionPermission(permissions, 'hr.work_units', 'create');
+  const canUpdateWorkUnits = hasScopedActionPermission(permissions, 'hr.work_units', 'update');
+  const canDeleteWorkUnits = hasScopedActionPermission(permissions, 'hr.work_units', 'delete');
   const canManageMembers = canUpdateWorkUnits;
 
   return (

--- a/components/projects/ProjectsView.tsx
+++ b/components/projects/ProjectsView.tsx
@@ -10,7 +10,7 @@ import { COLORS } from '../../constants';
 import { projectsApi, tasksApi } from '../../services/api';
 import type { Client, ClientsOrder, Project, ProjectTask, Role, User } from '../../types';
 import { formatInsertDate } from '../../utils/date';
-import { buildPermission, hasPermission } from '../../utils/permissions';
+import { buildPermission, hasPermission, hasScopedActionPermission } from '../../utils/permissions';
 import DeleteConfirmModal from '../shared/DeleteConfirmModal';
 import HeaderAddButton from '../shared/HeaderAddButton';
 import Modal from '../shared/Modal';
@@ -103,25 +103,16 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
   onViewOrder,
 }) => {
   const { t } = useTranslation(['projects', 'common', 'form']);
-  const canCreateProjects = hasPermission(
-    permissions,
-    buildPermission('projects.manage', 'create'),
-  );
-  const canUpdateProjects = hasPermission(
-    permissions,
-    buildPermission('projects.manage', 'update'),
-  );
-  const canDeleteProjects = hasPermission(
-    permissions,
-    buildPermission('projects.manage', 'delete'),
-  );
+  const canCreateProjects = hasScopedActionPermission(permissions, 'projects.manage', 'create');
+  const canUpdateProjects = hasScopedActionPermission(permissions, 'projects.manage', 'update');
+  const canDeleteProjects = hasScopedActionPermission(permissions, 'projects.manage', 'delete');
   const canManageAssignments = hasPermission(
     permissions,
     buildPermission('projects.assignments', 'update'),
   );
-  const canCreateTasks = hasPermission(permissions, buildPermission('projects.tasks', 'create'));
-  const canUpdateTasks = hasPermission(permissions, buildPermission('projects.tasks', 'update'));
-  const canDeleteTasks = hasPermission(permissions, buildPermission('projects.tasks', 'delete'));
+  const canCreateTasks = hasScopedActionPermission(permissions, 'projects.tasks', 'create');
+  const canUpdateTasks = hasScopedActionPermission(permissions, 'projects.tasks', 'update');
+  const canDeleteTasks = hasScopedActionPermission(permissions, 'projects.tasks', 'delete');
 
   // Modal State
   const [isModalOpen, setIsModalOpen] = useState(false);

--- a/components/projects/TasksView.tsx
+++ b/components/projects/TasksView.tsx
@@ -9,7 +9,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { tasksApi } from '../../services/api';
 import type { Client, Project, ProjectTask, Role, User } from '../../types';
 import { formatInsertDate } from '../../utils/date';
-import { buildPermission, hasPermission } from '../../utils/permissions';
+import { hasScopedActionPermission } from '../../utils/permissions';
 import DeleteConfirmModal from '../shared/DeleteConfirmModal';
 import HeaderAddButton from '../shared/HeaderAddButton';
 import Modal from '../shared/Modal';
@@ -64,9 +64,9 @@ const TasksView: React.FC<TasksViewProps> = ({
   onViewOrder,
 }) => {
   const { t } = useTranslation(['projects', 'common']);
-  const canCreateTasks = hasPermission(permissions, buildPermission('projects.tasks', 'create'));
-  const canUpdateTasks = hasPermission(permissions, buildPermission('projects.tasks', 'update'));
-  const canDeleteTasks = hasPermission(permissions, buildPermission('projects.tasks', 'delete'));
+  const canCreateTasks = hasScopedActionPermission(permissions, 'projects.tasks', 'create');
+  const canUpdateTasks = hasScopedActionPermission(permissions, 'projects.tasks', 'update');
+  const canDeleteTasks = hasScopedActionPermission(permissions, 'projects.tasks', 'delete');
   const [name, setName] = useState('');
   const [projectId, setProjectId] = useState('');
   const [description, setDescription] = useState('');

--- a/components/timesheet/DailyView.tsx
+++ b/components/timesheet/DailyView.tsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Client, Project, ProjectTask, TimeEntry, TimeEntryLocation } from '../../types';
 import { getLocalDateString } from '../../utils/date';
-import { buildPermission, hasAnyPermission } from '../../utils/permissions';
+import { hasScopedActionPermission } from '../../utils/permissions';
 import { formatRecurrencePattern } from '../../utils/recurrence';
 import CustomRepeatModal from '../shared/CustomRepeatModal';
 import SelectControl from '../shared/SelectControl';
@@ -216,9 +216,7 @@ const DailyView: React.FC<DailyViewProps> = ({
     return currentDayTotal + val > dailyGoal;
   }, [duration, currentDayTotal, dailyGoal]);
 
-  const canCreateCustomTask = hasAnyPermission(permissions, [
-    buildPermission('projects.tasks', 'create'),
-  ]);
+  const canCreateCustomTask = hasScopedActionPermission(permissions, 'projects.tasks', 'create');
 
   const clientOptions = clients.map((c) => ({ id: c.id, name: c.name }));
   const projectOptions = filteredProjects.map((p) => ({ id: p.id, name: p.name }));

--- a/docs-site/src/content/docs/administration.md
+++ b/docs-site/src/content/docs/administration.md
@@ -9,6 +9,8 @@ sidebar:
 
 Gli amministratori gestiscono utenti, ruoli e permessi. Ogni ruolo dovrebbe concedere solo le funzioni necessarie al lavoro quotidiano.
 
+Le righe di permesso con ambito **All** concedono accesso trasversale a tutti i record della stessa area, ad esempio tutti i clienti, fornitori, progetti, task, consuntivi o work unit. L'azione **View** abilita la vista e la consultazione su tutti i record; quando selezionate, anche **Create**, **Update** e **Delete** sono permessi reali e consentono scritture su record non assegnati. I permessi senza **All** mantengono l'ambito assegnato all'utente.
+
 Quando modifichi un ruolo, considera l'impatto su tutti gli utenti assegnati. Dopo modifiche importanti, verifica l'accesso con un profilo di prova o con un utente rappresentativo.
 
 ## Autenticazione

--- a/docs-site/src/content/docs/en/administration.md
+++ b/docs-site/src/content/docs/en/administration.md
@@ -9,6 +9,8 @@ sidebar:
 
 Administrators manage users, roles, and permissions. Each role should grant only the functions needed for daily work.
 
+Permission rows marked **All** grant cross-record access for the same area, such as all clients, suppliers, projects, tasks, time entries, or work units. **View** opens the matching view and allows reading every matching record; when selected, **Create**, **Update**, and **Delete** are real write permissions and can operate on records that are not assigned to the user. Non-**All** permissions keep the user's assigned-record scope.
+
 When changing a role, consider the impact on every assigned user. After major changes, verify access with a test profile or representative user.
 
 ## Authentication

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -3,7 +3,12 @@ import jwt, { type JwtPayload } from 'jsonwebtoken';
 import * as personalAccessTokensRepo from '../repositories/personalAccessTokensRepo.ts';
 import * as rolesRepo from '../repositories/rolesRepo.ts';
 import * as usersRepo from '../repositories/usersRepo.ts';
-import { getRolePermissions } from '../utils/permissions.ts';
+import {
+  equivalentPermissionsFor,
+  getRolePermissions,
+  type PermissionAction,
+  type PermissionResource,
+} from '../utils/permissions.ts';
 import { hashPersonalAccessToken, isPersonalAccessToken } from '../utils/personal-access-token.ts';
 import {
   INSECURE_DEFAULT_JWT_SECRETS,
@@ -185,6 +190,9 @@ export const requireAnyPermission = (...permissions: string[]) => {
   };
 };
 
+export const requireScopedPermission = (resource: PermissionResource, action: PermissionAction) =>
+  requireAnyPermission(...equivalentPermissionsFor(resource, action));
+
 export const generateToken = (
   userId: string,
   sessionStart: number = Date.now(),
@@ -200,5 +208,6 @@ export default {
   requireRole,
   requirePermission,
   requireAnyPermission,
+  requireScopedPermission,
   generateToken,
 };

--- a/server/routes/clients.ts
+++ b/server/routes/clients.ts
@@ -1,6 +1,10 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { withDbTransaction } from '../db/drizzle.ts';
-import { authenticateToken, requireAnyPermission, requirePermission } from '../middleware/auth.ts';
+import {
+  authenticateToken,
+  requireAnyPermission,
+  requireScopedPermission,
+} from '../middleware/auth.ts';
 import * as clientProfileOptionsRepo from '../repositories/clientProfileOptionsRepo.ts';
 import * as clientsRepo from '../repositories/clientsRepo.ts';
 import * as userAssignmentsRepo from '../repositories/userAssignmentsRepo.ts';
@@ -289,8 +293,12 @@ const buildPrimaryFieldsFromContacts = (contacts: ClientContact[]) => {
   };
 };
 
-const canAccessClient = (request: FastifyRequest, clientId: string) => {
-  if (hasPermission(request, 'crm.clients_all.view')) return Promise.resolve(true);
+const canAccessClient = (
+  request: FastifyRequest,
+  clientId: string,
+  allScopePermission = 'crm.clients_all.view',
+) => {
+  if (hasPermission(request, allScopePermission)) return Promise.resolve(true);
   const userId = request.user?.id;
   if (!userId) return Promise.resolve(false);
   return userAssignmentsRepo.isClientAssignedToUser(userId, clientId);
@@ -307,9 +315,12 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           'crm.clients.view',
           'crm.clients_all.view',
           'timesheets.tracker.view',
+          'timesheets.tracker_all.view',
           'timesheets.recurring.view',
           'projects.manage.view',
+          'projects.manage_all.view',
           'projects.tasks.view',
+          'projects.tasks_all.view',
           'sales.client_quotes.view',
           'sales.client_offers.view',
           'accounting.clients_orders.view',
@@ -357,7 +368,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.post(
     '/',
     {
-      onRequest: [authenticateToken, requirePermission('crm.clients.create')],
+      onRequest: [authenticateToken, requireScopedPermission('crm.clients', 'create')],
       schema: {
         tags: ['clients'],
         summary: 'Create client',
@@ -554,7 +565,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.put(
     '/:id',
     {
-      onRequest: [authenticateToken, requirePermission('crm.clients.update')],
+      onRequest: [authenticateToken, requireScopedPermission('crm.clients', 'update')],
       schema: {
         tags: ['clients'],
         summary: 'Update client',
@@ -573,7 +584,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
 
-      if (!(await canAccessClient(request, idResult.value))) {
+      if (!(await canAccessClient(request, idResult.value, 'crm.clients_all.update'))) {
         return reply.code(403).send({ error: 'Insufficient permissions' });
       }
 
@@ -804,7 +815,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.delete(
     '/:id',
     {
-      onRequest: [authenticateToken, requirePermission('crm.clients.delete')],
+      onRequest: [authenticateToken, requireScopedPermission('crm.clients', 'delete')],
       schema: {
         tags: ['clients'],
         summary: 'Delete client',
@@ -820,7 +831,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
 
-      if (!(await canAccessClient(request, idResult.value))) {
+      if (!(await canAccessClient(request, idResult.value, 'crm.clients_all.delete'))) {
         return reply.code(403).send({ error: 'Insufficient permissions' });
       }
 
@@ -849,7 +860,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       onRequest: [
         fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
         authenticateToken,
-        requireAnyPermission('crm.clients.view', 'crm.clients_all.view'),
+        requireScopedPermission('crm.clients', 'view'),
       ],
       schema: {
         tags: ['clients'],
@@ -874,7 +885,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.post(
     '/profile-options/:category',
     {
-      onRequest: [authenticateToken, requirePermission('crm.clients.update')],
+      onRequest: [authenticateToken, requireScopedPermission('crm.clients', 'update')],
       schema: {
         tags: ['clients'],
         summary: 'Create client profile option',
@@ -937,7 +948,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.put(
     '/profile-options/:category/:id',
     {
-      onRequest: [authenticateToken, requirePermission('crm.clients.update')],
+      onRequest: [authenticateToken, requireScopedPermission('crm.clients', 'update')],
       schema: {
         tags: ['clients'],
         summary: 'Update client profile option',
@@ -1022,7 +1033,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.delete(
     '/profile-options/:category/:id',
     {
-      onRequest: [authenticateToken, requirePermission('crm.clients.update')],
+      onRequest: [authenticateToken, requireScopedPermission('crm.clients', 'update')],
       schema: {
         tags: ['clients'],
         summary: 'Delete client profile option',

--- a/server/routes/entries.ts
+++ b/server/routes/entries.ts
@@ -1,5 +1,9 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
-import { authenticateToken, requireAnyPermission, requirePermission } from '../middleware/auth.ts';
+import {
+  authenticateToken,
+  requireAnyPermission,
+  requireScopedPermission,
+} from '../middleware/auth.ts';
 import {
   messageResponseSchema,
   standardErrorResponses,
@@ -137,7 +141,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       onRequest: [
         fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
         authenticateToken,
-        requirePermission('timesheets.tracker.view'),
+        requireScopedPermission('timesheets.tracker', 'view'),
       ],
       schema: {
         tags: ['entries'],
@@ -169,7 +173,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.post(
     '/',
     {
-      onRequest: [authenticateToken, requirePermission('timesheets.tracker.create')],
+      onRequest: [authenticateToken, requireScopedPermission('timesheets.tracker', 'create')],
       schema: {
         tags: ['entries'],
         summary: 'Create time entry',
@@ -196,7 +200,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.put(
     '/:id',
     {
-      onRequest: [authenticateToken, requirePermission('timesheets.tracker.update')],
+      onRequest: [authenticateToken, requireScopedPermission('timesheets.tracker', 'update')],
       schema: {
         tags: ['entries'],
         summary: 'Update time entry',
@@ -224,7 +228,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.delete(
     '/:id',
     {
-      onRequest: [authenticateToken, requirePermission('timesheets.tracker.delete')],
+      onRequest: [authenticateToken, requireScopedPermission('timesheets.tracker', 'delete')],
       schema: {
         tags: ['entries'],
         summary: 'Delete time entry',
@@ -254,7 +258,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       onRequest: [
         fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
         authenticateToken,
-        requireAnyPermission('timesheets.tracker.delete', 'timesheets.recurring.delete'),
+        requireAnyPermission(
+          'timesheets.tracker.delete',
+          'timesheets.tracker_all.delete',
+          'timesheets.recurring.delete',
+        ),
       ],
       schema: {
         tags: ['entries'],

--- a/server/routes/projects.ts
+++ b/server/routes/projects.ts
@@ -1,6 +1,11 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { withDbTransaction } from '../db/drizzle.ts';
-import { authenticateToken, requireAnyPermission, requirePermission } from '../middleware/auth.ts';
+import {
+  authenticateToken,
+  requireAnyPermission,
+  requirePermission,
+  requireScopedPermission,
+} from '../middleware/auth.ts';
 import * as projectsRepo from '../repositories/projectsRepo.ts';
 import * as userAssignmentsRepo from '../repositories/userAssignmentsRepo.ts';
 import {
@@ -77,15 +82,23 @@ const projectUpdateBodySchema = {
 
 class PermissionError extends Error {}
 
-const canAccessClient = (request: FastifyRequest, clientId: string) => {
-  if (hasPermission(request, 'crm.clients_all.view')) return Promise.resolve(true);
+const canAccessClient = (
+  request: FastifyRequest,
+  clientId: string,
+  allScopePermission = 'crm.clients_all.view',
+) => {
+  if (hasPermission(request, allScopePermission)) return Promise.resolve(true);
   const userId = request.user?.id;
   if (!userId) return Promise.resolve(false);
   return userAssignmentsRepo.isClientAssignedToUser(userId, clientId);
 };
 
-const canAccessProject = (request: FastifyRequest, projectId: string) => {
-  if (hasPermission(request, 'projects.manage_all.view')) return Promise.resolve(true);
+const canAccessProject = (
+  request: FastifyRequest,
+  projectId: string,
+  allScopePermission = 'projects.manage_all.view',
+) => {
+  if (hasPermission(request, allScopePermission)) return Promise.resolve(true);
   const userId = request.user?.id;
   if (!userId) return Promise.resolve(false);
   return userAssignmentsRepo.isProjectAssignedToUser(userId, projectId);
@@ -101,8 +114,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         authenticateToken,
         requireAnyPermission(
           'projects.manage.view',
+          'projects.manage_all.view',
           'projects.tasks.view',
+          'projects.tasks_all.view',
           'timesheets.tracker.view',
+          'timesheets.tracker_all.view',
           'timesheets.recurring.view',
         ),
       ],
@@ -127,7 +143,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.post(
     '/',
     {
-      onRequest: [authenticateToken, requirePermission('projects.manage.create')],
+      onRequest: [authenticateToken, requireScopedPermission('projects.manage', 'create')],
       schema: {
         tags: ['projects'],
         summary: 'Create project',
@@ -153,7 +169,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
 
       const clientIdResult = requireNonEmptyString(clientId, 'clientId');
       if (!clientIdResult.ok) return badRequest(reply, clientIdResult.message);
-      if (!(await canAccessClient(request, clientIdResult.value))) {
+      if (
+        !hasPermission(request, 'projects.manage_all.create') &&
+        !(await canAccessClient(request, clientIdResult.value))
+      ) {
         return reply.code(403).send({ error: 'Insufficient permissions' });
       }
 
@@ -206,7 +225,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.delete(
     '/:id',
     {
-      onRequest: [authenticateToken, requirePermission('projects.manage.delete')],
+      onRequest: [authenticateToken, requireScopedPermission('projects.manage', 'delete')],
       schema: {
         tags: ['projects'],
         summary: 'Delete project',
@@ -221,7 +240,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const { id } = request.params as { id: string };
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
-      if (!(await canAccessProject(request, idResult.value))) {
+      if (!(await canAccessProject(request, idResult.value, 'projects.manage_all.delete'))) {
         return reply.code(403).send({ error: 'Insufficient permissions' });
       }
 
@@ -269,7 +288,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.put(
     '/:id',
     {
-      onRequest: [authenticateToken, requirePermission('projects.manage.update')],
+      onRequest: [authenticateToken, requireScopedPermission('projects.manage', 'update')],
       schema: {
         tags: ['projects'],
         summary: 'Update project',
@@ -293,7 +312,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const { name, clientId, description, color, isDisabled } = body;
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
-      if (!(await canAccessProject(request, idResult.value))) {
+      if (!(await canAccessProject(request, idResult.value, 'projects.manage_all.update'))) {
         return reply.code(403).send({ error: 'Insufficient permissions' });
       }
       let normalizedColor = color;
@@ -320,6 +339,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
             typeof clientId === 'string' && clientId !== '' ? clientId : previousClientId;
           if (
             requestedClientId !== previousClientId &&
+            !hasPermission(request, 'projects.manage_all.update') &&
             !(await canAccessClient(request, requestedClientId))
           ) {
             throw new PermissionError();

--- a/server/routes/suppliers.ts
+++ b/server/routes/suppliers.ts
@@ -1,5 +1,9 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
-import { authenticateToken, requireAnyPermission, requirePermission } from '../middleware/auth.ts';
+import {
+  authenticateToken,
+  requireAnyPermission,
+  requireScopedPermission,
+} from '../middleware/auth.ts';
 import * as suppliersRepo from '../repositories/suppliersRepo.ts';
 import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
 import { logAudit } from '../utils/audit.ts';
@@ -105,7 +109,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.post(
     '/',
     {
-      onRequest: [requirePermission('crm.suppliers.create')],
+      onRequest: [requireScopedPermission('crm.suppliers', 'create')],
       schema: {
         tags: ['suppliers'],
         summary: 'Create supplier',
@@ -205,7 +209,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.put(
     '/:id',
     {
-      onRequest: [requirePermission('crm.suppliers.update')],
+      onRequest: [requireScopedPermission('crm.suppliers', 'update')],
       schema: {
         tags: ['suppliers'],
         summary: 'Update supplier',
@@ -344,7 +348,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.delete(
     '/:id',
     {
-      onRequest: [requirePermission('crm.suppliers.delete')],
+      onRequest: [requireScopedPermission('crm.suppliers', 'delete')],
       schema: {
         tags: ['suppliers'],
         summary: 'Delete supplier',

--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -1,6 +1,10 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { withDbTransaction } from '../db/drizzle.ts';
-import { authenticateToken, requireAnyPermission, requirePermission } from '../middleware/auth.ts';
+import {
+  authenticateToken,
+  requireAnyPermission,
+  requireScopedPermission,
+} from '../middleware/auth.ts';
 import * as projectsRepo from '../repositories/projectsRepo.ts';
 import * as tasksRepo from '../repositories/tasksRepo.ts';
 import * as userAssignmentsRepo from '../repositories/userAssignmentsRepo.ts';
@@ -97,15 +101,23 @@ const userIdsSchema = {
   required: ['userIds'],
 } as const;
 
-const canAccessProject = (request: FastifyRequest, projectId: string) => {
-  if (hasPermission(request, 'projects.manage_all.view')) return Promise.resolve(true);
+const canAccessProject = (
+  request: FastifyRequest,
+  projectId: string,
+  allScopePermission = 'projects.manage_all.view',
+) => {
+  if (hasPermission(request, allScopePermission)) return Promise.resolve(true);
   const userId = request.user?.id;
   if (!userId) return Promise.resolve(false);
   return userAssignmentsRepo.isProjectAssignedToUser(userId, projectId);
 };
 
-const canAccessTask = (request: FastifyRequest, taskId: string) => {
-  if (hasPermission(request, 'projects.tasks_all.view')) return Promise.resolve(true);
+const canAccessTask = (
+  request: FastifyRequest,
+  taskId: string,
+  allScopePermission = 'projects.tasks_all.view',
+) => {
+  if (hasPermission(request, allScopePermission)) return Promise.resolve(true);
   const userId = request.user?.id;
   if (!userId) return Promise.resolve(false);
   return userAssignmentsRepo.isTaskAssignedToUser(userId, taskId);
@@ -121,8 +133,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         authenticateToken,
         requireAnyPermission(
           'projects.tasks.view',
+          'projects.tasks_all.view',
           'projects.manage.view',
+          'projects.manage_all.view',
           'timesheets.tracker.view',
+          'timesheets.tracker_all.view',
           'timesheets.recurring.view',
         ),
       ],
@@ -146,7 +161,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.post(
     '/',
     {
-      onRequest: [authenticateToken, requirePermission('projects.tasks.create')],
+      onRequest: [authenticateToken, requireScopedPermission('projects.tasks', 'create')],
       schema: {
         tags: ['tasks'],
         summary: 'Create task',
@@ -187,7 +202,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
 
       const projectIdResult = requireNonEmptyString(projectId, 'projectId');
       if (!projectIdResult.ok) return badRequest(reply, projectIdResult.message);
-      if (!(await canAccessProject(request, projectIdResult.value))) {
+      if (
+        !hasPermission(request, 'projects.tasks_all.create') &&
+        !(await canAccessProject(request, projectIdResult.value))
+      ) {
         return reply.code(403).send({ error: 'Insufficient permissions' });
       }
 
@@ -266,8 +284,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         authenticateToken,
         requireAnyPermission(
           'projects.tasks.view',
+          'projects.tasks_all.view',
           'projects.manage.view',
+          'projects.manage_all.view',
           'timesheets.tracker.view',
+          'timesheets.tracker_all.view',
           'timesheets.recurring.view',
         ),
       ],
@@ -328,8 +349,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         authenticateToken,
         requireAnyPermission(
           'projects.tasks.view',
+          'projects.tasks_all.view',
           'projects.manage.view',
+          'projects.manage_all.view',
           'timesheets.tracker.view',
+          'timesheets.tracker_all.view',
           'timesheets.recurring.view',
         ),
       ],
@@ -370,7 +394,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.put(
     '/:id',
     {
-      onRequest: [authenticateToken, requirePermission('projects.tasks.update')],
+      onRequest: [authenticateToken, requireScopedPermission('projects.tasks', 'update')],
       schema: {
         tags: ['tasks'],
         summary: 'Update task',
@@ -412,7 +436,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       } = body;
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
-      if (!(await canAccessTask(request, idResult.value))) {
+      if (!(await canAccessTask(request, idResult.value, 'projects.tasks_all.update'))) {
         return reply.code(403).send({ error: 'Insufficient permissions' });
       }
       const durationResult = optionalLocalizedNonNegativeNumber(
@@ -491,7 +515,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.delete(
     '/:id',
     {
-      onRequest: [authenticateToken, requirePermission('projects.tasks.delete')],
+      onRequest: [authenticateToken, requireScopedPermission('projects.tasks', 'delete')],
       schema: {
         tags: ['tasks'],
         summary: 'Delete task',
@@ -506,7 +530,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const { id } = request.params as { id: string };
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
-      if (!(await canAccessTask(request, idResult.value))) {
+      if (!(await canAccessTask(request, idResult.value, 'projects.tasks_all.delete'))) {
         return reply.code(403).send({ error: 'Insufficient permissions' });
       }
 
@@ -533,7 +557,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/:id/users',
     {
-      onRequest: [authenticateToken, requirePermission('projects.tasks.update')],
+      onRequest: [authenticateToken, requireScopedPermission('projects.tasks', 'update')],
       schema: {
         tags: ['tasks'],
         summary: 'Get task user assignments',
@@ -548,7 +572,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const { id } = request.params as { id: string };
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
-      if (!(await canAccessTask(request, idResult.value))) {
+      if (!(await canAccessTask(request, idResult.value, 'projects.tasks_all.update'))) {
         return reply.code(403).send({ error: 'Insufficient permissions' });
       }
       return tasksRepo.findAssignedUserIds(idResult.value);
@@ -559,7 +583,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.post(
     '/:id/users',
     {
-      onRequest: [authenticateToken, requirePermission('projects.tasks.update')],
+      onRequest: [authenticateToken, requireScopedPermission('projects.tasks', 'update')],
       schema: {
         tags: ['tasks'],
         summary: 'Update task user assignments',
@@ -576,7 +600,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const { userIds } = request.body as { userIds: string[] };
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
-      if (!(await canAccessTask(request, idResult.value))) {
+      if (!(await canAccessTask(request, idResult.value, 'projects.tasks_all.update'))) {
         return reply.code(403).send({ error: 'Insufficient permissions' });
       }
 

--- a/server/routes/users.ts
+++ b/server/routes/users.ts
@@ -238,9 +238,13 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           'hr.internal.view',
           'hr.external.view',
           'timesheets.tracker.view',
+          'timesheets.tracker_all.view',
           'projects.manage.view',
+          'projects.manage_all.view',
           'projects.tasks.view',
+          'projects.tasks_all.view',
           'hr.work_units.view',
+          'hr.work_units_all.view',
         ),
       ],
       schema: {
@@ -258,7 +262,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const canViewUserManagement = hasPermission(request, 'administration.user_management.view');
       const canViewManagedUsers =
         hasPermission(request, 'timesheets.tracker.view') ||
+        hasPermission(request, 'timesheets.tracker_all.view') ||
         hasPermission(request, 'hr.work_units.view') ||
+        hasPermission(request, 'hr.work_units_all.view') ||
         canViewUserManagement;
       const canViewInternal = hasPermission(request, 'hr.internal.view');
       const canViewExternal = hasPermission(request, 'hr.external.view');

--- a/server/routes/work-units.ts
+++ b/server/routes/work-units.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { withDbTransaction } from '../db/drizzle.ts';
-import { authenticateToken, requirePermission } from '../middleware/auth.ts';
+import { authenticateToken, requireScopedPermission } from '../middleware/auth.ts';
 import * as workUnitsRepo from '../repositories/workUnitsRepo.ts';
 import { messageResponseSchema, standardRateLimitedErrorResponses } from '../schemas/common.ts';
 import { deriveToggleAction, getAuditChangedFields, logAudit } from '../utils/audit.ts';
@@ -79,7 +79,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
-      onRequest: [authenticateToken, requirePermission('hr.work_units.view')],
+      onRequest: [authenticateToken, requireScopedPermission('hr.work_units', 'view')],
       schema: {
         tags: ['work-units'],
         summary: 'List work units',
@@ -102,7 +102,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.post(
     '/',
     {
-      onRequest: [authenticateToken, requirePermission('hr.work_units.create')],
+      onRequest: [authenticateToken, requireScopedPermission('hr.work_units', 'create')],
       schema: {
         tags: ['work-units'],
         summary: 'Create work unit',
@@ -159,7 +159,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.put(
     '/:id',
     {
-      onRequest: [authenticateToken, requirePermission('hr.work_units.update')],
+      onRequest: [authenticateToken, requireScopedPermission('hr.work_units', 'update')],
       schema: {
         tags: ['work-units'],
         summary: 'Update work unit',
@@ -251,7 +251,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.delete(
     '/:id',
     {
-      onRequest: [authenticateToken, requirePermission('hr.work_units.delete')],
+      onRequest: [authenticateToken, requireScopedPermission('hr.work_units', 'delete')],
       schema: {
         tags: ['work-units'],
         summary: 'Delete work unit',
@@ -289,7 +289,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/:id/users',
     {
-      onRequest: [authenticateToken, requirePermission('hr.work_units.view')],
+      onRequest: [authenticateToken, requireScopedPermission('hr.work_units', 'view')],
       schema: {
         tags: ['work-units'],
         summary: 'Get users in work unit',
@@ -321,7 +321,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.post(
     '/:id/users',
     {
-      onRequest: [authenticateToken, requirePermission('hr.work_units.update')],
+      onRequest: [authenticateToken, requireScopedPermission('hr.work_units', 'update')],
       schema: {
         tags: ['work-units'],
         summary: 'Update work unit users',

--- a/server/services/timeEntries.ts
+++ b/server/services/timeEntries.ts
@@ -8,6 +8,7 @@ import * as usersRepo from '../repositories/usersRepo.ts';
 import * as workUnitsRepo from '../repositories/workUnitsRepo.ts';
 import { todayLocalDateOnly } from '../utils/date.ts';
 import { generatePrefixedId } from '../utils/order-ids.ts';
+import { hasScopedActionPermission } from '../utils/permissions.ts';
 import {
   isWeekendDate,
   optionalLocalizedNonNegativeNumber,
@@ -37,6 +38,11 @@ export class TimeEntryServiceError extends Error {
 const hasPermission = (actor: AuthenticatedActor, permission: string) =>
   actor.permissions.includes(permission);
 
+const hasTrackerPermission = (
+  actor: AuthenticatedActor,
+  action: 'view' | 'create' | 'update' | 'delete',
+) => hasScopedActionPermission(actor.permissions, 'timesheets.tracker', action);
+
 const fail = (statusCode: number, message: string): never => {
   throw new TimeEntryServiceError(statusCode, message);
 };
@@ -52,7 +58,7 @@ export const listTimeEntries = async (
   actor: AuthenticatedActor,
   input: { userId?: unknown; limit?: unknown; cursor?: unknown },
 ): Promise<{ entries: TimeEntry[]; nextCursor: string | null }> => {
-  if (!hasPermission(actor, 'timesheets.tracker.view')) fail(403, 'Insufficient permissions');
+  if (!hasTrackerPermission(actor, 'view')) fail(403, 'Insufficient permissions');
 
   const userId = typeof input.userId === 'string' ? input.userId : undefined;
   const limit =
@@ -99,7 +105,7 @@ export const createTimeEntry = async (
     location?: unknown;
   },
 ): Promise<TimeEntry> => {
-  if (!hasPermission(actor, 'timesheets.tracker.create')) fail(403, 'Insufficient permissions');
+  if (!hasTrackerPermission(actor, 'create')) fail(403, 'Insufficient permissions');
 
   const date = requireValid(parseDateString(input.date, 'date'));
 
@@ -121,7 +127,7 @@ export const createTimeEntry = async (
   if (input.userId) {
     targetUserId = requireValid(requireNonEmptyString(input.userId, 'userId'));
 
-    if (targetUserId !== actor.id && !hasPermission(actor, 'timesheets.tracker_all.view')) {
+    if (targetUserId !== actor.id && !hasPermission(actor, 'timesheets.tracker_all.create')) {
       const allowed = await workUnitsRepo.isUserManagedBy(actor.id, targetUserId);
       if (!allowed) fail(403, 'Not authorized to create entries for this user');
     }
@@ -135,7 +141,7 @@ export const createTimeEntry = async (
     badRequest('Project does not belong to the selected client');
   }
 
-  if (!hasPermission(actor, 'timesheets.tracker_all.view')) {
+  if (!hasPermission(actor, 'timesheets.tracker_all.create')) {
     const [clientAllowed, projectAllowed, taskAllowed] = await Promise.all([
       userAssignmentsRepo.isClientAssignedToUser(targetUserId, clientId),
       userAssignmentsRepo.isProjectAssignedToUser(targetUserId, projectId),
@@ -174,7 +180,7 @@ export const updateTimeEntry = async (
   id: unknown,
   input: { duration?: unknown; notes?: unknown; isPlaceholder?: unknown; location?: unknown },
 ): Promise<TimeEntry> => {
-  if (!hasPermission(actor, 'timesheets.tracker.update')) fail(403, 'Insufficient permissions');
+  if (!hasTrackerPermission(actor, 'update')) fail(403, 'Insufficient permissions');
   const entryId = requireValid(requireNonEmptyString(id, 'id'));
 
   let parsedDuration: number | undefined;
@@ -190,7 +196,7 @@ export const updateTimeEntry = async (
   const context = await entriesRepo.findContext(entryId);
   if (context === null) return fail(404, 'Entry not found');
 
-  if (context.userId !== actor.id && !hasPermission(actor, 'timesheets.tracker_all.view')) {
+  if (context.userId !== actor.id && !hasPermission(actor, 'timesheets.tracker_all.update')) {
     const allowed = await workUnitsRepo.isUserManagedBy(actor.id, context.userId);
     if (!allowed) fail(403, 'Not authorized to update this entry');
   }
@@ -218,12 +224,12 @@ export const deleteTimeEntry = async (
   actor: AuthenticatedActor,
   id: unknown,
 ): Promise<{ message: string }> => {
-  if (!hasPermission(actor, 'timesheets.tracker.delete')) fail(403, 'Insufficient permissions');
+  if (!hasTrackerPermission(actor, 'delete')) fail(403, 'Insufficient permissions');
   const entryId = requireValid(requireNonEmptyString(id, 'id'));
 
   const ownerId = await entriesRepo.findOwner(entryId);
   if (ownerId === null) return fail(404, 'Entry not found');
-  if (ownerId !== actor.id && !hasPermission(actor, 'timesheets.tracker_all.view')) {
+  if (ownerId !== actor.id && !hasPermission(actor, 'timesheets.tracker_all.delete')) {
     const allowed = await workUnitsRepo.isUserManagedBy(actor.id, ownerId);
     if (!allowed) fail(403, 'Not authorized to delete this entry');
   }
@@ -248,7 +254,7 @@ export const bulkDeleteTimeEntries = async (
 
   const futureOnlyValue = parseQueryBoolean(input.futureOnly) ?? false;
   const placeholderOnlyValue = parseQueryBoolean(input.placeholderOnly) ?? false;
-  const restrictToManagerScopeOf = hasPermission(actor, 'timesheets.tracker_all.view')
+  const restrictToManagerScopeOf = hasPermission(actor, 'timesheets.tracker_all.delete')
     ? undefined
     : actor.id;
 

--- a/server/test/routes/clients.test.ts
+++ b/server/test/routes/clients.test.ts
@@ -136,6 +136,9 @@ const HAPPY_USER = {
 const ALL_PERMS = [
   'crm.clients.view',
   'crm.clients_all.view',
+  'crm.clients_all.create',
+  'crm.clients_all.update',
+  'crm.clients_all.delete',
   'crm.clients.create',
   'crm.clients.update',
   'crm.clients.delete',
@@ -324,6 +327,23 @@ describe('POST /api/clients', () => {
     );
   });
 
+  test('201 accepts crm.clients_all.create without base create', async () => {
+    getRolePermissionsMock.mockResolvedValue(['crm.clients_all.create']);
+    findByFiscalCodeMock.mockResolvedValue(false);
+    findByClientCodeMock.mockResolvedValue(false);
+    createClientMock.mockResolvedValue(SAMPLE_CLIENT);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/clients',
+      headers: authHeader(),
+      payload: validBody,
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(createClientMock).toHaveBeenCalledTimes(1);
+  });
+
   test('400 whitespace-only name (handler validation)', async () => {
     const res = await testApp.inject({
       method: 'POST',
@@ -464,6 +484,24 @@ describe('PUT /api/clients/:id', () => {
     );
   });
 
+  test('200 crm.clients_all.update bypasses assigned-client check', async () => {
+    getRolePermissionsMock.mockResolvedValue(['crm.clients_all.update']);
+    isClientAssignedToUserMock.mockResolvedValue(false);
+    findContactsForUpdateMock.mockResolvedValue({ contacts: [] });
+    updateClientMock.mockResolvedValue({ ...SAMPLE_CLIENT, name: 'Renamed' });
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/clients/c-1',
+      headers: authHeader(),
+      payload: { name: 'Renamed' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(isClientAssignedToUserMock).not.toHaveBeenCalled();
+    expect(updateClientMock).toHaveBeenCalled();
+  });
+
   test('404 when current client missing', async () => {
     findContactsForUpdateMock.mockResolvedValue(null);
 
@@ -555,6 +593,22 @@ describe('DELETE /api/clients/:id', () => {
     expect(logAuditMock).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'client.deleted', entityId: 'c-1' }),
     );
+  });
+
+  test('200 crm.clients_all.delete bypasses assigned-client check', async () => {
+    getRolePermissionsMock.mockResolvedValue(['crm.clients_all.delete']);
+    isClientAssignedToUserMock.mockResolvedValue(false);
+    deleteClientByIdMock.mockResolvedValue({ id: 'c-1', name: 'ACME', clientCode: 'ACME-01' });
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/clients/c-1',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(isClientAssignedToUserMock).not.toHaveBeenCalled();
+    expect(deleteClientByIdMock).toHaveBeenCalledWith('c-1');
   });
 
   test('404 not found', async () => {

--- a/server/test/routes/suppliers.test.ts
+++ b/server/test/routes/suppliers.test.ts
@@ -81,6 +81,9 @@ const HAPPY_USER = {
 const ALL_PERMS = [
   'crm.suppliers.view',
   'crm.suppliers_all.view',
+  'crm.suppliers_all.create',
+  'crm.suppliers_all.update',
+  'crm.suppliers_all.delete',
   'crm.suppliers.create',
   'crm.suppliers.update',
   'crm.suppliers.delete',
@@ -188,6 +191,24 @@ describe('POST /api/suppliers', () => {
     );
   });
 
+  test('201 accepts crm.suppliers_all.create without base create', async () => {
+    getRolePermissionsMock.mockResolvedValue(['crm.suppliers_all.create']);
+    createMock.mockResolvedValue(SAMPLE_SUPPLIER);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/suppliers',
+      headers: authHeader(),
+      payload: {
+        name: 'ACME',
+        vatNumber: 'IT123',
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(createMock).toHaveBeenCalledTimes(1);
+  });
+
   test('400 missing name', async () => {
     const res = await testApp.inject({
       method: 'POST',
@@ -290,6 +311,21 @@ describe('PUT /api/suppliers/:id', () => {
     );
   });
 
+  test('200 accepts crm.suppliers_all.update without base update', async () => {
+    getRolePermissionsMock.mockResolvedValue(['crm.suppliers_all.update']);
+    updateMock.mockResolvedValue({ ...SAMPLE_SUPPLIER, name: 'ACME 2' });
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/suppliers/s-1',
+      headers: authHeader(),
+      payload: { name: 'ACME 2' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(updateMock).toHaveBeenCalledWith('s-1', expect.objectContaining({ name: 'ACME 2' }));
+  });
+
   test('404 when repo returns null', async () => {
     updateMock.mockResolvedValue(null);
 
@@ -353,6 +389,20 @@ describe('DELETE /api/suppliers/:id', () => {
         entityId: 's-1',
       }),
     );
+  });
+
+  test('204 accepts crm.suppliers_all.delete without base delete', async () => {
+    getRolePermissionsMock.mockResolvedValue(['crm.suppliers_all.delete']);
+    deleteByIdMock.mockResolvedValue({ name: 'ACME', supplierCode: 'ACM' });
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/suppliers/s-1',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(204);
+    expect(deleteByIdMock).toHaveBeenCalledWith('s-1');
   });
 
   test('404 when not found', async () => {

--- a/server/test/utils/permissions.test.ts
+++ b/server/test/utils/permissions.test.ts
@@ -7,7 +7,9 @@ import {
   buildPermission,
   buildPermissions,
   DEFAULT_ROLE_PERMISSIONS,
+  equivalentPermissionsFor,
   hasPermission,
+  hasScopedActionPermission,
   isPermissionKnown,
   isTopManagerOnlyPermission,
   normalizePermission,
@@ -38,7 +40,13 @@ describe('PERMISSION_DEFINITIONS / ALL_PERMISSIONS', () => {
 
   test('contains expected representative permissions', () => {
     expect(ALL_PERMISSIONS).toContain('crm.clients.view');
+    expect(ALL_PERMISSIONS).toContain('crm.clients_all.create');
+    expect(ALL_PERMISSIONS).toContain('crm.suppliers_all.update');
+    expect(ALL_PERMISSIONS).toContain('projects.manage_all.delete');
+    expect(ALL_PERMISSIONS).toContain('projects.tasks_all.create');
+    expect(ALL_PERMISSIONS).toContain('timesheets.tracker_all.update');
     expect(ALL_PERMISSIONS).toContain('hr.work_units.delete');
+    expect(ALL_PERMISSIONS).toContain('hr.work_units_all.delete');
     expect(ALL_PERMISSIONS).toContain('administration.roles.create');
     expect(ALL_PERMISSIONS).toContain('notifications.delete');
   });
@@ -102,6 +110,8 @@ describe('isTopManagerOnlyPermission', () => {
 
   test('matches hr.work_units_all.* permissions', () => {
     expect(isTopManagerOnlyPermission('hr.work_units_all.view')).toBe(true);
+    expect(isTopManagerOnlyPermission('hr.work_units_all.create')).toBe(true);
+    expect(isTopManagerOnlyPermission('hr.work_units_all.delete')).toBe(true);
   });
 
   test('does not match unrelated hr permissions', () => {
@@ -172,6 +182,30 @@ describe('DEFAULT_ROLE_PERMISSIONS', () => {
 
   test('user role does not include any administration.* permissions', () => {
     expect(DEFAULT_ROLE_PERMISSIONS.user.some((p) => p.startsWith('administration.'))).toBe(false);
+  });
+});
+
+describe('equivalentPermissionsFor / hasScopedActionPermission', () => {
+  test('returns base and all-scope equivalents for scoped resources', () => {
+    expect(equivalentPermissionsFor('crm.clients', 'update')).toEqual([
+      'crm.clients.update',
+      'crm.clients_all.update',
+    ]);
+  });
+
+  test('returns only base permission for resources without all-scope variants', () => {
+    expect(equivalentPermissionsFor('sales.client_quotes', 'delete')).toEqual([
+      'sales.client_quotes.delete',
+    ]);
+  });
+
+  test('accepts either base or all-scope action permissions', () => {
+    expect(hasScopedActionPermission(['projects.tasks.update'], 'projects.tasks', 'update')).toBe(
+      true,
+    );
+    expect(
+      hasScopedActionPermission(['projects.tasks_all.update'], 'projects.tasks', 'update'),
+    ).toBe(true);
   });
 });
 

--- a/server/utils/permissions.ts
+++ b/server/utils/permissions.ts
@@ -22,13 +22,13 @@ export const PERMISSION_DEFINITIONS: PermissionDefinition[] = [
   // Timesheets
   { id: 'timesheets.tracker', actions: CRUD },
   { id: 'timesheets.recurring', actions: CRUD },
-  { id: 'timesheets.tracker_all', actions: VIEW_ONLY, isScope: true },
+  { id: 'timesheets.tracker_all', actions: CRUD, isScope: true },
 
   // CRM
   { id: 'crm.clients', actions: CRUD },
-  { id: 'crm.clients_all', actions: VIEW_ONLY, isScope: true },
+  { id: 'crm.clients_all', actions: CRUD, isScope: true },
   { id: 'crm.suppliers', actions: CRUD },
-  { id: 'crm.suppliers_all', actions: VIEW_ONLY, isScope: true },
+  { id: 'crm.suppliers_all', actions: CRUD, isScope: true },
 
   // Sales
   { id: 'sales.client_quotes', actions: CRUD },
@@ -46,9 +46,9 @@ export const PERMISSION_DEFINITIONS: PermissionDefinition[] = [
 
   // Projects
   { id: 'projects.manage', actions: CRUD },
-  { id: 'projects.manage_all', actions: VIEW_ONLY, isScope: true },
+  { id: 'projects.manage_all', actions: CRUD, isScope: true },
   { id: 'projects.tasks', actions: CRUD },
-  { id: 'projects.tasks_all', actions: VIEW_ONLY, isScope: true },
+  { id: 'projects.tasks_all', actions: CRUD, isScope: true },
   { id: 'projects.assignments', actions: ['update'] },
 
   // HR
@@ -57,7 +57,7 @@ export const PERMISSION_DEFINITIONS: PermissionDefinition[] = [
   { id: 'hr.costs', actions: VIEW_UPDATE },
   { id: 'hr.employee_assignments', actions: ['update'] },
   { id: 'hr.work_units', actions: CRUD },
-  { id: 'hr.work_units_all', actions: VIEW_ONLY, isScope: true },
+  { id: 'hr.work_units_all', actions: CRUD, isScope: true },
 
   // Reports
   { id: 'reports.ai_reporting', actions: ['view', 'create'] },
@@ -230,6 +230,30 @@ export const getRolePermissions = async (roleId: string): Promise<Permission[]> 
 
 export const hasPermission = (permissions: string[] | undefined, permission: Permission) =>
   !!permissions?.includes(permission);
+
+export const scopeResourceFor = (resource: PermissionResource): PermissionResource | undefined => {
+  const scoped = `${resource}_all`;
+  return PERMISSION_DEFINITIONS.some((definition) => definition.id === scoped) ? scoped : undefined;
+};
+
+export const equivalentPermissionsFor = (
+  resource: PermissionResource,
+  action: PermissionAction,
+): Permission[] => {
+  const permissions = [buildPermission(resource, action)];
+  const scopeResource = scopeResourceFor(resource);
+  if (scopeResource) permissions.push(buildPermission(scopeResource, action));
+  return permissions;
+};
+
+export const hasAnyPermission = (permissions: string[] | undefined, required: string[]) =>
+  required.some((permission) => permissions?.includes(permission));
+
+export const hasScopedActionPermission = (
+  permissions: string[] | undefined,
+  resource: PermissionResource,
+  action: PermissionAction,
+) => hasAnyPermission(permissions, equivalentPermissionsFor(resource, action));
 
 export const requestHasPermission = (
   request: { user?: { permissions?: string[] } },

--- a/test/components/Layout.test.tsx
+++ b/test/components/Layout.test.tsx
@@ -263,6 +263,20 @@ describe('<Layout />', () => {
     expect(screen.queryByText('modules.accounting')).toBeNull();
   });
 
+  test('all-scope client view permission exposes the CRM clients route', () => {
+    renderLayout({
+      currentUser: {
+        ...mockUser,
+        permissions: ['timesheets.tracker.view', 'crm.clients_all.view'],
+      },
+    });
+
+    expect(screen.getByText('modules.crm')).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: 'modules.crm' }));
+    expect(screen.getByRole('button', { name: 'routes.clients' })).toBeDefined();
+    expect(screen.queryByText('routes.suppliers')).toBeNull();
+  });
+
   test('reports module stays visible with disabled AI reporting route when feature is off', async () => {
     localStorage.setItem(THEME_STORAGE_KEY, 'dark');
     const onViewChange = mock(() => {});

--- a/test/components/administration/RolesView.test.tsx
+++ b/test/components/administration/RolesView.test.tsx
@@ -1,0 +1,45 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { fireEvent, screen, within } from '@testing-library/react';
+import RolesView from '../../../components/administration/RolesView';
+import type { Role } from '../../../types';
+import { installI18nMock } from '../../helpers/i18n';
+import { render } from '../../helpers/render';
+
+installI18nMock();
+
+const roles: Role[] = [
+  {
+    id: 'manager',
+    name: 'Manager',
+    permissions: [],
+    isAdmin: false,
+    isSystem: false,
+  },
+];
+
+const renderRolesView = () =>
+  render(
+    <RolesView
+      roles={roles}
+      permissions={['administration.roles.create', 'administration.roles.update']}
+      onCreateRole={mock(async () => {})}
+      onRenameRole={mock(async () => {})}
+      onUpdateRolePermissions={mock(async () => {})}
+      onDeleteRole={mock(async () => {})}
+    />,
+  );
+
+describe('<RolesView />', () => {
+  test('renders create/update/delete checkboxes for all-scope permission rows', () => {
+    renderRolesView();
+
+    fireEvent.click(screen.getByRole('button', { name: 'common:buttons.create' }));
+    fireEvent.click(screen.getByRole('button', { name: 'layout:modules.crm' }));
+
+    const clientsAllLabel = screen.getByText('administration:permissions.crm.clients_all');
+    const row = clientsAllLabel.closest('tr');
+
+    expect(row).not.toBeNull();
+    expect(within(row as HTMLElement).getAllByRole('checkbox')).toHaveLength(4);
+  });
+});

--- a/test/utils/permissions.test.ts
+++ b/test/utils/permissions.test.ts
@@ -8,6 +8,8 @@ import {
   formatPermissionLabel,
   hasAnyPermission,
   hasPermission,
+  hasScopedActionPermission,
+  hasViewAccess,
   isTopManagerOnlyPermission,
   PERMISSION_DEFINITIONS,
   ROLE_EDITOR_EXCLUDED_MODULES,
@@ -42,7 +44,11 @@ describe('PERMISSION_DEFINITIONS / ALL_PERMISSIONS', () => {
 
   test('contains expected representative permissions', () => {
     expect(ALL_PERMISSIONS).toContain('crm.clients.view');
+    expect(ALL_PERMISSIONS).toContain('crm.clients_all.create');
+    expect(ALL_PERMISSIONS).toContain('projects.tasks_all.update');
+    expect(ALL_PERMISSIONS).toContain('timesheets.tracker_all.delete');
     expect(ALL_PERMISSIONS).toContain('hr.work_units.delete');
+    expect(ALL_PERMISSIONS).toContain('hr.work_units_all.delete');
     expect(ALL_PERMISSIONS).toContain('administration.roles.update');
   });
 });
@@ -75,6 +81,8 @@ describe('isTopManagerOnlyPermission', () => {
 
   test('matches hr.work_units_all.* scope permissions', () => {
     expect(isTopManagerOnlyPermission('hr.work_units_all.view')).toBe(true);
+    expect(isTopManagerOnlyPermission('hr.work_units_all.update')).toBe(true);
+    expect(isTopManagerOnlyPermission('hr.work_units_all.delete')).toBe(true);
   });
 
   test('does not match unrelated permissions', () => {
@@ -143,6 +151,35 @@ describe('hasAnyPermission', () => {
 
   test('returns false when required is empty', () => {
     expect(hasAnyPermission(['crm.clients.view'], [])).toBe(false);
+  });
+});
+
+describe('hasScopedActionPermission', () => {
+  test('returns true for the base action permission', () => {
+    expect(hasScopedActionPermission(['crm.clients.create'], 'crm.clients', 'create')).toBe(true);
+  });
+
+  test('returns true for the matching all-scope action permission', () => {
+    expect(hasScopedActionPermission(['crm.clients_all.delete'], 'crm.clients', 'delete')).toBe(
+      true,
+    );
+  });
+
+  test('does not treat all-scope view as an all-scope write', () => {
+    expect(hasScopedActionPermission(['crm.clients_all.view'], 'crm.clients', 'update')).toBe(
+      false,
+    );
+  });
+});
+
+describe('hasViewAccess', () => {
+  test('allows a scoped view with either base view or all-scope view', () => {
+    expect(hasViewAccess(['crm.clients.view'], 'crm/clients')).toBe(true);
+    expect(hasViewAccess(['crm.clients_all.view'], 'crm/clients')).toBe(true);
+  });
+
+  test('does not allow a scoped view with write permission only', () => {
+    expect(hasViewAccess(['crm.clients_all.update'], 'crm/clients')).toBe(false);
   });
 });
 

--- a/utils/permissions.ts
+++ b/utils/permissions.ts
@@ -27,13 +27,13 @@ export const PERMISSION_DEFINITIONS: PermissionDefinition[] = [
   // Timesheets
   { id: 'timesheets.tracker', actions: CRUD, module: 'timesheets' },
   { id: 'timesheets.recurring', actions: CRUD, module: 'timesheets' },
-  { id: 'timesheets.tracker_all', actions: VIEW_ONLY, isScope: true, module: 'timesheets' },
+  { id: 'timesheets.tracker_all', actions: CRUD, isScope: true, module: 'timesheets' },
 
   // CRM
   { id: 'crm.clients', actions: CRUD, module: 'crm' },
-  { id: 'crm.clients_all', actions: VIEW_ONLY, isScope: true, module: 'crm' },
+  { id: 'crm.clients_all', actions: CRUD, isScope: true, module: 'crm' },
   { id: 'crm.suppliers', actions: CRUD, module: 'crm' },
-  { id: 'crm.suppliers_all', actions: VIEW_ONLY, isScope: true, module: 'crm' },
+  { id: 'crm.suppliers_all', actions: CRUD, isScope: true, module: 'crm' },
 
   // Sales
   { id: 'sales.client_quotes', actions: CRUD, module: 'sales' },
@@ -51,9 +51,9 @@ export const PERMISSION_DEFINITIONS: PermissionDefinition[] = [
 
   // Projects
   { id: 'projects.manage', actions: CRUD, module: 'projects' },
-  { id: 'projects.manage_all', actions: VIEW_ONLY, isScope: true, module: 'projects' },
+  { id: 'projects.manage_all', actions: CRUD, isScope: true, module: 'projects' },
   { id: 'projects.tasks', actions: CRUD, module: 'projects' },
-  { id: 'projects.tasks_all', actions: VIEW_ONLY, isScope: true, module: 'projects' },
+  { id: 'projects.tasks_all', actions: CRUD, isScope: true, module: 'projects' },
   { id: 'projects.assignments', actions: ['update'], module: 'projects' },
 
   // HR
@@ -62,7 +62,7 @@ export const PERMISSION_DEFINITIONS: PermissionDefinition[] = [
   { id: 'hr.costs', actions: VIEW_UPDATE, module: 'hr' },
   { id: 'hr.employee_assignments', actions: ['update'], module: 'hr' },
   { id: 'hr.work_units', actions: CRUD, module: 'hr' },
-  { id: 'hr.work_units_all', actions: VIEW_ONLY, isScope: true, module: 'hr' },
+  { id: 'hr.work_units_all', actions: CRUD, isScope: true, module: 'hr' },
 
   // Reports
   { id: 'reports.ai_reporting', actions: ['view', 'create'], module: 'reports' },
@@ -127,6 +127,27 @@ export const hasPermission = (permissions: Permission[] | undefined, permission:
 export const hasAnyPermission = (permissions: Permission[] | undefined, required: Permission[]) =>
   required.some((permission) => hasPermission(permissions, permission));
 
+export const scopeResourceFor = (resource: PermissionResource): PermissionResource | undefined => {
+  const scoped = `${resource}_all`;
+  return PERMISSION_DEFINITIONS.some((definition) => definition.id === scoped) ? scoped : undefined;
+};
+
+export const equivalentPermissionsFor = (
+  resource: PermissionResource,
+  action: PermissionAction,
+): Permission[] => {
+  const permissions = [buildPermission(resource, action)];
+  const scopeResource = scopeResourceFor(resource);
+  if (scopeResource) permissions.push(buildPermission(scopeResource, action));
+  return permissions;
+};
+
+export const hasScopedActionPermission = (
+  permissions: Permission[] | undefined,
+  resource: PermissionResource,
+  action: PermissionAction,
+) => hasAnyPermission(permissions, equivalentPermissionsFor(resource, action));
+
 export const VIEW_PERMISSION_MAP: Record<View, Permission> = {
   'timesheets/tracker': buildPermission('timesheets.tracker', 'view'),
   'timesheets/recurring': buildPermission('timesheets.recurring', 'view'),
@@ -158,13 +179,24 @@ export const VIEW_PERMISSION_MAP: Record<View, Permission> = {
   'docs/frontend': buildPermission('docs.frontend', 'view'),
 };
 
+export const VIEW_PERMISSION_OPTIONS: Record<View, Permission[]> = Object.fromEntries(
+  Object.entries(VIEW_PERMISSION_MAP).map(([view, permission]) => {
+    const [resource, action] = permission.split(/\.(?=[^.]+$)/) as [
+      PermissionResource,
+      PermissionAction,
+    ];
+    return [view, equivalentPermissionsFor(resource, action)];
+  }),
+) as Record<View, Permission[]>;
+
+export const hasViewAccess = (permissions: Permission[] | undefined, view: View) =>
+  hasAnyPermission(permissions, VIEW_PERMISSION_OPTIONS[view] ?? []);
+
 export const getDefaultViewForPermissions = (
   permissions: Permission[] | undefined,
   validViews: View[],
 ): View => {
-  const allowedView = validViews.find((view) =>
-    hasPermission(permissions, VIEW_PERMISSION_MAP[view]),
-  );
+  const allowedView = validViews.find((view) => hasViewAccess(permissions, view));
 
   return allowedView || 'timesheets/tracker';
 };


### PR DESCRIPTION
## Summary
- Expand all-scope RBAC resources to support `create`, `update`, and `delete` alongside `view`
- Resolve view access through shared helpers so base and `_all` permissions are treated consistently across sidebar filtering, route selection, and guarded rendering
- Update backend permission middleware and row-level checks so all-scope write permissions can act on matching records where intended
- Refresh role editor behavior, route coverage, and documentation to match the new permission contract

## Testing
- Added and updated frontend permission utility tests and layout/roles view coverage
- Added backend permission, middleware, clients, and suppliers route tests for all-scope CRUD behavior
- Ran lint and focused RBAC test suites successfully