### PR TITLE
fix(forms): prevent double-submit on TasksView/WorkUnitsView (redo of #304)

### DIFF
--- a/components/WorkUnitsView.tsx
+++ b/components/WorkUnitsView.tsx
@@ -2,7 +2,7 @@ import type React from 'react';
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
-import { workUnitsApi } from '../services/api';
+import { workUnitsApi } from '../services/api/workUnits';
 import type { User, WorkUnit } from '../types';
 import { hasScopedActionPermission } from '../utils/permissions';
 import Checkbox from './shared/Checkbox';
@@ -55,6 +55,10 @@ const WorkUnitsView: React.FC<WorkUnitsViewProps> = ({
   const [assignmentSearch, setAssignmentSearch] = useState('');
   const [isLoadingAssignments, setIsLoadingAssignments] = useState(false);
 
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [isSavingAssignments, setIsSavingAssignments] = useState(false);
+
   const openCreateModal = () => {
     setName('');
     setSelectedManagerIds([]);
@@ -75,6 +79,7 @@ const WorkUnitsView: React.FC<WorkUnitsViewProps> = ({
 
   const handleCreate = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (isSubmitting) return;
     setErrors({});
 
     const newErrors: Record<string, string> = {};
@@ -87,12 +92,18 @@ const WorkUnitsView: React.FC<WorkUnitsViewProps> = ({
       return;
     }
 
-    await onAddWorkUnit({ name, managerIds: selectedManagerIds, description });
-    setIsCreateModalOpen(false);
+    setIsSubmitting(true);
+    try {
+      await onAddWorkUnit({ name, managerIds: selectedManagerIds, description });
+      setIsCreateModalOpen(false);
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   const handleUpdate = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (isSubmitting) return;
     setErrors({});
 
     const newErrors: Record<string, string> = {};
@@ -103,10 +114,14 @@ const WorkUnitsView: React.FC<WorkUnitsViewProps> = ({
       return;
     }
 
-    if (editingUnit && name) {
+    if (!editingUnit || !name) return;
+    setIsSubmitting(true);
+    try {
       await onUpdateWorkUnit(editingUnit.id, { name, managerIds: selectedManagerIds, description });
       setIsEditModalOpen(false);
       setEditingUnit(null);
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -116,10 +131,15 @@ const WorkUnitsView: React.FC<WorkUnitsViewProps> = ({
   };
 
   const handleDelete = async () => {
-    if (targetUnit) {
+    if (!targetUnit) return;
+    if (isDeleting) return;
+    setIsDeleting(true);
+    try {
       await onDeleteWorkUnit(targetUnit.id);
       setIsDeleteConfirmOpen(false);
       setTargetUnit(null);
+    } finally {
+      setIsDeleting(false);
     }
   };
 
@@ -139,6 +159,8 @@ const WorkUnitsView: React.FC<WorkUnitsViewProps> = ({
 
   const saveAssignments = async () => {
     if (!targetUnit) return;
+    if (isSavingAssignments) return;
+    setIsSavingAssignments(true);
     try {
       await workUnitsApi.updateUsers(targetUnit.id, assignedUserIds);
       await refreshWorkUnits(); // Update counts
@@ -147,7 +169,29 @@ const WorkUnitsView: React.FC<WorkUnitsViewProps> = ({
     } catch (err) {
       console.error('Failed to save assignments', err);
       alert(t('hr:workUnits.failedToSaveAssignments'));
+    } finally {
+      setIsSavingAssignments(false);
     }
+  };
+
+  const requestCloseCreateModal = () => {
+    if (isSubmitting) return;
+    setIsCreateModalOpen(false);
+  };
+
+  const requestCloseEditModal = () => {
+    if (isSubmitting) return;
+    setIsEditModalOpen(false);
+  };
+
+  const requestCloseAssignmentModal = () => {
+    if (isSavingAssignments) return;
+    setIsAssignmentModalOpen(false);
+  };
+
+  const requestCloseDeleteConfirm = () => {
+    if (isDeleting) return;
+    setIsDeleteConfirmOpen(false);
   };
 
   const toggleUserAssignment = (userId: string) => {
@@ -333,13 +377,15 @@ const WorkUnitsView: React.FC<WorkUnitsViewProps> = ({
       </div>
 
       {/* Create Modal */}
-      <Modal isOpen={isCreateModalOpen} onClose={() => setIsCreateModalOpen(false)}>
+      <Modal isOpen={isCreateModalOpen} onClose={requestCloseCreateModal}>
         <div className="bg-white rounded-2xl shadow-2xl w-full max-w-lg overflow-hidden animate-in zoom-in duration-200">
           <div className="p-6 border-b border-zinc-100 bg-zinc-50/50 flex justify-between items-center">
             <h3 className="text-lg font-semibold text-zinc-800">{t('hr:workUnits.newWorkUnit')}</h3>
             <button
-              onClick={() => setIsCreateModalOpen(false)}
-              className="text-zinc-400 hover:text-zinc-600"
+              type="button"
+              onClick={requestCloseCreateModal}
+              disabled={isSubmitting}
+              className="text-zinc-400 hover:text-zinc-600 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               <i className="fa-solid fa-xmark text-xl"></i>
             </button>
@@ -394,17 +440,18 @@ const WorkUnitsView: React.FC<WorkUnitsViewProps> = ({
             <div className="flex gap-3 pt-4">
               <button
                 type="button"
-                onClick={() => setIsCreateModalOpen(false)}
-                className="flex-1 py-3 text-sm font-bold text-zinc-500 hover:bg-zinc-50 rounded-xl transition-colors"
+                onClick={requestCloseCreateModal}
+                disabled={isSubmitting}
+                className="flex-1 py-3 text-sm font-bold text-zinc-500 hover:bg-zinc-50 rounded-xl transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {t('common:buttons.cancel')}
               </button>
               <button
                 type="submit"
-                disabled={selectedManagerIds.length === 0}
+                disabled={selectedManagerIds.length === 0 || isSubmitting}
                 className="flex-1 py-3 bg-praetor text-white text-sm font-bold rounded-xl shadow-lg shadow-zinc-200 hover:bg-zinc-700 transition-all active:scale-95 disabled:opacity-50 disabled:active:scale-100"
               >
-                {t('hr:workUnits.createUnit')}
+                {isSubmitting ? t('common:buttons.saving') : t('hr:workUnits.createUnit')}
               </button>
             </div>
           </form>
@@ -412,15 +459,17 @@ const WorkUnitsView: React.FC<WorkUnitsViewProps> = ({
       </Modal>
 
       {/* Edit Modal */}
-      <Modal isOpen={isEditModalOpen} onClose={() => setIsEditModalOpen(false)}>
+      <Modal isOpen={isEditModalOpen} onClose={requestCloseEditModal}>
         <div className="bg-white rounded-2xl shadow-2xl w-full max-w-lg overflow-hidden animate-in zoom-in duration-200">
           <div className="p-6 border-b border-zinc-100 bg-zinc-50/50 flex justify-between items-center">
             <h3 className="text-lg font-semibold text-zinc-800">
               {t('hr:workUnits.editWorkUnit')}
             </h3>
             <button
-              onClick={() => setIsEditModalOpen(false)}
-              className="text-zinc-400 hover:text-zinc-600"
+              type="button"
+              onClick={requestCloseEditModal}
+              disabled={isSubmitting}
+              className="text-zinc-400 hover:text-zinc-600 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               <i className="fa-solid fa-xmark text-xl"></i>
             </button>
@@ -475,16 +524,18 @@ const WorkUnitsView: React.FC<WorkUnitsViewProps> = ({
             <div className="flex gap-3 pt-4">
               <button
                 type="button"
-                onClick={() => setIsEditModalOpen(false)}
-                className="flex-1 py-3 text-sm font-bold text-zinc-500 hover:bg-zinc-50 rounded-xl transition-colors"
+                onClick={requestCloseEditModal}
+                disabled={isSubmitting}
+                className="flex-1 py-3 text-sm font-bold text-zinc-500 hover:bg-zinc-50 rounded-xl transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {t('common:buttons.cancel')}
               </button>
               <button
                 type="submit"
-                className="flex-1 py-3 bg-praetor text-white text-sm font-bold rounded-xl shadow-lg shadow-zinc-200 hover:bg-zinc-700 transition-all active:scale-95"
+                disabled={isSubmitting}
+                className="flex-1 py-3 bg-praetor text-white text-sm font-bold rounded-xl shadow-lg shadow-zinc-200 hover:bg-zinc-700 transition-all active:scale-95 disabled:opacity-50 disabled:active:scale-100"
               >
-                {t('hr:workUnits.saveChanges')}
+                {isSubmitting ? t('common:buttons.saving') : t('hr:workUnits.saveChanges')}
               </button>
             </div>
           </form>
@@ -494,7 +545,7 @@ const WorkUnitsView: React.FC<WorkUnitsViewProps> = ({
       {/* Assignment Modal */}
       <Modal
         isOpen={isAssignmentModalOpen && !!targetUnit}
-        onClose={() => setIsAssignmentModalOpen(false)}
+        onClose={requestCloseAssignmentModal}
       >
         <div className="bg-white rounded-2xl shadow-2xl w-full max-w-2xl h-[80vh] flex flex-col overflow-hidden animate-in zoom-in duration-200">
           <div className="p-6 border-b border-zinc-100 bg-zinc-50/50 flex justify-between items-center shrink-0">
@@ -507,8 +558,10 @@ const WorkUnitsView: React.FC<WorkUnitsViewProps> = ({
               </p>
             </div>
             <button
-              onClick={() => setIsAssignmentModalOpen(false)}
-              className="text-zinc-400 hover:text-zinc-600"
+              type="button"
+              onClick={requestCloseAssignmentModal}
+              disabled={isSavingAssignments}
+              className="text-zinc-400 hover:text-zinc-600 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               <i className="fa-solid fa-xmark text-xl"></i>
             </button>
@@ -570,17 +623,22 @@ const WorkUnitsView: React.FC<WorkUnitsViewProps> = ({
 
           <div className="p-6 border-t border-zinc-100 bg-zinc-50/50 flex justify-end gap-3 shrink-0">
             <button
-              onClick={() => setIsAssignmentModalOpen(false)}
-              className="px-6 py-2.5 text-sm font-bold text-zinc-500 hover:bg-zinc-200 rounded-xl transition-colors"
+              type="button"
+              onClick={requestCloseAssignmentModal}
+              disabled={isSavingAssignments}
+              className="px-6 py-2.5 text-sm font-bold text-zinc-500 hover:bg-zinc-200 rounded-xl transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {t('common:buttons.cancel')}
             </button>
             <button
+              type="button"
               onClick={saveAssignments}
-              disabled={isLoadingAssignments}
+              disabled={isLoadingAssignments || isSavingAssignments}
               className="px-8 py-2.5 bg-praetor text-white text-sm font-bold rounded-xl shadow-lg shadow-zinc-200 hover:bg-zinc-700 transition-all active:scale-95 disabled:opacity-50"
             >
-              {t('hr:workUnits.saveAssignments')}
+              {isSavingAssignments
+                ? t('common:buttons.saving')
+                : t('hr:workUnits.saveAssignments')}
             </button>
           </div>
         </div>
@@ -589,7 +647,7 @@ const WorkUnitsView: React.FC<WorkUnitsViewProps> = ({
       {/* Delete Confirm Modal */}
       <Modal
         isOpen={isDeleteConfirmOpen && !!targetUnit}
-        onClose={() => setIsDeleteConfirmOpen(false)}
+        onClose={requestCloseDeleteConfirm}
       >
         <div className="bg-white rounded-2xl shadow-2xl w-full max-w-sm overflow-hidden animate-in zoom-in duration-200">
           <div className="p-6 text-center space-y-4">
@@ -606,16 +664,20 @@ const WorkUnitsView: React.FC<WorkUnitsViewProps> = ({
             </div>
             <div className="flex gap-3 pt-2">
               <button
-                onClick={() => setIsDeleteConfirmOpen(false)}
-                className="flex-1 py-3 text-sm font-bold text-zinc-500 hover:bg-zinc-50 rounded-xl transition-colors"
+                type="button"
+                onClick={requestCloseDeleteConfirm}
+                disabled={isDeleting}
+                className="flex-1 py-3 text-sm font-bold text-zinc-500 hover:bg-zinc-50 rounded-xl transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {t('common:buttons.cancel')}
               </button>
               <button
+                type="button"
                 onClick={handleDelete}
-                className="flex-1 py-3 bg-red-600 text-white text-sm font-bold rounded-xl shadow-lg shadow-red-200 hover:bg-red-700 transition-all active:scale-95"
+                disabled={isDeleting}
+                className="flex-1 py-3 bg-red-600 text-white text-sm font-bold rounded-xl shadow-lg shadow-red-200 hover:bg-red-700 transition-all active:scale-95 disabled:opacity-50"
               >
-                {t('hr:workUnits.yesDelete')}
+                {isDeleting ? t('common:buttons.saving') : t('hr:workUnits.yesDelete')}
               </button>
             </div>
           </div>

--- a/components/WorkUnitsView.tsx
+++ b/components/WorkUnitsView.tsx
@@ -543,10 +543,7 @@ const WorkUnitsView: React.FC<WorkUnitsViewProps> = ({
       </Modal>
 
       {/* Assignment Modal */}
-      <Modal
-        isOpen={isAssignmentModalOpen && !!targetUnit}
-        onClose={requestCloseAssignmentModal}
-      >
+      <Modal isOpen={isAssignmentModalOpen && !!targetUnit} onClose={requestCloseAssignmentModal}>
         <div className="bg-white rounded-2xl shadow-2xl w-full max-w-2xl h-[80vh] flex flex-col overflow-hidden animate-in zoom-in duration-200">
           <div className="p-6 border-b border-zinc-100 bg-zinc-50/50 flex justify-between items-center shrink-0">
             <div>
@@ -636,19 +633,14 @@ const WorkUnitsView: React.FC<WorkUnitsViewProps> = ({
               disabled={isLoadingAssignments || isSavingAssignments}
               className="px-8 py-2.5 bg-praetor text-white text-sm font-bold rounded-xl shadow-lg shadow-zinc-200 hover:bg-zinc-700 transition-all active:scale-95 disabled:opacity-50"
             >
-              {isSavingAssignments
-                ? t('common:buttons.saving')
-                : t('hr:workUnits.saveAssignments')}
+              {isSavingAssignments ? t('common:buttons.saving') : t('hr:workUnits.saveAssignments')}
             </button>
           </div>
         </div>
       </Modal>
 
       {/* Delete Confirm Modal */}
-      <Modal
-        isOpen={isDeleteConfirmOpen && !!targetUnit}
-        onClose={requestCloseDeleteConfirm}
-      >
+      <Modal isOpen={isDeleteConfirmOpen && !!targetUnit} onClose={requestCloseDeleteConfirm}>
         <div className="bg-white rounded-2xl shadow-2xl w-full max-w-sm overflow-hidden animate-in zoom-in duration-200">
           <div className="p-6 text-center space-y-4">
             <div className="size-12 bg-red-100 rounded-full flex items-center justify-center mx-auto">

--- a/components/projects/TasksView.tsx
+++ b/components/projects/TasksView.tsx
@@ -686,10 +686,7 @@ const TasksView: React.FC<TasksViewProps> = ({
                 </span>
                 {editingTask ? t('tasks.editTask') : t('tasks.createNewTask')}
               </ModalTitle>
-              <ModalCloseButton
-                onClick={requestCloseModal}
-                disabled={isSubmitting || isDeleting}
-              />
+              <ModalCloseButton onClick={requestCloseModal} disabled={isSubmitting || isDeleting} />
             </ModalHeader>
 
             <ModalBody className="space-y-6">

--- a/components/projects/TasksView.tsx
+++ b/components/projects/TasksView.tsx
@@ -6,7 +6,7 @@ import { Field, FieldLabel } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
-import { tasksApi } from '../../services/api';
+import { tasksApi } from '../../services/api/tasks';
 import type {
   BillingFrequency,
   Client,
@@ -66,9 +66,9 @@ export interface TasksViewProps {
       ProjectTask,
       'expectedEffort' | 'monthlyEffort' | 'revenue' | 'notes' | 'billingType' | 'billingFrequency'
     >,
-  ) => void;
-  onUpdateTask: (id: string, updates: Partial<ProjectTask>) => void;
-  onDeleteTask: (id: string) => void;
+  ) => void | Promise<void>;
+  onUpdateTask: (id: string, updates: Partial<ProjectTask>) => void | Promise<void>;
+  onDeleteTask: (id: string) => void | Promise<void>;
   onViewOrder?: (orderId: string) => void;
 }
 
@@ -102,6 +102,8 @@ const TasksView: React.FC<TasksViewProps> = ({
   const [tempIsDisabled, setTempIsDisabled] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const [managingTaskId, setManagingTaskId] = useState<string | null>(null);
 
@@ -558,21 +560,24 @@ const TasksView: React.FC<TasksViewProps> = ({
     ],
   );
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (isSubmitting) return;
     if (editingTask && !canUpdateTasks) return;
     if (!editingTask && !canCreateTasks) return;
-    if (name && projectId) {
-      const details = {
-        billingType,
-        billingFrequency: billingType === 'time_and_materials' ? 'monthly' : billingFrequency,
-        monthlyEffort: monthlyEffort ? parseFloat(monthlyEffort) : undefined,
-        expectedEffort: expectedEffort ? parseFloat(expectedEffort) : undefined,
-        revenue: revenue ? parseFloat(revenue) : undefined,
-        notes: notes.trim() || undefined,
-      };
+    if (!name || !projectId) return;
+    const details = {
+      billingType,
+      billingFrequency: billingType === 'time_and_materials' ? 'monthly' : billingFrequency,
+      monthlyEffort: monthlyEffort ? parseFloat(monthlyEffort) : undefined,
+      expectedEffort: expectedEffort ? parseFloat(expectedEffort) : undefined,
+      revenue: revenue ? parseFloat(revenue) : undefined,
+      notes: notes.trim() || undefined,
+    };
+    setIsSubmitting(true);
+    try {
       if (editingTask) {
-        onUpdateTask(editingTask.id, {
+        await onUpdateTask(editingTask.id, {
           name,
           projectId,
           description,
@@ -580,9 +585,11 @@ const TasksView: React.FC<TasksViewProps> = ({
           ...details,
         });
       } else {
-        onAddTask(name, projectId, undefined, description, details);
+        await onAddTask(name, projectId, undefined, description, details);
       }
       closeModal();
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -601,15 +608,26 @@ const TasksView: React.FC<TasksViewProps> = ({
     setNotes('');
   };
 
+  const requestCloseModal = () => {
+    if (isSubmitting || isDeleting) return;
+    closeModal();
+  };
+
   const cancelDelete = () => {
+    if (isDeleting) return;
     setIsDeleteConfirmOpen(false);
   };
 
-  const handleDelete = () => {
+  const handleDelete = async () => {
     if (!canDeleteTasks) return;
-    if (editingTask) {
-      onDeleteTask(editingTask.id);
+    if (isDeleting) return;
+    if (!editingTask) return;
+    setIsDeleting(true);
+    try {
+      await onDeleteTask(editingTask.id);
       closeModal();
+    } finally {
+      setIsDeleting(false);
     }
   };
 
@@ -629,6 +647,7 @@ const TasksView: React.FC<TasksViewProps> = ({
         isOpen={isDeleteConfirmOpen}
         onClose={cancelDelete}
         onConfirm={handleDelete}
+        isDeleting={isDeleting}
         title={t('tasks.deleteTaskTitle', { name: editingTask?.name })}
         description={
           <Trans
@@ -654,7 +673,7 @@ const TasksView: React.FC<TasksViewProps> = ({
       />
 
       {/* Add/Edit Modal */}
-      <Modal isOpen={isModalOpen} onClose={closeModal}>
+      <Modal isOpen={isModalOpen} onClose={requestCloseModal}>
         <ModalContent size="2xl">
           <form onSubmit={handleSubmit} className="flex min-h-0 flex-col">
             <ModalHeader>
@@ -667,7 +686,10 @@ const TasksView: React.FC<TasksViewProps> = ({
                 </span>
                 {editingTask ? t('tasks.editTask') : t('tasks.createNewTask')}
               </ModalTitle>
-              <ModalCloseButton onClick={closeModal} />
+              <ModalCloseButton
+                onClick={requestCloseModal}
+                disabled={isSubmitting || isDeleting}
+              />
             </ModalHeader>
 
             <ModalBody className="space-y-6">
@@ -898,6 +920,7 @@ const TasksView: React.FC<TasksViewProps> = ({
                   type="button"
                   variant="ghost"
                   onClick={confirmDelete}
+                  disabled={isSubmitting || isDeleting}
                   className="text-destructive hover:bg-destructive/10 hover:text-destructive"
                 >
                   <i className="fa-solid fa-trash-can" aria-hidden="true"></i>
@@ -908,11 +931,20 @@ const TasksView: React.FC<TasksViewProps> = ({
               )}
 
               <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
-                <Button type="button" variant="outline" onClick={closeModal}>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={requestCloseModal}
+                  disabled={isSubmitting || isDeleting}
+                >
                   {t('common:buttons.cancel')}
                 </Button>
-                <Button type="submit" disabled={!canSubmit}>
-                  {editingTask ? t('projects.saveChanges') : t('tasks.addTask')}
+                <Button type="submit" disabled={!canSubmit || isSubmitting}>
+                  {isSubmitting
+                    ? t('common:buttons.saving')
+                    : editingTask
+                      ? t('projects.saveChanges')
+                      : t('tasks.addTask')}
                 </Button>
               </div>
             </ModalFooter>

--- a/components/shared/DeleteConfirmModal.tsx
+++ b/components/shared/DeleteConfirmModal.tsx
@@ -10,6 +10,7 @@ interface DeleteConfirmModalProps {
   onConfirm: () => void;
   title: React.ReactNode;
   description?: React.ReactNode;
+  isDeleting?: boolean;
 }
 
 const DeleteConfirmModal: React.FC<DeleteConfirmModalProps> = ({
@@ -18,6 +19,7 @@ const DeleteConfirmModal: React.FC<DeleteConfirmModalProps> = ({
   onConfirm,
   title,
   description,
+  isDeleting = false,
 }) => {
   const { t } = useTranslation('common');
   return (
@@ -38,11 +40,16 @@ const DeleteConfirmModal: React.FC<DeleteConfirmModalProps> = ({
             </ModalBody>
           )}
           <ModalFooter className="grid grid-cols-2 sm:flex">
-            <Button type="button" variant="outline" onClick={onClose}>
+            <Button type="button" variant="outline" onClick={onClose} disabled={isDeleting}>
               {t('buttons.noGoBack')}
             </Button>
-            <Button type="button" variant="destructive" onClick={onConfirm}>
-              {t('buttons.yesDelete')}
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={onConfirm}
+              disabled={isDeleting}
+            >
+              {isDeleting ? t('buttons.saving') : t('buttons.yesDelete')}
             </Button>
           </ModalFooter>
         </ModalContent>

--- a/components/shared/DeleteConfirmModal.tsx
+++ b/components/shared/DeleteConfirmModal.tsx
@@ -43,12 +43,7 @@ const DeleteConfirmModal: React.FC<DeleteConfirmModalProps> = ({
             <Button type="button" variant="outline" onClick={onClose} disabled={isDeleting}>
               {t('buttons.noGoBack')}
             </Button>
-            <Button
-              type="button"
-              variant="destructive"
-              onClick={onConfirm}
-              disabled={isDeleting}
-            >
+            <Button type="button" variant="destructive" onClick={onConfirm} disabled={isDeleting}>
               {isDeleting ? t('buttons.saving') : t('buttons.yesDelete')}
             </Button>
           </ModalFooter>

--- a/components/shared/ModalLayout.tsx
+++ b/components/shared/ModalLayout.tsx
@@ -116,9 +116,11 @@ export function ModalDescription({
 export function ModalCloseButton({
   onClick,
   className,
+  disabled,
 }: {
   onClick: () => void;
   className?: string;
+  disabled?: boolean;
 }) {
   return (
     <Button
@@ -127,6 +129,7 @@ export function ModalCloseButton({
       size="icon-sm"
       className={cn('shrink-0 text-muted-foreground', className)}
       onClick={onClick}
+      disabled={disabled}
     >
       <XIcon className="size-4" />
       <span className="sr-only">Close</span>

--- a/test/components/hr/WorkUnitsView.doubleSubmit.test.tsx
+++ b/test/components/hr/WorkUnitsView.doubleSubmit.test.tsx
@@ -42,13 +42,15 @@ const PERMISSIONS = [
   'hr.work_units.view',
 ];
 
-const renderWorkUnitsView = (overrides: {
-  onAdd?: ReturnType<typeof mock>;
-  onUpdate?: ReturnType<typeof mock>;
-  onDelete?: ReturnType<typeof mock>;
-  refresh?: ReturnType<typeof mock>;
-  workUnits?: WorkUnit[];
-} = {}) => {
+const renderWorkUnitsView = (
+  overrides: {
+    onAdd?: ReturnType<typeof mock>;
+    onUpdate?: ReturnType<typeof mock>;
+    onDelete?: ReturnType<typeof mock>;
+    refresh?: ReturnType<typeof mock>;
+    workUnits?: WorkUnit[];
+  } = {},
+) => {
   const onAdd = overrides.onAdd ?? mock(() => Promise.resolve());
   const onUpdate = overrides.onUpdate ?? mock(() => Promise.resolve());
   const onDelete = overrides.onDelete ?? mock(() => Promise.resolve());

--- a/test/components/hr/WorkUnitsView.doubleSubmit.test.tsx
+++ b/test/components/hr/WorkUnitsView.doubleSubmit.test.tsx
@@ -1,0 +1,245 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { User, WorkUnit } from '../../../types';
+import { installI18nMock } from '../../helpers/i18n';
+import { render } from '../../helpers/render';
+
+installI18nMock();
+
+// Mock the sub-module the component imports so we don't hit the network.
+mock.module('../../../services/api/workUnits', () => ({
+  workUnitsApi: {
+    getUsers: () => Promise.resolve([]),
+    updateUsers: () => Promise.resolve(),
+  },
+}));
+
+const WorkUnitsView = (await import('../../../components/WorkUnitsView')).default;
+
+const USERS: User[] = [
+  {
+    id: 'u1',
+    name: 'Alice',
+    username: 'alice',
+    role: 'admin',
+    avatarInitials: 'AL',
+  } as unknown as User,
+];
+
+const UNIT: WorkUnit = {
+  id: 'wu-1',
+  name: 'Engineering',
+  managers: [{ id: 'u1', name: 'Alice' }],
+  description: 'eng',
+  userCount: 1,
+};
+
+const PERMISSIONS = [
+  'hr.work_units.create',
+  'hr.work_units.update',
+  'hr.work_units.delete',
+  'hr.work_units.view',
+];
+
+const renderWorkUnitsView = (overrides: {
+  onAdd?: ReturnType<typeof mock>;
+  onUpdate?: ReturnType<typeof mock>;
+  onDelete?: ReturnType<typeof mock>;
+  refresh?: ReturnType<typeof mock>;
+  workUnits?: WorkUnit[];
+} = {}) => {
+  const onAdd = overrides.onAdd ?? mock(() => Promise.resolve());
+  const onUpdate = overrides.onUpdate ?? mock(() => Promise.resolve());
+  const onDelete = overrides.onDelete ?? mock(() => Promise.resolve());
+  const refresh = overrides.refresh ?? mock(() => Promise.resolve());
+
+  const utils = render(
+    <WorkUnitsView
+      workUnits={overrides.workUnits ?? [UNIT]}
+      users={USERS}
+      permissions={PERMISSIONS}
+      onAddWorkUnit={onAdd as unknown as never}
+      onUpdateWorkUnit={onUpdate as unknown as never}
+      onDeleteWorkUnit={onDelete as unknown as never}
+      refreshWorkUnits={refresh as unknown as never}
+    />,
+  );
+  return { ...utils, onAdd, onUpdate, onDelete, refresh };
+};
+
+const findFormByHeading = (heading: string) => {
+  // Prefer the heading rendered as an h3 (the modal title) to disambiguate
+  // from any HeaderAddButton text that may share the same translation key.
+  const headings = screen.getAllByText(heading);
+  const headingEl = headings.find((el) => el.tagName === 'H3') ?? headings[0];
+  if (!headingEl) throw new Error(`heading "${heading}" not found`);
+  const form = headingEl.parentElement?.parentElement?.querySelector('form');
+  if (!form) throw new Error(`form for "${heading}" not found`);
+  return form as HTMLFormElement;
+};
+
+describe('<WorkUnitsView /> double-submit guards', () => {
+  test('handleCreate: rapid submits call onAddWorkUnit only once', async () => {
+    let resolveAdd: (() => void) | undefined;
+    const onAdd = mock(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveAdd = () => resolve();
+        }),
+    );
+
+    const { onAdd: addMock } = renderWorkUnitsView({ onAdd, workUnits: [] });
+    const user = userEvent.setup();
+
+    // Open the create modal.
+    await user.click(screen.getByRole('button', { name: /hr:workUnits\.newWorkUnit/ }));
+
+    // Fill the unit name (the first required text input in the form).
+    const form = findFormByHeading('hr:workUnits.newWorkUnit');
+    const nameInput = form.querySelector('input[type="text"]') as HTMLInputElement;
+    if (!nameInput) throw new Error('unit name input not found');
+    fireEvent.change(nameInput, { target: { value: 'New Unit' } });
+
+    // Select a manager.
+    const managerButton = screen
+      .getAllByRole('button')
+      .find((b) => b.textContent?.includes('hr:workUnits.selectManagers'));
+    if (!managerButton) throw new Error('manager select trigger not found');
+    await user.click(managerButton);
+    const aliceOption = await screen.findByRole('option', { name: 'Alice' });
+    await user.click(aliceOption);
+
+    fireEvent.submit(form);
+    fireEvent.submit(form);
+    fireEvent.submit(form);
+
+    // The fix awaits onAddWorkUnit before closing — the modal stays open
+    // (the form must remain in the document while the await is pending).
+    expect(form.isConnected).toBe(true);
+
+    await act(async () => {
+      resolveAdd?.();
+    });
+
+    expect(addMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('handleUpdate: rapid submits call onUpdateWorkUnit only once', async () => {
+    let resolveUpdate: (() => void) | undefined;
+    const onUpdate = mock(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveUpdate = () => resolve();
+        }),
+    );
+
+    const { onUpdate: updateMock } = renderWorkUnitsView({ onUpdate });
+
+    // Open the edit modal via the per-row Edit button (single Edit button per unit).
+    const editButtons = screen.getAllByRole('button').filter((btn) => {
+      const icon = btn.querySelector('i.fa-solid.fa-pen');
+      return icon !== null && !btn.querySelector('i.fa-trash-can');
+    });
+    if (editButtons.length === 0) throw new Error('edit button not found');
+    fireEvent.click(editButtons[0]);
+
+    const form = findFormByHeading('hr:workUnits.editWorkUnit');
+
+    fireEvent.submit(form);
+    fireEvent.submit(form);
+    fireEvent.submit(form);
+
+    // While the update is in flight, the form should still be mounted.
+    expect(form.isConnected).toBe(true);
+
+    await act(async () => {
+      resolveUpdate?.();
+    });
+
+    expect(updateMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('handleDelete: rapid clicks call onDeleteWorkUnit only once', async () => {
+    let resolveDelete: (() => void) | undefined;
+    const onDelete = mock(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveDelete = () => resolve();
+        }),
+    );
+
+    const { onDelete: deleteMock } = renderWorkUnitsView({ onDelete });
+
+    // Open delete confirm via the per-row Delete (trash) button.
+    const deleteButtons = screen
+      .getAllByRole('button')
+      .filter((btn) => btn.querySelector('i.fa-trash-can'));
+    if (deleteButtons.length === 0) throw new Error('delete button not found');
+    fireEvent.click(deleteButtons[0]);
+
+    // Confirm dialog: find the Yes-delete button.
+    const confirm = await screen.findByRole('button', { name: 'hr:workUnits.yesDelete' });
+
+    fireEvent.click(confirm);
+    fireEvent.click(confirm);
+    fireEvent.click(confirm);
+
+    // While delete is in flight, the confirmation button must still be mounted.
+    expect(confirm.isConnected).toBe(true);
+
+    await act(async () => {
+      resolveDelete?.();
+    });
+
+    expect(deleteMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('close controls are inert while a create submit is in flight', async () => {
+    let resolveAdd: (() => void) | undefined;
+    const onAdd = mock(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveAdd = () => resolve();
+        }),
+    );
+
+    renderWorkUnitsView({ onAdd, workUnits: [] });
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole('button', { name: /hr:workUnits\.newWorkUnit/ }));
+
+    const form = findFormByHeading('hr:workUnits.newWorkUnit');
+    const nameInput = form.querySelector('input[type="text"]') as HTMLInputElement;
+    if (!nameInput) throw new Error('unit name input not found');
+    fireEvent.change(nameInput, { target: { value: 'New Unit' } });
+
+    // Select a manager.
+    const managerButton = screen
+      .getAllByRole('button')
+      .find((b) => b.textContent?.includes('hr:workUnits.selectManagers'));
+    if (!managerButton) throw new Error('manager select trigger not found');
+    await user.click(managerButton);
+    await user.click(await screen.findByRole('option', { name: 'Alice' }));
+
+    fireEvent.submit(form);
+
+    // Cancel button (inside the modal form) must be disabled while submit is in flight.
+    const cancel = Array.from(form.querySelectorAll('button')).find(
+      (b) => b.textContent?.trim() === 'common:buttons.cancel',
+    ) as HTMLButtonElement | undefined;
+    if (!cancel) throw new Error('cancel button not found inside form');
+    expect(cancel.disabled).toBe(true);
+
+    fireEvent.click(cancel);
+    // The form is still mounted because closing is blocked while submitting.
+    expect(form.isConnected).toBe(true);
+
+    await act(async () => {
+      resolveAdd?.();
+    });
+    await waitFor(() => {
+      expect(form.isConnected).toBe(false);
+    });
+  });
+});

--- a/test/components/projects/TasksView.doubleSubmit.test.tsx
+++ b/test/components/projects/TasksView.doubleSubmit.test.tsx
@@ -1,0 +1,241 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { Client, Project, ProjectTask, Role, User } from '../../../types';
+import { installI18nMock } from '../../helpers/i18n';
+import { render } from '../../helpers/render';
+
+installI18nMock();
+
+// Mock the sub-module the component imports so we don't hit the network.
+mock.module('../../../services/api/tasks', () => ({
+  tasksApi: {
+    getHoursForProjects: () => Promise.resolve({}),
+    getUsers: () => Promise.resolve([]),
+    updateUsers: () => Promise.resolve(),
+  },
+}));
+
+const TasksView = (await import('../../../components/projects/TasksView')).default;
+
+const PROJECT: Project = {
+  id: 'project-1',
+  name: 'Project Alpha',
+  clientId: 'client-1',
+  color: '#000000',
+} as unknown as Project;
+
+const CLIENT: Client = {
+  id: 'client-1',
+  name: 'Client One',
+} as unknown as Client;
+
+const TASK: ProjectTask = {
+  id: 'task-1',
+  name: 'Existing Task',
+  projectId: 'project-1',
+  description: 'desc',
+  billingType: 'time_and_materials',
+  billingFrequency: 'monthly',
+  expectedEffort: 10,
+  monthlyEffort: 2,
+  revenue: 100,
+  notes: '',
+};
+
+const PERMISSIONS = [
+  'projects.tasks.create',
+  'projects.tasks.update',
+  'projects.tasks.delete',
+  'projects.tasks.view',
+];
+
+const USERS: User[] = [];
+const ROLES: Role[] = [];
+
+const renderTasksView = (overrides: {
+  onAddTask?: ReturnType<typeof mock>;
+  onUpdateTask?: ReturnType<typeof mock>;
+  onDeleteTask?: ReturnType<typeof mock>;
+  tasks?: ProjectTask[];
+} = {}) => {
+  const onAddTask = overrides.onAddTask ?? mock(() => Promise.resolve());
+  const onUpdateTask = overrides.onUpdateTask ?? mock(() => Promise.resolve());
+  const onDeleteTask = overrides.onDeleteTask ?? mock(() => Promise.resolve());
+
+  const utils = render(
+    <TasksView
+      tasks={overrides.tasks ?? [TASK]}
+      projects={[PROJECT]}
+      clients={[CLIENT]}
+      permissions={PERMISSIONS}
+      users={USERS}
+      roles={ROLES}
+      currency="$"
+      onAddTask={onAddTask as unknown as never}
+      onUpdateTask={onUpdateTask as unknown as never}
+      onDeleteTask={onDeleteTask as unknown as never}
+    />,
+  );
+
+  return { ...utils, onAddTask, onUpdateTask, onDeleteTask };
+};
+
+const findCreateForm = () => {
+  const heading = screen.getByText('tasks.createNewTask');
+  const form = heading.closest('form');
+  if (!form) throw new Error('Add task form not found');
+  return form as HTMLFormElement;
+};
+
+const findEditForm = () => {
+  const heading = screen.getByText('tasks.editTask');
+  const form = heading.closest('form');
+  if (!form) throw new Error('Edit task form not found');
+  return form as HTMLFormElement;
+};
+
+describe('<TasksView /> double-submit guards', () => {
+  test('handleSubmit (create): rapid clicks call onAddTask only once', async () => {
+    let resolveAdd: (() => void) | undefined;
+    const onAddTask = mock(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveAdd = () => resolve();
+        }),
+    );
+
+    // Render with no pre-existing tasks so there's no row to confuse "Project Alpha" with.
+    const { onAddTask: addMock } = renderTasksView({ onAddTask, tasks: [] });
+    const user = userEvent.setup();
+
+    // Open the create modal via the HeaderAddButton.
+    await user.click(screen.getByRole('button', { name: /tasks\.addTask/ }));
+
+    // Fill required fields: name input and project select.
+    const nameInput = screen.getByPlaceholderText('tasks.taskNamePlaceholder') as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: 'My New Task' } });
+
+    // Open project SelectControl combobox (searchable Popover) and pick the project.
+    const projectButton = screen
+      .getAllByRole('button')
+      .find((btn) => btn.textContent?.includes('labels.selectOption'));
+    if (!projectButton) throw new Error('project select trigger not found');
+    await user.click(projectButton);
+
+    // Wait for the popover and pick the project option.
+    const option = await screen.findByRole('option', { name: 'Project Alpha' });
+    await user.click(option);
+
+    const form = findCreateForm();
+
+    // Rapid-fire 3 submits while the first promise is still pending.
+    fireEvent.submit(form);
+    fireEvent.submit(form);
+    fireEvent.submit(form);
+
+    // The fix awaits onAddTask before closing the modal — the modal should
+    // remain mounted while the promise is pending. On un-guarded code the
+    // modal would close synchronously after the first call, masking the
+    // duplicate-submit bug.
+    expect(screen.queryByText('tasks.createNewTask')).toBeInTheDocument();
+
+    // Resolve the pending promise so the finally-block runs.
+    await act(async () => {
+      resolveAdd?.();
+    });
+
+    expect(addMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('handleSubmit (edit): rapid clicks call onUpdateTask only once', async () => {
+    let resolveUpdate: (() => void) | undefined;
+    const onUpdateTask = mock(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveUpdate = () => resolve();
+        }),
+    );
+
+    const { onUpdateTask: updateMock } = renderTasksView({ onUpdateTask });
+
+    // Click the task row to open edit modal.
+    fireEvent.click(screen.getByText('Existing Task'));
+    const form = findEditForm();
+
+    fireEvent.submit(form);
+    fireEvent.submit(form);
+    fireEvent.submit(form);
+
+    // The modal must stay open while the submit awaits — see test above.
+    expect(screen.queryByText('tasks.editTask')).toBeInTheDocument();
+
+    await act(async () => {
+      resolveUpdate?.();
+    });
+
+    expect(updateMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('close controls are inert while a submit is in flight', async () => {
+    let resolveUpdate: (() => void) | undefined;
+    const onUpdateTask = mock(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveUpdate = () => resolve();
+        }),
+    );
+
+    renderTasksView({ onUpdateTask });
+
+    fireEvent.click(screen.getByText('Existing Task'));
+    const form = findEditForm();
+
+    fireEvent.submit(form);
+
+    // While the submit is in flight, the Cancel button must be disabled.
+    const cancelButton = await screen.findByRole('button', { name: 'common:buttons.cancel' });
+    expect((cancelButton as HTMLButtonElement).disabled).toBe(true);
+
+    // Clicking Cancel must not close the modal.
+    fireEvent.click(cancelButton);
+    expect(screen.queryByText('tasks.editTask')).toBeInTheDocument();
+
+    // Resolve and verify modal closes.
+    await act(async () => {
+      resolveUpdate?.();
+    });
+    await waitFor(() => {
+      expect(screen.queryByText('tasks.editTask')).not.toBeInTheDocument();
+    });
+  });
+
+  test('handleDelete: rapid clicks call onDeleteTask only once', async () => {
+    let resolveDelete: (() => void) | undefined;
+    const onDeleteTask = mock(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveDelete = () => resolve();
+        }),
+    );
+
+    const { onDeleteTask: deleteMock } = renderTasksView({ onDeleteTask });
+
+    // Open edit modal, then click Delete inside the footer.
+    fireEvent.click(screen.getByText('Existing Task'));
+    fireEvent.click(screen.getByRole('button', { name: /common:buttons\.delete/ }));
+
+    // Confirm delete in the DeleteConfirmModal.
+    const confirmButton = await screen.findByRole('button', { name: 'buttons.yesDelete' });
+
+    fireEvent.click(confirmButton);
+    fireEvent.click(confirmButton);
+    fireEvent.click(confirmButton);
+
+    await act(async () => {
+      resolveDelete?.();
+    });
+
+    expect(deleteMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/components/projects/TasksView.doubleSubmit.test.tsx
+++ b/test/components/projects/TasksView.doubleSubmit.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, mock, test } from 'bun:test';
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { createPortal } from 'react-dom';
 import type { Client, Project, ProjectTask, Role, User } from '../../../types';
 import { installI18nMock } from '../../helpers/i18n';
 import { render } from '../../helpers/render';
@@ -14,6 +15,38 @@ mock.module('../../../services/api/tasks', () => ({
     getUsers: () => Promise.resolve([]),
     updateUsers: () => Promise.resolve(),
   },
+}));
+
+// OfferVersionsPanel.test.tsx registers a global `mock.module` for DeleteConfirmModal
+// in Bun's runner; that mock persists across files and would otherwise stub out the
+// confirm button this suite asserts against. Re-mock here so the suite is hermetic. We
+// portal into document.body so the confirm buttons aren't hidden by the edit Dialog's
+// modal aria-hidden boundary (the real component does this via Radix Dialog).
+mock.module('../../../components/shared/DeleteConfirmModal', () => ({
+  default: ({
+    isOpen,
+    onConfirm,
+    onClose,
+    isDeleting,
+  }: {
+    isOpen: boolean;
+    onConfirm: () => void;
+    onClose: () => void;
+    isDeleting?: boolean;
+  }) =>
+    isOpen
+      ? createPortal(
+          <div role="dialog" aria-modal="true">
+            <button type="button" onClick={onClose} disabled={isDeleting}>
+              buttons.noGoBack
+            </button>
+            <button type="button" onClick={onConfirm} disabled={isDeleting}>
+              {isDeleting ? 'buttons.saving' : 'buttons.yesDelete'}
+            </button>
+          </div>,
+          document.body,
+        )
+      : null,
 }));
 
 const TasksView = (await import('../../../components/projects/TasksView')).default;
@@ -53,12 +86,14 @@ const PERMISSIONS = [
 const USERS: User[] = [];
 const ROLES: Role[] = [];
 
-const renderTasksView = (overrides: {
-  onAddTask?: ReturnType<typeof mock>;
-  onUpdateTask?: ReturnType<typeof mock>;
-  onDeleteTask?: ReturnType<typeof mock>;
-  tasks?: ProjectTask[];
-} = {}) => {
+const renderTasksView = (
+  overrides: {
+    onAddTask?: ReturnType<typeof mock>;
+    onUpdateTask?: ReturnType<typeof mock>;
+    onDeleteTask?: ReturnType<typeof mock>;
+    tasks?: ProjectTask[];
+  } = {},
+) => {
   const onAddTask = overrides.onAddTask ?? mock(() => Promise.resolve());
   const onUpdateTask = overrides.onUpdateTask ?? mock(() => Promise.resolve());
   const onDeleteTask = overrides.onDeleteTask ?? mock(() => Promise.resolve());


### PR DESCRIPTION
## Summary

Re-applies the double-submit fix from the closed PR #304 on top of current `main`, which has substantial refactors (billing types, shadcn imports, format callbacks) that conflicted irreconcilably with the original commit.

- Async create/update/delete handlers in `TasksView` and `WorkUnitsView` (and the work-unit assignment-save flow) now guard with `isSubmitting`/`isDeleting`/`isSavingAssignments`, `await` the callback before closing, and disable the submit, Cancel, and X-close controls while in flight. This addresses both the rapid-double-click duplication bug and the P2 race the codex review raised on #304 — closing the modal mid-flight is blocked, so the resolving `await` cannot clobber an unrelated modal's state.
- Switched `tasksApi`/`workUnitsApi` imports from the umbrella `services/api` to the sub-modules `services/api/tasks` and `services/api/workUnits`. Without this, Bun's `mock.module` in `Login.test.tsx` clobbers the umbrella module for the rest of the run, so any later test that imports these views crashes.
- Plumbed a new `isDeleting` prop through `DeleteConfirmModal` and a new `disabled` prop through `ModalCloseButton` so consumers can mark them inert without rebuilding the components.
- Translation key `common:buttons.saving` was already present in both `en` and `it` locale files; reused it for the in-flight button label.

## Test plan

- [x] `bun test test/components/projects/TasksView.doubleSubmit.test.tsx` — 4 new tests pass: rapid-click create, rapid-click edit, close-controls-inert-while-submitting, rapid-click delete. Each was verified to fail on the un-fixed handler (un-guarded sync version with synchronous `closeModal`).
- [x] `bun test test/components/hr/WorkUnitsView.doubleSubmit.test.tsx` — 4 new tests pass: rapid-click create, rapid-click edit, rapid-click delete, close-controls-inert. Each verified to fail on the un-fixed handlers.
- [x] `bun run test:server` — 2027 pass, 27 skip, 0 fail.
- [x] `bun test test/components/projects test/components/hr test/components/UserSettings.test.tsx test/components/Toggle.test.tsx test/components/Modal.test.tsx` — 51 pass, 0 fail.
- [x] `bun run lint` (Biome step) — clean for changed files. The `i18n:check` step reports missing keys in unrelated `.claude/worktrees/agent-*` paths (other agents' worktrees) — pre-existing, not introduced by this PR.
- [x] `bunx tsc --noEmit` from `server/` — clean.
- [x] `bunx tsc --noEmit` from repo root — clean on changed files. Pre-existing `TS1185` (merge conflict marker) errors are present in `components/Login.tsx`, `components/sales/ClientOffersView.tsx`, `components/projects/ProjectsView.tsx`, `components/accounting/ClientsOrdersView.tsx`, `components/CRM/ClientsView.tsx`, `components/CRM/SuppliersView.tsx`, `components/catalog/InternalListingView.tsx`, `services/api.ts`, `services/api/client.ts`, `services/api/normalizers.ts`, and `test/components/Login.test.tsx` — these exist on `main` and are unrelated to this PR.
- [x] Full frontend `bun test` cannot complete locally because those same pre-existing files have unresolved conflict markers and crash the test runner before assertions run.

https://claude.ai/code/session_01RYnzgoB4TeCHNUcqbvZvQT

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYnzgoB4TeCHNUcqbvZvQT)_