### PR TITLE
fix(auth): distinguish disabled-user error from invalid token

### DIFF
--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -41,7 +41,10 @@ export const authenticateToken = async (request: FastifyRequest, reply: FastifyR
     }
 
     if (user.isDisabled) {
-      return reply.code(401).send({ error: 'Invalid or expired token' });
+      // 403 (not 401): the token itself is valid; the account is forbidden from
+      // accessing the system. Matches the sibling-route convention for
+      // authenticated-but-forbidden responses (see requireRole/requirePermission).
+      return reply.code(403).send({ error: 'Account is disabled' });
     }
 
     const effectiveRole = decoded.activeRole ?? user.role;

--- a/server/test/middleware/auth.test.ts
+++ b/server/test/middleware/auth.test.ts
@@ -163,13 +163,15 @@ describe('authenticateToken', () => {
     expect(reply.body).toEqual({ error: 'User not found' });
   });
 
-  test('401 when user.isDisabled is true', async () => {
+  test('403 with "Account is disabled" when user.isDisabled is true (distinct from invalid/expired token)', async () => {
     findAuthUserByIdMock.mockResolvedValue({ ...HAPPY_USER, isDisabled: true });
     const request = buildFakeRequest(signToken({ userId: 'u1' }));
     const reply = buildFakeReply();
     await authenticateToken(request as never, reply as never);
-    expect(reply.statusCode).toBe(401);
-    expect(reply.body).toEqual({ error: 'Invalid or expired token' });
+    expect(reply.statusCode).toBe(403);
+    expect(reply.body).toEqual({ error: 'Account is disabled' });
+    // No rotated session token: a disabled user must not receive a fresh sliding-window token.
+    expect(reply.headers['x-auth-token']).toBeUndefined();
   });
 
   test('403 when rolesRepo.userHasRole returns false', async () => {


### PR DESCRIPTION
## Summary
- Disabled users previously received the same `401 Invalid or expired token` response as users with malformed or idle-expired tokens, making it impossible for admins to triage support requests from disabled accounts (third-party review High Issue 30, `server/middleware/auth.ts` ~line 44).
- The middleware now returns `403 { error: 'Account is disabled' }` for that case so the failure mode is distinguishable in logs and frontend error messages.
- `403` (not `401`) matches the sibling convention in this codebase for authenticated-but-forbidden responses: `requireRole`, `requirePermission`, and route-level access checks in `routes/users.ts`, `routes/work-units.ts`, `routes/entries.ts`, etc. all use `403` for "token is valid but user is not allowed".
- Frontend impact: `services/api/client.ts` rethrows on every `!response.ok`, including both `401` and `403`, so the existing logout-on-auth-failure flow continues to fire — no client changes needed.

## Test plan
- [x] `bun run lint` — no new findings on touched files.
- [x] `cd server && bun test ./test/middleware/auth.test.ts` — 24 pass, 0 fail.
- [x] `cd server && bun test` — 1098 pass, 0 fail.
- [x] Regression check: stashed the `auth.ts` change and re-ran the disabled-user test — it fails on the old code (`expected 403, got 401` / `expected 'Account is disabled', got 'Invalid or expired token'`) and passes on the fix.
- [x] New assertion in the disabled-user test confirms `x-auth-token` is **not** rotated on the disabled-user path — a disabled account must not receive a fresh sliding-window token.
- [ ] Remote E2E (curl an authed endpoint with a disabled user's token, expect `403 {"error":"Account is disabled"}`) — covered equivalently by the unit test; remote Docker dev server not run locally per project conventions.

https://claude.ai/code/session_01JoRTwXFkuga3Cfymy6HcJ9

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoRTwXFkuga3Cfymy6HcJ9)_