### PR TITLE
fix(db): seed verification inside transaction + compat default cleanup + safer bootstrap admin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,7 +36,9 @@ LOG_LEVEL=info
 # demo business dataset. Intended for demo/test Docker stacks and reused volumes.
 DEMO_SEEDING=false
 
-# Initial password for bootstrap admin user (username: admin)
-# Used only when the admin user does not already exist.
+# Initial password for the bootstrap admin user (username: admin).
+# Used only when the admin user does not already exist on first startup.
+# If unset or empty, the backend generates a one-time random password and logs it
+# (look for "Bootstrap admin created with a generated password" under db:bootstrap-admin).
 # Generate with: openssl rand -base64 24
 ADMIN_DEFAULT_PASSWORD=change-me-strong-admin-password

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The workflow runs on `v*` git tags and can also be run manually.
 ## Usage Guide
 
 - **Login**:
-  - Bootstrap Admin: `admin` / `password`
+  - Bootstrap Admin: `admin` / one-time password printed at first startup (or `ADMIN_DEFAULT_PASSWORD` env value if you set one). Existing installs that still use the legacy `password` default keep working until rotated.
   - Demo Manager: `manager` / `password` when `DEMO_SEEDING=true`
   - Demo User: `user` / `password` when `DEMO_SEEDING=true`
   

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -19,8 +19,13 @@ Set at least:
 - `ENCRYPTION_KEY`
 - `FRONTEND_URL`
 
-Fresh installs create the bootstrap admin as `admin` / `password`. Change that password after
-the first login.
+Fresh installs create the bootstrap admin user `admin` with a one-time random password that is
+written to the backend logs at startup under the `db:bootstrap-admin` module. Capture it before
+your first login and rotate it from the Security tab. To choose your own password instead, set
+`ADMIN_DEFAULT_PASSWORD` in the env file before the first run.
+
+Existing installs that already use the legacy `password` default continue to work; the app shows
+a persistent notification until the password is changed.
 
 ## 2) Authenticate to Registry (if private)
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -23,8 +23,10 @@ JWT_SECRET=change-me-long-random-jwt-secret
 # demo business dataset. Intended for demo/test environments and reused demo volumes.
 DEMO_SEEDING=false
 
-# Initial password for bootstrap admin user (username: admin)
-# Used only when the admin user does not already exist.
+# Initial password for the bootstrap admin user (username: admin).
+# Used only when the admin user does not already exist on first startup.
+# If unset or empty, the backend generates a one-time random password and logs it
+# (look for "Bootstrap admin created with a generated password" under db:bootstrap-admin).
 # Generate with: openssl rand -base64 24
 ADMIN_DEFAULT_PASSWORD=change-me-strong-admin-password
 

--- a/server/db/bootstrapAdmin.ts
+++ b/server/db/bootstrapAdmin.ts
@@ -83,7 +83,18 @@ export const ensureBootstrapAdmin = async () => {
 
     if (resolved.source === 'generated') {
       // Surface the generated credential exactly once so the operator can capture it
-      // before rotating. We deliberately avoid logging it on every restart.
+      // before rotating. Write directly to stderr in addition to the structured log so
+      // the credential is visible even when LOG_LEVEL filters out warn (e.g. `error`).
+      const banner = [
+        '====================================================================',
+        '  Praetor bootstrap admin created with a generated password.',
+        `  Capture it now and rotate it. Set ${ADMIN_PASSWORD_ENV} to override.`,
+        `  username: ${ADMIN_USERNAME}`,
+        `  password: ${resolved.password}`,
+        '====================================================================',
+        '',
+      ].join('\n');
+      process.stderr.write(banner);
       logger.warn(
         {
           adminUsername: ADMIN_USERNAME,

--- a/server/db/bootstrapAdmin.ts
+++ b/server/db/bootstrapAdmin.ts
@@ -1,4 +1,5 @@
 import bcrypt from 'bcryptjs';
+import { randomBytes } from 'crypto';
 import * as notificationsRepo from '../repositories/notificationsRepo.ts';
 import * as usersRepo from '../repositories/usersRepo.ts';
 import { createChildLogger } from '../utils/logger.ts';
@@ -7,9 +8,33 @@ import { query } from './index.ts';
 
 export const ADMIN_USERNAME = 'admin';
 export const DEFAULT_ADMIN_USER_ID = 'u1';
+
+// Legacy hardcoded default. Kept as a constant so we can keep flagging existing
+// installations that still use it via the password-change notification. We no
+// longer apply this to NEW installations — see `resolveAdminBootstrapPassword`.
 export const DEFAULT_BOOTSTRAP_ADMIN_PASSWORD = 'password';
 
+const ADMIN_PASSWORD_ENV = 'ADMIN_DEFAULT_PASSWORD';
+
 const logger = createChildLogger({ module: 'db:bootstrap-admin' });
+
+const generateRandomAdminPassword = (): string =>
+  // 24 bytes -> 32 base64url chars, plenty of entropy and shell-friendly.
+  randomBytes(24).toString('base64url');
+
+type AdminBootstrapPassword = {
+  password: string;
+  source: 'env' | 'generated';
+};
+
+export const resolveAdminBootstrapPassword = (
+  envValue: string | undefined = process.env[ADMIN_PASSWORD_ENV],
+): AdminBootstrapPassword => {
+  if (typeof envValue === 'string' && envValue.length > 0) {
+    return { password: envValue, source: 'env' };
+  }
+  return { password: generateRandomAdminPassword(), source: 'generated' };
+};
 
 export const syncDefaultAdminPasswordWarning = async (
   adminId: string,
@@ -44,7 +69,8 @@ export const ensureBootstrapAdmin = async () => {
     ]);
     adminId = defaultIdCheck.rows.length === 0 ? DEFAULT_ADMIN_USER_ID : generatePrefixedId('u');
 
-    adminPasswordHash = await bcrypt.hash(DEFAULT_BOOTSTRAP_ADMIN_PASSWORD, 12);
+    const resolved = resolveAdminBootstrapPassword();
+    adminPasswordHash = await bcrypt.hash(resolved.password, 12);
 
     await usersRepo.createUser({
       id: adminId,
@@ -54,7 +80,22 @@ export const ensureBootstrapAdmin = async () => {
       role: 'admin',
       avatarInitials: 'AD',
     });
-    logger.info('Bootstrap admin created');
+
+    if (resolved.source === 'generated') {
+      // Surface the generated credential exactly once so the operator can capture it
+      // before rotating. We deliberately avoid logging it on every restart.
+      logger.warn(
+        {
+          adminUsername: ADMIN_USERNAME,
+          generatedAdminPassword: resolved.password,
+        },
+        `Bootstrap admin created with a generated password. Capture it now and rotate it. Set ${ADMIN_PASSWORD_ENV} to override on first run.`,
+      );
+    } else {
+      logger.info(
+        `Bootstrap admin created with password from ${ADMIN_PASSWORD_ENV} environment variable`,
+      );
+    }
   }
 
   await query('INSERT INTO user_roles (user_id, role_id) VALUES ($1, $2) ON CONFLICT DO NOTHING', [

--- a/server/db/demoSeed.ts
+++ b/server/db/demoSeed.ts
@@ -4,6 +4,7 @@ import * as userAssignmentsRepo from '../repositories/userAssignmentsRepo.ts';
 import { createChildLogger, serializeError } from '../utils/logger.ts';
 import { ensureBootstrapAdmin } from './bootstrapAdmin.ts';
 import {
+  COMPATIBILITY_DEFAULTS,
   DEMO_CLIENTS,
   DEMO_CUSTOMER_OFFERS,
   DEMO_EXPECTED_COUNTS,
@@ -22,7 +23,7 @@ import {
   DEMO_USERS,
   DEMO_WORK_UNITS,
 } from './demoSeedManifest.ts';
-import pool, { query } from './index.ts';
+import pool from './index.ts';
 
 const logger = createChildLogger({ module: 'db:demo-seed' });
 
@@ -466,25 +467,31 @@ const cleanupDemoNamespace = async (client: PoolClient, demoUserIds: DemoUserCle
     }),
   );
 
+  // Tasks must be deleted before projects (FK), and we sweep both the demo namespace
+  // and the legacy compatibility-default IDs ('t1'..'t4') so re-seeds stay idempotent.
+  incrementCount(
+    cleanupCountsByTable,
+    'tasks',
+    await executeDelete(client, 'tasks', (builder) => {
+      pushTextArrayPredicate(builder, 'project_id', DEMO_IDS.projects);
+      pushTextArrayPredicate(builder, 'id', COMPATIBILITY_DEFAULTS.tasks);
+    }),
+  );
+
   incrementCount(
     cleanupCountsByTable,
     'projects',
     await executeDelete(client, 'projects', (builder) => {
-      pushTextArrayPredicate(builder, 'id', DEMO_IDS.projects);
+      pushTextArrayPredicate(builder, 'id', [
+        ...DEMO_IDS.projects,
+        ...COMPATIBILITY_DEFAULTS.projects,
+      ]);
       pushTextArrayPredicate(
         builder,
         'name',
         DEMO_PROJECTS.map((project) => project.name),
       );
       pushTextArrayPredicate(builder, 'client_id', DEMO_IDS.clients);
-    }),
-  );
-
-  incrementCount(
-    cleanupCountsByTable,
-    'tasks',
-    await executeDelete(client, 'tasks', (builder) => {
-      pushTextArrayPredicate(builder, 'project_id', DEMO_IDS.projects);
     }),
   );
 
@@ -505,7 +512,10 @@ const cleanupDemoNamespace = async (client: PoolClient, demoUserIds: DemoUserCle
     cleanupCountsByTable,
     'clients',
     await executeDelete(client, 'clients', (builder) => {
-      pushTextArrayPredicate(builder, 'id', DEMO_IDS.clients);
+      pushTextArrayPredicate(builder, 'id', [
+        ...DEMO_IDS.clients,
+        ...COMPATIBILITY_DEFAULTS.clients,
+      ]);
       pushTextArrayPredicate(
         builder,
         'client_code',
@@ -665,13 +675,13 @@ const verificationSteps: VerificationStep[] = [
   { table: 'time_entries', ids: DEMO_IDS.timeEntries, expected: DEMO_EXPECTED_COUNTS.time_entries },
 ];
 
-const verifyDemoDataset = async () => {
+const verifyDemoDataset = async (client: PoolClient) => {
   const verificationCountsByTable: Record<string, number> = {};
   const mismatches: Array<{ table: string; expected: number; actual: number }> = [];
 
   for (const step of verificationSteps) {
     const countColumn = step.countColumn ?? 'id';
-    const result = await query(
+    const result = await client.query(
       `SELECT COUNT(*)::int AS count FROM ${step.table} WHERE ${countColumn} = ANY($1::text[])`,
       [step.ids],
     );
@@ -705,6 +715,11 @@ const collectDemoUserCleanupIds = async (client: PoolClient) => {
   return selectDemoUserCleanupIds(result.rows);
 };
 
+// The bootstrap admin lives OUTSIDE the demo seed transaction by design:
+// `ensureBootstrapAdmin` is idempotent (ON CONFLICT DO NOTHING + check-before-insert)
+// and runs on every server startup, so it is safe to call before BEGIN. Demo data is
+// keyed on the `u2..u9` namespace and does not depend on the admin row, so a rollback
+// of the seed transaction leaves the admin untouched and the system still usable.
 export const runDemoSeedRefresh = async ({
   source,
 }: {
@@ -736,14 +751,19 @@ export const runDemoSeedRefresh = async ({
       throw new Error('Demo seed insert phase failed');
     }
 
+    const verification = await verifyDemoDataset(client);
+    verificationCountsByTable = verification.verificationCountsByTable;
+
+    if (verification.mismatches.length > 0) {
+      throw new Error(
+        `Demo seed verification failed for ${verification.mismatches
+          .map((item) => `${item.table} expected ${item.expected} got ${item.actual}`)
+          .join(', ')}`,
+      );
+    }
+
     await client.query('COMMIT');
     inTransaction = false;
-
-    for (const user of DEMO_USERS) {
-      if (user.role === 'top_manager') {
-        await userAssignmentsRepo.syncTopManagerAssignmentsForUser(user.id);
-      }
-    }
   } catch (err) {
     if (inTransaction) {
       await client.query('ROLLBACK');
@@ -755,61 +775,31 @@ export const runDemoSeedRefresh = async ({
         source,
         cleanupCountsByTable,
         insertCountsByTable,
+        verificationCountsByTable,
         failedStatements,
         err: serializeError(err),
       },
-      'Demo seed refresh failed during cleanup or insert phase',
+      'Demo seed refresh failed; transaction rolled back',
     );
     throw err;
   } finally {
     client.release();
   }
 
-  try {
-    const verification = await verifyDemoDataset();
-    verificationCountsByTable = verification.verificationCountsByTable;
-
-    if (verification.mismatches.length > 0) {
-      logger.error(
-        {
-          demoSeedingEnabled: true,
-          source,
-          cleanupCountsByTable,
-          insertCountsByTable,
-          verificationCountsByTable,
-          verificationMismatches: verification.mismatches,
-        },
-        'Demo seed verification failed',
-      );
-      throw new Error(
-        `Demo seed verification failed for ${verification.mismatches
-          .map((item) => `${item.table} expected ${item.expected} got ${item.actual}`)
-          .join(', ')}`,
-      );
+  for (const user of DEMO_USERS) {
+    if (user.role === 'top_manager') {
+      await userAssignmentsRepo.syncTopManagerAssignmentsForUser(user.id);
     }
-
-    const result: DemoSeedResult = {
-      demoSeedingEnabled: true,
-      source,
-      cleanupCountsByTable,
-      insertCountsByTable,
-      verificationCountsByTable,
-    };
-
-    logger.info(result, 'Demo seed refresh completed');
-    return result;
-  } catch (err) {
-    logger.error(
-      {
-        demoSeedingEnabled: true,
-        source,
-        cleanupCountsByTable,
-        insertCountsByTable,
-        verificationCountsByTable,
-        err: serializeError(err),
-      },
-      'Demo seed refresh failed after insert phase',
-    );
-    throw err;
   }
+
+  const result: DemoSeedResult = {
+    demoSeedingEnabled: true,
+    source,
+    cleanupCountsByTable,
+    insertCountsByTable,
+    verificationCountsByTable,
+  };
+
+  logger.info(result, 'Demo seed refresh completed');
+  return result;
 };

--- a/server/test/db/bootstrapAdmin.test.ts
+++ b/server/test/db/bootstrapAdmin.test.ts
@@ -66,28 +66,98 @@ beforeEach(() => {
   deleteAdminPasswordWarningMock.mockResolvedValue(undefined);
 });
 
+describe('resolveAdminBootstrapPassword', () => {
+  test('uses env value when provided', () => {
+    const resolved = bootstrapAdmin.resolveAdminBootstrapPassword('s3cret-from-env');
+    expect(resolved).toEqual({ password: 's3cret-from-env', source: 'env' });
+  });
+
+  test('generates a random password when env value is absent', () => {
+    const resolved = bootstrapAdmin.resolveAdminBootstrapPassword(undefined);
+    expect(resolved.source).toBe('generated');
+    expect(resolved.password).not.toBe('password');
+    expect(resolved.password.length).toBeGreaterThanOrEqual(20);
+  });
+
+  test('generates a random password when env value is empty', () => {
+    const resolved = bootstrapAdmin.resolveAdminBootstrapPassword('');
+    expect(resolved.source).toBe('generated');
+    expect(resolved.password).not.toBe('');
+  });
+
+  test('successive generated passwords differ', () => {
+    const a = bootstrapAdmin.resolveAdminBootstrapPassword(undefined);
+    const b = bootstrapAdmin.resolveAdminBootstrapPassword(undefined);
+    expect(a.password).not.toBe(b.password);
+  });
+});
+
 describe('ensureBootstrapAdmin', () => {
-  test('creates a fresh admin with the literal default password', async () => {
+  const ORIGINAL_ENV = process.env.ADMIN_DEFAULT_PASSWORD;
+
+  beforeEach(() => {
+    delete process.env.ADMIN_DEFAULT_PASSWORD;
+  });
+
+  afterAll(() => {
+    if (ORIGINAL_ENV === undefined) {
+      delete process.env.ADMIN_DEFAULT_PASSWORD;
+    } else {
+      process.env.ADMIN_DEFAULT_PASSWORD = ORIGINAL_ENV;
+    }
+  });
+
+  test('creates a fresh admin with a generated password when env is unset', async () => {
     queryMock
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [], rowCount: 1 });
-    bcryptHashMock.mockResolvedValue('$2a$password-hash');
-    bcryptCompareMock.mockResolvedValue(true);
+    bcryptHashMock.mockResolvedValue('$2a$generated-hash');
+    bcryptCompareMock.mockResolvedValue(false);
 
     const adminId = await bootstrapAdmin.ensureBootstrapAdmin();
 
     expect(adminId).toBe('u1');
-    expect(bcryptHashMock).toHaveBeenCalledWith('password', 12);
+    expect(bcryptHashMock).toHaveBeenCalledTimes(1);
+    const [hashedPassword, cost] = bcryptHashMock.mock.calls[0];
+    expect(hashedPassword).not.toBe('password');
+    expect(typeof hashedPassword).toBe('string');
+    expect((hashedPassword as string).length).toBeGreaterThanOrEqual(20);
+    expect(cost).toBe(12);
     expect(createUserMock).toHaveBeenCalledWith({
       id: 'u1',
       name: 'Admin User',
       username: 'admin',
-      passwordHash: '$2a$password-hash',
+      passwordHash: '$2a$generated-hash',
       role: 'admin',
       avatarInitials: 'AD',
     });
-    expect(upsertAdminPasswordWarningMock).toHaveBeenCalledWith('u1');
+    // Random password is not the legacy default so we must NOT raise the warning.
+    expect(upsertAdminPasswordWarningMock).not.toHaveBeenCalled();
+    expect(deleteAdminPasswordWarningMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('creates a fresh admin with the env-supplied password when set', async () => {
+    process.env.ADMIN_DEFAULT_PASSWORD = 'operator-chosen';
+    queryMock
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 });
+    bcryptHashMock.mockResolvedValue('$2a$env-hash');
+    bcryptCompareMock.mockResolvedValue(false);
+
+    const adminId = await bootstrapAdmin.ensureBootstrapAdmin();
+
+    expect(adminId).toBe('u1');
+    expect(bcryptHashMock).toHaveBeenCalledWith('operator-chosen', 12);
+    expect(createUserMock).toHaveBeenCalledWith({
+      id: 'u1',
+      name: 'Admin User',
+      username: 'admin',
+      passwordHash: '$2a$env-hash',
+      role: 'admin',
+      avatarInitials: 'AD',
+    });
   });
 
   test('existing admin with default password gets the warning', async () => {

--- a/server/test/db/demoSeedTransaction.test.ts
+++ b/server/test/db/demoSeedTransaction.test.ts
@@ -1,0 +1,234 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as realBootstrapAdmin from '../../db/bootstrapAdmin.ts';
+import { COMPATIBILITY_DEFAULTS, DEMO_EXPECTED_COUNTS } from '../../db/demoSeedManifest.ts';
+import * as realDbIndex from '../../db/index.ts';
+import * as realUserAssignmentsRepo from '../../repositories/userAssignmentsRepo.ts';
+
+type RunDemoSeedRefresh = typeof import('../../db/demoSeed.ts').runDemoSeedRefresh;
+
+type CountStub = {
+  match: (sql: string, params: readonly unknown[]) => boolean;
+  count: number;
+};
+
+type FakeClientOptions = {
+  countStubs?: CountStub[];
+};
+
+type FakeQueryResult = { rows: unknown[]; rowCount: number };
+
+const dbIndexSnap = { ...realDbIndex };
+const bootstrapAdminSnap = { ...realBootstrapAdmin };
+const userAssignmentsRepoSnap = { ...realUserAssignmentsRepo };
+
+const poolConnectMock = mock();
+const ensureBootstrapAdminMock = mock();
+const syncTopManagerAssignmentsForUserMock = mock();
+
+let runDemoSeedRefresh: RunDemoSeedRefresh;
+
+beforeAll(async () => {
+  mock.module('../../db/index.ts', () => ({
+    ...dbIndexSnap,
+    default: { connect: poolConnectMock },
+  }));
+  mock.module('../../db/bootstrapAdmin.ts', () => ({
+    ...bootstrapAdminSnap,
+    ensureBootstrapAdmin: ensureBootstrapAdminMock,
+  }));
+  mock.module('../../repositories/userAssignmentsRepo.ts', () => ({
+    ...userAssignmentsRepoSnap,
+    syncTopManagerAssignmentsForUser: syncTopManagerAssignmentsForUserMock,
+  }));
+
+  ({ runDemoSeedRefresh } = await import('../../db/demoSeed.ts'));
+});
+
+afterAll(() => {
+  mock.module('../../db/index.ts', () => dbIndexSnap);
+  mock.module('../../db/bootstrapAdmin.ts', () => bootstrapAdminSnap);
+  mock.module('../../repositories/userAssignmentsRepo.ts', () => userAssignmentsRepoSnap);
+});
+
+const createFakeClient = (options: FakeClientOptions = {}) => {
+  const queries: Array<{ sql: string; params: readonly unknown[] }> = [];
+  const released: { value: boolean } = { value: false };
+
+  const matchCount = (sql: string, params: readonly unknown[]): number | null => {
+    for (const stub of options.countStubs ?? []) {
+      if (stub.match(sql, params)) return stub.count;
+    }
+    return null;
+  };
+
+  const client = {
+    query: mock(
+      async (textOrConfig: unknown, params?: readonly unknown[]): Promise<FakeQueryResult> => {
+        const sql = typeof textOrConfig === 'string' ? textOrConfig : String(textOrConfig);
+        queries.push({ sql, params: params ?? [] });
+
+        const overrideCount = matchCount(sql, params ?? []);
+        if (overrideCount !== null) {
+          return { rows: [{ count: overrideCount }], rowCount: overrideCount };
+        }
+
+        if (/^\s*SELECT\s+id\s+FROM\s+users/i.test(sql)) {
+          return { rows: [], rowCount: 0 };
+        }
+        if (/COUNT\(\*\)/i.test(sql)) {
+          // Default: pretend every verification step finds exactly the expected number of
+          // rows so unfocused steps don't muddy the failure under inspection.
+          const tableMatch = sql.match(/FROM\s+([a-z_]+)/i);
+          const tableName = tableMatch ? tableMatch[1] : '';
+          const expected = (DEMO_EXPECTED_COUNTS as Record<string, number | undefined>)[tableName];
+          return { rows: [{ count: expected ?? 0 }], rowCount: 1 };
+        }
+        return { rows: [], rowCount: 1 };
+      },
+    ),
+    release: mock(() => {
+      released.value = true;
+    }),
+  };
+
+  return { client, queries, released };
+};
+
+beforeEach(() => {
+  poolConnectMock.mockReset();
+  ensureBootstrapAdminMock.mockReset();
+  syncTopManagerAssignmentsForUserMock.mockReset();
+  ensureBootstrapAdminMock.mockResolvedValue('u1');
+  syncTopManagerAssignmentsForUserMock.mockResolvedValue(undefined);
+});
+
+const seedSqlNames = (queries: Array<{ sql: string }>) => queries.map(({ sql }) => sql.trim());
+
+describe('runDemoSeedRefresh', () => {
+  test('rolls back when verification reports a mismatch and never issues COMMIT', async () => {
+    const { client } = createFakeClient({
+      countStubs: [
+        {
+          // Force the very first verification step (users) to under-report and trip a mismatch.
+          match: (sql) =>
+            /FROM\s+users\s+WHERE\s+id\s*=\s*ANY/i.test(sql) && /COUNT\(\*\)/i.test(sql),
+          count: 0,
+        },
+      ],
+    });
+    poolConnectMock.mockResolvedValue(client);
+
+    await expect(runDemoSeedRefresh({ source: 'manual' })).rejects.toThrow(
+      /Demo seed verification failed/,
+    );
+
+    const sqlSeen = seedSqlNames(client.query.mock.calls.map(([sql]) => ({ sql: String(sql) })));
+    expect(sqlSeen).toContain('BEGIN');
+    expect(sqlSeen).toContain('ROLLBACK');
+    expect(sqlSeen).not.toContain('COMMIT');
+    expect(client.release).toHaveBeenCalledTimes(1);
+    // Post-commit sync must not happen when verification failed.
+    expect(syncTopManagerAssignmentsForUserMock).not.toHaveBeenCalled();
+  });
+
+  test('verification SELECT statements run on the same client (inside the transaction)', async () => {
+    const { client } = createFakeClient({
+      countStubs: [
+        {
+          match: (sql) =>
+            /FROM\s+users\s+WHERE\s+id\s*=\s*ANY/i.test(sql) && /COUNT\(\*\)/i.test(sql),
+          count: 0,
+        },
+      ],
+    });
+    poolConnectMock.mockResolvedValue(client);
+
+    await expect(runDemoSeedRefresh({ source: 'manual' })).rejects.toThrow();
+
+    const calls = client.query.mock.calls.map(([sql]) => String(sql));
+    const beginIdx = calls.findIndex((sql) => /^\s*BEGIN/.test(sql));
+    const rollbackIdx = calls.findIndex(
+      (sql) => /^\s*ROLLBACK\b/.test(sql) && !/SAVEPOINT/.test(sql),
+    );
+    const firstCountIdx = calls.findIndex((sql) => /COUNT\(\*\)/i.test(sql));
+
+    expect(beginIdx).toBeGreaterThanOrEqual(0);
+    expect(rollbackIdx).toBeGreaterThan(beginIdx);
+    expect(firstCountIdx).toBeGreaterThan(beginIdx);
+    expect(firstCountIdx).toBeLessThan(rollbackIdx);
+  });
+
+  test('cleanupDemoNamespace also clears compatibility default IDs', async () => {
+    const { client } = createFakeClient({
+      countStubs: [
+        // Trip verification so we don't have to drive the full happy path,
+        // we just need to inspect cleanup SQL/params seen prior to verification.
+        {
+          match: (sql) =>
+            /FROM\s+users\s+WHERE\s+id\s*=\s*ANY/i.test(sql) && /COUNT\(\*\)/i.test(sql),
+          count: 0,
+        },
+      ],
+    });
+    poolConnectMock.mockResolvedValue(client);
+
+    await expect(runDemoSeedRefresh({ source: 'manual' })).rejects.toThrow();
+
+    const flatParams = (params: readonly unknown[]): unknown[] =>
+      params.flatMap((p) => (Array.isArray(p) ? p : [p]));
+
+    const cleanupCalls = client.query.mock.calls.filter(([sql]) =>
+      /^\s*DELETE\s+FROM/i.test(String(sql)),
+    );
+
+    const tasksCleanup = cleanupCalls.filter(([sql]) =>
+      /^\s*DELETE\s+FROM\s+tasks\b/i.test(String(sql)),
+    );
+    const projectsCleanup = cleanupCalls.filter(([sql]) =>
+      /^\s*DELETE\s+FROM\s+projects\b/i.test(String(sql)),
+    );
+    const clientsCleanup = cleanupCalls.filter(([sql]) =>
+      /^\s*DELETE\s+FROM\s+clients\b/i.test(String(sql)),
+    );
+
+    const taskParams = tasksCleanup.flatMap(([, params]) => flatParams(params ?? []));
+    const projectParams = projectsCleanup.flatMap(([, params]) => flatParams(params ?? []));
+    const clientParams = clientsCleanup.flatMap(([, params]) => flatParams(params ?? []));
+
+    for (const id of COMPATIBILITY_DEFAULTS.tasks) {
+      expect(taskParams).toContain(id);
+    }
+    for (const id of COMPATIBILITY_DEFAULTS.projects) {
+      expect(projectParams).toContain(id);
+    }
+    for (const id of COMPATIBILITY_DEFAULTS.clients) {
+      expect(clientParams).toContain(id);
+    }
+  });
+
+  test('commits only when verification passes and runs post-commit sync', async () => {
+    const { client } = createFakeClient();
+    poolConnectMock.mockResolvedValue(client);
+
+    const result = await runDemoSeedRefresh({ source: 'manual' });
+
+    expect(result.demoSeedingEnabled).toBe(true);
+    expect(result.source).toBe('manual');
+
+    const calls = client.query.mock.calls.map(([sql]) => String(sql));
+    const beginIdx = calls.findIndex((sql) => /^\s*BEGIN/.test(sql));
+    const commitIdx = calls.findIndex((sql) => /^\s*COMMIT/.test(sql));
+    const firstCountIdx = calls.findIndex((sql) => /COUNT\(\*\)/i.test(sql));
+
+    expect(beginIdx).toBeGreaterThanOrEqual(0);
+    expect(commitIdx).toBeGreaterThan(beginIdx);
+    expect(firstCountIdx).toBeGreaterThan(beginIdx);
+    // Verification must execute BEFORE commit.
+    expect(firstCountIdx).toBeLessThan(commitIdx);
+    expect(
+      calls.filter((sql) => /^\s*ROLLBACK\b/.test(sql) && !/SAVEPOINT/.test(sql)),
+    ).toHaveLength(0);
+    // Top-manager sync runs only after commit succeeds.
+    expect(syncTopManagerAssignmentsForUserMock).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- **High (Issue 21)**: Demo seed verification used to run AFTER `COMMIT`. A verification mismatch left corrupted seed data on disk with no rollback path. `verifyDemoDataset` now runs on the same `PoolClient` before `COMMIT`; a mismatch throws inside the `try` block, the `catch` handler issues `ROLLBACK`, and the error is surfaced. `client.release()` is still in `finally`.
- **Medium (compat defaults re-seed)**: `cleanupDemoNamespace` now sweeps the legacy compatibility-default IDs (`'c1'`, `'c2'`, `'p1'..'p3'`, `'t1'..'t4'`) alongside the demo namespace. Reordered `tasks` cleanup to run before `projects` (child-first, FK-safe).
- **Medium (bootstrap admin outside transaction)**: Documented the rationale via inline comment — `ensureBootstrapAdmin()` is already idempotent (check-before-insert + `ON CONFLICT DO NOTHING`) and demo data doesn't reference the admin row, so a seed rollback leaves the admin intact and the system usable. No behavior change needed beyond the comment.
- **Medium (bootstrap admin password)**: Fresh installs no longer get the hardcoded `'password'`. If `ADMIN_DEFAULT_PASSWORD` (the variable already documented in `.env.example` but never previously read) is set, it is used; otherwise the backend generates a 32-char `base64url` password via `crypto.randomBytes` and logs it once at `warn` under `db:bootstrap-admin`. Existing installations still using the legacy `'password'` continue to work — the in-app rotation notification remains active until the password is changed.
- **Docs**: Updated `README.md`, `deploy/README.md`, `.env.example`, and `server/.env.example` to reflect the new bootstrap admin password behavior.

## Test plan
- [x] `bun run lint` (i18n + tsc + biome) — clean
- [x] `cd server && bun test ./test/db/` — 26 pass, 0 fail (4 new regression tests in `demoSeedTransaction.test.ts`, 4 new bootstrap-admin tests for env-vs-generated resolution)
- [x] `cd server && bun test ./test` — 2003 pass, 1 pre-existing fail in `test/routes/entries.test.ts` (unrelated; reproduces on the base branch with my changes stashed)
- [x] No live DB e2e (no local Docker per task recipe); transactional rollback path is covered by the new unit tests:
  - `rolls back when verification reports a mismatch and never issues COMMIT`
  - `verification SELECT statements run on the same client (inside the transaction)`
  - `cleanupDemoNamespace also clears compatibility default IDs`
  - `commits only when verification passes and runs post-commit sync`

https://claude.ai/code/session_01JoRTwXFkuga3Cfymy6HcJ9

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoRTwXFkuga3Cfymy6HcJ9)_