### PR TITLE
fix(projects,tasks): atomic creation + use validated recurrenceEnd

### DIFF
--- a/server/routes/projects.ts
+++ b/server/routes/projects.ts
@@ -217,24 +217,36 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       }
 
       try {
-        const created = await projectsRepo.create({
-          id,
-          name: nameResult.value,
-          clientId: clientIdResult.value,
-          color: projectColor,
-          description: description || null,
-          isDisabled: false,
-          orderId: orderId || null,
-          billingType,
-          billingFrequency,
-        });
+        const created = await withDbTransaction(async (tx) => {
+          const project = await projectsRepo.create(
+            {
+              id,
+              name: nameResult.value,
+              clientId: clientIdResult.value,
+              color: projectColor,
+              description: description || null,
+              isDisabled: false,
+              orderId: orderId || null,
+              billingType,
+              billingFrequency,
+            },
+            tx,
+          );
 
-        await Promise.all([
-          userAssignmentsRepo.assignClientToUser(request.user.id, clientIdResult.value),
-          userAssignmentsRepo.assignProjectToUser(request.user.id, id),
-          userAssignmentsRepo.assignClientToTopManagers(clientIdResult.value),
-          userAssignmentsRepo.assignProjectToTopManagers(id),
-        ]);
+          await Promise.all([
+            userAssignmentsRepo.assignClientToUser(
+              request.user.id,
+              clientIdResult.value,
+              undefined,
+              tx,
+            ),
+            userAssignmentsRepo.assignProjectToUser(request.user.id, id, undefined, tx),
+            userAssignmentsRepo.assignClientToTopManagers(clientIdResult.value, tx),
+            userAssignmentsRepo.assignProjectToTopManagers(id, tx),
+          ]);
+
+          return project;
+        });
         await logAudit({
           request,
           action: 'project.created',

--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -286,36 +286,50 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const id = generatePrefixedId('t');
 
       try {
-        const created = await tasksRepo.create({
-          id,
-          name: nameResult.value,
-          projectId: projectIdResult.value,
-          description: description || null,
-          isRecurring: isRecurringValue,
-          recurrencePattern: recurrencePattern || null,
-          recurrenceStart: start,
-          recurrenceDuration: durationResult.value || 0,
-          expectedEffort: expectedEffortResult.value ?? 0,
-          monthlyEffort: monthlyEffortResult.value ?? 0,
-          revenue: revenueResult.value ?? 0,
-          notes: notes || null,
-          isDisabled: false,
-          billingType: taskBillingType,
-          billingFrequency: taskBillingFrequency,
+        const created = await withDbTransaction(async (tx) => {
+          const task = await tasksRepo.create(
+            {
+              id,
+              name: nameResult.value,
+              projectId: projectIdResult.value,
+              description: description || null,
+              isRecurring: isRecurringValue,
+              recurrencePattern: recurrencePattern || null,
+              recurrenceStart: start,
+              recurrenceDuration: durationResult.value || 0,
+              expectedEffort: expectedEffortResult.value ?? 0,
+              monthlyEffort: monthlyEffortResult.value ?? 0,
+              revenue: revenueResult.value ?? 0,
+              notes: notes || null,
+              isDisabled: false,
+              billingType: taskBillingType,
+              billingFrequency: taskBillingFrequency,
+            },
+            tx,
+          );
+
+          const clientId = await projectsRepo.findClientId(projectIdResult.value, tx);
+
+          await Promise.all(
+            [
+              clientId
+                ? userAssignmentsRepo.assignClientToUser(request.user.id, clientId, undefined, tx)
+                : null,
+              userAssignmentsRepo.assignProjectToUser(
+                request.user.id,
+                projectIdResult.value,
+                undefined,
+                tx,
+              ),
+              userAssignmentsRepo.assignTaskToUser(request.user.id, id, undefined, tx),
+              clientId ? userAssignmentsRepo.assignClientToTopManagers(clientId, tx) : null,
+              userAssignmentsRepo.assignProjectToTopManagers(projectIdResult.value, tx),
+              userAssignmentsRepo.assignTaskToTopManagers(id, tx),
+            ].filter((p): p is Promise<void> => p !== null),
+          );
+
+          return task;
         });
-
-        const clientId = await projectsRepo.findClientId(projectIdResult.value);
-
-        await Promise.all(
-          [
-            clientId ? userAssignmentsRepo.assignClientToUser(request.user.id, clientId) : null,
-            userAssignmentsRepo.assignProjectToUser(request.user.id, projectIdResult.value),
-            userAssignmentsRepo.assignTaskToUser(request.user.id, id),
-            clientId ? userAssignmentsRepo.assignClientToTopManagers(clientId) : null,
-            userAssignmentsRepo.assignProjectToTopManagers(projectIdResult.value),
-            userAssignmentsRepo.assignTaskToTopManagers(id),
-          ].filter((p): p is Promise<void> => p !== null),
-        );
         await logAudit({
           request,
           action: 'task.created',
@@ -532,14 +546,18 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       );
       if (!billingFrequencyResult.ok) return badRequest(reply, billingFrequencyResult.message);
 
+      let normalizedRecurrenceStart: string | undefined;
       if (recurrenceStart !== undefined && recurrenceStart !== null && recurrenceStart !== '') {
         const startResult = parseDateString(recurrenceStart, 'recurrenceStart');
         if (!startResult.ok) return badRequest(reply, startResult.message);
+        normalizedRecurrenceStart = startResult.value;
       }
 
+      let normalizedRecurrenceEnd: string | undefined;
       if (recurrenceEnd !== undefined && recurrenceEnd !== null && recurrenceEnd !== '') {
         const endResult = parseDateString(recurrenceEnd, 'recurrenceEnd');
         if (!endResult.ok) return badRequest(reply, endResult.message);
+        normalizedRecurrenceEnd = endResult.value;
       }
 
       const isRecurringValue =
@@ -550,8 +568,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         description: description || undefined,
         isRecurring: isRecurringValue,
         recurrencePattern: recurrencePattern || undefined,
-        recurrenceStart: recurrenceStart || undefined,
-        recurrenceEnd: recurrenceEnd || undefined,
+        recurrenceStart: normalizedRecurrenceStart,
+        recurrenceEnd: normalizedRecurrenceEnd,
         // optionalLocalizedNonNegativeNumber returns null when the body field is omitted; the
         // dynamic-SET in tasksRepo.update would interpret null as "set to NULL" and clobber the
         // existing recurrence_duration. Forward undefined instead so the column is left alone.

--- a/server/test/routes/projects.test.ts
+++ b/server/test/routes/projects.test.ts
@@ -281,10 +281,11 @@ describe('POST /api/projects', () => {
         orderId: 'o-1',
         isDisabled: false,
       }),
+      undefined,
     );
-    expect(assignClientToUserMock).toHaveBeenCalledWith('u1', 'c-1');
+    expect(assignClientToUserMock).toHaveBeenCalledWith('u1', 'c-1', undefined, undefined);
     expect(assignProjectToUserMock).toHaveBeenCalled();
-    expect(assignClientToTopManagersMock).toHaveBeenCalledWith('c-1');
+    expect(assignClientToTopManagersMock).toHaveBeenCalledWith('c-1', undefined);
     expect(assignProjectToTopManagersMock).toHaveBeenCalled();
     expect(logAuditMock).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'project.created', entityType: 'project' }),
@@ -304,7 +305,44 @@ describe('POST /api/projects', () => {
     expect(res.statusCode).toBe(201);
     expect(createMock).toHaveBeenCalledWith(
       expect.objectContaining({ color: '#3b82f6', orderId: null, description: null }),
+      undefined,
     );
+  });
+
+  test('201: create + assignments run inside one withDbTransaction', async () => {
+    createMock.mockResolvedValue(SAMPLE_PROJECT);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/projects',
+      headers: authHeader(),
+      payload: { name: 'Website', clientId: 'c-1' },
+    });
+
+    expect(res.statusCode).toBe(201);
+    // Atomic create: a single transaction wraps the project insert + the four assignment calls
+    expect(withDbTransactionMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('500: assignment failure rolls back project create (no audit, no 201)', async () => {
+    createMock.mockResolvedValue(SAMPLE_PROJECT);
+    // Simulate an assignment failure inside the transaction. On the old code the project would
+    // already be persisted before the assignment ran; the new code wraps both in a transaction
+    // so the failure must propagate out of withDbTransaction with no audit log emitted.
+    assignProjectToTopManagersMock.mockImplementation(async () => {
+      throw new Error('assignment failed');
+    });
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/projects',
+      headers: authHeader(),
+      payload: { name: 'Website', clientId: 'c-1' },
+    });
+
+    expect(res.statusCode).toBe(500);
+    expect(withDbTransactionMock).toHaveBeenCalledTimes(1);
+    expect(logAuditMock).not.toHaveBeenCalled();
   });
 
   test('400: missing name', async () => {

--- a/server/test/routes/tasks.test.ts
+++ b/server/test/routes/tasks.test.ts
@@ -312,12 +312,13 @@ describe('POST /api/tasks', () => {
         billingType: 'time_and_materials',
         billingFrequency: 'monthly',
       }),
+      undefined,
     );
-    expect(assignClientToUserMock).toHaveBeenCalledWith('u1', 'c-1');
-    expect(assignProjectToUserMock).toHaveBeenCalledWith('u1', 'p-1');
+    expect(assignClientToUserMock).toHaveBeenCalledWith('u1', 'c-1', undefined, undefined);
+    expect(assignProjectToUserMock).toHaveBeenCalledWith('u1', 'p-1', undefined, undefined);
     expect(assignTaskToUserMock).toHaveBeenCalled();
-    expect(assignClientToTopManagersMock).toHaveBeenCalledWith('c-1');
-    expect(assignProjectToTopManagersMock).toHaveBeenCalledWith('p-1');
+    expect(assignClientToTopManagersMock).toHaveBeenCalledWith('c-1', undefined);
+    expect(assignProjectToTopManagersMock).toHaveBeenCalledWith('p-1', undefined);
     expect(assignTaskToTopManagersMock).toHaveBeenCalled();
     expect(logAuditMock).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'task.created', entityType: 'task' }),
@@ -360,7 +361,46 @@ describe('POST /api/tasks', () => {
         billingType: 'retainer',
         billingFrequency: 'one_time',
       }),
+      undefined,
     );
+  });
+
+  test('201: create + assignments run inside one withDbTransaction', async () => {
+    createMock.mockResolvedValue(SAMPLE_TASK);
+    findClientIdMock.mockResolvedValue('c-1');
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/tasks',
+      headers: authHeader(),
+      payload: { name: 'Implement feature', projectId: 'p-1' },
+    });
+
+    expect(res.statusCode).toBe(201);
+    // Atomic create: a single transaction wraps the task insert + cascade assignments
+    expect(withDbTransactionMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('500: assignment failure rolls back task create (no audit, no 201)', async () => {
+    createMock.mockResolvedValue(SAMPLE_TASK);
+    findClientIdMock.mockResolvedValue('c-1');
+    // Simulate an assignment failure inside the transaction; on the old code the task row was
+    // already persisted before the assignments ran. The fix wraps everything in a transaction
+    // so the error must surface and no audit log is emitted.
+    assignTaskToTopManagersMock.mockImplementation(async () => {
+      throw new Error('assignment failed');
+    });
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/tasks',
+      headers: authHeader(),
+      payload: { name: 'Implement feature', projectId: 'p-1' },
+    });
+
+    expect(res.statusCode).toBe(500);
+    expect(withDbTransactionMock).toHaveBeenCalledTimes(1);
+    expect(logAuditMock).not.toHaveBeenCalled();
   });
 
   test('201: recurring task without recurrenceStart defaults to today', async () => {
@@ -685,6 +725,27 @@ describe('PUT /api/tasks/:id', () => {
         recurrenceDuration: 2,
       }),
     );
+  });
+
+  test('200: forwards validated (trimmed) recurrenceEnd to repo, not raw input', async () => {
+    updateMock.mockResolvedValue({ ...SAMPLE_TASK, isRecurring: true });
+
+    // parseDateString trims the raw string via isNonEmptyString. The old code passed
+    // the untrimmed raw value to the UPDATE; the fix passes the trimmed parser result.
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/tasks/t-1',
+      headers: authHeader(),
+      payload: { recurrenceStart: '  2025-01-01  ', recurrenceEnd: '  2025-12-31  ' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const [, patch] = updateMock.mock.calls[0] as [
+      string,
+      { recurrenceStart: unknown; recurrenceEnd: unknown },
+    ];
+    expect(patch.recurrenceStart).toBe('2025-01-01');
+    expect(patch.recurrenceEnd).toBe('2025-12-31');
   });
 
   test('200: isDisabled=true → task.disabled audit', async () => {


### PR DESCRIPTION
## Summary

- Wrap `POST /api/projects` and `POST /api/tasks` create + cascade-assignment writes in `withDbTransaction` so an assignment failure rolls the parent entity back instead of leaving an orphaned row. Repo calls thread the `tx` executor through.
- Fix `PUT /api/tasks/:id` discarding the `parseDateString` result and passing the raw, untrimmed `recurrenceEnd` (and `recurrenceStart`) to the UPDATE — now stores the validated, normalized string.

## Test plan

- [x] `bun test ./test/routes/projects.test.ts ./test/routes/tasks.test.ts` (93 pass, 0 fail)
- [x] Full `cd server && bun test` (1999 pass, 1 unrelated pre-existing failure in `entries.test.ts` on base branch)
- [x] `bunx biome check` clean on all four touched files
- [x] `bun run typecheck` exits 0
- [x] New regression tests fail on pre-fix source:
  - `POST /api/projects > 201: create + assignments run inside one withDbTransaction`
  - `POST /api/projects > 500: assignment failure rolls back project create (no audit, no 201)`
  - `POST /api/tasks > 201: create + assignments run inside one withDbTransaction`
  - `POST /api/tasks > 500: assignment failure rolls back task create (no audit, no 201)`
  - `PUT /api/tasks/:id > 200: forwards validated (trimmed) recurrenceEnd to repo, not raw input`

https://claude.ai/code/session_01JoRTwXFkuga3Cfymy6HcJ9

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoRTwXFkuga3Cfymy6HcJ9)_