### PR TITLE
fix(app): clear stale module-scoped state on module navigation

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -87,6 +87,7 @@ import {
 import { getTechnicalDocsViewFromPathname } from './utils/docsRoutes';
 import { getErrorMessage } from './utils/errors';
 import { isItalianHoliday } from './utils/holidays';
+import { clearStaleModuleScopedState } from './utils/moduleScopedState';
 import {
   buildPermission,
   equivalentPermissionsFor,
@@ -1078,6 +1079,30 @@ const App: React.FC = () => {
     const module = getModuleFromView(activeView);
     if (!module || module === 'settings') return;
     if (loadedModules.has(module)) return;
+
+    // Clear module-scoped arrays the incoming module isn't going to refresh,
+    // so leftover data from a previously-visited module doesn't leak into the
+    // new UI before the module's own datasets load.
+    clearStaleModuleScopedState(module, {
+      clients: () => setClients([]),
+      suppliers: () => setSuppliers([]),
+      projects: () => setProjects([]),
+      projectTasks: () => setProjectTasks([]),
+      products: () => setProducts([]),
+      quotes: () => setQuotes([]),
+      clientOffers: () => setClientOffers([]),
+      clientsOrders: () => setClientsOrders([]),
+      invoices: () => setInvoices([]),
+      supplierQuotes: () => setSupplierQuotes([]),
+      supplierOrders: () => setSupplierOrders([]),
+      supplierInvoices: () => setSupplierInvoices([]),
+      entries: () => {
+        entriesStreamTokenRef.current++;
+        setEntries([]);
+      },
+      workUnits: () => setWorkUnits([]),
+      users: () => setUsers([]),
+    });
 
     const loadGeneralSettings = async () => {
       if (hasLoadedGeneralSettings) return;

--- a/App.tsx
+++ b/App.tsx
@@ -87,7 +87,10 @@ import {
 import { getTechnicalDocsViewFromPathname } from './utils/docsRoutes';
 import { getErrorMessage } from './utils/errors';
 import { isItalianHoliday } from './utils/holidays';
-import { clearStaleModuleScopedState } from './utils/moduleScopedState';
+import {
+  clearStaleModuleScopedState,
+  getStaleModulesAfterNavigation,
+} from './utils/moduleScopedState';
 import {
   buildPermission,
   equivalentPermissionsFor,
@@ -640,6 +643,7 @@ const App: React.FC = () => {
     isModuleLoading,
     loadDatasets,
     markModuleLoaded,
+    invalidateModules,
     recordFailures,
     reset: resetModuleLoader,
   } = useModuleLoader();
@@ -1077,12 +1081,13 @@ const App: React.FC = () => {
     if (!currentUser) return;
     if (!isRouteAccessible) return;
     const module = getModuleFromView(activeView);
-    if (!module || module === 'settings') return;
+    if (!module) return;
     if (loadedModules.has(module)) return;
 
     // Clear module-scoped arrays the incoming module isn't going to refresh,
     // so leftover data from a previously-visited module doesn't leak into the
-    // new UI before the module's own datasets load.
+    // new UI before the module's own datasets load. Runs for settings too —
+    // settings has no datasets but still represents a module-scope transition.
     clearStaleModuleScopedState(module, {
       clients: () => setClients([]),
       suppliers: () => setSuppliers([]),
@@ -1103,6 +1108,17 @@ const App: React.FC = () => {
       workUnits: () => setWorkUnits([]),
       users: () => setUsers([]),
     });
+
+    // Drop the previously-visited modules from the loaded set so that revisiting
+    // them refetches instead of showing the empty arrays we just cleared.
+    invalidateModules(getStaleModulesAfterNavigation(module));
+
+    if (module === 'settings') {
+      // Settings has no datasets to load; mark it loaded so we don't re-clear
+      // and re-invalidate on every render while the user is on this view.
+      markModuleLoaded(module);
+      return;
+    }
 
     const loadGeneralSettings = async () => {
       if (hasLoadedGeneralSettings) return;
@@ -1610,6 +1626,7 @@ const App: React.FC = () => {
     loadedModules,
     loadDatasets,
     markModuleLoaded,
+    invalidateModules,
     recordFailures,
     hasLoadedGeneralSettings,
     hasLoadedLdapConfig,

--- a/hooks/useModuleLoader.ts
+++ b/hooks/useModuleLoader.ts
@@ -72,6 +72,31 @@ export function useModuleLoader() {
     });
   }, []);
 
+  // Drop modules from the loaded set so a subsequent visit re-fetches them.
+  // Used when cross-module data they cached has been cleared by navigation.
+  const invalidateModules = useCallback((moduleNames: readonly string[]) => {
+    if (moduleNames.length === 0) return;
+    setLoadedModules((prev) => {
+      let changed = false;
+      const next = new Set(prev);
+      for (const name of moduleNames) {
+        if (next.delete(name)) changed = true;
+      }
+      return changed ? next : prev;
+    });
+    setModuleLoadErrors((prev) => {
+      let changed = false;
+      const next = { ...prev };
+      for (const name of moduleNames) {
+        if (name in next) {
+          delete next[name];
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, []);
+
   const recordFailures = useCallback((moduleName: string, failures: string[]) => {
     setModuleLoadErrors((prev) => {
       const next = { ...prev };
@@ -102,6 +127,7 @@ export function useModuleLoader() {
     isModuleLoading,
     loadDatasets,
     markModuleLoaded,
+    invalidateModules,
     recordFailures,
     reset,
   };

--- a/test/hooks/useModuleLoader.test.ts
+++ b/test/hooks/useModuleLoader.test.ts
@@ -175,6 +175,42 @@ describe('useModuleLoader', () => {
     expect(result.current.moduleLoadErrors.crm).toBeUndefined();
   });
 
+  test('invalidateModules removes named modules from loaded set and their errors', () => {
+    const { result } = renderHook(() => useModuleLoader());
+
+    act(() => {
+      result.current.markModuleLoaded('crm');
+      result.current.markModuleLoaded('sales');
+      result.current.markModuleLoaded('projects');
+      result.current.recordFailures('crm', ['clients']);
+      result.current.recordFailures('sales', ['quotes']);
+    });
+    expect(result.current.loadedModules.size).toBe(3);
+
+    act(() => {
+      result.current.invalidateModules(['crm', 'sales']);
+    });
+
+    expect(result.current.loadedModules.has('crm')).toBe(false);
+    expect(result.current.loadedModules.has('sales')).toBe(false);
+    expect(result.current.loadedModules.has('projects')).toBe(true);
+    expect(result.current.moduleLoadErrors.crm).toBeUndefined();
+    expect(result.current.moduleLoadErrors.sales).toBeUndefined();
+  });
+
+  test('invalidateModules is a no-op when given an empty list', () => {
+    const { result } = renderHook(() => useModuleLoader());
+    act(() => {
+      result.current.markModuleLoaded('crm');
+    });
+    const before = result.current.loadedModules;
+    act(() => {
+      result.current.invalidateModules([]);
+    });
+    // Same identity — proves we didn't allocate a new Set.
+    expect(result.current.loadedModules).toBe(before);
+  });
+
   test('reset clears loaded modules and errors', () => {
     const { result } = renderHook(() => useModuleLoader());
 

--- a/test/utils/moduleScopedState.test.ts
+++ b/test/utils/moduleScopedState.test.ts
@@ -3,6 +3,7 @@ import {
   ALL_MODULE_SCOPED_KEYS,
   clearStaleModuleScopedState,
   getStaleModuleScopedKeys,
+  getStaleModulesAfterNavigation,
   type ModuleScopedStateKey,
 } from '../../utils/moduleScopedState';
 
@@ -162,6 +163,50 @@ describe('moduleScopedState', () => {
         'supplierQuotes',
       ];
       expect([...cleared].sort()).toEqual([...expected].sort());
+    });
+  });
+
+  describe('getStaleModulesAfterNavigation', () => {
+    test('returns empty array for null module', () => {
+      expect(getStaleModulesAfterNavigation(null)).toEqual([]);
+    });
+
+    test('navigating to reports stales every module with owned state', () => {
+      // Reports owns nothing, so any module that owned state has its data
+      // cleared and must be re-fetched on revisit.
+      const stale = getStaleModulesAfterNavigation('reports');
+      expect(stale).toContain('timesheets');
+      expect(stale).toContain('crm');
+      expect(stale).toContain('sales');
+      expect(stale).toContain('accounting');
+      expect(stale).toContain('catalog');
+      expect(stale).toContain('projects');
+      expect(stale).toContain('suppliers');
+      expect(stale).toContain('hr');
+      expect(stale).toContain('administration');
+      // Modules without owned state are never stale (nothing to clear).
+      expect(stale).not.toContain('reports');
+      expect(stale).not.toContain('settings');
+    });
+
+    test('navigating from CRM to sales does not stale CRM (shared keys preserved)', () => {
+      // CRM owns clients+suppliers; sales also owns clients+suppliers, so
+      // CRM's data is not cleared and CRM should not be invalidated.
+      const stale = getStaleModulesAfterNavigation('sales');
+      expect(stale).not.toContain('crm');
+    });
+
+    test('navigating from timesheets to CRM stales timesheets', () => {
+      // CRM owns only clients+suppliers; timesheets owns entries+clients+
+      // projects+projectTasks+users — its non-overlapping keys get cleared.
+      const stale = getStaleModulesAfterNavigation('crm');
+      expect(stale).toContain('timesheets');
+      // CRM itself should never appear.
+      expect(stale).not.toContain('crm');
+    });
+
+    test('returns empty for unknown module', () => {
+      expect(getStaleModulesAfterNavigation('does-not-exist')).toEqual([]);
     });
   });
 });

--- a/test/utils/moduleScopedState.test.ts
+++ b/test/utils/moduleScopedState.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, mock, test } from 'bun:test';
+import {
+  ALL_MODULE_SCOPED_KEYS,
+  clearStaleModuleScopedState,
+  getStaleModuleScopedKeys,
+  type ModuleScopedStateKey,
+} from '../../utils/moduleScopedState';
+
+describe('moduleScopedState', () => {
+  describe('getStaleModuleScopedKeys', () => {
+    test('returns empty array for null module', () => {
+      expect(getStaleModuleScopedKeys(null)).toEqual([]);
+    });
+
+    test('returns empty array for unknown module', () => {
+      expect(getStaleModuleScopedKeys('unknown-module')).toEqual([]);
+    });
+
+    test('modules with no module-scoped state stale everything', () => {
+      // Reports/settings own no module-scoped arrays, so every leftover key
+      // is stale and should be cleared when entering them.
+      expect(getStaleModuleScopedKeys('reports')).toEqual(ALL_MODULE_SCOPED_KEYS.slice());
+      expect(getStaleModuleScopedKeys('settings')).toEqual(ALL_MODULE_SCOPED_KEYS.slice());
+    });
+
+    test('CRM keeps clients and suppliers but stales everything else', () => {
+      const stale = getStaleModuleScopedKeys('crm');
+      // CRM owns clients + suppliers, so those should NOT be in the stale list.
+      expect(stale).not.toContain('clients');
+      expect(stale).not.toContain('suppliers');
+      // Cross-module data that CRM doesn't touch must be marked stale so it
+      // doesn't leak in when navigating from another module into CRM.
+      expect(stale).toContain('projects');
+      expect(stale).toContain('projectTasks');
+      expect(stale).toContain('entries');
+      expect(stale).toContain('invoices');
+      expect(stale).toContain('quotes');
+      expect(stale).toContain('clientOffers');
+      expect(stale).toContain('supplierOrders');
+      expect(stale).toContain('supplierInvoices');
+    });
+
+    test('projects module keeps its arrays and stales sales/accounting-only data', () => {
+      const stale = getStaleModuleScopedKeys('projects');
+      // projects owns projects/projectTasks/clients/users/workUnits/clientsOrders
+      expect(stale).not.toContain('projects');
+      expect(stale).not.toContain('projectTasks');
+      expect(stale).not.toContain('clients');
+      expect(stale).not.toContain('users');
+      expect(stale).not.toContain('workUnits');
+      expect(stale).not.toContain('clientsOrders');
+      // Projects doesn't touch sales/accounting data — must be cleared.
+      expect(stale).toContain('quotes');
+      expect(stale).toContain('clientOffers');
+      expect(stale).toContain('invoices');
+      expect(stale).toContain('supplierQuotes');
+      expect(stale).toContain('supplierOrders');
+      expect(stale).toContain('supplierInvoices');
+      // projects doesn't touch suppliers/products either.
+      expect(stale).toContain('suppliers');
+      expect(stale).toContain('products');
+      // projects doesn't touch entries.
+      expect(stale).toContain('entries');
+    });
+
+    test('catalog (smallest module) stales nearly everything', () => {
+      const stale = getStaleModuleScopedKeys('catalog');
+      expect(stale).not.toContain('products');
+      // Catalog only owns products, so 14 of 15 known keys are stale.
+      expect(stale).toHaveLength(ALL_MODULE_SCOPED_KEYS.length - 1);
+    });
+
+    test('every stale key is a member of ALL_MODULE_SCOPED_KEYS', () => {
+      const knownKeys = new Set<ModuleScopedStateKey>(ALL_MODULE_SCOPED_KEYS);
+      const stale = getStaleModuleScopedKeys('crm');
+      for (const key of stale) {
+        expect(knownKeys.has(key)).toBe(true);
+      }
+    });
+  });
+
+  describe('clearStaleModuleScopedState', () => {
+    test('invokes only the setters for stale keys', () => {
+      const setClients = mock(() => {});
+      const setSuppliers = mock(() => {});
+      const setProjects = mock(() => {});
+      const setEntries = mock(() => {});
+
+      // Going INTO CRM. CRM keeps clients + suppliers. Projects/entries are
+      // stale and their setters should fire.
+      clearStaleModuleScopedState('crm', {
+        clients: setClients,
+        suppliers: setSuppliers,
+        projects: setProjects,
+        entries: setEntries,
+      });
+
+      expect(setClients).not.toHaveBeenCalled();
+      expect(setSuppliers).not.toHaveBeenCalled();
+      expect(setProjects).toHaveBeenCalledTimes(1);
+      expect(setEntries).toHaveBeenCalledTimes(1);
+    });
+
+    test('returns the list of cleared keys', () => {
+      // Only supply a subset of setters — the helper should only report
+      // the keys it actually cleared.
+      const cleared = clearStaleModuleScopedState('crm', {
+        projects: () => {},
+        invoices: () => {},
+      });
+      expect(cleared).toContain('projects');
+      expect(cleared).toContain('invoices');
+      // suppliers/clients are NOT stale for CRM, so even if a setter were
+      // passed they wouldn't be in the result.
+      expect(cleared).not.toContain('suppliers');
+      expect(cleared).not.toContain('clients');
+    });
+
+    test('no-ops for null or unknown module', () => {
+      const setClients = mock(() => {});
+      clearStaleModuleScopedState(null, { clients: setClients });
+      clearStaleModuleScopedState('mystery', { clients: setClients });
+      expect(setClients).not.toHaveBeenCalled();
+    });
+
+    test('skips missing setters gracefully', () => {
+      // We don't supply a setter for `quotes` even though it's stale for CRM —
+      // helper should not throw and should report only what it cleared.
+      const setProjects = mock(() => {});
+      const cleared = clearStaleModuleScopedState('crm', {
+        projects: setProjects,
+      });
+      expect(setProjects).toHaveBeenCalledTimes(1);
+      expect(cleared).toEqual(['projects']);
+    });
+
+    test('repros the bug: switching from CRM to accounting clears stale CRM-only data', () => {
+      // CRM had loaded suppliers; accounting also loads suppliers so that's
+      // fine — but accounting doesn't touch CRM's "supplierQuotes" or
+      // "quotes" if they happened to be lingering. (Test that "quotes" is
+      // among the stale keys when entering accounting.)
+      const setQuotes = mock(() => {});
+      const setClientOffers = mock(() => {});
+      const setSupplierQuotes = mock(() => {});
+      const setEntries = mock(() => {});
+
+      const cleared = clearStaleModuleScopedState('accounting', {
+        quotes: setQuotes,
+        clientOffers: setClientOffers,
+        supplierQuotes: setSupplierQuotes,
+        entries: setEntries,
+      });
+
+      expect(setQuotes).toHaveBeenCalledTimes(1);
+      expect(setClientOffers).toHaveBeenCalledTimes(1);
+      expect(setSupplierQuotes).toHaveBeenCalledTimes(1);
+      expect(setEntries).toHaveBeenCalledTimes(1);
+      const expected: ModuleScopedStateKey[] = [
+        'clientOffers',
+        'entries',
+        'quotes',
+        'supplierQuotes',
+      ];
+      expect([...cleared].sort()).toEqual([...expected].sort());
+    });
+  });
+});

--- a/utils/moduleScopedState.ts
+++ b/utils/moduleScopedState.ts
@@ -1,0 +1,108 @@
+// Maps each app module to the list of state-array keys it loads/owns.
+// Used by App.tsx to clear stale data from previously-visited modules when a
+// new module's data starts loading, so cross-module data doesn't leak into
+// views that don't refresh it.
+
+export type ModuleScopedStateKey =
+  | 'clients'
+  | 'suppliers'
+  | 'projects'
+  | 'projectTasks'
+  | 'products'
+  | 'quotes'
+  | 'clientOffers'
+  | 'clientsOrders'
+  | 'invoices'
+  | 'supplierQuotes'
+  | 'supplierOrders'
+  | 'supplierInvoices'
+  | 'entries'
+  | 'workUnits'
+  | 'users';
+
+// Every key listed here is a module-scoped state-array on App.tsx.
+// Keep this list in sync with App.tsx's module-loading effect (the switch
+// on `module`).
+export const ALL_MODULE_SCOPED_KEYS: readonly ModuleScopedStateKey[] = [
+  'clients',
+  'suppliers',
+  'projects',
+  'projectTasks',
+  'products',
+  'quotes',
+  'clientOffers',
+  'clientsOrders',
+  'invoices',
+  'supplierQuotes',
+  'supplierOrders',
+  'supplierInvoices',
+  'entries',
+  'workUnits',
+  'users',
+];
+
+// Per-module: which state keys are loaded/owned by that module.
+// If a module doesn't appear here, no module-scoped state is associated
+// with it (e.g. reports, settings, administration is users-only).
+const MODULE_OWNED_KEYS: Record<string, readonly ModuleScopedStateKey[]> = {
+  timesheets: ['entries', 'clients', 'projects', 'projectTasks', 'users'],
+  hr: ['users', 'workUnits', 'clients', 'projects', 'projectTasks'],
+  administration: ['users'],
+  crm: ['clients', 'suppliers'],
+  sales: ['quotes', 'clientOffers', 'supplierQuotes', 'clients', 'suppliers', 'products'],
+  accounting: [
+    'clientsOrders',
+    'invoices',
+    'supplierOrders',
+    'supplierInvoices',
+    'clients',
+    'suppliers',
+    'products',
+  ],
+  catalog: ['products'],
+  projects: ['projects', 'projectTasks', 'clients', 'users', 'workUnits', 'clientsOrders'],
+  suppliers: ['suppliers', 'supplierQuotes', 'products'],
+  reports: [],
+  settings: [],
+};
+
+/**
+ * Returns the set of module-scoped state keys that should be cleared before
+ * loading `incomingModule`. These are keys NOT owned by `incomingModule` —
+ * i.e. data that the new module isn't going to refresh and that may be left
+ * over from a previously-visited module.
+ *
+ * If `incomingModule` is unknown, returns an empty array (defensive: don't
+ * wipe state we can't reason about).
+ */
+export function getStaleModuleScopedKeys(incomingModule: string | null): ModuleScopedStateKey[] {
+  if (!incomingModule) return [];
+  const owned = MODULE_OWNED_KEYS[incomingModule];
+  if (!owned) return [];
+  const ownedSet = new Set<ModuleScopedStateKey>(owned);
+  return ALL_MODULE_SCOPED_KEYS.filter((key) => !ownedSet.has(key));
+}
+
+export type ModuleScopedStateSetters = Partial<Record<ModuleScopedStateKey, () => void>>;
+
+/**
+ * Invokes the empty-array setters for every state key that should be cleared
+ * before loading `incomingModule`. The caller passes a record of
+ * setter callbacks (each clears one state array). Setters not present in the
+ * record are ignored, so callers can omit anything they don't manage.
+ */
+export function clearStaleModuleScopedState(
+  incomingModule: string | null,
+  setters: ModuleScopedStateSetters,
+): ModuleScopedStateKey[] {
+  const stale = getStaleModuleScopedKeys(incomingModule);
+  const cleared: ModuleScopedStateKey[] = [];
+  for (const key of stale) {
+    const fn = setters[key];
+    if (fn) {
+      fn();
+      cleared.push(key);
+    }
+  }
+  return cleared;
+}

--- a/utils/moduleScopedState.ts
+++ b/utils/moduleScopedState.ts
@@ -42,8 +42,9 @@ export const ALL_MODULE_SCOPED_KEYS: readonly ModuleScopedStateKey[] = [
 ];
 
 // Per-module: which state keys are loaded/owned by that module.
-// If a module doesn't appear here, no module-scoped state is associated
-// with it (e.g. reports, settings, administration is users-only).
+// Modules present with an empty array (e.g. reports, settings) own no
+// module-scoped state — entering them stales every leftover key.
+// A module not listed here returns no stale keys (defensive default).
 const MODULE_OWNED_KEYS: Record<string, readonly ModuleScopedStateKey[]> = {
   timesheets: ['entries', 'clients', 'projects', 'projectTasks', 'users'],
   hr: ['users', 'workUnits', 'clients', 'projects', 'projectTasks'],
@@ -84,6 +85,31 @@ export function getStaleModuleScopedKeys(incomingModule: string | null): ModuleS
 }
 
 export type ModuleScopedStateSetters = Partial<Record<ModuleScopedStateKey, () => void>>;
+
+/**
+ * Returns the set of previously-visited module names whose owned state was
+ * cleared by navigating to `incomingModule`. A module is stale if it has at
+ * least one owned key that's NOT also owned by `incomingModule`. Used by
+ * App.tsx to invalidate those modules' "loaded" flag so revisiting refetches
+ * instead of showing an empty UI.
+ */
+export function getStaleModulesAfterNavigation(incomingModule: string | null): string[] {
+  if (!incomingModule) return [];
+  const incomingOwned = MODULE_OWNED_KEYS[incomingModule];
+  // Defensive: an unknown module can't be reasoned about, so report no stale
+  // modules rather than invalidate everything. Mirrors getStaleModuleScopedKeys.
+  if (!incomingOwned) return [];
+  const incomingOwnedSet = new Set<ModuleScopedStateKey>(incomingOwned);
+  const stale: string[] = [];
+  for (const [moduleName, ownedKeys] of Object.entries(MODULE_OWNED_KEYS)) {
+    if (moduleName === incomingModule) continue;
+    if (ownedKeys.length === 0) continue;
+    if (ownedKeys.some((key) => !incomingOwnedSet.has(key))) {
+      stale.push(moduleName);
+    }
+  }
+  return stale;
+}
 
 /**
  * Invokes the empty-array setters for every state key that should be cleared


### PR DESCRIPTION
## Summary

- `clearAuthScopedAppState` in `App.tsx` only fires on login/logout, so navigating between modules (e.g. `crm/clients` -> `projects/manage`) leaves arrays owned by the outgoing module in App state. If the new module doesn't fetch those arrays, they linger and can leak into the new UI through cross-module consumers.
- Adds `utils/moduleScopedState.ts` mapping each module to the state keys it owns, plus `clearStaleModuleScopedState(incomingModule, setters)` that empties the keys not owned by the incoming module.
- The data-loading effect in `App.tsx` calls the helper right before fetching new datasets (inside the existing `loadedModules.has(module)` guard), so it runs exactly once per fresh module switch.

## Test plan

- [x] `bun run lint` (i18n check + frontend + server tsc + biome) green
- [x] `bun run test` (frontend 861/0, server 1997/0) green
- [x] `bunx tsc --noEmit` from repo root + `server/` green
- [x] New unit tests in `test/utils/moduleScopedState.test.ts` cover: unknown/null module no-op, modules that own no state stale everything, CRM/projects/catalog stale sets, helper invokes only stale setters, helper returns cleared keys, missing setters handled gracefully.

https://claude.ai/code/session_01RYnzgoB4TeCHNUcqbvZvQT

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYnzgoB4TeCHNUcqbvZvQT)_