### PR TITLE
feat(user-management): differentiate auth-method badges per protocol

### DIFF
--- a/components/administration/UserManagement.tsx
+++ b/components/administration/UserManagement.tsx
@@ -776,6 +776,18 @@ const UserManagement: React.FC<UserManagementProps> = ({
     }
     return t(`hr:workforce.authMethod.${method}`);
   };
+  const getAuthMethodBadgeType = (user: User): StatusType => {
+    switch (user.authMethod || 'local') {
+      case 'ldap':
+        return 'auth_ldap';
+      case 'oidc':
+        return 'auth_oidc';
+      case 'saml':
+        return 'auth_saml';
+      default:
+        return 'auth_local';
+    }
+  };
   const getUserStatusLabel = (user: User) =>
     user.isDisabled ? t('common:common.disabled') : t('common:common.active');
   const getRolePresentation = (user: User) => {
@@ -842,7 +854,9 @@ const UserManagement: React.FC<UserManagementProps> = ({
     {
       header: t('hr:workforce.authMethod.column'),
       accessorFn: (user) => getAuthMethodLabel(user),
-      cell: ({ row }) => <StatusBadge type="inherited" label={getAuthMethodLabel(row)} />,
+      cell: ({ row }) => (
+        <StatusBadge type={getAuthMethodBadgeType(row)} label={getAuthMethodLabel(row)} />
+      ),
     },
     {
       header: t('common:labels.status'),

--- a/components/shared/StatusBadge.tsx
+++ b/components/shared/StatusBadge.tsx
@@ -1,4 +1,5 @@
 import type React from 'react';
+import { siOpenid } from 'simple-icons';
 
 export type StatusType =
   | 'active'
@@ -33,7 +34,11 @@ export type StatusType =
   | 'role_top_manager'
   | 'role_manager'
   | 'role_custom'
-  | 'role_user';
+  | 'role_user'
+  | 'auth_local'
+  | 'auth_ldap'
+  | 'auth_oidc'
+  | 'auth_saml';
 
 export interface StatusBadgeProps {
   type: StatusType;
@@ -42,7 +47,7 @@ export interface StatusBadgeProps {
 }
 
 const StatusBadge: React.FC<StatusBadgeProps> = ({ type, label, className = '' }) => {
-  const styles = {
+  const styles: Record<StatusType, { container: string; icon: string; svgPath?: string }> = {
     active: {
       container: 'bg-emerald-50 text-emerald-600 border-emerald-100',
       icon: 'fa-check',
@@ -175,6 +180,23 @@ const StatusBadge: React.FC<StatusBadgeProps> = ({ type, label, className = '' }
       container: 'bg-zinc-100 text-zinc-600 border-zinc-200',
       icon: 'fa-user',
     },
+    auth_local: {
+      container: 'bg-zinc-100 text-zinc-700 border-zinc-200',
+      icon: 'fa-database',
+    },
+    auth_ldap: {
+      container: 'bg-blue-50 text-blue-700 border-blue-200',
+      icon: 'fa-sitemap',
+    },
+    auth_oidc: {
+      container: 'bg-purple-50 text-purple-700 border-purple-200',
+      icon: 'fa-id-card',
+      svgPath: siOpenid.path,
+    },
+    auth_saml: {
+      container: 'bg-teal-50 text-teal-700 border-teal-200',
+      icon: 'fa-building-shield',
+    },
   };
 
   const currentStyle = styles[type];
@@ -184,7 +206,19 @@ const StatusBadge: React.FC<StatusBadgeProps> = ({ type, label, className = '' }
       data-status-badge
       className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg border text-[10px] font-black uppercase tracking-wider transition-all duration-200 ${currentStyle.container} ${className}`}
     >
-      <i className={`fa-solid ${currentStyle.icon}`}></i>
+      {currentStyle.svgPath ? (
+        <svg
+          aria-hidden="true"
+          role="img"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          className="size-[1em]"
+        >
+          <path d={currentStyle.svgPath} />
+        </svg>
+      ) : (
+        <i className={`fa-solid ${currentStyle.icon}`}></i>
+      )}
       {label}
     </span>
   );

--- a/test/components/administration/UserManagement.test.tsx
+++ b/test/components/administration/UserManagement.test.tsx
@@ -120,6 +120,68 @@ describe('<UserManagement />', () => {
     expect(screen.getAllByText('common:common.active')).toHaveLength(2);
   });
 
+  test('renders a distinct auth-method badge per protocol', () => {
+    renderUserManagement({
+      users: [
+        {
+          id: 'u-local',
+          name: 'Local User',
+          role: 'user',
+          avatarInitials: 'LU',
+          username: 'local.user',
+          employeeType: 'app_user',
+          authMethod: 'local',
+        },
+        {
+          id: 'u-ldap',
+          name: 'Ldap User',
+          role: 'user',
+          avatarInitials: 'LD',
+          username: 'ldap.user',
+          employeeType: 'app_user',
+          authMethod: 'ldap',
+        },
+        {
+          id: 'u-oidc',
+          name: 'Oidc User',
+          role: 'user',
+          avatarInitials: 'OI',
+          username: 'oidc.user',
+          employeeType: 'app_user',
+          authMethod: 'oidc',
+          authProviderName: 'Keycloak',
+        },
+        {
+          id: 'u-saml',
+          name: 'Saml User',
+          role: 'user',
+          avatarInitials: 'SA',
+          username: 'saml.user',
+          employeeType: 'app_user',
+          authMethod: 'saml',
+          authProviderName: 'Okta',
+        },
+      ],
+    });
+
+    const authBadgeFor = (rowText: string) => {
+      const row = getRowFor(rowText);
+      const badges = row.querySelectorAll('[data-status-badge]');
+      const authBadge = badges[badges.length - 2];
+      if (!authBadge) throw new Error(`No auth badge found for ${rowText}`);
+      return authBadge as HTMLElement;
+    };
+
+    expect(authBadgeFor('Local User').querySelector('i')?.className ?? '').toContain('fa-database');
+    expect(authBadgeFor('Ldap User').querySelector('i')?.className ?? '').toContain('fa-sitemap');
+    expect(authBadgeFor('Saml User').querySelector('i')?.className ?? '').toContain(
+      'fa-building-shield',
+    );
+    const oidcBadge = authBadgeFor('Oidc User');
+    expect(oidcBadge.querySelector('svg')).not.toBeNull();
+    expect(oidcBadge.querySelector('i')).toBeNull();
+  });
+
   test('filters users with the external search input', () => {
     renderUserManagement();
 


### PR DESCRIPTION
## Summary

- The User Management table's **Authentication** column previously rendered every row's auth method with the same gray `inherited` badge (warning-triangle icon). Local, LDAP, OIDC, and SAML users were visually indistinguishable.
- Each protocol now has its own color + icon, mirroring the existing per-value role badge pattern in the same component.
- `StatusBadge` gains an optional `svgPath` field on style entries so it can render simple-icons SVGs in addition to Font Awesome glyphs.

## Icon choices

| Method | Container | Icon |
| ------ | --------- | ---- |
| `local` | zinc | Font Awesome `fa-database` |
| `ldap`  | blue | Font Awesome `fa-sitemap` |
| `oidc`  | purple | simple-icons `siOpenid` (inline SVG) |
| `saml`  | teal | Font Awesome `fa-building-shield` — same icon used in `AuthSettings` SAML tab and the SAML option on `Login` |

All color families are already used elsewhere in `StatusBadge`, so no new Tailwind classes need to be safelisted. simple-icons is already a project dependency (used by `UserSettings.tsx`).

## Files

- `components/shared/StatusBadge.tsx` — added 4 `auth_*` variants and SVG-path rendering branch.
- `components/administration/UserManagement.tsx` — new `getAuthMethodBadgeType` helper; auth-column cell now picks the variant per `user.authMethod` instead of hard-coding `"inherited"`.
- `test/components/administration/UserManagement.test.tsx` — new test renders one user per protocol and asserts each row carries the variant-specific icon (FA class for local/LDAP/SAML, inline SVG for OIDC).

No backend, schema, API, or i18n key changes — the four method values and their translations already existed.

## Test plan

- [x] `bun test test/components/administration/UserManagement.test.tsx` — 9/9 pass (8 existing + 1 new).
- [x] `bun run lint` (i18n:check + typecheck + biome) — clean on touched files.
- [ ] Manual: in **Administration → User Management**, confirm a local user shows a gray database badge, LDAP a blue sitemap, OIDC a purple OpenID mark with `OIDC: <provider>`, SAML a teal building-shield with `SAML: <provider>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)