### PR TITLE
fix(auth,api): align user shape end-to-end and resilient init (rebased)

### DIFF
--- a/components/HR/ExternalEmployeesView.tsx
+++ b/components/HR/ExternalEmployeesView.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Field, FieldError, FieldLabel } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import type { UpdateUserInput } from '../../services/api/users';
 import type { Client, Project, ProjectTask, User } from '../../types';
 import { buildPermission, hasPermission, TOP_MANAGER_ROLE_ID } from '../../utils/permissions';
 import DeleteConfirmModal from '../shared/DeleteConfirmModal';
@@ -31,7 +32,7 @@ export interface ExternalEmployeesViewProps {
     name: string,
     costPerHour?: number,
   ) => Promise<{ success: boolean; error?: string }>;
-  onUpdateEmployee: (id: string, updates: Partial<User>) => void;
+  onUpdateEmployee: (id: string, updates: UpdateUserInput) => void;
   onDeleteEmployee: (id: string) => void;
   currency: string;
   permissions: string[];
@@ -142,7 +143,7 @@ const ExternalEmployeesView: React.FC<ExternalEmployeesViewProps> = ({
 
     try {
       if (editingEmployee) {
-        const updates: Partial<User> = {
+        const updates: UpdateUserInput = {
           name: formData.name.trim(),
         };
 

--- a/components/HR/InternalEmployeesView.tsx
+++ b/components/HR/InternalEmployeesView.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Field, FieldError, FieldLabel } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import type { UpdateUserInput } from '../../services/api/users';
 import type { Client, Project, ProjectTask, User } from '../../types';
 import { buildPermission, hasPermission, TOP_MANAGER_ROLE_ID } from '../../utils/permissions';
 import DeleteConfirmModal from '../shared/DeleteConfirmModal';
@@ -31,7 +32,7 @@ export interface InternalEmployeesViewProps {
     name: string,
     costPerHour?: number,
   ) => Promise<{ success: boolean; error?: string }>;
-  onUpdateEmployee: (id: string, updates: Partial<User>) => void;
+  onUpdateEmployee: (id: string, updates: UpdateUserInput) => void;
   onDeleteEmployee: (id: string) => void;
   currency: string;
   permissions: string[];
@@ -147,7 +148,7 @@ const InternalEmployeesView: React.FC<InternalEmployeesViewProps> = ({
 
     try {
       if (editingEmployee) {
-        const updates: Partial<User> = {
+        const updates: UpdateUserInput = {
           name: formData.name.trim(),
         };
 

--- a/components/administration/UserManagement.tsx
+++ b/components/administration/UserManagement.tsx
@@ -18,7 +18,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
-import { usersApi } from '../../services/api/users';
+import { type UpdateUserInput, usersApi } from '../../services/api/users';
 import type {
   Client,
   Project,
@@ -54,7 +54,7 @@ export interface UserManagementProps {
     email?: string,
   ) => Promise<{ success: boolean; error?: string }>;
   onDeleteUser: (id: string) => Promise<void>;
-  onUpdateUser: (id: string, updates: Partial<User>) => void;
+  onUpdateUser: (id: string, updates: UpdateUserInput) => void;
   onUpdateUserRoles: (id: string, roleIds: string[], primaryRoleId: string) => Promise<void>;
   onUpdateUserAuthMethod: (
     id: string,
@@ -558,7 +558,7 @@ const UserManagement: React.FC<UserManagementProps> = ({
         return;
       }
 
-      const updates: Partial<User> = {
+      const updates: UpdateUserInput = {
         name: buildFullName(editFirstName, editSurname),
         email: editEmail.trim(),
         isDisabled: editIsDisabled,

--- a/components/timesheet/WeeklyView.tsx
+++ b/components/timesheet/WeeklyView.tsx
@@ -2,6 +2,7 @@ import type React from 'react';
 import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import type { UpdateTimeEntryInput } from '../../services/api/entries';
 import type { Client, Project, ProjectTask, TimeEntry, TimeEntryLocation, User } from '../../types';
 import { isItalianHoliday } from '../../utils/holidays';
 import SelectControl from '../shared/SelectControl';
@@ -14,7 +15,7 @@ export interface WeeklyViewProps {
   projectTasks: ProjectTask[];
   onAddBulkEntries: (entries: Omit<TimeEntry, 'id' | 'createdAt' | 'userId'>[]) => Promise<void>;
   onDeleteEntry: (id: string) => void;
-  onUpdateEntry: (id: string, updates: Partial<TimeEntry>) => void;
+  onUpdateEntry: (id: string, updates: UpdateTimeEntryInput) => void;
   viewingUserId: string;
   availableUsers: User[];
   onViewUserChange: (id: string) => void;
@@ -375,16 +376,13 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
               location: row.location,
             });
           } else {
-            // Handle update if needed? User didn't explicitly ask for editing existing in weekly view,
-            // but it's part of a full mirror. Let's stick to the core request first.
+            // Server only persists the mutable subset (duration/notes/location/
+            // isPlaceholder). Project/client/task changes are silently dropped
+            // server-side, so we don't ship them here - we'd need a
+            // delete-and-recreate flow to support that.
             onUpdateEntry(data.id, {
               duration: data.duration,
               notes: data.note || row.weekNote,
-              task: row.taskName,
-              projectId: row.projectId,
-              clientId: row.clientId,
-              clientName: client?.name || 'Unknown',
-              projectName: project?.name || 'General',
               location: row.location,
             });
           }

--- a/hooks/handlers/entryHandlers.ts
+++ b/hooks/handlers/entryHandlers.ts
@@ -1,5 +1,6 @@
 import type React from 'react';
 import api from '../../services/api';
+import type { UpdateTimeEntryInput } from '../../services/api/entries';
 import type { TimeEntry, User } from '../../types';
 
 export type EntryHandlersDeps = {
@@ -58,7 +59,7 @@ export const makeEntryHandlers = (deps: EntryHandlersDeps) => {
     }
   };
 
-  const update = async (id: string, updates: Partial<TimeEntry>) => {
+  const update = async (id: string, updates: UpdateTimeEntryInput) => {
     try {
       const updated = await api.entries.update(id, updates);
       setEntries((prev) => prev.map((e) => (e.id === id ? updated : e)));

--- a/hooks/handlers/userHandlers.ts
+++ b/hooks/handlers/userHandlers.ts
@@ -1,5 +1,6 @@
 import type React from 'react';
 import api from '../../services/api';
+import type { UpdateUserInput } from '../../services/api/users';
 import type { Role, User, UserAuthMethod, WorkUnit } from '../../types';
 import { ADMIN_ROLE_ID, TOP_MANAGER_ROLE_ID } from '../../utils/permissions';
 
@@ -32,7 +33,7 @@ export const makeUserHandlers = (deps: UserHandlersDeps) => {
     }
   };
 
-  const updateUser = async (id: string, updates: Partial<User>) => {
+  const updateUser = async (id: string, updates: UpdateUserInput) => {
     try {
       const updated = await api.users.update(id, updates);
       setUsers((prev) => prev.map((u) => (u.id === id ? updated : u)));
@@ -118,7 +119,7 @@ export const makeUserHandlers = (deps: UserHandlersDeps) => {
   const addExternalEmployee = (name: string, costPerHour?: number) =>
     addEmployee(name, 'external', costPerHour);
 
-  const updateEmployee = async (id: string, updates: Partial<User>) => {
+  const updateEmployee = async (id: string, updates: UpdateUserInput) => {
     try {
       const updated = await api.employees.update(id, updates);
       setUsers((prev) => prev.map((u) => (u.id === id ? updated : u)));

--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import api, { getAuthToken, type Settings, setAuthToken } from '../services/api';
+import { type ApiError, isApiError } from '../services/api/client';
 import type { User } from '../types';
 import { applyLanguagePreference } from '../utils/language';
 
@@ -8,6 +9,38 @@ const DEFAULT_SETTINGS: Settings = {
   email: '',
   language: 'auto',
 };
+
+const CACHED_USER_STORAGE_KEY = 'praetor_cached_auth_user';
+
+const readCachedUser = (): User | null => {
+  try {
+    const raw = localStorage.getItem(CACHED_USER_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as User;
+    if (!parsed || typeof parsed !== 'object' || typeof parsed.id !== 'string') return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+};
+
+const writeCachedUser = (user: User | null) => {
+  try {
+    if (user) {
+      localStorage.setItem(CACHED_USER_STORAGE_KEY, JSON.stringify(user));
+    } else {
+      localStorage.removeItem(CACHED_USER_STORAGE_KEY);
+    }
+  } catch {
+    // Storage may be full or unavailable (private mode). Cache is best-effort.
+  }
+};
+
+// 401/403 = real auth failure (clear the token). Anything else (network blip,
+// 5xx, parse failures) is treated as transient so we don't log the user out on
+// a flaky connection.
+const isAuthFailure = (err: unknown): err is ApiError =>
+  isApiError(err) && (err.statusCode === 401 || err.statusCode === 403);
 
 export type UseAuthOptions = {
   onLogin?: (user: User) => void;
@@ -46,10 +79,21 @@ export function useAuth(opts: UseAuthOptions = {}) {
           const user = await api.auth.me();
           if (cancelled) return;
           setCurrentUser(user);
+          writeCachedUser(user);
           await loadUserSettings();
-        } catch {
+        } catch (err) {
           if (cancelled) return;
-          setAuthToken(null);
+          if (isAuthFailure(err)) {
+            // Server explicitly rejected the token - clear it and any cache.
+            setAuthToken(null);
+            writeCachedUser(null);
+          } else {
+            // Transient (network/5xx). Keep the token; restore the previously
+            // cached user so the UI stays usable until the next successful
+            // request rotates the token or surfaces a real auth failure.
+            const cached = readCachedUser();
+            if (cached) setCurrentUser(cached);
+          }
         }
       }
       if (!cancelled) setIsLoading(false);
@@ -68,6 +112,7 @@ export function useAuth(opts: UseAuthOptions = {}) {
       // a login or role-switch can briefly resurface the previous session's data.
       onLoginRef.current?.(user);
       setCurrentUser(user);
+      writeCachedUser(user);
       await loadUserSettings();
     },
     [loadUserSettings],
@@ -76,6 +121,7 @@ export function useAuth(opts: UseAuthOptions = {}) {
   const logout = useCallback((reason?: 'inactivity') => {
     setAuthToken(null);
     setCurrentUser(null);
+    writeCachedUser(null);
     const finalReason = reason ?? null;
     setLogoutReason(finalReason);
     onLogoutRef.current?.(finalReason);

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -18,6 +18,15 @@ const authUserSchema = {
     username: { type: 'string' },
     role: { type: 'string' },
     avatarInitials: { type: 'string' },
+    email: { type: 'string' },
+    costPerHour: { type: 'number' },
+    isDisabled: { type: 'boolean' },
+    employeeType: { type: 'string', enum: ['app_user', 'internal', 'external'] },
+    authMethod: { type: 'string', enum: ['local', 'ldap', 'oidc', 'saml'] },
+    authProviderId: { type: ['string', 'null'] },
+    authProviderName: { type: ['string', 'null'] },
+    hasTopManagerRole: { type: 'boolean' },
+    isAdminOnly: { type: 'boolean' },
     permissions: { type: 'array', items: { type: 'string' } },
     availableRoles: {
       type: 'array',
@@ -33,7 +42,19 @@ const authUserSchema = {
       },
     },
   },
-  required: ['id', 'name', 'username', 'role', 'avatarInitials', 'permissions', 'availableRoles'],
+  required: [
+    'id',
+    'name',
+    'username',
+    'role',
+    'avatarInitials',
+    'email',
+    'costPerHour',
+    'employeeType',
+    'authMethod',
+    'permissions',
+    'availableRoles',
+  ],
 } as const;
 
 const loginBodySchema = {
@@ -61,6 +82,40 @@ const loginResponseSchema = {
   },
   required: ['token', 'user'],
 } as const;
+
+type AvailableRole = { id: string; name: string; isSystem: boolean; isAdmin: boolean };
+type CanonicalAuthUser = usersRepo.UserListRow & {
+  permissions: string[];
+  availableRoles: AvailableRole[];
+};
+
+// When the user has no explicit role assignments yet, synthesize a single
+// "available role" from the effective role so the client always has at least
+// one entry to render (matches the historical /login fallback).
+const fallbackAvailableRoles = (effectiveRole: string): AvailableRole[] => [
+  { id: effectiveRole, name: effectiveRole, isSystem: false, isAdmin: effectiveRole === 'admin' },
+];
+
+const buildCanonicalAuthUser = async (
+  userId: string,
+  effectiveRole: string,
+  permissions: string[],
+): Promise<CanonicalAuthUser | null> => {
+  const [fullUser, availableRoles] = await Promise.all([
+    usersRepo.findById(userId),
+    rolesRepo.listAvailableRolesForUser(userId),
+  ]);
+
+  if (!fullUser) return null;
+
+  return {
+    ...fullUser,
+    role: effectiveRole,
+    permissions,
+    availableRoles:
+      availableRoles.length > 0 ? availableRoles : fallbackAvailableRoles(effectiveRole),
+  };
+};
 
 export default async function (fastify: FastifyInstance, _opts: unknown) {
   // POST /login
@@ -155,30 +210,15 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         },
         userId: user.id,
       });
-      const availableRoles = await rolesRepo.listAvailableRolesForUser(user.id);
-      const effectiveAvailableRoles =
-        availableRoles.length > 0
-          ? availableRoles
-          : [
-              {
-                id: user.role,
-                name: user.role,
-                isSystem: false,
-                isAdmin: user.role === 'admin',
-              },
-            ];
+
+      const canonicalUser = await buildCanonicalAuthUser(user.id, user.role, permissions);
+      if (!canonicalUser) {
+        return reply.code(500).send({ error: 'Authenticated user not found' });
+      }
 
       return {
         token,
-        user: {
-          id: user.id,
-          name: user.name,
-          username: user.username,
-          role: user.role,
-          avatarInitials: user.avatarInitials,
-          permissions,
-          availableRoles: effectiveAvailableRoles,
-        },
+        user: canonicalUser,
       };
     },
   );
@@ -197,30 +237,21 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         },
       },
     },
-    async (request: FastifyRequest, _reply: FastifyReply) => {
-      const availableRoles = request.user?.id
-        ? await rolesRepo.listAvailableRolesForUser(request.user.id)
-        : [];
-      const effectiveAvailableRoles =
-        availableRoles.length > 0
-          ? availableRoles
-          : [
-              {
-                id: request.user?.role as string,
-                name: request.user?.role as string,
-                isSystem: false,
-                isAdmin: request.user?.role === 'admin',
-              },
-            ];
-      return {
-        id: request.user?.id,
-        name: request.user?.name,
-        username: request.user?.username,
-        role: request.user?.role,
-        avatarInitials: request.user?.avatarInitials,
-        permissions: request.user?.permissions || [],
-        availableRoles: effectiveAvailableRoles,
-      };
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      const userId = request.user?.id;
+      const role = request.user?.role;
+      if (!userId || !role) {
+        return reply.code(401).send({ error: 'Authentication required' });
+      }
+      const canonicalUser = await buildCanonicalAuthUser(
+        userId,
+        role,
+        request.user?.permissions ?? [],
+      );
+      if (!canonicalUser) {
+        return reply.code(401).send({ error: 'User not found' });
+      }
+      return canonicalUser;
     },
   );
 
@@ -257,18 +288,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       }
 
       const permissions = await getRolePermissions(roleIdResult.value);
-      const availableRoles = await rolesRepo.listAvailableRolesForUser(userId);
-      const effectiveAvailableRoles =
-        availableRoles.length > 0
-          ? availableRoles
-          : [
-              {
-                id: roleIdResult.value,
-                name: roleIdResult.value,
-                isSystem: false,
-                isAdmin: roleIdResult.value === 'admin',
-              },
-            ];
       const token = generateToken(
         userId,
         request.auth?.sessionStart ?? Date.now(),
@@ -289,17 +308,14 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         },
       });
 
+      const canonicalUser = await buildCanonicalAuthUser(userId, roleIdResult.value, permissions);
+      if (!canonicalUser) {
+        return reply.code(401).send({ error: 'User not found' });
+      }
+
       return {
         token,
-        user: {
-          id: userId,
-          name: request.user?.name,
-          username: request.user?.username,
-          role: roleIdResult.value,
-          avatarInitials: request.user?.avatarInitials,
-          permissions,
-          availableRoles: effectiveAvailableRoles,
-        },
+        user: canonicalUser,
       };
     },
   );

--- a/server/test/routes/auth.test.ts
+++ b/server/test/routes/auth.test.ts
@@ -37,6 +37,7 @@ const markPersonalAccessTokenUsedMock = mock();
 
 // Auth route deps
 const findLoginUserByUsernameMock = mock();
+const findByIdMock = mock();
 const listAvailableRolesForUserMock = mock();
 const logAuditMock = mock(async () => undefined);
 
@@ -54,6 +55,7 @@ beforeAll(async () => {
     ...usersRepoSnap,
     findAuthUserById: findAuthUserByIdMock,
     findLoginUserByUsername: findLoginUserByUsernameMock,
+    findById: findByIdMock,
   }));
   mock.module('../../repositories/rolesRepo.ts', () => ({
     ...rolesRepoSnap,
@@ -120,6 +122,26 @@ const LOGIN_USER = {
   authProviderId: null,
 };
 
+// What usersRepo.findById returns: the full canonical user row exposed by the
+// auth endpoints. This must include the fields that drove issue 31 (email,
+// costPerHour, employeeType, authMethod).
+const HAPPY_FULL_USER = {
+  id: 'u1',
+  name: 'Alice',
+  username: 'alice',
+  email: 'alice@example.com',
+  role: 'manager',
+  avatarInitials: 'AL',
+  costPerHour: 42.5,
+  isDisabled: false,
+  employeeType: 'app_user' as const,
+  hasTopManagerRole: false,
+  isAdminOnly: false,
+  authMethod: 'local' as const,
+  authProviderId: null,
+  authProviderName: null,
+};
+
 const HAPPY_PERMISSIONS = ['timesheets.tracker.view', 'timesheets.tracker.create'];
 
 const HAPPY_ROLES = [
@@ -134,6 +156,7 @@ const allMocks = [
   findPersonalAccessTokenByHashMock,
   markPersonalAccessTokenUsedMock,
   findLoginUserByUsernameMock,
+  findByIdMock,
   listAvailableRolesForUserMock,
   logAuditMock,
   bcryptCompareMock,
@@ -149,6 +172,7 @@ beforeEach(async () => {
 
   // Defaults: happy auth path for /me and /switch-role
   findAuthUserByIdMock.mockResolvedValue(HAPPY_USER);
+  findByIdMock.mockResolvedValue(HAPPY_FULL_USER);
   userHasRoleMock.mockResolvedValue(true);
   getRolePermissionsMock.mockResolvedValue(HAPPY_PERMISSIONS);
   findPersonalAccessTokenByHashMock.mockResolvedValue({
@@ -206,6 +230,15 @@ describe('POST /api/auth/login', () => {
       username: 'alice',
       role: 'manager',
       avatarInitials: 'AL',
+      email: 'alice@example.com',
+      costPerHour: 42.5,
+      isDisabled: false,
+      employeeType: 'app_user',
+      authMethod: 'local',
+      authProviderId: null,
+      authProviderName: null,
+      hasTopManagerRole: false,
+      isAdminOnly: false,
       permissions: HAPPY_PERMISSIONS,
       availableRoles: HAPPY_ROLES,
     });
@@ -322,6 +355,8 @@ describe('POST /api/auth/login', () => {
     expect(body.user.availableRoles).toEqual([
       { id: 'manager', name: 'manager', isSystem: false, isAdmin: false },
     ]);
+    // Canonical fields still populated even when availableRoles falls back.
+    expect(body.user.email).toBe('alice@example.com');
   });
 
   test('401 user not found', async () => {
@@ -420,7 +455,7 @@ describe('POST /api/auth/login', () => {
 });
 
 describe('GET /api/auth/me', () => {
-  test('200 returns current user with availableRoles', async () => {
+  test('200 returns canonical current user with email, costPerHour, employeeType', async () => {
     const res = await testApp.inject({
       method: 'GET',
       url: '/api/auth/me',
@@ -435,9 +470,30 @@ describe('GET /api/auth/me', () => {
       username: 'alice',
       role: 'manager',
       avatarInitials: 'AL',
+      email: 'alice@example.com',
+      costPerHour: 42.5,
+      isDisabled: false,
+      employeeType: 'app_user',
+      authMethod: 'local',
+      authProviderId: null,
+      authProviderName: null,
+      hasTopManagerRole: false,
+      isAdminOnly: false,
       permissions: HAPPY_PERMISSIONS,
       availableRoles: HAPPY_ROLES,
     });
+  });
+
+  test('401 when the underlying user record is missing', async () => {
+    findByIdMock.mockResolvedValue(null);
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/auth/me',
+      headers: authHeader('u1'),
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(JSON.parse(res.body)).toEqual({ error: 'User not found' });
   });
 
   test('200 sets x-auth-token sliding-window header', async () => {
@@ -481,6 +537,11 @@ describe('POST /api/auth/switch-role', () => {
     const body = JSON.parse(res.body);
     expect(body.user.role).toBe('admin');
     expect(body.user.permissions).toEqual(['admin.everything']);
+    // Canonical fields are part of the response shape, not invented by the client.
+    expect(body.user.email).toBe('alice@example.com');
+    expect(body.user.costPerHour).toBe(42.5);
+    expect(body.user.employeeType).toBe('app_user');
+    expect(body.user.authMethod).toBe('local');
 
     // Header rotation
     const headerToken = res.headers['x-auth-token'];

--- a/services/api.ts
+++ b/services/api.ts
@@ -5,7 +5,7 @@
 
 export { aiApi } from './api/ai';
 export { authApi } from './api/auth';
-export { getApiBase, getAuthToken, setAuthToken } from './api/client';
+export { ApiError, getApiBase, getAuthToken, isApiError, setAuthToken } from './api/client';
 export { clientOffersApi } from './api/clientOffers';
 export { clientQuotesApi } from './api/clientQuotes';
 export { clientsApi } from './api/clients';

--- a/services/api/auth.ts
+++ b/services/api/auth.ts
@@ -13,8 +13,28 @@ const ensureToken = (token: unknown): string => {
   return normalizedToken;
 };
 
-const normalizeAuthUser = (user: User): User => {
-  const normalizedUser = normalizeUser(user);
+/**
+ * Validate the canonical /auth/me shape. The server contract is that the
+ * authenticated user's own record is always fully populated (email,
+ * costPerHour, employeeType, authMethod, available roles). If any of those are
+ * missing we treat the response as invalid rather than silently inventing
+ * defaults — that masks real server-side regressions.
+ */
+const normalizeAuthUser = (rawUser: User): User => {
+  // Pre-check raw payload BEFORE normalization so we don't lose information
+  // (e.g. `email` collapses from `''` to `undefined` in the normalizer).
+  if (
+    rawUser === null ||
+    typeof rawUser !== 'object' ||
+    typeof rawUser.email !== 'string' ||
+    typeof rawUser.costPerHour !== 'number' ||
+    typeof rawUser.employeeType !== 'string' ||
+    typeof rawUser.authMethod !== 'string'
+  ) {
+    throw new Error(INVALID_AUTH_RESPONSE_ERROR);
+  }
+
+  const normalizedUser = normalizeUser(rawUser);
   if (
     !normalizedUser.id ||
     !normalizedUser.name ||

--- a/services/api/client.ts
+++ b/services/api/client.ts
@@ -15,6 +15,24 @@ export const getAuthToken = () => authToken;
 
 export const getApiBase = () => API_BASE;
 
+/**
+ * Error thrown by `fetchApi` when an HTTP request reaches the server but the
+ * response status is not OK. `statusCode` mirrors `response.status`, letting
+ * callers distinguish real auth failures (401/403) from transient server
+ * problems (5xx). Network failures still surface as plain `TypeError`s.
+ */
+export class ApiError extends Error {
+  readonly statusCode: number;
+
+  constructor(message: string, statusCode: number) {
+    super(message);
+    this.name = 'ApiError';
+    this.statusCode = statusCode;
+  }
+}
+
+export const isApiError = (err: unknown): err is ApiError => err instanceof ApiError;
+
 export const fetchApi = async <T>(endpoint: string, options: RequestInit = {}): Promise<T> => {
   const headers: HeadersInit = {
     ...(options.body ? { 'Content-Type': 'application/json' } : {}),
@@ -34,7 +52,7 @@ export const fetchApi = async <T>(endpoint: string, options: RequestInit = {}): 
 
   if (!response.ok) {
     const error = await response.json().catch(() => ({ error: 'Request failed' }));
-    throw new Error(error.message || error.error || `HTTP ${response.status}`);
+    throw new ApiError(error.message || error.error || `HTTP ${response.status}`, response.status);
   }
 
   if (response.status === 204) {

--- a/services/api/employees.ts
+++ b/services/api/employees.ts
@@ -1,6 +1,7 @@
 import type { EmployeeType, User } from '../../types';
 import { fetchApi } from './client';
 import { normalizeUser } from './normalizers';
+import type { UpdateUserInput } from './users';
 
 export const employeesApi = {
   create: (data: {
@@ -13,11 +14,11 @@ export const employeesApi = {
       body: JSON.stringify(data),
     }).then(normalizeUser),
 
-  update: (id: string, updates: Partial<User>): Promise<User> =>
+  update: (id: string, updates: UpdateUserInput): Promise<User> =>
     fetchApi<User>(`/users/${id}`, {
       method: 'PUT',
       body: JSON.stringify(updates),
     }).then(normalizeUser),
 
-  delete: (id: string): Promise<void> => fetchApi(`/users/${id}`, { method: 'DELETE' }),
+  delete: (id: string): Promise<void> => fetchApi<void>(`/users/${id}`, { method: 'DELETE' }),
 };

--- a/services/api/entries.ts
+++ b/services/api/entries.ts
@@ -1,10 +1,22 @@
-import type { TimeEntry } from '../../types';
+import type { TimeEntry, TimeEntryLocation } from '../../types';
 import { fetchApi } from './client';
 import { normalizeTimeEntry } from './normalizers';
 
 export type EntriesPage = {
   entries: TimeEntry[];
   nextCursor: string | null;
+};
+
+/**
+ * Update payload accepted by `PUT /api/entries/:id`. Mirrors
+ * `entryUpdateBodySchema` in `server/routes/entries.ts` — any field outside
+ * this DTO is silently dropped server-side, so we keep the type narrow.
+ */
+export type UpdateTimeEntryInput = {
+  duration?: number;
+  notes?: string;
+  isPlaceholder?: boolean;
+  location?: TimeEntryLocation;
 };
 
 export const entriesApi = {
@@ -25,13 +37,13 @@ export const entriesApi = {
       body: JSON.stringify(entry),
     }).then(normalizeTimeEntry),
 
-  update: (id: string, updates: Partial<TimeEntry>): Promise<TimeEntry> =>
+  update: (id: string, updates: UpdateTimeEntryInput): Promise<TimeEntry> =>
     fetchApi<TimeEntry>(`/entries/${id}`, {
       method: 'PUT',
       body: JSON.stringify(updates),
     }).then(normalizeTimeEntry),
 
-  delete: (id: string): Promise<void> => fetchApi(`/entries/${id}`, { method: 'DELETE' }),
+  delete: (id: string): Promise<void> => fetchApi<void>(`/entries/${id}`, { method: 'DELETE' }),
 
   bulkDelete: (
     projectId: string,
@@ -41,6 +53,6 @@ export const entriesApi = {
     const params = new URLSearchParams({ projectId, task });
     if (options?.futureOnly) params.append('futureOnly', 'true');
     if (options?.placeholderOnly) params.append('placeholderOnly', 'true');
-    return fetchApi(`/entries?${params.toString()}`, { method: 'DELETE' });
+    return fetchApi<void>(`/entries?${params.toString()}`, { method: 'DELETE' });
   },
 };

--- a/services/api/normalizers.ts
+++ b/services/api/normalizers.ts
@@ -15,6 +15,7 @@ import type {
   Quote,
   QuoteItem,
   RoleSummary,
+  Supplier,
   SupplierInvoice,
   SupplierInvoiceItem,
   SupplierQuote,
@@ -171,6 +172,20 @@ export const normalizeProduct = (p: Product): Product => ({
   ...p,
   costo: Number(p.costo || 0),
   molPercentage: Number(p.molPercentage || 0),
+});
+
+export const normalizeSupplier = (s: Supplier): Supplier => ({
+  ...s,
+  isDisabled: !!s.isDisabled,
+  supplierCode: s.supplierCode ?? undefined,
+  contactName: s.contactName ?? undefined,
+  email: s.email ?? undefined,
+  phone: s.phone ?? undefined,
+  address: s.address ?? undefined,
+  vatNumber: s.vatNumber ?? undefined,
+  taxCode: s.taxCode ?? undefined,
+  paymentTerms: s.paymentTerms ?? undefined,
+  notes: s.notes ?? undefined,
 });
 
 export const normalizeProject = (p: Project): Project => ({

--- a/services/api/notifications.ts
+++ b/services/api/notifications.ts
@@ -3,13 +3,14 @@ import { fetchApi } from './client';
 
 export const notificationsApi = {
   list: (): Promise<{ notifications: Notification[]; unreadCount: number }> =>
-    fetchApi('/notifications'),
+    fetchApi<{ notifications: Notification[]; unreadCount: number }>('/notifications'),
 
   markAsRead: (id: string): Promise<{ success: boolean }> =>
-    fetchApi(`/notifications/${id}/read`, { method: 'PUT' }),
+    fetchApi<{ success: boolean }>(`/notifications/${id}/read`, { method: 'PUT' }),
 
   markAllAsRead: (): Promise<{ success: boolean }> =>
-    fetchApi('/notifications/read-all', { method: 'PUT' }),
+    fetchApi<{ success: boolean }>('/notifications/read-all', { method: 'PUT' }),
 
-  delete: (id: string): Promise<void> => fetchApi(`/notifications/${id}`, { method: 'DELETE' }),
+  delete: (id: string): Promise<void> =>
+    fetchApi<void>(`/notifications/${id}`, { method: 'DELETE' }),
 };

--- a/services/api/projects.ts
+++ b/services/api/projects.ts
@@ -26,13 +26,13 @@ export const projectsApi = {
       body: JSON.stringify(updates),
     }).then(normalizeProject),
 
-  delete: (id: string): Promise<void> => fetchApi(`/projects/${id}`, { method: 'DELETE' }),
+  delete: (id: string): Promise<void> => fetchApi<void>(`/projects/${id}`, { method: 'DELETE' }),
 
   getUsers: (id: string, signal?: AbortSignal): Promise<string[]> =>
-    fetchApi(`/projects/${id}/users`, { signal }),
+    fetchApi<string[]>(`/projects/${id}/users`, { signal }),
 
   updateUsers: (id: string, userIds: string[]): Promise<void> =>
-    fetchApi(`/projects/${id}/users`, {
+    fetchApi<void>(`/projects/${id}/users`, {
       method: 'POST',
       body: JSON.stringify({ userIds }),
     }),

--- a/services/api/suppliers.ts
+++ b/services/api/suppliers.ts
@@ -1,20 +1,22 @@
 import type { Supplier } from '../../types';
 import { fetchApi } from './client';
+import { normalizeSupplier } from './normalizers';
 
 export const suppliersApi = {
-  list: (): Promise<Supplier[]> => fetchApi('/suppliers'),
+  list: (): Promise<Supplier[]> =>
+    fetchApi<Supplier[]>('/suppliers').then((suppliers) => suppliers.map(normalizeSupplier)),
 
   create: (supplierData: Partial<Supplier>): Promise<Supplier> =>
-    fetchApi('/suppliers', {
+    fetchApi<Supplier>('/suppliers', {
       method: 'POST',
       body: JSON.stringify(supplierData),
-    }),
+    }).then(normalizeSupplier),
 
   update: (id: string, updates: Partial<Supplier>): Promise<Supplier> =>
-    fetchApi(`/suppliers/${id}`, {
+    fetchApi<Supplier>(`/suppliers/${id}`, {
       method: 'PUT',
       body: JSON.stringify(updates),
-    }),
+    }).then(normalizeSupplier),
 
   delete: (id: string): Promise<void> => fetchApi(`/suppliers/${id}`, { method: 'DELETE' }),
 };

--- a/services/api/tasks.ts
+++ b/services/api/tasks.ts
@@ -42,24 +42,27 @@ export const tasksApi = {
       body: JSON.stringify(updates),
     }).then(normalizeTask),
 
-  delete: (id: string): Promise<void> => fetchApi(`/tasks/${id}`, { method: 'DELETE' }),
+  delete: (id: string): Promise<void> => fetchApi<void>(`/tasks/${id}`, { method: 'DELETE' }),
 
   getHours: (projectId: string, signal?: AbortSignal): Promise<Record<string, number>> =>
-    fetchApi(`/tasks/hours?projectId=${encodeURIComponent(projectId)}`, { signal }),
+    fetchApi<Record<string, number>>(`/tasks/hours?projectId=${encodeURIComponent(projectId)}`, {
+      signal,
+    }),
 
   getHoursForProjects: (
     projectIds: string[],
     signal?: AbortSignal,
   ): Promise<Record<string, Record<string, number>>> =>
-    fetchApi(`/tasks/hours/batch?projectIds=${projectIds.map(encodeURIComponent).join(',')}`, {
-      signal,
-    }),
+    fetchApi<Record<string, Record<string, number>>>(
+      `/tasks/hours/batch?projectIds=${projectIds.map(encodeURIComponent).join(',')}`,
+      { signal },
+    ),
 
   getUsers: (id: string, signal?: AbortSignal): Promise<string[]> =>
-    fetchApi(`/tasks/${id}/users`, { signal }),
+    fetchApi<string[]>(`/tasks/${id}/users`, { signal }),
 
   updateUsers: (id: string, userIds: string[]): Promise<void> =>
-    fetchApi(`/tasks/${id}/users`, {
+    fetchApi<void>(`/tasks/${id}/users`, {
       method: 'POST',
       body: JSON.stringify({ userIds }),
     }),

--- a/services/api/users.ts
+++ b/services/api/users.ts
@@ -3,6 +3,21 @@ import type { TrackerCatalogs } from '../../utils/trackerCatalogs';
 import { fetchApi } from './client';
 import { normalizeClient, normalizeProject, normalizeTask, normalizeUser } from './normalizers';
 
+/**
+ * Update payload accepted by `PUT /api/users/:id`. Mirrors
+ * `userUpdateBodySchema` in `server/routes/users.ts` — fields outside this DTO
+ * are silently dropped server-side, so we keep the type narrow so callers
+ * can't pretend to mutate (e.g.) `permissions` or `availableRoles` via this
+ * endpoint.
+ */
+export type UpdateUserInput = {
+  name?: string;
+  isDisabled?: boolean;
+  costPerHour?: number;
+  role?: string;
+  email?: string;
+};
+
 export const usersApi = {
   list: (): Promise<User[]> => fetchApi<User[]>('/users').then((users) => users.map(normalizeUser)),
 
@@ -19,12 +34,14 @@ export const usersApi = {
       body: JSON.stringify({ name, username, password, role, email, costPerHour }),
     }).then(normalizeUser),
 
-  delete: (id: string): Promise<void> => fetchApi(`/users/${id}`, { method: 'DELETE' }),
+  delete: (id: string): Promise<void> => fetchApi<void>(`/users/${id}`, { method: 'DELETE' }),
 
   getAssignments: (
     id: string,
   ): Promise<{ clientIds: string[]; projectIds: string[]; taskIds: string[] }> =>
-    fetchApi(`/users/${id}/assignments`),
+    fetchApi<{ clientIds: string[]; projectIds: string[]; taskIds: string[] }>(
+      `/users/${id}/assignments`,
+    ),
 
   getTrackerCatalogs: (id: string): Promise<TrackerCatalogs> =>
     fetchApi<{
@@ -43,26 +60,26 @@ export const usersApi = {
     projectIds: string[],
     taskIds?: string[],
   ): Promise<void> =>
-    fetchApi(`/users/${id}/assignments`, {
+    fetchApi<void>(`/users/${id}/assignments`, {
       method: 'POST',
       body: JSON.stringify({ clientIds, projectIds, taskIds }),
     }),
 
-  update: (id: string, updates: Partial<User>): Promise<User> =>
+  update: (id: string, updates: UpdateUserInput): Promise<User> =>
     fetchApi<User>(`/users/${id}`, {
       method: 'PUT',
       body: JSON.stringify(updates),
     }).then(normalizeUser),
 
   getRoles: (id: string): Promise<{ roleIds: string[]; primaryRoleId: string }> =>
-    fetchApi(`/users/${id}/roles`),
+    fetchApi<{ roleIds: string[]; primaryRoleId: string }>(`/users/${id}/roles`),
 
   updateRoles: (
     id: string,
     roleIds: string[],
     primaryRoleId: string,
   ): Promise<{ roleIds: string[]; primaryRoleId: string }> =>
-    fetchApi(`/users/${id}/roles`, {
+    fetchApi<{ roleIds: string[]; primaryRoleId: string }>(`/users/${id}/roles`, {
       method: 'PUT',
       body: JSON.stringify({ roleIds, primaryRoleId }),
     }),

--- a/test/hooks/useAuth.test.ts
+++ b/test/hooks/useAuth.test.ts
@@ -21,6 +21,15 @@ const i18nMock = {
   changeLanguage: mock((_lang: string) => {}),
 };
 
+class TestApiError extends Error {
+  readonly statusCode: number;
+  constructor(message: string, statusCode: number) {
+    super(message);
+    this.name = 'ApiError';
+    this.statusCode = statusCode;
+  }
+}
+
 mock.module('../../services/api', () => ({
   default: {
     auth: {
@@ -33,6 +42,11 @@ mock.module('../../services/api', () => ({
   },
   getAuthToken: () => getAuthTokenMock(),
   setAuthToken: (token: string | null) => setAuthTokenMock(token),
+}));
+
+mock.module('../../services/api/client', () => ({
+  ApiError: TestApiError,
+  isApiError: (err: unknown): err is TestApiError => err instanceof TestApiError,
 }));
 
 mock.module('../../i18n', () => ({
@@ -97,15 +111,78 @@ describe('useAuth', () => {
     expect(localStorage.getItem('i18nextLng')).toBe('it');
   });
 
-  test('initial mount: api.auth.me rejection clears token', async () => {
+  test('initial mount: api.auth.me 401 clears token (real auth failure)', async () => {
     tokenStore.token = 'bad-token';
-    apiMocks.authMe.mockImplementation(() => Promise.reject(new Error('bad token')));
+    apiMocks.authMe.mockImplementation(() => Promise.reject(new TestApiError('Unauthorized', 401)));
 
     const { result } = renderHook(() => useAuth());
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     expect(result.current.currentUser).toBeNull();
     expect(setAuthTokenMock).toHaveBeenCalledWith(null);
+  });
+
+  test('initial mount: api.auth.me 403 clears token (real auth failure)', async () => {
+    tokenStore.token = 'forbidden-token';
+    apiMocks.authMe.mockImplementation(() => Promise.reject(new TestApiError('Forbidden', 403)));
+
+    const { result } = renderHook(() => useAuth());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.currentUser).toBeNull();
+    expect(setAuthTokenMock).toHaveBeenCalledWith(null);
+  });
+
+  test('initial mount: transient 500 keeps token and restores cached user', async () => {
+    tokenStore.token = 'good-token';
+    const cached = { id: 'cached-u', name: 'Cached User' };
+    localStorage.setItem('praetor_cached_auth_user', JSON.stringify(cached));
+    apiMocks.authMe.mockImplementation(() => Promise.reject(new TestApiError('boom', 500)));
+
+    const { result } = renderHook(() => useAuth());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    // Token must NOT be cleared on a transient error.
+    expect(setAuthTokenMock).not.toHaveBeenCalledWith(null);
+    // Cached user is restored so the UI stays usable until the next refresh.
+    expect(result.current.currentUser?.id).toBe('cached-u');
+    expect(result.current.isAuthenticated).toBe(true);
+  });
+
+  test('initial mount: network error (no status) keeps token and restores cache', async () => {
+    tokenStore.token = 'good-token';
+    const cached = { id: 'cached-u', name: 'Cached User' };
+    localStorage.setItem('praetor_cached_auth_user', JSON.stringify(cached));
+    apiMocks.authMe.mockImplementation(() => Promise.reject(new TypeError('Failed to fetch')));
+
+    const { result } = renderHook(() => useAuth());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(setAuthTokenMock).not.toHaveBeenCalledWith(null);
+    expect(result.current.currentUser?.id).toBe('cached-u');
+  });
+
+  test('initial mount: transient error with no cached user leaves user null but token intact', async () => {
+    tokenStore.token = 'good-token';
+    apiMocks.authMe.mockImplementation(() => Promise.reject(new TestApiError('boom', 500)));
+
+    const { result } = renderHook(() => useAuth());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(setAuthTokenMock).not.toHaveBeenCalledWith(null);
+    expect(result.current.currentUser).toBeNull();
+  });
+
+  test('successful /auth/me caches the user for transient-recovery', async () => {
+    tokenStore.token = 'tok';
+    const user = { id: 'u-fresh', name: 'Fresh' };
+    apiMocks.authMe.mockImplementation(() => Promise.resolve(user));
+
+    const { result } = renderHook(() => useAuth());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(localStorage.getItem('praetor_cached_auth_user')).toBe(JSON.stringify(user));
+    expect(result.current.currentUser).toEqual(user as never);
   });
 
   test('language=auto removes localStorage entry and detects browser language', async () => {
@@ -183,6 +260,7 @@ describe('useAuth', () => {
     expect(result.current.currentUser).toBeNull();
     expect(result.current.logoutReason).toBe('inactivity');
     expect(onLogout).toHaveBeenCalledWith('inactivity');
+    expect(localStorage.getItem('praetor_cached_auth_user')).toBeNull();
   });
 
   test('logout without reason sets logoutReason to null', async () => {

--- a/test/services/auth.test.ts
+++ b/test/services/auth.test.ts
@@ -15,15 +15,23 @@ const { authApi } = await import('../../services/api/auth');
 const { getAuthToken, setAuthToken } = await import('../../services/api/client');
 
 // Canonical user shape that passes every guard inside `normalizeAuthUser`.
+// Mirrors the full server contract: email, costPerHour, employeeType, and
+// authMethod must all be present - the normalizer rejects partial payloads.
 const canonicalUser = {
   id: 'u-1',
   name: 'Canonical User',
   username: 'canonical',
   role: 'admin',
   avatarInitials: 'CU',
+  email: 'canonical@example.com',
+  costPerHour: 42.5,
+  employeeType: 'app_user' as const,
+  authMethod: 'local' as const,
+  authProviderId: null,
+  authProviderName: null,
+  isDisabled: false,
   availableRoles: [{ id: 'admin', name: 'Admin', isAdmin: true, permissions: [] }],
   permissions: ['*'],
-  costPerHour: 0,
   hasTopManagerRole: false,
   isAdminOnly: false,
 };
@@ -134,8 +142,34 @@ describe('authApi', () => {
       expect(String(fetchMock.mock.calls[0][0])).toContain('/auth/me');
     });
 
+    test('propagates canonical user fields (email, costPerHour, employeeType)', async () => {
+      programRoutes({
+        '/auth/me': {
+          ...canonicalUser,
+          email: 'real@user.com',
+          costPerHour: 99.5,
+          employeeType: 'internal',
+        },
+      });
+
+      const user = await authApi.me();
+      expect(user.email).toBe('real@user.com');
+      expect(user.costPerHour).toBe(99.5);
+      expect(user.employeeType).toBe('internal');
+    });
+
     test('throws when /auth/me responds with an empty available roles list', async () => {
       programRoutes({ '/auth/me': { ...canonicalUser, availableRoles: [] } });
+      await expect(authApi.me()).rejects.toThrow('Invalid authentication response');
+    });
+
+    test.each([
+      ['email', { email: undefined }],
+      ['costPerHour', { costPerHour: undefined }],
+      ['employeeType', { employeeType: undefined }],
+      ['authMethod', { authMethod: undefined }],
+    ])('throws when /auth/me is missing %s instead of inventing a default', async (_field, patch) => {
+      programRoutes({ '/auth/me': { ...canonicalUser, ...patch } });
       await expect(authApi.me()).rejects.toThrow('Invalid authentication response');
     });
   });

--- a/test/services/client.test.ts
+++ b/test/services/client.test.ts
@@ -7,7 +7,7 @@ const fetchMock = mock(
 );
 globalThis.fetch = fetchMock as unknown as typeof fetch;
 
-const { fetchApi, fetchApiStream, getAuthToken, setAuthToken } = await import(
+const { ApiError, fetchApi, fetchApiStream, getAuthToken, isApiError, setAuthToken } = await import(
   '../../services/api/client'
 );
 
@@ -115,11 +115,24 @@ describe('services/api/client', () => {
       await fetchApi('/get');
     });
 
-    test('error response with body.message throws Error with that message', async () => {
+    test('error response with body.message throws ApiError with that message + status', async () => {
       fetchMock.mockImplementationOnce(async () =>
         buildResponse({ status: 400, json: () => ({ message: 'Bad input' }) }),
       );
-      await expect(fetchApi('/bad')).rejects.toThrow('Bad input');
+      const error = await fetchApi('/bad').catch((err: unknown) => err);
+      expect(error).toBeInstanceOf(ApiError);
+      expect(isApiError(error)).toBe(true);
+      expect((error as InstanceType<typeof ApiError>).message).toBe('Bad input');
+      expect((error as InstanceType<typeof ApiError>).statusCode).toBe(400);
+    });
+
+    test('isApiError returns false for network errors (TypeError)', async () => {
+      fetchMock.mockImplementationOnce(async () => {
+        throw new TypeError('Failed to fetch');
+      });
+      const error = await fetchApi('/down').catch((err: unknown) => err);
+      expect(isApiError(error)).toBe(false);
+      expect(error).toBeInstanceOf(TypeError);
     });
 
     test('error response with body.error throws Error with that message', async () => {

--- a/test/services/entries.test.ts
+++ b/test/services/entries.test.ts
@@ -1,0 +1,65 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { UpdateTimeEntryInput } from '../../services/api/entries';
+import { buildResponse } from '../helpers/fetchMock';
+
+const originalFetch = globalThis.fetch;
+const fetchMock = mock(
+  async (_input: unknown, _init?: unknown): Promise<unknown> => buildResponse({ status: 200 }),
+);
+globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+const { entriesApi } = await import('../../services/api/entries');
+
+const baseEntry = {
+  id: 'e-1',
+  userId: 'u-1',
+  date: '2026-01-01',
+  clientId: 'c-1',
+  clientName: 'Acme',
+  projectId: 'p-1',
+  projectName: 'Project',
+  task: 'Task',
+  duration: 1,
+  hourlyCost: 50,
+  createdAt: 0,
+};
+
+beforeEach(() => {
+  fetchMock.mockReset();
+});
+
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('entriesApi.update', () => {
+  test('PUTs to /entries/:id with the DTO body and normalizes the response', async () => {
+    fetchMock.mockImplementationOnce(async () =>
+      buildResponse({ status: 200, json: () => ({ ...baseEntry, duration: '2.5' }) }),
+    );
+
+    const updates: UpdateTimeEntryInput = { duration: 2.5, notes: 'note', location: 'office' };
+    const result = await entriesApi.update('e-1', updates);
+
+    const call = fetchMock.mock.calls[0];
+    expect(String(call[0])).toContain('/entries/e-1');
+    expect((call[1] as { method: string }).method).toBe('PUT');
+    expect((call[1] as { body: string }).body).toBe(JSON.stringify(updates));
+
+    // Normalizer coerced the string duration back to a number.
+    expect(result.duration).toBe(2.5);
+  });
+
+  test('UpdateTimeEntryInput type rejects unknown fields at compile time', () => {
+    // The TS compiler must reject unknown keys like `clientId` or `task`.
+    // ts-expect-error proves the type contract holds; if the contract is
+    // accidentally widened, the test file fails to compile.
+    // @ts-expect-error - task is silently dropped server-side and excluded from the DTO
+    const _bad: UpdateTimeEntryInput = { task: 'new task' };
+    // @ts-expect-error - clientId is silently dropped server-side
+    const _bad2: UpdateTimeEntryInput = { clientId: 'other' };
+    void _bad;
+    void _bad2;
+    expect(true).toBe(true);
+  });
+});

--- a/test/services/normalizers.test.ts
+++ b/test/services/normalizers.test.ts
@@ -12,6 +12,7 @@ import {
   normalizeProject,
   normalizeQuote,
   normalizeQuoteItem,
+  normalizeSupplier,
   normalizeSupplierInvoice,
   normalizeSupplierInvoiceItem,
   normalizeSupplierQuote,
@@ -36,6 +37,7 @@ import type {
   ProjectTask,
   Quote,
   QuoteItem,
+  Supplier,
   SupplierInvoice,
   SupplierInvoiceItem,
   SupplierQuote,
@@ -447,6 +449,56 @@ describe('normalizeUser', () => {
   test('accepts "external" employeeType', () => {
     const input = make<User>(baseUser, { employeeType: 'external' });
     expect(normalizeUser(input).employeeType).toBe('external');
+  });
+});
+
+describe('normalizeSupplier', () => {
+  const baseSupplier: Supplier = { id: 's-1', name: 'SupplierCo' };
+
+  test('coerces null optional fields to undefined and isDisabled to boolean', () => {
+    const input = make<Supplier>(baseSupplier, {
+      isDisabled: 0,
+      supplierCode: null,
+      contactName: null,
+      email: null,
+      phone: null,
+      address: null,
+      vatNumber: null,
+      taxCode: null,
+      paymentTerms: null,
+      notes: null,
+    });
+    const result = normalizeSupplier(input);
+    expect(result.isDisabled).toBe(false);
+    expect(result.supplierCode).toBeUndefined();
+    expect(result.contactName).toBeUndefined();
+    expect(result.email).toBeUndefined();
+    expect(result.phone).toBeUndefined();
+    expect(result.address).toBeUndefined();
+    expect(result.vatNumber).toBeUndefined();
+    expect(result.taxCode).toBeUndefined();
+    expect(result.paymentTerms).toBeUndefined();
+    expect(result.notes).toBeUndefined();
+  });
+
+  test('preserves populated fields', () => {
+    const input: Supplier = {
+      id: 's-1',
+      name: 'SupplierCo',
+      isDisabled: true,
+      supplierCode: 'S001',
+      contactName: 'Jane',
+      email: 'jane@s.com',
+      phone: '555',
+      address: 'addr',
+      vatNumber: 'V1',
+      taxCode: 'T1',
+      paymentTerms: '30gg',
+      notes: 'note',
+      createdAt: 1234,
+    };
+    const result = normalizeSupplier(input);
+    expect(result).toEqual(input);
   });
 });
 

--- a/test/services/suppliers.test.ts
+++ b/test/services/suppliers.test.ts
@@ -1,0 +1,81 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { buildResponse } from '../helpers/fetchMock';
+
+const originalFetch = globalThis.fetch;
+const fetchMock = mock(
+  async (_input: unknown, _init?: unknown): Promise<unknown> => buildResponse({ status: 200 }),
+);
+globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+const { suppliersApi } = await import('../../services/api/suppliers');
+
+beforeEach(() => {
+  fetchMock.mockReset();
+});
+
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('suppliersApi normalization', () => {
+  test('list() normalizes each supplier (nulls → undefined, isDisabled → boolean)', async () => {
+    fetchMock.mockImplementationOnce(async () =>
+      buildResponse({
+        status: 200,
+        json: () => [
+          {
+            id: 's-1',
+            name: 'SupplierA',
+            isDisabled: null,
+            supplierCode: null,
+            email: null,
+            phone: null,
+          },
+          { id: 's-2', name: 'SupplierB', isDisabled: true, email: 'b@x.com' },
+        ],
+      }),
+    );
+
+    const suppliers = await suppliersApi.list();
+    expect(suppliers).toHaveLength(2);
+    expect(suppliers[0]).toMatchObject({
+      id: 's-1',
+      name: 'SupplierA',
+      isDisabled: false,
+      supplierCode: undefined,
+      email: undefined,
+      phone: undefined,
+    });
+    expect(suppliers[1]).toMatchObject({
+      id: 's-2',
+      isDisabled: true,
+      email: 'b@x.com',
+    });
+  });
+
+  test('create() returns a normalized supplier', async () => {
+    fetchMock.mockImplementationOnce(async () =>
+      buildResponse({
+        status: 200,
+        json: () => ({ id: 's-3', name: 'New', isDisabled: 0, email: null }),
+      }),
+    );
+
+    const created = await suppliersApi.create({ name: 'New' });
+    expect(created.isDisabled).toBe(false);
+    expect(created.email).toBeUndefined();
+  });
+
+  test('update() returns a normalized supplier', async () => {
+    fetchMock.mockImplementationOnce(async () =>
+      buildResponse({
+        status: 200,
+        json: () => ({ id: 's-1', name: 'Updated', isDisabled: 1, contactName: null }),
+      }),
+    );
+
+    const updated = await suppliersApi.update('s-1', { name: 'Updated' });
+    expect(updated.isDisabled).toBe(true);
+    expect(updated.contactName).toBeUndefined();
+  });
+});

--- a/test/services/users.test.ts
+++ b/test/services/users.test.ts
@@ -1,0 +1,64 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { UpdateUserInput } from '../../services/api/users';
+import { buildResponse } from '../helpers/fetchMock';
+
+const originalFetch = globalThis.fetch;
+const fetchMock = mock(
+  async (_input: unknown, _init?: unknown): Promise<unknown> => buildResponse({ status: 200 }),
+);
+globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+const { usersApi } = await import('../../services/api/users');
+
+const baseUser = {
+  id: 'u-1',
+  name: 'Alice',
+  role: 'admin',
+  avatarInitials: 'AL',
+  username: 'alice',
+  email: 'alice@x.com',
+  costPerHour: 50,
+  employeeType: 'app_user' as const,
+};
+
+beforeEach(() => {
+  fetchMock.mockReset();
+});
+
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('usersApi.update', () => {
+  test('PUTs to /users/:id with the DTO body and normalizes the response', async () => {
+    fetchMock.mockImplementationOnce(async () =>
+      buildResponse({ status: 200, json: () => ({ ...baseUser, costPerHour: '75' }) }),
+    );
+
+    const updates: UpdateUserInput = { name: 'Alice B.', costPerHour: 75, email: 'a@x.com' };
+    const result = await usersApi.update('u-1', updates);
+
+    const call = fetchMock.mock.calls[0];
+    expect(String(call[0])).toContain('/users/u-1');
+    expect((call[1] as { method: string }).method).toBe('PUT');
+    expect((call[1] as { body: string }).body).toBe(JSON.stringify(updates));
+
+    expect(result.costPerHour).toBe(75);
+  });
+
+  test('UpdateUserInput type rejects fields the server silently drops', () => {
+    // @ts-expect-error - permissions cannot be set via PUT /users/:id
+    const _bad: UpdateUserInput = { permissions: ['*'] };
+    // @ts-expect-error - availableRoles cannot be set via PUT /users/:id
+    const _bad2: UpdateUserInput = { availableRoles: [] };
+    // @ts-expect-error - hasTopManagerRole is server-derived
+    const _bad3: UpdateUserInput = { hasTopManagerRole: true };
+    // @ts-expect-error - id is the path param, not a body field
+    const _bad4: UpdateUserInput = { id: 'other' };
+    void _bad;
+    void _bad2;
+    void _bad3;
+    void _bad4;
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
Supersedes #281 — rebased onto the merged base.

## Summary
- `/auth/login`, `/auth/me`, `/auth/switch-role` return the full canonical user record (`email`, `costPerHour`, `employeeType`, etc.); normalizer rejects partials rather than fabricating defaults.
- `useAuth` distinguishes 401/403 from network/5xx — transient errors retain the token and restore the cached user.
- Typed `UpdateTimeEntryInput`/`UpdateUserInput` DTOs replace `Partial<TimeEntry>`/`Partial<User>` on update endpoints.
- `normalizeSupplier` added; explicit `fetchApi<T>` generics across service files.

Closes #281.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JoRTwXFkuga3Cfymy6HcJ9)_