### PR TITLE
bump(release): app version to 0.6.1

### DIFF
--- a/deploy/.env.customer.example
+++ b/deploy/.env.customer.example
@@ -4,7 +4,7 @@
 
 # Image source
 PRAETOR_IMAGE_PREFIX=ghcr.io/xbounceit
-PRAETOR_VERSION=v0.6.0
+PRAETOR_VERSION=v0.6.1
 
 # Public frontend origin used by backend CORS
 # Use your real URL in production (example: https://erp.example.com)

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Praetor API",
     "description": "Praetor API documentation",
-    "version": "0.6.0"
+    "version": "0.6.1"
   },
   "components": {
     "securitySchemes": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praetor",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server/app.ts
+++ b/server/app.ts
@@ -92,7 +92,7 @@ export const buildApp = async () => {
       info: {
         title: 'Praetor API',
         description: 'Praetor API documentation',
-        version: '0.6.0',
+        version: '0.6.1',
       },
       components: {
         securitySchemes: {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "praetor-server",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Praetor API Server",
   "main": "index.ts",
   "type": "module",

--- a/server/routes/mcp.ts
+++ b/server/routes/mcp.ts
@@ -235,7 +235,7 @@ const runBulkTimeEntryTool = async <T>(
 
 const buildServer = () => {
   const server = new McpServer(
-    { name: 'praetor', version: '0.6.0' },
+    { name: 'praetor', version: '0.6.1' },
     {
       instructions:
         'Use Praetor tools to inspect and update ERP data. Tool results are scoped to the authenticated MCP token user and their current Praetor role permissions.',

--- a/server/test/routes/mcp.test.ts
+++ b/server/test/routes/mcp.test.ts
@@ -357,7 +357,7 @@ describe('/api/mcp', () => {
 
     expect(res.statusCode).toBe(200);
     const body = parseMcpBody(res.body);
-    expect(body.result.serverInfo).toEqual({ name: 'praetor', version: '0.6.0' });
+    expect(body.result.serverInfo).toEqual({ name: 'praetor', version: '0.6.1' });
   });
 
   test('lists tools and calls permission-scoped list tools', async () => {


### PR DESCRIPTION
## Summary
- Bump app version `0.6.0` → `0.6.1` across all version-bearing files: root `package.json`, `server/package.json`, OpenAPI doc, Swagger registration, MCP server info, MCP initialize test assertion, and the customer deployment `.env` example.

## Test plan
- [ ] CI typecheck passes
- [ ] CI test suite passes (notably `server/test/routes/mcp.test.ts` which asserts the MCP `initialize` response carries the new version)