### PR TITLE
fix(app): remove duplicate supplier-quotes route registration

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -129,7 +129,6 @@ export const buildApp = async () => {
   await fastify.register(supplierQuotesRoutes, { prefix: '/api/sales/supplier-quotes' });
   await fastify.register(supplierOrdersRoutes, { prefix: '/api/accounting/supplier-orders' });
   await fastify.register(supplierInvoicesRoutes, { prefix: '/api/accounting/supplier-invoices' });
-  await fastify.register(supplierQuotesRoutes, { prefix: '/api/supplier-quotes' });
   await fastify.register(notificationsRoutes, { prefix: '/api/notifications' });
   await fastify.register(emailRoutes, { prefix: '/api/email' });
   await fastify.register(rolesRoutes, { prefix: '/api/roles' });

--- a/server/test/app.test.ts
+++ b/server/test/app.test.ts
@@ -1,0 +1,31 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import type { FastifyInstance } from 'fastify';
+import buildApp from '../app.ts';
+
+describe('buildApp route registration', () => {
+  let app: FastifyInstance;
+  let routeTree: string;
+
+  // buildApp wires every Fastify plugin and route module, which can take longer
+  // than Bun's 5s default when the test runner is warming up.
+  beforeAll(async () => {
+    app = await buildApp();
+    await app.ready();
+    routeTree = app.printRoutes({ commonPrefix: false });
+  }, 30000);
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  // Regression guard for the duplicate `supplierQuotesRoutes` registration that
+  // mounted the module at both `/api/sales/supplier-quotes` and `/api/supplier-quotes`,
+  // causing side effects (rate limiting, audit logs) to run twice.
+  test('mounts supplier-quotes only under the canonical /api/sales prefix', () => {
+    const salesMatches = routeTree.match(/\/api\/sales\/supplier-quotes \(/g) ?? [];
+    const legacyMatches = routeTree.match(/\/api\/supplier-quotes \(/g) ?? [];
+
+    expect(salesMatches.length).toBe(1);
+    expect(legacyMatches.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- `supplierQuotesRoutes` was registered twice in `server/app.ts` (under both `/api/sales/supplier-quotes` and `/api/supplier-quotes`), causing per-request side effects like rate-limit accounting and audit-log writes to fire twice on every request hitting the canonical URL.
- The legacy `/api/supplier-quotes` prefix has no consumers — all frontend services, tests, and documentation use `/api/sales/supplier-quotes` — so the duplicate registration is dropped entirely rather than aliased.
- Adds `server/test/app.test.ts` as a regression guard: it boots `buildApp()`, inspects the printed route tree, and asserts the supplier-quotes module mounts under exactly one prefix.

## Test plan
- [x] `bun run lint` (passes — only pre-existing warnings unrelated to this change)
- [x] `cd server && bun test ./test` (1995 pass; the lone failure in `entries.test.ts` `200 admin scope deletes across all users` is pre-existing on the base branch and unrelated)
- [x] `bun test ./test` (frontend, 302 pass)
- [x] New `server/test/app.test.ts` fails on the buggy app.ts (verified by temporarily re-adding the duplicate registration) and passes on the fix
- [x] `app.printRoutes({ commonPrefix: false })` confirms `/api/sales/supplier-quotes` is present once and `/api/supplier-quotes` is absent

https://claude.ai/code/session_01JoRTwXFkuga3Cfymy6HcJ9

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoRTwXFkuga3Cfymy6HcJ9)_