### PR TITLE
fix(timesheet): label entry row actions and center daily total in footer

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -498,9 +498,9 @@ const TrackerView: React.FC<{
                     })
                   : t('entry.recentActivity')
               }
-              footerExtras={
+              headerExtras={
                 selectedDate ? (
-                  <div className="flex flex-1 min-w-0 items-baseline justify-center gap-2">
+                  <div className="flex items-baseline gap-2">
                     <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
                       {t('tracker.dayTotal')}
                     </span>

--- a/App.tsx
+++ b/App.tsx
@@ -342,15 +342,25 @@ const TrackerView: React.FC<{
         disableFiltering: true,
         sticky: 'right',
         cell: ({ row }) => (
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              handleDeleteClick(row);
-            }}
-            className="text-zinc-200 hover:text-red-500 transition-colors p-1"
-          >
-            <i className="fa-solid fa-trash-can text-xs" />
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="inline-flex">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleDeleteClick(row);
+                  }}
+                  className="text-muted-foreground hover:text-destructive"
+                >
+                  <i className="fa-solid fa-trash-can text-xs"></i>
+                </Button>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>{t('common:buttons.delete')}</TooltipContent>
+          </Tooltip>
         ),
       },
     ],
@@ -488,14 +498,14 @@ const TrackerView: React.FC<{
                     })
                   : t('entry.recentActivity')
               }
-              headerExtras={
+              footerExtras={
                 selectedDate ? (
-                  <div className="text-right">
-                    <p className="text-[10px] font-bold text-zinc-400 uppercase">
+                  <div className="flex-1 min-w-0 text-center">
+                    <p className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
                       {t('tracker.dayTotal')}
                     </p>
                     <p
-                      className={`text-lg font-black transition-colors ${dailyTotal > dailyGoal ? 'text-red-600' : 'text-praetor'}`}
+                      className={`text-lg font-black transition-colors ${dailyTotal > dailyGoal ? 'text-destructive' : 'text-praetor'}`}
                     >
                       {dailyTotal.toFixed(2)} h
                     </p>

--- a/App.tsx
+++ b/App.tsx
@@ -500,15 +500,15 @@ const TrackerView: React.FC<{
               }
               footerExtras={
                 selectedDate ? (
-                  <div className="flex-1 min-w-0 text-center">
-                    <p className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
+                  <div className="flex flex-1 min-w-0 items-baseline justify-center gap-2">
+                    <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
                       {t('tracker.dayTotal')}
-                    </p>
-                    <p
+                    </span>
+                    <span
                       className={`text-lg font-black transition-colors ${dailyTotal > dailyGoal ? 'text-destructive' : 'text-praetor'}`}
                     >
                       {dailyTotal.toFixed(2)} h
-                    </p>
+                    </span>
                   </div>
                 ) : undefined
               }

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -165,6 +165,7 @@ export type StandardTableProps<T extends object = object> = {
   tableContainerClassName?: string;
   footer?: ReactNode;
   footerClassName?: string;
+  footerExtras?: ReactNode;
   children?: ReactNode;
   emptyState?: ReactNode;
   isLoading?: boolean;
@@ -188,6 +189,7 @@ const StandardTable = <T extends object>({
   tableContainerClassName,
   footer: externalFooter,
   footerClassName,
+  footerExtras,
   children,
   emptyState,
   isLoading = false,
@@ -1305,6 +1307,8 @@ const StandardTable = <T extends object>({
             </SelectContent>
           </Select>
         </div>
+
+        {footerExtras}
 
         <div className="flex items-center gap-2">
           <Button

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -165,7 +165,6 @@ export type StandardTableProps<T extends object = object> = {
   tableContainerClassName?: string;
   footer?: ReactNode;
   footerClassName?: string;
-  footerExtras?: ReactNode;
   children?: ReactNode;
   emptyState?: ReactNode;
   isLoading?: boolean;
@@ -189,7 +188,6 @@ const StandardTable = <T extends object>({
   tableContainerClassName,
   footer: externalFooter,
   footerClassName,
-  footerExtras,
   children,
   emptyState,
   isLoading = false,
@@ -1307,8 +1305,6 @@ const StandardTable = <T extends object>({
             </SelectContent>
           </Select>
         </div>
-
-        {footerExtras}
 
         <div className="flex items-center gap-2">
           <Button


### PR DESCRIPTION
## Summary

Two related Daily Tracker view fixes:

- **Action menu label**: the 3-dots dropdown and right-click context menu on entry rows now show the localized **Elimina / Delete** label next to the trash icon. Previously they rendered only the bare icon because the delete cell wasn't wrapped in a `<Tooltip>` — `StandardTable.renderActionMenuItems` extracts the menu-item label from `TooltipContent`. Now matches the pattern already used in `ProjectsView` and other tables.
- **Daily total placement**: moved the "TOTALE GIORNALIERO X.XX h" badge from the table header (top-right) to a new footer slot, horizontally centered between the rows-per-page selector (left) and the pagination buttons (right). Also swapped the hardcoded `text-zinc-400` / `text-red-600` shades for `text-muted-foreground` / `text-destructive` so the badge respects the active theme.

To support the second fix without duplicating the entire internal footer, added a generic `footerExtras?: ReactNode` prop to `StandardTable` that is symmetric with the existing `headerExtras` — pass-through, caller-controlled layout — so other tables can adopt the same center slot later.

## Test plan

- [x] Open Tracker → Daily mode, pick a date with at least one logged entry.
- [x] Click the 3-dots action button on a row — dropdown shows red trash icon **and** "Elimina" label.
- [x] Right-click a row — context menu shows the same icon + label.
- [x] Verify the daily total appears centered in the table footer, between "Righe per pagina" and "Precedente / 1 / Avanti", and disappears when no date is selected.
- [x] Verify the total turns destructive-red when exceeding the daily goal.
- [x] Toggle light/dark theme — total stays legible in both.
- [x] Frontend test suite still green (`bun test ./test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)