### PR TITLE
fix(entriesRepo): return 400 on malformed pagination cursor

### DIFF
--- a/server/repositories/entriesRepo.ts
+++ b/server/repositories/entriesRepo.ts
@@ -44,14 +44,15 @@ type TimeEntryRow = {
   location: string | null;
   created_at: string | Date | null;
   // Microsecond-precision text rep of created_at - pg returns TIMESTAMP as a JS Date (ms-only),
-  // which would lose precision in the cursor and skip rows at page boundaries. Using ::text keeps
-  // the full Postgres precision for cursor round-trips.
+  // which would lose precision in the cursor and skip rows at page boundaries. Format with to_char
+  // so the output is independent of the session's DateStyle setting (a non-ISO DateStyle would
+  // otherwise emit MM/DD/YYYY... and our cursor validator would reject the API's own cursors).
   created_at_text: string | null;
 };
 
 const ENTRY_COLUMNS_SQL = sql`id, user_id, date, client_id, client_name, project_id,
   project_name, task, task_id, notes, duration, hourly_cost, is_placeholder, location, created_at,
-  created_at::text AS created_at_text`;
+  to_char(created_at, 'YYYY-MM-DD HH24:MI:SS.US') AS created_at_text`;
 
 const mapRawRow = (row: TimeEntryRow): TimeEntry => {
   const date = normalizeNullableDateOnly(row.date, 'entry.date');

--- a/server/repositories/entriesRepo.ts
+++ b/server/repositories/entriesRepo.ts
@@ -192,21 +192,34 @@ export const listForManagerView = async (
 export const encodeCursor = (cursor: EntriesCursor): string =>
   Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url');
 
-export const decodeCursor = (raw: string): EntriesCursor | null => {
+// Matches Postgres' `timestamp::text` output (what `created_at_text` produces): `YYYY-MM-DD HH:MM:SS`
+// with an optional fractional `.f`..`.ffffff` part. Also accepts the ISO-8601 variant with `T` and
+// trailing `Z`, in case a caller hand-crafted the cursor. Anything else would make Postgres throw
+// at query time and surface as a 500, so we reject early with a typed error.
+const CURSOR_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(\.\d{1,6})?Z?$/;
+
+export const decodeCursor = (
+  raw: string,
+): { ok: true; value: EntriesCursor } | { ok: false; message: string } => {
+  let parsed: unknown;
   try {
-    const parsed = JSON.parse(Buffer.from(raw, 'base64url').toString('utf8')) as unknown;
-    if (
-      typeof parsed === 'object' &&
-      parsed !== null &&
-      typeof (parsed as EntriesCursor).createdAt === 'string' &&
-      typeof (parsed as EntriesCursor).id === 'string'
-    ) {
-      return parsed as EntriesCursor;
-    }
-    return null;
+    parsed = JSON.parse(Buffer.from(raw, 'base64url').toString('utf8'));
   } catch {
-    return null;
+    return { ok: false, message: 'Invalid cursor' };
   }
+  if (
+    typeof parsed !== 'object' ||
+    parsed === null ||
+    typeof (parsed as EntriesCursor).createdAt !== 'string' ||
+    typeof (parsed as EntriesCursor).id !== 'string'
+  ) {
+    return { ok: false, message: 'Invalid cursor' };
+  }
+  const cursor = parsed as EntriesCursor;
+  if (!CURSOR_TIMESTAMP_RE.test(cursor.createdAt)) {
+    return { ok: false, message: 'Invalid cursor' };
+  }
+  return { ok: true, value: cursor };
 };
 
 export const findOwner = async (id: string, exec: DbExecutor = db): Promise<string | null> => {

--- a/server/services/timeEntries.ts
+++ b/server/services/timeEntries.ts
@@ -73,10 +73,9 @@ export const listTimeEntries = async (
     if (!allowed) fail(403, 'Not authorized to view entries for this user');
   }
 
-  const decodedCursor = cursor ? entriesRepo.decodeCursor(cursor) : undefined;
-  if (cursor && !decodedCursor) badRequest('cursor is invalid');
+  const decodedCursor = cursor ? requireValid(entriesRepo.decodeCursor(cursor)) : undefined;
 
-  const options = { limit, cursor: decodedCursor ?? undefined };
+  const options = { limit, cursor: decodedCursor };
   const result = userId
     ? await entriesRepo.listForUser(userId, options)
     : canViewAll

--- a/server/test/repositories/entriesRepo.test.ts
+++ b/server/test/repositories/entriesRepo.test.ts
@@ -149,23 +149,27 @@ describe('encodeCursor / decodeCursor', () => {
       id: 'e-1',
     });
     expect(entriesRepo.decodeCursor(encoded)).toEqual({
-      createdAt: '2026-04-30 12:00:00.123456',
-      id: 'e-1',
+      ok: true,
+      value: { createdAt: '2026-04-30 12:00:00.123456', id: 'e-1' },
     });
   });
 
-  test('returns null for malformed input', () => {
-    expect(entriesRepo.decodeCursor('not base64')).toBeNull();
-    expect(
-      entriesRepo.decodeCursor(Buffer.from('garbage', 'utf8').toString('base64url')),
-    ).toBeNull();
+  test('returns Invalid cursor error for malformed input', () => {
+    expect(entriesRepo.decodeCursor('not base64')).toEqual({
+      ok: false,
+      message: 'Invalid cursor',
+    });
+    expect(entriesRepo.decodeCursor(Buffer.from('garbage', 'utf8').toString('base64url'))).toEqual({
+      ok: false,
+      message: 'Invalid cursor',
+    });
   });
 
   test('rejects legacy numeric createdAt cursors', () => {
     const legacy = Buffer.from(JSON.stringify({ createdAt: 12345, id: 'e-1' }), 'utf8').toString(
       'base64url',
     );
-    expect(entriesRepo.decodeCursor(legacy)).toBeNull();
+    expect(entriesRepo.decodeCursor(legacy)).toEqual({ ok: false, message: 'Invalid cursor' });
   });
 
   test.each([
@@ -176,7 +180,36 @@ describe('encodeCursor / decodeCursor', () => {
     ['array payload', ['2026-04-30 12:00:00.123456', 'e-1']],
   ])('rejects %s', (_label, payload) => {
     const encoded = Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
-    expect(entriesRepo.decodeCursor(encoded)).toBeNull();
+    expect(entriesRepo.decodeCursor(encoded)).toEqual({ ok: false, message: 'Invalid cursor' });
+  });
+
+  test.each([
+    ['plain garbage', 'not a timestamp'],
+    ['SQL injection', "2026-04-30'; DROP TABLE x"],
+    ['empty string', ''],
+    ['date only', '2026-04-30'],
+    ['too many fractional digits', '2026-04-30 12:00:00.1234567'],
+    ['negative year', '-2026-04-30 12:00:00'],
+  ])('rejects malformed createdAt timestamp (%s)', (_label, createdAt) => {
+    const encoded = Buffer.from(JSON.stringify({ createdAt, id: 'e-1' }), 'utf8').toString(
+      'base64url',
+    );
+    expect(entriesRepo.decodeCursor(encoded)).toEqual({ ok: false, message: 'Invalid cursor' });
+  });
+
+  test.each([
+    ['Postgres format with µs', '2026-04-30 12:00:00.123456'],
+    ['Postgres format no fractional', '2026-04-30 12:00:00'],
+    ['ISO 8601 with T', '2026-04-30T12:00:00.123'],
+    ['ISO 8601 with Z', '2026-04-30T12:00:00Z'],
+  ])('accepts valid timestamp format (%s)', (_label, createdAt) => {
+    const encoded = Buffer.from(JSON.stringify({ createdAt, id: 'e-1' }), 'utf8').toString(
+      'base64url',
+    );
+    expect(entriesRepo.decodeCursor(encoded)).toEqual({
+      ok: true,
+      value: { createdAt, id: 'e-1' },
+    });
   });
 
   test('produces a nextCursor that preserves µs precision from created_at_text', async () => {

--- a/server/test/routes/entries.test.ts
+++ b/server/test/routes/entries.test.ts
@@ -289,8 +289,11 @@ describe('GET /api/entries', () => {
     expect(isUserManagedByMock).toHaveBeenCalledWith('u1', 'u2');
   });
 
-  test('400: invalid cursor', async () => {
-    entriesDecodeCursorMock.mockReturnValue(null);
+  test('400: rejected cursor short-circuits before any DB call (no 500 bubble-up)', async () => {
+    // Covers both structurally malformed and bad-timestamp cursors - the decoder's typed
+    // `{ ok: false }` keeps the request out of the repo layer entirely. Before the fix,
+    // a bad `createdAt` reached Postgres and produced a 500.
+    entriesDecodeCursorMock.mockReturnValue({ ok: false, message: 'Invalid cursor' });
 
     const res = await testApp.inject({
       method: 'GET',
@@ -299,7 +302,10 @@ describe('GET /api/entries', () => {
     });
 
     expect(res.statusCode).toBe(400);
-    expect(JSON.parse(res.body)).toEqual({ error: 'cursor is invalid' });
+    expect(JSON.parse(res.body)).toEqual({ error: 'Invalid cursor' });
+    expect(entriesListAllMock).not.toHaveBeenCalled();
+    expect(entriesListForUserMock).not.toHaveBeenCalled();
+    expect(entriesListForManagerViewMock).not.toHaveBeenCalled();
   });
 
   test('401: missing token', async () => {


### PR DESCRIPTION
## Summary
- A pagination cursor with a malformed `createdAt` field slipped past `decodeCursor`'s shape check and reached Postgres as `${cursor.createdAt}::timestamp`, where it threw a `DataException` that bubbled up as a generic 500.
- Tighten `decodeCursor` to validate the timestamp matches Postgres' `text` output (`YYYY-MM-DD HH:MM:SS[.ffffff]`) or the ISO-8601 variant. The function now returns a typed `{ ok: true; value } | { ok: false; message }` so the service can route the failure through the existing `requireValid` helper and surface it as a 400.
- `listTimeEntries` in `server/services/timeEntries.ts` uses the existing `requireValid` helper for the new typed result, replacing the bespoke null-check.

## Test plan
- [x] `cd server && bun test ./test/repositories/entriesRepo.test.ts` (64 pass, +10 new regression cases covering bad timestamp shapes and the accepted Postgres/ISO formats).
- [x] `cd server && bun test ./test/routes/entries.test.ts` (32 pass; 1 pre-existing failure on `200 admin scope deletes across all users` is unrelated to this change).
- [x] `cd server && bun test ./test/repositories/` (804 pass).
- [x] `bunx biome check` on all modified files - clean.
- [x] Manual E2E (`curl /api/entries?cursor=garbage`) skipped per CLAUDE.md remote-Docker rule; unit + route tests cover the regression.

https://claude.ai/code/session_01JoRTwXFkuga3Cfymy6HcJ9

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoRTwXFkuga3Cfymy6HcJ9)_