### PR TITLE
fix(invoice-math): distinct subtotal/total with tax + required taxRate (rebased)

### DIFF
--- a/server/routes/invoices.ts
+++ b/server/routes/invoices.ts
@@ -41,6 +41,7 @@ const invoiceItemSchema = {
     quantity: { type: 'number' },
     unitPrice: { type: 'number' },
     discount: { type: 'number' },
+    taxRate: { type: 'number' },
   },
   required: [
     'id',
@@ -64,6 +65,7 @@ const invoiceSchema = {
     dueDate: { type: 'string', format: 'date' },
     status: { type: 'string' },
     subtotal: { type: 'number' },
+    tax: { type: 'number' },
     total: { type: 'number' },
     amountPaid: { type: 'number' },
     notes: { type: ['string', 'null'] },
@@ -96,6 +98,7 @@ const invoiceItemBodySchema = {
     quantity: { type: 'number' },
     unitPrice: { type: 'number' },
     discount: { type: 'number' },
+    taxRate: { type: 'number' },
   },
   required: ['description', 'unitOfMeasure', 'quantity', 'unitPrice'],
 } as const;
@@ -140,6 +143,7 @@ type NormalizedInvoiceItemInput = {
   quantity: number;
   unitPrice: number;
   discount: number;
+  taxRate: number;
 };
 
 const generateInvoiceItemId = () => generateItemId('inv-item-');
@@ -209,6 +213,18 @@ const validateAndNormalizeItems = (
       return null;
     }
 
+    const taxRateResult = optionalLocalizedNonNegativeNumber(item.taxRate, `items[${i}].taxRate`);
+    if (!taxRateResult.ok) {
+      badRequest(reply, taxRateResult.message);
+      return null;
+    }
+    // Mirror the discount bound — anything above 100% VAT is almost certainly client-side
+    // misuse and would balloon the total far beyond the subtotal.
+    if (taxRateResult.value !== null && taxRateResult.value > 100) {
+      badRequest(reply, `items[${i}].taxRate must be at most 100`);
+      return null;
+    }
+
     normalizedItems.push({
       productId: productIdResult.value || null,
       description: descriptionResult.value,
@@ -216,6 +232,7 @@ const validateAndNormalizeItems = (
       quantity: round2(quantityResult.value),
       unitPrice: round2(unitPriceResult.value),
       discount: round2(discountResult.value || 0),
+      taxRate: round2(taxRateResult.value || 0),
     });
   }
 

--- a/server/routes/invoices.ts
+++ b/server/routes/invoices.ts
@@ -100,7 +100,9 @@ const invoiceItemBodySchema = {
     discount: { type: 'number' },
     taxRate: { type: 'number' },
   },
-  required: ['description', 'unitOfMeasure', 'quantity', 'unitPrice'],
+  // taxRate is required so a PUT that omits it can't silently zero out tax on an
+  // existing taxed invoice. Clients must round-trip the field explicitly.
+  required: ['description', 'unitOfMeasure', 'quantity', 'unitPrice', 'taxRate'],
 } as const;
 
 // subtotal/total are server-computed from items; clients cannot set them.

--- a/server/test/routes/invoices.test.ts
+++ b/server/test/routes/invoices.test.ts
@@ -135,6 +135,7 @@ const SAMPLE_ITEM = {
   unitOfMeasure: 'unit' as const,
   quantity: 1,
   unitPrice: 100,
+  taxRate: 0,
   discount: 0,
 };
 
@@ -221,6 +222,7 @@ describe('POST /api/invoices', () => {
         unitOfMeasure: 'unit',
         quantity: 1,
         unitPrice: 100,
+        taxRate: 0,
       },
     ],
   };
@@ -318,6 +320,7 @@ describe('POST /api/invoices', () => {
             unitOfMeasure: 'unit',
             quantity: 2,
             unitPrice: 50,
+            taxRate: 0,
             discount: 10,
           },
         ],
@@ -397,7 +400,9 @@ describe('POST /api/invoices', () => {
       headers: authHeader(),
       payload: {
         ...validBody,
-        items: [{ description: 'X', unitOfMeasure: 'unit', quantity: -5, unitPrice: 100 }],
+        items: [
+          { description: 'X', unitOfMeasure: 'unit', quantity: -5, unitPrice: 100, taxRate: 0 },
+        ],
       },
     });
 
@@ -418,6 +423,7 @@ describe('POST /api/invoices', () => {
             unitOfMeasure: 'unit',
             quantity: 1,
             unitPrice: 100,
+            taxRate: 0,
             discount: 150,
           },
         ],
@@ -446,6 +452,7 @@ describe('POST /api/invoices', () => {
             unitOfMeasure: 'unit',
             quantity: 1,
             unitPrice: 100,
+            taxRate: 0,
             discount: 100,
           },
         ],
@@ -520,7 +527,15 @@ describe('PUT /api/invoices/:id', () => {
       url: '/api/invoices/inv-1',
       headers: authHeader(),
       payload: {
-        items: [{ description: 'Replaced', unitOfMeasure: 'unit', quantity: 2, unitPrice: 50 }],
+        items: [
+          {
+            description: 'Replaced',
+            unitOfMeasure: 'unit',
+            quantity: 2,
+            unitPrice: 50,
+            taxRate: 0,
+          },
+        ],
         // Client tries to submit a bogus 999 - server must override.
         subtotal: 999,
         total: 999,
@@ -548,7 +563,9 @@ describe('PUT /api/invoices/:id', () => {
       url: '/api/invoices/inv-1',
       headers: authHeader(),
       payload: {
-        items: [{ description: 'X', unitOfMeasure: 'unit', quantity: 1, unitPrice: 50 }],
+        items: [
+          { description: 'X', unitOfMeasure: 'unit', quantity: 1, unitPrice: 50, taxRate: 0 },
+        ],
       },
     });
 
@@ -566,7 +583,9 @@ describe('PUT /api/invoices/:id', () => {
       url: '/api/invoices/missing',
       headers: authHeader(),
       payload: {
-        items: [{ description: 'X', unitOfMeasure: 'unit', quantity: 1, unitPrice: 50 }],
+        items: [
+          { description: 'X', unitOfMeasure: 'unit', quantity: 1, unitPrice: 50, taxRate: 0 },
+        ],
       },
     });
 
@@ -584,7 +603,9 @@ describe('PUT /api/invoices/:id', () => {
       url: '/api/invoices/inv-1',
       headers: authHeader(),
       payload: {
-        items: [{ description: 'X', unitOfMeasure: 'unit', quantity: 1, unitPrice: 50 }],
+        items: [
+          { description: 'X', unitOfMeasure: 'unit', quantity: 1, unitPrice: 50, taxRate: 0 },
+        ],
       },
     });
 
@@ -616,7 +637,9 @@ describe('PUT /api/invoices/:id', () => {
       url: '/api/invoices/inv-1',
       headers: authHeader(),
       payload: {
-        items: [{ description: 'X', unitOfMeasure: 'unit', quantity: 1, unitPrice: 50 }],
+        items: [
+          { description: 'X', unitOfMeasure: 'unit', quantity: 1, unitPrice: 50, taxRate: 0 },
+        ],
         amountPaid: 9999,
       },
     });

--- a/server/test/utils/invoice-math.test.ts
+++ b/server/test/utils/invoice-math.test.ts
@@ -2,37 +2,40 @@ import { describe, expect, test } from 'bun:test';
 import { computeInvoiceTotals } from '../../utils/invoice-math.ts';
 
 describe('computeInvoiceTotals', () => {
-  test('empty items → zero subtotal and total', () => {
-    expect(computeInvoiceTotals([])).toEqual({ subtotal: 0, total: 0 });
+  test('empty items → zero subtotal, tax, and total', () => {
+    expect(computeInvoiceTotals([])).toEqual({ subtotal: 0, tax: 0, total: 0 });
   });
 
-  test('single item with no discount', () => {
+  test('single item with no discount and no tax', () => {
     expect(computeInvoiceTotals([{ quantity: 2, unitPrice: 50, discount: 0 }])).toEqual({
       subtotal: 100,
+      tax: 0,
       total: 100,
     });
   });
 
-  test('single item with 10% discount', () => {
+  test('single item with 10% discount and no tax', () => {
     expect(computeInvoiceTotals([{ quantity: 2, unitPrice: 50, discount: 10 }])).toEqual({
       subtotal: 90,
+      tax: 0,
       total: 90,
     });
   });
 
-  test('multiple items sum correctly', () => {
+  test('multiple items sum correctly without tax', () => {
     expect(
       computeInvoiceTotals([
         { quantity: 2, unitPrice: 50, discount: 0 }, // 100
         { quantity: 3, unitPrice: 20, discount: 0 }, // 60
         { quantity: 1, unitPrice: 40, discount: 25 }, // 30
       ]),
-    ).toEqual({ subtotal: 190, total: 190 });
+    ).toEqual({ subtotal: 190, tax: 0, total: 190 });
   });
 
   test('100% discount yields 0 line', () => {
     expect(computeInvoiceTotals([{ quantity: 5, unitPrice: 100, discount: 100 }])).toEqual({
       subtotal: 0,
+      tax: 0,
       total: 0,
     });
   });
@@ -41,6 +44,7 @@ describe('computeInvoiceTotals', () => {
     // 0.1 * 0.2 = 0.020000000000000004 in JS floats; rounding pins it to 0.02
     expect(computeInvoiceTotals([{ quantity: 0.1, unitPrice: 0.2, discount: 0 }])).toEqual({
       subtotal: 0.02,
+      tax: 0,
       total: 0.02,
     });
   });
@@ -49,6 +53,7 @@ describe('computeInvoiceTotals', () => {
     // 1 * 0.005 = 0.005 → rounds to 0.01
     expect(computeInvoiceTotals([{ quantity: 1, unitPrice: 0.005, discount: 0 }])).toEqual({
       subtotal: 0.01,
+      tax: 0,
       total: 0.01,
     });
   });
@@ -57,12 +62,58 @@ describe('computeInvoiceTotals', () => {
     // 7 * 13.50 * 0.85 = 80.325 → rounded to 80.33
     expect(computeInvoiceTotals([{ quantity: 7, unitPrice: 13.5, discount: 15 }])).toEqual({
       subtotal: 80.33,
+      tax: 0,
       total: 80.33,
     });
   });
 
-  test('subtotal equals total (no tax in this codebase)', () => {
+  test('subtotal equals total when no tax provided (backwards compatible)', () => {
     const result = computeInvoiceTotals([{ quantity: 1, unitPrice: 99.99, discount: 0 }]);
     expect(result.subtotal).toBe(result.total);
+    expect(result.tax).toBe(0);
+  });
+
+  test('regression: applies item-level tax so subtotal !== total', () => {
+    // 1 * 100 * 1.0 = 100 subtotal, 22% VAT → 22 tax, 122 total
+    const result = computeInvoiceTotals([
+      { quantity: 1, unitPrice: 100, discount: 0, taxRate: 22 },
+    ]);
+    expect(result).toEqual({ subtotal: 100, tax: 22, total: 122 });
+    expect(result.subtotal).not.toBe(result.total);
+  });
+
+  test('regression: applies tax after item discount', () => {
+    // 2 * 50 * (1 - 10/100) = 90 subtotal, 10% tax → 9 tax, 99 total
+    const result = computeInvoiceTotals([
+      { quantity: 2, unitPrice: 50, discount: 10, taxRate: 10 },
+    ]);
+    expect(result).toEqual({ subtotal: 90, tax: 9, total: 99 });
+    expect(result.subtotal).not.toBe(result.total);
+  });
+
+  test('mixes taxed and untaxed lines correctly', () => {
+    // Line 1: 100 subtotal, 22 tax (22%)
+    // Line 2: 60 subtotal, 0 tax (no rate)
+    // Line 3: 30 subtotal, 1.5 tax (5%)
+    const result = computeInvoiceTotals([
+      { quantity: 2, unitPrice: 50, discount: 0, taxRate: 22 },
+      { quantity: 3, unitPrice: 20, discount: 0 },
+      { quantity: 1, unitPrice: 40, discount: 25, taxRate: 5 },
+    ]);
+    expect(result).toEqual({ subtotal: 190, tax: 23.5, total: 213.5 });
+  });
+
+  test('tax is rounded to 2 decimals', () => {
+    // 1 * 10 * 1.0 = 10 subtotal, 12.345% tax → 1.2345 → rounded 1.23
+    const result = computeInvoiceTotals([
+      { quantity: 1, unitPrice: 10, discount: 0, taxRate: 12.345 },
+    ]);
+    expect(result).toEqual({ subtotal: 10, tax: 1.23, total: 11.23 });
+  });
+
+  test('zero taxRate behaves like no taxRate', () => {
+    const a = computeInvoiceTotals([{ quantity: 1, unitPrice: 100, discount: 0, taxRate: 0 }]);
+    const b = computeInvoiceTotals([{ quantity: 1, unitPrice: 100, discount: 0 }]);
+    expect(a).toEqual(b);
   });
 });

--- a/server/utils/invoice-math.ts
+++ b/server/utils/invoice-math.ts
@@ -1,12 +1,25 @@
-type ItemMath = { quantity: number; unitPrice: number; discount: number };
+type ItemMath = { quantity: number; unitPrice: number; discount: number; taxRate?: number };
 
 const roundCurrency = (value: number) => Math.round(value * 100) / 100;
 
-export const computeInvoiceTotals = (items: ItemMath[]): { subtotal: number; total: number } => {
-  const subtotal = items.reduce((acc, item) => {
+// Items without `taxRate` default to 0, keeping `total === subtotal` for callers
+// that haven't started passing VAT through.
+export const computeInvoiceTotals = (
+  items: ItemMath[],
+): { subtotal: number; tax: number; total: number } => {
+  let subtotal = 0;
+  let tax = 0;
+  for (const item of items) {
     const discountFactor = 1 - item.discount / 100;
-    return acc + item.quantity * item.unitPrice * discountFactor;
-  }, 0);
-  const rounded = roundCurrency(subtotal);
-  return { subtotal: rounded, total: rounded };
+    const lineSubtotal = item.quantity * item.unitPrice * discountFactor;
+    subtotal += lineSubtotal;
+    tax += lineSubtotal * ((item.taxRate ?? 0) / 100);
+  }
+  const roundedSubtotal = roundCurrency(subtotal);
+  const roundedTax = roundCurrency(tax);
+  return {
+    subtotal: roundedSubtotal,
+    tax: roundedTax,
+    total: roundCurrency(roundedSubtotal + roundedTax),
+  };
 };


### PR DESCRIPTION
Supersedes #267 — rebased onto the merged base.

## Summary
- `computeInvoiceTotals` now accepts item-level `taxRate`, computes `tax = subtotal * taxRate / 100`, and returns `{ subtotal, tax, total: subtotal + tax }`.
- `taxRate` is REQUIRED on POST/PUT invoice items so a stale client cannot silently zero out tax on update (Codex P1 fix-up from #267).

Closes #267.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoRTwXFkuga3Cfymy6HcJ9)_