### PR TITLE
fix(settings): stop overwriting unsaved profile edits on parent re-renders

### DIFF
--- a/components/UserSettings.tsx
+++ b/components/UserSettings.tsx
@@ -149,6 +149,11 @@ const UserSettings: React.FC<UserSettingsProps> = ({
   const { t } = useTranslation(['settings', 'common']);
   const translateRef = useRef(t);
 
+  // Initialize the editable fields from `settings` once at mount. We deliberately
+  // do not re-sync on later `settings` prop changes: the parent re-creates the
+  // settings object on unrelated re-renders, and re-syncing would clobber the
+  // user's in-progress edits. When the form should be reset (e.g. after a logout
+  // or user switch), the parent unmounts/remounts this component.
   const [fullName, setFullName] = useState(settings.fullName);
   const [email, setEmail] = useState(settings.email);
   const [language, setLanguage] = useState(settings.language || 'auto');
@@ -198,12 +203,6 @@ const UserSettings: React.FC<UserSettingsProps> = ({
   const [tokenCopied, setTokenCopied] = useState(false);
   const tokenLoadInFlightRef = useRef(false);
   const isMountedRef = useRef(true);
-
-  useEffect(() => {
-    setFullName(settings.fullName);
-    setEmail(settings.email);
-    setLanguage(settings.language || 'auto');
-  }, [settings]);
 
   useEffect(
     () => () => {

--- a/test/components/UserSettings.test.tsx
+++ b/test/components/UserSettings.test.tsx
@@ -76,6 +76,46 @@ const renderSettings = (
     />,
   );
 
+describe('<UserSettings /> profile form', () => {
+  test('preserves in-progress edits when the parent re-renders with a new settings reference', () => {
+    const { rerender } = render(
+      <UserSettings
+        settings={settings}
+        onUpdate={onUpdate}
+        onUpdatePassword={onUpdatePassword}
+        onListMcpTokens={onListMcpTokens}
+        onCreateMcpToken={onCreateMcpToken}
+        onRevokeMcpToken={onRevokeMcpToken}
+        onGetPersonalAccessToken={onGetPersonalAccessToken}
+        onRenewPersonalAccessToken={onRenewPersonalAccessToken}
+      />,
+    );
+
+    const fullNameInput = screen.getByDisplayValue('Alice') as HTMLInputElement;
+    fireEvent.change(fullNameInput, { target: { value: 'Alice (editing)' } });
+    expect(fullNameInput.value).toBe('Alice (editing)');
+
+    // Parent re-renders with a NEW object reference but identical values - the
+    // user's in-progress edit must not be wiped.
+    rerender(
+      <UserSettings
+        settings={{ ...settings }}
+        onUpdate={onUpdate}
+        onUpdatePassword={onUpdatePassword}
+        onListMcpTokens={onListMcpTokens}
+        onCreateMcpToken={onCreateMcpToken}
+        onRevokeMcpToken={onRevokeMcpToken}
+        onGetPersonalAccessToken={onGetPersonalAccessToken}
+        onRenewPersonalAccessToken={onRenewPersonalAccessToken}
+      />,
+    );
+
+    expect((screen.getByDisplayValue('Alice (editing)') as HTMLInputElement).value).toBe(
+      'Alice (editing)',
+    );
+  });
+});
+
 describe('<UserSettings /> Security tab', () => {
   beforeEach(() => {
     for (const m of [


### PR DESCRIPTION
## Summary

- `UserSettings` re-copied `settings.fullName`/`email`/`language` into local state on every `settings` prop change. Because the parent (`App.tsx`) re-creates the `userSettings` object on unrelated re-renders, any in-progress edit was wiped as soon as the parent re-rendered.
- Initialize the editable fields from `settings` once at mount instead. The view is conditionally mounted by `activeView === 'settings'`, so when the form should be reset (logout, user switch), the parent already unmounts/remounts the component.
- Add a regression test that types into the full-name input and then re-renders the component with a new `settings` object reference (identical values) - the typed value must survive.

## Test plan

- [x] `bun test ./test/components/UserSettings.test.tsx` - 9/9 pass on fix, fails on old code
- [x] `bun run lint` - clean (i18n + tsc + biome)
- [x] `bunx tsc --noEmit` from repo root and from `server/` - clean
- [x] Pre-existing `ClientsView` test failures are unrelated and reproduce on clean `origin/main`

https://claude.ai/code/session_01RYnzgoB4TeCHNUcqbvZvQT

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYnzgoB4TeCHNUcqbvZvQT)_