### PR TITLE
fix(types): tighten role/permission types + dedupe payment terms

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -1,5 +1,22 @@
-export type UserRole = string;
-export type Permission = string;
+/**
+ * Built-in role identifiers seeded by the backend.
+ * Custom roles created via Roles administration are also valid `UserRole`
+ * values — they keep the same `string` shape but are not known at compile
+ * time, hence the `(string & {})` fallback that preserves autocomplete on the
+ * literals while still accepting arbitrary DB-defined IDs.
+ */
+export type SystemRoleId = 'admin' | 'manager' | 'user' | 'top_manager';
+export type UserRole = SystemRoleId | (string & {});
+
+/**
+ * Permissions follow the `${resource}.${action}` shape (see
+ * `server/utils/permissions.ts`). The canonical set is generated from
+ * `PERMISSION_DEFINITIONS`; we accept any `string` here to stay flexible for
+ * custom permissions while keeping the type narrower than `unknown`.
+ */
+export type PermissionAction = 'view' | 'create' | 'update' | 'delete';
+export type Permission = `${string}.${PermissionAction}` | (string & {});
+
 export type EmployeeType = 'app_user' | 'internal' | 'external';
 export type UserAuthMethod = 'local' | 'ldap' | 'oidc' | 'saml';
 export type DiscountType = 'percentage' | 'currency';
@@ -7,6 +24,23 @@ export type TimeEntryLocation = 'office' | 'customer_premise' | 'remote' | 'tran
 export type StoredBillingType = 'retainer' | 'time_and_materials';
 export type BillingType = StoredBillingType | 'mixed';
 export type BillingFrequency = 'monthly' | 'one_time';
+
+/**
+ * Payment terms shared by quotes, offers, orders, and supplier-side
+ * documents. Centralised so the literal union doesn't drift between domains.
+ */
+export type PaymentTerm =
+  | 'immediate'
+  | '15gg'
+  | '21gg'
+  | '30gg'
+  | '45gg'
+  | '60gg'
+  | '90gg'
+  | '120gg'
+  | '180gg'
+  | '240gg'
+  | '365gg';
 
 export interface RoleSummary {
   id: string;
@@ -313,18 +347,7 @@ export interface Quote {
   clientId: string;
   clientName: string;
   items: QuoteItem[];
-  paymentTerms:
-    | 'immediate'
-    | '15gg'
-    | '21gg'
-    | '30gg'
-    | '45gg'
-    | '60gg'
-    | '90gg'
-    | '120gg'
-    | '180gg'
-    | '240gg'
-    | '365gg';
+  paymentTerms: PaymentTerm;
   discount: number;
   discountType: DiscountType;
   status: 'draft' | 'sent' | 'accepted' | 'denied';
@@ -381,18 +404,7 @@ export interface ClientOffer {
   clientId: string;
   clientName: string;
   items: ClientOfferItem[];
-  paymentTerms:
-    | 'immediate'
-    | '15gg'
-    | '21gg'
-    | '30gg'
-    | '45gg'
-    | '60gg'
-    | '90gg'
-    | '120gg'
-    | '180gg'
-    | '240gg'
-    | '365gg';
+  paymentTerms: PaymentTerm;
   discount: number;
   discountType: DiscountType;
   status: 'draft' | 'sent' | 'accepted' | 'denied';
@@ -451,18 +463,7 @@ export interface ClientsOrder {
   clientId: string;
   clientName: string;
   items: ClientsOrderItem[];
-  paymentTerms:
-    | 'immediate'
-    | '15gg'
-    | '21gg'
-    | '30gg'
-    | '45gg'
-    | '60gg'
-    | '90gg'
-    | '120gg'
-    | '180gg'
-    | '240gg'
-    | '365gg';
+  paymentTerms: PaymentTerm;
   discount: number;
   discountType: DiscountType;
   status: 'draft' | 'confirmed' | 'denied';
@@ -592,7 +593,6 @@ export interface InvoiceItem {
 
 export interface Invoice {
   id: string;
-  linkedOrderId?: string;
   linkedSaleId?: string;
   clientId: string;
   clientName: string;
@@ -642,18 +642,7 @@ export interface SupplierQuote {
   supplierId: string;
   supplierName: string;
   items: SupplierQuoteItem[];
-  paymentTerms:
-    | 'immediate'
-    | '15gg'
-    | '21gg'
-    | '30gg'
-    | '45gg'
-    | '60gg'
-    | '90gg'
-    | '120gg'
-    | '180gg'
-    | '240gg'
-    | '365gg';
+  paymentTerms: PaymentTerm;
   status: 'draft' | 'sent' | 'accepted' | 'denied';
   expirationDate: string;
   linkedOrderId?: string;
@@ -709,18 +698,7 @@ export interface SupplierSaleOrder {
   supplierId: string;
   supplierName: string;
   items: SupplierSaleOrderItem[];
-  paymentTerms:
-    | 'immediate'
-    | '15gg'
-    | '21gg'
-    | '30gg'
-    | '45gg'
-    | '60gg'
-    | '90gg'
-    | '120gg'
-    | '180gg'
-    | '240gg'
-    | '365gg';
+  paymentTerms: PaymentTerm;
   discount: number;
   discountType: DiscountType;
   status: 'draft' | 'sent';


### PR DESCRIPTION
## Summary

Addresses the type-safety issues a third-party review flagged in `types.ts`.

- **High (UserRole / Permission)** — replaced `type UserRole = string` and `type Permission = string` with literal-union-plus-fallback types. `UserRole = SystemRoleId | (string & {})` exposes the seeded role IDs (`admin`, `manager`, `user`, `top_manager`) for autocomplete while still accepting custom DB-defined roles. `Permission` mirrors the existing `${resource}.${action}` template shape used in `server/utils/permissions.ts` / `utils/permissions.ts`.
- **Medium (payment terms)** — extracted the `'immediate' | '15gg' | … | '365gg'` literal union that was duplicated five times (`Quote`, `ClientOffer`, `ClientsOrder`, `SupplierQuote`, `SupplierSaleOrder`) into a single `PaymentTerm` type and referenced it from each spot.
- **Low (Invoice.linkedOrderId)** — removed the dead `linkedOrderId` field from `Invoice`. Repo-wide grep finds no read/write path: `invoicesRepo` doesn't even map the column, and `linkedSaleId` is the only linkage used. Only the Invoice instance was flagged by the review; `SupplierQuote.linkedOrderId` (which is actively used) and `SupplierInvoice.linkedOrderId` (not in scope) are left untouched.

Net diff: `types.ts +41 / -63`. No production-runtime code changes.

## Test plan

- [x] `bun run lint` (i18n check + tsc for both `server/tsconfig.json` and `tsconfig.json` + biome) passes.
- [x] No unit-test updates required (type-only edits). Backend `bun test` only surfaces pre-existing/environment-related flakes unrelated to this diff (`<ClientsView />` and `products.test.ts > beforeEach hook timed out` — both reproduce on the unchanged base branch).

https://claude.ai/code/session_01JoRTwXFkuga3Cfymy6HcJ9

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoRTwXFkuga3Cfymy6HcJ9)_