### PR TITLE
fix(settings): reject reusing the current password when changing it

### DIFF
--- a/components/UserSettings.tsx
+++ b/components/UserSettings.tsx
@@ -317,6 +317,11 @@ const UserSettings: React.FC<UserSettingsProps> = ({
       return;
     }
 
+    if (newPassword === currentPassword) {
+      setPasswordError(t('password.sameAsCurrent'));
+      return;
+    }
+
     if (newPassword.length < 8) {
       setPasswordError(t('password.passwordMinLength'));
       return;

--- a/locales/en/settings.json
+++ b/locales/en/settings.json
@@ -52,6 +52,7 @@
     "updating": "Updating...",
     "passwordsDoNotMatch": "New passwords do not match",
     "passwordMinLength": "New password must be at least 8 characters long",
+    "sameAsCurrent": "New password must be different from the current password",
     "incorrectPassword": "Incorrect current password"
   },
   "mcp": {

--- a/locales/it/settings.json
+++ b/locales/it/settings.json
@@ -52,6 +52,7 @@
     "updating": "Aggiornamento...",
     "passwordsDoNotMatch": "Le nuove password non corrispondono",
     "passwordMinLength": "La nuova password deve avere almeno 8 caratteri",
+    "sameAsCurrent": "La nuova password deve essere diversa da quella attuale",
     "incorrectPassword": "Password attuale non corretta"
   },
   "mcp": {

--- a/server/routes/settings.ts
+++ b/server/routes/settings.ts
@@ -312,6 +312,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         return badRequest(reply, 'New password must be at least 8 characters long');
       }
 
+      if (currentPasswordResult.value === newPasswordResult.value) {
+        return badRequest(reply, 'New password must be different from the current password');
+      }
+
       const passwordHash = await usersRepo.getPasswordHash(request.user.id);
       if (passwordHash === null) {
         return reply.code(404).send({ error: 'User not found' });

--- a/server/test/routes/settings.test.ts
+++ b/server/test/routes/settings.test.ts
@@ -525,6 +525,21 @@ describe('PUT /api/settings/password', () => {
     expect(updatePasswordHashMock).not.toHaveBeenCalled();
   });
 
+  test('400 newPassword equals currentPassword', async () => {
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/settings/password',
+      headers: authHeader(),
+      payload: { currentPassword: 'same-pw-123', newPassword: 'same-pw-123' },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/different from the current password/i);
+    expect(getPasswordHashMock).not.toHaveBeenCalled();
+    expect(bcryptCompareMock).not.toHaveBeenCalled();
+    expect(bcryptHashMock).not.toHaveBeenCalled();
+    expect(updatePasswordHashMock).not.toHaveBeenCalled();
+  });
+
   test('401 missing token', async () => {
     const res = await testApp.inject({
       method: 'PUT',

--- a/test/components/UserSettings.test.tsx
+++ b/test/components/UserSettings.test.tsx
@@ -198,6 +198,27 @@ describe('<UserSettings /> Security tab', () => {
     }
   });
 
+  test('rejects a new password identical to the current password without calling the API', async () => {
+    renderSettings();
+    fireEvent.click(screen.getByText('security.title'));
+
+    const samePassword = 'same-pw-1234';
+    fireEvent.change(screen.getByLabelText('password.currentPassword'), {
+      target: { value: samePassword },
+    });
+    fireEvent.change(screen.getByLabelText('password.newPassword'), {
+      target: { value: samePassword },
+    });
+    fireEvent.change(screen.getByLabelText('password.confirmNewPassword'), {
+      target: { value: samePassword },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /password.updatePassword/ }));
+
+    expect(await screen.findByText('password.sameAsCurrent')).toBeInTheDocument();
+    expect(onUpdatePassword).not.toHaveBeenCalled();
+  });
+
   test('finishes token load when the user leaves and returns to Security before it resolves', async () => {
     let resolveToken!: (value: typeof tokenMetadata & { token: string }) => void;
     const onGetPersonalAccessToken = mock(


### PR DESCRIPTION
## Summary

The password-change form in **User Settings → Security** previously accepted a new password identical to the current one, producing a no-op update with success feedback. This adds a dedicated check on both layers:

- **Backend** ([server/routes/settings.ts](https://github.com/xBounceIT/praetor/blob/claude/festive-chandrasekhar-7c90c7/server/routes/settings.ts)): rejects with `400 "New password must be different from the current password"`. The check runs **before** `usersRepo.getPasswordHash` and `bcrypt.compare`, so the obvious-mistake case short-circuits without a DB round-trip or ~100ms of bcrypt CPU. No security concern — both values come from the same authenticated request body.
- **Frontend** ([components/UserSettings.tsx](https://github.com/xBounceIT/praetor/blob/claude/festive-chandrasekhar-7c90c7/components/UserSettings.tsx)): surfaces `t('password.sameAsCurrent')` inline via the existing `passwordError` plumbing, between the confirm-match and min-length checks.
- **i18n**: new `password.sameAsCurrent` key in both `locales/en/settings.json` and `locales/it/settings.json`.

## Tests

- `server/test/routes/settings.test.ts` — new `400 newPassword equals currentPassword` case asserts `getPasswordHash`, `bcryptCompare`, `bcryptHash`, and `updatePasswordHash` are all skipped.
- `test/components/UserSettings.test.tsx` — new test fills all three fields with the same value and asserts the inline error appears and `onUpdatePassword` is not called.

Full suite: 3009 tests pass (2055 frontend, 954 backend). `bun run lint` clean.

## Test plan

- [ ] In **Settings → Security**, enter your current password as both current and new password → inline error appears, no API call.
- [ ] Bypass frontend via DevTools and POST same value to `PUT /api/settings/password` → returns 400 with the same message text.
- [ ] Enter a genuinely different new password → happy path still works (password rotates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)