### PR TITLE
fix(ldap): auto-provision users on first LDAP login (#305)

### DIFF
--- a/docs-site/src/content/docs/administration.md
+++ b/docs-site/src/content/docs/administration.md
@@ -23,6 +23,8 @@ Quando vincoli un utente a LDAP, Praetor consulta la directory e applica subito 
 
 La sincronizzazione LDAP aggiorna solo utenti applicativi già impostati su LDAP. Un utente locale con lo stesso username resta locale finché un amministratore non cambia esplicitamente il suo metodo di autenticazione.
 
+Quando LDAP è abilitato, gli utenti applicativi presenti nella directory ma non ancora in Praetor vengono creati automaticamente al primo accesso riuscito. Il nuovo account viene salvato con lo username canonico LDAP (`uid` o `sAMAccountName`) — non con il valore digitato nella schermata di login — così che le successive sincronizzazioni LDAP aggiornino sempre la stessa riga anche quando l'utente accede con un alias, ad esempio la propria email. L'utente provisionato viene vincolato all'autenticazione LDAP e riceve i ruoli derivati dai gruppi LDAP a cui appartiene.
+
 Se un utente non riesce ad accedere, controlla credenziali, stato dell'utente, ruolo assegnato e log di autenticazione.
 
 ## Impostazioni generali ed email

--- a/docs-site/src/content/docs/en/administration.md
+++ b/docs-site/src/content/docs/en/administration.md
@@ -23,6 +23,8 @@ When you bind a user to LDAP, Praetor looks them up in the directory and immedia
 
 LDAP synchronization updates only application users that are already set to LDAP. A local user with the same username remains local until an administrator explicitly changes their authentication method.
 
+When LDAP is enabled, application users that exist in the directory but not yet in Praetor are auto-provisioned on their first successful login. The new account is created with the canonical LDAP username (`uid` or `sAMAccountName`) — not the value typed at the login form — so that subsequent LDAP synchronizations key the same row even when the user signs in with an alias such as their email address. The provisioned user is bound to LDAP authentication and receives the roles mapped from their LDAP groups.
+
 If a user cannot sign in, check credentials, user status, assigned role, and authentication logs.
 
 ## General and email settings

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -93,9 +93,31 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       }
 
       let user = await usersRepo.findLoginUserByUsername(usernameResult.value);
+      let ldapAutoProvisionSuccess = false;
+      let ldapAutoProvisioned = false;
 
       if (!user) {
-        return reply.code(401).send({ error: 'Invalid username or password' });
+        try {
+          const ldapService = (await import('../services/ldap.ts')).default;
+          const provision = await ldapService.authenticateAndProvision(
+            usernameResult.value,
+            passwordResult.value,
+          );
+          if (provision.authenticated && provision.userId) {
+            user = await usersRepo.findLoginUserById(provision.userId);
+            ldapAutoProvisionSuccess = !!user;
+            ldapAutoProvisioned = !!provision.created;
+          }
+        } catch (err) {
+          const errorMessage = err instanceof Error ? err.message : 'Unknown error';
+          fastify.log.warn(
+            { username: usernameResult.value, errorMessage },
+            'LDAP auto-provision attempt failed',
+          );
+        }
+        if (!user) {
+          return reply.code(401).send({ error: 'Invalid username or password' });
+        }
       }
 
       if (user.isDisabled || user.employeeType !== 'app_user') {
@@ -105,9 +127,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const { authMethod } = user;
 
       // LDAP Authentication
-      let ldapAuthSuccess = false;
+      let ldapAuthSuccess = ldapAutoProvisionSuccess;
       let ldapRoleIds: string[] = [];
-      if (authMethod === 'ldap') {
+      if (!ldapAuthSuccess && authMethod === 'ldap') {
         try {
           const ldapService = (await import('../services/ldap.ts')).default;
           const ldapAuthResult = await ldapService.authenticateWithProfile(
@@ -136,9 +158,23 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         return reply.code(401).send({ error: 'Invalid username or password' });
       }
 
-      if (ldapAuthSuccess) {
+      if (ldapAuthSuccess && !ldapAutoProvisionSuccess) {
         const roleIds = await applyExternalRoleIdsForUser(user.id, ldapRoleIds);
         user = { ...user, role: roleIds[0] };
+      }
+
+      if (ldapAutoProvisioned) {
+        await logAudit({
+          request,
+          action: 'user.created',
+          entityType: 'user',
+          entityId: user.id,
+          details: {
+            targetLabel: user.name,
+            secondaryLabel: user.username,
+          },
+          userId: user.id,
+        });
       }
 
       const token = generateToken(user.id, Date.now(), user.role);

--- a/server/services/external-auth.ts
+++ b/server/services/external-auth.ts
@@ -82,7 +82,7 @@ export const mapExternalGroupsToRoleIds = (
   return roleIds.length > 0 ? roleIds : [DEFAULT_ROLE_ID];
 };
 
-const filterExistingRoleIds = async (roleIds: string[]): Promise<string[]> => {
+export const filterExistingRoleIds = async (roleIds: string[]): Promise<string[]> => {
   const existing = await rolesRepo.findExistingIds(roleIds);
   const filtered = roleIds.filter((roleId) => existing.has(roleId));
   return filtered.length > 0 ? filtered : [DEFAULT_ROLE_ID];

--- a/server/services/ldap.ts
+++ b/server/services/ldap.ts
@@ -13,6 +13,7 @@ import { generatePrefixedId } from '../utils/order-ids.ts';
 import {
   applyExternalRolesForUser,
   type ExternalRoleMapping,
+  filterExistingRoleIds,
   mapExternalGroupsToRoleIds,
 } from './external-auth.ts';
 
@@ -204,7 +205,10 @@ class LDAPService {
       const userDn = userEntry.dn;
       const canonicalUsername = deriveCanonicalUsername(userEntry.attributes, username);
 
-      const groups = await this.findUserGroups(ldapClient, userDn, username);
+      // Search groups under both the canonical and typed identifiers so configs whose
+      // groupFilter expects e.g. `memberUid={0}` work even when the user typed an alias
+      // (email/UPN) that userFilter accepted.
+      const groups = await this.findUserGroups(ldapClient, userDn, [canonicalUsername, username]);
 
       // Try to bind as the user
       // We need a new client for this to verify credentials safely without messing up the service connection state
@@ -277,7 +281,13 @@ class LDAPService {
 
     const name = result.displayName ?? canonicalUsername;
     const id = generatePrefixedId('u');
-    const primaryRole = mapExternalGroupsToRoleIds(result.groups, roleMappings)[0];
+    // Filter against existing role rows so a mapping referencing a deleted role doesn't
+    // violate the users.role FK; applyExternalRolesForUser below will replace the primary
+    // role and user_roles set anyway, but the initial insert still needs a valid row.
+    const filteredRoleIds = await filterExistingRoleIds(
+      mapExternalGroupsToRoleIds(result.groups, roleMappings),
+    );
+    const primaryRole = filteredRoleIds[0];
 
     try {
       await usersRepo.createUser({
@@ -415,7 +425,7 @@ class LDAPService {
   async findUserGroups(
     client: LdapClient,
     userDn: string,
-    username: string,
+    usernames: string | string[],
     options: { throwOnError?: boolean } = {},
   ): Promise<string[]> {
     const config = this.config;
@@ -423,8 +433,12 @@ class LDAPService {
       return [];
     }
 
-    const searchValues = [userDn, username].filter((value, idx, arr) => arr.indexOf(value) === idx);
+    const usernameList = (Array.isArray(usernames) ? usernames : [usernames]).filter(Boolean);
+    const searchValues = [userDn, ...usernameList].filter(
+      (value, idx, arr) => value && arr.indexOf(value) === idx,
+    );
     const groups = new Set<string>();
+    const username = usernameList[0] ?? userDn;
 
     for (const searchValue of searchValues) {
       let searchOptions: {

--- a/server/services/ldap.ts
+++ b/server/services/ldap.ts
@@ -72,6 +72,44 @@ export type LdapAuthResult = {
   userDn?: string;
   groups: string[];
   roleIds: string[];
+  canonicalUsername?: string;
+  displayName?: string;
+};
+
+export type LdapUserEntry = {
+  dn: string;
+  attributes: Record<string, unknown>;
+};
+
+const pickFirstString = (value: unknown): string | undefined => {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      if (typeof item === 'string') {
+        const trimmed = item.trim();
+        if (trimmed.length > 0) return trimmed;
+      }
+    }
+  }
+  return undefined;
+};
+
+const deriveCanonicalUsername = (
+  attributes: Record<string, unknown>,
+  typedUsername: string,
+): string =>
+  pickFirstString(attributes.uid) ?? pickFirstString(attributes.sAMAccountName) ?? typedUsername;
+
+const deriveDisplayName = (attributes: Record<string, unknown>, fallback: string): string =>
+  pickFirstString(attributes.cn) ?? pickFirstString(attributes.displayName) ?? fallback;
+
+const isUniqueViolationError = (err: unknown): boolean => {
+  if (!err || typeof err !== 'object') return false;
+  const code = (err as { code?: unknown }).code;
+  return code === '23505';
 };
 
 class LDAPService {
@@ -158,11 +196,13 @@ class LDAPService {
         });
       });
 
-      // Find user DN
-      const userDn = await this.findUserDn(ldapClient, username);
-      if (!userDn) {
+      // Find user entry (DN + attributes for canonical username/display name)
+      const userEntry = await this.findUserEntry(ldapClient, username);
+      if (!userEntry) {
         return { authenticated: false, groups: [], roleIds: ['user'] };
       }
+      const userDn = userEntry.dn;
+      const canonicalUsername = deriveCanonicalUsername(userEntry.attributes, username);
 
       const groups = await this.findUserGroups(ldapClient, userDn, username);
 
@@ -181,6 +221,8 @@ class LDAPService {
         userDn,
         groups,
         roleIds: mapExternalGroupsToRoleIds(groups, this.getRoleMappings()),
+        canonicalUsername,
+        displayName: deriveDisplayName(userEntry.attributes, canonicalUsername),
       };
     } catch (err) {
       logger.error({ err: serializeError(err), username }, 'LDAP auth error');
@@ -194,6 +236,83 @@ class LDAPService {
         });
       }
     }
+  }
+
+  async authenticateAndProvision(
+    username: string,
+    password: string,
+  ): Promise<{
+    authenticated: boolean;
+    userId?: string;
+    created?: boolean;
+    canonicalUsername?: string;
+  }> {
+    const result = await this.authenticateWithProfile(username, password);
+    if (!result.authenticated) {
+      return { authenticated: false };
+    }
+    const canonicalUsername = result.canonicalUsername ?? username;
+    const roleMappings = this.getRoleMappings();
+
+    const existingByCanonical = await usersRepo.findLoginUserByUsername(canonicalUsername);
+    if (existingByCanonical) {
+      if (
+        existingByCanonical.employeeType !== 'app_user' ||
+        existingByCanonical.authMethod !== 'ldap'
+      ) {
+        logger.warn(
+          { username: canonicalUsername },
+          'LDAP login matched a local Praetor user not bound to LDAP; refusing auto-provision',
+        );
+        return { authenticated: false };
+      }
+      await applyExternalRolesForUser(existingByCanonical.id, result.groups, roleMappings);
+      return {
+        authenticated: true,
+        userId: existingByCanonical.id,
+        created: false,
+        canonicalUsername,
+      };
+    }
+
+    const name = result.displayName ?? canonicalUsername;
+    const id = generatePrefixedId('u');
+    const primaryRole = mapExternalGroupsToRoleIds(result.groups, roleMappings)[0];
+
+    try {
+      await usersRepo.createUser({
+        id,
+        name,
+        username: canonicalUsername,
+        passwordHash: usersRepo.EXTERNAL_PLACEHOLDER_PASSWORD_HASH,
+        role: primaryRole,
+        avatarInitials: computeAvatarInitials(name),
+        authMethod: 'ldap',
+        authProviderId: null,
+      });
+    } catch (err) {
+      if (isUniqueViolationError(err)) {
+        const racedUser = await usersRepo.findLoginUserByUsername(canonicalUsername);
+        if (racedUser && racedUser.employeeType === 'app_user' && racedUser.authMethod === 'ldap') {
+          await applyExternalRolesForUser(racedUser.id, result.groups, roleMappings);
+          return {
+            authenticated: true,
+            userId: racedUser.id,
+            created: false,
+            canonicalUsername,
+          };
+        }
+        logger.warn(
+          { username: canonicalUsername },
+          'LDAP auto-provision raced with a non-LDAP row; refusing login',
+        );
+        return { authenticated: false };
+      }
+      throw err;
+    }
+
+    await applyExternalRolesForUser(id, result.groups, roleMappings);
+    return { authenticated: true, userId: id, created: true, canonicalUsername };
   }
 
   async authenticate(username: string, password: string): Promise<boolean> {
@@ -250,6 +369,11 @@ class LDAPService {
   }
 
   async findUserDn(client: LdapClient, username: string): Promise<string | null> {
+    const entry = await this.findUserEntry(client, username);
+    return entry?.dn ?? null;
+  }
+
+  async findUserEntry(client: LdapClient, username: string): Promise<LdapUserEntry | null> {
     const config = this.config;
     if (!config) {
       return null;
@@ -257,17 +381,20 @@ class LDAPService {
     const searchOptions = {
       scope: 'sub',
       filter: buildUserLookupFilter(config.userFilter, username),
+      attributes: ['uid', 'sAMAccountName', 'cn', 'displayName'],
     };
 
     return new Promise((resolve, reject) => {
       client.search(config.baseDn, searchOptions, (err, res) => {
         if (err) return reject(err);
 
-        let foundDn: string | null = null;
+        let found: LdapUserEntry | null = null;
 
         res.on('searchEntry', (entry: LdapSearchEntry) => {
           // v3 emits a DN object; bind serializes via writeString which throws on non-strings.
-          foundDn = entry.objectName?.toString() ?? null;
+          const dn = entry.objectName?.toString() ?? null;
+          if (!dn) return;
+          found = { dn, attributes: flattenSearchEntryAttributes(entry) };
         });
 
         res.on('error', (err: Error) => {
@@ -278,7 +405,7 @@ class LDAPService {
           if (result.status !== 0) {
             reject(new Error('LDAP search failed status: ' + result.status));
           } else {
-            resolve(foundDn);
+            resolve(found);
           }
         });
       });

--- a/server/test/routes/auth.test.ts
+++ b/server/test/routes/auth.test.ts
@@ -37,6 +37,7 @@ const markPersonalAccessTokenUsedMock = mock();
 
 // Auth route deps
 const findLoginUserByUsernameMock = mock();
+const findLoginUserByIdMock = mock();
 const listAvailableRolesForUserMock = mock();
 const logAuditMock = mock(async () => undefined);
 
@@ -44,6 +45,7 @@ const logAuditMock = mock(async () => undefined);
 const bcryptCompareMock = mock();
 const ldapAuthenticateMock = mock();
 const ldapAuthenticateWithProfileMock = mock();
+const ldapAuthenticateAndProvisionMock = mock();
 const applyExternalRoleIdsForUserMock = mock();
 
 let authRoutePlugin: FastifyPluginAsync;
@@ -54,6 +56,7 @@ beforeAll(async () => {
     ...usersRepoSnap,
     findAuthUserById: findAuthUserByIdMock,
     findLoginUserByUsername: findLoginUserByUsernameMock,
+    findLoginUserById: findLoginUserByIdMock,
   }));
   mock.module('../../repositories/rolesRepo.ts', () => ({
     ...rolesRepoSnap,
@@ -85,6 +88,7 @@ beforeAll(async () => {
     default: {
       authenticate: ldapAuthenticateMock,
       authenticateWithProfile: ldapAuthenticateWithProfileMock,
+      authenticateAndProvision: ldapAuthenticateAndProvisionMock,
     },
   }));
 
@@ -134,11 +138,13 @@ const allMocks = [
   findPersonalAccessTokenByHashMock,
   markPersonalAccessTokenUsedMock,
   findLoginUserByUsernameMock,
+  findLoginUserByIdMock,
   listAvailableRolesForUserMock,
   logAuditMock,
   bcryptCompareMock,
   ldapAuthenticateMock,
   ldapAuthenticateWithProfileMock,
+  ldapAuthenticateAndProvisionMock,
   applyExternalRoleIdsForUserMock,
 ];
 
@@ -170,6 +176,8 @@ beforeEach(async () => {
     groups: [],
     roleIds: ['user'],
   });
+  ldapAuthenticateAndProvisionMock.mockResolvedValue({ authenticated: false });
+  findLoginUserByIdMock.mockResolvedValue(null);
   applyExternalRoleIdsForUserMock.mockImplementation(async (_userId: string, roleIds: string[]) =>
     roleIds.length > 0 ? roleIds : ['user'],
   );
@@ -324,8 +332,9 @@ describe('POST /api/auth/login', () => {
     ]);
   });
 
-  test('401 user not found', async () => {
+  test('401 user not found (LDAP auto-provision also fails)', async () => {
     findLoginUserByUsernameMock.mockResolvedValue(null);
+    ldapAuthenticateAndProvisionMock.mockResolvedValue({ authenticated: false });
 
     const res = await testApp.inject({
       method: 'POST',
@@ -335,7 +344,109 @@ describe('POST /api/auth/login', () => {
 
     expect(res.statusCode).toBe(401);
     expect(JSON.parse(res.body)).toEqual({ error: 'Invalid username or password' });
+    expect(ldapAuthenticateAndProvisionMock).toHaveBeenCalledWith('ghost', 'whatever');
     expect(logAuditMock).not.toHaveBeenCalled();
+  });
+
+  test('200: unknown user auto-provisioned via LDAP on first login', async () => {
+    findLoginUserByUsernameMock.mockResolvedValue(null);
+    ldapAuthenticateAndProvisionMock.mockResolvedValue({
+      authenticated: true,
+      userId: 'u-new',
+      created: true,
+      canonicalUsername: 'alice',
+    });
+    findLoginUserByIdMock.mockResolvedValue({
+      id: 'u-new',
+      name: 'Alice Provisioned',
+      username: 'alice',
+      role: 'user',
+      avatarInitials: 'AP',
+      passwordHash: '$2a$10$invalidpasswordhashforldapuser00000000000000',
+      isDisabled: false,
+      employeeType: 'app_user' as const,
+      authMethod: 'ldap' as const,
+      authProviderId: null,
+    });
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/auth/login',
+      payload: { username: 'ALICE@example.com', password: 'secret' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.user.id).toBe('u-new');
+    expect(body.user.username).toBe('alice');
+    // Auto-provisioned login should NOT bcrypt-compare against the placeholder hash
+    expect(bcryptCompareMock).not.toHaveBeenCalled();
+    // It should NOT re-run authenticateWithProfile (already authenticated by the helper)
+    expect(ldapAuthenticateWithProfileMock).not.toHaveBeenCalled();
+    // It should NOT re-apply role mapping (the provision helper already did it)
+    expect(applyExternalRoleIdsForUserMock).not.toHaveBeenCalled();
+    // Audit emits both user.created and user.login
+    const actions = logAuditMock.mock.calls.map(
+      (call) => (call as unknown as [{ action: string }])[0].action,
+    );
+    expect(actions).toEqual(expect.arrayContaining(['user.created', 'user.login']));
+  });
+
+  test('200: typed alias resolves to existing canonical LDAP user (no creation)', async () => {
+    findLoginUserByUsernameMock.mockResolvedValue(null);
+    ldapAuthenticateAndProvisionMock.mockResolvedValue({
+      authenticated: true,
+      userId: 'u-existing',
+      created: false,
+      canonicalUsername: 'alice',
+    });
+    findLoginUserByIdMock.mockResolvedValue({
+      ...LOGIN_USER,
+      id: 'u-existing',
+      authMethod: 'ldap' as const,
+    });
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/auth/login',
+      payload: { username: 'alice@example.com', password: 'secret' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.user.id).toBe('u-existing');
+    expect(body.user.username).toBe('alice');
+    // user.created is NOT emitted for existing users
+    const actions = logAuditMock.mock.calls.map(
+      (call) => (call as unknown as [{ action: string }])[0].action,
+    );
+    expect(actions).not.toContain('user.created');
+    expect(actions).toContain('user.login');
+  });
+
+  test('401: auto-provisioned user disabled is rejected', async () => {
+    findLoginUserByUsernameMock.mockResolvedValue(null);
+    ldapAuthenticateAndProvisionMock.mockResolvedValue({
+      authenticated: true,
+      userId: 'u-new',
+      created: true,
+      canonicalUsername: 'alice',
+    });
+    findLoginUserByIdMock.mockResolvedValue({
+      ...LOGIN_USER,
+      id: 'u-new',
+      authMethod: 'ldap' as const,
+      isDisabled: true,
+    });
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/auth/login',
+      payload: { username: 'alice', password: 'secret' },
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Invalid username or password' });
   });
 
   test('401 disabled user', async () => {

--- a/server/test/services/ldap.test.ts
+++ b/server/test/services/ldap.test.ts
@@ -22,6 +22,7 @@ const findLoginUserByUsernameMock = mock();
 const updateNameByUsernameMock = mock();
 const createUserMock = mock();
 const applyExternalRolesForUserMock = mock();
+const filterExistingRoleIdsMock = mock();
 
 // ─── ldapjs harness ───────────────────────────────────────────────────────────
 type SearchResponse = {
@@ -134,6 +135,7 @@ beforeAll(() => {
   mock.module('../../services/external-auth.ts', () => ({
     ...externalAuthSnapshot,
     applyExternalRolesForUser: applyExternalRolesForUserMock,
+    filterExistingRoleIds: filterExistingRoleIdsMock,
   }));
   mock.module('../../utils/initials.ts', () => ({
     ...initialsSnapshot,
@@ -211,6 +213,10 @@ beforeEach(() => {
   updateNameByUsernameMock.mockReset();
   createUserMock.mockReset();
   applyExternalRolesForUserMock.mockReset();
+  filterExistingRoleIdsMock.mockReset();
+  filterExistingRoleIdsMock.mockImplementation(async (ids: string[]) =>
+    ids.length > 0 ? ids : ['user'],
+  );
   createClientMock.mockClear();
 
   ldapRepoGetMock.mockResolvedValue(ENABLED_LDAP_CONFIG);
@@ -947,5 +953,70 @@ describe('authenticateAndProvision', () => {
     expect(createUserMock).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'Dave Display', username: 'dave' }),
     );
+  });
+
+  test('searches groups using the canonical uid in addition to the typed alias', async () => {
+    nextFixture = {
+      bindResponses: [null, null],
+      searchResponses: [
+        {
+          entries: [
+            { objectName: 'uid=alice,dc=test,dc=com', object: { uid: 'alice', cn: 'Alice' } },
+          ],
+          status: 0,
+        },
+        { entries: [], status: 0 }, // group search by userDn
+        { entries: [], status: 0 }, // group search by canonical
+        { entries: [], status: 0 }, // group search by typed alias
+      ],
+    };
+    findLoginUserByUsernameMock.mockResolvedValue(null);
+
+    await ldapService.authenticateAndProvision('ALICE@example.com', 'pw');
+
+    const groupFilterTexts = (lastClientStats?.searchCalls ?? [])
+      .filter((c) => c.base === 'ou=groups,dc=test,dc=com')
+      .map((c) => String(c.options.filter));
+    // Must include a search keyed on the canonical uid so configs like memberUid={0}
+    // resolve groups even when the user typed an email/UPN alias.
+    expect(groupFilterTexts.some((f) => f.includes('uid=alice,dc=test,dc=com'))).toBe(true);
+    expect(groupFilterTexts.some((f) => f.includes('member=alice') && !f.includes('@'))).toBe(true);
+  });
+
+  test('filters role IDs against existing roles before createUser to avoid FK violation', async () => {
+    ldapRepoGetMock.mockResolvedValue({
+      ...ENABLED_LDAP_CONFIG,
+      roleMappings: [
+        { ldapGroup: 'deleted-role-group', role: 'role-deleted-12345' },
+        { ldapGroup: 'managers', role: 'manager' },
+      ],
+    });
+    nextFixture = {
+      bindResponses: [null, null],
+      searchResponses: [
+        {
+          entries: [{ objectName: 'uid=eve,dc=test,dc=com', object: { uid: 'eve', cn: 'Eve' } }],
+          status: 0,
+        },
+        {
+          entries: [
+            {
+              objectName: 'cn=deleted-role-group,dc=test,dc=com',
+              object: { cn: 'deleted-role-group' },
+            },
+          ],
+          status: 0,
+        },
+      ],
+    };
+    findLoginUserByUsernameMock.mockResolvedValue(null);
+    // Simulate the deleted role being filtered out; only 'role-deleted-12345' would map.
+    filterExistingRoleIdsMock.mockResolvedValueOnce(['user']);
+
+    await ldapService.authenticateAndProvision('eve', 'pw');
+
+    // filterExistingRoleIds must be called with the unfiltered mapped IDs before createUser fires
+    expect(filterExistingRoleIdsMock).toHaveBeenCalledWith(['role-deleted-12345']);
+    expect(createUserMock).toHaveBeenCalledWith(expect.objectContaining({ role: 'user' }));
   });
 });

--- a/server/test/services/ldap.test.ts
+++ b/server/test/services/ldap.test.ts
@@ -438,6 +438,16 @@ describe('findUserDn (direct, with config preloaded)', () => {
     return createClientMock({ url: ENABLED_LDAP_CONFIG.serverUrl, tlsOptions: {} });
   };
 
+  test('requests canonical user attributes (uid, sAMAccountName, cn, displayName)', async () => {
+    const client = buildClient({
+      entries: [{ objectName: 'uid=alice,dc=test,dc=com', object: { uid: 'alice' } }],
+      status: 0,
+    });
+    await ldapService.findUserDn(client as never, 'alice');
+    const search = lastClientStats?.searchCalls[0];
+    expect(search?.options.attributes).toEqual(['uid', 'sAMAccountName', 'cn', 'displayName']);
+  });
+
   test('resolves to the last searchEntry.objectName when multiple entries fire (foundDn reassignment)', async () => {
     const client = buildClient({
       entries: [
@@ -760,5 +770,182 @@ describe('lookupUserGroups', () => {
     // empty group list.
     expect(result).toBeNull();
     expect(lastClientStats?.unbindCalls).toBe(1);
+  });
+});
+
+describe('authenticateAndProvision', () => {
+  test('returns { authenticated: false } when LDAP rejects credentials', async () => {
+    // service-account bind fails → authenticateWithProfile returns false
+    nextFixture = { bindResponses: [new Error('bad creds')] };
+    const result = await ldapService.authenticateAndProvision('alice', 'pw');
+    expect(result).toEqual({ authenticated: false });
+    expect(createUserMock).not.toHaveBeenCalled();
+  });
+
+  test('creates a new app_user using the canonical uid (not the typed alias)', async () => {
+    nextFixture = {
+      bindResponses: [null, null],
+      searchResponses: [
+        {
+          entries: [
+            {
+              objectName: 'uid=alice,dc=test,dc=com',
+              object: { uid: 'alice', cn: 'Alice Real' },
+            },
+          ],
+          status: 0,
+        },
+        // group search returns nothing
+        { entries: [], status: 0 },
+      ],
+    };
+    findLoginUserByUsernameMock.mockResolvedValue(null);
+
+    const result = await ldapService.authenticateAndProvision('ALICE@example.com', 'pw');
+
+    expect(result).toEqual({
+      authenticated: true,
+      userId: 'u_test_id',
+      created: true,
+      canonicalUsername: 'alice',
+    });
+    expect(createUserMock).toHaveBeenCalledWith({
+      id: 'u_test_id',
+      name: 'Alice Real',
+      username: 'alice',
+      passwordHash: realUsersRepo.EXTERNAL_PLACEHOLDER_PASSWORD_HASH,
+      role: 'user',
+      avatarInitials: 'AL',
+      authMethod: 'ldap',
+      authProviderId: null,
+    });
+    expect(applyExternalRolesForUserMock).toHaveBeenCalledWith('u_test_id', [], []);
+  });
+
+  test('falls back to sAMAccountName when uid is missing (AD)', async () => {
+    nextFixture = {
+      bindResponses: [null, null],
+      searchResponses: [
+        {
+          entries: [
+            {
+              objectName: 'cn=carol,dc=test,dc=com',
+              object: { sAMAccountName: 'carol', cn: 'Carol' },
+            },
+          ],
+          status: 0,
+        },
+        { entries: [], status: 0 },
+      ],
+    };
+    findLoginUserByUsernameMock.mockResolvedValue(null);
+
+    const result = await ldapService.authenticateAndProvision('CAROL', 'pw');
+    expect(result.canonicalUsername).toBe('carol');
+    expect(createUserMock).toHaveBeenCalledWith(
+      expect.objectContaining({ username: 'carol', name: 'Carol' }),
+    );
+  });
+
+  test('reuses an existing LDAP-bound user under the canonical username (no creation)', async () => {
+    nextFixture = {
+      bindResponses: [null, null],
+      searchResponses: [
+        {
+          entries: [
+            { objectName: 'uid=alice,dc=test,dc=com', object: { uid: 'alice', cn: 'Alice' } },
+          ],
+          status: 0,
+        },
+        { entries: [], status: 0 },
+      ],
+    };
+    findLoginUserByUsernameMock.mockResolvedValue(LDAP_LOGIN_USER);
+
+    const result = await ldapService.authenticateAndProvision('alice@example.com', 'pw');
+
+    expect(result).toEqual({
+      authenticated: true,
+      userId: LDAP_LOGIN_USER.id,
+      created: false,
+      canonicalUsername: 'alice',
+    });
+    expect(createUserMock).not.toHaveBeenCalled();
+    expect(applyExternalRolesForUserMock).toHaveBeenCalledWith(LDAP_LOGIN_USER.id, [], []);
+  });
+
+  test('refuses to bind LDAP login to an existing non-LDAP local user', async () => {
+    nextFixture = {
+      bindResponses: [null, null],
+      searchResponses: [
+        {
+          entries: [
+            { objectName: 'uid=alice,dc=test,dc=com', object: { uid: 'alice', cn: 'Alice' } },
+          ],
+          status: 0,
+        },
+        { entries: [], status: 0 },
+      ],
+    };
+    findLoginUserByUsernameMock.mockResolvedValue({
+      ...LDAP_LOGIN_USER,
+      authMethod: 'local' as const,
+    });
+
+    const result = await ldapService.authenticateAndProvision('alice', 'pw');
+    expect(result).toEqual({ authenticated: false });
+    expect(createUserMock).not.toHaveBeenCalled();
+    expect(applyExternalRolesForUserMock).not.toHaveBeenCalled();
+  });
+
+  test('races on unique constraint: re-fetches by canonical username after createUser throws 23505', async () => {
+    nextFixture = {
+      bindResponses: [null, null],
+      searchResponses: [
+        {
+          entries: [
+            { objectName: 'uid=alice,dc=test,dc=com', object: { uid: 'alice', cn: 'Alice' } },
+          ],
+          status: 0,
+        },
+        { entries: [], status: 0 },
+      ],
+    };
+    // First lookup: nothing (we'll try to create); second lookup (after race): the raced row
+    findLoginUserByUsernameMock.mockResolvedValueOnce(null).mockResolvedValueOnce(LDAP_LOGIN_USER);
+    const uniqueErr = Object.assign(new Error('duplicate key'), { code: '23505' });
+    createUserMock.mockRejectedValueOnce(uniqueErr);
+
+    const result = await ldapService.authenticateAndProvision('alice', 'pw');
+
+    expect(result).toEqual({
+      authenticated: true,
+      userId: LDAP_LOGIN_USER.id,
+      created: false,
+      canonicalUsername: 'alice',
+    });
+  });
+
+  test('uses displayName when cn is absent', async () => {
+    nextFixture = {
+      bindResponses: [null, null],
+      searchResponses: [
+        {
+          entries: [
+            {
+              objectName: 'uid=dave,dc=test,dc=com',
+              object: { uid: 'dave', displayName: 'Dave Display' },
+            },
+          ],
+          status: 0,
+        },
+        { entries: [], status: 0 },
+      ],
+    };
+    findLoginUserByUsernameMock.mockResolvedValue(null);
+    await ldapService.authenticateAndProvision('dave', 'pw');
+    expect(createUserMock).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Dave Display', username: 'dave' }),
+    );
   });
 });


### PR DESCRIPTION
## Summary

Closes #305. Replaces the closed PR #308 — rebuilt from current `origin/main` HEAD so the diff is clean and addresses the P1 raised in the previous review.

When LDAP is enabled, `/login` now auto-creates a local `app_user` on the first successful LDAP bind. Previously, the route rejected unknown usernames with 401 before any LDAP probe ran, so directory users that hadn't been pulled in via `syncUsers` could never log in.

- **Canonical username persistence (P1 from PR #308 review):** the new row is keyed by the LDAP entry's `uid` (or `sAMAccountName` for AD), not the value typed at the login form. Deployments whose `userFilter` accepts aliases (email, UPN, different casing) no longer end up with one row created under the alias and another created later by `syncUsers` under the canonical username.
- **Refactor:** `findUserDn` now delegates to a richer `findUserEntry` that captures `uid`/`sAMAccountName`/`cn`/`displayName`. `authenticateWithProfile` returns the canonical username + display name in addition to the existing `groups` and `roleIds`.
- **New helper:** `LDAPService.authenticateAndProvision` wraps `authenticateWithProfile`, ensures the local row exists (create or find by canonical username), handles the `23505` unique-constraint race, refuses to bind LDAP login to a pre-existing non-LDAP local user, and applies group → role mapping through `applyExternalRolesForUser` so it lands in `user_roles` and `users.role` in one transaction (same path as `syncUsers`).
- **Route wiring:** when `findLoginUserByUsername` returns null, the handler calls `authenticateAndProvision` and re-fetches the user by id (not username — avoids another canonical-vs-typed mismatch). Auto-provisioned LDAP users are treated as already-authenticated so no bcrypt comparison runs against the `EXTERNAL_PLACEHOLDER_PASSWORD_HASH`. The existing-user LDAP path at lines 139–142 is preserved unchanged.
- **Audit:** emits `user.created` for newly auto-provisioned rows in addition to the existing `user.login`.
- **Docs:** updated `docs-site/src/content/docs/administration.md` (IT) and `docs-site/src/content/docs/en/administration.md` (EN) to describe the new behavior and the canonical-username invariant.

## Test plan

- [x] `bun run test` from repo root — 2008 server tests + 849 frontend tests pass
- [x] `bun run lint` from repo root — i18n check + typecheck + biome clean
- [x] New tests cover: auto-provision happy path, typed alias → existing canonical LDAP user (no creation), unique-constraint race, refusal to bind LDAP login to a non-LDAP local user, disabled auto-provisioned user, and the `findUserEntry` attribute request

https://claude.ai/code/session_01WTmCkNUSMtL2uHWf3XPx6g

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTmCkNUSMtL2uHWf3XPx6g)_