### PR TITLE
fix(ldap): auto-provision users on first LDAP login (#305)

### DIFF
--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -91,30 +91,57 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         return badRequest(reply, passwordResult.message);
       }
 
-      const user = await usersRepo.findLoginUserByUsername(usernameResult.value);
+      let user = await usersRepo.findLoginUserByUsername(usernameResult.value);
+
+      let ldapAuthSuccess = false;
+      let autoProvisioned = false;
 
       if (!user) {
-        return reply.code(401).send({ error: 'Invalid username or password' });
+        // No local row yet — give LDAP a chance to authenticate and auto-provision the user
+        // on first login. Silently no-ops when LDAP is disabled.
+        try {
+          const ldapService = (await import('../services/ldap.ts')).default;
+          const provision = await ldapService.authenticateAndProvision(
+            usernameResult.value,
+            passwordResult.value,
+          );
+          if (provision.authenticated && provision.userId) {
+            user = await usersRepo.findLoginUserByUsername(usernameResult.value);
+            ldapAuthSuccess = true;
+            autoProvisioned = !!provision.created;
+          }
+        } catch (err) {
+          const errorMessage = err instanceof Error ? err.message : 'Unknown error';
+          fastify.log.warn(
+            { username: usernameResult.value, errorMessage },
+            'LDAP auto-provision attempt failed',
+          );
+        }
+
+        if (!user) {
+          return reply.code(401).send({ error: 'Invalid username or password' });
+        }
       }
 
       if (user.isDisabled) {
         return reply.code(401).send({ error: 'Invalid username or password' });
       }
 
-      // LDAP Authentication
-      let ldapAuthSuccess = false;
-      try {
-        const ldapService = (await import('../services/ldap.ts')).default;
-        ldapAuthSuccess = await ldapService.authenticate(
-          usernameResult.value,
-          passwordResult.value,
-        );
-      } catch (err) {
-        const errorMessage = err instanceof Error ? err.message : 'Unknown error';
-        fastify.log.warn(
-          { username: usernameResult.value, errorMessage },
-          'LDAP auth attempt failed; falling back to local password validation',
-        );
+      // LDAP Authentication for existing users (auto-provisioned users already authenticated above)
+      if (!ldapAuthSuccess) {
+        try {
+          const ldapService = (await import('../services/ldap.ts')).default;
+          ldapAuthSuccess = await ldapService.authenticate(
+            usernameResult.value,
+            passwordResult.value,
+          );
+        } catch (err) {
+          const errorMessage = err instanceof Error ? err.message : 'Unknown error';
+          fastify.log.warn(
+            { username: usernameResult.value, errorMessage },
+            'LDAP auth attempt failed; falling back to local password validation',
+          );
+        }
       }
 
       let validPassword = false;
@@ -130,6 +157,20 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
 
       const token = generateToken(user.id, Date.now(), user.role);
       const permissions = await getRolePermissions(user.role);
+
+      if (autoProvisioned) {
+        await logAudit({
+          request,
+          action: 'user.created',
+          entityType: 'user',
+          entityId: user.id,
+          details: {
+            targetLabel: user.name,
+            secondaryLabel: user.username,
+          },
+          userId: user.id,
+        });
+      }
 
       await logAudit({
         request,

--- a/server/services/ldap.ts
+++ b/server/services/ldap.ts
@@ -43,6 +43,16 @@ interface LdapSearchEntry {
   object: Record<string, unknown>;
 }
 
+const flattenAttr = (value: unknown): string | undefined => {
+  if (Array.isArray(value)) return typeof value[0] === 'string' ? value[0] : undefined;
+  return typeof value === 'string' ? value : undefined;
+};
+
+const pickDisplayName = (entry: Record<string, unknown> | undefined): string | undefined => {
+  if (!entry) return undefined;
+  return flattenAttr(entry.cn) ?? flattenAttr(entry.displayName);
+};
+
 class LDAPService {
   config: ldapRepo.LdapConfig | null;
 
@@ -100,19 +110,27 @@ class LDAPService {
   }
 
   async authenticate(username: string, password: string): Promise<boolean> {
+    const result = await this.authenticateWithProfile(username, password);
+    return result.authenticated;
+  }
+
+  async authenticateWithProfile(
+    username: string,
+    password: string,
+  ): Promise<{ authenticated: boolean; userDn?: string; entry?: Record<string, unknown> }> {
     let client: LdapClient | null = null;
     try {
       client = await this.getClient();
       if (!client) {
-        return false;
+        return { authenticated: false };
       }
       const ldapClient = client;
       const config = this.config;
       if (!config) {
-        return false;
+        return { authenticated: false };
       }
 
-      // Bind with service account first to find the user's DN
+      // Service-account bind to look up the user's DN, then re-bind as the user to verify creds.
       await new Promise<void>((resolve, reject) => {
         ldapClient.bind(config.bindDn, config.bindPassword, (err) => {
           if (err) reject(err);
@@ -120,26 +138,22 @@ class LDAPService {
         });
       });
 
-      // Find user DN
-      const userDn = await this.findUserDn(ldapClient, username);
-      if (!userDn) {
-        return false;
+      const userEntry = await this.findUserEntry(ldapClient, username);
+      if (!userEntry) {
+        return { authenticated: false };
       }
 
-      // Try to bind as the user
-      // We need a new client for this to verify credentials safely without messing up the service connection state
-      // or we can just re-bind. Re-binding on the same client is standard.
       await new Promise<void>((resolve, reject) => {
-        ldapClient.bind(userDn, password, (err) => {
+        ldapClient.bind(userEntry.dn, password, (err) => {
           if (err) reject(err);
           else resolve();
         });
       });
 
-      return true;
+      return { authenticated: true, userDn: userEntry.dn, entry: userEntry.object };
     } catch (err) {
       logger.error({ err: serializeError(err), username }, 'LDAP auth error');
-      return false;
+      return { authenticated: false };
     } finally {
       if (client) {
         client.unbind((err) => {
@@ -151,7 +165,58 @@ class LDAPService {
     }
   }
 
+  // Authenticate against LDAP and, on success, ensure a local user row exists. Returns the
+  // local userId only when authentication succeeded; the caller then re-fetches the row.
+  async authenticateAndProvision(
+    username: string,
+    password: string,
+  ): Promise<{ authenticated: boolean; userId?: string; created?: boolean }> {
+    const result = await this.authenticateWithProfile(username, password);
+    if (!result.authenticated) {
+      return { authenticated: false };
+    }
+
+    const existing = await usersRepo.findLoginUserByUsername(username);
+    if (existing) {
+      return { authenticated: true, userId: existing.id, created: false };
+    }
+
+    const name = pickDisplayName(result.entry) ?? username;
+    const id = generatePrefixedId('u');
+    try {
+      await usersRepo.createUser({
+        id,
+        name,
+        username,
+        passwordHash: usersRepo.LDAP_PLACEHOLDER_PASSWORD_HASH,
+        role: 'user',
+        avatarInitials: computeAvatarInitials(name),
+      });
+      logger.info({ username, userId: id }, 'LDAP auto-provisioned new user on first login');
+      return { authenticated: true, userId: id, created: true };
+    } catch (err) {
+      // Race: a concurrent login may have just created the row. Re-fetch and reuse it.
+      const racedExisting = await usersRepo.findLoginUserByUsername(username);
+      if (racedExisting) {
+        return { authenticated: true, userId: racedExisting.id, created: false };
+      }
+      logger.error(
+        { err: serializeError(err), username },
+        'Failed to auto-provision LDAP user on first login',
+      );
+      return { authenticated: false };
+    }
+  }
+
   async findUserDn(client: LdapClient, username: string): Promise<string | null> {
+    const entry = await this.findUserEntry(client, username);
+    return entry?.dn ?? null;
+  }
+
+  async findUserEntry(
+    client: LdapClient,
+    username: string,
+  ): Promise<{ dn: string; object: Record<string, unknown> } | null> {
     const config = this.config;
     if (!config) {
       return null;
@@ -159,16 +224,17 @@ class LDAPService {
     const searchOptions = {
       scope: 'sub',
       filter: buildUserLookupFilter(config.userFilter, username),
+      attributes: ['uid', 'cn', 'sn', 'givenName', 'mail', 'displayName', 'sAMAccountName'],
     };
 
     return new Promise((resolve, reject) => {
       client.search(config.baseDn, searchOptions, (err, res) => {
         if (err) return reject(err);
 
-        let foundDn: string | null = null;
+        let found: { dn: string; object: Record<string, unknown> } | null = null;
 
         res.on('searchEntry', (entry: LdapSearchEntry) => {
-          foundDn = entry.objectName;
+          found = { dn: entry.objectName, object: entry.object ?? {} };
         });
 
         res.on('error', (err: Error) => {
@@ -179,7 +245,7 @@ class LDAPService {
           if (result.status !== 0) {
             reject(new Error('LDAP search failed status: ' + result.status));
           } else {
-            resolve(foundDn);
+            resolve(found);
           }
         });
       });
@@ -246,27 +312,15 @@ class LDAPService {
       let createdCount = 0;
 
       for (const entry of entries) {
-        let username = entry.uid;
-        if (Array.isArray(username)) username = username[0];
-
-        // Fallback for AD, where the username attribute is sAMAccountName rather than uid.
-        if (!username && entry.sAMAccountName) {
-          username = entry.sAMAccountName;
-          if (Array.isArray(username)) username = username[0];
-        }
+        // Fall back to sAMAccountName when uid is missing (AD path).
+        const username = flattenAttr(entry.uid) ?? flattenAttr(entry.sAMAccountName);
 
         if (!username) {
           logger.warn('Skipping LDAP entry without username');
           continue;
         }
 
-        const nameValue: string | string[] | undefined = entry.cn || entry.displayName;
-        let name: string;
-        if (nameValue) {
-          name = Array.isArray(nameValue) ? nameValue[0] : nameValue;
-        } else {
-          name = username;
-        }
+        const name = pickDisplayName(entry as Record<string, unknown>) ?? username;
 
         const existing = await usersRepo.findLoginUserByUsername(username);
 

--- a/server/test/routes/auth.test.ts
+++ b/server/test/routes/auth.test.ts
@@ -36,6 +36,7 @@ const logAuditMock = mock(async () => undefined);
 // External: bcryptjs.compare and the LDAP service (dynamically imported by /login)
 const bcryptCompareMock = mock();
 const ldapAuthenticateMock = mock();
+const ldapAuthenticateAndProvisionMock = mock();
 
 let authRoutePlugin: FastifyPluginAsync;
 
@@ -64,7 +65,10 @@ beforeAll(async () => {
     compare: bcryptCompareMock,
   }));
   mock.module('../../services/ldap.ts', () => ({
-    default: { authenticate: ldapAuthenticateMock },
+    default: {
+      authenticate: ldapAuthenticateMock,
+      authenticateAndProvision: ldapAuthenticateAndProvisionMock,
+    },
   }));
 
   authRoutePlugin = (await import('../../routes/auth.ts')).default as FastifyPluginAsync;
@@ -110,6 +114,7 @@ const allMocks = [
   logAuditMock,
   bcryptCompareMock,
   ldapAuthenticateMock,
+  ldapAuthenticateAndProvisionMock,
 ];
 
 let testApp: FastifyInstance;
@@ -126,6 +131,7 @@ beforeEach(async () => {
 
   // Defaults for /login: LDAP off (returns false), bcrypt fails by default
   ldapAuthenticateMock.mockResolvedValue(false);
+  ldapAuthenticateAndProvisionMock.mockResolvedValue({ authenticated: false });
   bcryptCompareMock.mockResolvedValue(false);
 
   testApp = await buildRouteTestApp(authRoutePlugin, '/api/auth');
@@ -246,8 +252,83 @@ describe('POST /api/auth/login', () => {
     ]);
   });
 
-  test('401 user not found', async () => {
+  test('401 user not found and LDAP disabled/auth fails', async () => {
     findLoginUserByUsernameMock.mockResolvedValue(null);
+    ldapAuthenticateAndProvisionMock.mockResolvedValue({ authenticated: false });
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/auth/login',
+      payload: { username: 'ghost', password: 'whatever' },
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Invalid username or password' });
+    expect(logAuditMock).not.toHaveBeenCalled();
+    expect(ldapAuthenticateAndProvisionMock).toHaveBeenCalledWith('ghost', 'whatever');
+  });
+
+  test('200: user not found triggers LDAP auto-provision; subsequent fetch returns the new user', async () => {
+    const NEW_LDAP_USER = {
+      id: 'u_new',
+      name: 'New LDAP User',
+      username: 'newldap',
+      role: 'user',
+      avatarInitials: 'NL',
+      isDisabled: false,
+      passwordHash: '$2a$10$invalidpasswordhashforldapuser00000000000000',
+    };
+    findLoginUserByUsernameMock
+      .mockResolvedValueOnce(null) // initial lookup → triggers provisioning
+      .mockResolvedValueOnce(NEW_LDAP_USER); // post-provision re-fetch
+    ldapAuthenticateAndProvisionMock.mockResolvedValue({
+      authenticated: true,
+      userId: 'u_new',
+      created: true,
+    });
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/auth/login',
+      payload: { username: 'newldap', password: 'pw' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.user).toMatchObject({
+      id: 'u_new',
+      username: 'newldap',
+      role: 'user',
+    });
+
+    // The auto-provision path must not double-authenticate via authenticate()
+    expect(ldapAuthenticateMock).not.toHaveBeenCalled();
+    // bcrypt must NOT have been called — the LDAP placeholder hash must never match a real password
+    expect(bcryptCompareMock).not.toHaveBeenCalled();
+
+    // Both user.created and user.login audits must fire, in that order
+    expect(logAuditMock).toHaveBeenCalledTimes(2);
+    expect(logAuditMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        action: 'user.created',
+        entityType: 'user',
+        entityId: 'u_new',
+      }),
+    );
+    expect(logAuditMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        action: 'user.login',
+        entityType: 'user',
+        entityId: 'u_new',
+      }),
+    );
+  });
+
+  test('401: user not found and LDAP auto-provision throws → handler returns 401, not 500', async () => {
+    findLoginUserByUsernameMock.mockResolvedValue(null);
+    ldapAuthenticateAndProvisionMock.mockRejectedValue(new Error('LDAP server down'));
 
     const res = await testApp.inject({
       method: 'POST',

--- a/server/test/services/ldap.test.ts
+++ b/server/test/services/ldap.test.ts
@@ -589,3 +589,135 @@ describe('syncUsers', () => {
     expect(lastClientStats?.unbindCalls).toBe(1);
   });
 });
+
+describe('authenticateAndProvision', () => {
+  test('returns authenticated:false when LDAP is disabled', async () => {
+    ldapRepoGetMock.mockResolvedValue({ ...ENABLED_LDAP_CONFIG, enabled: false });
+    const result = await ldapService.authenticateAndProvision('alice', 'pw');
+    expect(result).toEqual({ authenticated: false });
+    expect(createUserMock).not.toHaveBeenCalled();
+  });
+
+  test('returns authenticated:false when LDAP credentials are rejected', async () => {
+    nextFixture = {
+      bindResponses: [null, new Error('wrong password')],
+      searchResponses: [
+        {
+          entries: [{ objectName: 'uid=alice,dc=test,dc=com', object: { uid: 'alice' } }],
+          status: 0,
+        },
+      ],
+    };
+    findLoginUserByUsernameMock.mockResolvedValue(null);
+    const result = await ldapService.authenticateAndProvision('alice', 'pw');
+    expect(result.authenticated).toBe(false);
+    expect(createUserMock).not.toHaveBeenCalled();
+  });
+
+  test('returns existing userId without creating when local row already exists', async () => {
+    nextFixture = {
+      bindResponses: [null, null],
+      searchResponses: [
+        {
+          entries: [
+            { objectName: 'uid=alice,dc=test,dc=com', object: { uid: 'alice', cn: 'Alice' } },
+          ],
+          status: 0,
+        },
+      ],
+    };
+    findLoginUserByUsernameMock.mockResolvedValue({ id: 'u-existing' });
+    const result = await ldapService.authenticateAndProvision('alice', 'pw');
+    expect(result).toEqual({ authenticated: true, userId: 'u-existing', created: false });
+    expect(createUserMock).not.toHaveBeenCalled();
+  });
+
+  test('auto-provisions a new user on first successful LDAP login using cn for the name', async () => {
+    nextFixture = {
+      bindResponses: [null, null],
+      searchResponses: [
+        {
+          entries: [
+            {
+              objectName: 'uid=alice,dc=test,dc=com',
+              object: { uid: 'alice', cn: 'Alice Wonderland' },
+            },
+          ],
+          status: 0,
+        },
+      ],
+    };
+    findLoginUserByUsernameMock.mockResolvedValue(null);
+    const result = await ldapService.authenticateAndProvision('alice', 'pw');
+    expect(result).toEqual({ authenticated: true, userId: 'u_test_id', created: true });
+    expect(createUserMock).toHaveBeenCalledWith({
+      id: 'u_test_id',
+      name: 'Alice Wonderland',
+      username: 'alice',
+      passwordHash: realUsersRepo.LDAP_PLACEHOLDER_PASSWORD_HASH,
+      role: 'user',
+      avatarInitials: 'AL',
+    });
+  });
+
+  test('falls back to displayName, then to the typed username, when cn is missing', async () => {
+    nextFixture = {
+      bindResponses: [null, null],
+      searchResponses: [
+        {
+          entries: [
+            {
+              objectName: 'uid=bob,dc=test,dc=com',
+              object: { uid: 'bob', displayName: ['Bobby D'] },
+            },
+          ],
+          status: 0,
+        },
+      ],
+    };
+    findLoginUserByUsernameMock.mockResolvedValue(null);
+    await ldapService.authenticateAndProvision('bob', 'pw');
+    expect(createUserMock).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Bobby D', username: 'bob' }),
+    );
+
+    createUserMock.mockReset();
+    findLoginUserByUsernameMock.mockResolvedValue(null);
+    nextFixture = {
+      bindResponses: [null, null],
+      searchResponses: [
+        {
+          entries: [{ objectName: 'uid=carol,dc=test,dc=com', object: { uid: 'carol' } }],
+          status: 0,
+        },
+      ],
+    };
+    await ldapService.authenticateAndProvision('carol', 'pw');
+    expect(createUserMock).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'carol', username: 'carol' }),
+    );
+  });
+
+  test('on duplicate-key race during create, re-fetches the existing row and reports created:false', async () => {
+    nextFixture = {
+      bindResponses: [null, null],
+      searchResponses: [
+        {
+          entries: [
+            { objectName: 'uid=alice,dc=test,dc=com', object: { uid: 'alice', cn: 'Alice' } },
+          ],
+          status: 0,
+        },
+      ],
+    };
+    // First call (existing lookup): not found → triggers create attempt.
+    // createUser fails (unique violation). Second findLoginUserByUsername returns the raced row.
+    findLoginUserByUsernameMock
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ id: 'u-raced' });
+    createUserMock.mockRejectedValueOnce(new Error('duplicate key value violates unique'));
+
+    const result = await ldapService.authenticateAndProvision('alice', 'pw');
+    expect(result).toEqual({ authenticated: true, userId: 'u-raced', created: false });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #305 — LDAP-authenticated users couldn't log in for the first time because `/login` required a pre-existing local row before any authentication ran. Now first-time LDAP logins auto-provision the local user.

- New `LDAPService.authenticateAndProvision(username, password)` helper mirrors the `syncUsers` pattern: bind-as-service, look up the user entry (now also pulling `cn`/`displayName`), re-bind as the user, and on success insert a row with `LDAP_PLACEHOLDER_PASSWORD_HASH` so bcrypt can never match. Handles the unique-username race by re-fetching when `createUser` throws.
- `/login` now calls `authenticateAndProvision` when `findLoginUserByUsername` returns null, re-fetches the new row, and emits a `user.created` audit alongside the usual `user.login` audit when provisioning fires.
- Refactored `syncUsers` to use the new `flattenAttr`/`pickDisplayName` helpers, removing duplicated attribute-flattening logic.

## Test plan

- [x] `bun run test:server` — 1106 pass (added 5 cases for `authenticateAndProvision` + 2 cases for the route's provisioning path)
- [x] `bun run test` — full suite green
- [x] `bun run lint` — clean (pre-existing warnings only, no new ones in touched files)
- [ ] In-browser e2e skipped: no LDAP server reachable from this sandbox. Standard verification for this code is the `ldapjs.createClient` mock harness, which is exercised by the new tests.

https://claude.ai/code/session_01WTmCkNUSMtL2uHWf3XPx6g

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTmCkNUSMtL2uHWf3XPx6g)_