### PR TITLE
refactor(timesheet): restyle WeeklyView with Anuko-style grid + shared catalog selector

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -485,7 +485,6 @@ const TrackerView: React.FC<{
               projectTasks={projectTasks}
               viewingUserId={viewingUserId}
               selectedDate={selectedDate}
-              onSelectedDateChange={setSelectedDate}
               startOfWeek={startOfWeek}
               treatSaturdayAsHoliday={treatSaturdayAsHoliday}
               allowWeekendSelection={allowWeekendSelection}

--- a/App.tsx
+++ b/App.tsx
@@ -152,6 +152,7 @@ const TrackerView: React.FC<{
   projectTasks: ProjectTask[];
   onAddEntry: (entry: Omit<TimeEntry, 'id' | 'createdAt' | 'userId' | 'hourlyCost'>) => void;
   onDeleteEntry: (id: string) => void;
+  onUpdateEntry: (id: string, updates: Partial<TimeEntry>) => void;
   startOfWeek: 'Monday' | 'Sunday';
   treatSaturdayAsHoliday: boolean;
   allowWeekendSelection: boolean;
@@ -168,6 +169,7 @@ const TrackerView: React.FC<{
   availableUsers: User[];
   currentUser: User;
   dailyGoal: number;
+  onAddBulkEntries: (entries: Omit<TimeEntry, 'id' | 'createdAt' | 'userId'>[]) => Promise<void>;
   onRecurringAction: (taskId: string, action: 'stop' | 'delete_future' | 'delete_all') => void;
   defaultLocation?: TimeEntryLocation;
   onAddCustomTask: (
@@ -188,6 +190,7 @@ const TrackerView: React.FC<{
   projectTasks,
   onAddEntry,
   onDeleteEntry,
+  onUpdateEntry,
   startOfWeek,
   treatSaturdayAsHoliday,
   allowWeekendSelection,
@@ -198,6 +201,7 @@ const TrackerView: React.FC<{
   availableUsers,
   currentUser,
   dailyGoal,
+  onAddBulkEntries,
   onRecurringAction,
   defaultLocation = 'remote',
   onAddCustomTask,
@@ -445,52 +449,59 @@ const TrackerView: React.FC<{
         </div>
       )}
 
-      <div className="space-y-6">
-        <div className="w-full xl:w-[calc(45%+300px+1.5rem)] xl:mx-auto space-y-6">
-          <div className="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_300px] gap-6 items-start xl:items-stretch">
-            <DailyView
-              clients={clients}
-              projects={projects}
-              projectTasks={projectTasks}
-              onAdd={onAddEntry}
-              selectedDate={selectedDate}
-              onMakeRecurring={onMakeRecurring}
-              permissions={permissions}
-              dailyGoal={dailyGoal}
-              currentDayTotal={dailyTotal}
-              defaultLocation={defaultLocation}
-              onAddCustomTask={onAddCustomTask}
-              currency={currency}
-            />
-
-            <div className="w-full xl:max-w-[300px] xl:h-full">
-              <Calendar
+      {trackerMode === 'weekly' ? (
+        <WeeklyView
+          entries={entries}
+          clients={clients}
+          projects={projects}
+          projectTasks={projectTasks}
+          permissions={permissions}
+          currency={currency}
+          onAddCustomTask={onAddCustomTask}
+          onAddBulkEntries={onAddBulkEntries}
+          onUpdateEntry={onUpdateEntry}
+          viewingUserId={viewingUserId}
+          selectedDate={selectedDate}
+          onSelectedDateChange={setSelectedDate}
+          startOfWeek={startOfWeek}
+          treatSaturdayAsHoliday={treatSaturdayAsHoliday}
+          allowWeekendSelection={allowWeekendSelection}
+          defaultLocation={defaultLocation}
+          dailyGoal={dailyGoal}
+        />
+      ) : (
+        <div className="space-y-6">
+          <div className="w-full xl:w-[calc(45%+300px+1.5rem)] xl:mx-auto space-y-6">
+            <div className="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_300px] gap-6 items-start xl:items-stretch">
+              <DailyView
+                clients={clients}
+                projects={projects}
+                projectTasks={projectTasks}
+                onAdd={onAddEntry}
                 selectedDate={selectedDate}
-                onDateSelect={setSelectedDate}
-                entries={entries}
-                startOfWeek={startOfWeek}
-                treatSaturdayAsHoliday={treatSaturdayAsHoliday}
+                onMakeRecurring={onMakeRecurring}
+                permissions={permissions}
                 dailyGoal={dailyGoal}
-                allowWeekendSelection={allowWeekendSelection}
-                size="compact"
+                currentDayTotal={dailyTotal}
+                defaultLocation={defaultLocation}
+                onAddCustomTask={onAddCustomTask}
+                currency={currency}
               />
-            </div>
-          </div>
 
-          {trackerMode === 'weekly' ? (
-            <WeeklyView
-              entries={entries}
-              clients={clients}
-              projects={projects}
-              projectTasks={projectTasks}
-              viewingUserId={viewingUserId}
-              selectedDate={selectedDate}
-              startOfWeek={startOfWeek}
-              treatSaturdayAsHoliday={treatSaturdayAsHoliday}
-              allowWeekendSelection={allowWeekendSelection}
-              dailyGoal={dailyGoal}
-            />
-          ) : (
+              <div className="w-full xl:max-w-[300px] xl:h-full">
+                <Calendar
+                  selectedDate={selectedDate}
+                  onDateSelect={setSelectedDate}
+                  entries={entries}
+                  startOfWeek={startOfWeek}
+                  treatSaturdayAsHoliday={treatSaturdayAsHoliday}
+                  dailyGoal={dailyGoal}
+                  allowWeekendSelection={allowWeekendSelection}
+                  size="compact"
+                />
+              </div>
+            </div>
+
             <StandardTable<TimeEntry>
               title={
                 selectedDate
@@ -527,9 +538,9 @@ const TrackerView: React.FC<{
                 </div>
               }
             />
-          )}
+          </div>
         </div>
-      </div>
+      )}
 
       {/* Recurring Delete Modal */}
       {pendingDeleteEntry && (
@@ -1979,7 +1990,9 @@ const App: React.FC = () => {
   );
 
   const handleAddEntry = entryHandlers.add;
+  const handleAddBulkEntries = entryHandlers.addBulk;
   const handleDeleteEntry = entryHandlers.delete;
+  const handleUpdateEntry = entryHandlers.update;
 
   const handleUpdateTask = taskHandlers.update;
   const handleMakeRecurring = taskHandlers.makeRecurring;
@@ -2282,6 +2295,7 @@ const App: React.FC = () => {
                 projectTasks={trackerCatalogs.projectTasks}
                 onAddEntry={handleAddEntry}
                 onDeleteEntry={handleDeleteEntry}
+                onUpdateEntry={handleUpdateEntry}
                 startOfWeek={generalSettings.startOfWeek}
                 treatSaturdayAsHoliday={generalSettings.treatSaturdayAsHoliday}
                 allowWeekendSelection={generalSettings.allowWeekendSelection}
@@ -2292,6 +2306,7 @@ const App: React.FC = () => {
                 availableUsers={availableUsers}
                 currentUser={currentUser}
                 dailyGoal={generalSettings.dailyLimit}
+                onAddBulkEntries={handleAddBulkEntries}
                 onRecurringAction={handleRecurringAction}
                 defaultLocation={generalSettings.defaultLocation}
                 onAddCustomTask={addProjectTask}

--- a/App.tsx
+++ b/App.tsx
@@ -405,6 +405,50 @@ const TrackerView: React.FC<{
         </div>
       </div>
 
+      {/* Manager Selection Header — shared across daily and weekly modes. */}
+      {availableUsers.length > 1 && (
+        <div className="max-w-xl mx-auto">
+          <div className="rounded-lg border border-border bg-background shadow-sm p-3.5 sm:p-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+            <div className="flex items-center gap-3 min-w-0">
+              <div
+                className={`size-9 rounded-full flex items-center justify-center font-bold text-xs shadow-sm shrink-0 ${isViewingSelf ? 'bg-praetor/10 text-praetor' : 'bg-amber-500/10 text-amber-600'}`}
+              >
+                {viewingUser?.avatarInitials}
+              </div>
+              <div className="min-w-0">
+                <p className="text-[11px] font-bold text-muted-foreground uppercase tracking-wider">
+                  {isViewingSelf ? t('tracker.myTimesheet') : t('tracker.managingUser')}
+                </p>
+                <p className="text-sm font-bold text-foreground truncate">{viewingUser?.name}</p>
+              </div>
+            </div>
+            <div className="w-full sm:w-56 space-y-1.5 shrink-0">
+              <div className="flex min-h-6 items-center justify-between gap-2">
+                <FieldLabel>{t('tracker.switchUserView')}</FieldLabel>
+                {!isViewingSelf && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="xs"
+                    onClick={() => onViewUserChange(currentUser.id)}
+                    className="gap-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
+                  >
+                    <i className="fa-solid fa-arrow-left" aria-hidden="true"></i>
+                    {t('tracker.backToMe')}
+                  </Button>
+                )}
+              </div>
+              <SelectControl
+                options={userOptions}
+                value={viewingUserId}
+                onChange={(val) => onViewUserChange(val as string)}
+                searchable={true}
+              />
+            </div>
+          </div>
+        </div>
+      )}
+
       {trackerMode === 'weekly' ? (
         <WeeklyView
           entries={entries}
@@ -414,63 +458,15 @@ const TrackerView: React.FC<{
           onDeleteEntry={onDeleteEntry}
           onUpdateEntry={onUpdateEntry}
           viewingUserId={viewingUserId}
-          currentUserId={currentUser.id}
-          availableUsers={availableUsers}
-          onViewUserChange={onViewUserChange}
           onAddBulkEntries={onAddBulkEntries}
           startOfWeek={startOfWeek}
           treatSaturdayAsHoliday={treatSaturdayAsHoliday}
           allowWeekendSelection={allowWeekendSelection}
           defaultLocation={defaultLocation}
+          dailyGoal={dailyGoal}
         />
       ) : (
         <div className="space-y-6">
-          {/* Manager Selection Header */}
-          {availableUsers.length > 1 && (
-            <div className="max-w-xl mx-auto">
-              <div className="rounded-lg border border-border bg-background shadow-sm p-3.5 sm:p-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-                <div className="flex items-center gap-3 min-w-0">
-                  <div
-                    className={`size-9 rounded-full flex items-center justify-center font-bold text-xs shadow-sm shrink-0 ${isViewingSelf ? 'bg-praetor/10 text-praetor' : 'bg-amber-500/10 text-amber-600'}`}
-                  >
-                    {viewingUser?.avatarInitials}
-                  </div>
-                  <div className="min-w-0">
-                    <p className="text-[11px] font-bold text-muted-foreground uppercase tracking-wider">
-                      {isViewingSelf ? t('tracker.myTimesheet') : t('tracker.managingUser')}
-                    </p>
-                    <p className="text-sm font-bold text-foreground truncate">
-                      {viewingUser?.name}
-                    </p>
-                  </div>
-                </div>
-                <div className="w-full sm:w-56 space-y-1.5 shrink-0">
-                  <div className="flex min-h-6 items-center justify-between gap-2">
-                    <FieldLabel>{t('tracker.switchUserView')}</FieldLabel>
-                    {!isViewingSelf && (
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="xs"
-                        onClick={() => onViewUserChange(currentUser.id)}
-                        className="gap-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
-                      >
-                        <i className="fa-solid fa-arrow-left" aria-hidden="true"></i>
-                        {t('tracker.backToMe')}
-                      </Button>
-                    )}
-                  </div>
-                  <SelectControl
-                    options={userOptions}
-                    value={viewingUserId}
-                    onChange={(val) => onViewUserChange(val as string)}
-                    searchable={true}
-                  />
-                </div>
-              </div>
-            </div>
-          )}
-
           <div className="w-full xl:w-[calc(45%+300px+1.5rem)] xl:mx-auto space-y-6">
             <div className="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_300px] gap-6 items-start xl:items-stretch">
               <DailyView

--- a/App.tsx
+++ b/App.tsx
@@ -152,7 +152,6 @@ const TrackerView: React.FC<{
   projectTasks: ProjectTask[];
   onAddEntry: (entry: Omit<TimeEntry, 'id' | 'createdAt' | 'userId' | 'hourlyCost'>) => void;
   onDeleteEntry: (id: string) => void;
-  onUpdateEntry: (id: string, updates: Partial<TimeEntry>) => void;
   startOfWeek: 'Monday' | 'Sunday';
   treatSaturdayAsHoliday: boolean;
   allowWeekendSelection: boolean;
@@ -169,7 +168,6 @@ const TrackerView: React.FC<{
   availableUsers: User[];
   currentUser: User;
   dailyGoal: number;
-  onAddBulkEntries: (entries: Omit<TimeEntry, 'id' | 'createdAt' | 'userId'>[]) => Promise<void>;
   onRecurringAction: (taskId: string, action: 'stop' | 'delete_future' | 'delete_all') => void;
   defaultLocation?: TimeEntryLocation;
   onAddCustomTask: (
@@ -190,7 +188,6 @@ const TrackerView: React.FC<{
   projectTasks,
   onAddEntry,
   onDeleteEntry,
-  onUpdateEntry,
   startOfWeek,
   treatSaturdayAsHoliday,
   allowWeekendSelection,
@@ -201,7 +198,6 @@ const TrackerView: React.FC<{
   availableUsers,
   currentUser,
   dailyGoal,
-  onAddBulkEntries,
   onRecurringAction,
   defaultLocation = 'remote',
   onAddCustomTask,
@@ -449,55 +445,53 @@ const TrackerView: React.FC<{
         </div>
       )}
 
-      {trackerMode === 'weekly' ? (
-        <WeeklyView
-          entries={entries}
-          clients={clients}
-          projects={projects}
-          projectTasks={projectTasks}
-          onDeleteEntry={onDeleteEntry}
-          onUpdateEntry={onUpdateEntry}
-          viewingUserId={viewingUserId}
-          onAddBulkEntries={onAddBulkEntries}
-          startOfWeek={startOfWeek}
-          treatSaturdayAsHoliday={treatSaturdayAsHoliday}
-          allowWeekendSelection={allowWeekendSelection}
-          defaultLocation={defaultLocation}
-          dailyGoal={dailyGoal}
-        />
-      ) : (
-        <div className="space-y-6">
-          <div className="w-full xl:w-[calc(45%+300px+1.5rem)] xl:mx-auto space-y-6">
-            <div className="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_300px] gap-6 items-start xl:items-stretch">
-              <DailyView
-                clients={clients}
-                projects={projects}
-                projectTasks={projectTasks}
-                onAdd={onAddEntry}
+      <div className="space-y-6">
+        <div className="w-full xl:w-[calc(45%+300px+1.5rem)] xl:mx-auto space-y-6">
+          <div className="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_300px] gap-6 items-start xl:items-stretch">
+            <DailyView
+              clients={clients}
+              projects={projects}
+              projectTasks={projectTasks}
+              onAdd={onAddEntry}
+              selectedDate={selectedDate}
+              onMakeRecurring={onMakeRecurring}
+              permissions={permissions}
+              dailyGoal={dailyGoal}
+              currentDayTotal={dailyTotal}
+              defaultLocation={defaultLocation}
+              onAddCustomTask={onAddCustomTask}
+              currency={currency}
+            />
+
+            <div className="w-full xl:max-w-[300px] xl:h-full">
+              <Calendar
                 selectedDate={selectedDate}
-                onMakeRecurring={onMakeRecurring}
-                permissions={permissions}
+                onDateSelect={setSelectedDate}
+                entries={entries}
+                startOfWeek={startOfWeek}
+                treatSaturdayAsHoliday={treatSaturdayAsHoliday}
                 dailyGoal={dailyGoal}
-                currentDayTotal={dailyTotal}
-                defaultLocation={defaultLocation}
-                onAddCustomTask={onAddCustomTask}
-                currency={currency}
+                allowWeekendSelection={allowWeekendSelection}
+                size="compact"
               />
-
-              <div className="w-full xl:max-w-[300px] xl:h-full">
-                <Calendar
-                  selectedDate={selectedDate}
-                  onDateSelect={setSelectedDate}
-                  entries={entries}
-                  startOfWeek={startOfWeek}
-                  treatSaturdayAsHoliday={treatSaturdayAsHoliday}
-                  dailyGoal={dailyGoal}
-                  allowWeekendSelection={allowWeekendSelection}
-                  size="compact"
-                />
-              </div>
             </div>
+          </div>
 
+          {trackerMode === 'weekly' ? (
+            <WeeklyView
+              entries={entries}
+              clients={clients}
+              projects={projects}
+              projectTasks={projectTasks}
+              viewingUserId={viewingUserId}
+              selectedDate={selectedDate}
+              onSelectedDateChange={setSelectedDate}
+              startOfWeek={startOfWeek}
+              treatSaturdayAsHoliday={treatSaturdayAsHoliday}
+              allowWeekendSelection={allowWeekendSelection}
+              dailyGoal={dailyGoal}
+            />
+          ) : (
             <StandardTable<TimeEntry>
               title={
                 selectedDate
@@ -534,9 +528,9 @@ const TrackerView: React.FC<{
                 </div>
               }
             />
-          </div>
+          )}
         </div>
-      )}
+      </div>
 
       {/* Recurring Delete Modal */}
       {pendingDeleteEntry && (
@@ -1986,9 +1980,7 @@ const App: React.FC = () => {
   );
 
   const handleAddEntry = entryHandlers.add;
-  const handleAddBulkEntries = entryHandlers.addBulk;
   const handleDeleteEntry = entryHandlers.delete;
-  const handleUpdateEntry = entryHandlers.update;
 
   const handleUpdateTask = taskHandlers.update;
   const handleMakeRecurring = taskHandlers.makeRecurring;
@@ -2291,7 +2283,6 @@ const App: React.FC = () => {
                 projectTasks={trackerCatalogs.projectTasks}
                 onAddEntry={handleAddEntry}
                 onDeleteEntry={handleDeleteEntry}
-                onUpdateEntry={handleUpdateEntry}
                 startOfWeek={generalSettings.startOfWeek}
                 treatSaturdayAsHoliday={generalSettings.treatSaturdayAsHoliday}
                 allowWeekendSelection={generalSettings.allowWeekendSelection}
@@ -2302,7 +2293,6 @@ const App: React.FC = () => {
                 availableUsers={availableUsers}
                 currentUser={currentUser}
                 dailyGoal={generalSettings.dailyLimit}
-                onAddBulkEntries={handleAddBulkEntries}
                 onRecurringAction={handleRecurringAction}
                 defaultLocation={generalSettings.defaultLocation}
                 onAddCustomTask={addProjectTask}

--- a/components/timesheet/DailyView.tsx
+++ b/components/timesheet/DailyView.tsx
@@ -15,6 +15,8 @@ import { Button } from '../ui/button';
 import { Field, FieldLabel } from '../ui/field';
 import { Input } from '../ui/input';
 import { Separator } from '../ui/separator';
+import EntryCatalogSelector from './EntryCatalogSelector';
+import { CUSTOM_TASK_SENTINEL, useCatalogSelection } from './useCatalogSelection';
 
 export interface DailyViewProps {
   clients: Client[];
@@ -58,17 +60,11 @@ const DailyView: React.FC<DailyViewProps> = ({
   currency,
 }) => {
   const { t } = useTranslation('timesheets');
+  const canCreateCustomTask = hasScopedActionPermission(permissions, 'projects.tasks', 'create');
 
-  // Manual fields
   const [date, setDate] = useState(selectedDate || getLocalDateString());
-  const [selectedClientId, setSelectedClientId] = useState(clients[0]?.id || '');
-  const [selectedProjectId, setSelectedProjectId] = useState('');
-  const [selectedTaskName, setSelectedTaskName] = useState('');
-  const [selectedTaskId, setSelectedTaskId] = useState('');
-  const [isAddTaskModalOpen, setIsAddTaskModalOpen] = useState(false);
   const [notes, setNotes] = useState('');
   const [duration, setDuration] = useState('');
-  const [location, setLocation] = useState<TimeEntryLocation>(defaultLocation);
   const [errors, setErrors] = useState<{
     clientId?: string;
     projectId?: string;
@@ -76,15 +72,20 @@ const DailyView: React.FC<DailyViewProps> = ({
     recurrenceEndDate?: string;
   }>({});
 
-  // New user controls
   const [makeRecurring, setMakeRecurring] = useState(false);
   const [recurrencePattern, setRecurrencePattern] = useState<
     'daily' | 'weekly' | 'monthly' | string
   >('weekly');
   const [recurrenceEndDate, setRecurrenceEndDate] = useState('');
   const [isCustomRepeatModalOpen, setIsCustomRepeatModalOpen] = useState(false);
+  const [isAddTaskModalOpen, setIsAddTaskModalOpen] = useState(false);
 
-  const canCreateCustomTask = hasScopedActionPermission(permissions, 'projects.tasks', 'create');
+  const selection = useCatalogSelection({
+    clients,
+    projects,
+    projectTasks,
+    defaultLocation,
+  });
 
   const handleDurationInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const rawValue = event.target.value;
@@ -94,7 +95,6 @@ const DailyView: React.FC<DailyViewProps> = ({
 
   const hasValidDuration = parseFloat(duration) > 0;
 
-  // Sync internal date when calendar selection changes
   useEffect(() => {
     if (selectedDate && selectedDate !== date) {
       setDate(selectedDate);
@@ -102,65 +102,9 @@ const DailyView: React.FC<DailyViewProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedDate, date]);
 
-  // Keep client selection valid when RBAC-scoped catalogs change.
-  useEffect(() => {
-    if (clients.length === 0) {
-      if (selectedClientId !== '') setSelectedClientId('');
-      return;
-    }
-
-    if (!clients.some((client) => client.id === selectedClientId)) {
-      setSelectedClientId(clients[0].id);
-    }
-  }, [clients, selectedClientId]);
-
-  // Filter projects when client changes
-  const filteredProjects = useMemo(
-    () => projects.filter((p) => p.clientId === selectedClientId),
-    [projects, selectedClientId],
-  );
-  const firstFilteredProjectId = filteredProjects[0]?.id ?? '';
-
-  // Filter tasks when project changes
-  const filteredTasks = useMemo(
-    () => projectTasks.filter((t) => t.projectId === selectedProjectId),
-    [projectTasks, selectedProjectId],
-  );
-  const firstFilteredTaskId = filteredTasks[0]?.id ?? '';
-  const firstFilteredTaskName = filteredTasks[0]?.name ?? '';
-
-  // Keep project/task selections valid when the selected client or scoped catalogs change.
-  useEffect(() => {
-    if (filteredProjects.length === 0) {
-      if (selectedProjectId !== '') {
-        setSelectedProjectId('');
-      }
-      return;
-    }
-
-    if (!filteredProjects.some((project) => project.id === selectedProjectId)) {
-      setSelectedProjectId(firstFilteredProjectId);
-    }
-  }, [filteredProjects, firstFilteredProjectId, selectedProjectId]);
-
-  useEffect(() => {
-    if (filteredTasks.length === 0) {
-      setSelectedTaskId('');
-      setSelectedTaskName('');
-      return;
-    }
-
-    if (!filteredTasks.some((task) => task.id === selectedTaskId)) {
-      setSelectedTaskName(firstFilteredTaskName);
-      setSelectedTaskId(firstFilteredTaskId);
-    }
-  }, [filteredTasks, firstFilteredTaskId, firstFilteredTaskName, selectedTaskId]);
-
-  useEffect(() => {
-    if (selectedClientId === '') {
-      setSelectedProjectId('');
-    }
-  }, [selectedClientId]);
+  const clearTaskError = () => {
+    if (errors.task) setErrors((prev) => ({ ...prev, task: '' }));
+  };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -169,14 +113,12 @@ const DailyView: React.FC<DailyViewProps> = ({
     const newErrors: typeof errors = {};
     const durationVal = parseFloat(duration);
 
-    // Validate client/project/task
-    if (!selectedClientId) newErrors.clientId = t('entry.clientRequired');
-    if (!selectedProjectId) newErrors.projectId = t('entry.projectRequired');
-    if (!selectedTaskName || (!selectedTaskId && !selectedTaskName)) {
+    if (!selection.clientId) newErrors.clientId = t('entry.clientRequired');
+    if (!selection.projectId) newErrors.projectId = t('entry.projectRequired');
+    if (!selection.taskName) {
       newErrors.task = t('entry.taskRequired');
     }
 
-    // Validate recurrence date if enabled
     if (makeRecurring && recurrenceEndDate && date && recurrenceEndDate < date) {
       newErrors.recurrenceEndDate = t('entry.endDateAfterStart');
     }
@@ -186,25 +128,24 @@ const DailyView: React.FC<DailyViewProps> = ({
       return;
     }
 
-    const project = projects.find((p) => p.id === selectedProjectId);
-    const client = clients.find((c) => c.id === selectedClientId);
+    const project = projects.find((p) => p.id === selection.projectId);
+    const client = clients.find((c) => c.id === selection.clientId);
 
     onAdd({
       date,
-      clientId: selectedClientId,
+      clientId: selection.clientId,
       clientName: client?.name || 'Unknown Client',
-      projectId: selectedProjectId,
+      projectId: selection.projectId,
       projectName: project?.name || 'General',
-      task: selectedTaskName,
+      task: selection.taskName,
       notes,
       duration: durationVal,
-      location,
+      location: selection.location,
     });
 
-    // Handle recursion if checked
-    if (makeRecurring && onMakeRecurring && selectedTaskId) {
+    if (makeRecurring && onMakeRecurring && selection.taskId) {
       onMakeRecurring(
-        selectedTaskId,
+        selection.taskId,
         recurrencePattern,
         date,
         recurrenceEndDate || undefined,
@@ -212,10 +153,9 @@ const DailyView: React.FC<DailyViewProps> = ({
       );
     }
 
-    // Reset form
     setDuration('');
     setNotes('');
-    setLocation(defaultLocation);
+    selection.resetLocation();
     setMakeRecurring(false);
     setRecurrenceEndDate('');
     setRecurrencePattern('weekly');
@@ -230,19 +170,6 @@ const DailyView: React.FC<DailyViewProps> = ({
     }
   };
 
-  const handleTaskChange = (taskId: string) => {
-    if (taskId === 'custom') {
-      setIsAddTaskModalOpen(true);
-      return;
-    }
-    const task = filteredTasks.find((t) => t.id === taskId);
-    if (task) {
-      setSelectedTaskName(task.name);
-      setSelectedTaskId(task.id);
-    }
-    if (errors.task) setErrors((prev) => ({ ...prev, task: '' }));
-  };
-
   const handleAddCustomTaskSubmit = async (
     taskName: string,
     taskProjectId: string,
@@ -253,14 +180,13 @@ const DailyView: React.FC<DailyViewProps> = ({
     // If `onAddCustomTask` rejects, the throw propagates to TaskFormModal's submit handler,
     // which keeps the modal open and resets `isSubmitting` via its `finally`. No silent failure.
     const created = await onAddCustomTask(taskName, taskProjectId, undefined, description, details);
-    setSelectedTaskId(created.id);
-    setSelectedTaskName(created.name);
-    // Clear any pending recurrence state from a previously-selected task so the new task
-    // starts with a clean slate.
+    // The fresh task may not be in `filteredTasks` yet (parent re-render hasn't flowed back),
+    // so pass the name explicitly so the hook doesn't fall back to a stale lookup.
+    selection.setTask(created.id, created.name);
     setMakeRecurring(false);
     setRecurrenceEndDate('');
     setRecurrencePattern('weekly');
-    if (errors.task) setErrors((prev) => ({ ...prev, task: '' }));
+    clearTaskError();
     return created;
   };
 
@@ -270,17 +196,9 @@ const DailyView: React.FC<DailyViewProps> = ({
     return currentDayTotal + val > dailyGoal;
   }, [duration, currentDayTotal, dailyGoal]);
 
-  const clientOptions = clients.map((c) => ({ id: c.id, name: c.name }));
-  const projectOptions = filteredProjects.map((p) => ({ id: p.id, name: p.name }));
-  const taskOptions = useMemo(() => {
-    const opts = filteredTasks.map((t) => ({ id: t.id, name: t.name }));
-    // Only offer "+ Custom Task..." when a project is selected — the modal locks the project to
-    // the current selection, so an empty project would render a stuck, unsubmittable form.
-    if (canCreateCustomTask && selectedProjectId !== '') {
-      opts.push({ id: 'custom', name: t('entry.customTask') });
-    }
-    return opts;
-  }, [filteredTasks, canCreateCustomTask, selectedProjectId, t]);
+  // The "+ Custom Task..." option is only useful when a project is selected,
+  // since the modal locks the project to the current selection.
+  const allowCustomTask = canCreateCustomTask && selection.projectId !== '';
 
   return (
     <div className="rounded-lg border border-border bg-background shadow-sm p-5">
@@ -314,93 +232,52 @@ const DailyView: React.FC<DailyViewProps> = ({
       </div>
 
       <form onSubmit={handleSubmit} className="space-y-4">
-        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-[minmax(0,1.3fr)_minmax(0,1.3fr)_minmax(0,1.3fr)_minmax(0,1fr)_50px] gap-4 items-start">
-          <div className="min-w-0">
-            <SelectControl
-              label={t('entry.client')}
-              options={clientOptions}
-              value={selectedClientId}
-              onChange={(val) => {
-                setSelectedClientId(val as string);
-                if (errors.clientId) setErrors((prev) => ({ ...prev, clientId: '' }));
-              }}
-              searchable={true}
-              className={errors.clientId ? 'border-destructive' : ''}
-            />
-            {errors.clientId && (
-              <p className="text-destructive text-[10px] font-bold ml-1 mt-1">{errors.clientId}</p>
-            )}
-          </div>
-
-          <div className="min-w-0">
-            <SelectControl
-              label={t('entry.project')}
-              options={projectOptions}
-              value={selectedProjectId}
-              onChange={(val) => {
-                setSelectedProjectId(val as string);
-                if (errors.projectId) setErrors((prev) => ({ ...prev, projectId: '' }));
-              }}
-              placeholder={
-                filteredProjects.length === 0 ? t('entry.noProjects') : t('entry.selectProject')
-              }
-              searchable={true}
-              className={errors.projectId ? 'border-destructive' : ''}
-            />
-            {errors.projectId && (
-              <p className="text-destructive text-[10px] font-bold ml-1 mt-1">{errors.projectId}</p>
-            )}
-          </div>
-
-          <div className="min-w-0">
-            <SelectControl
-              label={t('entry.task')}
-              options={taskOptions}
-              value={selectedTaskId}
-              onChange={(val) => handleTaskChange(val as string)}
-              placeholder={
-                filteredTasks.length === 0 && !canCreateCustomTask
-                  ? t('entry.noTasks')
-                  : t('entry.selectTask')
-              }
-              searchable={true}
-              className={errors.task ? 'border-destructive' : ''}
-            />
-            {errors.task && (
-              <p className="text-destructive text-[10px] font-bold ml-1 mt-1">{errors.task}</p>
-            )}
-          </div>
-
-          <div className="min-w-0">
-            <SelectControl
-              label={t('entry.location')}
-              options={[
-                { id: 'office', name: t('entry.locationTypes.office') },
-                { id: 'customer_premise', name: t('entry.locationTypes.customerPremise') },
-                { id: 'remote', name: t('entry.locationTypes.remote') },
-                { id: 'transfer', name: t('entry.locationTypes.transfer') },
-              ]}
-              value={location}
-              onChange={(val) => setLocation(val as TimeEntryLocation)}
-            />
-          </div>
-
-          <Field className="min-w-0">
-            <FieldLabel htmlFor="daily-entry-hours">
-              {t('entry.hours')} <span className="text-destructive">*</span>
-            </FieldLabel>
-            <Input
-              id="daily-entry-hours"
-              type="text"
-              inputMode="decimal"
-              pattern="^[0-9]*([.,][0-9]*)?$"
-              value={duration}
-              onChange={handleDurationInputChange}
-              placeholder="0.0"
-              className="h-9 min-h-9 max-h-9 rounded-lg py-2"
-            />
-          </Field>
-        </div>
+        <EntryCatalogSelector
+          clients={clients}
+          filteredProjects={selection.filteredProjects}
+          filteredTasks={selection.filteredTasks}
+          selectedClientId={selection.clientId}
+          selectedProjectId={selection.projectId}
+          selectedTaskId={selection.taskId}
+          location={selection.location}
+          onClientChange={(id) => {
+            selection.setClient(id);
+            if (errors.clientId) setErrors((prev) => ({ ...prev, clientId: '' }));
+          }}
+          onProjectChange={(id) => {
+            selection.setProject(id);
+            if (errors.projectId) setErrors((prev) => ({ ...prev, projectId: '' }));
+          }}
+          onTaskChange={(taskId) => {
+            if (taskId === CUSTOM_TASK_SENTINEL) {
+              setIsAddTaskModalOpen(true);
+              return;
+            }
+            selection.setTask(taskId);
+            clearTaskError();
+          }}
+          onLocationChange={selection.setLocation}
+          allowCustomTask={allowCustomTask}
+          errors={errors}
+          className="xl:grid-cols-[minmax(0,1.3fr)_minmax(0,1.3fr)_minmax(0,1.3fr)_minmax(0,1fr)_50px]"
+          extraTrailing={
+            <Field className="min-w-0">
+              <FieldLabel htmlFor="daily-entry-hours">
+                {t('entry.hours')} <span className="text-destructive">*</span>
+              </FieldLabel>
+              <Input
+                id="daily-entry-hours"
+                type="text"
+                inputMode="decimal"
+                pattern="^[0-9]*([.,][0-9]*)?$"
+                value={duration}
+                onChange={handleDurationInputChange}
+                placeholder="0.0"
+                className="h-9 min-h-9 max-h-9 rounded-lg py-2"
+              />
+            </Field>
+          }
+        />
 
         <div className="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_180px] gap-4 items-end">
           <Field className="min-w-0">
@@ -422,7 +299,7 @@ const DailyView: React.FC<DailyViewProps> = ({
           </div>
         </div>
 
-        {selectedTaskId && (
+        {selection.taskId && (
           <div
             className={`transition-all duration-300 border rounded-xl px-2 py-1 ${makeRecurring ? 'bg-muted/40 border-border' : 'bg-transparent border-transparent'}`}
           >
@@ -504,7 +381,7 @@ const DailyView: React.FC<DailyViewProps> = ({
         canDelete={false}
         onAdd={handleAddCustomTaskSubmit}
         onUpdate={() => {}}
-        initialProjectId={selectedProjectId}
+        initialProjectId={selection.projectId}
         projectLocked={true}
       />
     </div>

--- a/components/timesheet/DailyView.tsx
+++ b/components/timesheet/DailyView.tsx
@@ -1,3 +1,4 @@
+import { Save } from 'lucide-react';
 import type React from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -294,6 +295,7 @@ const DailyView: React.FC<DailyViewProps> = ({
 
           <div className="min-w-0 flex items-end">
             <Button type="submit" disabled={!hasValidDuration} className="h-10 w-full rounded-lg">
+              <Save className="size-4" aria-hidden="true" />
               {t('entry.logTime')}
             </Button>
           </div>

--- a/components/timesheet/EntryCatalogSelector.tsx
+++ b/components/timesheet/EntryCatalogSelector.tsx
@@ -1,0 +1,147 @@
+import type React from 'react';
+import { useTranslation } from 'react-i18next';
+import { cn } from '@/lib/utils';
+import type { Client, Project, ProjectTask, TimeEntryLocation } from '../../types';
+import SelectControl from '../shared/SelectControl';
+import { CUSTOM_TASK_SENTINEL } from './useCatalogSelection';
+
+export interface EntryCatalogSelectorErrors {
+  clientId?: string;
+  projectId?: string;
+  task?: string;
+}
+
+export interface EntryCatalogSelectorProps {
+  clients: Client[];
+  filteredProjects: Project[];
+  filteredTasks: ProjectTask[];
+  selectedClientId: string;
+  selectedProjectId: string;
+  selectedTaskId: string;
+  location: TimeEntryLocation;
+  onClientChange: (id: string) => void;
+  onProjectChange: (id: string) => void;
+  onTaskChange: (taskId: string) => void;
+  onLocationChange: (location: TimeEntryLocation) => void;
+  errors?: EntryCatalogSelectorErrors;
+  // Show the "+ Custom Task..." option in the task dropdown. The parent
+  // intercepts `onTaskChange(CUSTOM_TASK_SENTINEL)` to open a modal — the
+  // selector itself never renders an inline custom-task input.
+  allowCustomTask?: boolean;
+  showLocation?: boolean;
+  className?: string;
+  extraTrailing?: React.ReactNode;
+}
+
+const EntryCatalogSelector: React.FC<EntryCatalogSelectorProps> = ({
+  clients,
+  filteredProjects,
+  filteredTasks,
+  selectedClientId,
+  selectedProjectId,
+  selectedTaskId,
+  location,
+  onClientChange,
+  onProjectChange,
+  onTaskChange,
+  onLocationChange,
+  errors,
+  allowCustomTask = false,
+  showLocation = true,
+  className,
+  extraTrailing,
+}) => {
+  const { t } = useTranslation('timesheets');
+
+  const clientOptions = clients.map((c) => ({ id: c.id, name: c.name }));
+  const projectOptions = filteredProjects.map((p) => ({ id: p.id, name: p.name }));
+  const taskOptions = filteredTasks.map((task) => ({ id: task.id, name: task.name }));
+  if (allowCustomTask) {
+    taskOptions.push({ id: CUSTOM_TASK_SENTINEL, name: t('entry.customTask') });
+  }
+
+  const gridClass = cn(
+    'grid grid-cols-1 md:grid-cols-2 gap-4 items-start',
+    showLocation
+      ? 'xl:grid-cols-[minmax(0,1.3fr)_minmax(0,1.3fr)_minmax(0,1.3fr)_minmax(0,1fr)]'
+      : 'xl:grid-cols-3',
+    extraTrailing
+      ? 'xl:grid-cols-[minmax(0,1.3fr)_minmax(0,1.3fr)_minmax(0,1.3fr)_minmax(0,1fr)_auto]'
+      : null,
+    className,
+  );
+
+  return (
+    <div className={gridClass}>
+      <div className="min-w-0">
+        <SelectControl
+          label={t('entry.client')}
+          options={clientOptions}
+          value={selectedClientId}
+          onChange={(val) => onClientChange(val as string)}
+          searchable={true}
+          className={errors?.clientId ? 'border-destructive' : ''}
+        />
+        {errors?.clientId && (
+          <p className="text-destructive text-[10px] font-bold ml-1 mt-1">{errors.clientId}</p>
+        )}
+      </div>
+
+      <div className="min-w-0">
+        <SelectControl
+          label={t('entry.project')}
+          options={projectOptions}
+          value={selectedProjectId}
+          onChange={(val) => onProjectChange(val as string)}
+          placeholder={
+            filteredProjects.length === 0 ? t('entry.noProjects') : t('entry.selectProject')
+          }
+          searchable={true}
+          className={errors?.projectId ? 'border-destructive' : ''}
+        />
+        {errors?.projectId && (
+          <p className="text-destructive text-[10px] font-bold ml-1 mt-1">{errors.projectId}</p>
+        )}
+      </div>
+
+      <div className="min-w-0">
+        <SelectControl
+          label={t('entry.task')}
+          options={taskOptions}
+          value={selectedTaskId}
+          onChange={(val) => onTaskChange(val as string)}
+          placeholder={
+            filteredTasks.length === 0 && !allowCustomTask
+              ? t('entry.noTasks')
+              : t('entry.selectTask')
+          }
+          searchable={true}
+          className={errors?.task ? 'border-destructive' : ''}
+        />
+        {errors?.task && (
+          <p className="text-destructive text-[10px] font-bold ml-1 mt-1">{errors.task}</p>
+        )}
+      </div>
+
+      {showLocation && (
+        <div className="min-w-0">
+          <SelectControl
+            label={t('entry.location')}
+            options={[
+              { id: 'office', name: t('entry.locationTypes.office') },
+              { id: 'customer_premise', name: t('entry.locationTypes.customerPremise') },
+              { id: 'remote', name: t('entry.locationTypes.remote') },
+              { id: 'transfer', name: t('entry.locationTypes.transfer') },
+            ]}
+            value={location}
+            onChange={(val) => onLocationChange(val as TimeEntryLocation)}
+          />
+        </div>
+      )}
+
+      {extraTrailing}
+    </div>
+  );
+};
+
+export default EntryCatalogSelector;

--- a/components/timesheet/WeeklyEntryForm.tsx
+++ b/components/timesheet/WeeklyEntryForm.tsx
@@ -1,4 +1,4 @@
-import { ArrowUp } from 'lucide-react';
+import { Save } from 'lucide-react';
 import type React from 'react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -160,8 +160,8 @@ const WeeklyEntryForm: React.FC<WeeklyEntryFormProps> = ({
                 showSubmitSuccess && 'bg-emerald-600 hover:bg-emerald-600',
               )}
             >
+              <Save className="size-4" aria-hidden="true" />
               {showSubmitSuccess ? t('weekly.success') : t('weekly.submitTime')}
-              <ArrowUp className="size-4" aria-hidden="true" />
             </Button>
           </div>
         </div>

--- a/components/timesheet/WeeklyEntryForm.tsx
+++ b/components/timesheet/WeeklyEntryForm.tsx
@@ -1,12 +1,15 @@
+import { ArrowUp } from 'lucide-react';
 import type React from 'react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { cn } from '@/lib/utils';
 import type { Client, Project, ProjectTask, TimeEntryLocation } from '../../types';
 import { hasScopedActionPermission } from '../../utils/permissions';
 import TaskFormModal, {
   type RecurringConfig,
   type TaskFormDetails,
 } from '../projects/TaskFormModal';
+import { Button } from '../ui/button';
 import { Field, FieldLabel } from '../ui/field';
 import { Input } from '../ui/input';
 import EntryCatalogSelector from './EntryCatalogSelector';
@@ -37,6 +40,10 @@ export interface WeeklyEntryFormProps {
     details?: TaskFormDetails,
   ) => Promise<ProjectTask>;
   defaultLocation?: TimeEntryLocation;
+  onSubmit: () => void;
+  isSubmitting: boolean;
+  showSubmitSuccess: boolean;
+  canSubmit: boolean;
 }
 
 const WeeklyEntryForm: React.FC<WeeklyEntryFormProps> = ({
@@ -51,6 +58,10 @@ const WeeklyEntryForm: React.FC<WeeklyEntryFormProps> = ({
   permissions,
   currency,
   onAddCustomTask,
+  onSubmit,
+  isSubmitting,
+  showSubmitSuccess,
+  canSubmit,
 }) => {
   const { t } = useTranslation('timesheets');
   const canCreateCustomTask = hasScopedActionPermission(permissions, 'projects.tasks', 'create');
@@ -126,17 +137,34 @@ const WeeklyEntryForm: React.FC<WeeklyEntryFormProps> = ({
           errors={errors}
         />
 
-        <Field>
-          <FieldLabel htmlFor="weekly-form-week-note">{t('weekly.weekNoteLabel')}</FieldLabel>
-          <Input
-            id="weekly-form-week-note"
-            type="text"
-            value={weekNote}
-            onChange={(e) => onWeekNoteChange(e.target.value)}
-            placeholder={t('weekly.weekNotePlaceholder')}
-            className="h-10 rounded-lg"
-          />
-        </Field>
+        <div className="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_180px] gap-4 items-end">
+          <Field className="min-w-0">
+            <FieldLabel htmlFor="weekly-form-week-note">{t('weekly.weekNoteLabel')}</FieldLabel>
+            <Input
+              id="weekly-form-week-note"
+              type="text"
+              value={weekNote}
+              onChange={(e) => onWeekNoteChange(e.target.value)}
+              placeholder={t('weekly.weekNotePlaceholder')}
+              className="h-10 rounded-lg"
+            />
+          </Field>
+
+          <div className="min-w-0 flex items-end">
+            <Button
+              type="button"
+              onClick={onSubmit}
+              disabled={isSubmitting || !canSubmit}
+              className={cn(
+                'h-10 w-full rounded-lg',
+                showSubmitSuccess && 'bg-emerald-600 hover:bg-emerald-600',
+              )}
+            >
+              {showSubmitSuccess ? t('weekly.success') : t('weekly.submitTime')}
+              <ArrowUp className="size-4" aria-hidden="true" />
+            </Button>
+          </div>
+        </div>
       </div>
 
       <TaskFormModal

--- a/components/timesheet/WeeklyEntryForm.tsx
+++ b/components/timesheet/WeeklyEntryForm.tsx
@@ -1,0 +1,161 @@
+import type React from 'react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { Client, Project, ProjectTask, TimeEntryLocation } from '../../types';
+import { hasScopedActionPermission } from '../../utils/permissions';
+import TaskFormModal, {
+  type RecurringConfig,
+  type TaskFormDetails,
+} from '../projects/TaskFormModal';
+import { Field, FieldLabel } from '../ui/field';
+import { Input } from '../ui/input';
+import EntryCatalogSelector from './EntryCatalogSelector';
+import { CUSTOM_TASK_SENTINEL, type UseCatalogSelectionResult } from './useCatalogSelection';
+
+export interface WeeklyEntryFormErrors {
+  clientId?: string;
+  projectId?: string;
+  task?: string;
+}
+
+export interface WeeklyEntryFormProps {
+  selectedDate: string;
+  selection: UseCatalogSelectionResult;
+  weekNote: string;
+  errors: WeeklyEntryFormErrors;
+  onWeekNoteChange: (value: string) => void;
+  onClearError: (field: 'clientId' | 'projectId' | 'task') => void;
+  clients: Client[];
+  projects: Project[];
+  permissions: string[];
+  currency: string;
+  onAddCustomTask: (
+    name: string,
+    projectId: string,
+    recurringConfig?: RecurringConfig,
+    description?: string,
+    details?: TaskFormDetails,
+  ) => Promise<ProjectTask>;
+  defaultLocation?: TimeEntryLocation;
+}
+
+const WeeklyEntryForm: React.FC<WeeklyEntryFormProps> = ({
+  selectedDate,
+  selection,
+  weekNote,
+  errors,
+  onWeekNoteChange,
+  onClearError,
+  clients,
+  projects,
+  permissions,
+  currency,
+  onAddCustomTask,
+}) => {
+  const { t } = useTranslation('timesheets');
+  const canCreateCustomTask = hasScopedActionPermission(permissions, 'projects.tasks', 'create');
+  const [isAddTaskModalOpen, setIsAddTaskModalOpen] = useState(false);
+  const allowCustomTask = canCreateCustomTask && selection.projectId !== '';
+
+  const handleAddCustomTaskSubmit = async (
+    taskName: string,
+    taskProjectId: string,
+    _recurringConfig: RecurringConfig | undefined,
+    description: string,
+    details: TaskFormDetails,
+  ): Promise<ProjectTask> => {
+    const created = await onAddCustomTask(taskName, taskProjectId, undefined, description, details);
+    selection.setTask(created.id, created.name);
+    onClearError('task');
+    return created;
+  };
+
+  const dateForDisplay = new Date(selectedDate);
+
+  return (
+    <div className="rounded-lg border border-border bg-background shadow-sm p-5">
+      <div className="flex justify-between items-center gap-4 mb-4">
+        <div className="flex items-center gap-3 shrink-0">
+          <div className="flex flex-col">
+            <span className="text-[11px] font-bold uppercase tracking-wider text-muted-foreground leading-none mb-1">
+              {t('entry.loggingFor')}
+            </span>
+            <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1 leading-none">
+              <span className="text-base sm:text-lg font-black text-praetor uppercase">
+                {dateForDisplay.toLocaleDateString(undefined, { weekday: 'long' })}
+              </span>
+              <span className="text-sm sm:text-base font-medium text-muted-foreground">
+                {dateForDisplay.toLocaleDateString(undefined, {
+                  month: 'short',
+                  day: 'numeric',
+                  year: 'numeric',
+                })}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        <EntryCatalogSelector
+          clients={clients}
+          filteredProjects={selection.filteredProjects}
+          filteredTasks={selection.filteredTasks}
+          selectedClientId={selection.clientId}
+          selectedProjectId={selection.projectId}
+          selectedTaskId={selection.taskId}
+          location={selection.location}
+          onClientChange={(id) => {
+            selection.setClient(id);
+            onClearError('clientId');
+          }}
+          onProjectChange={(id) => {
+            selection.setProject(id);
+            onClearError('projectId');
+          }}
+          onTaskChange={(taskId) => {
+            if (taskId === CUSTOM_TASK_SENTINEL) {
+              setIsAddTaskModalOpen(true);
+              return;
+            }
+            selection.setTask(taskId);
+            onClearError('task');
+          }}
+          onLocationChange={selection.setLocation}
+          allowCustomTask={allowCustomTask}
+          errors={errors}
+        />
+
+        <Field>
+          <FieldLabel htmlFor="weekly-form-week-note">{t('weekly.weekNoteLabel')}</FieldLabel>
+          <Input
+            id="weekly-form-week-note"
+            type="text"
+            value={weekNote}
+            onChange={(e) => onWeekNoteChange(e.target.value)}
+            placeholder={t('weekly.weekNotePlaceholder')}
+            className="h-10 rounded-lg"
+          />
+        </Field>
+      </div>
+
+      <TaskFormModal
+        isOpen={isAddTaskModalOpen}
+        onClose={() => setIsAddTaskModalOpen(false)}
+        mode="add"
+        projects={projects}
+        clients={clients}
+        currency={currency}
+        canCreate={canCreateCustomTask}
+        canUpdate={false}
+        canDelete={false}
+        onAdd={handleAddCustomTaskSubmit}
+        onUpdate={() => {}}
+        initialProjectId={selection.projectId}
+        projectLocked={true}
+      />
+    </div>
+  );
+};
+
+export default WeeklyEntryForm;

--- a/components/timesheet/WeeklyView.tsx
+++ b/components/timesheet/WeeklyView.tsx
@@ -548,7 +548,32 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
     );
   };
 
-  const hasPendingEdits = Object.values(pendingEdits).some((row) => Object.keys(row).length > 0);
+  // True when at least one pending edit would actually change state on
+  // submit — i.e. a non-zero new value on a fresh cell, or an existing entry
+  // whose duration / note differs from its baseline. Mirrors submitRow's
+  // gating so the button stays disabled when the user types a value and then
+  // clears it (net zero change).
+  const hasPendingEdits = useMemo(() => {
+    const rowHasChange = (rowKey: string, baseDays: DayMap) => {
+      const edits = pendingEdits[rowKey];
+      if (!edits) return false;
+      for (const [dateStr, edit] of Object.entries(edits)) {
+        const base = baseDays[dateStr];
+        const newDuration = parseDuration(edit.duration);
+        const baseDuration = base ? parseDuration(base.duration) : 0;
+        const noteChanged = (edit.note ?? '') !== (base?.note ?? '');
+        if (base?.entryId) {
+          if (newDuration > 0 && (newDuration !== baseDuration || noteChanged)) return true;
+        } else if (newDuration > 0) {
+          return true;
+        }
+      }
+      return false;
+    };
+
+    if (rowHasChange(FORM_ROW_KEY, formRowBaseDays)) return true;
+    return entryRows.some((row) => rowHasChange(row.key, row.baseDays));
+  }, [pendingEdits, formRowBaseDays, entryRows]);
   const weeklyGoal = dailyGoal * 5;
 
   const handleExportToCsv = () => {

--- a/components/timesheet/WeeklyView.tsx
+++ b/components/timesheet/WeeklyView.tsx
@@ -708,7 +708,7 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
           </div>
         </div>
 
-        <div className="-mx-5 overflow-x-auto">
+        <div className="-mx-5 -mb-5 overflow-x-auto">
           <Table className="border-collapse">
             <TableHeader className="bg-muted/40">
               <TableRow className="border-b border-border">

--- a/components/timesheet/WeeklyView.tsx
+++ b/components/timesheet/WeeklyView.tsx
@@ -72,10 +72,11 @@ type DayMap = Record<string, DayCell>;
 type EntryRow = {
   key: string;
   clientId: string;
+  clientName: string;
   projectId: string;
+  projectName: string;
   taskName: string;
   location: TimeEntryLocation;
-  label: string;
   baseDays: DayMap;
 };
 
@@ -226,10 +227,11 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
           row: {
             key,
             clientId: entry.clientId,
+            clientName: client?.name ?? '',
             projectId: entry.projectId,
+            projectName: project?.name ?? '',
             taskName: entry.task,
             location: entry.location ?? defaultLocation,
-            label: [client?.name, project?.name, entry.task].filter(Boolean).join(' · '),
             baseDays: {},
           },
           maxCreatedAt: entry.createdAt,
@@ -511,12 +513,40 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
       .reduce((sum, e) => sum + e.duration, 0);
   }, [userEntries, currentWeekStart]);
 
-  const formLabel = useMemo(() => {
+  const formSelectionLabels = useMemo(() => {
     const client = clients.find((c) => c.id === selection.clientId);
     const project = projects.find((p) => p.id === selection.projectId);
-    const parts = [client?.name, project?.name, selection.taskName].filter((p) => Boolean(p));
-    return parts.length > 0 ? parts.join(' · ') : t('weekly.newEntry');
-  }, [clients, projects, selection.clientId, selection.projectId, selection.taskName, t]);
+    return {
+      clientName: client?.name ?? '',
+      projectName: project?.name ?? '',
+      taskName: selection.taskName,
+    };
+  }, [clients, projects, selection.clientId, selection.projectId, selection.taskName]);
+
+  const renderRowLabel = (
+    clientName: string,
+    projectName: string,
+    taskName: string,
+  ): React.ReactNode => {
+    const rows: Array<{ icon: string; text: string }> = [];
+    if (clientName) rows.push({ icon: 'fa-building', text: clientName });
+    if (projectName) rows.push({ icon: 'fa-folder-open', text: projectName });
+    if (taskName) rows.push({ icon: 'fa-list-check', text: taskName });
+    if (rows.length === 0) return null;
+    return (
+      <div className="flex flex-col gap-1">
+        {rows.map(({ icon, text }) => (
+          <div key={icon} className="flex items-center gap-2 text-xs text-foreground">
+            <i
+              className={cn('fa-solid w-3 text-[10px] text-muted-foreground', icon)}
+              aria-hidden="true"
+            />
+            <span className="line-clamp-1">{text}</span>
+          </div>
+        ))}
+      </div>
+    );
+  };
 
   const hasPendingEdits = Object.values(pendingEdits).some((row) => Object.keys(row).length > 0);
   const weeklyGoal = dailyGoal * 5;
@@ -533,13 +563,22 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
     ];
     const rows: string[][] = [headerRow];
 
+    const joinLabel = (clientName: string, projectName: string, taskName: string) =>
+      [clientName, projectName, taskName].filter(Boolean).join(' · ');
+
     const formRowValues = visibleWeekDays.map((day) => {
       const cell = getCellValue(FORM_ROW_KEY, day.dateStr, formRowBaseDays);
       return formatHours(parseDuration(cell.duration));
     });
     const formRowTotal = sumDayValues(formRowValues);
     if (formRowTotal > 0) {
-      rows.push([formLabel, ...formRowValues, formatHours(formRowTotal)]);
+      const label =
+        joinLabel(
+          formSelectionLabels.clientName,
+          formSelectionLabels.projectName,
+          formSelectionLabels.taskName,
+        ) || t('weekly.newEntry');
+      rows.push([label, ...formRowValues, formatHours(formRowTotal)]);
     }
 
     for (const row of entryRows) {
@@ -548,7 +587,11 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
         return formatHours(parseDuration(cell.duration));
       });
       const rowTotal = sumDayValues(dayValues);
-      rows.push([row.label, ...dayValues, formatHours(rowTotal)]);
+      rows.push([
+        joinLabel(row.clientName, row.projectName, row.taskName),
+        ...dayValues,
+        formatHours(rowTotal),
+      ]);
     }
 
     rows.push([
@@ -721,10 +764,14 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
             <TableBody>
               <TableRow className="bg-praetor/5 hover:bg-praetor/10">
                 <TableCell className="px-4 py-3 align-top whitespace-normal">
-                  <p className="text-[10px] font-bold text-praetor uppercase tracking-wider mb-1">
+                  <p className="text-[10px] font-bold text-praetor uppercase tracking-wider mb-2">
                     {t('weekly.newEntry')}
                   </p>
-                  <p className="text-xs text-muted-foreground line-clamp-2">{formLabel}</p>
+                  {renderRowLabel(
+                    formSelectionLabels.clientName,
+                    formSelectionLabels.projectName,
+                    formSelectionLabels.taskName,
+                  )}
                 </TableCell>
                 {visibleWeekDays.map((day) => (
                   <TableCell
@@ -754,12 +801,7 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
                 entryRows.map((row) => (
                   <TableRow key={row.key} className="hover:bg-muted/30">
                     <TableCell className="px-4 py-3 align-middle whitespace-normal">
-                      <p
-                        className="text-xs font-semibold text-foreground line-clamp-2"
-                        title={row.label}
-                      >
-                        {row.label}
-                      </p>
+                      {renderRowLabel(row.clientName, row.projectName, row.taskName)}
                     </TableCell>
                     {visibleWeekDays.map((day) => {
                       const cell = getCellValue(row.key, day.dateStr, row.baseDays);

--- a/components/timesheet/WeeklyView.tsx
+++ b/components/timesheet/WeeklyView.tsx
@@ -539,9 +539,8 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
           <Table className="min-w-max border-collapse">
             <TableHeader className="bg-muted/40">
               <TableRow className="border-b border-border">
-                <TableHead className="px-4 py-3 text-[10px] font-bold text-muted-foreground uppercase tracking-tighter min-w-56">
-                  {t('weekly.task')}
-                </TableHead>
+                <TableHead className="px-4 py-3 min-w-56" />
+
                 {weekDays.map((day) => (
                   <TableHead
                     key={day.dateStr}
@@ -650,16 +649,7 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
                 })}
               </TableRow>
             </TableBody>
-            <TableBody className="divide-y divide-border">
-              {/* Recent tasks section header */}
-              <TableRow className="bg-muted/30 hover:bg-muted/30 border-t-[3px] border-t-border">
-                <TableCell
-                  colSpan={1 + weekDays.length}
-                  className="px-4 py-2 text-[10px] font-bold text-muted-foreground uppercase tracking-wider"
-                >
-                  {t('weekly.recentTasks')}
-                </TableCell>
-              </TableRow>
+            <TableBody className="divide-y divide-border border-t-[3px] border-t-border">
               {entryRows.length === 0 ? (
                 <TableRow>
                   <TableCell

--- a/components/timesheet/WeeklyView.tsx
+++ b/components/timesheet/WeeklyView.tsx
@@ -786,6 +786,9 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
                   </TableCell>
                 ))}
               </TableRow>
+              <TableRow className="hover:bg-transparent border-b-0">
+                <TableCell colSpan={1 + visibleWeekDays.length} className="h-6 p-0" />
+              </TableRow>
             </TableBody>
             <TableBody className="divide-y divide-border border-t-[3px] border-t-border">
               {entryRows.length === 0 ? (

--- a/components/timesheet/WeeklyView.tsx
+++ b/components/timesheet/WeeklyView.tsx
@@ -626,6 +626,25 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
                 <span className="inline-flex">
                   <Button
                     type="button"
+                    variant="outline"
+                    size="sm"
+                    aria-label={t('common:table.exportToCsv')}
+                    onClick={handleExportToCsv}
+                    className={TABLE_CONTROL_BUTTON_CLASSNAME}
+                  >
+                    <i className="fa-solid fa-file-export text-xs" aria-hidden="true"></i>
+                    <span>{t('common:table.export')}</span>
+                  </Button>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">{t('common:table.exportToCsv')}</TooltipContent>
+            </Tooltip>
+
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="inline-flex">
+                  <Button
+                    type="button"
                     variant={hideWeekend ? 'secondary' : 'outline'}
                     size="sm"
                     aria-label={t('weekly.hideWeekend')}
@@ -643,30 +662,11 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
               </TooltipTrigger>
               <TooltipContent side="bottom">{t('weekly.hideWeekend')}</TooltipContent>
             </Tooltip>
-
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span className="inline-flex">
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    aria-label={t('common:table.exportToCsv')}
-                    onClick={handleExportToCsv}
-                    className={TABLE_CONTROL_BUTTON_CLASSNAME}
-                  >
-                    <i className="fa-solid fa-file-export text-xs" aria-hidden="true"></i>
-                    <span>{t('common:table.export')}</span>
-                  </Button>
-                </span>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">{t('common:table.exportToCsv')}</TooltipContent>
-            </Tooltip>
           </div>
         </div>
 
         <div className="-mx-5 overflow-x-auto">
-          <Table className="min-w-max border-collapse">
+          <Table className="border-collapse">
             <TableHeader className="bg-muted/40">
               <TableRow className="border-b border-border">
                 <TableHead className="px-4 py-3 min-w-56" />
@@ -675,7 +675,7 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
                   <TableHead
                     key={day.dateStr}
                     className={cn(
-                      'w-28 px-2 py-2 text-center relative align-middle',
+                      'min-w-28 px-2 py-2 text-center relative align-middle',
                       day.isToday && 'bg-accent',
                       day.isWeekendOrHoliday && 'bg-destructive/5',
                     )}
@@ -730,7 +730,7 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
                   <TableCell
                     key={day.dateStr}
                     className={cn(
-                      'w-28 px-2 py-3 align-top',
+                      'min-w-28 px-2 py-3 align-top',
                       day.isToday && 'bg-accent/60',
                       day.isWeekendOrHoliday && 'bg-destructive/5',
                     )}
@@ -767,7 +767,7 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
                         <TableCell
                           key={day.dateStr}
                           className={cn(
-                            'w-28 px-2 py-3 align-top',
+                            'min-w-28 px-2 py-3 align-top',
                             day.isToday && 'bg-accent/60',
                             day.isWeekendOrHoliday && 'bg-destructive/5',
                             showSuccess && parseDuration(cell.duration) > 0 && 'bg-emerald-500/10',
@@ -790,7 +790,7 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
                   <TableCell
                     key={day.dateStr}
                     className={cn(
-                      'w-28 px-2 py-3 text-center',
+                      'min-w-28 px-2 py-3 text-center',
                       day.isToday && 'bg-accent',
                       day.isWeekendOrHoliday && 'bg-destructive/5',
                     )}

--- a/components/timesheet/WeeklyView.tsx
+++ b/components/timesheet/WeeklyView.tsx
@@ -1,13 +1,19 @@
 import type React from 'react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
-import { FieldLabel } from '@/components/ui/field';
+import { Card } from '@/components/ui/card';
+import { Field, FieldLabel } from '@/components/ui/field';
+import { Input } from '@/components/ui/input';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
 import type { Client, Project, ProjectTask, TimeEntry, TimeEntryLocation, User } from '../../types';
+import { getLocalDateString } from '../../utils/date';
 import { isItalianHoliday } from '../../utils/holidays';
 import SelectControl from '../shared/SelectControl';
 import ValidatedNumberInput from '../shared/ValidatedNumberInput';
+import EntryCatalogSelector from './EntryCatalogSelector';
+import { useCatalogSelection } from './useCatalogSelection';
 
 export interface WeeklyViewProps {
   entries: TimeEntry[];
@@ -27,13 +33,6 @@ export interface WeeklyViewProps {
   defaultLocation?: TimeEntryLocation;
 }
 
-const toLocalISOString = (date: Date) => {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
-};
-
 const getWeekStart = (date: Date, startOfWeek: 'Monday' | 'Sunday'): Date => {
   const d = new Date(date);
   const day = d.getDay();
@@ -46,13 +45,33 @@ const getWeekStart = (date: Date, startOfWeek: 'Monday' | 'Sunday'): Date => {
   return start;
 };
 
+type DayCell = { duration: string; note: string; entryId?: string };
+type DayMap = Record<string, DayCell>;
+
+type RecentRow = {
+  key: string;
+  clientId: string;
+  projectId: string;
+  taskName: string;
+  location: TimeEntryLocation;
+  label: string;
+  baseDays: DayMap;
+};
+
+const FORM_ROW_KEY = '__form_row__';
+
+const parseDuration = (raw: string): number => {
+  if (!raw) return 0;
+  const parsed = parseFloat(raw.replace(',', '.'));
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
 const WeeklyView: React.FC<WeeklyViewProps> = ({
   entries,
   clients,
   projects,
   projectTasks,
   onAddBulkEntries,
-
   onUpdateEntry,
   viewingUserId,
   currentUserId,
@@ -64,6 +83,7 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
   defaultLocation = 'remote',
 }) => {
   const { t, i18n } = useTranslation('timesheets');
+
   const [currentWeekStart, setCurrentWeekStart] = useState(() =>
     getWeekStart(new Date(), startOfWeek),
   );
@@ -81,8 +101,8 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
     return [0, 1, 2, 3, 4, 5, 6].map((offset) => {
       const d = new Date(currentWeekStart);
       d.setDate(d.getDate() + offset);
-      const dateStr = toLocalISOString(d);
-      const holidayName = isItalianHoliday(new Date(dateStr + 'T00:00:00'));
+      const dateStr = getLocalDateString(d);
+      const holidayName = isItalianHoliday(new Date(`${dateStr}T00:00:00`));
       const isSunday = d.getDay() === 0;
       const isSaturday = d.getDay() === 6;
       const isWeekendOrHoliday =
@@ -94,431 +114,515 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
         dateStr,
         dayKey,
         dayNum: d.getDate(),
-        isToday: dateStr === toLocalISOString(new Date()),
+        isToday: dateStr === getLocalDateString(new Date()),
         isForbidden,
         isWeekendOrHoliday,
         holidayName,
       };
     });
-    // `t` is intentionally excluded: weekDays now carries `dayKey` and the caller
-    // translates at render time, so the heavy date math is not invalidated by
-    // unstable `t` references (which would otherwise re-trigger the in-render
-    // setState that syncs `rows ← initialRows`, causing infinite loops in tests).
   }, [currentWeekStart, treatSaturdayAsHoliday, allowWeekendSelection]);
 
-  type RowData = {
-    clientId: string;
-    projectId: string;
-    taskName: string;
-    location: TimeEntryLocation;
-    days: Record<string, { duration: number; note: string; id?: string }>;
-    weekNote: string;
-  };
-  const [rows, setRows] = useState<RowData[]>([]);
-  const [prevInitialRowsSignature, setPrevInitialRowsSignature] = useState('');
-  const [isLoading, setIsLoading] = useState(false);
-  const [showSuccess, setShowSuccess] = useState(false);
-  const [hasChanges, setHasChanges] = useState(false);
-  const [rowErrors, setRowErrors] = useState<
-    Record<number, { clientId?: string; projectId?: string; taskName?: string }>
-  >({});
-  const createEmptyRow = useCallback((): RowData => {
-    const firstClientId = clients[0]?.id || '';
-    const firstProjectId = projects.find((p) => p.clientId === firstClientId)?.id || '';
-    const firstTaskName =
-      projectTasks.find((task) => task.projectId === firstProjectId)?.name || '';
+  const weekDates = useMemo(() => weekDays.map((d) => d.dateStr), [weekDays]);
 
-    return {
-      clientId: firstClientId,
-      projectId: firstProjectId,
-      taskName: firstTaskName,
-      location: defaultLocation,
-      days: {},
-      weekNote: '',
-    };
-  }, [clients, projects, projectTasks, defaultLocation]);
-
-  const sanitizeRow = useCallback(
-    (row: RowData): RowData => {
-      const clientIsValid = clients.some((client) => client.id === row.clientId);
-      const clientId = clientIsValid ? row.clientId : '';
-      const validProjects = projects.filter((project) => project.clientId === clientId);
-      const projectIsValid = validProjects.some((project) => project.id === row.projectId);
-      const projectId = projectIsValid ? row.projectId : '';
-      const validTasks = projectTasks.filter((task) => task.projectId === projectId);
-      const taskIsValid = validTasks.some((task) => task.name === row.taskName);
-      const taskName = taskIsValid ? row.taskName : '';
-
-      return {
-        ...row,
-        clientId,
-        projectId,
-        taskName,
-      };
-    },
-    [clients, projects, projectTasks],
+  const userEntries = useMemo(
+    () => entries.filter((e) => e.userId === viewingUserId),
+    [entries, viewingUserId],
   );
 
-  // Initialize rows from existing entries in this week using useMemo
-  const initialRows = useMemo(() => {
-    const weekDates = weekDays.map((d) => d.dateStr);
-    const weekEntries = entries.filter((e) => weekDates.includes(e.date));
+  const selection = useCatalogSelection({
+    clients,
+    projects,
+    projectTasks,
+    defaultLocation,
+  });
 
-    // Group by client/project/task/location
-    const groups: Record<string, RowData> = {};
-    weekEntries.forEach((e) => {
-      const key = `${e.clientId}-${e.projectId}-${e.task}-${e.location || defaultLocation}`;
-      if (!groups[key]) {
-        groups[key] = {
-          clientId: e.clientId,
-          projectId: e.projectId,
-          taskName: e.task,
-          location: e.location || defaultLocation,
-          days: {
-            [e.date]: { duration: e.duration, note: e.notes || '', id: e.id },
-          },
-          weekNote: '',
-        };
-      } else {
-        groups[key].days[e.date] = { duration: e.duration, note: e.notes || '', id: e.id };
-      }
-    });
+  const [errors, setErrors] = useState<{ clientId?: string; projectId?: string; task?: string }>(
+    {},
+  );
 
-    const result = Object.values(groups).map(sanitizeRow);
-    // Add one empty row for new entries
-    if (result.length === 0) {
-      result.push(createEmptyRow());
+  const [isLoading, setIsLoading] = useState(false);
+  const [showSuccess, setShowSuccess] = useState(false);
+  const [weekNote, setWeekNote] = useState('');
+
+  // Per-row, per-day edits the user has made since the last sync from props.
+  const [pendingEdits, setPendingEdits] = useState<Record<string, DayMap>>({});
+
+  // Reset pending edits whenever the visible week changes.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: currentWeekStart is the intended trigger
+  useEffect(() => {
+    setPendingEdits({});
+  }, [currentWeekStart]);
+
+  const formRowBaseDays = useMemo<DayMap>(() => {
+    if (!selection.clientId || !selection.projectId || !selection.taskName) return {};
+    const days: DayMap = {};
+    for (const entry of userEntries) {
+      if (entry.clientId !== selection.clientId) continue;
+      if (entry.projectId !== selection.projectId) continue;
+      if (entry.task !== selection.taskName) continue;
+      if (!weekDates.includes(entry.date)) continue;
+      days[entry.date] = {
+        duration: String(entry.duration),
+        note: entry.notes ?? '',
+        entryId: entry.id,
+      };
     }
-    return result;
-  }, [entries, weekDays, sanitizeRow, createEmptyRow, defaultLocation]);
-  const initialRowsSignature = JSON.stringify(initialRows);
+    return days;
+  }, [userEntries, weekDates, selection.clientId, selection.projectId, selection.taskName]);
 
-  // Update rows when initialRows changes
-  // Update rows when initialRows changes (pattern: adjust state during render)
-  if (initialRowsSignature !== prevInitialRowsSignature) {
-    setPrevInitialRowsSignature(initialRowsSignature);
-    setRows(initialRows);
-    setHasChanges(false);
-    setRowErrors({});
-  }
+  const recentRows: RecentRow[] = useMemo(() => {
+    const groups = new Map<
+      string,
+      {
+        row: RecentRow;
+        maxCreatedAt: number;
+        hasWeekEntry: boolean;
+      }
+    >();
+
+    const clientById = new Map(clients.map((c) => [c.id, c]));
+    const projectById = new Map(projects.map((p) => [p.id, p]));
+    const taskKey = (projectId: string, name: string) => `${projectId}|${name}`;
+    const taskSet = new Set(projectTasks.map((task) => taskKey(task.projectId, task.name)));
+
+    for (const entry of userEntries) {
+      if (!clientById.has(entry.clientId)) continue;
+      if (!projectById.has(entry.projectId)) continue;
+      if (!taskSet.has(taskKey(entry.projectId, entry.task))) continue;
+
+      const key = `${entry.clientId}|${entry.projectId}|${entry.task}`;
+      let group = groups.get(key);
+      if (!group) {
+        const client = clientById.get(entry.clientId);
+        const project = projectById.get(entry.projectId);
+        group = {
+          row: {
+            key,
+            clientId: entry.clientId,
+            projectId: entry.projectId,
+            taskName: entry.task,
+            location: entry.location ?? defaultLocation,
+            label: [client?.name, project?.name, entry.task].filter(Boolean).join(' · '),
+            baseDays: {},
+          },
+          maxCreatedAt: entry.createdAt,
+          hasWeekEntry: false,
+        };
+        groups.set(key, group);
+      }
+
+      if (entry.createdAt > group.maxCreatedAt) group.maxCreatedAt = entry.createdAt;
+
+      if (weekDates.includes(entry.date)) {
+        group.hasWeekEntry = true;
+        group.row.baseDays[entry.date] = {
+          duration: String(entry.duration),
+          note: entry.notes ?? '',
+          entryId: entry.id,
+        };
+        if (entry.location) {
+          group.row.location = entry.location;
+        }
+      }
+    }
+
+    const formKey =
+      selection.clientId && selection.projectId && selection.taskName
+        ? `${selection.clientId}|${selection.projectId}|${selection.taskName}`
+        : '';
+    if (formKey) groups.delete(formKey);
+
+    return Array.from(groups.values())
+      .sort((a, b) => {
+        if (a.hasWeekEntry !== b.hasWeekEntry) return a.hasWeekEntry ? -1 : 1;
+        return b.maxCreatedAt - a.maxCreatedAt;
+      })
+      .slice(0, 5)
+      .map((g) => g.row);
+  }, [
+    userEntries,
+    weekDates,
+    clients,
+    projects,
+    projectTasks,
+    selection.clientId,
+    selection.projectId,
+    selection.taskName,
+    defaultLocation,
+  ]);
+
+  // When the set of recent rows changes (e.g. user switches), drop stale edits
+  // that no longer match an existing row.
+  const recentRowKeysSignature = recentRows.map((r) => r.key).join('|');
+  useEffect(() => {
+    const validKeys = new Set([FORM_ROW_KEY, ...recentRowKeysSignature.split('|')]);
+    setPendingEdits((prev) => {
+      let changed = false;
+      const next: Record<string, DayMap> = {};
+      for (const [key, value] of Object.entries(prev)) {
+        if (validKeys.has(key)) {
+          next[key] = value;
+        } else {
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [recentRowKeysSignature]);
+
+  const getCellValue = (rowKey: string, dateStr: string, baseDays?: DayMap): DayCell => {
+    const edit = pendingEdits[rowKey]?.[dateStr];
+    if (edit) return edit;
+    if (baseDays?.[dateStr]) return baseDays[dateStr];
+    return { duration: '', note: '' };
+  };
+
+  const updateCell = (
+    rowKey: string,
+    dateStr: string,
+    patch: Partial<Pick<DayCell, 'duration' | 'note'>>,
+    baseCell?: DayCell,
+  ) => {
+    setPendingEdits((prev) => {
+      const rowEdits = prev[rowKey] ?? {};
+      const existing = rowEdits[dateStr];
+      const seed: DayCell = existing ?? baseCell ?? { duration: '', note: '' };
+      const nextCell: DayCell = {
+        duration: patch.duration ?? seed.duration,
+        note: patch.note ?? seed.note,
+        entryId: seed.entryId,
+      };
+      return {
+        ...prev,
+        [rowKey]: { ...rowEdits, [dateStr]: nextCell },
+      };
+    });
+  };
 
   const handleWeekChange = (offset: number) => {
     const newStart = new Date(currentWeekStart);
     newStart.setDate(newStart.getDate() + offset * 7);
     setCurrentWeekStart(newStart);
-    setHasChanges(false);
-    setRowErrors({});
-  };
-
-  const handleValueChange = (
-    rowIndex: number,
-    dateStr: string,
-    field: 'duration' | 'note',
-    value: string,
-  ) => {
-    const newRows = [...rows];
-    if (!newRows[rowIndex].days[dateStr]) {
-      newRows[rowIndex].days[dateStr] = { duration: 0, note: '' };
-    }
-
-    if (field === 'duration') {
-      if (value === '') {
-        newRows[rowIndex].days[dateStr].duration = 0;
-      } else {
-        const parsed = parseFloat(value);
-        newRows[rowIndex].days[dateStr].duration = Number.isNaN(parsed) ? 0 : parsed;
-      }
-    } else {
-      newRows[rowIndex].days[dateStr].note = value;
-    }
-    setRows(newRows);
-    setHasChanges(true);
-  };
-
-  const handleRowInfoChange = (
-    rowIndex: number,
-    field: Exclude<keyof RowData, 'days'>,
-    value: string,
-  ) => {
-    const newRows = [...rows];
-    if (field === 'location') {
-      newRows[rowIndex].location = value as TimeEntryLocation;
-    } else {
-      newRows[rowIndex][field] = value;
-    }
-
-    // Auto-fill project if client changes
-    if (field === 'clientId') {
-      const firstProj = projects.find((p) => p.clientId === value);
-      newRows[rowIndex].projectId = firstProj?.id || '';
-      const firstTask = projectTasks.find((t) => t.projectId === firstProj?.id);
-      newRows[rowIndex].taskName = firstTask?.name || '';
-    }
-    // Auto-fill task if project changes
-    if (field === 'projectId') {
-      const firstTask = projectTasks.find((t) => t.projectId === value);
-      newRows[rowIndex].taskName = firstTask?.name || '';
-    }
-
-    // Clear error for the changed field
-    if (rowErrors[rowIndex]?.[field as keyof (typeof rowErrors)[number]]) {
-      const newErrors = { ...rowErrors };
-      if (newErrors[rowIndex]) {
-        delete newErrors[rowIndex][field as keyof (typeof newErrors)[number]];
-        if (Object.keys(newErrors[rowIndex]).length === 0) {
-          delete newErrors[rowIndex];
-        }
-      }
-      setRowErrors(newErrors);
-    }
-
-    setRows(newRows);
-    setHasChanges(true);
-  };
-
-  const addRow = () => {
-    setRows([...rows, createEmptyRow()]);
-    setHasChanges(true);
-    // Clear errors for the new row index
-    const newRowIndex = rows.length;
-    if (rowErrors[newRowIndex]) {
-      const newErrors = { ...rowErrors };
-      delete newErrors[newRowIndex];
-      setRowErrors(newErrors);
-    }
-  };
-
-  const deleteRow = (rowIndex: number) => {
-    const newRows = rows.filter((_, index) => index !== rowIndex);
-    // Ensure at least one row remains
-    if (newRows.length === 0) {
-      newRows.push(createEmptyRow());
-    }
-    setRows(newRows);
-    setHasChanges(true);
-    // Remove errors for deleted row and shift remaining errors
-    const newErrors: Record<number, { clientId?: string; projectId?: string; taskName?: string }> =
-      {};
-    Object.entries(rowErrors).forEach(([key, value]) => {
-      const idx = parseInt(key, 10);
-      if (idx < rowIndex) {
-        newErrors[idx] = value;
-      } else if (idx > rowIndex) {
-        newErrors[idx - 1] = value;
-      }
-    });
-    setRowErrors(newErrors);
+    setErrors({});
   };
 
   const handleSubmit = async () => {
     setIsLoading(true);
+    setErrors({});
 
-    // Validation
-    const newErrors: Record<number, { clientId?: string; projectId?: string; taskName?: string }> =
-      {};
-    let hasValidationErrors = false;
+    const newErrors: typeof errors = {};
+    const formEdits = pendingEdits[FORM_ROW_KEY] ?? {};
+    const hasFormHours = Object.values(formEdits).some((cell) => parseDuration(cell.duration) > 0);
 
-    rows.forEach((row, rowIndex) => {
-      const hasTimeEntries = Object.values(row.days).some((d) => d.duration > 0);
-      if (!hasTimeEntries) return;
-
-      const rowError: { clientId?: string; projectId?: string; taskName?: string } = {};
-
-      if (!row.clientId) {
-        rowError.clientId = t('common:validation.clientRequired');
-        hasValidationErrors = true;
+    if (hasFormHours) {
+      if (!selection.clientId) newErrors.clientId = t('common:validation.clientRequired');
+      if (!selection.projectId) newErrors.projectId = t('common:validation.projectRequired');
+      if (!selection.taskName) {
+        const availableTasks = projectTasks.filter(
+          (task) => task.projectId === selection.projectId,
+        );
+        if (availableTasks.length > 0) {
+          newErrors.task = t('common:validation.taskNameRequired');
+        }
       }
-      if (!row.projectId) {
-        rowError.projectId = t('common:validation.projectRequired');
-        hasValidationErrors = true;
-      }
-      // Only validate task if project has tasks available
-      const availableTasks = projectTasks.filter((t) => t.projectId === row.projectId);
-      if (availableTasks.length > 0 && !row.taskName) {
-        rowError.taskName = t('common:validation.taskNameRequired');
-        hasValidationErrors = true;
-      }
+    }
 
-      if (Object.keys(rowError).length > 0) {
-        newErrors[rowIndex] = rowError;
-      }
-    });
-
-    if (hasValidationErrors) {
-      setRowErrors(newErrors);
+    if (Object.keys(newErrors).length > 0) {
+      setErrors(newErrors);
       setIsLoading(false);
       return;
     }
 
     const entriesToAdd: Omit<TimeEntry, 'id' | 'createdAt' | 'userId'>[] = [];
 
-    rows.forEach((row) => {
-      const client = clients.find((c) => c.id === row.clientId);
-      const project = projects.find((p) => p.id === row.projectId);
-
-      Object.entries(row.days).forEach(([dateStr, data]) => {
-        if (data.duration > 0) {
-          // If it has an ID, it's an update, but user request implies mirror Anuko which has a Submit for bulk.
-          // For simplicity, we'll only ADD new ones here or we'd need bit more complex logic.
-          // Anuko typically handles both. Let's focus on adding new entries as requested.
-          if (!data.id) {
-            entriesToAdd.push({
-              date: dateStr,
-              clientId: row.clientId,
-              clientName: client?.name || 'Unknown',
-              projectId: row.projectId,
-              projectName: project?.name || 'General',
-              task: row.taskName,
-              duration: data.duration,
-              notes: data.note || row.weekNote, // Use individual note or fallback to week note
-              hourlyCost: 0,
-              location: row.location,
-            });
-          } else {
-            // Handle update if needed? User didn't explicitly ask for editing existing in weekly view,
-            // but it's part of a full mirror. Let's stick to the core request first.
-            onUpdateEntry(data.id, {
-              duration: data.duration,
-              notes: data.note || row.weekNote,
-              task: row.taskName,
-              projectId: row.projectId,
-              clientId: row.clientId,
+    const submitRow = (
+      rowKey: string,
+      meta: {
+        clientId: string;
+        projectId: string;
+        taskName: string;
+        location: TimeEntryLocation;
+        baseDays: DayMap;
+      },
+    ) => {
+      const client = clients.find((c) => c.id === meta.clientId);
+      const project = projects.find((p) => p.id === meta.projectId);
+      const rowEdits = pendingEdits[rowKey] ?? {};
+      for (const day of weekDays) {
+        const base = meta.baseDays[day.dateStr];
+        const edit = rowEdits[day.dateStr];
+        if (!edit) continue;
+        const newDuration = parseDuration(edit.duration);
+        const baseDuration = base ? parseDuration(base.duration) : 0;
+        const noteChanged = (edit.note ?? '') !== (base?.note ?? '');
+        if (base?.entryId) {
+          if (newDuration > 0 && (newDuration !== baseDuration || noteChanged)) {
+            onUpdateEntry(base.entryId, {
+              duration: newDuration,
+              notes: edit.note || weekNote || base.note,
+              task: meta.taskName,
+              projectId: meta.projectId,
+              clientId: meta.clientId,
               clientName: client?.name || 'Unknown',
               projectName: project?.name || 'General',
-              location: row.location,
+              location: meta.location,
             });
           }
+          continue;
         }
+        if (newDuration > 0) {
+          entriesToAdd.push({
+            date: day.dateStr,
+            clientId: meta.clientId,
+            clientName: client?.name || 'Unknown',
+            projectId: meta.projectId,
+            projectName: project?.name || 'General',
+            task: meta.taskName,
+            duration: newDuration,
+            notes: edit.note || weekNote,
+            hourlyCost: 0,
+            location: meta.location,
+          });
+        }
+      }
+    };
+
+    if (hasFormHours) {
+      submitRow(FORM_ROW_KEY, {
+        clientId: selection.clientId,
+        projectId: selection.projectId,
+        taskName: selection.taskName,
+        location: selection.location,
+        baseDays: formRowBaseDays,
       });
-    });
+    }
+
+    for (const row of recentRows) {
+      submitRow(row.key, {
+        clientId: row.clientId,
+        projectId: row.projectId,
+        taskName: row.taskName,
+        location: row.location,
+        baseDays: row.baseDays,
+      });
+    }
 
     if (entriesToAdd.length > 0) {
       await onAddBulkEntries(entriesToAdd);
     }
+
+    setPendingEdits({});
+    setWeekNote('');
     setIsLoading(false);
-    setHasChanges(false);
     setShowSuccess(true);
-    setTimeout(() => setShowSuccess(false), 3000);
   };
 
-  const dayTotals = useMemo(() => {
-    const totals: { [key: string]: number } = {};
-    weekDays.forEach((d) => {
-      totals[d.dateStr] = rows.reduce((sum, row) => sum + (row.days[d.dateStr]?.duration || 0), 0);
-    });
-    return totals;
-  }, [rows, weekDays]);
+  useEffect(() => {
+    if (!showSuccess) return;
+    const timer = setTimeout(() => setShowSuccess(false), 2500);
+    return () => clearTimeout(timer);
+  }, [showSuccess]);
 
-  const weekTotal = (Object.values(dayTotals) as number[]).reduce(
-    (a: number, b: number) => a + b,
-    0,
-  );
+  const dayTotals = useMemo(() => {
+    const totals: Record<string, number> = {};
+    for (const day of weekDays) {
+      let sum = 0;
+      const formEdit = pendingEdits[FORM_ROW_KEY]?.[day.dateStr];
+      if (formEdit) {
+        sum += parseDuration(formEdit.duration);
+      } else {
+        const formBase = formRowBaseDays[day.dateStr];
+        if (formBase) sum += parseDuration(formBase.duration);
+      }
+      for (const row of recentRows) {
+        const edit = pendingEdits[row.key]?.[day.dateStr];
+        if (edit) {
+          sum += parseDuration(edit.duration);
+        } else {
+          const base = row.baseDays[day.dateStr];
+          if (base) sum += parseDuration(base.duration);
+        }
+      }
+      totals[day.dateStr] = sum;
+    }
+    return totals;
+  }, [weekDays, recentRows, pendingEdits, formRowBaseDays]);
+
+  const weekTotal = useMemo(() => Object.values(dayTotals).reduce((a, b) => a + b, 0), [dayTotals]);
+
+  const monthTotal = useMemo(() => {
+    const monthYear = `${currentWeekStart.getFullYear()}-${String(currentWeekStart.getMonth() + 1).padStart(2, '0')}`;
+    return userEntries
+      .filter((e) => e.date.startsWith(monthYear))
+      .reduce((sum, e) => sum + e.duration, 0);
+  }, [userEntries, currentWeekStart]);
+
+  const weekEnd = useMemo(() => {
+    const end = new Date(currentWeekStart);
+    end.setDate(end.getDate() + 6);
+    return end;
+  }, [currentWeekStart]);
+
+  const weekRangeLabel = `${currentWeekStart.toLocaleDateString(i18n.language, {
+    month: 'short',
+    day: 'numeric',
+  })} – ${weekEnd.toLocaleDateString(i18n.language, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })}`;
+
+  const formLabel = useMemo(() => {
+    const client = clients.find((c) => c.id === selection.clientId);
+    const project = projects.find((p) => p.id === selection.projectId);
+    const parts = [client?.name, project?.name, selection.taskName].filter((p) => Boolean(p));
+    return parts.length > 0 ? parts.join(' · ') : t('weekly.newEntry');
+  }, [clients, projects, selection.clientId, selection.projectId, selection.taskName, t]);
+
+  const hasPendingEdits = Object.values(pendingEdits).some((row) => Object.keys(row).length > 0);
 
   return (
     <div className="w-full xl:w-[calc(45%+300px+1.5rem)] xl:mx-auto space-y-6">
-      {/* Header and Controls */}
-      <div className="flex flex-col md:flex-row justify-between items-center gap-4 bg-white p-4 rounded-lg border border-zinc-200 shadow-sm">
-        <div className="flex items-center gap-4">
-          <button
-            onClick={() => handleWeekChange(-1)}
-            className="p-2 hover:bg-zinc-100 rounded-full transition-colors"
-          >
-            <i className="fa-solid fa-chevron-left"></i>
-          </button>
-          <div className="text-center min-w-50">
-            <h3 className="text-sm font-semibold text-zinc-800 uppercase tracking-wider">
-              {currentWeekStart.toLocaleDateString(i18n.language, {
-                month: 'short',
-                day: 'numeric',
-              })}{' '}
-              -{' '}
-              {new Date(
-                new Date(currentWeekStart).setDate(currentWeekStart.getDate() + 4),
-              ).toLocaleDateString(i18n.language, {
-                month: 'short',
-                day: 'numeric',
-                year: 'numeric',
-              })}
-            </h3>
-            <p className="text-[10px] font-bold text-praetor uppercase">{t('weekly.weekView')}</p>
-          </div>
-          <button
-            onClick={() => handleWeekChange(1)}
-            className="p-2 hover:bg-zinc-100 rounded-full transition-colors"
-          >
-            <i className="fa-solid fa-chevron-right"></i>
-          </button>
-          <button
-            onClick={() => setCurrentWeekStart(getWeekStart(new Date(), startOfWeek))}
-            className="text-[10px] font-bold text-white bg-praetor hover:bg-praetor/90 uppercase tracking-widest ml-2 px-3 py-1.5 rounded-full transition-colors"
-          >
-            {t('weekly.goToToday')}
-          </button>
-        </div>
-
-        {availableUsers.length > 1 && (
-          <div className="w-64 space-y-1.5">
-            <div className="flex min-h-6 items-center justify-between gap-2">
-              <FieldLabel>{t('weekly.viewingUser')}</FieldLabel>
-              {currentUserId && viewingUserId !== currentUserId && (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="xs"
-                  onClick={() => onViewUserChange(currentUserId)}
-                  className="gap-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
-                >
-                  <i className="fa-solid fa-arrow-left" aria-hidden="true"></i>
-                  {t('tracker.backToMe')}
-                </Button>
-              )}
+      <Card className="px-6 py-4">
+        <div className="flex flex-col md:flex-row justify-between items-center gap-4">
+          <div className="flex items-center gap-3">
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              onClick={() => handleWeekChange(-1)}
+              aria-label={t('weekly.weekView')}
+            >
+              <i className="fa-solid fa-chevron-left"></i>
+            </Button>
+            <div className="text-center min-w-50">
+              <h3 className="text-sm font-semibold text-foreground uppercase tracking-wider">
+                {weekRangeLabel}
+              </h3>
+              <p className="text-[10px] font-bold text-praetor uppercase">{t('weekly.weekView')}</p>
             </div>
-            <SelectControl
-              options={availableUsers.map((u) => ({
-                id: u.id,
-                name: u.name,
-                badge: u.id === currentUserId ? t('tracker.you') : undefined,
-              }))}
-              value={viewingUserId}
-              onChange={(val) => onViewUserChange(val as string)}
-              searchable={true}
-            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              onClick={() => handleWeekChange(1)}
+              aria-label={t('weekly.weekView')}
+            >
+              <i className="fa-solid fa-chevron-right"></i>
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              onClick={() => setCurrentWeekStart(getWeekStart(new Date(), startOfWeek))}
+              className="rounded-full text-[10px] font-bold uppercase tracking-widest"
+            >
+              {t('weekly.goToToday')}
+            </Button>
           </div>
-        )}
-      </div>
 
-      {/* Grid */}
-      <div className="bg-white rounded-lg shadow-sm border border-zinc-200 overflow-hidden">
+          {availableUsers.length > 1 && (
+            <div className="w-64 space-y-1.5">
+              <div className="flex min-h-6 items-center justify-between gap-2">
+                <FieldLabel>{t('weekly.viewingUser')}</FieldLabel>
+                {currentUserId && viewingUserId !== currentUserId && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="xs"
+                    onClick={() => onViewUserChange(currentUserId)}
+                    className="gap-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
+                  >
+                    <i className="fa-solid fa-arrow-left" aria-hidden="true"></i>
+                    {t('tracker.backToMe')}
+                  </Button>
+                )}
+              </div>
+              <SelectControl
+                options={availableUsers.map((u) => ({
+                  id: u.id,
+                  name: u.name,
+                  badge: u.id === currentUserId ? t('tracker.you') : undefined,
+                }))}
+                value={viewingUserId}
+                onChange={(val) => onViewUserChange(val as string)}
+                searchable={true}
+              />
+            </div>
+          )}
+        </div>
+      </Card>
+
+      <Card className="px-6 py-5 gap-4">
+        <EntryCatalogSelector
+          clients={clients}
+          filteredProjects={selection.filteredProjects}
+          filteredTasks={selection.filteredTasks}
+          selectedClientId={selection.clientId}
+          selectedProjectId={selection.projectId}
+          selectedTaskId={selection.taskId}
+          location={selection.location}
+          onClientChange={(id) => {
+            selection.setClient(id);
+            if (errors.clientId) setErrors((prev) => ({ ...prev, clientId: '' }));
+          }}
+          onProjectChange={(id) => {
+            selection.setProject(id);
+            if (errors.projectId) setErrors((prev) => ({ ...prev, projectId: '' }));
+          }}
+          onTaskChange={(taskId) => {
+            selection.setTask(taskId);
+            if (errors.task) setErrors((prev) => ({ ...prev, task: '' }));
+          }}
+          onLocationChange={selection.setLocation}
+          errors={errors}
+        />
+
+        <Field>
+          <FieldLabel htmlFor="weekly-week-note">{t('weekly.weekNote')}</FieldLabel>
+          <Input
+            id="weekly-week-note"
+            type="text"
+            value={weekNote}
+            onChange={(e) => setWeekNote(e.target.value)}
+            placeholder={t('weekly.weekNote')}
+            className="rounded-lg"
+          />
+        </Field>
+      </Card>
+
+      <Card className="px-0 py-0 overflow-hidden">
         <div className="overflow-x-auto">
           <table className="w-full min-w-max text-left border-collapse">
-            <thead className="bg-zinc-50 border-b border-zinc-200">
+            <thead className="bg-muted/40 border-b border-border">
               <tr>
-                <th className="px-4 py-2 text-[10px] font-bold text-zinc-500 uppercase tracking-tighter min-w-28">
-                  {t('weekly.client')}
-                </th>
-                <th className="px-4 py-2 text-[10px] font-bold text-zinc-500 uppercase tracking-tighter min-w-28">
-                  {t('weekly.project')}
-                </th>
-                <th className="px-4 py-2 text-[10px] font-bold text-zinc-500 uppercase tracking-tighter min-w-28">
+                <th className="px-4 py-3 text-[10px] font-bold text-muted-foreground uppercase tracking-tighter min-w-56">
                   {t('weekly.task')}
-                </th>
-                <th className="px-4 py-2 text-[10px] font-bold text-zinc-500 uppercase tracking-tighter min-w-24">
-                  {t('weekly.location')}
                 </th>
                 {weekDays.map((day) => (
                   <th
                     key={day.dateStr}
-                    className={`w-28 p-2 text-center relative ${day.isToday ? 'bg-zinc-100' : ''} ${day.isWeekendOrHoliday ? 'bg-red-50/50' : ''}`}
+                    className={cn(
+                      'w-28 p-2 text-center relative',
+                      day.isToday && 'bg-accent',
+                      day.isWeekendOrHoliday && 'bg-destructive/5',
+                    )}
                   >
                     <div
-                      className={`flex items-center justify-center gap-1 text-[10px] font-black uppercase ${day.isToday ? 'text-praetor' : day.isWeekendOrHoliday ? 'text-red-500' : 'text-zinc-400'}`}
+                      className={cn(
+                        'flex items-center justify-center gap-1 text-[10px] font-black uppercase',
+                        day.isToday
+                          ? 'text-praetor'
+                          : day.isWeekendOrHoliday
+                            ? 'text-destructive'
+                            : 'text-muted-foreground',
+                      )}
                     >
                       {t(`weekly.days.${day.dayKey}`)}
                       {day.holidayName && (
                         <Tooltip>
                           <TooltipTrigger asChild>
                             <span className="inline-flex">
-                              <span className="size-1.5 bg-red-500 rounded-full animate-pulse block"></span>
+                              <span className="size-1.5 bg-destructive rounded-full animate-pulse block"></span>
                             </span>
                           </TooltipTrigger>
                           <TooltipContent>{day.holidayName}</TooltipContent>
@@ -526,205 +630,220 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
                       )}
                     </div>
                     <p
-                      className={`text-sm font-black leading-none ${day.isToday ? 'text-praetor' : day.isWeekendOrHoliday ? 'text-red-600' : 'text-zinc-700'}`}
+                      className={cn(
+                        'text-sm font-black leading-none mt-0.5',
+                        day.isToday
+                          ? 'text-praetor'
+                          : day.isWeekendOrHoliday
+                            ? 'text-destructive'
+                            : 'text-foreground',
+                      )}
                     >
                       {day.dayNum}
                     </p>
                   </th>
                 ))}
-                <th className="px-4 py-2 text-[10px] font-bold text-zinc-500 uppercase tracking-tighter w-20 text-center sticky right-0 bg-zinc-50 border-l border-zinc-200 z-10 shadow-[-4px_0_6px_-1px_rgba(0,0,0,0.05)]">
-                  {t('weekly.total')}
-                </th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-zinc-100">
-              {rows.map((row, rowIndex) => (
-                <tr
-                  key={rowIndex}
-                  className="group hover:bg-zinc-50/30 transition-all duration-500"
-                >
-                  <td className="p-4">
-                    <div className="flex flex-col gap-1 w-full">
-                      <SelectControl
-                        options={clients.map((c) => ({ id: c.id, name: c.name }))}
-                        value={row.clientId}
-                        onChange={(val) => handleRowInfoChange(rowIndex, 'clientId', val as string)}
-                        className={`bg-transparent! ${rowErrors[rowIndex]?.clientId ? 'border-red-500!' : ''}`}
-                        searchable={true}
-                      />
-                      {rowErrors[rowIndex]?.clientId && (
-                        <p className="text-red-500 text-[10px] font-bold">
-                          {rowErrors[rowIndex].clientId}
-                        </p>
-                      )}
-                      <div className="h-7 invisible">Spacer</div>
-                    </div>
-                  </td>
-                  <td className="p-4">
-                    <div className="flex flex-col gap-1 w-full">
-                      <SelectControl
-                        options={projects
-                          .filter((p) => p.clientId === row.clientId)
-                          .map((p) => ({ id: p.id, name: p.name }))}
-                        value={row.projectId}
-                        onChange={(val) =>
-                          handleRowInfoChange(rowIndex, 'projectId', val as string)
-                        }
-                        className={`bg-transparent! ${rowErrors[rowIndex]?.projectId ? 'border-red-500!' : ''}`}
-                        placeholder={t('weekly.selectProject')}
-                        searchable={true}
-                      />
-                      {rowErrors[rowIndex]?.projectId && (
-                        <p className="text-red-500 text-[10px] font-bold">
-                          {rowErrors[rowIndex].projectId}
-                        </p>
-                      )}
-                      <div className="h-7 invisible">Spacer</div>
-                    </div>
-                  </td>
-                  <td className="p-4">
-                    <div className="flex flex-col gap-1 w-full">
-                      <SelectControl
-                        options={projectTasks
-                          .filter((t) => t.projectId === row.projectId)
-                          .map((t) => ({ id: t.name, name: t.name }))}
-                        value={row.taskName}
-                        onChange={(val) => handleRowInfoChange(rowIndex, 'taskName', val as string)}
-                        className={`bg-transparent! ${rowErrors[rowIndex]?.taskName ? 'border-red-500!' : ''}`}
-                        placeholder={t('weekly.selectTask')}
-                        searchable={true}
-                      />
-                      {rowErrors[rowIndex]?.taskName && (
-                        <p className="text-red-500 text-[10px] font-bold">
-                          {rowErrors[rowIndex].taskName}
-                        </p>
-                      )}
-                      <input
-                        type="text"
-                        placeholder={t('weekly.weekNote')}
-                        value={row.weekNote}
-                        onChange={(e) => handleRowInfoChange(rowIndex, 'weekNote', e.target.value)}
-                        className="w-full text-xs bg-zinc-50 border border-zinc-200 rounded px-2 py-1.5 focus:outline-none focus:border-praetor focus:ring-1 focus:ring-praetor text-zinc-600 h-7"
-                      />
-                    </div>
-                  </td>
-                  <td className="p-4">
-                    <div className="flex flex-col gap-1 w-full">
-                      <SelectControl
-                        options={[
-                          { id: 'office', name: t('weekly.locationTypes.office') },
-                          {
-                            id: 'customer_premise',
-                            name: t('weekly.locationTypes.customerPremise'),
-                          },
-                          { id: 'remote', name: t('weekly.locationTypes.remote') },
-                          { id: 'transfer', name: t('weekly.locationTypes.transfer') },
-                        ]}
-                        value={row.location}
-                        onChange={(val) => handleRowInfoChange(rowIndex, 'location', val as string)}
-                        className="bg-transparent!"
-                      />
-                      <div className="h-7 invisible">Spacer</div>
-                    </div>
-                  </td>
-                  {weekDays.map((day) => (
+            <tbody className="divide-y divide-border">
+              <tr className="bg-praetor/5">
+                <td className="px-4 py-3 align-top">
+                  <p className="text-[10px] font-bold text-praetor uppercase tracking-wider mb-1">
+                    {t('weekly.newEntry')}
+                  </p>
+                  <p className="text-xs text-muted-foreground line-clamp-2">{formLabel}</p>
+                </td>
+                {weekDays.map((day) => {
+                  const cell = getCellValue(FORM_ROW_KEY, day.dateStr, formRowBaseDays);
+                  return (
                     <td
                       key={day.dateStr}
-                      className={`w-28 px-2 py-4 transition-all duration-700 ${day.isToday ? 'bg-zinc-50' : ''} ${day.isWeekendOrHoliday ? 'bg-red-50/30' : ''} ${showSuccess && row.days[day.dateStr]?.duration > 0 ? 'bg-emerald-50' : ''}`}
+                      className={cn(
+                        'w-28 px-2 py-3 transition-colors',
+                        day.isToday && 'bg-accent/60',
+                        day.isWeekendOrHoliday && 'bg-destructive/5',
+                      )}
                     >
-                      <div className="flex flex-col gap-2 items-center relative">
-                        {showSuccess && row.days[day.dateStr]?.duration > 0 && (
-                          <i className="fa-solid fa-circle-check text-emerald-500 text-[10px] absolute -top-2 -right-1 animate-in fade-in zoom-in duration-300"></i>
-                        )}
+                      <div className="flex flex-col gap-2">
                         <ValidatedNumberInput
                           placeholder="0.0"
                           disabled={day.isForbidden}
-                          value={row.days[day.dateStr]?.duration || ''}
+                          value={cell.duration}
                           onValueChange={(value) =>
-                            handleValueChange(rowIndex, day.dateStr, 'duration', value)
+                            updateCell(
+                              FORM_ROW_KEY,
+                              day.dateStr,
+                              { duration: value },
+                              formRowBaseDays[day.dateStr],
+                            )
                           }
-                          className={`w-full text-center text-sm font-black transition-all duration-300 ${showSuccess && row.days[day.dateStr]?.duration > 0 ? 'text-emerald-700 border-emerald-200 bg-white scale-105 shadow-sm' : 'text-zinc-700 bg-zinc-50 border-zinc-200'} ${day.isForbidden ? 'opacity-50 cursor-not-allowed' : ''} ${day.isWeekendOrHoliday ? 'bg-red-50/50 border-red-100' : 'border-zinc-200'} border rounded-lg py-2.5 focus:ring-2 focus:ring-praetor outline-none`}
+                          className={cn(
+                            'h-9 w-full text-center text-sm font-bold',
+                            day.isForbidden && 'opacity-50 cursor-not-allowed',
+                          )}
                         />
-                        <input
+                        <Input
                           type="text"
-                          placeholder="Note..."
+                          placeholder={t('weekly.note')}
                           disabled={day.isForbidden}
-                          value={row.days[day.dateStr]?.note || ''}
+                          value={cell.note}
                           onChange={(e) =>
-                            handleValueChange(rowIndex, day.dateStr, 'note', e.target.value)
+                            updateCell(
+                              FORM_ROW_KEY,
+                              day.dateStr,
+                              { note: e.target.value },
+                              formRowBaseDays[day.dateStr],
+                            )
                           }
-                          className={`w-full text-xs border focus:border-praetor focus:ring-1 focus:ring-praetor rounded px-2 py-1.5 transition-colors h-7 ${showSuccess && row.days[day.dateStr]?.duration > 0 ? 'text-emerald-600 bg-zinc-50' : 'text-red-600 focus:text-zinc-700'} ${day.isForbidden ? 'opacity-30 cursor-not-allowed' : ''} ${day.isWeekendOrHoliday ? 'bg-red-50/30 border-red-100' : 'bg-zinc-50 border-zinc-100'}`}
+                          className={cn(
+                            'h-7 text-xs rounded',
+                            day.isForbidden && 'opacity-40 cursor-not-allowed',
+                          )}
                         />
                       </div>
                     </td>
-                  ))}
-                  <td className="px-4 py-3 text-center sticky right-0 bg-white group-hover:bg-zinc-50 transition-all duration-500 border-l border-zinc-200 z-10 shadow-[-4px_0_6px_-1px_rgba(0,0,0,0.05)]">
-                    <div className="flex flex-col items-center gap-2">
-                      <span className="text-sm font-black text-zinc-800">
-                        {Object.values(row.days)
-                          .reduce((sum, d) => sum + (d.duration || 0), 0)
-                          .toFixed(1)}
-                      </span>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <span className="inline-flex">
-                            <button
-                              onClick={() => deleteRow(rowIndex)}
-                              className="p-1.5 text-red-600 hover:text-red-500 hover:bg-red-50 rounded-lg transition-all duration-300"
-                            >
-                              <i className="fa-solid fa-trash-can text-sm"></i>
-                            </button>
-                          </span>
-                        </TooltipTrigger>
-                        <TooltipContent>{t('weekly.deleteRow')}</TooltipContent>
-                      </Tooltip>
-                    </div>
+                  );
+                })}
+              </tr>
+              {recentRows.length === 0 ? (
+                <tr>
+                  <td
+                    colSpan={1 + weekDays.length}
+                    className="px-4 py-6 text-center text-xs text-muted-foreground"
+                  >
+                    {t('weekly.noRecentTasks')}
                   </td>
                 </tr>
-              ))}
+              ) : (
+                recentRows.map((row) => (
+                  <tr key={row.key} className="hover:bg-muted/30 transition-colors">
+                    <td className="px-4 py-3 align-top">
+                      <p className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider mb-1">
+                        {t('weekly.recentTask')}
+                      </p>
+                      <p
+                        className="text-xs font-semibold text-foreground line-clamp-2"
+                        title={row.label}
+                      >
+                        {row.label}
+                      </p>
+                    </td>
+                    {weekDays.map((day) => {
+                      const cell = getCellValue(row.key, day.dateStr, row.baseDays);
+                      return (
+                        <td
+                          key={day.dateStr}
+                          className={cn(
+                            'w-28 px-2 py-3 transition-colors',
+                            day.isToday && 'bg-accent/60',
+                            day.isWeekendOrHoliday && 'bg-destructive/5',
+                            showSuccess && parseDuration(cell.duration) > 0 && 'bg-emerald-500/10',
+                          )}
+                        >
+                          <div className="flex flex-col gap-2">
+                            <ValidatedNumberInput
+                              placeholder="0.0"
+                              disabled={day.isForbidden}
+                              value={cell.duration}
+                              onValueChange={(value) =>
+                                updateCell(
+                                  row.key,
+                                  day.dateStr,
+                                  { duration: value },
+                                  row.baseDays[day.dateStr],
+                                )
+                              }
+                              className={cn(
+                                'h-9 w-full text-center text-sm font-bold',
+                                day.isForbidden && 'opacity-50 cursor-not-allowed',
+                              )}
+                            />
+                            <Input
+                              type="text"
+                              placeholder={t('weekly.note')}
+                              disabled={day.isForbidden}
+                              value={cell.note}
+                              onChange={(e) =>
+                                updateCell(
+                                  row.key,
+                                  day.dateStr,
+                                  { note: e.target.value },
+                                  row.baseDays[day.dateStr],
+                                )
+                              }
+                              className={cn(
+                                'h-7 text-xs rounded',
+                                day.isForbidden && 'opacity-40 cursor-not-allowed',
+                              )}
+                            />
+                          </div>
+                        </td>
+                      );
+                    })}
+                  </tr>
+                ))
+              )}
             </tbody>
-            <tfoot className="bg-zinc-50/50 border-t border-zinc-200">
+            <tfoot className="bg-muted/30 border-t border-border">
               <tr>
-                <td colSpan={4} className="p-4">
-                  <button
-                    onClick={addRow}
-                    className="text-xs font-bold text-praetor bg-transparent px-4 py-2 rounded-lg flex items-center gap-2 uppercase tracking-widest transition-all duration-300 ease-in-out"
-                  >
-                    <i className="fa-solid fa-plus"></i> {t('weekly.addRow')}
-                  </button>
+                <td className="px-4 py-3 text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
+                  {t('weekly.total')}
                 </td>
                 {weekDays.map((day) => (
                   <td
                     key={day.dateStr}
-                    className={`w-28 px-2 py-4 text-center ${day.isToday ? 'bg-zinc-100' : ''} ${day.isWeekendOrHoliday ? 'bg-red-50/50' : ''}`}
+                    className={cn(
+                      'w-28 px-2 py-3 text-center',
+                      day.isToday && 'bg-accent',
+                      day.isWeekendOrHoliday && 'bg-destructive/5',
+                    )}
                   >
                     <p
-                      className={`text-xs font-black ${(dayTotals[day.dateStr] as number) > 8 ? 'text-red-600' : 'text-praetor'}`}
+                      className={cn(
+                        'text-sm font-black',
+                        dayTotals[day.dateStr] > 8 ? 'text-destructive' : 'text-praetor',
+                      )}
                     >
-                      {(dayTotals[day.dateStr] as number).toFixed(1)}
+                      {dayTotals[day.dateStr].toFixed(1)}
                     </p>
                   </td>
                 ))}
-                <td className="p-4 text-center sticky right-0 bg-zinc-50 border-l border-zinc-200 z-10 shadow-[-4px_0_6px_-1px_rgba(0,0,0,0.05)]">
-                  <p className="text-sm font-black text-zinc-900">
-                    {(weekTotal as number).toFixed(1)}{' '}
-                  </p>
-                </td>
               </tr>
             </tfoot>
           </table>
         </div>
-      </div>
+      </Card>
 
-      {/* Footer Actions */}
-      <div className="flex justify-end gap-4 p-4">
-        <button
+      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+        <Card className="px-6 py-4 flex-1">
+          <div className="flex flex-wrap items-center justify-center gap-8">
+            <div className="text-center">
+              <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+                {t('weekly.weekTotal')}
+              </p>
+              <p className="text-2xl font-black text-praetor">{weekTotal.toFixed(1)}</p>
+            </div>
+            <div className="text-center">
+              <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+                {t('weekly.monthTotal')}
+              </p>
+              <p className="text-2xl font-black text-foreground">{monthTotal.toFixed(1)}</p>
+            </div>
+          </div>
+        </Card>
+
+        <Button
+          type="button"
           onClick={handleSubmit}
-          disabled={isLoading || !hasChanges}
-          className={`bg-praetor text-white px-10 py-3 rounded-xl hover:bg-zinc-800 transition-all shadow-lg hover:shadow-zinc-200 font-bold text-sm flex items-center gap-3 disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none disabled:grayscale-[0.5] ${showSuccess ? 'bg-emerald-600 hover:bg-emerald-600 shadow-emerald-500/20' : ''}`}
+          disabled={isLoading || !hasPendingEdits}
+          size="lg"
+          className={cn(
+            'h-12 px-10 rounded-xl font-bold text-sm uppercase tracking-widest',
+            showSuccess && 'bg-emerald-600 hover:bg-emerald-600',
+          )}
         >
           {showSuccess ? t('weekly.success') : t('weekly.submitTime')}
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/components/timesheet/WeeklyView.tsx
+++ b/components/timesheet/WeeklyView.tsx
@@ -1,10 +1,8 @@
 import type React from 'react';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
-import { Field, FieldLabel } from '@/components/ui/field';
-import { Input } from '@/components/ui/input';
 import {
   Table,
   TableBody,
@@ -16,27 +14,21 @@ import {
 } from '@/components/ui/table';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
-import type { Client, Project, ProjectTask, TimeEntry, TimeEntryLocation } from '../../types';
+import type { Client, Project, ProjectTask, TimeEntry } from '../../types';
 import { getLocalDateString } from '../../utils/date';
 import { isItalianHoliday } from '../../utils/holidays';
-import Calendar from '../shared/Calendar';
-import ValidatedNumberInput from '../shared/ValidatedNumberInput';
-import EntryCatalogSelector from './EntryCatalogSelector';
-import { useCatalogSelection } from './useCatalogSelection';
 
 export interface WeeklyViewProps {
   entries: TimeEntry[];
   clients: Client[];
   projects: Project[];
   projectTasks: ProjectTask[];
-  onAddBulkEntries: (entries: Omit<TimeEntry, 'id' | 'createdAt' | 'userId'>[]) => Promise<void>;
-  onDeleteEntry: (id: string) => void;
-  onUpdateEntry: (id: string, updates: Partial<TimeEntry>) => void;
   viewingUserId: string;
+  selectedDate: string;
+  onSelectedDateChange: (date: string) => void;
   startOfWeek: 'Monday' | 'Sunday';
   treatSaturdayAsHoliday: boolean;
   allowWeekendSelection?: boolean;
-  defaultLocation?: TimeEntryLocation;
   dailyGoal: number;
 }
 
@@ -52,25 +44,16 @@ const getWeekStart = (date: Date, startOfWeek: 'Monday' | 'Sunday'): Date => {
   return start;
 };
 
-type DayCell = { duration: string; note: string; entryId?: string };
-type DayMap = Record<string, DayCell>;
+const dateOnlyToLocalDate = (dateOnly: string): Date => {
+  const [year, month, day] = dateOnly.split('-').map(Number);
+  return new Date(year, month - 1, day);
+};
 
 type EntryRow = {
   key: string;
-  clientId: string;
-  projectId: string;
-  taskName: string;
-  location: TimeEntryLocation;
   label: string;
-  baseDays: DayMap;
-};
-
-const FORM_ROW_KEY = '__form_row__';
-
-const parseDuration = (raw: string): number => {
-  if (!raw) return 0;
-  const parsed = parseFloat(raw.replace(',', '.'));
-  return Number.isFinite(parsed) ? parsed : 0;
+  days: Record<string, number>;
+  maxCreatedAt: number;
 };
 
 const WeeklyView: React.FC<WeeklyViewProps> = ({
@@ -78,29 +61,20 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
   clients,
   projects,
   projectTasks,
-  onAddBulkEntries,
-  onUpdateEntry,
   viewingUserId,
+  selectedDate,
+  onSelectedDateChange,
   startOfWeek,
   treatSaturdayAsHoliday,
   allowWeekendSelection = false,
-  defaultLocation = 'remote',
   dailyGoal,
 }) => {
   const { t, i18n } = useTranslation('timesheets');
 
-  const [currentWeekStart, setCurrentWeekStart] = useState(() =>
-    getWeekStart(new Date(), startOfWeek),
+  const currentWeekStart = useMemo(
+    () => getWeekStart(dateOnlyToLocalDate(selectedDate), startOfWeek),
+    [selectedDate, startOfWeek],
   );
-
-  // Re-align the current week when the startOfWeek setting changes — generalSettings
-  // loads async, so the prop can flip after mount and the displayed week must follow.
-  useEffect(() => {
-    setCurrentWeekStart((prev) => {
-      const realigned = getWeekStart(prev, startOfWeek);
-      return realigned.getTime() === prev.getTime() ? prev : realigned;
-    });
-  }, [startOfWeek]);
 
   const weekDays = useMemo(() => {
     return [0, 1, 2, 3, 4, 5, 6].map((offset) => {
@@ -134,52 +108,11 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
     [entries, viewingUserId],
   );
 
-  const selection = useCatalogSelection({
-    clients,
-    projects,
-    projectTasks,
-    defaultLocation,
-  });
-
-  const [errors, setErrors] = useState<{ clientId?: string; projectId?: string; task?: string }>(
-    {},
-  );
-
-  const [isLoading, setIsLoading] = useState(false);
-  const [showSuccess, setShowSuccess] = useState(false);
-  const [weekNote, setWeekNote] = useState('');
-
-  // Per-row, per-day edits the user has made since the last sync from props.
-  const [pendingEdits, setPendingEdits] = useState<Record<string, DayMap>>({});
-
-  // Reset pending edits whenever the visible week changes.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: currentWeekStart is the intended trigger
-  useEffect(() => {
-    setPendingEdits({});
-  }, [currentWeekStart]);
-
-  const formRowBaseDays = useMemo<DayMap>(() => {
-    if (!selection.clientId || !selection.projectId || !selection.taskName) return {};
-    const days: DayMap = {};
-    for (const entry of userEntries) {
-      if (entry.clientId !== selection.clientId) continue;
-      if (entry.projectId !== selection.projectId) continue;
-      if (entry.task !== selection.taskName) continue;
-      if (!weekDates.includes(entry.date)) continue;
-      days[entry.date] = {
-        duration: String(entry.duration),
-        note: entry.notes ?? '',
-        entryId: entry.id,
-      };
-    }
-    return days;
-  }, [userEntries, weekDates, selection.clientId, selection.projectId, selection.taskName]);
-
   // Every distinct (client, project, task) combination with at least one entry
   // in the current week, in-scope of the user's catalogs. No row cap — the
-  // weekly grid mirrors what's actually logged this week.
+  // grid mirrors exactly what's logged for the visible week.
   const entryRows: EntryRow[] = useMemo(() => {
-    const groups = new Map<string, { row: EntryRow; maxCreatedAt: number }>();
+    const groups = new Map<string, EntryRow>();
     const clientById = new Map(clients.map((c) => [c.id, c]));
     const projectById = new Map(projects.map((p) => [p.id, p]));
     const taskKey = (projectId: string, name: string) => `${projectId}|${name}`;
@@ -192,261 +125,36 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
       if (!taskSet.has(taskKey(entry.projectId, entry.task))) continue;
 
       const key = `${entry.clientId}|${entry.projectId}|${entry.task}`;
-      let group = groups.get(key);
-      if (!group) {
+      let row = groups.get(key);
+      if (!row) {
         const client = clientById.get(entry.clientId);
         const project = projectById.get(entry.projectId);
-        group = {
-          row: {
-            key,
-            clientId: entry.clientId,
-            projectId: entry.projectId,
-            taskName: entry.task,
-            location: entry.location ?? defaultLocation,
-            label: [client?.name, project?.name, entry.task].filter(Boolean).join(' · '),
-            baseDays: {},
-          },
+        row = {
+          key,
+          label: [client?.name, project?.name, entry.task].filter(Boolean).join(' · '),
+          days: {},
           maxCreatedAt: entry.createdAt,
         };
-        groups.set(key, group);
+        groups.set(key, row);
       }
-      if (entry.createdAt > group.maxCreatedAt) group.maxCreatedAt = entry.createdAt;
-      group.row.baseDays[entry.date] = {
-        duration: String(entry.duration),
-        note: entry.notes ?? '',
-        entryId: entry.id,
-      };
-      if (entry.location) {
-        group.row.location = entry.location;
-      }
+      if (entry.createdAt > row.maxCreatedAt) row.maxCreatedAt = entry.createdAt;
+      // Multiple entries on the same day for the same combo are summed — the
+      // grid shows the day's total hours per task, not individual entries.
+      row.days[entry.date] = (row.days[entry.date] ?? 0) + entry.duration;
     }
 
-    const formKey =
-      selection.clientId && selection.projectId && selection.taskName
-        ? `${selection.clientId}|${selection.projectId}|${selection.taskName}`
-        : '';
-    if (formKey) groups.delete(formKey);
-
-    return Array.from(groups.values())
-      .sort((a, b) => b.maxCreatedAt - a.maxCreatedAt)
-      .map((g) => g.row);
-  }, [
-    userEntries,
-    weekDates,
-    clients,
-    projects,
-    projectTasks,
-    selection.clientId,
-    selection.projectId,
-    selection.taskName,
-    defaultLocation,
-  ]);
-
-  // When the set of entry rows changes, drop stale edits that no longer match.
-  const entryRowKeySet = useMemo(() => new Set(entryRows.map((r) => r.key)), [entryRows]);
-  useEffect(() => {
-    setPendingEdits((prev) => {
-      let changed = false;
-      const next: Record<string, DayMap> = {};
-      for (const [key, value] of Object.entries(prev)) {
-        if (key === FORM_ROW_KEY || entryRowKeySet.has(key)) {
-          next[key] = value;
-        } else {
-          changed = true;
-        }
-      }
-      return changed ? next : prev;
-    });
-  }, [entryRowKeySet]);
-
-  const getCellValue = (rowKey: string, dateStr: string, baseDays?: DayMap): DayCell => {
-    const edit = pendingEdits[rowKey]?.[dateStr];
-    if (edit) return edit;
-    if (baseDays?.[dateStr]) return baseDays[dateStr];
-    return { duration: '', note: '' };
-  };
-
-  const updateCell = (
-    rowKey: string,
-    dateStr: string,
-    patch: Partial<Pick<DayCell, 'duration' | 'note'>>,
-    baseCell?: DayCell,
-  ) => {
-    setPendingEdits((prev) => {
-      const rowEdits = prev[rowKey] ?? {};
-      const existing = rowEdits[dateStr];
-      const seed: DayCell = existing ?? baseCell ?? { duration: '', note: '' };
-      const nextCell: DayCell = {
-        duration: patch.duration ?? seed.duration,
-        note: patch.note ?? seed.note,
-        entryId: seed.entryId,
-      };
-      return {
-        ...prev,
-        [rowKey]: { ...rowEdits, [dateStr]: nextCell },
-      };
-    });
-  };
-
-  const handleWeekChange = (offset: number) => {
-    const newStart = new Date(currentWeekStart);
-    newStart.setDate(newStart.getDate() + offset * 7);
-    setCurrentWeekStart(newStart);
-    setErrors({});
-  };
-
-  const handleCalendarSelect = (dateStr: string) => {
-    const [year, month, day] = dateStr.split('-').map(Number);
-    setCurrentWeekStart(getWeekStart(new Date(year, month - 1, day), startOfWeek));
-    setErrors({});
-  };
-
-  const handleSubmit = async () => {
-    setIsLoading(true);
-    setErrors({});
-
-    const newErrors: typeof errors = {};
-    const formEdits = pendingEdits[FORM_ROW_KEY] ?? {};
-    const hasFormHours = Object.values(formEdits).some((cell) => parseDuration(cell.duration) > 0);
-
-    if (hasFormHours) {
-      if (!selection.clientId) newErrors.clientId = t('common:validation.clientRequired');
-      if (!selection.projectId) newErrors.projectId = t('common:validation.projectRequired');
-      if (!selection.taskName) {
-        const availableTasks = projectTasks.filter(
-          (task) => task.projectId === selection.projectId,
-        );
-        if (availableTasks.length > 0) {
-          newErrors.task = t('common:validation.taskNameRequired');
-        }
-      }
-    }
-
-    if (Object.keys(newErrors).length > 0) {
-      setErrors(newErrors);
-      setIsLoading(false);
-      return;
-    }
-
-    const entriesToAdd: Omit<TimeEntry, 'id' | 'createdAt' | 'userId'>[] = [];
-
-    const submitRow = (
-      rowKey: string,
-      meta: {
-        clientId: string;
-        projectId: string;
-        taskName: string;
-        location: TimeEntryLocation;
-        baseDays: DayMap;
-      },
-    ) => {
-      const client = clients.find((c) => c.id === meta.clientId);
-      const project = projects.find((p) => p.id === meta.projectId);
-      const rowEdits = pendingEdits[rowKey] ?? {};
-      for (const day of weekDays) {
-        const base = meta.baseDays[day.dateStr];
-        const edit = rowEdits[day.dateStr];
-        if (!edit) continue;
-        const newDuration = parseDuration(edit.duration);
-        const baseDuration = base ? parseDuration(base.duration) : 0;
-        const noteChanged = (edit.note ?? '') !== (base?.note ?? '');
-        if (base?.entryId) {
-          if (newDuration > 0 && (newDuration !== baseDuration || noteChanged)) {
-            // Use `edit.note` directly so a user can intentionally clear a
-            // previously-set note. `noteChanged` already gated us on a real
-            // change in either direction.
-            onUpdateEntry(base.entryId, {
-              duration: newDuration,
-              notes: edit.note,
-              task: meta.taskName,
-              projectId: meta.projectId,
-              clientId: meta.clientId,
-              clientName: client?.name || 'Unknown',
-              projectName: project?.name || 'General',
-              location: meta.location,
-            });
-          }
-          continue;
-        }
-        if (newDuration > 0) {
-          entriesToAdd.push({
-            date: day.dateStr,
-            clientId: meta.clientId,
-            clientName: client?.name || 'Unknown',
-            projectId: meta.projectId,
-            projectName: project?.name || 'General',
-            task: meta.taskName,
-            duration: newDuration,
-            notes: edit.note || weekNote,
-            hourlyCost: 0,
-            location: meta.location,
-          });
-        }
-      }
-    };
-
-    if (hasFormHours) {
-      submitRow(FORM_ROW_KEY, {
-        clientId: selection.clientId,
-        projectId: selection.projectId,
-        taskName: selection.taskName,
-        location: selection.location,
-        baseDays: formRowBaseDays,
-      });
-    }
-
-    for (const row of entryRows) {
-      submitRow(row.key, {
-        clientId: row.clientId,
-        projectId: row.projectId,
-        taskName: row.taskName,
-        location: row.location,
-        baseDays: row.baseDays,
-      });
-    }
-
-    try {
-      if (entriesToAdd.length > 0) {
-        await onAddBulkEntries(entriesToAdd);
-      }
-      setPendingEdits({});
-      setWeekNote('');
-      setShowSuccess(true);
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    if (!showSuccess) return;
-    const timer = setTimeout(() => setShowSuccess(false), 2500);
-    return () => clearTimeout(timer);
-  }, [showSuccess]);
+    return Array.from(groups.values()).sort((a, b) => b.maxCreatedAt - a.maxCreatedAt);
+  }, [userEntries, weekDates, clients, projects, projectTasks]);
 
   const dayTotals = useMemo(() => {
     const totals: Record<string, number> = {};
     for (const day of weekDays) {
       let sum = 0;
-      const formEdit = pendingEdits[FORM_ROW_KEY]?.[day.dateStr];
-      if (formEdit) {
-        sum += parseDuration(formEdit.duration);
-      } else {
-        const formBase = formRowBaseDays[day.dateStr];
-        if (formBase) sum += parseDuration(formBase.duration);
-      }
-      for (const row of entryRows) {
-        const edit = pendingEdits[row.key]?.[day.dateStr];
-        if (edit) {
-          sum += parseDuration(edit.duration);
-        } else {
-          const base = row.baseDays[day.dateStr];
-          if (base) sum += parseDuration(base.duration);
-        }
-      }
+      for (const row of entryRows) sum += row.days[day.dateStr] ?? 0;
       totals[day.dateStr] = sum;
     }
     return totals;
-  }, [weekDays, entryRows, pendingEdits, formRowBaseDays]);
+  }, [weekDays, entryRows]);
 
   const weekTotal = useMemo(() => Object.values(dayTotals).reduce((a, b) => a + b, 0), [dayTotals]);
 
@@ -470,365 +178,203 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
     })}`;
   }, [currentWeekStart, i18n.language]);
 
-  const formLabel = useMemo(() => {
-    const client = clients.find((c) => c.id === selection.clientId);
-    const project = projects.find((p) => p.id === selection.projectId);
-    const parts = [client?.name, project?.name, selection.taskName].filter((p) => Boolean(p));
-    return parts.length > 0 ? parts.join(' · ') : t('weekly.newEntry');
-  }, [clients, projects, selection.clientId, selection.projectId, selection.taskName, t]);
-
-  const hasPendingEdits = Object.values(pendingEdits).some((row) => Object.keys(row).length > 0);
-
-  // A working-week's worth of daily goal hours — used to colour the week-total
-  // stat red once the user passes the typical full-week target.
+  // Use `dailyGoal * 5` as the typical full-week target so the week-total stat
+  // can flip red once it's exceeded.
   const weeklyGoal = dailyGoal * 5;
 
+  const shiftSelectedDate = (offsetDays: number) => {
+    const d = dateOnlyToLocalDate(selectedDate);
+    d.setDate(d.getDate() + offsetDays);
+    onSelectedDateChange(getLocalDateString(d));
+  };
+
   return (
-    <div className="w-full xl:w-[calc(45%+300px+1.5rem)] xl:mx-auto space-y-6">
-      <div className="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_300px] gap-6 items-start xl:items-stretch">
-        <Card className="px-6 py-5 gap-4">
-          <EntryCatalogSelector
-            clients={clients}
-            filteredProjects={selection.filteredProjects}
-            filteredTasks={selection.filteredTasks}
-            selectedClientId={selection.clientId}
-            selectedProjectId={selection.projectId}
-            selectedTaskId={selection.taskId}
-            location={selection.location}
-            onClientChange={(id) => {
-              selection.setClient(id);
-              if (errors.clientId) setErrors((prev) => ({ ...prev, clientId: '' }));
-            }}
-            onProjectChange={(id) => {
-              selection.setProject(id);
-              if (errors.projectId) setErrors((prev) => ({ ...prev, projectId: '' }));
-            }}
-            onTaskChange={(taskId) => {
-              selection.setTask(taskId);
-              if (errors.task) setErrors((prev) => ({ ...prev, task: '' }));
-            }}
-            onLocationChange={selection.setLocation}
-            errors={errors}
-          />
+    <Card className="px-0 py-0 overflow-hidden">
+      <div className="flex flex-col gap-2 px-4 pt-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex flex-wrap items-baseline gap-x-6 gap-y-1">
+          <div className="flex items-baseline gap-2">
+            <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
+              {t('weekly.weekTotal')}
+            </span>
+            <span
+              className={cn(
+                'text-lg font-black transition-colors',
+                weekTotal > weeklyGoal ? 'text-destructive' : 'text-praetor',
+              )}
+            >
+              {weekTotal.toFixed(2)} h
+            </span>
+          </div>
+          <div className="flex items-baseline gap-2">
+            <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
+              {t('weekly.monthTotal')}
+            </span>
+            <span className="text-lg font-black text-foreground">{monthTotal.toFixed(2)} h</span>
+          </div>
+        </div>
 
-          <Field>
-            <FieldLabel htmlFor="weekly-week-note">{t('weekly.weekNote')}</FieldLabel>
-            <Input
-              id="weekly-week-note"
-              type="text"
-              value={weekNote}
-              onChange={(e) => setWeekNote(e.target.value)}
-              placeholder={t('weekly.weekNote')}
-              className="rounded-lg"
-            />
-          </Field>
-        </Card>
-
-        <div className="w-full xl:max-w-[300px] xl:h-full flex flex-col gap-3">
-          <Calendar
-            selectedDate={getLocalDateString(currentWeekStart)}
-            onDateSelect={handleCalendarSelect}
-            entries={userEntries}
-            startOfWeek={startOfWeek}
-            treatSaturdayAsHoliday={treatSaturdayAsHoliday}
-            dailyGoal={dailyGoal}
-            allowWeekendSelection={allowWeekendSelection}
-            size="compact"
-          />
+        <div className="flex items-center gap-2 self-end sm:self-auto">
           <Button
             type="button"
-            onClick={handleSubmit}
-            disabled={isLoading || !hasPendingEdits}
-            className={cn(
-              'w-full h-11 rounded-xl font-bold text-sm uppercase tracking-widest',
-              showSuccess && 'bg-emerald-600 hover:bg-emerald-600',
-            )}
+            variant="ghost"
+            size="icon"
+            onClick={() => shiftSelectedDate(-7)}
+            aria-label={t('weekly.weekView')}
           >
-            {showSuccess ? t('weekly.success') : t('weekly.submitTime')}
+            <i className="fa-solid fa-chevron-left"></i>
+          </Button>
+          <span className="text-xs font-semibold text-foreground uppercase tracking-wide whitespace-nowrap">
+            {weekRangeLabel}
+          </span>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            onClick={() => shiftSelectedDate(7)}
+            aria-label={t('weekly.weekView')}
+          >
+            <i className="fa-solid fa-chevron-right"></i>
+          </Button>
+          <Button
+            type="button"
+            size="xs"
+            onClick={() => onSelectedDateChange(getLocalDateString(new Date()))}
+            className="rounded-full text-[10px] font-bold uppercase tracking-widest"
+          >
+            {t('weekly.goToToday')}
           </Button>
         </div>
       </div>
 
-      <Card className="px-0 py-0 overflow-hidden">
-        <div className="flex flex-col gap-2 px-4 pt-4 sm:flex-row sm:items-start sm:justify-between">
-          <div className="flex flex-wrap items-baseline gap-x-6 gap-y-1">
-            <div className="flex items-baseline gap-2">
-              <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
-                {t('weekly.weekTotal')}
-              </span>
-              <span
-                className={cn(
-                  'text-lg font-black transition-colors',
-                  weekTotal > weeklyGoal ? 'text-destructive' : 'text-praetor',
-                )}
-              >
-                {weekTotal.toFixed(2)} h
-              </span>
-            </div>
-            <div className="flex items-baseline gap-2">
-              <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
-                {t('weekly.monthTotal')}
-              </span>
-              <span className="text-lg font-black text-foreground">{monthTotal.toFixed(2)} h</span>
-            </div>
-          </div>
-
-          <div className="flex items-center gap-2 self-end sm:self-auto">
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              onClick={() => handleWeekChange(-1)}
-              aria-label={t('weekly.weekView')}
-            >
-              <i className="fa-solid fa-chevron-left"></i>
-            </Button>
-            <span className="text-xs font-semibold text-foreground uppercase tracking-wide whitespace-nowrap">
-              {weekRangeLabel}
-            </span>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              onClick={() => handleWeekChange(1)}
-              aria-label={t('weekly.weekView')}
-            >
-              <i className="fa-solid fa-chevron-right"></i>
-            </Button>
-            <Button
-              type="button"
-              size="xs"
-              onClick={() => setCurrentWeekStart(getWeekStart(new Date(), startOfWeek))}
-              className="rounded-full text-[10px] font-bold uppercase tracking-widest"
-            >
-              {t('weekly.goToToday')}
-            </Button>
-          </div>
-        </div>
-
-        <div className="overflow-x-auto">
-          <Table className="min-w-max border-collapse">
-            <TableHeader className="bg-muted/40">
-              <TableRow className="border-b border-border">
-                <TableHead className="px-4 py-3 text-[10px] font-bold text-muted-foreground uppercase tracking-tighter min-w-56">
-                  {t('weekly.task')}
-                </TableHead>
-                {weekDays.map((day) => (
-                  <TableHead
-                    key={day.dateStr}
+      <div className="overflow-x-auto">
+        <Table className="min-w-max border-collapse">
+          <TableHeader className="bg-muted/40">
+            <TableRow className="border-b border-border">
+              <TableHead className="px-4 py-3 text-[10px] font-bold text-muted-foreground uppercase tracking-tighter min-w-56">
+                {t('weekly.task')}
+              </TableHead>
+              {weekDays.map((day) => (
+                <TableHead
+                  key={day.dateStr}
+                  className={cn(
+                    'w-28 px-2 py-2 text-center relative align-middle',
+                    day.isToday && 'bg-accent',
+                    day.isWeekendOrHoliday && 'bg-destructive/5',
+                  )}
+                >
+                  <div
                     className={cn(
-                      'w-28 px-2 py-2 text-center relative align-middle',
-                      day.isToday && 'bg-accent',
-                      day.isWeekendOrHoliday && 'bg-destructive/5',
+                      'flex items-center justify-center gap-1 text-[10px] font-black uppercase',
+                      day.isToday
+                        ? 'text-praetor'
+                        : day.isWeekendOrHoliday
+                          ? 'text-destructive'
+                          : 'text-muted-foreground',
                     )}
                   >
-                    <div
-                      className={cn(
-                        'flex items-center justify-center gap-1 text-[10px] font-black uppercase',
-                        day.isToday
-                          ? 'text-praetor'
-                          : day.isWeekendOrHoliday
-                            ? 'text-destructive'
-                            : 'text-muted-foreground',
-                      )}
-                    >
-                      {t(`weekly.days.${day.dayKey}`)}
-                      {day.holidayName && (
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <span className="inline-flex">
-                              <span className="size-1.5 bg-destructive rounded-full animate-pulse block"></span>
-                            </span>
-                          </TooltipTrigger>
-                          <TooltipContent>{day.holidayName}</TooltipContent>
-                        </Tooltip>
-                      )}
-                    </div>
-                    <p
-                      className={cn(
-                        'text-sm font-black leading-none mt-0.5',
-                        day.isToday
-                          ? 'text-praetor'
-                          : day.isWeekendOrHoliday
-                            ? 'text-destructive'
-                            : 'text-foreground',
-                      )}
-                    >
-                      {day.dayNum}
-                    </p>
-                  </TableHead>
-                ))}
-              </TableRow>
-            </TableHeader>
-            <TableBody className="divide-y divide-border">
-              <TableRow className="bg-praetor/5 hover:bg-praetor/10">
-                <TableCell className="px-4 py-3 align-top whitespace-normal">
-                  <p className="text-[10px] font-bold text-praetor uppercase tracking-wider mb-1">
-                    {t('weekly.newEntry')}
+                    {t(`weekly.days.${day.dayKey}`)}
+                    {day.holidayName && (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span className="inline-flex">
+                            <span className="size-1.5 bg-destructive rounded-full animate-pulse block"></span>
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent>{day.holidayName}</TooltipContent>
+                      </Tooltip>
+                    )}
+                  </div>
+                  <p
+                    className={cn(
+                      'text-sm font-black leading-none mt-0.5',
+                      day.isToday
+                        ? 'text-praetor'
+                        : day.isWeekendOrHoliday
+                          ? 'text-destructive'
+                          : 'text-foreground',
+                    )}
+                  >
+                    {day.dayNum}
                   </p>
-                  <p className="text-xs text-muted-foreground line-clamp-2">{formLabel}</p>
+                </TableHead>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody className="divide-y divide-border">
+            {entryRows.length === 0 ? (
+              <TableRow>
+                <TableCell
+                  colSpan={1 + weekDays.length}
+                  className="px-4 py-10 text-center text-xs text-muted-foreground"
+                >
+                  {t('weekly.noRecentTasks')}
                 </TableCell>
-                {weekDays.map((day) => {
-                  const cell = getCellValue(FORM_ROW_KEY, day.dateStr, formRowBaseDays);
-                  return (
-                    <TableCell
-                      key={day.dateStr}
-                      className={cn(
-                        'w-28 px-2 py-3 align-top',
-                        day.isToday && 'bg-accent/60',
-                        day.isWeekendOrHoliday && 'bg-destructive/5',
-                      )}
-                    >
-                      <div className="flex flex-col gap-2">
-                        <ValidatedNumberInput
-                          placeholder="0.0"
-                          disabled={day.isForbidden}
-                          value={cell.duration}
-                          onValueChange={(value) =>
-                            updateCell(
-                              FORM_ROW_KEY,
-                              day.dateStr,
-                              { duration: value },
-                              formRowBaseDays[day.dateStr],
-                            )
-                          }
-                          className={cn(
-                            'h-9 w-full text-center text-sm font-bold',
-                            day.isForbidden && 'opacity-50 cursor-not-allowed',
-                          )}
-                        />
-                        <Input
-                          type="text"
-                          placeholder={t('weekly.note')}
-                          disabled={day.isForbidden}
-                          value={cell.note}
-                          onChange={(e) =>
-                            updateCell(
-                              FORM_ROW_KEY,
-                              day.dateStr,
-                              { note: e.target.value },
-                              formRowBaseDays[day.dateStr],
-                            )
-                          }
-                          className={cn(
-                            'h-7 text-xs rounded',
-                            day.isForbidden && 'opacity-40 cursor-not-allowed',
-                          )}
-                        />
-                      </div>
-                    </TableCell>
-                  );
-                })}
               </TableRow>
-              {entryRows.length === 0 ? (
-                <TableRow>
-                  <TableCell
-                    colSpan={1 + weekDays.length}
-                    className="px-4 py-6 text-center text-xs text-muted-foreground"
-                  >
-                    {t('weekly.noRecentTasks')}
-                  </TableCell>
-                </TableRow>
-              ) : (
-                entryRows.map((row) => (
-                  <TableRow key={row.key} className="hover:bg-muted/30">
-                    <TableCell className="px-4 py-3 align-top whitespace-normal">
-                      <p className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider mb-1">
-                        {t('weekly.recentTask')}
-                      </p>
-                      <p
-                        className="text-xs font-semibold text-foreground line-clamp-2"
-                        title={row.label}
-                      >
-                        {row.label}
-                      </p>
-                    </TableCell>
-                    {weekDays.map((day) => {
-                      const cell = getCellValue(row.key, day.dateStr, row.baseDays);
-                      return (
-                        <TableCell
-                          key={day.dateStr}
-                          className={cn(
-                            'w-28 px-2 py-3 align-top',
-                            day.isToday && 'bg-accent/60',
-                            day.isWeekendOrHoliday && 'bg-destructive/5',
-                            showSuccess && parseDuration(cell.duration) > 0 && 'bg-emerald-500/10',
-                          )}
-                        >
-                          <div className="flex flex-col gap-2">
-                            <ValidatedNumberInput
-                              placeholder="0.0"
-                              disabled={day.isForbidden}
-                              value={cell.duration}
-                              onValueChange={(value) =>
-                                updateCell(
-                                  row.key,
-                                  day.dateStr,
-                                  { duration: value },
-                                  row.baseDays[day.dateStr],
-                                )
-                              }
-                              className={cn(
-                                'h-9 w-full text-center text-sm font-bold',
-                                day.isForbidden && 'opacity-50 cursor-not-allowed',
-                              )}
-                            />
-                            <Input
-                              type="text"
-                              placeholder={t('weekly.note')}
-                              disabled={day.isForbidden}
-                              value={cell.note}
-                              onChange={(e) =>
-                                updateCell(
-                                  row.key,
-                                  day.dateStr,
-                                  { note: e.target.value },
-                                  row.baseDays[day.dateStr],
-                                )
-                              }
-                              className={cn(
-                                'h-7 text-xs rounded',
-                                day.isForbidden && 'opacity-40 cursor-not-allowed',
-                              )}
-                            />
-                          </div>
-                        </TableCell>
-                      );
-                    })}
-                  </TableRow>
-                ))
-              )}
-            </TableBody>
-            <TableFooter className="bg-muted/30">
-              <TableRow className="border-t border-border">
-                <TableCell className="px-4 py-3 text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
-                  {t('weekly.total')}
-                </TableCell>
-                {weekDays.map((day) => (
-                  <TableCell
-                    key={day.dateStr}
-                    className={cn(
-                      'w-28 px-2 py-3 text-center',
-                      day.isToday && 'bg-accent',
-                      day.isWeekendOrHoliday && 'bg-destructive/5',
-                    )}
-                  >
+            ) : (
+              entryRows.map((row) => (
+                <TableRow key={row.key} className="hover:bg-muted/30">
+                  <TableCell className="px-4 py-3 align-middle whitespace-normal">
                     <p
-                      className={cn(
-                        'text-sm font-black',
-                        dayTotals[day.dateStr] > dailyGoal ? 'text-destructive' : 'text-praetor',
-                      )}
+                      className="text-xs font-semibold text-foreground line-clamp-2"
+                      title={row.label}
                     >
-                      {dayTotals[day.dateStr].toFixed(1)}
+                      {row.label}
                     </p>
                   </TableCell>
-                ))}
-              </TableRow>
-            </TableFooter>
-          </Table>
-        </div>
-      </Card>
-    </div>
+                  {weekDays.map((day) => {
+                    const hours = row.days[day.dateStr];
+                    return (
+                      <TableCell
+                        key={day.dateStr}
+                        className={cn(
+                          'w-28 px-2 py-3 text-center align-middle',
+                          day.isToday && 'bg-accent/60',
+                          day.isWeekendOrHoliday && 'bg-destructive/5',
+                        )}
+                      >
+                        {hours ? (
+                          <span className="text-sm font-bold text-foreground">
+                            {hours.toFixed(2)}
+                          </span>
+                        ) : (
+                          <span className="text-xs text-muted-foreground/50">—</span>
+                        )}
+                      </TableCell>
+                    );
+                  })}
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+          <TableFooter className="bg-muted/30">
+            <TableRow className="border-t border-border">
+              <TableCell className="px-4 py-3 text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
+                {t('weekly.total')}
+              </TableCell>
+              {weekDays.map((day) => (
+                <TableCell
+                  key={day.dateStr}
+                  className={cn(
+                    'w-28 px-2 py-3 text-center',
+                    day.isToday && 'bg-accent',
+                    day.isWeekendOrHoliday && 'bg-destructive/5',
+                  )}
+                >
+                  <p
+                    className={cn(
+                      'text-sm font-black',
+                      dayTotals[day.dateStr] > dailyGoal ? 'text-destructive' : 'text-praetor',
+                    )}
+                  >
+                    {dayTotals[day.dateStr].toFixed(1)}
+                  </p>
+                </TableCell>
+              ))}
+            </TableRow>
+          </TableFooter>
+        </Table>
+      </div>
+    </Card>
   );
 };
 

--- a/components/timesheet/WeeklyView.tsx
+++ b/components/timesheet/WeeklyView.tsx
@@ -5,12 +5,21 @@ import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { Field, FieldLabel } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
-import type { Client, Project, ProjectTask, TimeEntry, TimeEntryLocation, User } from '../../types';
+import type { Client, Project, ProjectTask, TimeEntry, TimeEntryLocation } from '../../types';
 import { getLocalDateString } from '../../utils/date';
 import { isItalianHoliday } from '../../utils/holidays';
-import SelectControl from '../shared/SelectControl';
+import Calendar from '../shared/Calendar';
 import ValidatedNumberInput from '../shared/ValidatedNumberInput';
 import EntryCatalogSelector from './EntryCatalogSelector';
 import { useCatalogSelection } from './useCatalogSelection';
@@ -24,13 +33,11 @@ export interface WeeklyViewProps {
   onDeleteEntry: (id: string) => void;
   onUpdateEntry: (id: string, updates: Partial<TimeEntry>) => void;
   viewingUserId: string;
-  currentUserId?: string;
-  availableUsers: User[];
-  onViewUserChange: (id: string) => void;
   startOfWeek: 'Monday' | 'Sunday';
   treatSaturdayAsHoliday: boolean;
   allowWeekendSelection?: boolean;
   defaultLocation?: TimeEntryLocation;
+  dailyGoal: number;
 }
 
 const getWeekStart = (date: Date, startOfWeek: 'Monday' | 'Sunday'): Date => {
@@ -48,7 +55,7 @@ const getWeekStart = (date: Date, startOfWeek: 'Monday' | 'Sunday'): Date => {
 type DayCell = { duration: string; note: string; entryId?: string };
 type DayMap = Record<string, DayCell>;
 
-type RecentRow = {
+type EntryRow = {
   key: string;
   clientId: string;
   projectId: string;
@@ -74,13 +81,11 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
   onAddBulkEntries,
   onUpdateEntry,
   viewingUserId,
-  currentUserId,
-  availableUsers,
-  onViewUserChange,
   startOfWeek,
   treatSaturdayAsHoliday,
   allowWeekendSelection = false,
   defaultLocation = 'remote',
+  dailyGoal,
 }) => {
   const { t, i18n } = useTranslation('timesheets');
 
@@ -170,22 +175,18 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
     return days;
   }, [userEntries, weekDates, selection.clientId, selection.projectId, selection.taskName]);
 
-  const recentRows: RecentRow[] = useMemo(() => {
-    const groups = new Map<
-      string,
-      {
-        row: RecentRow;
-        maxCreatedAt: number;
-        hasWeekEntry: boolean;
-      }
-    >();
-
+  // Every distinct (client, project, task) combination with at least one entry
+  // in the current week, in-scope of the user's catalogs. No row cap — the
+  // weekly grid mirrors what's actually logged this week.
+  const entryRows: EntryRow[] = useMemo(() => {
+    const groups = new Map<string, { row: EntryRow; maxCreatedAt: number }>();
     const clientById = new Map(clients.map((c) => [c.id, c]));
     const projectById = new Map(projects.map((p) => [p.id, p]));
     const taskKey = (projectId: string, name: string) => `${projectId}|${name}`;
     const taskSet = new Set(projectTasks.map((task) => taskKey(task.projectId, task.name)));
 
     for (const entry of userEntries) {
+      if (!weekDates.includes(entry.date)) continue;
       if (!clientById.has(entry.clientId)) continue;
       if (!projectById.has(entry.projectId)) continue;
       if (!taskSet.has(taskKey(entry.projectId, entry.task))) continue;
@@ -206,23 +207,17 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
             baseDays: {},
           },
           maxCreatedAt: entry.createdAt,
-          hasWeekEntry: false,
         };
         groups.set(key, group);
       }
-
       if (entry.createdAt > group.maxCreatedAt) group.maxCreatedAt = entry.createdAt;
-
-      if (weekDates.includes(entry.date)) {
-        group.hasWeekEntry = true;
-        group.row.baseDays[entry.date] = {
-          duration: String(entry.duration),
-          note: entry.notes ?? '',
-          entryId: entry.id,
-        };
-        if (entry.location) {
-          group.row.location = entry.location;
-        }
+      group.row.baseDays[entry.date] = {
+        duration: String(entry.duration),
+        note: entry.notes ?? '',
+        entryId: entry.id,
+      };
+      if (entry.location) {
+        group.row.location = entry.location;
       }
     }
 
@@ -233,11 +228,7 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
     if (formKey) groups.delete(formKey);
 
     return Array.from(groups.values())
-      .sort((a, b) => {
-        if (a.hasWeekEntry !== b.hasWeekEntry) return a.hasWeekEntry ? -1 : 1;
-        return b.maxCreatedAt - a.maxCreatedAt;
-      })
-      .slice(0, 5)
+      .sort((a, b) => b.maxCreatedAt - a.maxCreatedAt)
       .map((g) => g.row);
   }, [
     userEntries,
@@ -251,17 +242,14 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
     defaultLocation,
   ]);
 
-  // When the set of recent rows changes (e.g. user switches), drop stale edits
-  // that no longer match an existing row. Each row's key is itself a
-  // `|`-joined composite, so a join+split would lose key boundaries — use the
-  // raw Set directly.
-  const recentRowKeySet = useMemo(() => new Set(recentRows.map((r) => r.key)), [recentRows]);
+  // When the set of entry rows changes, drop stale edits that no longer match.
+  const entryRowKeySet = useMemo(() => new Set(entryRows.map((r) => r.key)), [entryRows]);
   useEffect(() => {
     setPendingEdits((prev) => {
       let changed = false;
       const next: Record<string, DayMap> = {};
       for (const [key, value] of Object.entries(prev)) {
-        if (key === FORM_ROW_KEY || recentRowKeySet.has(key)) {
+        if (key === FORM_ROW_KEY || entryRowKeySet.has(key)) {
           next[key] = value;
         } else {
           changed = true;
@@ -269,7 +257,7 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
       }
       return changed ? next : prev;
     });
-  }, [recentRowKeySet]);
+  }, [entryRowKeySet]);
 
   const getCellValue = (rowKey: string, dateStr: string, baseDays?: DayMap): DayCell => {
     const edit = pendingEdits[rowKey]?.[dateStr];
@@ -304,6 +292,12 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
     const newStart = new Date(currentWeekStart);
     newStart.setDate(newStart.getDate() + offset * 7);
     setCurrentWeekStart(newStart);
+    setErrors({});
+  };
+
+  const handleCalendarSelect = (dateStr: string) => {
+    const [year, month, day] = dateStr.split('-').map(Number);
+    setCurrentWeekStart(getWeekStart(new Date(year, month - 1, day), startOfWeek));
     setErrors({});
   };
 
@@ -358,9 +352,9 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
         const noteChanged = (edit.note ?? '') !== (base?.note ?? '');
         if (base?.entryId) {
           if (newDuration > 0 && (newDuration !== baseDuration || noteChanged)) {
-            // Use `edit.note` directly (not `|| base.note`) so a user can
-            // intentionally clear a previously-set note. `noteChanged` already
-            // gated us on a real change, including '' → 'x' and 'x' → ''.
+            // Use `edit.note` directly so a user can intentionally clear a
+            // previously-set note. `noteChanged` already gated us on a real
+            // change in either direction.
             onUpdateEntry(base.entryId, {
               duration: newDuration,
               notes: edit.note,
@@ -401,7 +395,7 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
       });
     }
 
-    for (const row of recentRows) {
+    for (const row of entryRows) {
       submitRow(row.key, {
         clientId: row.clientId,
         projectId: row.projectId,
@@ -415,9 +409,6 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
       if (entriesToAdd.length > 0) {
         await onAddBulkEntries(entriesToAdd);
       }
-      // Only clear edits + flash success when the bulk-add resolves cleanly
-      // — on failure the user's in-flight values must survive so they can
-      // retry. The parent surfaces the error via App.tsx's global handler.
       setPendingEdits({});
       setWeekNote('');
       setShowSuccess(true);
@@ -443,7 +434,7 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
         const formBase = formRowBaseDays[day.dateStr];
         if (formBase) sum += parseDuration(formBase.duration);
       }
-      for (const row of recentRows) {
+      for (const row of entryRows) {
         const edit = pendingEdits[row.key]?.[day.dateStr];
         if (edit) {
           sum += parseDuration(edit.duration);
@@ -455,7 +446,7 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
       totals[day.dateStr] = sum;
     }
     return totals;
-  }, [weekDays, recentRows, pendingEdits, formRowBaseDays]);
+  }, [weekDays, entryRows, pendingEdits, formRowBaseDays]);
 
   const weekTotal = useMemo(() => Object.values(dayTotals).reduce((a, b) => a + b, 0), [dayTotals]);
 
@@ -466,20 +457,18 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
       .reduce((sum, e) => sum + e.duration, 0);
   }, [userEntries, currentWeekStart]);
 
-  const weekEnd = useMemo(() => {
+  const weekRangeLabel = useMemo(() => {
     const end = new Date(currentWeekStart);
     end.setDate(end.getDate() + 6);
-    return end;
-  }, [currentWeekStart]);
-
-  const weekRangeLabel = `${currentWeekStart.toLocaleDateString(i18n.language, {
-    month: 'short',
-    day: 'numeric',
-  })} – ${weekEnd.toLocaleDateString(i18n.language, {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  })}`;
+    return `${currentWeekStart.toLocaleDateString(i18n.language, {
+      month: 'short',
+      day: 'numeric',
+    })} – ${end.toLocaleDateString(i18n.language, {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    })}`;
+  }, [currentWeekStart, i18n.language]);
 
   const formLabel = useMemo(() => {
     const client = clients.find((c) => c.id === selection.clientId);
@@ -490,11 +479,101 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
 
   const hasPendingEdits = Object.values(pendingEdits).some((row) => Object.keys(row).length > 0);
 
+  // A working-week's worth of daily goal hours — used to colour the week-total
+  // stat red once the user passes the typical full-week target.
+  const weeklyGoal = dailyGoal * 5;
+
   return (
     <div className="w-full xl:w-[calc(45%+300px+1.5rem)] xl:mx-auto space-y-6">
-      <Card className="px-6 py-4">
-        <div className="flex flex-col md:flex-row justify-between items-center gap-4">
-          <div className="flex items-center gap-3">
+      <div className="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_300px] gap-6 items-start xl:items-stretch">
+        <Card className="px-6 py-5 gap-4">
+          <EntryCatalogSelector
+            clients={clients}
+            filteredProjects={selection.filteredProjects}
+            filteredTasks={selection.filteredTasks}
+            selectedClientId={selection.clientId}
+            selectedProjectId={selection.projectId}
+            selectedTaskId={selection.taskId}
+            location={selection.location}
+            onClientChange={(id) => {
+              selection.setClient(id);
+              if (errors.clientId) setErrors((prev) => ({ ...prev, clientId: '' }));
+            }}
+            onProjectChange={(id) => {
+              selection.setProject(id);
+              if (errors.projectId) setErrors((prev) => ({ ...prev, projectId: '' }));
+            }}
+            onTaskChange={(taskId) => {
+              selection.setTask(taskId);
+              if (errors.task) setErrors((prev) => ({ ...prev, task: '' }));
+            }}
+            onLocationChange={selection.setLocation}
+            errors={errors}
+          />
+
+          <Field>
+            <FieldLabel htmlFor="weekly-week-note">{t('weekly.weekNote')}</FieldLabel>
+            <Input
+              id="weekly-week-note"
+              type="text"
+              value={weekNote}
+              onChange={(e) => setWeekNote(e.target.value)}
+              placeholder={t('weekly.weekNote')}
+              className="rounded-lg"
+            />
+          </Field>
+        </Card>
+
+        <div className="w-full xl:max-w-[300px] xl:h-full flex flex-col gap-3">
+          <Calendar
+            selectedDate={getLocalDateString(currentWeekStart)}
+            onDateSelect={handleCalendarSelect}
+            entries={userEntries}
+            startOfWeek={startOfWeek}
+            treatSaturdayAsHoliday={treatSaturdayAsHoliday}
+            dailyGoal={dailyGoal}
+            allowWeekendSelection={allowWeekendSelection}
+            size="compact"
+          />
+          <Button
+            type="button"
+            onClick={handleSubmit}
+            disabled={isLoading || !hasPendingEdits}
+            className={cn(
+              'w-full h-11 rounded-xl font-bold text-sm uppercase tracking-widest',
+              showSuccess && 'bg-emerald-600 hover:bg-emerald-600',
+            )}
+          >
+            {showSuccess ? t('weekly.success') : t('weekly.submitTime')}
+          </Button>
+        </div>
+      </div>
+
+      <Card className="px-0 py-0 overflow-hidden">
+        <div className="flex flex-col gap-2 px-4 pt-4 sm:flex-row sm:items-start sm:justify-between">
+          <div className="flex flex-wrap items-baseline gap-x-6 gap-y-1">
+            <div className="flex items-baseline gap-2">
+              <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
+                {t('weekly.weekTotal')}
+              </span>
+              <span
+                className={cn(
+                  'text-lg font-black transition-colors',
+                  weekTotal > weeklyGoal ? 'text-destructive' : 'text-praetor',
+                )}
+              >
+                {weekTotal.toFixed(2)} h
+              </span>
+            </div>
+            <div className="flex items-baseline gap-2">
+              <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
+                {t('weekly.monthTotal')}
+              </span>
+              <span className="text-lg font-black text-foreground">{monthTotal.toFixed(2)} h</span>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2 self-end sm:self-auto">
             <Button
               type="button"
               variant="ghost"
@@ -504,12 +583,9 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
             >
               <i className="fa-solid fa-chevron-left"></i>
             </Button>
-            <div className="text-center min-w-50">
-              <h3 className="text-sm font-semibold text-foreground uppercase tracking-wider">
-                {weekRangeLabel}
-              </h3>
-              <p className="text-[10px] font-bold text-praetor uppercase">{t('weekly.weekView')}</p>
-            </div>
+            <span className="text-xs font-semibold text-foreground uppercase tracking-wide whitespace-nowrap">
+              {weekRangeLabel}
+            </span>
             <Button
               type="button"
               variant="ghost"
@@ -521,97 +597,27 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
             </Button>
             <Button
               type="button"
-              size="sm"
+              size="xs"
               onClick={() => setCurrentWeekStart(getWeekStart(new Date(), startOfWeek))}
               className="rounded-full text-[10px] font-bold uppercase tracking-widest"
             >
               {t('weekly.goToToday')}
             </Button>
           </div>
-
-          {availableUsers.length > 1 && (
-            <div className="w-64 space-y-1.5">
-              <div className="flex min-h-6 items-center justify-between gap-2">
-                <FieldLabel>{t('weekly.viewingUser')}</FieldLabel>
-                {currentUserId && viewingUserId !== currentUserId && (
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="xs"
-                    onClick={() => onViewUserChange(currentUserId)}
-                    className="gap-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
-                  >
-                    <i className="fa-solid fa-arrow-left" aria-hidden="true"></i>
-                    {t('tracker.backToMe')}
-                  </Button>
-                )}
-              </div>
-              <SelectControl
-                options={availableUsers.map((u) => ({
-                  id: u.id,
-                  name: u.name,
-                  badge: u.id === currentUserId ? t('tracker.you') : undefined,
-                }))}
-                value={viewingUserId}
-                onChange={(val) => onViewUserChange(val as string)}
-                searchable={true}
-              />
-            </div>
-          )}
         </div>
-      </Card>
 
-      <Card className="px-6 py-5 gap-4">
-        <EntryCatalogSelector
-          clients={clients}
-          filteredProjects={selection.filteredProjects}
-          filteredTasks={selection.filteredTasks}
-          selectedClientId={selection.clientId}
-          selectedProjectId={selection.projectId}
-          selectedTaskId={selection.taskId}
-          location={selection.location}
-          onClientChange={(id) => {
-            selection.setClient(id);
-            if (errors.clientId) setErrors((prev) => ({ ...prev, clientId: '' }));
-          }}
-          onProjectChange={(id) => {
-            selection.setProject(id);
-            if (errors.projectId) setErrors((prev) => ({ ...prev, projectId: '' }));
-          }}
-          onTaskChange={(taskId) => {
-            selection.setTask(taskId);
-            if (errors.task) setErrors((prev) => ({ ...prev, task: '' }));
-          }}
-          onLocationChange={selection.setLocation}
-          errors={errors}
-        />
-
-        <Field>
-          <FieldLabel htmlFor="weekly-week-note">{t('weekly.weekNote')}</FieldLabel>
-          <Input
-            id="weekly-week-note"
-            type="text"
-            value={weekNote}
-            onChange={(e) => setWeekNote(e.target.value)}
-            placeholder={t('weekly.weekNote')}
-            className="rounded-lg"
-          />
-        </Field>
-      </Card>
-
-      <Card className="px-0 py-0 overflow-hidden">
         <div className="overflow-x-auto">
-          <table className="w-full min-w-max text-left border-collapse">
-            <thead className="bg-muted/40 border-b border-border">
-              <tr>
-                <th className="px-4 py-3 text-[10px] font-bold text-muted-foreground uppercase tracking-tighter min-w-56">
+          <Table className="min-w-max border-collapse">
+            <TableHeader className="bg-muted/40">
+              <TableRow className="border-b border-border">
+                <TableHead className="px-4 py-3 text-[10px] font-bold text-muted-foreground uppercase tracking-tighter min-w-56">
                   {t('weekly.task')}
-                </th>
+                </TableHead>
                 {weekDays.map((day) => (
-                  <th
+                  <TableHead
                     key={day.dateStr}
                     className={cn(
-                      'w-28 p-2 text-center relative',
+                      'w-28 px-2 py-2 text-center relative align-middle',
                       day.isToday && 'bg-accent',
                       day.isWeekendOrHoliday && 'bg-destructive/5',
                     )}
@@ -650,25 +656,25 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
                     >
                       {day.dayNum}
                     </p>
-                  </th>
+                  </TableHead>
                 ))}
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border">
-              <tr className="bg-praetor/5">
-                <td className="px-4 py-3 align-top">
+              </TableRow>
+            </TableHeader>
+            <TableBody className="divide-y divide-border">
+              <TableRow className="bg-praetor/5 hover:bg-praetor/10">
+                <TableCell className="px-4 py-3 align-top whitespace-normal">
                   <p className="text-[10px] font-bold text-praetor uppercase tracking-wider mb-1">
                     {t('weekly.newEntry')}
                   </p>
                   <p className="text-xs text-muted-foreground line-clamp-2">{formLabel}</p>
-                </td>
+                </TableCell>
                 {weekDays.map((day) => {
                   const cell = getCellValue(FORM_ROW_KEY, day.dateStr, formRowBaseDays);
                   return (
-                    <td
+                    <TableCell
                       key={day.dateStr}
                       className={cn(
-                        'w-28 px-2 py-3 transition-colors',
+                        'w-28 px-2 py-3 align-top',
                         day.isToday && 'bg-accent/60',
                         day.isWeekendOrHoliday && 'bg-destructive/5',
                       )}
@@ -710,23 +716,23 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
                           )}
                         />
                       </div>
-                    </td>
+                    </TableCell>
                   );
                 })}
-              </tr>
-              {recentRows.length === 0 ? (
-                <tr>
-                  <td
+              </TableRow>
+              {entryRows.length === 0 ? (
+                <TableRow>
+                  <TableCell
                     colSpan={1 + weekDays.length}
                     className="px-4 py-6 text-center text-xs text-muted-foreground"
                   >
                     {t('weekly.noRecentTasks')}
-                  </td>
-                </tr>
+                  </TableCell>
+                </TableRow>
               ) : (
-                recentRows.map((row) => (
-                  <tr key={row.key} className="hover:bg-muted/30 transition-colors">
-                    <td className="px-4 py-3 align-top">
+                entryRows.map((row) => (
+                  <TableRow key={row.key} className="hover:bg-muted/30">
+                    <TableCell className="px-4 py-3 align-top whitespace-normal">
                       <p className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider mb-1">
                         {t('weekly.recentTask')}
                       </p>
@@ -736,14 +742,14 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
                       >
                         {row.label}
                       </p>
-                    </td>
+                    </TableCell>
                     {weekDays.map((day) => {
                       const cell = getCellValue(row.key, day.dateStr, row.baseDays);
                       return (
-                        <td
+                        <TableCell
                           key={day.dateStr}
                           className={cn(
-                            'w-28 px-2 py-3 transition-colors',
+                            'w-28 px-2 py-3 align-top',
                             day.isToday && 'bg-accent/60',
                             day.isWeekendOrHoliday && 'bg-destructive/5',
                             showSuccess && parseDuration(cell.duration) > 0 && 'bg-emerald-500/10',
@@ -786,20 +792,20 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
                               )}
                             />
                           </div>
-                        </td>
+                        </TableCell>
                       );
                     })}
-                  </tr>
+                  </TableRow>
                 ))
               )}
-            </tbody>
-            <tfoot className="bg-muted/30 border-t border-border">
-              <tr>
-                <td className="px-4 py-3 text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
+            </TableBody>
+            <TableFooter className="bg-muted/30">
+              <TableRow className="border-t border-border">
+                <TableCell className="px-4 py-3 text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
                   {t('weekly.total')}
-                </td>
+                </TableCell>
                 {weekDays.map((day) => (
-                  <td
+                  <TableCell
                     key={day.dateStr}
                     className={cn(
                       'w-28 px-2 py-3 text-center',
@@ -810,50 +816,18 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
                     <p
                       className={cn(
                         'text-sm font-black',
-                        dayTotals[day.dateStr] > 8 ? 'text-destructive' : 'text-praetor',
+                        dayTotals[day.dateStr] > dailyGoal ? 'text-destructive' : 'text-praetor',
                       )}
                     >
                       {dayTotals[day.dateStr].toFixed(1)}
                     </p>
-                  </td>
+                  </TableCell>
                 ))}
-              </tr>
-            </tfoot>
-          </table>
+              </TableRow>
+            </TableFooter>
+          </Table>
         </div>
       </Card>
-
-      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
-        <Card className="px-6 py-4 flex-1">
-          <div className="flex flex-wrap items-center justify-center gap-8">
-            <div className="text-center">
-              <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
-                {t('weekly.weekTotal')}
-              </p>
-              <p className="text-2xl font-black text-praetor">{weekTotal.toFixed(1)}</p>
-            </div>
-            <div className="text-center">
-              <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
-                {t('weekly.monthTotal')}
-              </p>
-              <p className="text-2xl font-black text-foreground">{monthTotal.toFixed(1)}</p>
-            </div>
-          </div>
-        </Card>
-
-        <Button
-          type="button"
-          onClick={handleSubmit}
-          disabled={isLoading || !hasPendingEdits}
-          size="lg"
-          className={cn(
-            'h-12 px-10 rounded-xl font-bold text-sm uppercase tracking-widest',
-            showSuccess && 'bg-emerald-600 hover:bg-emerald-600',
-          )}
-        >
-          {showSuccess ? t('weekly.success') : t('weekly.submitTime')}
-        </Button>
-      </div>
     </div>
   );
 };

--- a/components/timesheet/WeeklyView.tsx
+++ b/components/timesheet/WeeklyView.tsx
@@ -17,7 +17,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { cn } from '@/lib/utils';
 import type { Client, Project, ProjectTask, TimeEntry, TimeEntryLocation } from '../../types';
 import { downloadCsv } from '../../utils/csv';
-import { getLocalDateString } from '../../utils/date';
+import { dateOnlyStringToLocalDate, getLocalDateString } from '../../utils/date';
 import { isItalianHoliday } from '../../utils/holidays';
 import Calendar from '../shared/Calendar';
 import { TABLE_CONTROL_BUTTON_CLASSNAME } from '../shared/tableControlStyles';
@@ -66,11 +66,6 @@ const getWeekStart = (date: Date, startOfWeek: 'Monday' | 'Sunday'): Date => {
   return start;
 };
 
-const dateOnlyToLocalDate = (dateOnly: string): Date => {
-  const [year, month, day] = dateOnly.split('-').map(Number);
-  return new Date(year, month - 1, day);
-};
-
 type DayCell = { duration: string; note: string; entryId?: string };
 type DayMap = Record<string, DayCell>;
 
@@ -114,7 +109,7 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
   const { t } = useTranslation('timesheets');
 
   const currentWeekStart = useMemo(
-    () => getWeekStart(dateOnlyToLocalDate(selectedDate), startOfWeek),
+    () => getWeekStart(dateOnlyStringToLocalDate(selectedDate), startOfWeek),
     [selectedDate, startOfWeek],
   );
 
@@ -175,7 +170,6 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
     [weekDays, hideWeekend],
   );
 
-  // Per-row, per-day edits the user has made since the last sync from props.
   const [pendingEdits, setPendingEdits] = useState<Record<string, DayMap>>({});
 
   // Reset pending edits whenever the visible week changes.
@@ -323,6 +317,40 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
       };
       return { ...prev, [rowKey]: { ...rowEdits, [dateStr]: nextCell } };
     });
+  };
+
+  const renderDayCellInputs = (
+    rowKey: string,
+    day: (typeof weekDays)[number],
+    baseDays: DayMap,
+  ) => {
+    const cell = getCellValue(rowKey, day.dateStr, baseDays);
+    return (
+      <div className="flex flex-col gap-2">
+        <ValidatedNumberInput
+          placeholder="0.0"
+          disabled={day.isForbidden}
+          value={cell.duration}
+          onValueChange={(value) =>
+            updateCell(rowKey, day.dateStr, { duration: value }, baseDays[day.dateStr])
+          }
+          className={cn(
+            'h-9 w-full text-center text-sm font-bold',
+            day.isForbidden && 'opacity-50 cursor-not-allowed',
+          )}
+        />
+        <Input
+          type="text"
+          placeholder={t('weekly.note')}
+          disabled={day.isForbidden}
+          value={cell.note}
+          onChange={(e) =>
+            updateCell(rowKey, day.dateStr, { note: e.target.value }, baseDays[day.dateStr])
+          }
+          className={cn('h-7 text-xs rounded', day.isForbidden && 'opacity-40 cursor-not-allowed')}
+        />
+      </div>
+    );
   };
 
   const clearError = (field: keyof WeeklyEntryFormErrors) => {
@@ -698,57 +726,18 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
                   </p>
                   <p className="text-xs text-muted-foreground line-clamp-2">{formLabel}</p>
                 </TableCell>
-                {visibleWeekDays.map((day) => {
-                  const cell = getCellValue(FORM_ROW_KEY, day.dateStr, formRowBaseDays);
-                  return (
-                    <TableCell
-                      key={day.dateStr}
-                      className={cn(
-                        'w-28 px-2 py-3 align-top',
-                        day.isToday && 'bg-accent/60',
-                        day.isWeekendOrHoliday && 'bg-destructive/5',
-                      )}
-                    >
-                      <div className="flex flex-col gap-2">
-                        <ValidatedNumberInput
-                          placeholder="0.0"
-                          disabled={day.isForbidden}
-                          value={cell.duration}
-                          onValueChange={(value) =>
-                            updateCell(
-                              FORM_ROW_KEY,
-                              day.dateStr,
-                              { duration: value },
-                              formRowBaseDays[day.dateStr],
-                            )
-                          }
-                          className={cn(
-                            'h-9 w-full text-center text-sm font-bold',
-                            day.isForbidden && 'opacity-50 cursor-not-allowed',
-                          )}
-                        />
-                        <Input
-                          type="text"
-                          placeholder={t('weekly.note')}
-                          disabled={day.isForbidden}
-                          value={cell.note}
-                          onChange={(e) =>
-                            updateCell(
-                              FORM_ROW_KEY,
-                              day.dateStr,
-                              { note: e.target.value },
-                              formRowBaseDays[day.dateStr],
-                            )
-                          }
-                          className={cn(
-                            'h-7 text-xs rounded',
-                            day.isForbidden && 'opacity-40 cursor-not-allowed',
-                          )}
-                        />
-                      </div>
-                    </TableCell>
-                  );
-                })}
+                {visibleWeekDays.map((day) => (
+                  <TableCell
+                    key={day.dateStr}
+                    className={cn(
+                      'w-28 px-2 py-3 align-top',
+                      day.isToday && 'bg-accent/60',
+                      day.isWeekendOrHoliday && 'bg-destructive/5',
+                    )}
+                  >
+                    {renderDayCellInputs(FORM_ROW_KEY, day, formRowBaseDays)}
+                  </TableCell>
+                ))}
               </TableRow>
             </TableBody>
             <TableBody className="divide-y divide-border border-t-[3px] border-t-border">
@@ -784,43 +773,7 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
                             showSuccess && parseDuration(cell.duration) > 0 && 'bg-emerald-500/10',
                           )}
                         >
-                          <div className="flex flex-col gap-2">
-                            <ValidatedNumberInput
-                              placeholder="0.0"
-                              disabled={day.isForbidden}
-                              value={cell.duration}
-                              onValueChange={(value) =>
-                                updateCell(
-                                  row.key,
-                                  day.dateStr,
-                                  { duration: value },
-                                  row.baseDays[day.dateStr],
-                                )
-                              }
-                              className={cn(
-                                'h-9 w-full text-center text-sm font-bold',
-                                day.isForbidden && 'opacity-50 cursor-not-allowed',
-                              )}
-                            />
-                            <Input
-                              type="text"
-                              placeholder={t('weekly.note')}
-                              disabled={day.isForbidden}
-                              value={cell.note}
-                              onChange={(e) =>
-                                updateCell(
-                                  row.key,
-                                  day.dateStr,
-                                  { note: e.target.value },
-                                  row.baseDays[day.dateStr],
-                                )
-                              }
-                              className={cn(
-                                'h-7 text-xs rounded',
-                                day.isForbidden && 'opacity-40 cursor-not-allowed',
-                              )}
-                            />
-                          </div>
+                          {renderDayCellInputs(row.key, day, row.baseDays)}
                         </TableCell>
                       );
                     })}

--- a/components/timesheet/WeeklyView.tsx
+++ b/components/timesheet/WeeklyView.tsx
@@ -1,6 +1,8 @@
 import type React from 'react';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import {
   Table,
   TableBody,
@@ -12,20 +14,40 @@ import {
 } from '@/components/ui/table';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
-import type { Client, Project, ProjectTask, TimeEntry } from '../../types';
+import type { Client, Project, ProjectTask, TimeEntry, TimeEntryLocation } from '../../types';
 import { getLocalDateString } from '../../utils/date';
 import { isItalianHoliday } from '../../utils/holidays';
+import Calendar from '../shared/Calendar';
+import ValidatedNumberInput from '../shared/ValidatedNumberInput';
+import { useCatalogSelection } from './useCatalogSelection';
+import WeeklyEntryForm, { type WeeklyEntryFormErrors } from './WeeklyEntryForm';
 
 export interface WeeklyViewProps {
   entries: TimeEntry[];
   clients: Client[];
   projects: Project[];
   projectTasks: ProjectTask[];
+  permissions: string[];
+  currency: string;
+  onAddCustomTask: (
+    name: string,
+    projectId: string,
+    recurringConfig?: { isRecurring: boolean; pattern: 'daily' | 'weekly' | 'monthly' },
+    description?: string,
+    details?: Pick<
+      ProjectTask,
+      'expectedEffort' | 'monthlyEffort' | 'revenue' | 'notes' | 'billingType' | 'billingFrequency'
+    >,
+  ) => Promise<ProjectTask>;
+  onAddBulkEntries: (entries: Omit<TimeEntry, 'id' | 'createdAt' | 'userId'>[]) => Promise<void>;
+  onUpdateEntry: (id: string, updates: Partial<TimeEntry>) => void;
   viewingUserId: string;
   selectedDate: string;
+  onSelectedDateChange: (date: string) => void;
   startOfWeek: 'Monday' | 'Sunday';
   treatSaturdayAsHoliday: boolean;
   allowWeekendSelection?: boolean;
+  defaultLocation?: TimeEntryLocation;
   dailyGoal: number;
 }
 
@@ -46,11 +68,25 @@ const dateOnlyToLocalDate = (dateOnly: string): Date => {
   return new Date(year, month - 1, day);
 };
 
+type DayCell = { duration: string; note: string; entryId?: string };
+type DayMap = Record<string, DayCell>;
+
 type EntryRow = {
   key: string;
+  clientId: string;
+  projectId: string;
+  taskName: string;
+  location: TimeEntryLocation;
   label: string;
-  days: Record<string, number>;
-  maxCreatedAt: number;
+  baseDays: DayMap;
+};
+
+const FORM_ROW_KEY = '__form_row__';
+
+const parseDuration = (raw: string): number => {
+  if (!raw) return 0;
+  const parsed = parseFloat(raw.replace(',', '.'));
+  return Number.isFinite(parsed) ? parsed : 0;
 };
 
 const WeeklyView: React.FC<WeeklyViewProps> = ({
@@ -58,11 +94,18 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
   clients,
   projects,
   projectTasks,
+  permissions,
+  currency,
+  onAddCustomTask,
+  onAddBulkEntries,
+  onUpdateEntry,
   viewingUserId,
   selectedDate,
+  onSelectedDateChange,
   startOfWeek,
   treatSaturdayAsHoliday,
   allowWeekendSelection = false,
+  defaultLocation = 'remote',
   dailyGoal,
 }) => {
   const { t } = useTranslation('timesheets');
@@ -104,53 +147,316 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
     [entries, viewingUserId],
   );
 
-  // Every distinct (client, project, task) combination with at least one entry
-  // in the current week, in-scope of the user's catalogs. No row cap — the
-  // grid mirrors exactly what's logged for the visible week.
+  const selection = useCatalogSelection({
+    clients,
+    projects,
+    projectTasks,
+    defaultLocation,
+  });
+
+  const [errors, setErrors] = useState<WeeklyEntryFormErrors>({});
+  const [isLoading, setIsLoading] = useState(false);
+  const [showSuccess, setShowSuccess] = useState(false);
+  const [weekNote, setWeekNote] = useState('');
+
+  // Per-row, per-day edits the user has made since the last sync from props.
+  const [pendingEdits, setPendingEdits] = useState<Record<string, DayMap>>({});
+
+  // Reset pending edits whenever the visible week changes.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: currentWeekStart is the intended trigger
+  useEffect(() => {
+    setPendingEdits({});
+  }, [currentWeekStart]);
+
+  // Entries matching the form selection in the current week — used to pre-fill
+  // the "Nuova voce" row so an existing combo isn't double-rendered.
+  const formRowBaseDays = useMemo<DayMap>(() => {
+    if (!selection.clientId || !selection.projectId || !selection.taskName) return {};
+    const days: DayMap = {};
+    for (const entry of userEntries) {
+      if (entry.clientId !== selection.clientId) continue;
+      if (entry.projectId !== selection.projectId) continue;
+      if (entry.task !== selection.taskName) continue;
+      if (!weekDates.includes(entry.date)) continue;
+      days[entry.date] = {
+        duration: String(entry.duration),
+        note: entry.notes ?? '',
+        entryId: entry.id,
+      };
+    }
+    return days;
+  }, [userEntries, weekDates, selection.clientId, selection.projectId, selection.taskName]);
+
+  // Rows for previously-logged combos. Includes every distinct (client,
+  // project, task) the viewing user has used and is still in scope. Combos
+  // with entries in the current week sort first; the rest fall back to most-
+  // recent `createdAt`. The combo matching the form selection is dropped so
+  // the "Nuova voce" row at the top isn't duplicated.
   const entryRows: EntryRow[] = useMemo(() => {
-    const groups = new Map<string, EntryRow>();
+    const groups = new Map<
+      string,
+      { row: EntryRow; maxCreatedAt: number; hasWeekEntry: boolean }
+    >();
     const clientById = new Map(clients.map((c) => [c.id, c]));
     const projectById = new Map(projects.map((p) => [p.id, p]));
     const taskKey = (projectId: string, name: string) => `${projectId}|${name}`;
     const taskSet = new Set(projectTasks.map((task) => taskKey(task.projectId, task.name)));
 
     for (const entry of userEntries) {
-      if (!weekDates.includes(entry.date)) continue;
       if (!clientById.has(entry.clientId)) continue;
       if (!projectById.has(entry.projectId)) continue;
       if (!taskSet.has(taskKey(entry.projectId, entry.task))) continue;
 
       const key = `${entry.clientId}|${entry.projectId}|${entry.task}`;
-      let row = groups.get(key);
-      if (!row) {
+      let group = groups.get(key);
+      if (!group) {
         const client = clientById.get(entry.clientId);
         const project = projectById.get(entry.projectId);
-        row = {
-          key,
-          label: [client?.name, project?.name, entry.task].filter(Boolean).join(' · '),
-          days: {},
+        group = {
+          row: {
+            key,
+            clientId: entry.clientId,
+            projectId: entry.projectId,
+            taskName: entry.task,
+            location: entry.location ?? defaultLocation,
+            label: [client?.name, project?.name, entry.task].filter(Boolean).join(' · '),
+            baseDays: {},
+          },
           maxCreatedAt: entry.createdAt,
+          hasWeekEntry: false,
         };
-        groups.set(key, row);
+        groups.set(key, group);
       }
-      if (entry.createdAt > row.maxCreatedAt) row.maxCreatedAt = entry.createdAt;
-      // Multiple entries on the same day for the same combo are summed — the
-      // grid shows the day's total hours per task, not individual entries.
-      row.days[entry.date] = (row.days[entry.date] ?? 0) + entry.duration;
+      if (entry.createdAt > group.maxCreatedAt) group.maxCreatedAt = entry.createdAt;
+      if (weekDates.includes(entry.date)) {
+        group.hasWeekEntry = true;
+        group.row.baseDays[entry.date] = {
+          duration: String(entry.duration),
+          note: entry.notes ?? '',
+          entryId: entry.id,
+        };
+        if (entry.location) group.row.location = entry.location;
+      }
     }
 
-    return Array.from(groups.values()).sort((a, b) => b.maxCreatedAt - a.maxCreatedAt);
-  }, [userEntries, weekDates, clients, projects, projectTasks]);
+    const formKey =
+      selection.clientId && selection.projectId && selection.taskName
+        ? `${selection.clientId}|${selection.projectId}|${selection.taskName}`
+        : '';
+    if (formKey) groups.delete(formKey);
+
+    return Array.from(groups.values())
+      .sort((a, b) => {
+        if (a.hasWeekEntry !== b.hasWeekEntry) return a.hasWeekEntry ? -1 : 1;
+        return b.maxCreatedAt - a.maxCreatedAt;
+      })
+      .slice(0, 5)
+      .map((g) => g.row);
+  }, [
+    userEntries,
+    weekDates,
+    clients,
+    projects,
+    projectTasks,
+    selection.clientId,
+    selection.projectId,
+    selection.taskName,
+    defaultLocation,
+  ]);
+
+  // When the set of entry rows changes (e.g. user switches), drop stale edits
+  // that no longer match an existing row. Use a Set of raw keys — each row
+  // key already contains `|`, so split/join would lose boundaries.
+  const entryRowKeySet = useMemo(() => new Set(entryRows.map((r) => r.key)), [entryRows]);
+  useEffect(() => {
+    setPendingEdits((prev) => {
+      let changed = false;
+      const next: Record<string, DayMap> = {};
+      for (const [key, value] of Object.entries(prev)) {
+        if (key === FORM_ROW_KEY || entryRowKeySet.has(key)) {
+          next[key] = value;
+        } else {
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [entryRowKeySet]);
+
+  const getCellValue = (rowKey: string, dateStr: string, baseDays?: DayMap): DayCell => {
+    const edit = pendingEdits[rowKey]?.[dateStr];
+    if (edit) return edit;
+    if (baseDays?.[dateStr]) return baseDays[dateStr];
+    return { duration: '', note: '' };
+  };
+
+  const updateCell = (
+    rowKey: string,
+    dateStr: string,
+    patch: Partial<Pick<DayCell, 'duration' | 'note'>>,
+    baseCell?: DayCell,
+  ) => {
+    setPendingEdits((prev) => {
+      const rowEdits = prev[rowKey] ?? {};
+      const existing = rowEdits[dateStr];
+      const seed: DayCell = existing ?? baseCell ?? { duration: '', note: '' };
+      const nextCell: DayCell = {
+        duration: patch.duration ?? seed.duration,
+        note: patch.note ?? seed.note,
+        entryId: seed.entryId,
+      };
+      return { ...prev, [rowKey]: { ...rowEdits, [dateStr]: nextCell } };
+    });
+  };
+
+  const clearError = (field: keyof WeeklyEntryFormErrors) => {
+    if (errors[field]) setErrors((prev) => ({ ...prev, [field]: undefined }));
+  };
+
+  const handleSubmit = async () => {
+    setIsLoading(true);
+    setErrors({});
+
+    const newErrors: WeeklyEntryFormErrors = {};
+    const formEdits = pendingEdits[FORM_ROW_KEY] ?? {};
+    const hasFormHours = Object.values(formEdits).some((cell) => parseDuration(cell.duration) > 0);
+
+    if (hasFormHours) {
+      if (!selection.clientId) newErrors.clientId = t('common:validation.clientRequired');
+      if (!selection.projectId) newErrors.projectId = t('common:validation.projectRequired');
+      if (!selection.taskName) {
+        const availableTasks = projectTasks.filter(
+          (task) => task.projectId === selection.projectId,
+        );
+        if (availableTasks.length > 0) {
+          newErrors.task = t('common:validation.taskNameRequired');
+        }
+      }
+    }
+
+    if (Object.keys(newErrors).length > 0) {
+      setErrors(newErrors);
+      setIsLoading(false);
+      return;
+    }
+
+    const entriesToAdd: Omit<TimeEntry, 'id' | 'createdAt' | 'userId'>[] = [];
+
+    const submitRow = (
+      rowKey: string,
+      meta: {
+        clientId: string;
+        projectId: string;
+        taskName: string;
+        location: TimeEntryLocation;
+        baseDays: DayMap;
+      },
+    ) => {
+      const client = clients.find((c) => c.id === meta.clientId);
+      const project = projects.find((p) => p.id === meta.projectId);
+      const rowEdits = pendingEdits[rowKey] ?? {};
+      for (const day of weekDays) {
+        const base = meta.baseDays[day.dateStr];
+        const edit = rowEdits[day.dateStr];
+        if (!edit) continue;
+        const newDuration = parseDuration(edit.duration);
+        const baseDuration = base ? parseDuration(base.duration) : 0;
+        const noteChanged = (edit.note ?? '') !== (base?.note ?? '');
+        if (base?.entryId) {
+          if (newDuration > 0 && (newDuration !== baseDuration || noteChanged)) {
+            // `edit.note` directly so a user can clear a previously-set note.
+            onUpdateEntry(base.entryId, {
+              duration: newDuration,
+              notes: edit.note,
+              task: meta.taskName,
+              projectId: meta.projectId,
+              clientId: meta.clientId,
+              clientName: client?.name || 'Unknown',
+              projectName: project?.name || 'General',
+              location: meta.location,
+            });
+          }
+          continue;
+        }
+        if (newDuration > 0) {
+          entriesToAdd.push({
+            date: day.dateStr,
+            clientId: meta.clientId,
+            clientName: client?.name || 'Unknown',
+            projectId: meta.projectId,
+            projectName: project?.name || 'General',
+            task: meta.taskName,
+            duration: newDuration,
+            notes: edit.note || weekNote,
+            hourlyCost: 0,
+            location: meta.location,
+          });
+        }
+      }
+    };
+
+    if (hasFormHours) {
+      submitRow(FORM_ROW_KEY, {
+        clientId: selection.clientId,
+        projectId: selection.projectId,
+        taskName: selection.taskName,
+        location: selection.location,
+        baseDays: formRowBaseDays,
+      });
+    }
+
+    for (const row of entryRows) {
+      submitRow(row.key, {
+        clientId: row.clientId,
+        projectId: row.projectId,
+        taskName: row.taskName,
+        location: row.location,
+        baseDays: row.baseDays,
+      });
+    }
+
+    try {
+      if (entriesToAdd.length > 0) {
+        await onAddBulkEntries(entriesToAdd);
+      }
+      setPendingEdits({});
+      setWeekNote('');
+      setShowSuccess(true);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!showSuccess) return;
+    const timer = setTimeout(() => setShowSuccess(false), 2500);
+    return () => clearTimeout(timer);
+  }, [showSuccess]);
 
   const dayTotals = useMemo(() => {
     const totals: Record<string, number> = {};
     for (const day of weekDays) {
       let sum = 0;
-      for (const row of entryRows) sum += row.days[day.dateStr] ?? 0;
+      const formEdit = pendingEdits[FORM_ROW_KEY]?.[day.dateStr];
+      if (formEdit) {
+        sum += parseDuration(formEdit.duration);
+      } else {
+        const formBase = formRowBaseDays[day.dateStr];
+        if (formBase) sum += parseDuration(formBase.duration);
+      }
+      for (const row of entryRows) {
+        const edit = pendingEdits[row.key]?.[day.dateStr];
+        if (edit) {
+          sum += parseDuration(edit.duration);
+        } else {
+          const base = row.baseDays[day.dateStr];
+          if (base) sum += parseDuration(base.duration);
+        }
+      }
       totals[day.dateStr] = sum;
     }
     return totals;
-  }, [weekDays, entryRows]);
+  }, [weekDays, entryRows, pendingEdits, formRowBaseDays]);
 
   const weekTotal = useMemo(() => Object.values(dayTotals).reduce((a, b) => a + b, 0), [dayTotals]);
 
@@ -161,161 +467,303 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
       .reduce((sum, e) => sum + e.duration, 0);
   }, [userEntries, currentWeekStart]);
 
-  // Use `dailyGoal * 5` as the typical full-week target so the week-total stat
-  // can flip red once it's exceeded.
+  const formLabel = useMemo(() => {
+    const client = clients.find((c) => c.id === selection.clientId);
+    const project = projects.find((p) => p.id === selection.projectId);
+    const parts = [client?.name, project?.name, selection.taskName].filter((p) => Boolean(p));
+    return parts.length > 0 ? parts.join(' · ') : t('weekly.newEntry');
+  }, [clients, projects, selection.clientId, selection.projectId, selection.taskName, t]);
+
+  const hasPendingEdits = Object.values(pendingEdits).some((row) => Object.keys(row).length > 0);
   const weeklyGoal = dailyGoal * 5;
 
   return (
-    <div className="rounded-lg border border-border bg-background shadow-sm p-5">
-      <div className="flex flex-wrap items-baseline gap-x-6 gap-y-1 mb-4">
-        <div className="flex items-baseline gap-2">
-          <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
-            {t('weekly.weekTotal')}
-          </span>
-          <span
+    <div className="w-full xl:w-[calc(45%+300px+1.5rem)] xl:mx-auto space-y-6">
+      <div className="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_300px] gap-6 items-start xl:items-stretch">
+        <WeeklyEntryForm
+          selectedDate={selectedDate}
+          selection={selection}
+          weekNote={weekNote}
+          errors={errors}
+          onWeekNoteChange={setWeekNote}
+          onClearError={clearError}
+          clients={clients}
+          projects={projects}
+          permissions={permissions}
+          currency={currency}
+          onAddCustomTask={onAddCustomTask}
+          defaultLocation={defaultLocation}
+        />
+
+        <div className="w-full xl:max-w-[300px] xl:h-full flex flex-col gap-3">
+          <Calendar
+            selectedDate={selectedDate}
+            onDateSelect={onSelectedDateChange}
+            entries={userEntries}
+            startOfWeek={startOfWeek}
+            treatSaturdayAsHoliday={treatSaturdayAsHoliday}
+            dailyGoal={dailyGoal}
+            allowWeekendSelection={allowWeekendSelection}
+            size="compact"
+          />
+          <Button
+            type="button"
+            onClick={handleSubmit}
+            disabled={isLoading || !hasPendingEdits}
             className={cn(
-              'text-lg font-black transition-colors',
-              weekTotal > weeklyGoal ? 'text-destructive' : 'text-praetor',
+              'w-full h-11 rounded-xl font-bold text-sm uppercase tracking-widest',
+              showSuccess && 'bg-emerald-600 hover:bg-emerald-600',
             )}
           >
-            {weekTotal.toFixed(2)} h
-          </span>
-        </div>
-        <div className="flex items-baseline gap-2">
-          <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
-            {t('weekly.monthTotal')}
-          </span>
-          <span className="text-lg font-black text-foreground">{monthTotal.toFixed(2)} h</span>
+            {showSuccess ? t('weekly.success') : t('weekly.submitTime')}
+          </Button>
         </div>
       </div>
 
-      <div className="-mx-5 overflow-x-auto">
-        <Table className="min-w-max border-collapse">
-          <TableHeader className="bg-muted/40">
-            <TableRow className="border-b border-border">
-              <TableHead className="px-4 py-3 text-[10px] font-bold text-muted-foreground uppercase tracking-tighter min-w-56">
-                {t('weekly.task')}
-              </TableHead>
-              {weekDays.map((day) => (
-                <TableHead
-                  key={day.dateStr}
-                  className={cn(
-                    'w-28 px-2 py-2 text-center relative align-middle',
-                    day.isToday && 'bg-accent',
-                    day.isWeekendOrHoliday && 'bg-destructive/5',
-                  )}
-                >
-                  <div
-                    className={cn(
-                      'flex items-center justify-center gap-1 text-[10px] font-black uppercase',
-                      day.isToday
-                        ? 'text-praetor'
-                        : day.isWeekendOrHoliday
-                          ? 'text-destructive'
-                          : 'text-muted-foreground',
-                    )}
-                  >
-                    {t(`weekly.days.${day.dayKey}`)}
-                    {day.holidayName && (
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <span className="inline-flex">
-                            <span className="size-1.5 bg-destructive rounded-full animate-pulse block"></span>
-                          </span>
-                        </TooltipTrigger>
-                        <TooltipContent>{day.holidayName}</TooltipContent>
-                      </Tooltip>
-                    )}
-                  </div>
-                  <p
-                    className={cn(
-                      'text-sm font-black leading-none mt-0.5',
-                      day.isToday
-                        ? 'text-praetor'
-                        : day.isWeekendOrHoliday
-                          ? 'text-destructive'
-                          : 'text-foreground',
-                    )}
-                  >
-                    {day.dayNum}
-                  </p>
+      <div className="rounded-lg border border-border bg-background shadow-sm p-5">
+        <div className="flex flex-wrap items-baseline gap-x-6 gap-y-1 mb-4">
+          <div className="flex items-baseline gap-2">
+            <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
+              {t('weekly.weekTotal')}
+            </span>
+            <span
+              className={cn(
+                'text-lg font-black transition-colors',
+                weekTotal > weeklyGoal ? 'text-destructive' : 'text-praetor',
+              )}
+            >
+              {weekTotal.toFixed(2)} h
+            </span>
+          </div>
+          <div className="flex items-baseline gap-2">
+            <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
+              {t('weekly.monthTotal')}
+            </span>
+            <span className="text-lg font-black text-foreground">{monthTotal.toFixed(2)} h</span>
+          </div>
+        </div>
+
+        <div className="-mx-5 overflow-x-auto">
+          <Table className="min-w-max border-collapse">
+            <TableHeader className="bg-muted/40">
+              <TableRow className="border-b border-border">
+                <TableHead className="px-4 py-3 text-[10px] font-bold text-muted-foreground uppercase tracking-tighter min-w-56">
+                  {t('weekly.task')}
                 </TableHead>
-              ))}
-            </TableRow>
-          </TableHeader>
-          <TableBody className="divide-y divide-border">
-            {entryRows.length === 0 ? (
-              <TableRow>
-                <TableCell
-                  colSpan={1 + weekDays.length}
-                  className="px-4 py-10 text-center text-xs text-muted-foreground"
-                >
-                  {t('weekly.noRecentTasks')}
-                </TableCell>
-              </TableRow>
-            ) : (
-              entryRows.map((row) => (
-                <TableRow key={row.key} className="hover:bg-muted/30">
-                  <TableCell className="px-4 py-3 align-middle whitespace-normal">
-                    <p
-                      className="text-xs font-semibold text-foreground line-clamp-2"
-                      title={row.label}
+                {weekDays.map((day) => (
+                  <TableHead
+                    key={day.dateStr}
+                    className={cn(
+                      'w-28 px-2 py-2 text-center relative align-middle',
+                      day.isToday && 'bg-accent',
+                      day.isWeekendOrHoliday && 'bg-destructive/5',
+                    )}
+                  >
+                    <div
+                      className={cn(
+                        'flex items-center justify-center gap-1 text-[10px] font-black uppercase',
+                        day.isToday
+                          ? 'text-praetor'
+                          : day.isWeekendOrHoliday
+                            ? 'text-destructive'
+                            : 'text-muted-foreground',
+                      )}
                     >
-                      {row.label}
+                      {t(`weekly.days.${day.dayKey}`)}
+                      {day.holidayName && (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <span className="inline-flex">
+                              <span className="size-1.5 bg-destructive rounded-full animate-pulse block"></span>
+                            </span>
+                          </TooltipTrigger>
+                          <TooltipContent>{day.holidayName}</TooltipContent>
+                        </Tooltip>
+                      )}
+                    </div>
+                    <p
+                      className={cn(
+                        'text-sm font-black leading-none mt-0.5',
+                        day.isToday
+                          ? 'text-praetor'
+                          : day.isWeekendOrHoliday
+                            ? 'text-destructive'
+                            : 'text-foreground',
+                      )}
+                    >
+                      {day.dayNum}
+                    </p>
+                  </TableHead>
+                ))}
+              </TableRow>
+            </TableHeader>
+            <TableBody className="divide-y divide-border">
+              <TableRow className="bg-praetor/5 hover:bg-praetor/10">
+                <TableCell className="px-4 py-3 align-top whitespace-normal">
+                  <p className="text-[10px] font-bold text-praetor uppercase tracking-wider mb-1">
+                    {t('weekly.newEntry')}
+                  </p>
+                  <p className="text-xs text-muted-foreground line-clamp-2">{formLabel}</p>
+                </TableCell>
+                {weekDays.map((day) => {
+                  const cell = getCellValue(FORM_ROW_KEY, day.dateStr, formRowBaseDays);
+                  return (
+                    <TableCell
+                      key={day.dateStr}
+                      className={cn(
+                        'w-28 px-2 py-3 align-top',
+                        day.isToday && 'bg-accent/60',
+                        day.isWeekendOrHoliday && 'bg-destructive/5',
+                      )}
+                    >
+                      <div className="flex flex-col gap-2">
+                        <ValidatedNumberInput
+                          placeholder="0.0"
+                          disabled={day.isForbidden}
+                          value={cell.duration}
+                          onValueChange={(value) =>
+                            updateCell(
+                              FORM_ROW_KEY,
+                              day.dateStr,
+                              { duration: value },
+                              formRowBaseDays[day.dateStr],
+                            )
+                          }
+                          className={cn(
+                            'h-9 w-full text-center text-sm font-bold',
+                            day.isForbidden && 'opacity-50 cursor-not-allowed',
+                          )}
+                        />
+                        <Input
+                          type="text"
+                          placeholder={t('weekly.note')}
+                          disabled={day.isForbidden}
+                          value={cell.note}
+                          onChange={(e) =>
+                            updateCell(
+                              FORM_ROW_KEY,
+                              day.dateStr,
+                              { note: e.target.value },
+                              formRowBaseDays[day.dateStr],
+                            )
+                          }
+                          className={cn(
+                            'h-7 text-xs rounded',
+                            day.isForbidden && 'opacity-40 cursor-not-allowed',
+                          )}
+                        />
+                      </div>
+                    </TableCell>
+                  );
+                })}
+              </TableRow>
+              {entryRows.length === 0 ? (
+                <TableRow>
+                  <TableCell
+                    colSpan={1 + weekDays.length}
+                    className="px-4 py-6 text-center text-xs text-muted-foreground"
+                  >
+                    {t('weekly.noRecentTasks')}
+                  </TableCell>
+                </TableRow>
+              ) : (
+                entryRows.map((row) => (
+                  <TableRow key={row.key} className="hover:bg-muted/30">
+                    <TableCell className="px-4 py-3 align-top whitespace-normal">
+                      <p className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider mb-1">
+                        {t('weekly.recentTask')}
+                      </p>
+                      <p
+                        className="text-xs font-semibold text-foreground line-clamp-2"
+                        title={row.label}
+                      >
+                        {row.label}
+                      </p>
+                    </TableCell>
+                    {weekDays.map((day) => {
+                      const cell = getCellValue(row.key, day.dateStr, row.baseDays);
+                      return (
+                        <TableCell
+                          key={day.dateStr}
+                          className={cn(
+                            'w-28 px-2 py-3 align-top',
+                            day.isToday && 'bg-accent/60',
+                            day.isWeekendOrHoliday && 'bg-destructive/5',
+                            showSuccess && parseDuration(cell.duration) > 0 && 'bg-emerald-500/10',
+                          )}
+                        >
+                          <div className="flex flex-col gap-2">
+                            <ValidatedNumberInput
+                              placeholder="0.0"
+                              disabled={day.isForbidden}
+                              value={cell.duration}
+                              onValueChange={(value) =>
+                                updateCell(
+                                  row.key,
+                                  day.dateStr,
+                                  { duration: value },
+                                  row.baseDays[day.dateStr],
+                                )
+                              }
+                              className={cn(
+                                'h-9 w-full text-center text-sm font-bold',
+                                day.isForbidden && 'opacity-50 cursor-not-allowed',
+                              )}
+                            />
+                            <Input
+                              type="text"
+                              placeholder={t('weekly.note')}
+                              disabled={day.isForbidden}
+                              value={cell.note}
+                              onChange={(e) =>
+                                updateCell(
+                                  row.key,
+                                  day.dateStr,
+                                  { note: e.target.value },
+                                  row.baseDays[day.dateStr],
+                                )
+                              }
+                              className={cn(
+                                'h-7 text-xs rounded',
+                                day.isForbidden && 'opacity-40 cursor-not-allowed',
+                              )}
+                            />
+                          </div>
+                        </TableCell>
+                      );
+                    })}
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+            <TableFooter className="bg-muted/30">
+              <TableRow className="border-t border-border">
+                <TableCell className="px-4 py-3 text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
+                  {t('weekly.total')}
+                </TableCell>
+                {weekDays.map((day) => (
+                  <TableCell
+                    key={day.dateStr}
+                    className={cn(
+                      'w-28 px-2 py-3 text-center',
+                      day.isToday && 'bg-accent',
+                      day.isWeekendOrHoliday && 'bg-destructive/5',
+                    )}
+                  >
+                    <p
+                      className={cn(
+                        'text-sm font-black',
+                        dayTotals[day.dateStr] > dailyGoal ? 'text-destructive' : 'text-praetor',
+                      )}
+                    >
+                      {dayTotals[day.dateStr].toFixed(1)}
                     </p>
                   </TableCell>
-                  {weekDays.map((day) => {
-                    const hours = row.days[day.dateStr];
-                    return (
-                      <TableCell
-                        key={day.dateStr}
-                        className={cn(
-                          'w-28 px-2 py-3 text-center align-middle',
-                          day.isToday && 'bg-accent/60',
-                          day.isWeekendOrHoliday && 'bg-destructive/5',
-                        )}
-                      >
-                        {hours ? (
-                          <span className="text-sm font-bold text-foreground">
-                            {hours.toFixed(2)}
-                          </span>
-                        ) : (
-                          <span className="text-xs text-muted-foreground/50">—</span>
-                        )}
-                      </TableCell>
-                    );
-                  })}
-                </TableRow>
-              ))
-            )}
-          </TableBody>
-          <TableFooter className="bg-muted/30">
-            <TableRow className="border-t border-border">
-              <TableCell className="px-4 py-3 text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
-                {t('weekly.total')}
-              </TableCell>
-              {weekDays.map((day) => (
-                <TableCell
-                  key={day.dateStr}
-                  className={cn(
-                    'w-28 px-2 py-3 text-center',
-                    day.isToday && 'bg-accent',
-                    day.isWeekendOrHoliday && 'bg-destructive/5',
-                  )}
-                >
-                  <p
-                    className={cn(
-                      'text-sm font-black',
-                      dayTotals[day.dateStr] > dailyGoal ? 'text-destructive' : 'text-praetor',
-                    )}
-                  >
-                    {dayTotals[day.dateStr].toFixed(1)}
-                  </p>
-                </TableCell>
-              ))}
-            </TableRow>
-          </TableFooter>
-        </Table>
+                ))}
+              </TableRow>
+            </TableFooter>
+          </Table>
+        </div>
       </div>
     </div>
   );

--- a/components/timesheet/WeeklyView.tsx
+++ b/components/timesheet/WeeklyView.tsx
@@ -358,9 +358,12 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
         const noteChanged = (edit.note ?? '') !== (base?.note ?? '');
         if (base?.entryId) {
           if (newDuration > 0 && (newDuration !== baseDuration || noteChanged)) {
+            // Use `edit.note` directly (not `|| base.note`) so a user can
+            // intentionally clear a previously-set note. `noteChanged` already
+            // gated us on a real change, including '' → 'x' and 'x' → ''.
             onUpdateEntry(base.entryId, {
               duration: newDuration,
-              notes: edit.note || weekNote || base.note,
+              notes: edit.note,
               task: meta.taskName,
               projectId: meta.projectId,
               clientId: meta.clientId,

--- a/components/timesheet/WeeklyView.tsx
+++ b/components/timesheet/WeeklyView.tsx
@@ -252,15 +252,16 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
   ]);
 
   // When the set of recent rows changes (e.g. user switches), drop stale edits
-  // that no longer match an existing row.
-  const recentRowKeysSignature = recentRows.map((r) => r.key).join('|');
+  // that no longer match an existing row. Each row's key is itself a
+  // `|`-joined composite, so a join+split would lose key boundaries — use the
+  // raw Set directly.
+  const recentRowKeySet = useMemo(() => new Set(recentRows.map((r) => r.key)), [recentRows]);
   useEffect(() => {
-    const validKeys = new Set([FORM_ROW_KEY, ...recentRowKeysSignature.split('|')]);
     setPendingEdits((prev) => {
       let changed = false;
       const next: Record<string, DayMap> = {};
       for (const [key, value] of Object.entries(prev)) {
-        if (validKeys.has(key)) {
+        if (key === FORM_ROW_KEY || recentRowKeySet.has(key)) {
           next[key] = value;
         } else {
           changed = true;
@@ -268,7 +269,7 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
       }
       return changed ? next : prev;
     });
-  }, [recentRowKeysSignature]);
+  }, [recentRowKeySet]);
 
   const getCellValue = (rowKey: string, dateStr: string, baseDays?: DayMap): DayCell => {
     const edit = pendingEdits[rowKey]?.[dateStr];

--- a/components/timesheet/WeeklyView.tsx
+++ b/components/timesheet/WeeklyView.tsx
@@ -1,8 +1,6 @@
 import type React from 'react';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Button } from '@/components/ui/button';
-import { Card } from '@/components/ui/card';
 import {
   Table,
   TableBody,
@@ -25,7 +23,6 @@ export interface WeeklyViewProps {
   projectTasks: ProjectTask[];
   viewingUserId: string;
   selectedDate: string;
-  onSelectedDateChange: (date: string) => void;
   startOfWeek: 'Monday' | 'Sunday';
   treatSaturdayAsHoliday: boolean;
   allowWeekendSelection?: boolean;
@@ -63,13 +60,12 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
   projectTasks,
   viewingUserId,
   selectedDate,
-  onSelectedDateChange,
   startOfWeek,
   treatSaturdayAsHoliday,
   allowWeekendSelection = false,
   dailyGoal,
 }) => {
-  const { t, i18n } = useTranslation('timesheets');
+  const { t } = useTranslation('timesheets');
 
   const currentWeekStart = useMemo(
     () => getWeekStart(dateOnlyToLocalDate(selectedDate), startOfWeek),
@@ -165,88 +161,35 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
       .reduce((sum, e) => sum + e.duration, 0);
   }, [userEntries, currentWeekStart]);
 
-  const weekRangeLabel = useMemo(() => {
-    const end = new Date(currentWeekStart);
-    end.setDate(end.getDate() + 6);
-    return `${currentWeekStart.toLocaleDateString(i18n.language, {
-      month: 'short',
-      day: 'numeric',
-    })} – ${end.toLocaleDateString(i18n.language, {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-    })}`;
-  }, [currentWeekStart, i18n.language]);
-
   // Use `dailyGoal * 5` as the typical full-week target so the week-total stat
   // can flip red once it's exceeded.
   const weeklyGoal = dailyGoal * 5;
 
-  const shiftSelectedDate = (offsetDays: number) => {
-    const d = dateOnlyToLocalDate(selectedDate);
-    d.setDate(d.getDate() + offsetDays);
-    onSelectedDateChange(getLocalDateString(d));
-  };
-
   return (
-    <Card className="px-0 py-0 overflow-hidden">
-      <div className="flex flex-col gap-2 px-4 pt-4 sm:flex-row sm:items-start sm:justify-between">
-        <div className="flex flex-wrap items-baseline gap-x-6 gap-y-1">
-          <div className="flex items-baseline gap-2">
-            <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
-              {t('weekly.weekTotal')}
-            </span>
-            <span
-              className={cn(
-                'text-lg font-black transition-colors',
-                weekTotal > weeklyGoal ? 'text-destructive' : 'text-praetor',
-              )}
-            >
-              {weekTotal.toFixed(2)} h
-            </span>
-          </div>
-          <div className="flex items-baseline gap-2">
-            <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
-              {t('weekly.monthTotal')}
-            </span>
-            <span className="text-lg font-black text-foreground">{monthTotal.toFixed(2)} h</span>
-          </div>
-        </div>
-
-        <div className="flex items-center gap-2 self-end sm:self-auto">
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            onClick={() => shiftSelectedDate(-7)}
-            aria-label={t('weekly.weekView')}
-          >
-            <i className="fa-solid fa-chevron-left"></i>
-          </Button>
-          <span className="text-xs font-semibold text-foreground uppercase tracking-wide whitespace-nowrap">
-            {weekRangeLabel}
+    <div className="rounded-lg border border-border bg-background shadow-sm p-5">
+      <div className="flex flex-wrap items-baseline gap-x-6 gap-y-1 mb-4">
+        <div className="flex items-baseline gap-2">
+          <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
+            {t('weekly.weekTotal')}
           </span>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            onClick={() => shiftSelectedDate(7)}
-            aria-label={t('weekly.weekView')}
+          <span
+            className={cn(
+              'text-lg font-black transition-colors',
+              weekTotal > weeklyGoal ? 'text-destructive' : 'text-praetor',
+            )}
           >
-            <i className="fa-solid fa-chevron-right"></i>
-          </Button>
-          <Button
-            type="button"
-            size="xs"
-            onClick={() => onSelectedDateChange(getLocalDateString(new Date()))}
-            className="rounded-full text-[10px] font-bold uppercase tracking-widest"
-          >
-            {t('weekly.goToToday')}
-          </Button>
+            {weekTotal.toFixed(2)} h
+          </span>
+        </div>
+        <div className="flex items-baseline gap-2">
+          <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
+            {t('weekly.monthTotal')}
+          </span>
+          <span className="text-lg font-black text-foreground">{monthTotal.toFixed(2)} h</span>
         </div>
       </div>
 
-      <div className="overflow-x-auto">
+      <div className="-mx-5 overflow-x-auto">
         <Table className="min-w-max border-collapse">
           <TableHeader className="bg-muted/40">
             <TableRow className="border-b border-border">
@@ -374,7 +317,7 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
           </TableFooter>
         </Table>
       </div>
-    </Card>
+    </div>
   );
 };
 

--- a/components/timesheet/WeeklyView.tsx
+++ b/components/timesheet/WeeklyView.tsx
@@ -1,6 +1,8 @@
+import { Eye, EyeOff } from 'lucide-react';
 import type React from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import {
   Table,
@@ -14,9 +16,11 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 import type { Client, Project, ProjectTask, TimeEntry, TimeEntryLocation } from '../../types';
+import { downloadCsv } from '../../utils/csv';
 import { getLocalDateString } from '../../utils/date';
 import { isItalianHoliday } from '../../utils/holidays';
 import Calendar from '../shared/Calendar';
+import { TABLE_CONTROL_BUTTON_CLASSNAME } from '../shared/tableControlStyles';
 import ValidatedNumberInput from '../shared/ValidatedNumberInput';
 import { useCatalogSelection } from './useCatalogSelection';
 import WeeklyEntryForm, { type WeeklyEntryFormErrors } from './WeeklyEntryForm';
@@ -157,6 +161,19 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
   const [isLoading, setIsLoading] = useState(false);
   const [showSuccess, setShowSuccess] = useState(false);
   const [weekNote, setWeekNote] = useState('');
+  const [hideWeekend, setHideWeekend] = useState(false);
+
+  // Saturday and Sunday columns are hidden when `hideWeekend` is on so the
+  // weekday columns can claim the freed width. State + submit still operate
+  // on all seven days — hiding is purely a display concern, so a user who
+  // had weekend hours pending won't lose them by toggling visibility.
+  const visibleWeekDays = useMemo(
+    () =>
+      hideWeekend
+        ? weekDays.filter((day) => day.dayKey !== 'sat' && day.dayKey !== 'sun')
+        : weekDays,
+    [weekDays, hideWeekend],
+  );
 
   // Per-row, per-day edits the user has made since the last sync from props.
   const [pendingEdits, setPendingEdits] = useState<Record<string, DayMap>>({});
@@ -476,6 +493,45 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
   const hasPendingEdits = Object.values(pendingEdits).some((row) => Object.keys(row).length > 0);
   const weeklyGoal = dailyGoal * 5;
 
+  const handleExportToCsv = () => {
+    const formatHours = (hours: number) => (hours > 0 ? hours.toFixed(2) : '');
+    const sumDayValues = (values: string[]) =>
+      values.reduce((sum, v) => sum + (parseFloat(v) || 0), 0);
+
+    const headerRow = [
+      '',
+      ...visibleWeekDays.map((day) => `${t(`weekly.days.${day.dayKey}`)} ${day.dayNum}`),
+      t('weekly.total'),
+    ];
+    const rows: string[][] = [headerRow];
+
+    const formRowValues = visibleWeekDays.map((day) => {
+      const cell = getCellValue(FORM_ROW_KEY, day.dateStr, formRowBaseDays);
+      return formatHours(parseDuration(cell.duration));
+    });
+    const formRowTotal = sumDayValues(formRowValues);
+    if (formRowTotal > 0) {
+      rows.push([formLabel, ...formRowValues, formatHours(formRowTotal)]);
+    }
+
+    for (const row of entryRows) {
+      const dayValues = visibleWeekDays.map((day) => {
+        const cell = getCellValue(row.key, day.dateStr, row.baseDays);
+        return formatHours(parseDuration(cell.duration));
+      });
+      const rowTotal = sumDayValues(dayValues);
+      rows.push([row.label, ...dayValues, formatHours(rowTotal)]);
+    }
+
+    rows.push([
+      t('weekly.total'),
+      ...visibleWeekDays.map((day) => formatHours(dayTotals[day.dateStr] ?? 0)),
+      formatHours(weekTotal),
+    ]);
+
+    downloadCsv(rows, `weekly_timesheet_${getLocalDateString(currentWeekStart)}.csv`);
+  };
+
   return (
     <div className="w-full xl:w-[calc(45%+300px+1.5rem)] xl:mx-auto space-y-6">
       <div className="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_300px] gap-6 items-start xl:items-stretch">
@@ -513,25 +569,71 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
       </div>
 
       <div className="rounded-lg border border-border bg-background shadow-sm p-5">
-        <div className="flex flex-wrap items-baseline gap-x-6 gap-y-1 mb-4">
-          <div className="flex items-baseline gap-2">
-            <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
-              {t('weekly.weekTotal')}
-            </span>
-            <span
-              className={cn(
-                'text-lg font-black transition-colors',
-                weekTotal > weeklyGoal ? 'text-destructive' : 'text-praetor',
-              )}
-            >
-              {weekTotal.toFixed(2)} h
-            </span>
+        <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-2 mb-4">
+          <div className="flex flex-wrap items-baseline gap-x-6 gap-y-1">
+            <div className="flex items-baseline gap-2">
+              <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
+                {t('weekly.weekTotal')}
+              </span>
+              <span
+                className={cn(
+                  'text-lg font-black transition-colors',
+                  weekTotal > weeklyGoal ? 'text-destructive' : 'text-praetor',
+                )}
+              >
+                {weekTotal.toFixed(2)} h
+              </span>
+            </div>
+            <div className="flex items-baseline gap-2">
+              <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
+                {t('weekly.monthTotal')}
+              </span>
+              <span className="text-lg font-black text-foreground">{monthTotal.toFixed(2)} h</span>
+            </div>
           </div>
-          <div className="flex items-baseline gap-2">
-            <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
-              {t('weekly.monthTotal')}
-            </span>
-            <span className="text-lg font-black text-foreground">{monthTotal.toFixed(2)} h</span>
+
+          <div className="flex items-center gap-2">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="inline-flex">
+                  <Button
+                    type="button"
+                    variant={hideWeekend ? 'secondary' : 'outline'}
+                    size="sm"
+                    aria-label={t('weekly.hideWeekend')}
+                    aria-pressed={hideWeekend}
+                    onClick={() => setHideWeekend((v) => !v)}
+                    className={TABLE_CONTROL_BUTTON_CLASSNAME}
+                  >
+                    {hideWeekend ? (
+                      <EyeOff className="size-3.5" aria-hidden="true" />
+                    ) : (
+                      <Eye className="size-3.5" aria-hidden="true" />
+                    )}
+                  </Button>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">{t('weekly.hideWeekend')}</TooltipContent>
+            </Tooltip>
+
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="inline-flex">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    aria-label={t('common:table.exportToCsv')}
+                    onClick={handleExportToCsv}
+                    className={TABLE_CONTROL_BUTTON_CLASSNAME}
+                  >
+                    <i className="fa-solid fa-file-export text-xs" aria-hidden="true"></i>
+                    <span>{t('common:table.export')}</span>
+                  </Button>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">{t('common:table.exportToCsv')}</TooltipContent>
+            </Tooltip>
           </div>
         </div>
 
@@ -541,7 +643,7 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
               <TableRow className="border-b border-border">
                 <TableHead className="px-4 py-3 min-w-56" />
 
-                {weekDays.map((day) => (
+                {visibleWeekDays.map((day) => (
                   <TableHead
                     key={day.dateStr}
                     className={cn(
@@ -596,7 +698,7 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
                   </p>
                   <p className="text-xs text-muted-foreground line-clamp-2">{formLabel}</p>
                 </TableCell>
-                {weekDays.map((day) => {
+                {visibleWeekDays.map((day) => {
                   const cell = getCellValue(FORM_ROW_KEY, day.dateStr, formRowBaseDays);
                   return (
                     <TableCell
@@ -653,7 +755,7 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
               {entryRows.length === 0 ? (
                 <TableRow>
                   <TableCell
-                    colSpan={1 + weekDays.length}
+                    colSpan={1 + visibleWeekDays.length}
                     className="px-4 py-6 text-center text-xs text-muted-foreground"
                   >
                     {t('weekly.noRecentTasks')}
@@ -670,7 +772,7 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
                         {row.label}
                       </p>
                     </TableCell>
-                    {weekDays.map((day) => {
+                    {visibleWeekDays.map((day) => {
                       const cell = getCellValue(row.key, day.dateStr, row.baseDays);
                       return (
                         <TableCell
@@ -731,7 +833,7 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
                 <TableCell className="px-4 py-3 text-[10px] font-bold text-muted-foreground uppercase tracking-wider">
                   {t('weekly.total')}
                 </TableCell>
-                {weekDays.map((day) => (
+                {visibleWeekDays.map((day) => (
                   <TableCell
                     key={day.dateStr}
                     className={cn(

--- a/components/timesheet/WeeklyView.tsx
+++ b/components/timesheet/WeeklyView.tsx
@@ -408,14 +408,19 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
       });
     }
 
-    if (entriesToAdd.length > 0) {
-      await onAddBulkEntries(entriesToAdd);
+    try {
+      if (entriesToAdd.length > 0) {
+        await onAddBulkEntries(entriesToAdd);
+      }
+      // Only clear edits + flash success when the bulk-add resolves cleanly
+      // — on failure the user's in-flight values must survive so they can
+      // retry. The parent surfaces the error via App.tsx's global handler.
+      setPendingEdits({});
+      setWeekNote('');
+      setShowSuccess(true);
+    } finally {
+      setIsLoading(false);
     }
-
-    setPendingEdits({});
-    setWeekNote('');
-    setIsLoading(false);
-    setShowSuccess(true);
   };
 
   useEffect(() => {

--- a/components/timesheet/WeeklyView.tsx
+++ b/components/timesheet/WeeklyView.tsx
@@ -1,7 +1,6 @@
 import type React from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import {
   Table,
@@ -493,9 +492,13 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
           currency={currency}
           onAddCustomTask={onAddCustomTask}
           defaultLocation={defaultLocation}
+          onSubmit={handleSubmit}
+          isSubmitting={isLoading}
+          showSubmitSuccess={showSuccess}
+          canSubmit={hasPendingEdits}
         />
 
-        <div className="w-full xl:max-w-[300px] xl:h-full flex flex-col gap-3">
+        <div className="w-full xl:max-w-[300px] xl:h-full">
           <Calendar
             selectedDate={selectedDate}
             onDateSelect={onSelectedDateChange}
@@ -506,17 +509,6 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
             allowWeekendSelection={allowWeekendSelection}
             size="compact"
           />
-          <Button
-            type="button"
-            onClick={handleSubmit}
-            disabled={isLoading || !hasPendingEdits}
-            className={cn(
-              'w-full h-11 rounded-xl font-bold text-sm uppercase tracking-widest',
-              showSuccess && 'bg-emerald-600 hover:bg-emerald-600',
-            )}
-          >
-            {showSuccess ? t('weekly.success') : t('weekly.submitTime')}
-          </Button>
         </div>
       </div>
 

--- a/components/timesheet/WeeklyView.tsx
+++ b/components/timesheet/WeeklyView.tsx
@@ -589,7 +589,7 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
                 ))}
               </TableRow>
             </TableHeader>
-            <TableBody className="divide-y divide-border">
+            <TableBody>
               <TableRow className="bg-praetor/5 hover:bg-praetor/10">
                 <TableCell className="px-4 py-3 align-top whitespace-normal">
                   <p className="text-[10px] font-bold text-praetor uppercase tracking-wider mb-1">
@@ -649,6 +649,17 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
                   );
                 })}
               </TableRow>
+            </TableBody>
+            <TableBody className="divide-y divide-border">
+              {/* Recent tasks section header */}
+              <TableRow className="bg-muted/30 hover:bg-muted/30 border-t-[3px] border-t-border">
+                <TableCell
+                  colSpan={1 + weekDays.length}
+                  className="px-4 py-2 text-[10px] font-bold text-muted-foreground uppercase tracking-wider"
+                >
+                  {t('weekly.recentTasks')}
+                </TableCell>
+              </TableRow>
               {entryRows.length === 0 ? (
                 <TableRow>
                   <TableCell
@@ -661,10 +672,7 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
               ) : (
                 entryRows.map((row) => (
                   <TableRow key={row.key} className="hover:bg-muted/30">
-                    <TableCell className="px-4 py-3 align-top whitespace-normal">
-                      <p className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider mb-1">
-                        {t('weekly.recentTask')}
-                      </p>
+                    <TableCell className="px-4 py-3 align-middle whitespace-normal">
                       <p
                         className="text-xs font-semibold text-foreground line-clamp-2"
                         title={row.label}

--- a/components/timesheet/useCatalogSelection.ts
+++ b/components/timesheet/useCatalogSelection.ts
@@ -1,0 +1,134 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { Client, Project, ProjectTask, TimeEntryLocation } from '../../types';
+
+export const CUSTOM_TASK_SENTINEL = 'custom';
+
+export interface UseCatalogSelectionOptions {
+  clients: Client[];
+  projects: Project[];
+  projectTasks: ProjectTask[];
+  defaultLocation?: TimeEntryLocation;
+}
+
+export interface UseCatalogSelectionResult {
+  clientId: string;
+  projectId: string;
+  taskId: string;
+  taskName: string;
+  location: TimeEntryLocation;
+  filteredProjects: Project[];
+  filteredTasks: ProjectTask[];
+  setClient: (id: string) => void;
+  setProject: (id: string) => void;
+  setTask: (taskId: string, taskName?: string) => void;
+  setLocation: (location: TimeEntryLocation) => void;
+  resetLocation: () => void;
+}
+
+export function useCatalogSelection({
+  clients,
+  projects,
+  projectTasks,
+  defaultLocation = 'remote',
+}: UseCatalogSelectionOptions): UseCatalogSelectionResult {
+  const [clientId, setClientId] = useState(clients[0]?.id ?? '');
+  const [projectId, setProjectId] = useState('');
+  const [taskId, setTaskId] = useState('');
+  const [taskName, setTaskName] = useState('');
+  const [location, setLocation] = useState<TimeEntryLocation>(defaultLocation);
+
+  useEffect(() => {
+    if (clients.length === 0) {
+      if (clientId !== '') setClientId('');
+      return;
+    }
+    if (!clients.some((client) => client.id === clientId)) {
+      setClientId(clients[0].id);
+    }
+  }, [clients, clientId]);
+
+  const filteredProjects = useMemo(
+    () => projects.filter((project) => project.clientId === clientId),
+    [projects, clientId],
+  );
+  const firstFilteredProjectId = filteredProjects[0]?.id ?? '';
+
+  const filteredTasks = useMemo(
+    () => projectTasks.filter((task) => task.projectId === projectId),
+    [projectTasks, projectId],
+  );
+  const firstFilteredTaskId = filteredTasks[0]?.id ?? '';
+  const firstFilteredTaskName = filteredTasks[0]?.name ?? '';
+
+  useEffect(() => {
+    if (filteredProjects.length === 0) {
+      if (projectId !== '') setProjectId('');
+      return;
+    }
+    if (!filteredProjects.some((project) => project.id === projectId)) {
+      setProjectId(firstFilteredProjectId);
+    }
+  }, [filteredProjects, firstFilteredProjectId, projectId]);
+
+  useEffect(() => {
+    if (filteredTasks.length === 0) {
+      setTaskId('');
+      setTaskName('');
+      return;
+    }
+
+    if (!filteredTasks.some((task) => task.id === taskId)) {
+      setTaskName(firstFilteredTaskName);
+      setTaskId(firstFilteredTaskId);
+    }
+  }, [filteredTasks, firstFilteredTaskId, firstFilteredTaskName, taskId]);
+
+  useEffect(() => {
+    if (clientId === '') {
+      setProjectId('');
+    }
+  }, [clientId]);
+
+  const setClient = (id: string) => {
+    setClientId(id);
+  };
+
+  const setProject = (id: string) => {
+    setProjectId(id);
+  };
+
+  // When `nextTaskName` is provided the assignment is direct — used after a
+  // task is freshly created via a modal flow where `filteredTasks` may not
+  // yet contain it. Otherwise the name is looked up from the scoped catalog.
+  const setTask = (nextTaskId: string, nextTaskName?: string) => {
+    if (nextTaskName !== undefined) {
+      setTaskId(nextTaskId);
+      setTaskName(nextTaskName);
+      return;
+    }
+    const task = filteredTasks.find((t) => t.id === nextTaskId);
+    if (task) {
+      setTaskName(task.name);
+      setTaskId(task.id);
+    }
+  };
+
+  const resetLocation = () => {
+    setLocation(defaultLocation);
+  };
+
+  return {
+    clientId,
+    projectId,
+    taskId,
+    taskName,
+    location,
+    filteredProjects,
+    filteredTasks,
+    setClient,
+    setProject,
+    setTask,
+    setLocation,
+    resetLocation,
+  };
+}

--- a/locales/en/timesheets.json
+++ b/locales/en/timesheets.json
@@ -138,9 +138,13 @@
     "deleteRow": "Delete row",
     "selectProject": "Select project...",
     "selectTask": "Select task...",
+    "newEntry": "New entry",
+    "recentTask": "Recent",
     "noRecentTasks": "No entries logged for this week yet.",
     "weekTotal": "Week total",
     "monthTotal": "Month total",
+    "weekNoteLabel": "Weekly Note",
+    "weekNotePlaceholder": "Note that applies to the whole week...",
     "days": {
       "mon": "Mon",
       "tue": "Tue",

--- a/locales/en/timesheets.json
+++ b/locales/en/timesheets.json
@@ -139,7 +139,7 @@
     "selectProject": "Select project...",
     "selectTask": "Select task...",
     "newEntry": "New entry",
-    "recentTask": "Recent",
+    "recentTasks": "Recent tasks",
     "noRecentTasks": "No entries logged for this week yet.",
     "weekTotal": "Week total",
     "monthTotal": "Month total",

--- a/locales/en/timesheets.json
+++ b/locales/en/timesheets.json
@@ -145,6 +145,7 @@
     "monthTotal": "Month total",
     "weekNoteLabel": "Weekly Note",
     "weekNotePlaceholder": "Note that applies to the whole week...",
+    "hideWeekend": "Hide weekend days",
     "days": {
       "mon": "Mon",
       "tue": "Tue",

--- a/locales/en/timesheets.json
+++ b/locales/en/timesheets.json
@@ -131,7 +131,7 @@
     "task": "Task",
     "total": "Total",
     "addRow": "Add Row",
-    "submitTime": "Submit time",
+    "submitTime": "Register Time",
     "success": "Success!",
     "note": "Note...",
     "weekNote": "Week note...",

--- a/locales/en/timesheets.json
+++ b/locales/en/timesheets.json
@@ -138,6 +138,11 @@
     "deleteRow": "Delete row",
     "selectProject": "Select project...",
     "selectTask": "Select task...",
+    "newEntry": "New entry",
+    "recentTask": "Recent",
+    "noRecentTasks": "No recent tasks yet — pick a client and project above to log time.",
+    "weekTotal": "Week total",
+    "monthTotal": "Month total",
     "days": {
       "mon": "Mon",
       "tue": "Tue",

--- a/locales/en/timesheets.json
+++ b/locales/en/timesheets.json
@@ -138,9 +138,7 @@
     "deleteRow": "Delete row",
     "selectProject": "Select project...",
     "selectTask": "Select task...",
-    "newEntry": "New entry",
-    "recentTask": "Recent",
-    "noRecentTasks": "No recent tasks yet — pick a client and project above to log time.",
+    "noRecentTasks": "No entries logged for this week yet.",
     "weekTotal": "Week total",
     "monthTotal": "Month total",
     "days": {

--- a/locales/en/timesheets.json
+++ b/locales/en/timesheets.json
@@ -131,7 +131,7 @@
     "task": "Task",
     "total": "Total",
     "addRow": "Add Row",
-    "submitTime": "Register Time",
+    "submitTime": "Submit time",
     "success": "Success!",
     "note": "Note...",
     "weekNote": "Week note...",

--- a/locales/it/timesheets.json
+++ b/locales/it/timesheets.json
@@ -138,9 +138,13 @@
     "deleteRow": "Elimina riga",
     "selectProject": "Seleziona progetto...",
     "selectTask": "Seleziona attività...",
+    "newEntry": "Nuova voce",
+    "recentTask": "Recente",
     "noRecentTasks": "Nessuna voce registrata per questa settimana.",
     "weekTotal": "Totale settimanale",
     "monthTotal": "Totale mensile",
+    "weekNoteLabel": "Nota settimanale",
+    "weekNotePlaceholder": "Nota che si applica a tutta la settimana...",
     "days": {
       "mon": "Lun",
       "tue": "Mar",

--- a/locales/it/timesheets.json
+++ b/locales/it/timesheets.json
@@ -139,7 +139,7 @@
     "selectProject": "Seleziona progetto...",
     "selectTask": "Seleziona attività...",
     "newEntry": "Nuova voce",
-    "recentTask": "Recente",
+    "recentTasks": "Attività recenti",
     "noRecentTasks": "Nessuna voce registrata per questa settimana.",
     "weekTotal": "Totale settimanale",
     "monthTotal": "Totale mensile",

--- a/locales/it/timesheets.json
+++ b/locales/it/timesheets.json
@@ -145,6 +145,7 @@
     "monthTotal": "Totale mensile",
     "weekNoteLabel": "Nota settimanale",
     "weekNotePlaceholder": "Nota che si applica a tutta la settimana...",
+    "hideWeekend": "Nascondi i giorni del weekend",
     "days": {
       "mon": "Lun",
       "tue": "Mar",

--- a/locales/it/timesheets.json
+++ b/locales/it/timesheets.json
@@ -131,7 +131,7 @@
     "task": "Attività",
     "total": "Totale",
     "addRow": "Aggiungi Riga",
-    "submitTime": "Registra Tempo",
+    "submitTime": "Invia tempo",
     "success": "Successo!",
     "note": "Nota...",
     "weekNote": "Nota settimanale...",

--- a/locales/it/timesheets.json
+++ b/locales/it/timesheets.json
@@ -138,6 +138,11 @@
     "deleteRow": "Elimina riga",
     "selectProject": "Seleziona progetto...",
     "selectTask": "Seleziona attività...",
+    "newEntry": "Nuova voce",
+    "recentTask": "Recente",
+    "noRecentTasks": "Nessuna attività recente — scegli cliente e progetto sopra per registrare ore.",
+    "weekTotal": "Totale settimanale",
+    "monthTotal": "Totale mensile",
     "days": {
       "mon": "Lun",
       "tue": "Mar",

--- a/locales/it/timesheets.json
+++ b/locales/it/timesheets.json
@@ -131,7 +131,7 @@
     "task": "Attività",
     "total": "Totale",
     "addRow": "Aggiungi Riga",
-    "submitTime": "Invia tempo",
+    "submitTime": "Registra Tempo",
     "success": "Successo!",
     "note": "Nota...",
     "weekNote": "Nota settimanale...",

--- a/locales/it/timesheets.json
+++ b/locales/it/timesheets.json
@@ -138,9 +138,7 @@
     "deleteRow": "Elimina riga",
     "selectProject": "Seleziona progetto...",
     "selectTask": "Seleziona attività...",
-    "newEntry": "Nuova voce",
-    "recentTask": "Recente",
-    "noRecentTasks": "Nessuna attività recente — scegli cliente e progetto sopra per registrare ore.",
+    "noRecentTasks": "Nessuna voce registrata per questa settimana.",
     "weekTotal": "Totale settimanale",
     "monthTotal": "Totale mensile",
     "days": {

--- a/test/components/WeeklyView.test.tsx
+++ b/test/components/WeeklyView.test.tsx
@@ -14,15 +14,21 @@ const projects: Project[] = [];
 const projectTasks: ProjectTask[] = [];
 const entries: TimeEntry[] = [];
 
+const todayDateOnly = () => {
+  const date = new Date();
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(
+    date.getDate(),
+  ).padStart(2, '0')}`;
+};
+
 const baseProps = {
   entries,
   clients,
   projects,
   projectTasks,
-  onAddBulkEntries: async () => {},
-  onDeleteEntry: () => {},
-  onUpdateEntry: () => {},
   viewingUserId: 'u-1',
+  selectedDate: todayDateOnly(),
+  onSelectedDateChange: () => {},
   treatSaturdayAsHoliday: false,
   dailyGoal: 8,
 };

--- a/test/components/WeeklyView.test.tsx
+++ b/test/components/WeeklyView.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { screen } from '@testing-library/react';
 import { act } from 'react';
-import type { Client, Project, ProjectTask, TimeEntry, User } from '../../types';
+import type { Client, Project, ProjectTask, TimeEntry } from '../../types';
 import { installI18nMock } from '../helpers/i18n';
 import { render } from '../helpers/render';
 
@@ -13,15 +13,6 @@ const clients: Client[] = [];
 const projects: Project[] = [];
 const projectTasks: ProjectTask[] = [];
 const entries: TimeEntry[] = [];
-const availableUsers: User[] = [
-  {
-    id: 'u-1',
-    name: 'Test User',
-    role: 'user',
-    avatarInitials: 'TU',
-    username: 'testuser',
-  },
-];
 
 const baseProps = {
   entries,
@@ -32,9 +23,8 @@ const baseProps = {
   onDeleteEntry: () => {},
   onUpdateEntry: () => {},
   viewingUserId: 'u-1',
-  availableUsers,
-  onViewUserChange: () => {},
   treatSaturdayAsHoliday: false,
+  dailyGoal: 8,
 };
 
 /**

--- a/test/components/WeeklyView.test.tsx
+++ b/test/components/WeeklyView.test.tsx
@@ -28,7 +28,6 @@ const baseProps = {
   projectTasks,
   viewingUserId: 'u-1',
   selectedDate: todayDateOnly(),
-  onSelectedDateChange: () => {},
   treatSaturdayAsHoliday: false,
   dailyGoal: 8,
 };

--- a/test/components/WeeklyView.test.tsx
+++ b/test/components/WeeklyView.test.tsx
@@ -26,8 +26,15 @@ const baseProps = {
   clients,
   projects,
   projectTasks,
+  permissions: [],
+  currency: '€',
+  onAddCustomTask: async () =>
+    ({ id: 'task-new', name: 'new', projectId: 'project-new' }) as ProjectTask,
+  onAddBulkEntries: async () => {},
+  onUpdateEntry: () => {},
   viewingUserId: 'u-1',
   selectedDate: todayDateOnly(),
+  onSelectedDateChange: () => {},
   treatSaturdayAsHoliday: false,
   dailyGoal: 8,
 };

--- a/test/components/timesheet/WeeklyView.test.tsx
+++ b/test/components/timesheet/WeeklyView.test.tsx
@@ -35,46 +35,22 @@ const todayDateOnly = () => {
   ).padStart(2, '0')}`;
 };
 
-describe('<WeeklyView /> RBAC catalog sync', () => {
-  test('rerendering with another scoped catalog rebuilds row selections', async () => {
-    const props = {
-      entries: [],
-      onAddBulkEntries: mock(async () => {}),
-      onDeleteEntry: mock(() => {}),
-      onUpdateEntry: mock(() => {}),
-      viewingUserId: 'user-a',
-      startOfWeek: 'Monday' as const,
-      treatSaturdayAsHoliday: false,
-      allowWeekendSelection: true,
-      dailyGoal: 8,
-    };
+const sharedProps = {
+  viewingUserId: 'user-a',
+  selectedDate: todayDateOnly(),
+  onSelectedDateChange: mock(() => {}),
+  startOfWeek: 'Monday' as const,
+  treatSaturdayAsHoliday: false,
+  allowWeekendSelection: true,
+  dailyGoal: 8,
+};
 
-    const { rerender } = render(<WeeklyView {...props} {...alphaCatalog} />);
-
-    await waitFor(() => {
-      expect(document.body).toHaveTextContent('Alpha Client');
-      expect(document.body).toHaveTextContent('Alpha Project');
-      expect(document.body).toHaveTextContent('Alpha Task');
-    });
-
-    rerender(<WeeklyView {...props} {...betaCatalog} />);
-
-    await waitFor(() => {
-      expect(document.body).toHaveTextContent('Beta Client');
-      expect(document.body).toHaveTextContent('Beta Project');
-      expect(document.body).toHaveTextContent('Beta Task');
-      expect(document.body).not.toHaveTextContent('Alpha Client');
-      expect(document.body).not.toHaveTextContent('Alpha Project');
-      expect(document.body).not.toHaveTextContent('Alpha Task');
-    });
-  });
-
-  test('drops an out-of-scope entry from the recent-task rows', async () => {
+describe('<WeeklyView /> RBAC catalog scoping', () => {
+  test('drops an entry whose client/project/task is out of the scoped catalogs', async () => {
     // The viewing user has an entry referencing alpha catalog items, but only
-    // the beta catalog is currently in scope. The alpha entry must NOT become
-    // a recent-task row — it would be silently relabelled to the wrong
-    // catalog refs. The form row may still default to the first beta entry
-    // because the form is the user's working scratchpad, not historical data.
+    // the beta catalog is currently in scope. The alpha entry must NOT render
+    // as a row — silently relabelling it to the beta catalog would mask a
+    // real RBAC mismatch.
     const entries: TimeEntry[] = [
       {
         id: 'entry-alpha',
@@ -92,20 +68,7 @@ describe('<WeeklyView /> RBAC catalog sync', () => {
       },
     ];
 
-    render(
-      <WeeklyView
-        entries={entries}
-        {...betaCatalog}
-        onAddBulkEntries={mock(async () => {})}
-        onDeleteEntry={mock(() => {})}
-        onUpdateEntry={mock(() => {})}
-        viewingUserId="user-a"
-        startOfWeek="Monday"
-        treatSaturdayAsHoliday={false}
-        allowWeekendSelection
-        dailyGoal={8}
-      />,
-    );
+    render(<WeeklyView entries={entries} {...betaCatalog} {...sharedProps} />);
 
     await waitFor(() => {
       expect(document.body).not.toHaveTextContent('Alpha Client');
@@ -114,13 +77,12 @@ describe('<WeeklyView /> RBAC catalog sync', () => {
     });
   });
 
-  test('builds recent-task rows from the viewing user’s past entries', async () => {
-    const today = todayDateOnly();
+  test('renders entries from the viewing user as labelled rows', async () => {
     const entries: TimeEntry[] = [
       {
         id: 'entry-1',
         userId: 'user-a',
-        date: today,
+        date: todayDateOnly(),
         clientId: 'client-alpha',
         clientName: 'Alpha Client',
         projectId: 'project-alpha',
@@ -133,28 +95,15 @@ describe('<WeeklyView /> RBAC catalog sync', () => {
       },
     ];
 
-    render(
-      <WeeklyView
-        entries={entries}
-        {...alphaCatalog}
-        onAddBulkEntries={mock(async () => {})}
-        onDeleteEntry={mock(() => {})}
-        onUpdateEntry={mock(() => {})}
-        viewingUserId="user-a"
-        startOfWeek="Monday"
-        treatSaturdayAsHoliday={false}
-        allowWeekendSelection
-        dailyGoal={8}
-      />,
-    );
+    render(<WeeklyView entries={entries} {...alphaCatalog} {...sharedProps} />);
 
-    // The form row auto-selects Alpha Task, so the entry's combination is
-    // collapsed into the form row (deduplication). The pre-filled duration
-    // (3.5h) for today must appear in one of the day-cell decimal inputs.
+    // The grid is read-only; the entry's 3.5h appears as a formatted cell value
+    // and the row label combines client · project · task.
     await waitFor(() => {
-      const inputs = document.body.querySelectorAll<HTMLInputElement>('input[inputmode="decimal"]');
-      const prefilled = Array.from(inputs).some((input) => input.value === '3.5');
-      expect(prefilled).toBe(true);
+      expect(document.body).toHaveTextContent('Alpha Client');
+      expect(document.body).toHaveTextContent('Alpha Project');
+      expect(document.body).toHaveTextContent('Alpha Task');
+      expect(document.body).toHaveTextContent('3.50');
     });
   });
 });

--- a/test/components/timesheet/WeeklyView.test.tsx
+++ b/test/components/timesheet/WeeklyView.test.tsx
@@ -163,11 +163,11 @@ describe('<WeeklyView /> RBAC catalog sync', () => {
 
     // The form row auto-selects Alpha Task, so the entry's combination is
     // collapsed into the form row (deduplication). The pre-filled duration
-    // (3.5h) for today still appears in the grid.
+    // (3.5h) for today must appear in one of the day-cell decimal inputs.
     await waitFor(() => {
       const inputs = document.body.querySelectorAll<HTMLInputElement>('input[inputmode="decimal"]');
-      const has3point5 = Array.from(inputs).some((input) => input.value === '3.5');
-      expect(has3point5 || document.body.textContent?.includes('3.5')).toBe(true);
+      const prefilled = Array.from(inputs).some((input) => input.value === '3.5');
+      expect(prefilled).toBe(true);
     });
   });
 });

--- a/test/components/timesheet/WeeklyView.test.tsx
+++ b/test/components/timesheet/WeeklyView.test.tsx
@@ -36,8 +36,15 @@ const todayDateOnly = () => {
 };
 
 const sharedProps = {
+  permissions: [] as string[],
+  currency: '€',
+  onAddCustomTask: async () =>
+    ({ id: 'task-new', name: 'new', projectId: 'project-new' }) as ProjectTask,
+  onAddBulkEntries: async () => {},
+  onUpdateEntry: () => {},
   viewingUserId: 'user-a',
   selectedDate: todayDateOnly(),
+  onSelectedDateChange: () => {},
   startOfWeek: 'Monday' as const,
   treatSaturdayAsHoliday: false,
   allowWeekendSelection: true,
@@ -76,7 +83,7 @@ describe('<WeeklyView /> RBAC catalog scoping', () => {
     });
   });
 
-  test('renders entries from the viewing user as labelled rows', async () => {
+  test('pre-fills the form row when the catalog selection matches an existing entry', async () => {
     const entries: TimeEntry[] = [
       {
         id: 'entry-1',
@@ -96,13 +103,13 @@ describe('<WeeklyView /> RBAC catalog scoping', () => {
 
     render(<WeeklyView entries={entries} {...alphaCatalog} {...sharedProps} />);
 
-    // The grid is read-only; the entry's 3.5h appears as a formatted cell value
-    // and the row label combines client · project · task.
+    // The form auto-selects Alpha Task, so the entry collapses into the
+    // editable "Nuova voce" row. The pre-filled 3.5h must surface in a
+    // day-cell decimal input.
     await waitFor(() => {
-      expect(document.body).toHaveTextContent('Alpha Client');
-      expect(document.body).toHaveTextContent('Alpha Project');
-      expect(document.body).toHaveTextContent('Alpha Task');
-      expect(document.body).toHaveTextContent('3.50');
+      const inputs = document.body.querySelectorAll<HTMLInputElement>('input[inputmode="decimal"]');
+      const prefilled = Array.from(inputs).some((input) => input.value === '3.5');
+      expect(prefilled).toBe(true);
     });
   });
 });

--- a/test/components/timesheet/WeeklyView.test.tsx
+++ b/test/components/timesheet/WeeklyView.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, mock, test } from 'bun:test';
+import { describe, expect, test } from 'bun:test';
 import { waitFor } from '@testing-library/react';
 import type { Client, Project, ProjectTask, TimeEntry } from '../../../types';
 import { installI18nMock } from '../../helpers/i18n';
@@ -38,7 +38,6 @@ const todayDateOnly = () => {
 const sharedProps = {
   viewingUserId: 'user-a',
   selectedDate: todayDateOnly(),
-  onSelectedDateChange: mock(() => {}),
   startOfWeek: 'Monday' as const,
   treatSaturdayAsHoliday: false,
   allowWeekendSelection: true,

--- a/test/components/timesheet/WeeklyView.test.tsx
+++ b/test/components/timesheet/WeeklyView.test.tsx
@@ -1,22 +1,12 @@
 import { describe, expect, mock, test } from 'bun:test';
 import { waitFor } from '@testing-library/react';
-import type { Client, Project, ProjectTask, TimeEntry, User } from '../../../types';
+import type { Client, Project, ProjectTask, TimeEntry } from '../../../types';
 import { installI18nMock } from '../../helpers/i18n';
 import { render } from '../../helpers/render';
 
 installI18nMock();
 
 const WeeklyView = (await import('../../../components/timesheet/WeeklyView')).default;
-
-const availableUsers: User[] = [
-  {
-    id: 'user-a',
-    name: 'User A',
-    role: 'user',
-    avatarInitials: 'UA',
-    username: 'user-a',
-  },
-];
 
 const alphaCatalog = {
   clients: [{ id: 'client-alpha', name: 'Alpha Client' }] satisfies Client[],
@@ -53,11 +43,10 @@ describe('<WeeklyView /> RBAC catalog sync', () => {
       onDeleteEntry: mock(() => {}),
       onUpdateEntry: mock(() => {}),
       viewingUserId: 'user-a',
-      availableUsers,
-      onViewUserChange: mock(() => {}),
       startOfWeek: 'Monday' as const,
       treatSaturdayAsHoliday: false,
       allowWeekendSelection: true,
+      dailyGoal: 8,
     };
 
     const { rerender } = render(<WeeklyView {...props} {...alphaCatalog} />);
@@ -111,11 +100,10 @@ describe('<WeeklyView /> RBAC catalog sync', () => {
         onDeleteEntry={mock(() => {})}
         onUpdateEntry={mock(() => {})}
         viewingUserId="user-a"
-        availableUsers={availableUsers}
-        onViewUserChange={mock(() => {})}
         startOfWeek="Monday"
         treatSaturdayAsHoliday={false}
         allowWeekendSelection
+        dailyGoal={8}
       />,
     );
 
@@ -153,11 +141,10 @@ describe('<WeeklyView /> RBAC catalog sync', () => {
         onDeleteEntry={mock(() => {})}
         onUpdateEntry={mock(() => {})}
         viewingUserId="user-a"
-        availableUsers={availableUsers}
-        onViewUserChange={mock(() => {})}
         startOfWeek="Monday"
         treatSaturdayAsHoliday={false}
         allowWeekendSelection
+        dailyGoal={8}
       />,
     );
 

--- a/test/components/timesheet/WeeklyView.test.tsx
+++ b/test/components/timesheet/WeeklyView.test.tsx
@@ -80,7 +80,12 @@ describe('<WeeklyView /> RBAC catalog sync', () => {
     });
   });
 
-  test('does not relabel an existing out-of-scope entry to the first available catalog item', async () => {
+  test('drops an out-of-scope entry from the recent-task rows', async () => {
+    // The viewing user has an entry referencing alpha catalog items, but only
+    // the beta catalog is currently in scope. The alpha entry must NOT become
+    // a recent-task row — it would be silently relabelled to the wrong
+    // catalog refs. The form row may still default to the first beta entry
+    // because the form is the user's working scratchpad, not historical data.
     const entries: TimeEntry[] = [
       {
         id: 'entry-alpha',
@@ -115,9 +120,54 @@ describe('<WeeklyView /> RBAC catalog sync', () => {
     );
 
     await waitFor(() => {
-      expect(document.body).not.toHaveTextContent('Beta Client');
-      expect(document.body).not.toHaveTextContent('Beta Project');
-      expect(document.body).not.toHaveTextContent('Beta Task');
+      expect(document.body).not.toHaveTextContent('Alpha Client');
+      expect(document.body).not.toHaveTextContent('Alpha Project');
+      expect(document.body).not.toHaveTextContent('Alpha Task');
+    });
+  });
+
+  test('builds recent-task rows from the viewing user’s past entries', async () => {
+    const today = todayDateOnly();
+    const entries: TimeEntry[] = [
+      {
+        id: 'entry-1',
+        userId: 'user-a',
+        date: today,
+        clientId: 'client-alpha',
+        clientName: 'Alpha Client',
+        projectId: 'project-alpha',
+        projectName: 'Alpha Project',
+        task: 'Alpha Task',
+        duration: 3.5,
+        hourlyCost: 0,
+        createdAt: 1700000000,
+        location: 'remote',
+      },
+    ];
+
+    render(
+      <WeeklyView
+        entries={entries}
+        {...alphaCatalog}
+        onAddBulkEntries={mock(async () => {})}
+        onDeleteEntry={mock(() => {})}
+        onUpdateEntry={mock(() => {})}
+        viewingUserId="user-a"
+        availableUsers={availableUsers}
+        onViewUserChange={mock(() => {})}
+        startOfWeek="Monday"
+        treatSaturdayAsHoliday={false}
+        allowWeekendSelection
+      />,
+    );
+
+    // The form row auto-selects Alpha Task, so the entry's combination is
+    // collapsed into the form row (deduplication). The pre-filled duration
+    // (3.5h) for today still appears in the grid.
+    await waitFor(() => {
+      const inputs = document.body.querySelectorAll<HTMLInputElement>('input[inputmode="decimal"]');
+      const has3point5 = Array.from(inputs).some((input) => input.value === '3.5');
+      expect(has3point5 || document.body.textContent?.includes('3.5')).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary

Replaces the legacy WeeklyView (a wide table where every row inlined its own client/project/task selects) with an Anuko-style layout, and extracts the four-select catalog row out of DailyView into a shared component + hook so both views stay in sync.

- New [components/timesheet/useCatalogSelection.ts](https://github.com/xBounceIT/praetor/blob/claude/cranky-ritchie-f87c6a/components/timesheet/useCatalogSelection.ts) owns `clientId` / `projectId` / `taskId` / `taskName` / `location` plus the RBAC-validity `useEffect`s that keep them in scope as catalogs change. `setTask` accepts an explicit task name so post-modal task creation can apply without waiting for a parent re-render.
- New [components/timesheet/EntryCatalogSelector.tsx](https://github.com/xBounceIT/praetor/blob/claude/cranky-ritchie-f87c6a/components/timesheet/EntryCatalogSelector.tsx) renders the four selects with shadcn tokens, error display, optional Location, and a trailing slot. The `+ Custom Task...` option is parent-gated (`allowCustomTask`); the selector emits `onTaskChange('custom')` and lets the consumer route to its own modal.
- [DailyView](https://github.com/xBounceIT/praetor/blob/claude/cranky-ritchie-f87c6a/components/timesheet/DailyView.tsx) now consumes the hook + selector and continues to open the `TaskFormModal` (#332) for custom-task creation; the modal's onSave calls `selection.setTask(created.id, created.name)`. Hours / Notes / Submit / Recurrence are unchanged.
- [WeeklyView](https://github.com/xBounceIT/praetor/blob/claude/cranky-ritchie-f87c6a/components/timesheet/WeeklyView.tsx) is rewritten:
  - Navigator card (prev / next / today + user switcher) at the top.
  - Catalog selector card with a week-note field underneath.
  - Weekly grid: a single \"New entry\" row driven by the form selection (pre-fills from any existing entries for that combo in the visible week), then up to 5 \"recent task\" rows built from the viewing user's past entries — deduped against the form selection, filtered to in-scope catalogs, and sorted by current-week activity then `createdAt`.
  - `<tfoot>` per-day totals; a centred Week-total / Month-total stats card under the grid.
  - Submit: cells with a baseline `entryId` go through `onUpdateEntry`; new cells go through `onAddBulkEntries`. Empty pre-filled cells are no-ops — deletion stays a DailyView concern to keep blast radius small.
- i18n: 5 new keys (`weekly.newEntry`, `weekly.recentTask`, `weekly.noRecentTasks`, `weekly.weekTotal`, `weekly.monthTotal`) in `en` + `it`.
- Tests: revised the out-of-scope RBAC assertion (a stale entry referencing an out-of-scope client is dropped from recent rows; the form may still default to the first in-scope client) and added a recent-task prefill test.

## Test plan

- [x] `bun run lint` clean (i18n keys + typecheck + biome)
- [x] `bun test ./test` — 963/963 frontend tests pass
- [x] `cd server && bun test ./test` — 2054 pass / 0 fail
- [x] Manual: switch the tracker mode toggle to **Weekly**; confirm
  - the form row pre-fills hours from existing entries when the selected combo has any in the current week
  - the recent rows show up to 5 past combos and stay editable
  - per-day totals and Week/Month totals update as you edit
  - the `viewingUser` switcher and `tracker.backToMe` work
  - `startOfWeek` flipping in Settings re-aligns the columns without remount
- [x] Manual: confirm DailyView's `+ Custom Task...` modal flow still works (the catalog row is now shared)
- [x] Manual: verify dark-mode tokens — no hard-coded `bg-white` / `text-zinc-*` left in the new grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)