### PR TITLE
fix(routes): rate-limit invoice mutations + allow empty assignment arrays

### DIFF
--- a/server/routes/invoices.ts
+++ b/server/routes/invoices.ts
@@ -2,7 +2,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { withDbTransaction } from '../db/drizzle.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
 import * as invoicesRepo from '../repositories/invoicesRepo.ts';
-import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
+import { standardRateLimitedErrorResponses } from '../schemas/common.ts';
 import { logAudit } from '../utils/audit.ts';
 import { getForeignKeyViolation, getUniqueViolation } from '../utils/db-errors.ts';
 import { computeInvoiceTotals } from '../utils/invoice-math.ts';
@@ -263,14 +263,17 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.post(
     '/',
     {
-      onRequest: [requirePermission('accounting.clients_invoices.create')],
+      onRequest: [
+        fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
+        requirePermission('accounting.clients_invoices.create'),
+      ],
       schema: {
         tags: ['invoices'],
         summary: 'Create invoice',
         body: invoiceCreateBodySchema,
         response: {
           201: invoiceSchema,
-          ...standardErrorResponses,
+          ...standardRateLimitedErrorResponses,
         },
       },
     },
@@ -391,7 +394,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.put(
     '/:id',
     {
-      onRequest: [requirePermission('accounting.clients_invoices.update')],
+      onRequest: [
+        fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
+        requirePermission('accounting.clients_invoices.update'),
+      ],
       schema: {
         tags: ['invoices'],
         summary: 'Update invoice',
@@ -399,7 +405,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         body: invoiceUpdateBodySchema,
         response: {
           200: invoiceSchema,
-          ...standardErrorResponses,
+          ...standardRateLimitedErrorResponses,
         },
       },
     },
@@ -583,14 +589,17 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.delete(
     '/:id',
     {
-      onRequest: [requirePermission('accounting.clients_invoices.delete')],
+      onRequest: [
+        fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
+        requirePermission('accounting.clients_invoices.delete'),
+      ],
       schema: {
         tags: ['invoices'],
         summary: 'Delete invoice',
         params: idParamSchema,
         response: {
           204: { type: 'null' },
-          ...standardErrorResponses,
+          ...standardRateLimitedErrorResponses,
         },
       },
     },

--- a/server/routes/users.ts
+++ b/server/routes/users.ts
@@ -293,20 +293,21 @@ const ensureSubmittedAssignmentsInScope = async (
   const userId = request.user?.id;
   if (!userId || hasPermission(request, 'administration.user_management_all.view')) return true;
 
-  if (clientIds && !hasPermission(request, 'crm.clients_all.view')) {
-    if (clientIds.length === 0) return false;
+  // Empty arrays are a legitimate "clear all my assignments" intent, not a request to view
+  // everyone's data. The outer route already requires `hr.employee_assignments.update`, so
+  // we let empty arrays through without an _all.view scope check. Non-empty arrays still
+  // need filtering: each id has to be inside the actor's assigned scope.
+  if (clientIds && clientIds.length > 0 && !hasPermission(request, 'crm.clients_all.view')) {
     const allowed = await userAssignmentsRepo.filterAssignedClientIds(userId, clientIds);
     if (clientIds.some((id) => !allowed.has(id))) return false;
   }
 
-  if (projectIds && !hasPermission(request, 'projects.manage_all.view')) {
-    if (projectIds.length === 0) return false;
+  if (projectIds && projectIds.length > 0 && !hasPermission(request, 'projects.manage_all.view')) {
     const allowed = await userAssignmentsRepo.filterAssignedProjectIds(userId, projectIds);
     if (projectIds.some((id) => !allowed.has(id))) return false;
   }
 
-  if (taskIds && !hasPermission(request, 'projects.tasks_all.view')) {
-    if (taskIds.length === 0) return false;
+  if (taskIds && taskIds.length > 0 && !hasPermission(request, 'projects.tasks_all.view')) {
     const allowed = await userAssignmentsRepo.filterAssignedTaskIds(userId, taskIds);
     if (taskIds.some((id) => !allowed.has(id))) return false;
   }
@@ -560,9 +561,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       },
     },
     async (request: FastifyRequest, reply: FastifyReply) => {
+      if (!assertAuthenticated(request, reply)) return;
       const { id } = request.params as { id: string };
 
-      if (id === request.user?.id) {
+      if (id === request.user.id) {
         return badRequest(reply, 'Cannot delete your own account');
       }
 
@@ -619,6 +621,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       },
     },
     async (request: FastifyRequest, reply: FastifyReply) => {
+      if (!assertAuthenticated(request, reply)) return;
       const { id } = request.params as { id: string };
       const { name, email, isDisabled, costPerHour, role } = request.body as {
         name?: string;
@@ -668,15 +671,15 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       if (
         targetEmployeeType === 'app_user' &&
         !hasPermission(request, 'administration.user_management_all.view') &&
-        idResult.value !== request.user?.id &&
-        !(await usersRepo.canManageUser(idResult.value, request.user?.id ?? ''))
+        idResult.value !== request.user.id &&
+        !(await usersRepo.canManageUser(idResult.value, request.user.id))
       ) {
         return reply.code(403).send({ error: 'Insufficient permissions' });
       }
 
       let roleValue: string | null = null;
       if (role !== undefined) {
-        if (idResult.value === request.user?.id) {
+        if (idResult.value === request.user.id) {
           return reply.code(403).send({ error: 'Cannot change your own role' });
         }
         const roleResult = requireNonEmptyString(role, 'role');
@@ -690,7 +693,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         fields.role = roleValue;
       }
 
-      if (idResult.value === request.user?.id && isDisabled === true) {
+      if (idResult.value === request.user.id && isDisabled === true) {
         return badRequest(reply, 'Cannot disable your own account');
       }
 
@@ -791,6 +794,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       },
     },
     async (request: FastifyRequest, reply: FastifyReply) => {
+      if (!assertAuthenticated(request, reply)) return;
       const { id } = request.params as { id: string };
       const { authMethod, authProviderId } = request.body as {
         authMethod?: unknown;
@@ -816,12 +820,12 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       }
       if (
         !hasPermission(request, 'administration.user_management_all.view') &&
-        idResult.value !== request.user?.id &&
-        !(await usersRepo.canManageUser(idResult.value, request.user?.id ?? ''))
+        idResult.value !== request.user.id &&
+        !(await usersRepo.canManageUser(idResult.value, request.user.id))
       ) {
         return reply.code(403).send({ error: 'Insufficient permissions' });
       }
-      if (idResult.value === request.user?.id) {
+      if (idResult.value === request.user.id) {
         return badRequest(reply, 'Cannot change your own authentication method');
       }
 
@@ -920,11 +924,12 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       },
     },
     async (request: FastifyRequest, reply: FastifyReply) => {
+      if (!assertAuthenticated(request, reply)) return;
       const { id } = request.params as { id: string };
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
 
-      if (idResult.value === request.user?.id) {
+      if (idResult.value === request.user.id) {
         return reply.code(403).send({ error: 'Cannot change your own role' });
       }
 
@@ -1088,6 +1093,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       },
     },
     async (request: FastifyRequest, reply: FastifyReply) => {
+      if (!assertAuthenticated(request, reply)) return;
       const { id } = request.params as { id: string };
       const { clientIds, projectIds, taskIds } = request.body as {
         clientIds?: string[];
@@ -1097,8 +1103,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
 
-      if (!canViewAllUsers(request) && idResult.value !== request.user?.id) {
-        if (!(await usersRepo.canManageUser(idResult.value, request.user?.id ?? ''))) {
+      if (!canViewAllUsers(request) && idResult.value !== request.user.id) {
+        if (!(await usersRepo.canManageUser(idResult.value, request.user.id))) {
           return reply.code(403).send({ error: 'Insufficient permissions' });
         }
       }

--- a/server/test/routes/invoices.test.ts
+++ b/server/test/routes/invoices.test.ts
@@ -1,11 +1,12 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
-import type { FastifyInstance, FastifyPluginAsync } from 'fastify';
+import Fastify, { type FastifyInstance, type FastifyPluginAsync } from 'fastify';
 import * as realDrizzle from '../../db/drizzle.ts';
 import * as realInvoicesRepo from '../../repositories/invoicesRepo.ts';
 import * as realRolesRepo from '../../repositories/rolesRepo.ts';
 import * as realUsersRepo from '../../repositories/usersRepo.ts';
 import * as realAudit from '../../utils/audit.ts';
 import * as realPermissions from '../../utils/permissions.ts';
+import { STANDARD_ROUTE_RATE_LIMIT } from '../../utils/rate-limit.ts';
 import {
   installAuthMiddlewareMock,
   restoreAuthMiddlewareMock,
@@ -785,5 +786,30 @@ describe('DELETE /api/invoices/:id', () => {
     expect(JSON.parse(res.body)).toEqual({
       error: 'Cannot delete invoice because it is referenced by other records',
     });
+  });
+});
+
+// Rate-limit configuration regression: mutating handlers must opt in to the standard
+// per-route rate limit, not only GET. Without this an attacker can trivially flood
+// the database with POST/PUT/DELETE traffic.
+describe('rate-limit configuration on invoice mutations', () => {
+  test('GET, POST, PUT, DELETE all install fastify.rateLimit with STANDARD_ROUTE_RATE_LIMIT', async () => {
+    // Spy on the rateLimit decorator instead of the no-op in buildRouteTestApp so we can
+    // assert which route options reach it.
+    const rateLimitMock = mock((_options: unknown) => async () => {});
+    const app = Fastify({ logger: false });
+    app.decorate('rateLimit', rateLimitMock);
+    await app.register(invoicesRoutePlugin, { prefix: '/api/invoices' });
+    await app.ready();
+
+    // One call per route (GET, POST, PUT, DELETE) - four total. Every call must use the
+    // standard config so abuse on mutations is gated the same way as the listing.
+    expect(rateLimitMock).toHaveBeenCalledTimes(4);
+    expect(rateLimitMock).toHaveBeenNthCalledWith(1, STANDARD_ROUTE_RATE_LIMIT);
+    expect(rateLimitMock).toHaveBeenNthCalledWith(2, STANDARD_ROUTE_RATE_LIMIT);
+    expect(rateLimitMock).toHaveBeenNthCalledWith(3, STANDARD_ROUTE_RATE_LIMIT);
+    expect(rateLimitMock).toHaveBeenNthCalledWith(4, STANDARD_ROUTE_RATE_LIMIT);
+
+    await app.close();
   });
 });

--- a/server/test/routes/users.test.ts
+++ b/server/test/routes/users.test.ts
@@ -1564,9 +1564,16 @@ describe('POST /api/users/:id/assignments', () => {
     expect(filterAssignedClientIdsMock).toHaveBeenCalledWith(MANAGER_USER.id, ['c-out']);
   });
 
-  test('403 scoped manager cannot clear assignments with an empty array', async () => {
+  test('200 scoped manager clears clientIds with an empty array (clear-all is not view-all)', async () => {
+    // Regression: previously ensureSubmittedAssignmentsInScope rejected empty arrays from
+    // anyone without `crm.clients_all.view`, blocking the legitimate "clear my assignments"
+    // request. The route already requires `hr.employee_assignments.update`, so an empty
+    // array is just a clear intent and must be allowed through. We don't need to call the
+    // scope filter because there's nothing to filter.
     findAuthUserByIdMock.mockResolvedValue(MANAGER_USER);
     getRolePermissionsMock.mockResolvedValue(['hr.employee_assignments.update']);
+    findCoreByIdMock.mockResolvedValue({ ...SAMPLE_USER_CORE, id: MANAGER_USER.id });
+    userHasTopManagerRoleMock.mockResolvedValue(false);
 
     const res = await testApp.inject({
       method: 'POST',
@@ -1575,8 +1582,56 @@ describe('POST /api/users/:id/assignments', () => {
       payload: { clientIds: [] },
     });
 
+    expect(res.statusCode).toBe(200);
+    expect(replaceUserClientsMock).toHaveBeenCalled();
+    const [userIdArg, clientIdsArg] = replaceUserClientsMock.mock.calls[0];
+    expect(userIdArg).toBe(MANAGER_USER.id);
+    expect(clientIdsArg).toEqual([]);
+    // The scope filter is intentionally skipped for empty arrays - there's nothing to filter.
+    expect(filterAssignedClientIdsMock).not.toHaveBeenCalled();
+  });
+
+  test('200 scoped manager clears projectIds and taskIds with empty arrays', async () => {
+    findAuthUserByIdMock.mockResolvedValue(MANAGER_USER);
+    getRolePermissionsMock.mockResolvedValue(['hr.employee_assignments.update']);
+    findCoreByIdMock.mockResolvedValue({ ...SAMPLE_USER_CORE, id: MANAGER_USER.id });
+    userHasTopManagerRoleMock.mockResolvedValue(false);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: `/api/users/${MANAGER_USER.id}/assignments`,
+      headers: managerAuth(),
+      payload: { projectIds: [], taskIds: [] },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(replaceUserProjectsMock).toHaveBeenCalled();
+    expect(replaceUserProjectsMock.mock.calls[0][0]).toBe(MANAGER_USER.id);
+    expect(replaceUserProjectsMock.mock.calls[0][1]).toEqual([]);
+    expect(replaceUserTasksMock).toHaveBeenCalled();
+    expect(replaceUserTasksMock.mock.calls[0][0]).toBe(MANAGER_USER.id);
+    expect(replaceUserTasksMock.mock.calls[0][1]).toEqual([]);
+    expect(filterAssignedProjectIdsMock).not.toHaveBeenCalled();
+    expect(filterAssignedTaskIdsMock).not.toHaveBeenCalled();
+  });
+
+  test('403 scoped manager still cannot assign clients outside scope when mixing with empty arrays', async () => {
+    // Defense-in-depth: clearing one list with `[]` must NOT bypass the scope check for
+    // populated lists in the same request.
+    findAuthUserByIdMock.mockResolvedValue(MANAGER_USER);
+    getRolePermissionsMock.mockResolvedValue(['hr.employee_assignments.update']);
+    filterAssignedProjectIdsMock.mockResolvedValue(new Set());
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: `/api/users/${MANAGER_USER.id}/assignments`,
+      headers: managerAuth(),
+      payload: { clientIds: [], projectIds: ['p-out'] },
+    });
+
     expect(res.statusCode).toBe(403);
     expect(replaceUserClientsMock).not.toHaveBeenCalled();
-    expect(filterAssignedClientIdsMock).not.toHaveBeenCalled();
+    expect(replaceUserProjectsMock).not.toHaveBeenCalled();
+    expect(filterAssignedProjectIdsMock).toHaveBeenCalledWith(MANAGER_USER.id, ['p-out']);
   });
 });


### PR DESCRIPTION
## Summary

Third-party review flagged three medium-severity issues in `server/routes/invoices.ts` and `server/routes/users.ts`. This PR addresses Unit 8:

- **Invoice mutations are now rate-limited.** The existing `STANDARD_ROUTE_RATE_LIMIT` was only wired to `GET /api/invoices`; `POST/PUT/DELETE` were unprotected. They now all go through the same per-user/IP budget that other route files use for both reads and writes, and their schemas advertise `429`.
- **`ensureSubmittedAssignmentsInScope` no longer rejects empty arrays.** Previously a manager without `crm.clients_all.view` (or the corresponding `_all.view` for projects/tasks) could not submit `{ clientIds: [] }` to clear an assignment list — the function treated the empty case as "view-all," which it isn't. The route already requires `hr.employee_assignments.update`, so an empty array is now allowed through as a legitimate "clear my list" intent. Non-empty arrays still go through the existing per-id `filterAssignedX` checks, so a scoped manager cannot widen access by mixing `[]` with an out-of-scope id list.
- **`assertAuthenticated` added** to every users.ts mutation handler that accesses `request.user.id` (DELETE/:id, PUT/:id, PUT/:id/auth-method, PUT/:id/roles, POST/:id/assignments). Replaces the prior `request.user?.id ?? ''` / `request.user?.id` patterns with the asserted narrow type. `invoices.ts` does not access `request.user` so no change was needed there.

## Test plan

- [x] `bun run lint` (typecheck + biome)
- [x] `cd server && bun test ./test/routes/invoices.test.ts ./test/routes/users.test.ts` — 104 pass, 0 fail
- [x] New regression test in `invoices.test.ts` spies on `fastify.rateLimit` and asserts all four routes register `STANDARD_ROUTE_RATE_LIMIT` (GET, POST, PUT, DELETE)
- [x] New regression tests in `users.test.ts`:
  - 200 scoped manager clears `clientIds` with `[]` and the scope filter is correctly skipped
  - 200 scoped manager clears `projectIds` and `taskIds` with `[]`
  - 403 scoped manager mixing `clientIds: []` with an out-of-scope `projectIds` is still rejected (defense-in-depth)
- [x] Updated the previously-passing "403 cannot clear with empty array" test that documented the broken behavior into the new "200" expectation


---
_Generated by [Claude Code](https://claude.ai/code/session_01JoRTwXFkuga3Cfymy6HcJ9)_