### PR TITLE
fix(server): resolve tsconfig noEmit/outDir contradiction

### DIFF
--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -5,7 +5,6 @@
     "moduleResolution": "NodeNext",
     "lib": ["ES2022"],
     "rootDir": ".",
-    "outDir": "dist",
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
@@ -16,5 +15,5 @@
     "allowImportingTsExtensions": true
   },
   "include": ["**/*.ts"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- Remove the unreachable `outDir: "dist"` from `server/tsconfig.json` (and the matching `"dist"` entry in `exclude`). `noEmit: true` already prevents emission, so `outDir` was dead config that misleadingly implied `tsc` produced runtime artifacts.
- The server is actually executed by `bun run index.ts` (see `server/package.json` `start`/`dev` scripts and `server/Dockerfile` `CMD`), so no compiled `dist/` is needed. `tsc -p tsconfig.json` (`bun run build` in `server/`) is used purely as a type-check gate.
- Keeping `noEmit: true` also satisfies TypeScript's requirement that `allowImportingTsExtensions` be paired with `noEmit` or `emitDeclarationOnly`.

## Test plan
- [x] `bun run lint` (root) — runs `i18n:check` + `tsc -p server/tsconfig.json && tsc -p tsconfig.json` + `biome check .`; all pass.
- [x] `cd server && bun run build` — `tsc -p tsconfig.json` succeeds with no errors and produces no `dist/` artifacts (as expected with `noEmit: true`).
- [x] `cd server && bun run start` — module graph loads cleanly; execution proceeds to runtime config (fails only because `JWT_SECRET` env var isn't set, which is the expected runtime guard, not a missing-module/TS error).
- [x] `cd server && bun test ./test` — 1994 pass / 27 skip / 1 fail; the single failing test (`DELETE /api/entries (bulk) > 200 admin scope deletes across all users`) is reproducible on the unmodified base branch and is unrelated to this change.

https://claude.ai/code/session_01JoRTwXFkuga3Cfymy6HcJ9

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoRTwXFkuga3Cfymy6HcJ9)_