### PR TITLE
fix(rbac): close all-scope gaps left after PR #257

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2506,10 +2506,7 @@ const App: React.FC = () => {
                 />
               )}
 
-            {hasPermission(
-              currentUser.permissions,
-              VIEW_PERMISSION_MAP['administration/user-management'],
-            ) &&
+            {hasViewAccess(currentUser.permissions, 'administration/user-management') &&
               activeView === 'administration/user-management' && (
                 <UserManagement
                   clients={clients}

--- a/server/services/timeEntries.ts
+++ b/server/services/timeEntries.ts
@@ -243,7 +243,7 @@ export const bulkDeleteTimeEntries = async (
   input: { projectId?: unknown; task?: unknown; futureOnly?: unknown; placeholderOnly?: unknown },
 ): Promise<{ message: string }> => {
   if (
-    !hasPermission(actor, 'timesheets.tracker.delete') &&
+    !hasTrackerPermission(actor, 'delete') &&
     !hasPermission(actor, 'timesheets.recurring.delete')
   ) {
     fail(403, 'Insufficient permissions');

--- a/server/test/routes/entries.test.ts
+++ b/server/test/routes/entries.test.ts
@@ -724,7 +724,10 @@ describe('DELETE /api/entries (bulk)', () => {
   });
 
   test('200 admin scope deletes across all users', async () => {
-    getRolePermissionsMock.mockResolvedValue(TRACKER_ALL_PERMS);
+    getRolePermissionsMock.mockResolvedValue([
+      ...TRACKER_ALL_PERMS,
+      'timesheets.tracker_all.delete',
+    ]);
     entriesBulkDeleteMock.mockResolvedValue(7);
 
     const res = await testApp.inject({
@@ -774,5 +777,47 @@ describe('DELETE /api/entries (bulk)', () => {
 
     expect(res.statusCode).toBe(403);
     expect(JSON.parse(res.body)).toEqual({ error: 'Insufficient permissions' });
+  });
+
+  test('200 with only timesheets.tracker_all.delete widens scope across users', async () => {
+    getRolePermissionsMock.mockResolvedValue(['timesheets.tracker_all.delete']);
+    entriesBulkDeleteMock.mockResolvedValue(5);
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/entries?projectId=p1&task=Dev',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ message: 'Deleted 5 entries' });
+    expect(entriesBulkDeleteMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: 'p1',
+        task: 'Dev',
+        restrictToManagerScopeOf: undefined,
+      }),
+    );
+  });
+
+  test('200 with only timesheets.recurring.delete stays restricted to actor', async () => {
+    getRolePermissionsMock.mockResolvedValue(['timesheets.recurring.delete']);
+    entriesBulkDeleteMock.mockResolvedValue(2);
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/entries?projectId=p1&task=Dev',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ message: 'Deleted 2 entries' });
+    expect(entriesBulkDeleteMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: 'p1',
+        task: 'Dev',
+        restrictToManagerScopeOf: 'u1',
+      }),
+    );
   });
 });

--- a/test/utils/permissions.test.ts
+++ b/test/utils/permissions.test.ts
@@ -181,6 +181,24 @@ describe('hasViewAccess', () => {
   test('does not allow a scoped view with write permission only', () => {
     expect(hasViewAccess(['crm.clients_all.update'], 'crm/clients')).toBe(false);
   });
+
+  test('allows administration/user-management with either base or all-scope view', () => {
+    expect(
+      hasViewAccess(['administration.user_management.view'], 'administration/user-management'),
+    ).toBe(true);
+    expect(
+      hasViewAccess(['administration.user_management_all.view'], 'administration/user-management'),
+    ).toBe(true);
+  });
+
+  test('does not allow administration/user-management with non-view all-scope permission', () => {
+    expect(
+      hasViewAccess(
+        ['administration.user_management_all.update'],
+        'administration/user-management',
+      ),
+    ).toBe(false);
+  });
 });
 
 describe('VIEW_PERMISSION_MAP', () => {


### PR DESCRIPTION
## Summary

Two authorization-consistency defects survived [PR #257](https://github.com/xBounceIT/praetor/pull/257) (the RBAC all-scope expansion). Both were flagged in the post-merge review (one P1 from Codex, one from Copilot) — this PR addresses both and pins the contract with tests.

In both cases, a caller holding only an `_all` permission variant passed one access-check layer but got rejected by a stale guard further in.

## Changes

### Frontend — [App.tsx:2509](App.tsx:2509)

The `UserManagement` render guard still used `hasPermission(..., VIEW_PERMISSION_MAP['administration/user-management'])`, which only matches the base `administration.user_management.view`. Sidebar filtering, default-view selection, and `getNotFoundReturnView` had been migrated to `hasViewAccess` (which honors both base and `_all` view permissions), so a user holding only `administration.user_management_all.view` was routed to the page but the component never mounted — blank pane. Switched the guard to `hasViewAccess(...)`.

Audited every other `hasPermission(..., VIEW_PERMISSION_MAP[...])` call site in `App.tsx`: each targets a view whose resource has no `_all` scope variant in `PERMISSION_DEFINITIONS`, so they're behaviorally equivalent and left unchanged to keep this PR minimal.

### Backend — [server/services/timeEntries.ts:246](server/services/timeEntries.ts:246)

The bulk-delete route ([entries.ts:261-265](server/routes/entries.ts:261)) accepts `timesheets.tracker.delete`, `timesheets.tracker_all.delete`, or `timesheets.recurring.delete`. The service guard at the top of `bulkDeleteTimeEntries` only accepted the first and third, so a role configured with only the new `_all.delete` right always 403'd despite the route advertising it as valid. Switched to `hasTrackerPermission(actor, 'delete')` — the same scoped helper already used by `deleteTimeEntry`, `listTimeEntries`, `createTimeEntry`, and `updateTimeEntry`. The companion `timesheets.recurring.delete` check stays raw since that resource has no `_all` scope.

## Tests

- [test/utils/permissions.test.ts](test/utils/permissions.test.ts) — extend `hasViewAccess` coverage for `administration/user-management` (positive case for both base and `_all` view permissions; negative case for a non-view all-scope permission). Mirrors the existing `crm/clients` pattern.
- [server/test/routes/entries.test.ts](server/test/routes/entries.test.ts) — two new bulk-delete cases:
  - `200 with only timesheets.tracker_all.delete widens scope across users` (verified to **fail with 403 on the pre-fix code**, pass after the fix)
  - `200 with only timesheets.recurring.delete stays restricted to actor`
- Also fix a pre-existing failing test in the same file: `200 admin scope deletes across all users` used `TRACKER_ALL_PERMS` (which lacks `tracker_all.delete`) while asserting `restrictToManagerScopeOf: undefined`. Added `tracker_all.delete` to the test's permission set so it actually exercises the all-scope branch.

## Verification

- `bun run lint` — clean
- `bun run test` — 1997 backend + 846 frontend tests pass, 0 fail
- Reviewer pass (reuse / quality / efficiency): no further issues found

## References

- [PR #257](https://github.com/xBounceIT/praetor/pull/257) (RBAC all-scope expansion, merged 2026-05-11)
- Copilot review comment (low-confidence, suppressed) on App.tsx render guard
- Codex P1 review comment on bulk-delete authorization mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)