### PR TITLE
fix(projects): align project-name values with their column header

### DIFF
--- a/components/projects/ProjectsView.tsx
+++ b/components/projects/ProjectsView.tsx
@@ -1370,18 +1370,15 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
               header: t('projects:projects.tableHeaders.projectName'),
               accessorKey: 'name',
               cell: ({ row }) => (
-                <div className="flex items-center gap-2">
-                  <div className="size-2.5 rounded-full" style={{ backgroundColor: row.color }} />
-                  <span
-                    className={`text-sm font-bold ${
-                      row.isDisabled
-                        ? 'text-zinc-600 line-through decoration-zinc-300'
-                        : 'text-zinc-800'
-                    }`}
-                  >
-                    {row.name}
-                  </span>
-                </div>
+                <span
+                  className={`text-sm font-bold ${
+                    row.isDisabled
+                      ? 'text-zinc-600 line-through decoration-zinc-300'
+                      : 'text-zinc-800'
+                  }`}
+                >
+                  {row.name}
+                </span>
               ),
             },
             {


### PR DESCRIPTION
## Summary
- The `Nome Progetto` cell prefixed the project name with a 10px colored dot (`size-2.5 rounded-full` + `gap-2`), shifting the name ~18 px to the right of the column header text. Every other column rendered plain content at the StandardTable's standard `px-3` boundary, so the offset showed up as a visible gap before the value.
- Drop the inline dot from the cell renderer; project name now renders as a plain `<span>` and lines up flush with the header (matching the `Cliente` column shape).
- `row.color` is still stored on the project and surfaced elsewhere (timesheet, calendar, charts) — only its visual representation in this one table view goes away.

## Test plan
- [x] `bun run lint` — biome clean on the changed file
- [x] `bun test test/` — 2979 pass / 28 skip / 0 fail
- [x] Manual: open `/projects` and confirm `Nome Progetto` values start at the same x position as their column header in both light and dark themes
- [x] Manual: disabled project still renders with the strike-through styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)