### PR TITLE
fix(forms): prevent double-submit on TasksView and WorkUnitsView

### DIFF
--- a/components/WorkUnitsView.tsx
+++ b/components/WorkUnitsView.tsx
@@ -1,7 +1,7 @@
 import type React from 'react';
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { workUnitsApi } from '../services/api';
+import { workUnitsApi } from '../services/api/workUnits';
 import type { User, WorkUnit } from '../types';
 import { buildPermission, hasPermission } from '../utils/permissions';
 import Checkbox from './shared/Checkbox';
@@ -54,6 +54,11 @@ const WorkUnitsView: React.FC<WorkUnitsViewProps> = ({
   const [assignmentSearch, setAssignmentSearch] = useState('');
   const [isLoadingAssignments, setIsLoadingAssignments] = useState(false);
 
+  // Submission guards - prevent double-submit on async mutations
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [isSavingAssignments, setIsSavingAssignments] = useState(false);
+
   const openCreateModal = () => {
     setName('');
     setSelectedManagerIds([]);
@@ -74,6 +79,7 @@ const WorkUnitsView: React.FC<WorkUnitsViewProps> = ({
 
   const handleCreate = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (isSubmitting) return;
     setErrors({});
 
     const newErrors: Record<string, string> = {};
@@ -86,12 +92,18 @@ const WorkUnitsView: React.FC<WorkUnitsViewProps> = ({
       return;
     }
 
-    await onAddWorkUnit({ name, managerIds: selectedManagerIds, description });
-    setIsCreateModalOpen(false);
+    setIsSubmitting(true);
+    try {
+      await onAddWorkUnit({ name, managerIds: selectedManagerIds, description });
+      setIsCreateModalOpen(false);
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   const handleUpdate = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (isSubmitting) return;
     setErrors({});
 
     const newErrors: Record<string, string> = {};
@@ -103,9 +115,18 @@ const WorkUnitsView: React.FC<WorkUnitsViewProps> = ({
     }
 
     if (editingUnit && name) {
-      await onUpdateWorkUnit(editingUnit.id, { name, managerIds: selectedManagerIds, description });
-      setIsEditModalOpen(false);
-      setEditingUnit(null);
+      setIsSubmitting(true);
+      try {
+        await onUpdateWorkUnit(editingUnit.id, {
+          name,
+          managerIds: selectedManagerIds,
+          description,
+        });
+        setIsEditModalOpen(false);
+        setEditingUnit(null);
+      } finally {
+        setIsSubmitting(false);
+      }
     }
   };
 
@@ -115,10 +136,14 @@ const WorkUnitsView: React.FC<WorkUnitsViewProps> = ({
   };
 
   const handleDelete = async () => {
-    if (targetUnit) {
+    if (!targetUnit || isDeleting) return;
+    setIsDeleting(true);
+    try {
       await onDeleteWorkUnit(targetUnit.id);
       setIsDeleteConfirmOpen(false);
       setTargetUnit(null);
+    } finally {
+      setIsDeleting(false);
     }
   };
 
@@ -137,7 +162,8 @@ const WorkUnitsView: React.FC<WorkUnitsViewProps> = ({
   };
 
   const saveAssignments = async () => {
-    if (!targetUnit) return;
+    if (!targetUnit || isSavingAssignments) return;
+    setIsSavingAssignments(true);
     try {
       await workUnitsApi.updateUsers(targetUnit.id, assignedUserIds);
       await refreshWorkUnits(); // Update counts
@@ -146,6 +172,8 @@ const WorkUnitsView: React.FC<WorkUnitsViewProps> = ({
     } catch (err) {
       console.error('Failed to save assignments', err);
       alert(t('hr:workUnits.failedToSaveAssignments'));
+    } finally {
+      setIsSavingAssignments(false);
     }
   };
 
@@ -397,10 +425,10 @@ const WorkUnitsView: React.FC<WorkUnitsViewProps> = ({
               </button>
               <button
                 type="submit"
-                disabled={selectedManagerIds.length === 0}
+                disabled={selectedManagerIds.length === 0 || isSubmitting}
                 className="flex-1 py-3 bg-praetor text-white text-sm font-bold rounded-xl shadow-lg shadow-slate-200 hover:bg-slate-700 transition-all active:scale-95 disabled:opacity-50 disabled:active:scale-100"
               >
-                {t('hr:workUnits.createUnit')}
+                {isSubmitting ? t('common:buttons.saving') : t('hr:workUnits.createUnit')}
               </button>
             </div>
           </form>
@@ -476,9 +504,10 @@ const WorkUnitsView: React.FC<WorkUnitsViewProps> = ({
               </button>
               <button
                 type="submit"
-                className="flex-1 py-3 bg-praetor text-white text-sm font-bold rounded-xl shadow-lg shadow-slate-200 hover:bg-slate-700 transition-all active:scale-95"
+                disabled={isSubmitting}
+                className="flex-1 py-3 bg-praetor text-white text-sm font-bold rounded-xl shadow-lg shadow-slate-200 hover:bg-slate-700 transition-all active:scale-95 disabled:opacity-50 disabled:active:scale-100"
               >
-                {t('hr:workUnits.saveChanges')}
+                {isSubmitting ? t('common:buttons.saving') : t('hr:workUnits.saveChanges')}
               </button>
             </div>
           </form>
@@ -571,10 +600,10 @@ const WorkUnitsView: React.FC<WorkUnitsViewProps> = ({
             </button>
             <button
               onClick={saveAssignments}
-              disabled={isLoadingAssignments}
+              disabled={isLoadingAssignments || isSavingAssignments}
               className="px-8 py-2.5 bg-praetor text-white text-sm font-bold rounded-xl shadow-lg shadow-slate-200 hover:bg-slate-700 transition-all active:scale-95 disabled:opacity-50"
             >
-              {t('hr:workUnits.saveAssignments')}
+              {isSavingAssignments ? t('common:buttons.saving') : t('hr:workUnits.saveAssignments')}
             </button>
           </div>
         </div>
@@ -607,9 +636,10 @@ const WorkUnitsView: React.FC<WorkUnitsViewProps> = ({
               </button>
               <button
                 onClick={handleDelete}
-                className="flex-1 py-3 bg-red-600 text-white text-sm font-bold rounded-xl shadow-lg shadow-red-200 hover:bg-red-700 transition-all active:scale-95"
+                disabled={isDeleting}
+                className="flex-1 py-3 bg-red-600 text-white text-sm font-bold rounded-xl shadow-lg shadow-red-200 hover:bg-red-700 transition-all active:scale-95 disabled:opacity-50 disabled:active:scale-100"
               >
-                {t('hr:workUnits.yesDelete')}
+                {isDeleting ? t('common:buttons.saving') : t('hr:workUnits.yesDelete')}
               </button>
             </div>
           </div>

--- a/components/projects/TasksView.tsx
+++ b/components/projects/TasksView.tsx
@@ -492,7 +492,16 @@ const TasksView: React.FC<TasksViewProps> = ({
     setDescription('');
   };
 
+  // User-driven close paths must be inert while a save/delete is in flight:
+  // otherwise the user could close, open a new modal, and the resolving await
+  // would call closeModal() — wiping the newer modal's state.
+  const requestCloseModal = () => {
+    if (isSubmitting || isDeleting) return;
+    closeModal();
+  };
+
   const cancelDelete = () => {
+    if (isDeleting) return;
     setIsDeleteConfirmOpen(false);
   };
 
@@ -550,7 +559,7 @@ const TasksView: React.FC<TasksViewProps> = ({
       />
 
       {/* Add/Edit Modal */}
-      <Modal isOpen={isModalOpen} onClose={closeModal}>
+      <Modal isOpen={isModalOpen} onClose={requestCloseModal}>
         <div className="bg-white rounded-2xl shadow-2xl w-full max-w-lg overflow-hidden animate-in zoom-in duration-300">
           <div className="p-6 border-b border-slate-100 flex justify-between items-center bg-slate-50/50">
             <h3 className="text-xl font-black text-slate-800 flex items-center gap-3">
@@ -560,8 +569,9 @@ const TasksView: React.FC<TasksViewProps> = ({
               {editingTask ? t('tasks.editTask') : t('tasks.createNewTask')}
             </h3>
             <button
-              onClick={closeModal}
-              className="w-10 h-10 flex items-center justify-center rounded-xl hover:bg-slate-100 text-slate-400 transition-colors"
+              onClick={requestCloseModal}
+              disabled={isSubmitting || isDeleting}
+              className="w-10 h-10 flex items-center justify-center rounded-xl hover:bg-slate-100 text-slate-400 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
             >
               <i className="fa-solid fa-xmark text-lg"></i>
             </button>
@@ -698,8 +708,9 @@ const TasksView: React.FC<TasksViewProps> = ({
               <div className="flex gap-3 ml-auto">
                 <button
                   type="button"
-                  onClick={closeModal}
-                  className="px-6 py-2.5 text-sm font-bold text-slate-500 hover:bg-slate-50 rounded-xl transition-colors border border-slate-200"
+                  onClick={requestCloseModal}
+                  disabled={isSubmitting || isDeleting}
+                  className="px-6 py-2.5 text-sm font-bold text-slate-500 hover:bg-slate-50 rounded-xl transition-colors border border-slate-200 disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   {t('common:buttons.cancel')}
                 </button>

--- a/components/projects/TasksView.tsx
+++ b/components/projects/TasksView.tsx
@@ -1,7 +1,7 @@
 import type React from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import { tasksApi } from '../../services/api';
+import { tasksApi } from '../../services/api/tasks';
 import type { Client, Project, ProjectTask, Role, User } from '../../types';
 import { formatInsertDate } from '../../utils/date';
 import { buildPermission, hasPermission } from '../../utils/permissions';
@@ -31,9 +31,9 @@ export interface TasksViewProps {
     projectId: string,
     recurringConfig?: RecurringConfig,
     description?: string,
-  ) => void;
-  onUpdateTask: (id: string, updates: Partial<ProjectTask>) => void;
-  onDeleteTask: (id: string) => void;
+  ) => void | Promise<void>;
+  onUpdateTask: (id: string, updates: Partial<ProjectTask>) => void | Promise<void>;
+  onDeleteTask: (id: string) => void | Promise<void>;
   onViewOrder?: (orderId: string) => void;
 }
 
@@ -61,6 +61,8 @@ const TasksView: React.FC<TasksViewProps> = ({
   const [tempIsDisabled, setTempIsDisabled] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const [managingTaskId, setManagingTaskId] = useState<string | null>(null);
 
@@ -456,17 +458,28 @@ const TasksView: React.FC<TasksViewProps> = ({
     ],
   );
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (isSubmitting) return;
     if (editingTask && !canUpdateTasks) return;
     if (!editingTask && !canCreateTasks) return;
     if (name && projectId) {
-      if (editingTask) {
-        onUpdateTask(editingTask.id, { name, projectId, description, isDisabled: tempIsDisabled });
-      } else {
-        onAddTask(name, projectId, undefined, description);
+      setIsSubmitting(true);
+      try {
+        if (editingTask) {
+          await onUpdateTask(editingTask.id, {
+            name,
+            projectId,
+            description,
+            isDisabled: tempIsDisabled,
+          });
+        } else {
+          await onAddTask(name, projectId, undefined, description);
+        }
+        closeModal();
+      } finally {
+        setIsSubmitting(false);
       }
-      closeModal();
     }
   };
 
@@ -483,11 +496,16 @@ const TasksView: React.FC<TasksViewProps> = ({
     setIsDeleteConfirmOpen(false);
   };
 
-  const handleDelete = () => {
-    if (!canDeleteTasks) return;
+  const handleDelete = async () => {
+    if (!canDeleteTasks || isDeleting) return;
     if (editingTask) {
-      onDeleteTask(editingTask.id);
-      closeModal();
+      setIsDeleting(true);
+      try {
+        await onDeleteTask(editingTask.id);
+        closeModal();
+      } finally {
+        setIsDeleting(false);
+      }
     }
   };
 
@@ -687,14 +705,18 @@ const TasksView: React.FC<TasksViewProps> = ({
                 </button>
                 <button
                   type="submit"
-                  disabled={!canSubmit}
+                  disabled={!canSubmit || isSubmitting}
                   className={`px-8 py-2.5 rounded-xl text-white text-sm font-bold shadow-lg transform active:scale-95 transition-all ${
-                    canSubmit
+                    canSubmit && !isSubmitting
                       ? 'bg-praetor shadow-slate-200 hover:bg-slate-700'
                       : 'bg-slate-300 shadow-none cursor-not-allowed'
                   }`}
                 >
-                  {editingTask ? t('projects.saveChanges') : t('tasks.addTask')}
+                  {isSubmitting
+                    ? t('common:buttons.saving')
+                    : editingTask
+                      ? t('projects.saveChanges')
+                      : t('tasks.addTask')}
                 </button>
               </div>
             </div>

--- a/test/components/TasksView.test.tsx
+++ b/test/components/TasksView.test.tsx
@@ -188,4 +188,63 @@ describe('<TasksView /> double-submit prevention', () => {
       expect(onUpdateTask).toHaveBeenCalledTimes(1);
     });
   });
+
+  test('close controls are inert while a submit is in flight', async () => {
+    // Regression: if Cancel/X stayed active during the await, a user could
+    // close, open a new task modal, then the resolving await would call
+    // closeModal() — wiping the newer modal's state.
+    let resolveAdd: (() => void) | undefined;
+    const onAddTask = mock(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveAdd = resolve;
+        }),
+    );
+
+    render(
+      <TasksView
+        tasks={[]}
+        projects={[project]}
+        clients={[client]}
+        permissions={basePerms}
+        users={[user]}
+        roles={[role]}
+        currency="EUR"
+        onAddTask={onAddTask}
+        onUpdateTask={() => {}}
+        onDeleteTask={() => {}}
+      />,
+    );
+
+    const addButtons = screen.getAllByText('tasks.addTask');
+    fireEvent.click(addButtons[0] as HTMLElement);
+
+    const modal = screen.getByTestId('modal');
+    const selectTrigger = modal.querySelector('button[type="button"]') as HTMLButtonElement;
+    fireEvent.click(selectTrigger);
+    fireEvent.click(screen.getByText(project.name));
+
+    const nameInput = screen.getByPlaceholderText('tasks.taskNamePlaceholder') as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: 'New Task' } });
+
+    const form = modal.querySelector('form') as HTMLFormElement;
+    fireEvent.submit(form);
+
+    // Cancel button should be disabled while the submit is in flight.
+    const cancelButton = await waitFor(() => {
+      const btn = screen.getByText('common:buttons.cancel').closest('button') as HTMLButtonElement;
+      expect(btn.disabled).toBe(true);
+      return btn;
+    });
+
+    // Clicking the still-disabled Cancel must not close the modal.
+    fireEvent.click(cancelButton);
+    expect(screen.queryByTestId('modal')).not.toBeNull();
+
+    resolveAdd?.();
+
+    await waitFor(() => {
+      expect(onAddTask).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/test/components/TasksView.test.tsx
+++ b/test/components/TasksView.test.tsx
@@ -1,0 +1,191 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import type { Client, Project, ProjectTask, Role, User } from '../../types';
+import { installI18nMock } from '../helpers/i18n';
+
+installI18nMock();
+
+// Modal uses createPortal; passthrough is friendlier for screen queries in happy-dom.
+mock.module('../../components/shared/Modal', () => ({
+  default: ({ isOpen, children }: { isOpen: boolean; children: ReactNode }) =>
+    isOpen ? <div data-testid="modal">{children}</div> : null,
+}));
+
+// DeleteConfirmModal also relies on a portal; stub with inline confirm/cancel.
+mock.module('../../components/shared/DeleteConfirmModal', () => ({
+  default: ({
+    isOpen,
+    onConfirm,
+    onClose,
+  }: {
+    isOpen: boolean;
+    onConfirm: () => void;
+    onClose: () => void;
+  }) =>
+    isOpen ? (
+      <div data-testid="confirm-modal">
+        <button type="button" onClick={onClose}>
+          confirm-cancel
+        </button>
+        <button type="button" onClick={onConfirm}>
+          confirm-yes
+        </button>
+      </div>
+    ) : null,
+}));
+
+// UserAssignmentModal isn't relevant to this test scope; render null.
+mock.module('../../components/shared/UserAssignmentModal', () => ({
+  default: () => null,
+}));
+
+// Stub tasksApi at the sub-module level. TasksView imports tasksApi from this path,
+// which sidesteps any pollution of the services/api umbrella mock from sibling test files.
+mock.module('../../services/api/tasks', () => ({
+  tasksApi: {
+    getHoursForProjects: () => Promise.resolve({}),
+    getUsers: () => Promise.resolve([]),
+    updateUsers: () => Promise.resolve(),
+  },
+}));
+
+const TasksView = (await import('../../components/projects/TasksView')).default;
+
+const client: Client = { id: 'c-1', name: 'Acme' };
+const project: Project = { id: 'p-1', name: 'Project Alpha', clientId: 'c-1', color: '#000' };
+const user: User = {
+  id: 'u-1',
+  name: 'Test User',
+  role: 'user',
+  avatarInitials: 'TU',
+  username: 'tuser',
+};
+const role: Role = { id: 'r-1', name: 'Member', isSystem: false, isAdmin: false, permissions: [] };
+const existingTask: ProjectTask = {
+  id: 't-1',
+  name: 'Original Task',
+  projectId: 'p-1',
+  description: 'desc',
+};
+
+const basePerms = [
+  'projects.tasks.view',
+  'projects.tasks.create',
+  'projects.tasks.update',
+  'projects.tasks.delete',
+];
+
+afterEach(() => {
+  document.body.style.overflow = '';
+});
+
+describe('<TasksView /> double-submit prevention', () => {
+  test('handleSubmit (create): rapid clicks call onAddTask only once', async () => {
+    let resolveAdd: (() => void) | undefined;
+    const onAddTask = mock(
+      (_name: string, _projectId: string) =>
+        new Promise<void>((resolve) => {
+          resolveAdd = resolve;
+        }),
+    );
+
+    render(
+      <TasksView
+        tasks={[]}
+        projects={[project]}
+        clients={[client]}
+        permissions={basePerms}
+        users={[user]}
+        roles={[role]}
+        currency="EUR"
+        onAddTask={onAddTask}
+        onUpdateTask={() => {}}
+        onDeleteTask={() => {}}
+      />,
+    );
+
+    // Open the Add Task modal (the header button uses i18n key projects:tasks.addTask).
+    const addButtons = screen.getAllByText('tasks.addTask');
+    fireEvent.click(addButtons[0] as HTMLElement);
+
+    // Pick a project via the real CustomSelect: open dropdown, then click the project option.
+    const modal = screen.getByTestId('modal');
+    const selectTrigger = modal.querySelector('button[type="button"]') as HTMLButtonElement;
+    fireEvent.click(selectTrigger);
+    fireEvent.click(screen.getByText(project.name));
+
+    const nameInput = screen.getByPlaceholderText('tasks.taskNamePlaceholder') as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: 'New Task' } });
+
+    // Locate the actual submit button (type="submit") inside the form.
+    const form = modal.querySelector('form') as HTMLFormElement;
+    const findSubmit = () => form.querySelector('button[type="submit"]') as HTMLButtonElement;
+
+    // Fire the form's submit event 3 times rapidly. Only the first should trigger onAddTask;
+    // the others should be guarded by isSubmitting.
+    fireEvent.submit(form);
+    fireEvent.submit(form);
+    fireEvent.submit(form);
+
+    await waitFor(() => {
+      expect(findSubmit().disabled).toBe(true);
+    });
+
+    resolveAdd?.();
+
+    await waitFor(() => {
+      expect(onAddTask).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  test('handleSubmit (edit): rapid clicks call onUpdateTask only once', async () => {
+    let resolveUpdate: (() => void) | undefined;
+    const onUpdateTask = mock(
+      (_id: string, _updates: Partial<ProjectTask>) =>
+        new Promise<void>((resolve) => {
+          resolveUpdate = resolve;
+        }),
+    );
+
+    render(
+      <TasksView
+        tasks={[existingTask]}
+        projects={[project]}
+        clients={[client]}
+        permissions={basePerms}
+        users={[user]}
+        roles={[role]}
+        currency="EUR"
+        onAddTask={() => {}}
+        onUpdateTask={onUpdateTask}
+        onDeleteTask={() => {}}
+      />,
+    );
+
+    // Open the edit modal by clicking on the edit pencil button (icon: fa-pen-to-square).
+    const editIcons = document.querySelectorAll('i.fa-pen-to-square');
+    expect(editIcons.length).toBeGreaterThan(0);
+    const editButton = editIcons[0]?.closest('button') as HTMLButtonElement;
+    fireEvent.click(editButton);
+
+    // Submit the form rapidly; only the first submit should call onUpdateTask.
+    const modal = screen.getByTestId('modal');
+    const form = modal.querySelector('form') as HTMLFormElement;
+    const findSubmit = () => form.querySelector('button[type="submit"]') as HTMLButtonElement;
+
+    fireEvent.submit(form);
+    fireEvent.submit(form);
+    fireEvent.submit(form);
+
+    await waitFor(() => {
+      expect(findSubmit().disabled).toBe(true);
+    });
+
+    resolveUpdate?.();
+
+    await waitFor(() => {
+      expect(onUpdateTask).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/test/components/WorkUnitsView.test.tsx
+++ b/test/components/WorkUnitsView.test.tsx
@@ -1,0 +1,182 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import type { User, WorkUnit } from '../../types';
+import { installI18nMock } from '../helpers/i18n';
+
+installI18nMock();
+
+// Modal renders via createPortal which is unreliable in happy-dom + React 19; replace
+// with a passthrough that flattens children when isOpen.
+mock.module('../../components/shared/Modal', () => ({
+  default: ({ isOpen, children }: { isOpen: boolean; children: ReactNode }) =>
+    isOpen ? <div data-testid="modal">{children}</div> : null,
+}));
+
+// Stub workUnitsApi at the sub-module level. WorkUnitsView imports workUnitsApi from this
+// path, which sidesteps any pollution of the services/api umbrella mock from sibling tests.
+const updateUsersMock = mock((_id: string, _ids: string[]) => Promise.resolve(undefined));
+const getUsersMock = mock((_id: string) => Promise.resolve<string[]>([]));
+mock.module('../../services/api/workUnits', () => ({
+  workUnitsApi: {
+    getUsers: (id: string) => getUsersMock(id),
+    updateUsers: (id: string, ids: string[]) => updateUsersMock(id, ids),
+  },
+}));
+
+const WorkUnitsView = (await import('../../components/WorkUnitsView')).default;
+
+const user: User = {
+  id: 'u-1',
+  name: 'Test Manager',
+  role: 'manager',
+  avatarInitials: 'TM',
+  username: 'tmanager',
+};
+
+const unit: WorkUnit = {
+  id: 'wu-1',
+  name: 'Engineering',
+  managers: [{ id: 'u-1', name: 'Test Manager' }],
+  description: 'Engineering team',
+  userCount: 5,
+};
+
+const allPermissions = [
+  'hr.work_units.view',
+  'hr.work_units.create',
+  'hr.work_units.update',
+  'hr.work_units.delete',
+];
+
+afterEach(() => {
+  document.body.style.overflow = '';
+  updateUsersMock.mockClear();
+  getUsersMock.mockClear();
+});
+
+describe('<WorkUnitsView /> double-submit prevention', () => {
+  test('handleCreate: rapidly clicking submit calls onAddWorkUnit only once', async () => {
+    let resolveAdd: (() => void) | undefined;
+    const onAddWorkUnit = mock(
+      (_data: { name: string; managerIds: string[]; description: string }) =>
+        new Promise<void>((resolve) => {
+          resolveAdd = resolve;
+        }),
+    );
+
+    render(
+      <WorkUnitsView
+        workUnits={[]}
+        users={[user]}
+        permissions={allPermissions}
+        onAddWorkUnit={onAddWorkUnit}
+        onUpdateWorkUnit={() => Promise.resolve()}
+        onDeleteWorkUnit={() => Promise.resolve()}
+        refreshWorkUnits={() => Promise.resolve()}
+      />,
+    );
+
+    // Open create modal
+    fireEvent.click(screen.getByText('hr:workUnits.newWorkUnit'));
+
+    // Fill in form: name input + pick a manager via the real CustomSelect.
+    const nameInput = document.querySelector('input[type="text"]') as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: 'New Unit' } });
+
+    // The select trigger is a button rendered by CustomSelect; open it then click the option.
+    const modal = screen.getByTestId('modal');
+    const selectTriggers = modal.querySelectorAll('button[type="button"]');
+    // The first button is the X close, the second is the CustomSelect trigger.
+    const selectTrigger = Array.from(selectTriggers).find((b) =>
+      b.textContent?.includes('hr:workUnits.selectManagers'),
+    ) as HTMLButtonElement;
+    fireEvent.click(selectTrigger);
+    fireEvent.click(screen.getByText(user.name));
+
+    // Find submit button (Create Unit) - the form's submit button. Its text changes
+    // between "createUnit" and "saving" when isSubmitting toggles, so we look it up via
+    // type="submit" each time.
+    const form = modal.querySelector('form') as HTMLFormElement;
+    const findSubmit = () => form.querySelector('button[type="submit"]') as HTMLButtonElement;
+
+    await waitFor(() => {
+      expect(findSubmit().disabled).toBe(false);
+    });
+
+    // Submit the form three times rapidly. The first call fires the async handler;
+    // subsequent submits should be no-ops because isSubmitting is true.
+    fireEvent.submit(form);
+    fireEvent.submit(form);
+    fireEvent.submit(form);
+
+    await waitFor(() => {
+      expect(findSubmit().disabled).toBe(true);
+    });
+
+    // Resolve the in-flight call
+    resolveAdd?.();
+
+    await waitFor(() => {
+      expect(onAddWorkUnit).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  test('handleDelete: rapidly clicking confirm calls onDeleteWorkUnit only once', async () => {
+    let resolveDel: (() => void) | undefined;
+    const onDeleteWorkUnit = mock(
+      (_id: string) =>
+        new Promise<void>((resolve) => {
+          resolveDel = resolve;
+        }),
+    );
+
+    render(
+      <WorkUnitsView
+        workUnits={[unit]}
+        users={[user]}
+        permissions={allPermissions}
+        onAddWorkUnit={() => Promise.resolve()}
+        onUpdateWorkUnit={() => Promise.resolve()}
+        onDeleteWorkUnit={onDeleteWorkUnit}
+        refreshWorkUnits={() => Promise.resolve()}
+      />,
+    );
+
+    // Locate the delete trigger button on the unit card (icon button -> opens confirm modal)
+    // The delete trigger has a `<i className="fa-solid fa-trash-can" />` inside.
+    const trashIcons = document.querySelectorAll('i.fa-trash-can');
+    expect(trashIcons.length).toBeGreaterThan(0);
+    const trashButton = trashIcons[0]?.closest('button') as HTMLButtonElement;
+    fireEvent.click(trashButton);
+
+    // Now the delete confirm modal is open. The confirm button's text toggles between
+    // "yesDelete" and "saving" while in-flight; find it by being inside the visible modal
+    // and using the red styling. Two modals render: one for assignments (closed) and one
+    // for delete confirm (open). The yesDelete button is unique by its initial text.
+    const initialConfirm = screen.getByText('hr:workUnits.yesDelete') as HTMLButtonElement;
+    expect(initialConfirm.disabled).toBe(false);
+    // Find a stable handle: the parent <div className="flex gap-3 pt-2"> contains both the
+    // cancel and confirm buttons in the delete modal. Keep a reference to that container so
+    // we can re-query the confirm button after re-render.
+    const buttonsContainer = initialConfirm.parentElement as HTMLElement;
+    const findConfirm = () =>
+      Array.from(buttonsContainer.querySelectorAll('button')).find(
+        (b) => b.className.includes('bg-red-600') || b.className.includes('opacity-50'),
+      ) as HTMLButtonElement;
+
+    fireEvent.click(initialConfirm);
+    fireEvent.click(initialConfirm);
+    fireEvent.click(initialConfirm);
+
+    await waitFor(() => {
+      expect(findConfirm().disabled).toBe(true);
+    });
+
+    resolveDel?.();
+
+    await waitFor(() => {
+      expect(onDeleteWorkUnit).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
## Status: closing — needs re-apply on top of main

This PR's double-submit fix conflicts irreconcilably with substantial refactors that landed on main while this PR was open (billing types/frequencies, formatBillingType/formatBillingFrequency callbacks, new shadcn component imports in TasksView and WorkUnitsView).

The original fix is captured in the commit history. To re-apply on top of current main:
1. Add `const [isSubmitting, setIsSubmitting] = useState(false)` + `[isDeleting, setIsDeleting]` to TasksView and WorkUnitsView
2. Guard each async handler with `if (isSubmitting) return; setIsSubmitting(true); try { ... await ... } finally { setIsSubmitting(false); }`
3. Disable submit buttons when `isSubmitting || isDeleting` is true
4. Tie close controls (Cancel, X, Modal `onClose`) to be inert during `isSubmitting || isDeleting` to avoid the post-await closeModal race
5. Re-port the tests from the closed PR's commit

Closed in favor of a fresh apply on current main.