### PR TITLE
fix(test): stabilize bun test order by including ApiError in services/api mocks

### DIFF
--- a/test/components/NotificationBell.test.tsx
+++ b/test/components/NotificationBell.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, mock, test } from 'bun:test';
 import { fireEvent, screen } from '@testing-library/react';
 import type { Notification } from '../../types';
+import { ApiErrorStub } from '../helpers/apiErrorStub';
 import { installI18nMock } from '../helpers/i18n';
 import { render } from '../helpers/render';
 
@@ -18,6 +19,7 @@ mock.module('../../services/api', () => ({
       delete: mock(() => Promise.resolve()),
     },
   },
+  ApiError: ApiErrorStub,
   getAuthToken: () => null,
   setAuthToken: () => {},
 }));

--- a/test/handlers/entryHandlers.test.ts
+++ b/test/handlers/entryHandlers.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { ApiErrorStub } from '../helpers/apiErrorStub';
 
 const apiMocks = {
   entriesCreate: mock(
@@ -20,6 +21,7 @@ mock.module('../../services/api', () => ({
       delete: (id: string) => apiMocks.entriesDelete(id),
     },
   },
+  ApiError: ApiErrorStub,
   getAuthToken: () => null,
   setAuthToken: () => {},
 }));

--- a/test/handlers/invoiceHandlers.test.ts
+++ b/test/handlers/invoiceHandlers.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { ApiErrorStub } from '../helpers/apiErrorStub';
 
 const apiMocks = {
   invoicesCreate: mock(
@@ -19,6 +20,7 @@ mock.module('../../services/api', () => ({
       delete: (id: string) => apiMocks.invoicesDelete(id),
     },
   },
+  ApiError: ApiErrorStub,
   getAuthToken: () => null,
   setAuthToken: () => {},
 }));

--- a/test/handlers/quoteHandlers.test.ts
+++ b/test/handlers/quoteHandlers.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { ApiErrorStub } from '../helpers/apiErrorStub';
 
 const apiMocks = {
   quotesList: mock((): Promise<unknown[]> => Promise.resolve([])),
@@ -55,6 +56,7 @@ mock.module('../../services/api', () => ({
       list: () => apiMocks.invoicesList(),
     },
   },
+  ApiError: ApiErrorStub,
   getAuthToken: () => null,
   setAuthToken: () => {},
 }));

--- a/test/handlers/supplierHandlers.test.ts
+++ b/test/handlers/supplierHandlers.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { ApiErrorStub } from '../helpers/apiErrorStub';
 
 const apiMocks = {
   suppliersCreate: mock(
@@ -19,6 +20,7 @@ mock.module('../../services/api', () => ({
       delete: (id: string) => apiMocks.suppliersDelete(id),
     },
   },
+  ApiError: ApiErrorStub,
   getAuthToken: () => null,
   setAuthToken: () => {},
 }));

--- a/test/handlers/supplierInvoiceHandlers.test.ts
+++ b/test/handlers/supplierInvoiceHandlers.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { ApiErrorStub } from '../helpers/apiErrorStub';
 
 const apiMocks = {
   supplierInvoicesUpdate: mock(
@@ -19,6 +20,7 @@ mock.module('../../services/api', () => ({
       create: (data: unknown) => apiMocks.supplierInvoicesCreate(data),
     },
   },
+  ApiError: ApiErrorStub,
   getAuthToken: () => null,
   setAuthToken: () => {},
 }));

--- a/test/handlers/supplierQuoteHandlers.test.ts
+++ b/test/handlers/supplierQuoteHandlers.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { ApiErrorStub } from '../helpers/apiErrorStub';
 
 const apiMocks = {
   supplierQuotesList: mock((): Promise<unknown[]> => Promise.resolve([])),
@@ -40,6 +41,7 @@ mock.module('../../services/api', () => ({
       list: () => apiMocks.supplierInvoicesList(),
     },
   },
+  ApiError: ApiErrorStub,
   getAuthToken: () => null,
   setAuthToken: () => {},
 }));

--- a/test/handlers/userHandlers.test.ts
+++ b/test/handlers/userHandlers.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { ApiErrorStub } from '../helpers/apiErrorStub';
 
 const apiMocks = {
   usersCreate: mock(
@@ -76,6 +77,7 @@ mock.module('../../services/api', () => ({
       list: () => apiMocks.workUnitsList(),
     },
   },
+  ApiError: ApiErrorStub,
   getAuthToken: () => null,
   setAuthToken: () => {},
 }));


### PR DESCRIPTION
## Summary

- CI's **Tests** job has been failing on every recent frontend PR (e.g. [#316](https://github.com/xBounceIT/praetor/pull/316)) with `SyntaxError: Export named 'ApiError' not found in module '.../services/api.ts'` inside `test/hooks/useAuth.test.ts`.
- Root cause: Bun's `mock.module('../../services/api', factory)` locks the module namespace shape from the **first** registration in a `bun test` process. Later `mock.module` calls can swap method bodies but cannot add missing named exports for consumers that haven't been linked yet. 8 test files mocked `services/api` without `ApiError`; depending on Bun's discovery order, one of them ran first, "froze" the namespace without `ApiError`, and then `useAuth.ts`'s `import { ApiError } from '../services/api'` failed ESM linking.
- Fix: add `ApiError: ApiErrorStub` (and the matching import) to the 8 test files that were missing it, so the first registered shape always carries `ApiError` regardless of order.

## Why this kept biting multiple PRs

This is a latent, order-dependent bug. Any unrelated file add/rename can shift Bun's discovery order and re-expose it, which is why several otherwise-unrelated PRs hit the same red **Tests** check.

## Files changed

- `test/handlers/{entry,invoice,quote,supplier,supplierInvoice,supplierQuote,user}Handlers.test.ts`
- `test/components/NotificationBell.test.tsx`

Each gets `+import { ApiErrorStub } from '../helpers/apiErrorStub';` and `+ApiError: ApiErrorStub,` added to its existing `mock.module('../../services/api', ...)` factory.

## Test plan

- [x] Regression repro fails on `main`: `bun test ./test/handlers/quoteHandlers.test.ts ./test/hooks/useAuth.test.ts` → 1 fail, 1 error
- [x] Regression repro passes on this branch: same command → 41 pass, 0 fail
- [x] `bun run test:frontend` → 927 pass, 0 fail (was 909 pass / 1 fail / 1 error on red CI)
- [x] `bun run test:server` → 2027 pass, 27 skip, 0 fail
- [x] `bun run lint` → only 3 pre-existing warnings, none from this change
- [ ] CI **Tests** check turns green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)