### PR TITLE
fix(user-management): strip special characters from auto-generated username

### DIFF
--- a/components/administration/UserManagement.tsx
+++ b/components/administration/UserManagement.tsx
@@ -41,6 +41,12 @@ import ValidatedNumberInput from '../shared/ValidatedNumberInput';
 const isSsoAuthMethod = (authMethod: UserAuthMethod): authMethod is 'oidc' | 'saml' =>
   authMethod === 'oidc' || authMethod === 'saml';
 
+const sanitizeUsernamePart = (s: string) =>
+  s
+    .normalize('NFD')
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '');
+
 export interface UserManagementProps {
   users: User[];
   clients: Client[];
@@ -1371,8 +1377,8 @@ const UserManagement: React.FC<UserManagementProps> = ({
                       const val = e.target.value;
                       setNewFirstName(val);
                       if (!usernameManuallyEdited.current) {
-                        const surname = newSurname.trim().toLowerCase().replace(/\s+/g, '');
-                        const first = val.trim().toLowerCase().replace(/\s+/g, '');
+                        const surname = sanitizeUsernamePart(newSurname);
+                        const first = sanitizeUsernamePart(val);
                         setNewUsername(first && surname ? `${first}.${surname}` : first || surname);
                       }
                       if (formErrors.firstName || formErrors.general) {
@@ -1397,8 +1403,8 @@ const UserManagement: React.FC<UserManagementProps> = ({
                       const val = e.target.value;
                       setNewSurname(val);
                       if (!usernameManuallyEdited.current) {
-                        const first = newFirstName.trim().toLowerCase().replace(/\s+/g, '');
-                        const surname = val.trim().toLowerCase().replace(/\s+/g, '');
+                        const first = sanitizeUsernamePart(newFirstName);
+                        const surname = sanitizeUsernamePart(val);
                         setNewUsername(first && surname ? `${first}.${surname}` : first || surname);
                       }
                       if (formErrors.surname || formErrors.general) {

--- a/test/components/administration/UserManagement.test.tsx
+++ b/test/components/administration/UserManagement.test.tsx
@@ -22,6 +22,7 @@ const UserManagement = (await import('../../../components/administration/UserMan
 
 const updatePermission = 'administration.user_management.update';
 const deletePermission = 'administration.user_management.delete';
+const createPermission = 'administration.user_management.create';
 
 const users: User[] = [
   {
@@ -183,5 +184,34 @@ describe('<UserManagement />', () => {
     await user.click(screen.getByRole('button', { name: 'common:buttons.save' }));
 
     expect(props.onUpdateUserAuthMethod).toHaveBeenCalledWith('u2', 'local', null);
+  });
+
+  const openCreateUserModal = async () => {
+    const user = userEvent.setup();
+    renderUserManagement({
+      permissions: [updatePermission, deletePermission, createPermission],
+    });
+    await user.click(screen.getByText('hr:workforce.addUser'));
+    const firstNameInput = await screen.findByPlaceholderText('e.g. Alice');
+    const usernameInput = screen.getByPlaceholderText('e.g. alice.smith') as HTMLInputElement;
+    return { user, firstNameInput, usernameInput };
+  };
+
+  test('strips accents and special characters when auto-generating username', async () => {
+    const { user, firstNameInput, usernameInput } = await openCreateUserModal();
+    const surnameInput = screen.getByPlaceholderText('e.g. Smith');
+
+    await user.type(firstNameInput, 'José');
+    await user.type(surnameInput, "O'Brien");
+
+    expect(usernameInput.value).toBe('jose.obrien');
+  });
+
+  test('strips hyphens and inner whitespace from a single name field', async () => {
+    const { user, firstNameInput, usernameInput } = await openCreateUserModal();
+
+    await user.type(firstNameInput, 'Anna-Maria');
+
+    expect(usernameInput.value).toBe('annamaria');
   });
 });


### PR DESCRIPTION
## Summary

- The create-user modal auto-fills the `username` field from first name + surname, but only lowercased and collapsed whitespace — accents and punctuation were leaking through (e.g. "José" / "O'Brien" → `josé.o'brien`).
- Normalize via Unicode NFD decomposition and keep only `[a-z0-9]`, so the suggestion is now ASCII-clean (e.g. `jose.obrien`, `muller`, `annamaria`). Digits are preserved.
- The existing `usernameManuallyEdited` ref still locks the field once the user types into it directly, so manual overrides aren't clobbered.
- Pure client-side fix in [components/administration/UserManagement.tsx](https://github.com/xBounceIT/praetor/blob/claude/eloquent-cray-3da3c7/components/administration/UserManagement.tsx); the server accepts the username as-is and is unchanged.

## Test plan

- [x] `bun test test/components/administration/UserManagement.test.tsx` — two new tests cover the José/O'Brien combined case and the Anna-Maria single-field case; both fail on the old code (which leaves the accent and apostrophe) and pass on the fix.
- [x] `bun run lint` — i18n check + typecheck + Biome all clean.
- [x] Manual smoke: open user management → Create new user → type names with accents/apostrophes/hyphens → confirm username field shows clean lowercase ASCII; verify that editing the username manually still locks it against subsequent name changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)