### PR TITLE
fix(handlers): eliminate stale closures via ref-based deps (rebased)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -50,6 +50,7 @@ import { makeSupplierQuoteHandlers } from './hooks/handlers/supplierQuoteHandler
 import { makeTaskHandlers } from './hooks/handlers/taskHandlers';
 import { makeUserHandlers } from './hooks/handlers/userHandlers';
 import { useAuth } from './hooks/useAuth';
+import { useLatestRef } from './hooks/useLatestRef';
 import { listRequest, useModuleLoader } from './hooks/useModuleLoader';
 import api, { type PersonalAccessToken, type Settings } from './services/api';
 import type {
@@ -742,6 +743,18 @@ const App: React.FC = () => {
     [switchRole],
   );
 
+  // Stable getters that always read the latest rendered state. Handler
+  // factories receive these instead of state snapshots, so they aren't rebuilt
+  // on every change and don't capture stale values.
+  const getCurrentUser = useLatestRef(currentUser);
+  const getViewingUserId = useLatestRef(viewingUserId);
+  const getProjects = useLatestRef(projects);
+  const getClientsOrders = useLatestRef(clientsOrders);
+  const getProjectTasks = useLatestRef(projectTasks);
+  const getQuotes = useLatestRef(quotes);
+  const getClientQuoteFilterId = useLatestRef(clientQuoteFilterId);
+  const getClientOfferFilterId = useLatestRef(clientOfferFilterId);
+
   const supplierQuoteHandlers = useMemo(
     () =>
       makeSupplierQuoteHandlers({
@@ -758,9 +771,9 @@ const App: React.FC = () => {
   const quoteHandlers = useMemo(
     () =>
       makeQuoteHandlers({
-        quotes,
-        clientQuoteFilterId,
-        clientOfferFilterId,
+        getQuotes,
+        getClientQuoteFilterId,
+        getClientOfferFilterId,
         setQuotes,
         setClientOffers,
         setClientsOrders,
@@ -771,9 +784,9 @@ const App: React.FC = () => {
         refreshSupplierQuoteFlow: supplierQuoteHandlers.refreshSupplierQuoteFlow,
       }),
     [
-      quotes,
-      clientQuoteFilterId,
-      clientOfferFilterId,
+      getQuotes,
+      getClientQuoteFilterId,
+      getClientOfferFilterId,
       supplierQuoteHandlers.refreshSupplierQuoteFlow,
     ],
   );
@@ -781,12 +794,12 @@ const App: React.FC = () => {
   const clientHandlers = useMemo(
     () =>
       makeClientHandlers({
-        projects,
+        getProjects,
         setClients,
         setProjects,
         setProjectTasks,
       }),
-    [projects],
+    [getProjects],
   );
 
   const productHandlers = useMemo(() => makeProductHandlers({ setProducts }), []);
@@ -794,23 +807,23 @@ const App: React.FC = () => {
   const projectHandlers = useMemo(
     () =>
       makeProjectHandlers({
-        projects,
-        clientsOrders,
+        getProjects,
+        getClientsOrders,
         setProjects,
         setProjectTasks,
         setEntries,
       }),
-    [projects, clientsOrders],
+    [getProjects, getClientsOrders],
   );
 
   const entryHandlers = useMemo(
     () =>
       makeEntryHandlers({
-        currentUser,
-        viewingUserId,
+        getCurrentUser,
+        getViewingUserId,
         setEntries,
       }),
-    [currentUser, viewingUserId],
+    [getCurrentUser, getViewingUserId],
   );
 
   const invoiceHandlers = useMemo(() => makeInvoiceHandlers({ setInvoices }), []);
@@ -1914,12 +1927,12 @@ const App: React.FC = () => {
   const taskHandlers = useMemo(
     () =>
       makeTaskHandlers({
-        projectTasks,
+        getProjectTasks,
         setProjectTasks,
         setEntries,
         generateRecurringEntries,
       }),
-    [projectTasks, generateRecurringEntries],
+    [getProjectTasks, generateRecurringEntries],
   );
 
   const handleAddEntry = entryHandlers.add;

--- a/hooks/handlers/clientHandlers.ts
+++ b/hooks/handlers/clientHandlers.ts
@@ -9,14 +9,14 @@ import type {
 } from '../../types';
 
 export type ClientHandlersDeps = {
-  projects: Project[];
+  getProjects: () => Project[];
   setClients: React.Dispatch<React.SetStateAction<Client[]>>;
   setProjects: React.Dispatch<React.SetStateAction<Project[]>>;
   setProjectTasks: React.Dispatch<React.SetStateAction<ProjectTask[]>>;
 };
 
 export const makeClientHandlers = (deps: ClientHandlersDeps) => {
-  const { projects, setClients, setProjects, setProjectTasks } = deps;
+  const { getProjects, setClients, setProjects, setProjectTasks } = deps;
 
   const add = async (clientData: Partial<Client>) => {
     try {
@@ -41,7 +41,9 @@ export const makeClientHandlers = (deps: ClientHandlersDeps) => {
   const remove = async (id: string) => {
     try {
       await api.clients.delete(id);
-      const projectIdsForClient = projects.filter((p) => p.clientId === id).map((p) => p.id);
+      const projectIdsForClient = getProjects()
+        .filter((p) => p.clientId === id)
+        .map((p) => p.id);
       setClients((prev) => prev.filter((c) => c.id !== id));
       setProjects((prev) => prev.filter((p) => p.clientId !== id));
       setProjectTasks((prev) => prev.filter((t) => !projectIdsForClient.includes(t.projectId)));

--- a/hooks/handlers/entryHandlers.ts
+++ b/hooks/handlers/entryHandlers.ts
@@ -3,18 +3,19 @@ import api from '../../services/api';
 import type { TimeEntry, User } from '../../types';
 
 export type EntryHandlersDeps = {
-  currentUser: User | null;
-  viewingUserId: string;
+  getCurrentUser: () => User | null;
+  getViewingUserId: () => string;
   setEntries: React.Dispatch<React.SetStateAction<TimeEntry[]>>;
 };
 
 export const makeEntryHandlers = (deps: EntryHandlersDeps) => {
-  const { currentUser, viewingUserId, setEntries } = deps;
+  const { getCurrentUser, getViewingUserId, setEntries } = deps;
 
   const add = async (newEntry: Omit<TimeEntry, 'id' | 'createdAt' | 'userId' | 'hourlyCost'>) => {
+    const currentUser = getCurrentUser();
     if (!currentUser) return;
     try {
-      const targetUserId = viewingUserId || currentUser.id;
+      const targetUserId = getViewingUserId() || currentUser.id;
       const entry = await api.entries.create({
         ...newEntry,
         userId: targetUserId,
@@ -28,9 +29,10 @@ export const makeEntryHandlers = (deps: EntryHandlersDeps) => {
   };
 
   const addBulk = async (newEntries: Omit<TimeEntry, 'id' | 'createdAt' | 'userId'>[]) => {
+    const currentUser = getCurrentUser();
     if (!currentUser) return;
     try {
-      const targetUserId = viewingUserId || currentUser.id;
+      const targetUserId = getViewingUserId() || currentUser.id;
       const createdEntries = await Promise.all(
         newEntries.map((entry) =>
           api.entries.create({

--- a/hooks/handlers/projectHandlers.ts
+++ b/hooks/handlers/projectHandlers.ts
@@ -12,15 +12,16 @@ import type {
 } from '../../types';
 
 export type ProjectHandlersDeps = {
-  projects: Project[];
-  clientsOrders: ClientsOrder[];
+  getProjects: () => Project[];
+  getClientsOrders: () => ClientsOrder[];
   setProjects: React.Dispatch<React.SetStateAction<Project[]>>;
   setProjectTasks: React.Dispatch<React.SetStateAction<ProjectTask[]>>;
   setEntries: React.Dispatch<React.SetStateAction<TimeEntry[]>>;
+  onError?: (err: unknown, context: 'add' | 'addTask' | 'update' | 'delete') => void;
 };
 
 export const makeProjectHandlers = (deps: ProjectHandlersDeps) => {
-  const { projects, clientsOrders, setProjects, setProjectTasks, setEntries } = deps;
+  const { getProjects, getClientsOrders, setProjects, setProjectTasks, setEntries, onError } = deps;
 
   const add = async (
     name: string,
@@ -31,11 +32,11 @@ export const makeProjectHandlers = (deps: ProjectHandlersDeps) => {
     billingFrequency?: BillingFrequency,
   ) => {
     try {
-      const order = clientsOrders.find((o) => o.id === orderId);
+      const order = getClientsOrders().find((o) => o.id === orderId);
       if (!order) throw new Error('Order not found');
       const clientId = order.clientId;
 
-      const usedColors = projects.map((p) => p.color);
+      const usedColors = getProjects().map((p) => p.color);
       const availableColors = COLORS.filter((c) => !usedColors.includes(c));
       const color =
         availableColors.length > 0
@@ -75,6 +76,7 @@ export const makeProjectHandlers = (deps: ProjectHandlersDeps) => {
       }
     } catch (err) {
       console.error('Failed to add project:', err);
+      onError?.(err, 'add');
     }
   };
 
@@ -105,6 +107,7 @@ export const makeProjectHandlers = (deps: ProjectHandlersDeps) => {
       setProjectTasks((prev) => [...prev, task]);
     } catch (err) {
       console.error('Failed to add task:', err);
+      onError?.(err, 'addTask');
     }
   };
 
@@ -115,6 +118,7 @@ export const makeProjectHandlers = (deps: ProjectHandlersDeps) => {
     } catch (err) {
       console.error('Failed to update project:', err);
       alert('Failed to update project');
+      onError?.(err, 'update');
     }
   };
 
@@ -127,6 +131,7 @@ export const makeProjectHandlers = (deps: ProjectHandlersDeps) => {
     } catch (err) {
       console.error('Failed to delete project:', err);
       alert('Failed to delete project');
+      onError?.(err, 'delete');
     }
   };
 

--- a/hooks/handlers/quoteHandlers.ts
+++ b/hooks/handlers/quoteHandlers.ts
@@ -5,9 +5,9 @@ import { getLocalDateString } from '../../utils/date';
 import { makeTempId } from '../../utils/tempId';
 
 export type QuoteHandlersDeps = {
-  quotes: Quote[];
-  clientQuoteFilterId: string | null;
-  clientOfferFilterId: string | null;
+  getQuotes: () => Quote[];
+  getClientQuoteFilterId: () => string | null;
+  getClientOfferFilterId: () => string | null;
   setQuotes: React.Dispatch<React.SetStateAction<Quote[]>>;
   setClientOffers: React.Dispatch<React.SetStateAction<ClientOffer[]>>;
   setClientsOrders: React.Dispatch<React.SetStateAction<ClientsOrder[]>>;
@@ -20,9 +20,9 @@ export type QuoteHandlersDeps = {
 
 export const makeQuoteHandlers = (deps: QuoteHandlersDeps) => {
   const {
-    quotes,
-    clientQuoteFilterId,
-    clientOfferFilterId,
+    getQuotes,
+    getClientQuoteFilterId,
+    getClientOfferFilterId,
     setQuotes,
     setClientOffers,
     setClientsOrders,
@@ -64,7 +64,7 @@ export const makeQuoteHandlers = (deps: QuoteHandlersDeps) => {
 
   const updateQuote = async (id: string, updates: Partial<Quote>) => {
     try {
-      const currentQuote = quotes.find((quote) => quote.id === id);
+      const currentQuote = getQuotes().find((quote) => quote.id === id);
       const isRestore = Boolean(
         updates.status === 'draft' &&
           updates.isExpired === false &&
@@ -76,7 +76,7 @@ export const makeQuoteHandlers = (deps: QuoteHandlersDeps) => {
         : updates;
 
       const updated = await api.quotes.update(id, updatesWithRestore);
-      if (clientQuoteFilterId === id) {
+      if (getClientQuoteFilterId() === id) {
         setClientQuoteFilterId(updated.id);
       }
       await refreshClientQuoteFlow();
@@ -97,7 +97,7 @@ export const makeQuoteHandlers = (deps: QuoteHandlersDeps) => {
   const updateClientOffer = async (id: string, updates: Partial<ClientOffer>) => {
     try {
       const updated = await api.clientOffers.update(id, updates);
-      if (clientOfferFilterId === id) {
+      if (getClientOfferFilterId() === id) {
         setClientOfferFilterId(updated.id);
       }
       await refreshClientQuoteFlow();

--- a/hooks/handlers/taskHandlers.ts
+++ b/hooks/handlers/taskHandlers.ts
@@ -4,14 +4,14 @@ import type { ProjectTask, TimeEntry } from '../../types';
 import { getLocalDateString } from '../../utils/date';
 
 export type TaskHandlersDeps = {
-  projectTasks: ProjectTask[];
+  getProjectTasks: () => ProjectTask[];
   setProjectTasks: React.Dispatch<React.SetStateAction<ProjectTask[]>>;
   setEntries: React.Dispatch<React.SetStateAction<TimeEntry[]>>;
   generateRecurringEntries: () => Promise<void> | void;
 };
 
 export const makeTaskHandlers = (deps: TaskHandlersDeps) => {
-  const { projectTasks, setProjectTasks, setEntries, generateRecurringEntries } = deps;
+  const { getProjectTasks, setProjectTasks, setEntries, generateRecurringEntries } = deps;
 
   const update = async (id: string, updates: Partial<ProjectTask>) => {
     try {
@@ -34,7 +34,7 @@ export const makeTaskHandlers = (deps: TaskHandlersDeps) => {
       // so generateRecurringEntries doesn't leave behind orphans from the old
       // pattern/date range (e.g. weekly → monthly, or moving end date earlier).
       // No-op for the first-time "make recurring" flow.
-      const existing = projectTasks.find((t) => t.id === taskId);
+      const existing = getProjectTasks().find((t) => t.id === taskId);
       if (existing?.isRecurring) {
         await api.entries.bulkDelete(existing.projectId, existing.name, {
           placeholderOnly: true,
@@ -55,9 +55,7 @@ export const makeTaskHandlers = (deps: TaskHandlersDeps) => {
         recurrenceDuration: duration,
       });
       setProjectTasks((prev) => prev.map((t) => (t.id === taskId ? updated : t)));
-      setTimeout(() => {
-        void generateRecurringEntries();
-      }, 100);
+      await generateRecurringEntries();
     } catch (err) {
       console.error('Failed to make task recurring:', err);
     }
@@ -67,7 +65,7 @@ export const makeTaskHandlers = (deps: TaskHandlersDeps) => {
     taskId: string,
     action: 'stop' | 'delete_future' | 'delete_all',
   ) => {
-    const task = projectTasks.find((t) => t.id === taskId);
+    const task = getProjectTasks().find((t) => t.id === taskId);
     if (!task) return;
 
     try {

--- a/hooks/useLatestRef.ts
+++ b/hooks/useLatestRef.ts
@@ -1,16 +1,19 @@
-import { useRef } from 'react';
+import { useLayoutEffect, useRef } from 'react';
 
 /**
- * Returns a stable getter that always reads the latest value, without forcing
- * downstream consumers (e.g. memoized handler factories) to re-run when the
- * value changes. The ref is synced during render so reads after commit observe
- * the value rendered in the same commit. The returned getter has stable
- * identity across renders, so it is safe to put in a `useMemo`/`useCallback`
- * dependency array.
+ * Returns a stable getter that always reads the latest *committed* value,
+ * without forcing downstream consumers (e.g. memoized handler factories) to
+ * re-run when the value changes. The ref is synced in `useLayoutEffect` so
+ * interrupted/discarded transition renders don't leak uncommitted state to
+ * handlers (e.g. attributing an entry to a user the UI hasn't switched to
+ * yet). The returned getter has stable identity across renders, so it is safe
+ * to put in a `useMemo`/`useCallback` dependency array.
  */
 export const useLatestRef = <T>(value: T): (() => T) => {
   const valueRef = useRef(value);
-  valueRef.current = value;
+  useLayoutEffect(() => {
+    valueRef.current = value;
+  }, [value]);
   const getterRef = useRef<() => T>(() => valueRef.current);
   return getterRef.current;
 };

--- a/hooks/useLatestRef.ts
+++ b/hooks/useLatestRef.ts
@@ -1,0 +1,16 @@
+import { useRef } from 'react';
+
+/**
+ * Returns a stable getter that always reads the latest value, without forcing
+ * downstream consumers (e.g. memoized handler factories) to re-run when the
+ * value changes. The ref is synced during render so reads after commit observe
+ * the value rendered in the same commit. The returned getter has stable
+ * identity across renders, so it is safe to put in a `useMemo`/`useCallback`
+ * dependency array.
+ */
+export const useLatestRef = <T>(value: T): (() => T) => {
+  const valueRef = useRef(value);
+  valueRef.current = value;
+  const getterRef = useRef<() => T>(() => valueRef.current);
+  return getterRef.current;
+};

--- a/test/handlers/clientHandlers.test.ts
+++ b/test/handlers/clientHandlers.test.ts
@@ -76,7 +76,7 @@ describe('makeClientHandlers', () => {
     );
     const clients = makeStubSetter<ClientLike>([{ id: 'c1' }]);
     const handlers = makeClientHandlers({
-      projects: [],
+      getProjects: () => [],
       setClients: clients.setter,
       setProjects: makeStubSetter<ProjectLike>([]).setter,
       setProjectTasks: makeStubSetter<TaskLike>([]).setter,
@@ -91,7 +91,7 @@ describe('makeClientHandlers', () => {
   test('add rethrows on api error', async () => {
     apiMocks.clientsCreate.mockImplementation(() => Promise.reject(new Error('boom')));
     const handlers = makeClientHandlers({
-      projects: [],
+      getProjects: () => [],
       setClients: makeStubSetter<ClientLike>([]).setter,
       setProjects: makeStubSetter<ProjectLike>([]).setter,
       setProjectTasks: makeStubSetter<TaskLike>([]).setter,
@@ -108,7 +108,7 @@ describe('makeClientHandlers', () => {
       { id: 'c2', name: 'Beta' },
     ]);
     const handlers = makeClientHandlers({
-      projects: [],
+      getProjects: () => [],
       setClients: clients.setter,
       setProjects: makeStubSetter<ProjectLike>([]).setter,
       setProjectTasks: makeStubSetter<TaskLike>([]).setter,
@@ -134,7 +134,7 @@ describe('makeClientHandlers', () => {
     ]);
 
     const handlers = makeClientHandlers({
-      projects: projects.get() as never,
+      getProjects: () => projects.get() as never,
       setClients: clients.setter,
       setProjects: projects.setter,
       setProjectTasks: tasks.setter,
@@ -157,7 +157,7 @@ describe('makeClientHandlers', () => {
     );
     const clients = makeStubSetter<ClientLike>([{ id: 'c-old' }]);
     const handlers = makeClientHandlers({
-      projects: [],
+      getProjects: () => [],
       setClients: clients.setter,
       setProjects: makeStubSetter<ProjectLike>([]).setter,
       setProjectTasks: makeStubSetter<TaskLike>([]).setter,
@@ -175,7 +175,7 @@ describe('makeClientHandlers', () => {
   test('createProfileOption rethrows on api error', async () => {
     apiMocks.clientsCreateProfileOption.mockImplementation(() => Promise.reject(new Error('nope')));
     const handlers = makeClientHandlers({
-      projects: [],
+      getProjects: () => [],
       setClients: makeStubSetter<ClientLike>([]).setter,
       setProjects: makeStubSetter<ProjectLike>([]).setter,
       setProjectTasks: makeStubSetter<TaskLike>([]).setter,
@@ -192,7 +192,7 @@ describe('makeClientHandlers', () => {
     );
     const clients = makeStubSetter<ClientLike>([{ id: 'c-stale' }]);
     const handlers = makeClientHandlers({
-      projects: [],
+      getProjects: () => [],
       setClients: clients.setter,
       setProjects: makeStubSetter<ProjectLike>([]).setter,
       setProjectTasks: makeStubSetter<TaskLike>([]).setter,
@@ -214,5 +214,36 @@ describe('makeClientHandlers', () => {
     });
     await expect(handlers.deleteProfileOption('industry' as never, 'po-2')).rejects.toThrow('nope');
     expect(apiMocks.clientsList).not.toHaveBeenCalled();
+  });
+
+  test('regression: delete observes latest projects via getter when cleaning tasks', async () => {
+    apiMocks.clientsDelete.mockImplementation(() => Promise.resolve());
+    // Initial state has no projects. After construction, projects load.
+    const clients = makeStubSetter<ClientLike>([{ id: 'c1' }]);
+    const projects = makeStubSetter<ProjectLike>([]);
+    const tasks = makeStubSetter<TaskLike>([
+      { id: 't-old', projectId: 'p1' },
+      { id: 't-keep', projectId: 'p2' },
+    ]);
+
+    const handlers = makeClientHandlers({
+      getProjects: () => projects.get() as never,
+      setClients: clients.setter,
+      setProjects: projects.setter,
+      setProjectTasks: tasks.setter,
+    });
+
+    // Now projects load AFTER the factory was created.
+    (projects.setter as (next: ProjectLike[]) => void)([
+      { id: 'p1', clientId: 'c1' },
+      { id: 'p2', clientId: 'c2' },
+    ]);
+
+    await handlers.delete('c1');
+
+    // With the stale-snapshot bug, projectIdsForClient would have been [], so
+    // tasks would not be cleaned. With the getter, t-old (project p1, client c1)
+    // should be removed and t-keep should remain.
+    expect(tasks.get()).toEqual([{ id: 't-keep', projectId: 'p2' }]);
   });
 });

--- a/test/handlers/entryHandlers.test.ts
+++ b/test/handlers/entryHandlers.test.ts
@@ -68,8 +68,8 @@ describe('makeEntryHandlers', () => {
   test('add returns early when no current user', async () => {
     const entries = makeStubSetter<EntryLike>([]);
     const handlers = makeEntryHandlers({
-      currentUser: null,
-      viewingUserId: '',
+      getCurrentUser: () => null,
+      getViewingUserId: () => '',
       setEntries: entries.setter,
     });
 
@@ -84,8 +84,8 @@ describe('makeEntryHandlers', () => {
     );
     const entries = makeStubSetter<EntryLike>([{ id: 'e1', createdAt: 500 }]);
     const handlers = makeEntryHandlers({
-      currentUser: { id: 'u-current', costPerHour: 50 } as never,
-      viewingUserId: 'u-viewing',
+      getCurrentUser: () => ({ id: 'u-current', costPerHour: 50 }) as never,
+      getViewingUserId: () => 'u-viewing',
       setEntries: entries.setter,
     });
 
@@ -104,8 +104,8 @@ describe('makeEntryHandlers', () => {
       Promise.resolve({ id: 'e-new', createdAt: 1, ...(data as object) }),
     );
     const handlers = makeEntryHandlers({
-      currentUser: { id: 'u-current', costPerHour: 0 } as never,
-      viewingUserId: '',
+      getCurrentUser: () => ({ id: 'u-current', costPerHour: 0 }) as never,
+      getViewingUserId: () => '',
       setEntries: makeStubSetter<EntryLike>([]).setter,
     });
 
@@ -119,8 +119,8 @@ describe('makeEntryHandlers', () => {
     apiMocks.entriesCreate.mockImplementation(() => Promise.reject(new Error('boom')));
     const entries = makeStubSetter<EntryLike>([{ id: 'e1', createdAt: 1 }]);
     const handlers = makeEntryHandlers({
-      currentUser: { id: 'u', costPerHour: 10 } as never,
-      viewingUserId: '',
+      getCurrentUser: () => ({ id: 'u', costPerHour: 10 }) as never,
+      getViewingUserId: () => '',
       setEntries: entries.setter,
     });
 
@@ -136,8 +136,8 @@ describe('makeEntryHandlers', () => {
   test('addBulk returns early when no current user', async () => {
     const entries = makeStubSetter<EntryLike>([]);
     const handlers = makeEntryHandlers({
-      currentUser: null,
-      viewingUserId: '',
+      getCurrentUser: () => null,
+      getViewingUserId: () => '',
       setEntries: entries.setter,
     });
 
@@ -157,8 +157,8 @@ describe('makeEntryHandlers', () => {
     });
     const entries = makeStubSetter<EntryLike>([{ id: 'e0', createdAt: 50 }]);
     const handlers = makeEntryHandlers({
-      currentUser: { id: 'u1', costPerHour: 25 } as never,
-      viewingUserId: 'u2',
+      getCurrentUser: () => ({ id: 'u1', costPerHour: 25 }) as never,
+      getViewingUserId: () => 'u2',
       setEntries: entries.setter,
     });
 
@@ -173,8 +173,8 @@ describe('makeEntryHandlers', () => {
     apiMocks.entriesCreate.mockImplementation(() => Promise.reject(new Error('boom')));
     const entries = makeStubSetter<EntryLike>([]);
     const handlers = makeEntryHandlers({
-      currentUser: { id: 'u', costPerHour: 0 } as never,
-      viewingUserId: '',
+      getCurrentUser: () => ({ id: 'u', costPerHour: 0 }) as never,
+      getViewingUserId: () => '',
       setEntries: entries.setter,
     });
 
@@ -194,8 +194,8 @@ describe('makeEntryHandlers', () => {
       { id: 'e2', createdAt: 2 },
     ]);
     const handlers = makeEntryHandlers({
-      currentUser: { id: 'u' } as never,
-      viewingUserId: '',
+      getCurrentUser: () => ({ id: 'u' }) as never,
+      getViewingUserId: () => '',
       setEntries: entries.setter,
     });
 
@@ -208,8 +208,8 @@ describe('makeEntryHandlers', () => {
     apiMocks.entriesDelete.mockImplementation(() => Promise.reject(new Error('nope')));
     const entries = makeStubSetter<EntryLike>([{ id: 'e1', createdAt: 1 }]);
     const handlers = makeEntryHandlers({
-      currentUser: { id: 'u' } as never,
-      viewingUserId: '',
+      getCurrentUser: () => ({ id: 'u' }) as never,
+      getViewingUserId: () => '',
       setEntries: entries.setter,
     });
 
@@ -231,8 +231,8 @@ describe('makeEntryHandlers', () => {
       { id: 'e2', createdAt: 2, task: 'B' },
     ]);
     const handlers = makeEntryHandlers({
-      currentUser: { id: 'u' } as never,
-      viewingUserId: '',
+      getCurrentUser: () => ({ id: 'u' }) as never,
+      getViewingUserId: () => '',
       setEntries: entries.setter,
     });
 
@@ -245,8 +245,8 @@ describe('makeEntryHandlers', () => {
     apiMocks.entriesUpdate.mockImplementation(() => Promise.reject(new Error('boom')));
     const entries = makeStubSetter<EntryLike>([{ id: 'e1', createdAt: 1, task: 'A' }]);
     const handlers = makeEntryHandlers({
-      currentUser: { id: 'u' } as never,
-      viewingUserId: '',
+      getCurrentUser: () => ({ id: 'u' }) as never,
+      getViewingUserId: () => '',
       setEntries: entries.setter,
     });
 
@@ -257,5 +257,52 @@ describe('makeEntryHandlers', () => {
     } finally {
       restore();
     }
+  });
+
+  test('add observes latest viewingUserId via getter (regression: stale closure)', async () => {
+    apiMocks.entriesCreate.mockImplementation((data: unknown) =>
+      Promise.resolve({ id: 'e-new', createdAt: 0, ...(data as object) }),
+    );
+    let viewingUserId = 'u-A';
+    let currentUser = { id: 'u-current', costPerHour: 10 } as { id: string; costPerHour: number };
+    const handlers = makeEntryHandlers({
+      getCurrentUser: () => currentUser as never,
+      getViewingUserId: () => viewingUserId,
+      setEntries: makeStubSetter<EntryLike>([]).setter,
+    });
+
+    // Initial state: manager is viewing user A.
+    await handlers.add({ task: 'first' } as never);
+    expect((apiMocks.entriesCreate.mock.calls[0][0] as Record<string, unknown>).userId).toBe('u-A');
+
+    // Manager switches to view user B; cost-per-hour can also change.
+    viewingUserId = 'u-B';
+    currentUser = { id: 'u-current', costPerHour: 99 };
+
+    await handlers.add({ task: 'second' } as never);
+    const secondCall = apiMocks.entriesCreate.mock.calls[1][0] as Record<string, unknown>;
+    expect(secondCall.userId).toBe('u-B');
+    expect(secondCall.hourlyCost).toBe(99);
+  });
+
+  test('addBulk observes latest viewingUserId via getter (regression: stale closure)', async () => {
+    let counter = 0;
+    apiMocks.entriesCreate.mockImplementation((data: unknown) => {
+      counter += 1;
+      return Promise.resolve({ id: `e-${counter}`, createdAt: counter, ...(data as object) });
+    });
+    let viewingUserId = 'u-A';
+    const handlers = makeEntryHandlers({
+      getCurrentUser: () => ({ id: 'mgr', costPerHour: 0 }) as never,
+      getViewingUserId: () => viewingUserId,
+      setEntries: makeStubSetter<EntryLike>([]).setter,
+    });
+
+    viewingUserId = 'u-B';
+    await handlers.addBulk([{ task: 'a' } as never, { task: 'b' } as never]);
+    const calls = apiMocks.entriesCreate.mock.calls.map(
+      (c) => (c[0] as Record<string, unknown>).userId,
+    );
+    expect(calls).toEqual(['u-B', 'u-B']);
   });
 });

--- a/test/handlers/projectHandlers.test.ts
+++ b/test/handlers/projectHandlers.test.ts
@@ -65,8 +65,8 @@ describe('makeProjectHandlers', () => {
     );
     const projects = makeStubSetter<ProjectLike>([]);
     const handlers = makeProjectHandlers({
-      projects: projects.get() as never,
-      clientsOrders: [{ id: 'order-1', clientId: 'client-A' } as never],
+      getProjects: () => projects.get() as never,
+      getClientsOrders: () => [{ id: 'order-1', clientId: 'client-A' } as never],
       setProjects: projects.setter,
       setProjectTasks: makeStubSetter<TaskLike>([]).setter,
       setEntries: makeStubSetter<EntryLike>([]).setter,
@@ -90,8 +90,8 @@ describe('makeProjectHandlers', () => {
     const projects = makeStubSetter<ProjectLike>([]);
     const tasks = makeStubSetter<TaskLike>([]);
     const handlers = makeProjectHandlers({
-      projects: projects.get() as never,
-      clientsOrders: [{ id: 'order-1', clientId: 'c1' } as never],
+      getProjects: () => projects.get() as never,
+      getClientsOrders: () => [{ id: 'order-1', clientId: 'c1' } as never],
       setProjects: projects.setter,
       setProjectTasks: tasks.setter,
       setEntries: makeStubSetter<EntryLike>([]).setter,
@@ -106,14 +106,16 @@ describe('makeProjectHandlers', () => {
     expect(tasks.get()).toHaveLength(2);
   });
 
-  test('add with unknown order silently fails', async () => {
+  test('add with unknown order silently fails and reports via onError', async () => {
     const projects = makeStubSetter<ProjectLike>([]);
+    const onError = mock(() => {});
     const handlers = makeProjectHandlers({
-      projects: projects.get() as never,
-      clientsOrders: [],
+      getProjects: () => projects.get() as never,
+      getClientsOrders: () => [],
       setProjects: projects.setter,
       setProjectTasks: makeStubSetter<TaskLike>([]).setter,
       setEntries: makeStubSetter<EntryLike>([]).setter,
+      onError,
     });
 
     const originalError = console.error;
@@ -122,6 +124,10 @@ describe('makeProjectHandlers', () => {
       await handlers.add('P', 'unknown-order');
       expect(apiMocks.projectsCreate).not.toHaveBeenCalled();
       expect(projects.get()).toEqual([]);
+      expect(onError).toHaveBeenCalledTimes(1);
+      const [err, context] = onError.mock.calls[0] as unknown as [Error, string];
+      expect(err.message).toBe('Order not found');
+      expect(context).toBe('add');
     } finally {
       console.error = originalError;
     }
@@ -133,8 +139,8 @@ describe('makeProjectHandlers', () => {
     );
     const tasks = makeStubSetter<TaskLike>([{ id: 't1', projectId: 'p1' }]);
     const handlers = makeProjectHandlers({
-      projects: [],
-      clientsOrders: [],
+      getProjects: () => [],
+      getClientsOrders: () => [],
       setProjects: makeStubSetter<ProjectLike>([]).setter,
       setProjectTasks: tasks.setter,
       setEntries: makeStubSetter<EntryLike>([]).setter,
@@ -153,8 +159,8 @@ describe('makeProjectHandlers', () => {
       { id: 'p2', clientId: 'c2', color: 'blue' },
     ]);
     const handlers = makeProjectHandlers({
-      projects: projects.get() as never,
-      clientsOrders: [],
+      getProjects: () => projects.get() as never,
+      getClientsOrders: () => [],
       setProjects: projects.setter,
       setProjectTasks: makeStubSetter<TaskLike>([]).setter,
       setEntries: makeStubSetter<EntryLike>([]).setter,
@@ -181,8 +187,8 @@ describe('makeProjectHandlers', () => {
     ]);
 
     const handlers = makeProjectHandlers({
-      projects: projects.get() as never,
-      clientsOrders: [],
+      getProjects: () => projects.get() as never,
+      getClientsOrders: () => [],
       setProjects: projects.setter,
       setProjectTasks: tasks.setter,
       setEntries: entries.setter,
@@ -193,5 +199,83 @@ describe('makeProjectHandlers', () => {
     expect(projects.get()).toEqual([{ id: 'p2', clientId: 'c1' }]);
     expect(tasks.get()).toEqual([{ id: 't2', projectId: 'p2' }]);
     expect(entries.get()).toEqual([{ id: 'e2', projectId: 'p2' }]);
+  });
+
+  test('regression: add observes latest clientsOrders via getter', async () => {
+    apiMocks.projectsCreate.mockImplementation((data: unknown) =>
+      Promise.resolve({ id: 'proj-new', ...(data as object) }),
+    );
+    // Initial state: no orders. Snapshot-based factory would only see empty list
+    // and always throw "Order not found".
+    const orders = makeStubSetter<{ id: string; clientId: string }>([]);
+    const projects = makeStubSetter<ProjectLike>([]);
+    const handlers = makeProjectHandlers({
+      getProjects: () => projects.get() as never,
+      getClientsOrders: () => orders.get() as never,
+      setProjects: projects.setter,
+      setProjectTasks: makeStubSetter<TaskLike>([]).setter,
+      setEntries: makeStubSetter<EntryLike>([]).setter,
+    });
+
+    // State updates after factory construction.
+    (orders.setter as (next: { id: string; clientId: string }[]) => void)([
+      { id: 'order-late', clientId: 'client-Z' },
+    ]);
+
+    await handlers.add('Project Beta', 'order-late');
+    expect(apiMocks.projectsCreate).toHaveBeenCalled();
+    const callArg = apiMocks.projectsCreate.mock.calls[0][0] as Record<string, unknown>;
+    expect(callArg.clientId).toBe('client-Z');
+  });
+
+  test('regression: add observes latest projects via getter (color picking)', async () => {
+    apiMocks.projectsCreate.mockImplementation((data: unknown) =>
+      Promise.resolve({ id: 'proj-new', ...(data as object) }),
+    );
+    const projects = makeStubSetter<ProjectLike>([]);
+    const handlers = makeProjectHandlers({
+      getProjects: () => projects.get() as never,
+      getClientsOrders: () => [{ id: 'order-1', clientId: 'c1' }] as never,
+      setProjects: projects.setter,
+      setProjectTasks: makeStubSetter<TaskLike>([]).setter,
+      setEntries: makeStubSetter<EntryLike>([]).setter,
+    });
+    // State updates: now projects exist with various colors.
+    (projects.setter as (next: ProjectLike[]) => void)([
+      { id: 'p1', clientId: 'c1', color: 'red' },
+      { id: 'p2', clientId: 'c1', color: 'blue' },
+    ]);
+
+    await handlers.add('Project', 'order-1');
+    expect(apiMocks.projectsCreate).toHaveBeenCalled();
+    const callArg = apiMocks.projectsCreate.mock.calls[0][0] as Record<string, unknown>;
+    expect(callArg.color).toBeDefined();
+  });
+
+  test('update invokes onError on api failure', async () => {
+    apiMocks.projectsUpdate.mockImplementation(() => Promise.reject(new Error('boom')));
+    const projects = makeStubSetter<ProjectLike>([{ id: 'p1', clientId: 'c1' }]);
+    const onError = mock(() => {});
+    const originalError = console.error;
+    const originalAlert = globalThis.alert;
+    console.error = mock(() => {}) as unknown as typeof console.error;
+    globalThis.alert = mock(() => {}) as unknown as typeof globalThis.alert;
+    try {
+      const handlers = makeProjectHandlers({
+        getProjects: () => projects.get() as never,
+        getClientsOrders: () => [],
+        setProjects: projects.setter,
+        setProjectTasks: makeStubSetter<TaskLike>([]).setter,
+        setEntries: makeStubSetter<EntryLike>([]).setter,
+        onError,
+      });
+      await handlers.update('p1', { color: 'green' });
+      expect(onError).toHaveBeenCalledTimes(1);
+      const [, context] = onError.mock.calls[0] as unknown as [Error, string];
+      expect(context).toBe('update');
+    } finally {
+      console.error = originalError;
+      globalThis.alert = originalAlert;
+    }
   });
 });

--- a/test/handlers/quoteHandlers.test.ts
+++ b/test/handlers/quoteHandlers.test.ts
@@ -105,9 +105,9 @@ const buildHandlers = (overrides: Record<string, unknown> = {}) => {
   const refreshSupplierQuoteFlow = mock(() => Promise.resolve()) as unknown as () => Promise<void>;
 
   const handlers = makeQuoteHandlers({
-    quotes: quotes.get() as never,
-    clientQuoteFilterId: clientQuoteFilterId.get(),
-    clientOfferFilterId: clientOfferFilterId.get(),
+    getQuotes: () => quotes.get() as never,
+    getClientQuoteFilterId: () => clientQuoteFilterId.get(),
+    getClientOfferFilterId: () => clientOfferFilterId.get(),
     setQuotes: quotes.setter as never,
     setClientOffers: clientOffers.setter as never,
     setClientsOrders: clientsOrders.setter as never,
@@ -480,6 +480,57 @@ describe('makeQuoteHandlers', () => {
     } finally {
       restore();
     }
+  });
+
+  test('regression: updateQuote observes latest quotes via getter', async () => {
+    apiMocks.quotesUpdate.mockImplementation((id: string, updates: unknown) =>
+      Promise.resolve({ id, ...(updates as object) }),
+    );
+    apiMocks.quotesList.mockImplementation(() => Promise.resolve([]));
+    apiMocks.clientOffersList.mockImplementation(() => Promise.resolve([]));
+    apiMocks.clientsOrdersList.mockImplementation(() => Promise.resolve([]));
+    // Build handlers with empty quotes list initially. After construction,
+    // the parent state populates and includes a non-draft quote.
+    const ctx = buildHandlers();
+    ctx.quotes.setter([
+      { id: 'q1', status: 'rejected', isExpired: true, expirationDate: '2020-01-01' },
+    ] as never);
+
+    // Old (snapshot) handler would not see q1 and would skip the expirationDate
+    // restoration. With getter, it must observe the mutated list.
+    await ctx.handlers.updateQuote('q1', { status: 'draft', isExpired: false } as never);
+    const callArgs = apiMocks.quotesUpdate.mock.calls[0] as [string, Record<string, unknown>];
+    expect(callArgs[1].expirationDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  test('regression: updateQuote observes latest clientQuoteFilterId via getter', async () => {
+    apiMocks.quotesUpdate.mockImplementation((id: string, updates: unknown) =>
+      Promise.resolve({ id, ...(updates as object) }),
+    );
+    apiMocks.quotesList.mockImplementation(() => Promise.resolve([]));
+    apiMocks.clientOffersList.mockImplementation(() => Promise.resolve([]));
+    apiMocks.clientsOrdersList.mockImplementation(() => Promise.resolve([]));
+    // Build with no filter, then set it after construction.
+    const ctx = buildHandlers({ quotes: [{ id: 'q1', status: 'draft' }] });
+    ctx.clientQuoteFilterId.setter('q1');
+
+    await ctx.handlers.updateQuote('q1', { status: 'sent' } as never);
+    // Should still propagate via the getter, not the captured snapshot.
+    expect(ctx.clientQuoteFilterId.get()).toBe('q1');
+  });
+
+  test('regression: updateClientOffer observes latest clientOfferFilterId via getter', async () => {
+    apiMocks.clientOffersUpdate.mockImplementation((id: string, updates: unknown) =>
+      Promise.resolve({ id, ...(updates as object) }),
+    );
+    apiMocks.quotesList.mockImplementation(() => Promise.resolve([]));
+    apiMocks.clientOffersList.mockImplementation(() => Promise.resolve([]));
+    apiMocks.clientsOrdersList.mockImplementation(() => Promise.resolve([]));
+    const ctx = buildHandlers();
+    ctx.clientOfferFilterId.setter('of-1');
+
+    await ctx.handlers.updateClientOffer('of-1', { status: 'sent' } as never);
+    expect(ctx.clientOfferFilterId.get()).toBe('of-1');
   });
 
   test('createClientsOrderFromOffer swallows refresh errors after success', async () => {

--- a/test/handlers/taskHandlers.test.ts
+++ b/test/handlers/taskHandlers.test.ts
@@ -74,7 +74,7 @@ describe('makeTaskHandlers.makeRecurring', () => {
     const entries = makeStubSetter<EntryLike>([]);
     const generateSpy = mock(() => Promise.resolve());
     const handlers = makeTaskHandlers({
-      projectTasks: tasks.get() as never,
+      getProjectTasks: () => tasks.get() as never,
       setProjectTasks: tasks.setter,
       setEntries: entries.setter,
       generateRecurringEntries: generateSpy,
@@ -90,6 +90,8 @@ describe('makeTaskHandlers.makeRecurring', () => {
     expect(updates.recurrenceStart).toBe('2026-05-01');
     expect(updates.recurrenceEnd).toBe('2026-12-01');
     expect(updates.recurrenceDuration).toBe(8);
+    // generateRecurringEntries is awaited directly (no setTimeout workaround).
+    expect(generateSpy).toHaveBeenCalledTimes(1);
   });
 
   test('editing already-recurring task: clears placeholder entries before update', async () => {
@@ -113,7 +115,7 @@ describe('makeTaskHandlers.makeRecurring', () => {
       { id: 'e5', projectId: 'p1', task: 'other-task', isPlaceholder: true }, // different task
     ]);
     const handlers = makeTaskHandlers({
-      projectTasks: tasks.get() as never,
+      getProjectTasks: () => tasks.get() as never,
       setProjectTasks: tasks.setter,
       setEntries: entries.setter,
       generateRecurringEntries: mock(() => Promise.resolve()),
@@ -145,7 +147,7 @@ describe('makeTaskHandlers.makeRecurring', () => {
       { id: 't1', name: 'task-A', projectId: 'p1', isRecurring: false },
     ]);
     const handlers = makeTaskHandlers({
-      projectTasks: tasks.get() as never,
+      getProjectTasks: () => tasks.get() as never,
       setProjectTasks: tasks.setter,
       setEntries: makeStubSetter<EntryLike>([]).setter,
       generateRecurringEntries: mock(() => Promise.resolve()),
@@ -158,5 +160,59 @@ describe('makeTaskHandlers.makeRecurring', () => {
     expect(updates.recurrenceEnd).toBeUndefined();
     // recurrenceStart defaults to today (YYYY-MM-DD shape) when omitted.
     expect(updates.recurrenceStart).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  test('regression: makeRecurring observes latest projectTasks via getter', async () => {
+    apiMocks.tasksUpdate.mockImplementation((id: string, updates: unknown) =>
+      Promise.resolve({ id, name: 'task-A', projectId: 'p1', ...(updates as object) }),
+    );
+    // Initial: no tasks present. Handler is created with empty list.
+    const tasks = makeStubSetter<TaskLike>([]);
+    const entries = makeStubSetter<EntryLike>([
+      { id: 'e1', projectId: 'p1', task: 'task-A', isPlaceholder: true },
+    ]);
+    const handlers = makeTaskHandlers({
+      getProjectTasks: () => tasks.get() as never,
+      setProjectTasks: tasks.setter,
+      setEntries: entries.setter,
+      generateRecurringEntries: mock(() => Promise.resolve()),
+    });
+
+    // Now state mutates: t1 exists and is already recurring.
+    (tasks.setter as (next: TaskLike[]) => void)([
+      { id: 't1', name: 'task-A', projectId: 'p1', isRecurring: true },
+    ]);
+
+    await handlers.makeRecurring('t1', 'monthly');
+    // Old (snapshot) handler would not see the task and would skip bulkDelete.
+    // With getter, it must observe the updated state and clear placeholders.
+    expect(apiMocks.entriesBulkDelete).toHaveBeenCalledTimes(1);
+  });
+
+  test('regression: recurringAction observes latest projectTasks via getter', async () => {
+    apiMocks.tasksUpdate.mockImplementation((id: string, updates: unknown) =>
+      Promise.resolve({ id, name: 'task-A', projectId: 'p1', ...(updates as object) }),
+    );
+    const tasks = makeStubSetter<TaskLike>([]);
+    const entries = makeStubSetter<EntryLike>([
+      { id: 'e1', projectId: 'p1', task: 'task-A', isPlaceholder: true },
+    ]);
+    const handlers = makeTaskHandlers({
+      getProjectTasks: () => tasks.get() as never,
+      setProjectTasks: tasks.setter,
+      setEntries: entries.setter,
+      generateRecurringEntries: mock(() => Promise.resolve()),
+    });
+
+    // State mutates after factory creation.
+    (tasks.setter as (next: TaskLike[]) => void)([
+      { id: 't1', name: 'task-A', projectId: 'p1', isRecurring: true },
+    ]);
+
+    await handlers.recurringAction('t1', 'stop');
+    expect(apiMocks.tasksUpdate).toHaveBeenCalledTimes(1);
+    // Should clear placeholders because it found the task via the getter.
+    expect(apiMocks.entriesBulkDelete).toHaveBeenCalledTimes(1);
+    expect(entries.get()).toEqual([]);
   });
 });


### PR DESCRIPTION
Supersedes #279 — rebased onto the merged base.

## Summary
Handler factories in `hooks/handlers/*` now take stable getter functions instead of snapshot arrays so they always observe the latest committed state.
- `useLatestRef` synced in `useLayoutEffect` (Codex P1 fix from #279) so `React.startTransition` interrupted renders don't leak uncommitted state to handlers.
- `makeRecurring` awaits `generateRecurringEntries()` directly (no more `setTimeout` workaround).
- `projectHandlers.add` surfaces "Order not found" via an optional `onError` callback.

Closes #279.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoRTwXFkuga3Cfymy6HcJ9)_