### PR TITLE
fix(ldap): apply role mapping when changing auth method to LDAP (#306)

### DIFF
--- a/docs-site/src/content/docs/administration.md
+++ b/docs-site/src/content/docs/administration.md
@@ -19,6 +19,8 @@ Praetor supporta autenticazione locale e integrazioni aziendali come LDAP o SSO 
 
 Nella lista utenti puoi usare il menu azioni e scegliere **Cambia metodo di autenticazione** per vincolare un utente applicativo a credenziali locali, LDAP, OIDC o SAML. Per OIDC e SAML seleziona anche il provider specifico: l'utente potrà accedere solo tramite quel provider. Dipendenti interni o esterni non sono account applicativi e non possono essere vincolati a LDAP/SSO.
 
+Quando vincoli un utente a LDAP, Praetor consulta la directory e applica subito i ruoli configurati nel mapping dei gruppi LDAP, sovrascrivendo il ruolo locale. Se la directory non è raggiungibile o l'utente non vi è presente, il ruolo esistente viene mantenuto e il prossimo accesso o sincronizzazione riapplicherà il mapping.
+
 La sincronizzazione LDAP aggiorna solo utenti applicativi già impostati su LDAP. Un utente locale con lo stesso username resta locale finché un amministratore non cambia esplicitamente il suo metodo di autenticazione.
 
 Se un utente non riesce ad accedere, controlla credenziali, stato dell'utente, ruolo assegnato e log di autenticazione.

--- a/docs-site/src/content/docs/en/administration.md
+++ b/docs-site/src/content/docs/en/administration.md
@@ -19,6 +19,8 @@ Praetor supports local authentication and company integrations such as LDAP or S
 
 In the user list, open the row actions menu and choose **Change authentication method** to restrict an application user to local credentials, LDAP, OIDC, or SAML. For OIDC and SAML, also select the specific provider: the user will be able to sign in only through that provider. Internal and external employees are not application accounts and cannot be bound to LDAP/SSO.
 
+When you bind a user to LDAP, Praetor looks them up in the directory and immediately applies the roles configured in the LDAP group role mapping, overriding the local role. If the directory is unreachable or the user is not in it yet, the existing role is kept and the next login or sync will re-apply the mapping.
+
 LDAP synchronization updates only application users that are already set to LDAP. A local user with the same username remains local until an administrator explicitly changes their authentication method.
 
 If a user cannot sign in, check credentials, user status, assigned role, and authentication logs.

--- a/server/routes/users.ts
+++ b/server/routes/users.ts
@@ -16,6 +16,7 @@ import {
   standardErrorResponses,
   standardRateLimitedErrorResponses,
 } from '../schemas/common.ts';
+import { applyExternalRolesForUser } from '../services/external-auth.ts';
 import { getAuditChangedFields, getAuditCounts, logAudit } from '../utils/audit.ts';
 import { assertAuthenticated } from '../utils/auth-assert.ts';
 import { getUniqueViolation } from '../utils/db-errors.ts';
@@ -847,6 +848,25 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       );
       if (!updated) return reply.code(404).send({ error: 'User not found' });
 
+      let mappedRoleIds: string[] | null = null;
+      if (methodResult.value === 'ldap') {
+        const ldapService = (await import('../services/ldap.ts')).default;
+        const lookup = await ldapService.lookupUserGroups(updated.username);
+        if (lookup) {
+          mappedRoleIds = await applyExternalRolesForUser(
+            updated.id,
+            lookup.groups,
+            lookup.roleMappings,
+          );
+          updated.role = mappedRoleIds[0];
+        } else {
+          fastify.log.warn(
+            { userId: updated.id, username: updated.username },
+            'LDAP role mapping skipped: directory lookup unavailable or user not found',
+          );
+        }
+      }
+
       await logAudit({
         request,
         action: 'user.auth_method_changed',
@@ -857,6 +877,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           secondaryLabel: updated.username,
           fromValue: targetUser.authMethod,
           toValue: methodResult.value,
+          ...(mappedRoleIds ? { roleIds: mappedRoleIds } : {}),
         },
       });
 

--- a/server/services/ldap.ts
+++ b/server/services/ldap.ts
@@ -228,7 +228,12 @@ class LDAPService {
         return null;
       }
 
-      const groups = await this.findUserGroups(ldapClient, userDn, username);
+      // Use throwOnError so a transient group-search failure surfaces here as null
+      // (keep existing role) instead of falling through to applyExternalRolesForUser with
+      // an empty group list, which would demote the user to the default 'user' role.
+      const groups = await this.findUserGroups(ldapClient, userDn, username, {
+        throwOnError: true,
+      });
       return { groups, roleMappings: this.getRoleMappings() };
     } catch (err) {
       logger.warn({ err: serializeError(err), username }, 'LDAP user lookup failed');
@@ -280,7 +285,12 @@ class LDAPService {
     });
   }
 
-  async findUserGroups(client: LdapClient, userDn: string, username: string): Promise<string[]> {
+  async findUserGroups(
+    client: LdapClient,
+    userDn: string,
+    username: string,
+    options: { throwOnError?: boolean } = {},
+  ): Promise<string[]> {
     const config = this.config;
     if (!config?.groupBaseDn || !config.groupFilter) {
       return [];
@@ -303,6 +313,7 @@ class LDAPService {
           attributes: ['cn', 'dn', 'distinguishedName'],
         };
       } catch (err) {
+        if (options.throwOnError) throw err;
         logger.warn(
           { err: serializeError(err), username },
           'LDAP group filter is invalid; skipping group role mapping',
@@ -333,6 +344,7 @@ class LDAPService {
           });
         });
       } catch (err) {
+        if (options.throwOnError) throw err;
         logger.warn(
           { err: serializeError(err), username },
           'LDAP group lookup failed; skipping group role mapping',

--- a/server/services/ldap.ts
+++ b/server/services/ldap.ts
@@ -201,6 +201,49 @@ class LDAPService {
     return result.authenticated;
   }
 
+  async lookupUserGroups(
+    username: string,
+  ): Promise<{ groups: string[]; roleMappings: ExternalRoleMapping[] } | null> {
+    let client: LdapClient | null = null;
+    try {
+      client = await this.getClient();
+      if (!client) {
+        return null;
+      }
+      const ldapClient = client;
+      const config = this.config;
+      if (!config) {
+        return null;
+      }
+
+      await new Promise<void>((resolve, reject) => {
+        ldapClient.bind(config.bindDn, config.bindPassword, (err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      });
+
+      const userDn = await this.findUserDn(ldapClient, username);
+      if (!userDn) {
+        return null;
+      }
+
+      const groups = await this.findUserGroups(ldapClient, userDn, username);
+      return { groups, roleMappings: this.getRoleMappings() };
+    } catch (err) {
+      logger.warn({ err: serializeError(err), username }, 'LDAP user lookup failed');
+      return null;
+    } finally {
+      if (client) {
+        client.unbind((err) => {
+          if (err) {
+            logger.warn({ err: serializeError(err) }, 'Error unbinding LDAP client');
+          }
+        });
+      }
+    }
+  }
+
   async findUserDn(client: LdapClient, username: string): Promise<string | null> {
     const config = this.config;
     if (!config) {

--- a/server/test/routes/users.test.ts
+++ b/server/test/routes/users.test.ts
@@ -9,6 +9,8 @@ import * as realSsoProvidersRepo from '../../repositories/ssoProvidersRepo.ts';
 import * as realTasksRepo from '../../repositories/tasksRepo.ts';
 import * as realUserAssignmentsRepo from '../../repositories/userAssignmentsRepo.ts';
 import * as realUsersRepo from '../../repositories/usersRepo.ts';
+import * as realExternalAuth from '../../services/external-auth.ts';
+import realLdapService from '../../services/ldap.ts';
 import * as realAudit from '../../utils/audit.ts';
 import * as realPermissions from '../../utils/permissions.ts';
 import {
@@ -26,6 +28,8 @@ const rolesRepoSnap = { ...realRolesRepo };
 const settingsRepoSnap = { ...realSettingsRepo };
 const ssoProvidersRepoSnap = { ...realSsoProvidersRepo };
 const userAssignmentsRepoSnap = { ...realUserAssignmentsRepo };
+const externalAuthSnap = { ...realExternalAuth };
+const ldapServiceSnap = realLdapService;
 const permissionsSnap = { ...realPermissions };
 const auditSnap = { ...realAudit };
 const drizzleSnap = { ...realDrizzle };
@@ -80,6 +84,10 @@ const applyProjectCascadeToClientsMock = mock();
 const filterAssignedClientIdsMock = mock();
 const filterAssignedProjectIdsMock = mock();
 const filterAssignedTaskIdsMock = mock();
+
+// LDAP / external-auth
+const ldapLookupUserGroupsMock = mock();
+const applyExternalRolesForUserMock = mock();
 
 // audit / drizzle
 const logAuditMock = mock(async () => undefined);
@@ -162,6 +170,15 @@ beforeAll(async () => {
     ...drizzleSnap,
     withDbTransaction: withDbTransactionMock,
   }));
+  mock.module('../../services/external-auth.ts', () => ({
+    ...externalAuthSnap,
+    applyExternalRolesForUser: applyExternalRolesForUserMock,
+  }));
+  mock.module('../../services/ldap.ts', () => ({
+    default: {
+      lookupUserGroups: ldapLookupUserGroupsMock,
+    },
+  }));
 
   routePlugin = (await import('../../routes/users.ts')).default as FastifyPluginAsync;
 });
@@ -179,6 +196,8 @@ afterAll(() => {
   mock.module('../../utils/permissions.ts', () => permissionsSnap);
   mock.module('../../utils/audit.ts', () => auditSnap);
   mock.module('../../db/drizzle.ts', () => drizzleSnap);
+  mock.module('../../services/external-auth.ts', () => externalAuthSnap);
+  mock.module('../../services/ldap.ts', () => ({ default: ldapServiceSnap }));
 });
 
 const ADMIN_USER = {
@@ -298,6 +317,8 @@ const allMocks = [
   filterAssignedClientIdsMock,
   filterAssignedProjectIdsMock,
   filterAssignedTaskIdsMock,
+  ldapLookupUserGroupsMock,
+  applyExternalRolesForUserMock,
   logAuditMock,
   withDbTransactionMock,
 ];
@@ -321,6 +342,10 @@ beforeEach(async () => {
   listProjectsForUserMock.mockResolvedValue([]);
   listProjectsByIdsMock.mockResolvedValue([]);
   listTasksForUserMock.mockResolvedValue([]);
+
+  // Default: LDAP unreachable / disabled — route falls back to existing role.
+  ldapLookupUserGroupsMock.mockResolvedValue(null);
+  applyExternalRolesForUserMock.mockResolvedValue(['user']);
 
   testApp = await buildRouteTestApp(routePlugin, '/api/users');
 });
@@ -925,9 +950,18 @@ describe('PUT /api/users/:id', () => {
 // =========================================================================
 
 describe('PUT /api/users/:id/auth-method', () => {
-  test('200 changes app user to LDAP', async () => {
+  test('200 changes app user to LDAP and applies role mapping from directory groups', async () => {
     findCoreByIdMock.mockResolvedValue(SAMPLE_USER_CORE);
-    updateAuthMethodMock.mockResolvedValue({ ...SAMPLE_USER_ROW, authMethod: 'ldap' });
+    updateAuthMethodMock.mockResolvedValue({
+      ...SAMPLE_USER_ROW,
+      authMethod: 'ldap',
+      role: 'user',
+    });
+    ldapLookupUserGroupsMock.mockResolvedValue({
+      groups: ['cn=managers,ou=groups,dc=test,dc=com'],
+      roleMappings: [{ externalGroup: 'managers', role: 'manager' }],
+    });
+    applyExternalRolesForUserMock.mockResolvedValue(['manager']);
 
     const res = await testApp.inject({
       method: 'PUT',
@@ -938,7 +972,84 @@ describe('PUT /api/users/:id/auth-method', () => {
 
     expect(res.statusCode).toBe(200);
     expect(updateAuthMethodMock).toHaveBeenCalledWith('u-target', 'ldap', null);
-    expect(JSON.parse(res.body).authMethod).toBe('ldap');
+    expect(ldapLookupUserGroupsMock).toHaveBeenCalledWith('target');
+    expect(applyExternalRolesForUserMock).toHaveBeenCalledWith(
+      'u-target',
+      ['cn=managers,ou=groups,dc=test,dc=com'],
+      [{ externalGroup: 'managers', role: 'manager' }],
+    );
+    const body = JSON.parse(res.body);
+    expect(body.authMethod).toBe('ldap');
+    expect(body.role).toBe('manager');
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'user.auth_method_changed',
+        details: expect.objectContaining({ roleIds: ['manager'] }),
+      }),
+    );
+  });
+
+  test('200 changes app user to LDAP with no matching mapping → role becomes "user"', async () => {
+    findCoreByIdMock.mockResolvedValue({ ...SAMPLE_USER_CORE, role: 'manager' });
+    updateAuthMethodMock.mockResolvedValue({
+      ...SAMPLE_USER_ROW,
+      authMethod: 'ldap',
+      role: 'manager',
+    });
+    ldapLookupUserGroupsMock.mockResolvedValue({
+      groups: ['cn=unrelated,ou=groups,dc=test,dc=com'],
+      roleMappings: [{ externalGroup: 'managers', role: 'manager' }],
+    });
+    applyExternalRolesForUserMock.mockResolvedValue(['user']);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/users/u-target/auth-method',
+      headers: adminAuth(),
+      payload: { authMethod: 'ldap' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(applyExternalRolesForUserMock).toHaveBeenCalled();
+    expect(JSON.parse(res.body).role).toBe('user');
+  });
+
+  test('200 changes app user to LDAP when LDAP is disabled → role unchanged, no failure', async () => {
+    findCoreByIdMock.mockResolvedValue(SAMPLE_USER_CORE);
+    updateAuthMethodMock.mockResolvedValue({
+      ...SAMPLE_USER_ROW,
+      authMethod: 'ldap',
+      role: 'manager',
+    });
+    ldapLookupUserGroupsMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/users/u-target/auth-method',
+      headers: adminAuth(),
+      payload: { authMethod: 'ldap' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(ldapLookupUserGroupsMock).toHaveBeenCalledWith('target');
+    expect(applyExternalRolesForUserMock).not.toHaveBeenCalled();
+    expect(JSON.parse(res.body).role).toBe('manager');
+  });
+
+  test('200 changes to local does not trigger any LDAP lookup', async () => {
+    findCoreByIdMock.mockResolvedValue({ ...SAMPLE_USER_CORE, authMethod: 'ldap' });
+    updateAuthMethodMock.mockResolvedValue({ ...SAMPLE_USER_ROW, authMethod: 'local' });
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/users/u-target/auth-method',
+      headers: adminAuth(),
+      payload: { authMethod: 'local' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(ldapLookupUserGroupsMock).not.toHaveBeenCalled();
+    expect(applyExternalRolesForUserMock).not.toHaveBeenCalled();
   });
 
   test('200 changes app user to OIDC with enabled matching provider', async () => {

--- a/server/test/services/ldap.test.ts
+++ b/server/test/services/ldap.test.ts
@@ -683,3 +683,81 @@ describe('syncUsers', () => {
     expect(lastClientStats?.unbindCalls).toBe(1);
   });
 });
+
+describe('lookupUserGroups', () => {
+  test('returns null when LDAP is disabled', async () => {
+    ldapRepoGetMock.mockResolvedValue({ ...ENABLED_LDAP_CONFIG, enabled: false });
+    const result = await ldapService.lookupUserGroups('alice');
+    expect(result).toBeNull();
+    expect(createClientMock).not.toHaveBeenCalled();
+  });
+
+  test('returns null and logs when service-account bind fails; unbind still called', async () => {
+    nextFixture = { bindResponses: [new Error('bad bind')] };
+    const result = await ldapService.lookupUserGroups('alice');
+    expect(result).toBeNull();
+    expect(lastClientStats?.unbindCalls).toBe(1);
+  });
+
+  test('returns null when findUserDn yields no entries; unbind still called', async () => {
+    nextFixture = {
+      bindResponses: [null],
+      searchResponses: [{ entries: [], status: 0 }],
+    };
+    const result = await ldapService.lookupUserGroups('alice');
+    expect(result).toBeNull();
+    expect(lastClientStats?.unbindCalls).toBe(1);
+  });
+
+  test('returns groups and roleMappings on happy path; binds service account only', async () => {
+    ldapRepoGetMock.mockResolvedValue({
+      ...ENABLED_LDAP_CONFIG,
+      roleMappings: [{ ldapGroup: 'managers', role: 'manager' }],
+    });
+    nextFixture = {
+      bindResponses: [null],
+      searchResponses: [
+        {
+          entries: [{ objectName: 'uid=alice,dc=test,dc=com', object: {} }],
+          status: 0,
+        },
+        {
+          entries: [
+            {
+              objectName: 'cn=managers,ou=groups,dc=test,dc=com',
+              object: { cn: 'managers' },
+            },
+          ],
+          status: 0,
+        },
+      ],
+    };
+    const result = await ldapService.lookupUserGroups('alice');
+    expect(result).not.toBeNull();
+    expect(result?.groups).toContain('cn=managers,ou=groups,dc=test,dc=com');
+    expect(result?.groups).toContain('managers');
+    expect(result?.roleMappings).toEqual([{ externalGroup: 'managers', role: 'manager' }]);
+    expect(lastClientStats?.bindCalls).toEqual([
+      { dn: 'cn=admin,dc=test,dc=com', password: 'admin-pw' },
+    ]);
+    expect(lastClientStats?.unbindCalls).toBe(1);
+  });
+
+  test('returns null when group lookup throws unexpectedly; unbind still called', async () => {
+    nextFixture = {
+      bindResponses: [null],
+      searchResponses: [
+        {
+          entries: [{ objectName: 'uid=alice,dc=test,dc=com', object: {} }],
+          status: 0,
+        },
+        { err: new Error('group search failed') },
+      ],
+    };
+    const result = await ldapService.lookupUserGroups('alice');
+    // findUserGroups catches search errors and returns []; the helper still returns groups.
+    expect(result).not.toBeNull();
+    expect(result?.groups).toEqual([]);
+    expect(lastClientStats?.unbindCalls).toBe(1);
+  });
+});

--- a/server/test/services/ldap.test.ts
+++ b/server/test/services/ldap.test.ts
@@ -743,7 +743,7 @@ describe('lookupUserGroups', () => {
     expect(lastClientStats?.unbindCalls).toBe(1);
   });
 
-  test('returns null when group lookup throws unexpectedly; unbind still called', async () => {
+  test('returns null when group lookup throws; unbind still called', async () => {
     nextFixture = {
       bindResponses: [null],
       searchResponses: [
@@ -755,9 +755,10 @@ describe('lookupUserGroups', () => {
       ],
     };
     const result = await ldapService.lookupUserGroups('alice');
-    // findUserGroups catches search errors and returns []; the helper still returns groups.
-    expect(result).not.toBeNull();
-    expect(result?.groups).toEqual([]);
+    // Transient group-search failure must surface as null so the caller keeps the
+    // existing role, instead of demoting the user to the default 'user' role on an
+    // empty group list.
+    expect(result).toBeNull();
     expect(lastClientStats?.unbindCalls).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #306 — LDAP role mapping is now respected when an admin changes a user's authentication method from `local` to `ldap`.

Previously, `PUT /api/users/:id/auth-method` only updated the `authMethod` and `authProviderId` columns. The configured `roleMappings` for the user's LDAP groups were ignored, so a user kept whatever local role they had until the next scheduled LDAP sync or login.

## Changes

- **`server/services/ldap.ts`** — new `LDAPService.lookupUserGroups(username)` helper that service-binds, locates the user DN via `findUserDn`, gathers their groups via `findUserGroups`, and returns `{ groups, roleMappings }`. Returns `null` when LDAP is disabled, the user isn't in the directory, or the lookup raises (so the route never fails because of a transient directory problem).
- **`server/routes/users.ts`** — after a successful `updateAuthMethod` to `ldap`, the handler calls `lookupUserGroups` and, on success, runs `applyExternalRolesForUser` to replace `user_roles` and the primary role in a single transaction. The response and audit details reflect the new role IDs. When the lookup returns `null`, the handler logs a warning and keeps the existing role so the admin can still pre-bind users.
- **Tests**
  - `server/test/services/ldap.test.ts` — covers `lookupUserGroups`: disabled config, bind failure, missing user, happy path, and a failing group search.
  - `server/test/routes/users.test.ts` — adds cases for: mapping applied, no matching mapping falls back to `user`, LDAP disabled keeps the existing role, and changing to `local` skips the lookup entirely.
- **Docs** — `docs-site/src/content/docs/administration.md` (Italian) and `docs-site/src/content/docs/en/administration.md` (English) now describe the immediate role-mapping behavior and the keep-existing-role fallback.

## Test plan

- [x] `cd server && bun test ./test` — 2005 pass, 0 fail
- [x] `bun run test:frontend` — 849 pass, 0 fail
- [x] `bun run lint` — i18n check, typecheck, biome all clean
- [ ] In-browser e2e skipped: no LDAP server reachable from the sandbox; the mocked `ldapjs.createClient` harness is this repo's standard verification for LDAP code paths.

https://claude.ai/code/session_01WTmCkNUSMtL2uHWf3XPx6g

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTmCkNUSMtL2uHWf3XPx6g)_