### PR TITLE
fix(merge): resolve unresolved conflict markers from PR #303

### DIFF
--- a/components/CRM/ClientsView.tsx
+++ b/components/CRM/ClientsView.tsx
@@ -711,13 +711,8 @@ const ClientsView: React.FC<ClientsViewProps> = ({
             return <span className="text-xs text-zinc-400">-</span>;
           }
           return (
-<<<<<<< HEAD
             <span className="text-xs text-slate-500 whitespace-nowrap">
               {formatInsertDate(row.createdAt, language)}
-=======
-            <span className="text-xs text-zinc-500 whitespace-nowrap">
-              {formatInsertDate(row.createdAt)}
->>>>>>> origin/main
             </span>
           );
         },

--- a/components/CRM/SuppliersView.tsx
+++ b/components/CRM/SuppliersView.tsx
@@ -54,17 +54,10 @@ const SuppliersView: React.FC<SuppliersViewProps> = ({
   onDeleteSupplier,
   permissions,
 }) => {
-<<<<<<< HEAD
   const { t, i18n } = useTranslation(['crm', 'common']);
-  const canCreateSuppliers = hasPermission(permissions, buildPermission('crm.suppliers', 'create'));
-  const canUpdateSuppliers = hasPermission(permissions, buildPermission('crm.suppliers', 'update'));
-  const canDeleteSuppliers = hasPermission(permissions, buildPermission('crm.suppliers', 'delete'));
-=======
-  const { t } = useTranslation(['crm', 'common']);
   const canCreateSuppliers = hasScopedActionPermission(permissions, 'crm.suppliers', 'create');
   const canUpdateSuppliers = hasScopedActionPermission(permissions, 'crm.suppliers', 'update');
   const canDeleteSuppliers = hasScopedActionPermission(permissions, 'crm.suppliers', 'delete');
->>>>>>> origin/main
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingSupplier, setEditingSupplier] = useState<Supplier | null>(null);
   const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
@@ -236,13 +229,8 @@ const SuppliersView: React.FC<SuppliersViewProps> = ({
             return <span className="text-xs text-zinc-400">-</span>;
           }
           return (
-<<<<<<< HEAD
             <span className="text-xs text-slate-500 whitespace-nowrap">
               {formatInsertDate(row.createdAt, i18n.language)}
-=======
-            <span className="text-xs text-zinc-500 whitespace-nowrap">
-              {formatInsertDate(row.createdAt)}
->>>>>>> origin/main
             </span>
           );
         },

--- a/components/Login.tsx
+++ b/components/Login.tsx
@@ -132,7 +132,6 @@ const Login: React.FC<LoginProps> = ({
           </div>
         )}
 
-<<<<<<< HEAD
         {serverUnreachable && (
           <div
             role="alert"
@@ -155,7 +154,9 @@ const Login: React.FC<LoginProps> = ({
                 <i className="fa-solid fa-xmark"></i>
               </button>
             )}
-=======
+          </div>
+        )}
+
         {ssoProviders.length > 0 && (
           <div className="space-y-3 mb-5">
             {ssoProviders.map((provider) => (
@@ -177,7 +178,6 @@ const Login: React.FC<LoginProps> = ({
               <span>{t('auth:login.orPassword', 'or use password')}</span>
               <div className="h-px flex-1 bg-zinc-100"></div>
             </div>
->>>>>>> origin/main
           </div>
         )}
 

--- a/components/accounting/ClientsOrdersView.tsx
+++ b/components/accounting/ClientsOrdersView.tsx
@@ -425,13 +425,8 @@ const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
         cell: ({ row }: { row: ClientsOrder }) => {
           if (!row.createdAt) return <span className="text-xs text-zinc-400">-</span>;
           return (
-<<<<<<< HEAD
             <span className="text-xs text-slate-500 whitespace-nowrap">
               {formatInsertDate(row.createdAt, i18n.language)}
-=======
-            <span className="text-xs text-zinc-500 whitespace-nowrap">
-              {formatInsertDate(row.createdAt)}
->>>>>>> origin/main
             </span>
           );
         },

--- a/components/catalog/InternalListingView.tsx
+++ b/components/catalog/InternalListingView.tsx
@@ -1518,13 +1518,8 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
             id: 'createdAt',
             accessorFn: (row) => row.createdAt ?? 0,
             cell: ({ value }) => (
-<<<<<<< HEAD
               <span className="text-xs text-slate-500 whitespace-nowrap">
                 {formatInsertDate(value as number | null, i18n.language)}
-=======
-              <span className="text-xs text-zinc-500 whitespace-nowrap">
-                {formatInsertDate(value as number | null)}
->>>>>>> origin/main
               </span>
             ),
             filterFormat: (value) => formatInsertDate(value as number | null, i18n.language),

--- a/components/projects/ProjectsView.tsx
+++ b/components/projects/ProjectsView.tsx
@@ -137,26 +137,10 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
   onDeleteTask,
   onViewOrder,
 }) => {
-<<<<<<< HEAD
   const { t, i18n } = useTranslation(['projects', 'common', 'form']);
-  const canCreateProjects = hasPermission(
-    permissions,
-    buildPermission('projects.manage', 'create'),
-  );
-  const canUpdateProjects = hasPermission(
-    permissions,
-    buildPermission('projects.manage', 'update'),
-  );
-  const canDeleteProjects = hasPermission(
-    permissions,
-    buildPermission('projects.manage', 'delete'),
-  );
-=======
-  const { t } = useTranslation(['projects', 'common', 'form']);
   const canCreateProjects = hasScopedActionPermission(permissions, 'projects.manage', 'create');
   const canUpdateProjects = hasScopedActionPermission(permissions, 'projects.manage', 'update');
   const canDeleteProjects = hasScopedActionPermission(permissions, 'projects.manage', 'delete');
->>>>>>> origin/main
   const canManageAssignments = hasPermission(
     permissions,
     buildPermission('projects.assignments', 'update'),
@@ -1377,13 +1361,8 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
               id: 'createdAt',
               accessorFn: (row) => row.createdAt ?? 0,
               cell: ({ row }) => (
-<<<<<<< HEAD
                 <span className="text-xs text-slate-500 whitespace-nowrap">
                   {row.createdAt ? formatInsertDate(row.createdAt, i18n.language) : '—'}
-=======
-                <span className="text-xs text-zinc-500 whitespace-nowrap">
-                  {row.createdAt ? formatInsertDate(row.createdAt) : '-'}
->>>>>>> origin/main
                 </span>
               ),
             },

--- a/components/projects/TasksView.tsx
+++ b/components/projects/TasksView.tsx
@@ -85,17 +85,10 @@ const TasksView: React.FC<TasksViewProps> = ({
   onDeleteTask,
   onViewOrder,
 }) => {
-<<<<<<< HEAD
   const { t, i18n } = useTranslation(['projects', 'common']);
-  const canCreateTasks = hasPermission(permissions, buildPermission('projects.tasks', 'create'));
-  const canUpdateTasks = hasPermission(permissions, buildPermission('projects.tasks', 'update'));
-  const canDeleteTasks = hasPermission(permissions, buildPermission('projects.tasks', 'delete'));
-=======
-  const { t } = useTranslation(['projects', 'common']);
   const canCreateTasks = hasScopedActionPermission(permissions, 'projects.tasks', 'create');
   const canUpdateTasks = hasScopedActionPermission(permissions, 'projects.tasks', 'update');
   const canDeleteTasks = hasScopedActionPermission(permissions, 'projects.tasks', 'delete');
->>>>>>> origin/main
   const [name, setName] = useState('');
   const [projectId, setProjectId] = useState('');
   const [description, setDescription] = useState('');
@@ -256,13 +249,8 @@ const TasksView: React.FC<TasksViewProps> = ({
         id: 'createdAt',
         accessorFn: (task) => task.createdAt ?? 0,
         cell: ({ row }) => (
-<<<<<<< HEAD
           <span className="text-xs text-slate-500 whitespace-nowrap">
             {row.createdAt ? formatInsertDate(row.createdAt, i18n.language) : '—'}
-=======
-          <span className="text-xs text-zinc-500 whitespace-nowrap">
-            {row.createdAt ? formatInsertDate(row.createdAt) : '-'}
->>>>>>> origin/main
           </span>
         ),
       },
@@ -564,12 +552,9 @@ const TasksView: React.FC<TasksViewProps> = ({
       currency,
       taskHours,
       hoursLoadState,
-<<<<<<< HEAD
       i18n.language,
-=======
       formatBillingType,
       formatBillingFrequency,
->>>>>>> origin/main
     ],
   );
 

--- a/components/sales/ClientOffersView.tsx
+++ b/components/sales/ClientOffersView.tsx
@@ -53,7 +53,6 @@ import StandardTable, { type Column } from '../shared/StandardTable';
 import StatusBadge, { type StatusType } from '../shared/StatusBadge';
 import UnitTypeSelector from '../shared/UnitTypeSelector';
 import ValidatedNumberInput from '../shared/ValidatedNumberInput';
-import { Input } from '../ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
 import OfferVersionsPanel from './OfferVersionsPanel';
 
@@ -359,13 +358,8 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
       cell: ({ row }) => {
         if (!row.createdAt) return <span className="text-xs text-zinc-400">-</span>;
         return (
-<<<<<<< HEAD
           <span className="text-xs text-slate-500 whitespace-nowrap">
             {formatInsertDate(row.createdAt, i18n.language)}
-=======
-          <span className="text-xs text-zinc-500 whitespace-nowrap">
-            {formatInsertDate(row.createdAt)}
->>>>>>> origin/main
           </span>
         );
       },

--- a/scripts/check-i18n-keys.mjs
+++ b/scripts/check-i18n-keys.mjs
@@ -8,7 +8,7 @@ import { PERMISSION_DEFINITIONS, ROLE_EDITOR_EXCLUDED_MODULES } from '../utils/p
 const ROOT_DIR = process.cwd();
 const SUPPORTED_LANGUAGES = ['en', 'it'];
 const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx']);
-const IGNORED_DIRECTORIES = new Set(['.git', 'dist', 'docs', 'node_modules', 'server']);
+const IGNORED_DIRECTORIES = new Set(['.claude', '.git', 'dist', 'docs', 'node_modules', 'server']);
 
 const flattenKeys = (value, prefix = '', output = new Set()) => {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {

--- a/services/api.ts
+++ b/services/api.ts
@@ -5,7 +5,6 @@
 
 export { aiApi } from './api/ai';
 export { authApi } from './api/auth';
-export { ApiError, getApiBase, getAuthToken, setAuthToken } from './api/client';
 export { clientOffersApi } from './api/clientOffers';
 export { clientQuotesApi } from './api/clientQuotes';
 export { clientsApi } from './api/clients';
@@ -36,7 +35,7 @@ export { workUnitsApi } from './api/workUnits';
 
 import { aiApi } from './api/ai';
 import { authApi } from './api/auth';
-import { getApiBase, getAuthToken, setAuthToken } from './api/client';
+import { ApiError, getApiBase, getAuthToken, setAuthToken } from './api/client';
 import { clientOffersApi } from './api/clientOffers';
 import { clientQuotesApi } from './api/clientQuotes';
 import { clientsApi } from './api/clients';
@@ -62,6 +61,8 @@ import { suppliersApi } from './api/suppliers';
 import { tasksApi } from './api/tasks';
 import { usersApi } from './api/users';
 import { workUnitsApi } from './api/workUnits';
+
+export { ApiError, getApiBase, getAuthToken, setAuthToken };
 
 export default {
   auth: authApi,

--- a/services/api.ts
+++ b/services/api.ts
@@ -5,7 +5,7 @@
 
 export { aiApi } from './api/ai';
 export { authApi } from './api/auth';
-export * from './api/client';
+export { ApiError, getApiBase, getAuthToken, setAuthToken } from './api/client';
 export { clientOffersApi } from './api/clientOffers';
 export { clientQuotesApi } from './api/clientQuotes';
 export { clientsApi } from './api/clients';
@@ -36,7 +36,7 @@ export { workUnitsApi } from './api/workUnits';
 
 import { aiApi } from './api/ai';
 import { authApi } from './api/auth';
-import { ApiError, getApiBase, getAuthToken, setAuthToken } from './api/client';
+import { getApiBase, getAuthToken, setAuthToken } from './api/client';
 import { clientOffersApi } from './api/clientOffers';
 import { clientQuotesApi } from './api/clientQuotes';
 import { clientsApi } from './api/clients';
@@ -64,7 +64,6 @@ import { usersApi } from './api/users';
 import { workUnitsApi } from './api/workUnits';
 
 export default {
-  ApiError,
   auth: authApi,
   ai: aiApi,
   reports: reportsApi,

--- a/services/api.ts
+++ b/services/api.ts
@@ -5,6 +5,7 @@
 
 export { aiApi } from './api/ai';
 export { authApi } from './api/auth';
+export * from './api/client';
 export { clientOffersApi } from './api/clientOffers';
 export { clientQuotesApi } from './api/clientQuotes';
 export { clientsApi } from './api/clients';
@@ -61,8 +62,6 @@ import { suppliersApi } from './api/suppliers';
 import { tasksApi } from './api/tasks';
 import { usersApi } from './api/users';
 import { workUnitsApi } from './api/workUnits';
-
-export { ApiError, getApiBase, getAuthToken, setAuthToken };
 
 export default {
   ApiError,

--- a/services/api.ts
+++ b/services/api.ts
@@ -65,6 +65,7 @@ import { workUnitsApi } from './api/workUnits';
 export { ApiError, getApiBase, getAuthToken, setAuthToken };
 
 export default {
+  ApiError,
   auth: authApi,
   ai: aiApi,
   reports: reportsApi,

--- a/services/api.ts
+++ b/services/api.ts
@@ -5,11 +5,7 @@
 
 export { aiApi } from './api/ai';
 export { authApi } from './api/auth';
-<<<<<<< HEAD
-export { ApiError, getAuthToken, setAuthToken } from './api/client';
-=======
-export { getApiBase, getAuthToken, setAuthToken } from './api/client';
->>>>>>> origin/main
+export { ApiError, getApiBase, getAuthToken, setAuthToken } from './api/client';
 export { clientOffersApi } from './api/clientOffers';
 export { clientQuotesApi } from './api/clientQuotes';
 export { clientsApi } from './api/clients';

--- a/services/api/client.ts
+++ b/services/api/client.ts
@@ -13,12 +13,11 @@ export const setAuthToken = (token: string | null) => {
 
 export const getAuthToken = () => authToken;
 
-<<<<<<< HEAD
-/**
- * Error thrown by the API client. Carries the HTTP status so callers can
- * distinguish auth rejections (401/403) from transient failures (network
- * errors -> status 0, 5xx, etc).
- */
+export const getApiBase = () => API_BASE;
+
+// Error thrown by the API client. Carries the HTTP status so callers can
+// distinguish auth rejections (401/403) from transient failures (network
+// errors -> status 0, 5xx, etc).
 export class ApiError extends Error {
   public readonly status: number;
   public readonly isNetworkError: boolean;
@@ -30,9 +29,6 @@ export class ApiError extends Error {
     this.isNetworkError = isNetworkError;
   }
 }
-=======
-export const getApiBase = () => API_BASE;
->>>>>>> origin/main
 
 export const fetchApi = async <T>(endpoint: string, options: RequestInit = {}): Promise<T> => {
   const headers: HeadersInit = {

--- a/services/api/normalizers.ts
+++ b/services/api/normalizers.ts
@@ -155,7 +155,6 @@ const assignIfPresent = <V>(
   }
 };
 
-<<<<<<< HEAD
 const normalizeCostPerHour = (raw: unknown): number => {
   const n = Number(raw ?? 0);
   return Number.isFinite(n) ? n : 0;
@@ -163,6 +162,9 @@ const normalizeCostPerHour = (raw: unknown): number => {
 
 const normalizeOptionalString = (raw: unknown): string | undefined =>
   normalizeTrimmedString(raw) || undefined;
+
+const normalizeNullableTrimmedString = (raw: unknown): string | null =>
+  normalizeTrimmedString(raw) || null;
 
 export const normalizeUser = (u: User): User => {
   // /auth/login and /auth/me only return id, name, username, role,
@@ -185,28 +187,11 @@ export const normalizeUser = (u: User): User => {
   assignIfPresent(raw, result, 'email', normalizeOptionalString);
   assignIfPresent(raw, result, 'costPerHour', normalizeCostPerHour);
   assignIfPresent(raw, result, 'employeeType', normalizeEmployeeType);
+  assignIfPresent(raw, result, 'authMethod', normalizeUserAuthMethod);
+  assignIfPresent(raw, result, 'authProviderId', normalizeNullableTrimmedString);
+  assignIfPresent(raw, result, 'authProviderName', normalizeNullableTrimmedString);
 
   return result as unknown as User;
-=======
-  return {
-    ...u,
-    id: normalizeTrimmedString(u.id),
-    name: normalizeTrimmedString(u.name),
-    role: normalizeTrimmedString(u.role),
-    avatarInitials: normalizeTrimmedString(u.avatarInitials),
-    username: normalizeTrimmedString(u.username),
-    hasTopManagerRole: !!u.hasTopManagerRole,
-    isAdminOnly: !!u.isAdminOnly,
-    email: normalizeTrimmedString(u.email) || undefined,
-    permissions: normalizeStringArray(u.permissions),
-    availableRoles: normalizeAvailableRoles(u.availableRoles),
-    costPerHour: Number.isFinite(normalizedCostPerHour) ? normalizedCostPerHour : 0,
-    employeeType: normalizeEmployeeType(u.employeeType),
-    authMethod: normalizeUserAuthMethod(u.authMethod),
-    authProviderId: normalizeTrimmedString(u.authProviderId) || null,
-    authProviderName: normalizeTrimmedString(u.authProviderName) || null,
-  };
->>>>>>> origin/main
 };
 
 export const normalizeProduct = (p: Product): Product => ({

--- a/test/components/Calendar.test.tsx
+++ b/test/components/Calendar.test.tsx
@@ -8,19 +8,32 @@ installI18nMock();
 const Calendar = (await import('../../components/shared/Calendar')).default;
 
 describe('<Calendar />', () => {
-  test('renders Italian day headers in Monday-first order', () => {
+  // PR #293 moved Calendar day/month strings to i18next. Tests run under the identity
+  // mock in test/helpers/i18n.tsx (t(key) => key), so we assert on the literal keys
+  // emitted by t(`calendar.daysShort.${key}`) / t(`calendar.months.${key}`).
+  const DAY_KEYS_MONDAY = [
+    'calendar.daysShort.mon',
+    'calendar.daysShort.tue',
+    'calendar.daysShort.wed',
+    'calendar.daysShort.thu',
+    'calendar.daysShort.fri',
+    'calendar.daysShort.sat',
+    'calendar.daysShort.sun',
+  ];
+  const DAY_KEY_PATTERN = /^calendar\.daysShort\.(mon|tue|wed|thu|fri|sat|sun)$/;
+
+  test('renders day headers in Monday-first order', () => {
     render(<Calendar startOfWeek="Monday" />);
-    const headers = ['Lun', 'Mar', 'Mer', 'Gio', 'Ven', 'Sab', 'Dom'];
-    headers.forEach((h) => {
-      expect(screen.getByText(h)).toBeInTheDocument();
+    DAY_KEYS_MONDAY.forEach((key) => {
+      expect(screen.getByText(key)).toBeInTheDocument();
     });
   });
 
   test('Sunday-first order swaps headers', () => {
     render(<Calendar startOfWeek="Sunday" />);
-    const headers = screen.getAllByText(/^(Lun|Mar|Mer|Gio|Ven|Sab|Dom)$/);
-    expect(headers[0].textContent).toBe('Dom');
-    expect(headers[6].textContent).toBe('Sab');
+    const headers = screen.getAllByText(DAY_KEY_PATTERN);
+    expect(headers[0].textContent).toBe('calendar.daysShort.sun');
+    expect(headers[6].textContent).toBe('calendar.daysShort.sat');
   });
 
   test('clicking a non-weekend day calls onDateSelect', () => {
@@ -116,7 +129,7 @@ describe('<Calendar />', () => {
   test('Today button selects today in single mode', () => {
     const onDateSelect = mock((_d: string) => {});
     render(<Calendar onDateSelect={onDateSelect} startOfWeek="Monday" allowWeekendSelection />);
-    fireEvent.click(screen.getByText('Oggi'));
+    fireEvent.click(screen.getByText('calendar.today'));
     expect(onDateSelect).toHaveBeenCalled();
     const arg = onDateSelect.mock.calls[0][0] as string;
     expect(arg).toMatch(/^\d{4}-\d{2}-\d{2}$/);
@@ -124,12 +137,15 @@ describe('<Calendar />', () => {
 
   test('month picker opens on click and selects a month', () => {
     render(<Calendar selectedDate="2024-03-15" startOfWeek="Monday" />);
-    // Click the month-name button in the header (March in Italian = "Marzo")
-    fireEvent.click(screen.getByText('Marzo'));
-    // Picker shows abbreviated names - click "Mag" for May
-    fireEvent.click(screen.getByText('Mag'));
-    // Header should now show full name "Maggio"
-    expect(screen.getByText('Maggio')).toBeInTheDocument();
+    // Click the month-name button in the header (March → calendar.months.march under the
+    // identity i18n mock). The picker shows the first 3 chars of each translated name —
+    // under the mock that's "cal" for every month, so target the May button by index.
+    fireEvent.click(screen.getByText('calendar.months.march'));
+    const pickerButtons = screen.getAllByRole('button').filter((btn) => btn.textContent === 'cal');
+    expect(pickerButtons.length).toBeGreaterThanOrEqual(12);
+    fireEvent.click(pickerButtons[4]); // index 4 = May
+    // Header should now show the May key in the title button.
+    expect(screen.getByText('calendar.months.may')).toBeInTheDocument();
   });
 
   test('mousedown outside container closes the open picker', () => {
@@ -139,13 +155,13 @@ describe('<Calendar />', () => {
         <Calendar selectedDate="2024-03-15" startOfWeek="Monday" />
       </div>,
     );
-    fireEvent.click(screen.getByText('Marzo'));
-    // Picker shows abbreviated month names - "Apr" appears only when picker is open
-    expect(screen.getByText('Apr')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('calendar.months.march'));
+    // Open picker renders 12 month buttons (each rendering "cal" under identity mock).
+    expect(screen.getAllByRole('button').filter((b) => b.textContent === 'cal').length).toBe(12);
 
     fireEvent.mouseDown(screen.getByTestId('outside'));
-    // Picker now closed: "Apr" should no longer be in DOM
-    expect(screen.queryByText('Apr')).not.toBeInTheDocument();
+    // Picker now closed: no "cal" buttons remain.
+    expect(screen.queryAllByRole('button').filter((b) => b.textContent === 'cal').length).toBe(0);
   });
 
   test('Italian holiday Jan 1 marks day as forbidden in single mode', () => {

--- a/test/components/ClientOffersView.test.tsx
+++ b/test/components/ClientOffersView.test.tsx
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, test } from 'bun:test';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import type { Client, ClientOffer, Product, SupplierQuote } from '../../types';
 import { installI18nMock } from '../helpers/i18n';
+import { render } from '../helpers/render';
 
 installI18nMock();
 

--- a/test/components/Login.test.tsx
+++ b/test/components/Login.test.tsx
@@ -1,10 +1,6 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
-<<<<<<< HEAD
-import { fireEvent, render, screen } from '@testing-library/react';
-import { ApiErrorStub } from '../helpers/apiErrorStub';
-=======
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
->>>>>>> origin/main
+import { ApiErrorStub } from '../helpers/apiErrorStub';
 import { installI18nMock } from '../helpers/i18n';
 
 installI18nMock();

--- a/test/handlers/quoteHandlers.test.ts
+++ b/test/handlers/quoteHandlers.test.ts
@@ -105,9 +105,9 @@ const buildHandlers = (overrides: Record<string, unknown> = {}) => {
   const refreshSupplierQuoteFlow = mock(() => Promise.resolve()) as unknown as () => Promise<void>;
 
   const handlers = makeQuoteHandlers({
-    quotes: quotes.get() as never,
-    clientQuoteFilterId: clientQuoteFilterId.get(),
-    clientOfferFilterId: clientOfferFilterId.get(),
+    getQuotes: (() => quotes.get()) as never,
+    getClientQuoteFilterId: () => clientQuoteFilterId.get(),
+    getClientOfferFilterId: () => clientOfferFilterId.get(),
     setQuotes: quotes.setter as never,
     setClientOffers: clientOffers.setter as never,
     setClientsOrders: clientsOrders.setter as never,

--- a/test/services/normalizers.test.ts
+++ b/test/services/normalizers.test.ts
@@ -401,15 +401,18 @@ describe('normalizeUser', () => {
     expect(normalizeUser(input).employeeType).toBe('app_user');
   });
 
-  test('handles undefined/empty optional fields safely', () => {
+  test('leaves optional fields absent when the payload omits them', () => {
+    // normalizeUser must not fabricate defaults (costPerHour=0, employeeType='app_user',
+    // etc.) for fields the API never sent — that would hide contract drift behind ghost
+    // values. Only permissions/availableRoles are always normalized (to [] / undefined).
     const result = normalizeUser(baseUser);
     expect(result.email).toBeUndefined();
     expect(result.permissions).toEqual([]);
     expect(result.availableRoles).toBeUndefined();
-    expect(result.costPerHour).toBe(0);
-    expect(result.hasTopManagerRole).toBe(false);
-    expect(result.isAdminOnly).toBe(false);
-    expect(result.employeeType).toBe('app_user');
+    expect(result.costPerHour).toBeUndefined();
+    expect(result.hasTopManagerRole).toBeUndefined();
+    expect(result.isAdminOnly).toBeUndefined();
+    expect(result.employeeType).toBeUndefined();
   });
 
   test('returns 0 for non-finite costPerHour input', () => {


### PR DESCRIPTION
## Summary

PR #303 (auth-boundary fix) was merged with literal git conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) left in 10 source files. The markers broke `tsc` parsing across the entire frontend, which:

- made `bun run lint`, `bun run typecheck`, and `bun run build` fail on `main`;
- masked two other pre-existing typecheck errors plus three stale tests that would otherwise have been caught by CI.

This restores `main` to a buildable + green state.

## Conflicts resolved

For each conflict I picked the resolution that preserves both the new functionality from PR #303 and any code that landed on `main` while PR #303 was in flight.

| File | Resolution |
| --- | --- |
| `components/Login.tsx` | Kept both the `serverUnreachable` banner (PR #303) and the `ssoProviders` block (existing) as adjacent siblings inside the same parent. |
| `components/CRM/ClientsView.tsx`, `CRM/SuppliersView.tsx`, `accounting/ClientsOrdersView.tsx`, `catalog/InternalListingView.tsx`, `projects/ProjectsView.tsx`, `projects/TasksView.tsx`, `sales/ClientOffersView.tsx` | Kept `text-slate-500` + locale-aware `formatInsertDate(..., i18n.language)` from PR #293. Combined PR #303's `i18n` destructure with the newer `hasScopedActionPermission` RBAC pattern that landed in the interim. |
| `services/api.ts`, `services/api/client.ts` | Combined PR #303's new `ApiError` class with the existing `getApiBase` export. |
| `services/api/normalizers.ts` | Kept PR #303's `assignIfPresent` approach that stops fabricating defaults for fields the API doesn't send. Added `assignIfPresent` calls for `authMethod` / `authProviderId` / `authProviderName` so those are still normalized when the payload carries them. |
| `test/components/Login.test.tsx` | Combined the `waitFor` import with the `ApiErrorStub` import. |

## Bugs unmasked by removing the conflict markers

These were latent issues that the broken `tsc` parse was hiding:

- `components/sales/ClientOffersView.tsx` had two `Input` imports (one via `@/` alias, one via relative path) added by two different PRs. Removed the duplicate (`TS2300`).
- `test/handlers/quoteHandlers.test.ts` was still passing direct values for `quotes` / `clientQuoteFilterId` / `clientOfferFilterId`, but `QuoteHandlersDeps` was refactored to getter functions (`getQuotes`, etc.). Updated the test to the current shape (`TS2353`).
- `test/services/normalizers.test.ts` had a "handles undefined/empty optional fields safely" assertion expecting `costPerHour=0`, `employeeType='app_user'`, etc. — i.e. the pre-#303 behavior. Updated the assertions to `toBeUndefined()` to match PR #303's stated intent (don't fabricate defaults).

## Pre-existing test failures from PRs #293 / #298

Once the conflict markers were gone and `bun run test` could actually run, two more test files were red — also from prior merges that didn't update their tests:

- **`test/components/Calendar.test.tsx`** — PR #293 moved Calendar day/month strings to `i18next` but the tests still asserted on literal Italian strings ("Lun", "Oggi", "Marzo", ...). Updated the assertions to the translation keys the project's identity-translator mock emits (`calendar.daysShort.mon`, `calendar.today`, `calendar.months.march`, ...). The month-picker tests target buttons by index because all month buttons render as `"cal"` (first 3 chars of the translation key) under the identity mock.
- **`test/components/ClientOffersView.test.tsx`** — PR #298 added a `Tooltip` to the filter row but the test file used RTL's raw `render` directly instead of the shared helper at `test/helpers/render.tsx`, which already wraps everything in `TooltipProvider`. Switched to the helper.

## Tooling

`scripts/check-i18n-keys.mjs` now ignores `.claude/`, so the i18n checker doesn't scan files inside `.claude/worktrees/` (test fixtures for the Claude Code agent infrastructure, which may reference keys from older codebase revisions).

## Test plan

- [x] `bun run test:server` — 2054 tests pass, 0 fail
- [x] `bun run test:frontend` — 926 tests pass, 0 fail
- [x] `bun run lint` — i18n check + `tsc` + biome all clean (3 pre-existing warnings unrelated to this change)

https://claude.ai/code/session_01WTmCkNUSMtL2uHWf3XPx6g