### PR TITLE
fix(user-management): honor theme and open Select reliably in auth-method dialog

### DIFF
--- a/components/administration/UserManagement.tsx
+++ b/components/administration/UserManagement.tsx
@@ -1065,7 +1065,7 @@ const UserManagement: React.FC<UserManagementProps> = ({
                 <SelectTrigger className="w-full">
                   <SelectValue />
                 </SelectTrigger>
-                <SelectContent>
+                <SelectContent position="popper" sideOffset={4}>
                   <SelectGroup>
                     {authMethodOptions.map((option) => (
                       <SelectItem key={option.id} value={option.id}>
@@ -1092,7 +1092,7 @@ const UserManagement: React.FC<UserManagementProps> = ({
                   <SelectTrigger className="w-full">
                     <SelectValue placeholder={t('hr:workforce.authMethod.providerPlaceholder')} />
                   </SelectTrigger>
-                  <SelectContent>
+                  <SelectContent position="popper" sideOffset={4}>
                     <SelectGroup>
                       {providerOptions.map((provider) => (
                         <SelectItem key={provider.id} value={provider.id}>

--- a/components/shared/Modal.tsx
+++ b/components/shared/Modal.tsx
@@ -13,8 +13,7 @@ import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { FieldLabel } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
-import { getShadcnThemeClassName, useResolvedShadcnTheme } from '@/components/ui/use-shadcn-theme';
-import { cn } from '@/lib/utils';
+import { useResolvedShadcnTheme } from '@/components/ui/use-shadcn-theme';
 import { ModalThemeContext } from './ModalThemeContext';
 
 export interface ModalProps {
@@ -160,14 +159,9 @@ const Modal: React.FC<ModalProps> = ({
         overlayClassName={backdropClass}
         overlayProps={{ onClick: handleBackdropClick }}
         overlayStyle={{ zIndex }}
-        data-shadcn-theme-scope=""
-        data-shadcn-theme={resolvedTheme}
         aria-modal="true"
         aria-describedby={undefined}
-        className={cn(
-          'shadcn-theme-bridge fixed inset-0 top-0 left-0 z-auto flex h-dvh w-dvw max-w-none translate-x-0 translate-y-0 items-center justify-center gap-0 rounded-none border-0 bg-transparent p-4 text-foreground shadow-none duration-0 outline-none pointer-events-none [&>*]:pointer-events-auto sm:max-w-none',
-          getShadcnThemeClassName(resolvedTheme),
-        )}
+        className="shadcn-theme-bridge fixed inset-0 top-0 left-0 z-auto flex h-dvh w-dvw max-w-none translate-x-0 translate-y-0 items-center justify-center gap-0 rounded-none border-0 bg-transparent p-4 text-foreground shadow-none duration-0 outline-none pointer-events-none [&>*]:pointer-events-auto sm:max-w-none"
         style={{ zIndex: zIndex + 1 }}
         tabIndex={-1}
         onEscapeKeyDown={(e) => {

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -2,6 +2,7 @@ import { XIcon } from 'lucide-react';
 import { Dialog as DialogPrimitive } from 'radix-ui';
 import type * as React from 'react';
 import { Button } from '@/components/ui/button';
+import { getShadcnThemeClassName, useResolvedShadcnTheme } from '@/components/ui/use-shadcn-theme';
 import { cn } from '@/lib/utils';
 
 function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
@@ -50,13 +51,19 @@ function DialogContent({
   overlayProps?: Omit<React.ComponentProps<typeof DialogPrimitive.Overlay>, 'className' | 'style'>;
   overlayStyle?: React.CSSProperties;
 }) {
+  const resolvedTheme = useResolvedShadcnTheme();
+  const themeClassName = getShadcnThemeClassName(resolvedTheme);
+
   return (
     <DialogPortal data-slot="dialog-portal">
       <DialogOverlay {...overlayProps} className={overlayClassName} style={overlayStyle} />
       <DialogPrimitive.Content
+        data-shadcn-theme-scope=""
+        data-shadcn-theme={resolvedTheme}
         data-slot="dialog-content"
         className={cn(
           'fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg',
+          themeClassName,
           className,
         )}
         {...props}

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -62,7 +62,7 @@ function DialogContent({
         data-shadcn-theme={resolvedTheme}
         data-slot="dialog-content"
         className={cn(
-          'fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg',
+          'fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 text-foreground shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg',
           themeClassName,
           className,
         )}

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -62,7 +62,7 @@ function DialogContent({
         data-shadcn-theme={resolvedTheme}
         data-slot="dialog-content"
         className={cn(
-          'fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 text-foreground shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg',
+          'fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border border-border bg-background p-6 text-foreground shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg',
           themeClassName,
           className,
         )}

--- a/test/components/Modal.test.tsx
+++ b/test/components/Modal.test.tsx
@@ -258,7 +258,8 @@ describe('<Modal />', () => {
       const themeSubscriptions = addEventListenerSpy.mock.calls.filter(
         ([eventName]) => eventName === THEME_CHANGE_EVENT,
       );
-      expect(themeSubscriptions).toHaveLength(1);
+      // Modal + DialogContent each subscribe; ModalContent must read from ModalThemeContext, not add a third.
+      expect(themeSubscriptions).toHaveLength(2);
     } finally {
       addEventListenerSpy.mockRestore();
     }

--- a/test/components/administration/UserManagement.test.tsx
+++ b/test/components/administration/UserManagement.test.tsx
@@ -1,8 +1,9 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
-import { fireEvent, screen } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { ComponentProps } from 'react';
 import type { User } from '../../../types';
+import { THEME_STORAGE_KEY } from '../../../utils/theme';
 import { installI18nMock } from '../../helpers/i18n';
 import { render } from '../../helpers/render';
 
@@ -167,23 +168,96 @@ describe('<UserManagement />', () => {
     expect(screen.queryByText('Bob Brown')).not.toBeInTheDocument();
   });
 
-  test('opens authentication method dialog from row actions and saves', async () => {
+  const openAuthMethodDialog = async (
+    rowName = 'Bob Brown',
+    overrides: Partial<ComponentProps<typeof UserManagement>> = {},
+  ) => {
     const user = userEvent.setup();
-    const props = renderUserManagement();
-    const bobRow = getRowFor('Bob Brown');
-    const actionButton = bobRow.querySelector('[aria-label="table.rowActions"]');
+    const props = renderUserManagement(overrides);
+    const row = getRowFor(rowName);
+    const actionButton = row.querySelector('[aria-label="table.rowActions"]');
     if (!actionButton) throw new Error('Could not find row actions button');
 
     await user.click(actionButton);
     await user.click(
       await screen.findByRole('button', { name: 'hr:workforce.authMethod.changeAction' }),
     );
+    return { user, props };
+  };
+
+  test('opens authentication method dialog from row actions and saves', async () => {
+    const { user, props } = await openAuthMethodDialog();
 
     expect(screen.getByText('hr:workforce.authMethod.description')).toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'common:buttons.save' }));
 
     expect(props.onUpdateUserAuthMethod).toHaveBeenCalledWith('u2', 'local', null);
+  });
+
+  test('auth-method dialog carries the resolved shadcn theme scope', async () => {
+    localStorage.setItem(THEME_STORAGE_KEY, 'dark');
+
+    await openAuthMethodDialog();
+
+    const dialogContent = await waitFor(() => {
+      const node = document.body.querySelector<HTMLElement>('[data-slot="dialog-content"]');
+      if (!node) throw new Error('Dialog content not rendered yet');
+      return node;
+    });
+
+    expect(dialogContent.getAttribute('data-shadcn-theme-scope')).toBe('');
+    expect(dialogContent.getAttribute('data-shadcn-theme')).toBe('dark');
+    expect(dialogContent.className).toContain('dark');
+  });
+
+  test('auth-method select opens via popper and lists all four protocols', async () => {
+    const { user } = await openAuthMethodDialog();
+
+    const trigger = screen.getAllByRole('combobox')[0];
+    if (!trigger) throw new Error('Auth-method select trigger not rendered');
+
+    await user.click(trigger);
+
+    // position="popper" renders the listbox in a portal at body level. Wait
+    // for it to appear and assert all four protocol labels are mounted.
+    const listbox = await waitFor(() => {
+      const node = document.body.querySelector<HTMLElement>('[role="listbox"]');
+      if (!node) throw new Error('Listbox not rendered yet');
+      return node;
+    });
+
+    const optionTexts = Array.from(listbox.querySelectorAll<HTMLElement>('[role="option"]')).map(
+      (opt) => opt.textContent ?? '',
+    );
+
+    expect(optionTexts).toEqual(
+      expect.arrayContaining([
+        'hr:workforce.authMethod.local',
+        'hr:workforce.authMethod.ldap',
+        'hr:workforce.authMethod.oidc',
+        'hr:workforce.authMethod.saml',
+      ]),
+    );
+  });
+
+  test('provider select appears when the user is already on an SSO method', async () => {
+    const ssoUser: User = {
+      id: 'u3',
+      name: 'Carla SSO',
+      role: 'user',
+      avatarInitials: 'CS',
+      username: 'carla.sso',
+      email: 'carla@example.com',
+      employeeType: 'app_user',
+      authMethod: 'oidc',
+      authProviderId: 'sso-1',
+      authProviderName: 'Keycloak',
+    };
+
+    await openAuthMethodDialog('Carla SSO', { users: [...users, ssoUser] });
+
+    expect(await screen.findByText('hr:workforce.authMethod.providerLabel')).toBeInTheDocument();
   });
 
   const openCreateUserModal = async () => {


### PR DESCRIPTION
## Summary

The **Cambia metodo di autenticazione** dialog on the User Management page had two visible bugs in dark mode:

- The dialog rendered with a white background and dark text regardless of the active theme.
- Clicking the *Metodo di autenticazione* `Select` (and the *Provider SSO* select beneath it) did not open the dropdown — the OpenID Connect / SAML options were unreachable.

Both root causes are structural, not specific to this dialog:

1. **shadcn `DialogContent` is portaled to `document.body`**, outside the layout's `data-shadcn-theme-scope` element, so `bg-background`/`text-foreground` resolved to the light defaults. `PopoverContent`, `SelectContent`, `TooltipContent`, `DropdownMenuContent`, and `ContextMenuContent` already own their own theme scope inside the portal — `Dialog` was the outlier. Moved that responsibility into `DialogContent` so every Dialog automatically inherits the resolved theme.
2. **Radix `Select` defaults to `position="item-aligned"`** which conflicts with the `Dialog` focus trap and frequently leaves the listbox unrendered inside a Dialog. Switched the two Selects inside the auth-method dialog to `position="popper"` with a small `sideOffset`.

Side effect of the primitive change: `components/shared/Modal.tsx` no longer needs to apply theme-scope props manually, and its `cn(…)` wrapper around a single-string className collapsed to a plain string literal (`cn` import dropped along with it).

## Test plan

- [x] `bun run test:frontend` — 929/929 pass, including three new regression tests:
  - Auth-method dialog carries `data-shadcn-theme-scope` / `data-shadcn-theme="dark"` / `dark` class when opened with the dark theme active.
  - Auth-method `Select` opens via popper and lists all four protocols (`local`, `ldap`, `oidc`, `saml`).
  - Provider `Select` appears when the user being edited is already on an SSO method.
- [x] `bun run lint` clean (3 pre-existing warnings unrelated to this change).
- [x] Manual browser check on a deployed container: Administration → Personale → key icon (any non-current user) in dark mode. Verify the dialog renders with the dark surface, the auth-method dropdown opens and shows all four options, and selecting OpenID Connect surfaces the provider dropdown with a configured Keycloak provider (or the empty-state message if none configured).

🤖 Generated with [Claude Code](https://claude.com/claude-code)