### PR TITLE
fix(timeEntries): handle empty location on update

### DIFF
--- a/server/services/timeEntries.ts
+++ b/server/services/timeEntries.ts
@@ -212,7 +212,8 @@ export const updateTimeEntry = async (
     notes: validatedNotes,
     isPlaceholder:
       input.isPlaceholder === undefined ? undefined : parseBoolean(input.isPlaceholder),
-    location: typeof input.location === 'string' ? input.location : undefined,
+    location:
+      typeof input.location === 'string' && input.location.trim() ? input.location : undefined,
     taskId: backfilledTaskId,
   });
 

--- a/server/test/services/timeEntries.test.ts
+++ b/server/test/services/timeEntries.test.ts
@@ -1,0 +1,109 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as realEntriesRepo from '../../repositories/entriesRepo.ts';
+import * as realTasksRepo from '../../repositories/tasksRepo.ts';
+import * as realWorkUnitsRepo from '../../repositories/workUnitsRepo.ts';
+
+const entriesRepoSnap = { ...realEntriesRepo };
+const tasksRepoSnap = { ...realTasksRepo };
+const workUnitsRepoSnap = { ...realWorkUnitsRepo };
+
+const findContextMock = mock();
+const updateMock = mock();
+const findIdByProjectAndNameMock = mock();
+const isUserManagedByMock = mock();
+
+let updateTimeEntry: typeof import('../../services/timeEntries.ts').updateTimeEntry;
+
+beforeAll(async () => {
+  mock.module('../../repositories/entriesRepo.ts', () => ({
+    ...entriesRepoSnap,
+    findContext: findContextMock,
+    update: updateMock,
+  }));
+  mock.module('../../repositories/tasksRepo.ts', () => ({
+    ...tasksRepoSnap,
+    findIdByProjectAndName: findIdByProjectAndNameMock,
+  }));
+  mock.module('../../repositories/workUnitsRepo.ts', () => ({
+    ...workUnitsRepoSnap,
+    isUserManagedBy: isUserManagedByMock,
+  }));
+
+  updateTimeEntry = (await import('../../services/timeEntries.ts')).updateTimeEntry;
+});
+
+afterAll(() => {
+  mock.module('../../repositories/entriesRepo.ts', () => entriesRepoSnap);
+  mock.module('../../repositories/tasksRepo.ts', () => tasksRepoSnap);
+  mock.module('../../repositories/workUnitsRepo.ts', () => workUnitsRepoSnap);
+});
+
+const ACTOR = {
+  id: 'u1',
+  permissions: ['timesheets.tracker.update'],
+};
+
+const SAMPLE_ENTRY = {
+  id: 'te-1',
+  userId: 'u1',
+  date: '2025-06-02',
+  clientId: 'c1',
+  clientName: 'Client',
+  projectId: 'p1',
+  projectName: 'Project',
+  task: 'Dev',
+  taskId: 't1',
+  notes: null,
+  duration: 4,
+  hourlyCost: 50,
+  isPlaceholder: false,
+  location: 'remote',
+  createdAt: 1_700_000_000_000,
+};
+
+beforeEach(() => {
+  findContextMock.mockReset();
+  updateMock.mockReset();
+  findIdByProjectAndNameMock.mockReset();
+  isUserManagedByMock.mockReset();
+
+  findContextMock.mockResolvedValue({
+    userId: 'u1',
+    projectId: 'p1',
+    task: 'Dev',
+    taskId: 't1',
+  });
+  updateMock.mockResolvedValue(SAMPLE_ENTRY);
+});
+
+describe('updateTimeEntry', () => {
+  test('passes valid location through to repo', async () => {
+    await updateTimeEntry(ACTOR, 'te-1', { location: 'office' });
+    expect(updateMock).toHaveBeenCalledWith(
+      'te-1',
+      expect.objectContaining({ location: 'office' }),
+    );
+  });
+
+  test('empty-string location does not touch DB column (regression for High #13)', async () => {
+    // Empty string used to pass straight to the DB, violating the
+    // CHECK (location IN ('remote', 'office', 'customer_premise', 'transfer'))
+    // constraint and surfacing as an unhandled 500.
+    await updateTimeEntry(ACTOR, 'te-1', { location: '' });
+    expect(updateMock).toHaveBeenCalledTimes(1);
+    const patch = updateMock.mock.calls[0][1] as { location?: unknown };
+    expect(patch.location).toBeUndefined();
+  });
+
+  test('whitespace-only location does not touch DB column', async () => {
+    await updateTimeEntry(ACTOR, 'te-1', { location: '   ' });
+    const patch = updateMock.mock.calls[0][1] as { location?: unknown };
+    expect(patch.location).toBeUndefined();
+  });
+
+  test('omitted location leaves DB column untouched', async () => {
+    await updateTimeEntry(ACTOR, 'te-1', { duration: 5 });
+    const patch = updateMock.mock.calls[0][1] as { location?: unknown };
+    expect(patch.location).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Mirror create-path semantics on `updateTimeEntry`: an empty or whitespace-only `location` string is now treated as "leave the DB column untouched" instead of being forwarded as `""`, which used to violate the `CHECK (location IN ('remote', 'office', 'customer_premise', 'transfer'))` constraint and surface as an unhandled 500.
- Add `server/test/services/timeEntries.test.ts` covering the regression (empty string, whitespace-only) plus omitted/valid cases.

## Test plan
- [x] `cd server && bun test ./test/services/timeEntries.test.ts` -> 4/4 pass on the fix
- [x] Verified the new empty- and whitespace-only tests fail on the prior code (asserts `location: ""` / `"   "` was leaking to the patch).
- [x] `cd server && bun test ./test/services/` -> 69/69 pass (no regressions).
- [x] `cd server && bun test ./test/routes/entries.test.ts ./test/repositories/entriesRepo.test.ts` -> 86 pass, 1 fail (pre-existing bulk-delete admin-scope test, confirmed unrelated by running against baseline).

https://claude.ai/code/session_01JoRTwXFkuga3Cfymy6HcJ9

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoRTwXFkuga3Cfymy6HcJ9)_