### PR TITLE
fix(auth): distinguish disabled-user error from invalid token (rebased)

### DIFF
--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -50,7 +50,10 @@ const loadAuthenticatedUserContext = async (
   }
 
   if (user.isDisabled) {
-    reply.code(401).send({ error: 'Invalid or expired token' });
+    // 403 (not 401): the token itself is valid; the account is forbidden from
+    // accessing the system. Matches the sibling-route convention for
+    // authenticated-but-forbidden responses (see requireRole/requirePermission).
+    reply.code(403).send({ error: 'Account is disabled' });
     return null;
   }
 

--- a/server/test/middleware/auth.test.ts
+++ b/server/test/middleware/auth.test.ts
@@ -192,13 +192,15 @@ describe('authenticateToken', () => {
     expect(reply.body).toEqual({ error: 'User not found' });
   });
 
-  test('401 when user.isDisabled is true', async () => {
+  test('403 Account is disabled when user.isDisabled is true', async () => {
     findAuthUserByIdMock.mockResolvedValue({ ...HAPPY_USER, isDisabled: true });
     const request = buildFakeRequest(signToken({ userId: 'u1' }));
     const reply = buildFakeReply();
     await authenticateToken(request as never, reply as never);
-    expect(reply.statusCode).toBe(401);
-    expect(reply.body).toEqual({ error: 'Invalid or expired token' });
+    expect(reply.statusCode).toBe(403);
+    expect(reply.body).toEqual({ error: 'Account is disabled' });
+    // Sliding-window token must not be rotated for disabled accounts.
+    expect(reply.headers?.['x-auth-token']).toBeUndefined();
   });
 
   test('403 when rolesRepo.userHasRole returns false', async () => {
@@ -366,15 +368,15 @@ describe('authenticateToken', () => {
     expect(markPersonalAccessTokenUsedMock).not.toHaveBeenCalled();
   });
 
-  test('PAT rejects disabled users', async () => {
+  test('PAT rejects disabled users with 403 Account is disabled', async () => {
     findAuthUserByIdMock.mockResolvedValue({ ...HAPPY_USER, isDisabled: true });
     const request = buildFakeRequest('praetor_pat_valid-token');
     const reply = buildFakeReply();
 
     await authenticateToken(request as never, reply as never);
 
-    expect(reply.statusCode).toBe(401);
-    expect(reply.body).toEqual({ error: 'Invalid or expired token' });
+    expect(reply.statusCode).toBe(403);
+    expect(reply.body).toEqual({ error: 'Account is disabled' });
     expect(markPersonalAccessTokenUsedMock).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
Supersedes #259 — rebased onto the merged base which introduced the `loadAuthenticatedUserContext` helper.

## Summary
- Disabled users now receive `403 Account is disabled` instead of the misleading `401 Invalid or expired token`. Fix is applied inside `loadAuthenticatedUserContext`, which both the JWT and PAT auth paths consult.
- Tests updated for both paths.

Closes #259.

https://claude.ai/code/session_01JoRTwXFkuga3Cfymy6HcJ9

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoRTwXFkuga3Cfymy6HcJ9)_