### PR TITLE
fix(ldap): mask bindPassword in GET /config and preserve on PUT

### DIFF
--- a/server/routes/ldap.ts
+++ b/server/routes/ldap.ts
@@ -14,6 +14,19 @@ import { badRequest, parseBoolean, requireNonEmptyString } from '../utils/valida
 const TLS_CA_MAX_LENGTH = 65536;
 const PEM_BLOCK_REGEX = /-----BEGIN CERTIFICATE-----[\s\S]+?-----END CERTIFICATE-----/g;
 
+// Sentinel returned in place of the stored bindPassword on GET /config so the
+// secret never leaves the server. The UI round-trips this sentinel back on save
+// when the operator did not edit the field, and PUT /config drops it from the
+// patch so the existing column value is preserved.
+// (tlsCaCertificate is a public CA certificate, not a private key, so it is
+// returned as-is.)
+const BIND_PASSWORD_MASK = '***';
+
+const maskBindPassword = (config: ldapRepo.LdapConfig): ldapRepo.LdapConfig => ({
+  ...config,
+  bindPassword: config.bindPassword ? BIND_PASSWORD_MASK : '',
+});
+
 // Returns the patch fragment to merge into ldapRepo.update():
 //   - omitted body field   -> {} (preserve existing column)
 //   - null / empty / blank -> { tlsCaCertificate: '' } (clear the column)
@@ -153,7 +166,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         },
       },
     },
-    async (_request, _reply) => (await ldapRepo.get()) ?? ldapRepo.DEFAULT_CONFIG,
+    async (_request, _reply) => maskBindPassword((await ldapRepo.get()) ?? ldapRepo.DEFAULT_CONFIG),
   );
 
   // PUT /config - Update LDAP configuration (admin only)
@@ -189,14 +202,21 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         enabled,
         serverUrl,
         baseDn,
-        bindDn,
-        bindPassword,
         userFilter,
         groupBaseDn,
         groupFilter,
         roleMappings,
         autoProvisionAll,
       } = body;
+      // When the client round-trips the masking sentinel returned by GET /config, treat the
+      // whole bindDn/bindPassword pair as "no change" so the stored secret is preserved. The
+      // UI re-sends the existing bindDn alongside the masked password on every save; without
+      // also clearing bindDn here, the paired-validation below would reject the request when
+      // the operator intentionally avoided re-typing the secret. Operators who actually want
+      // to rotate bindDn must also re-enter bindPassword (i.e. supply a non-mask value).
+      const isBindPasswordMasked = body.bindPassword === BIND_PASSWORD_MASK;
+      const bindDn = isBindPasswordMasked ? undefined : body.bindDn;
+      const bindPassword = isBindPasswordMasked ? undefined : body.bindPassword;
       const enabledValue = parseBoolean(enabled);
       const tlsCaResult = parseTlsCaForPatch(body.tlsCaCertificate);
       if (!tlsCaResult.ok) {
@@ -304,7 +324,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           secondaryLabel: updated.serverUrl,
         },
       });
-      return updated;
+      return maskBindPassword(updated);
     },
   );
 

--- a/server/routes/ldap.ts
+++ b/server/routes/ldap.ts
@@ -207,15 +207,30 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         roleMappings,
         autoProvisionAll,
       } = body;
-      // When the client round-trips the MASKED_SECRET sentinel returned by GET /config, treat the
-      // whole bindDn/bindPassword pair as "no change" so the stored secret is preserved. The
-      // UI re-sends the existing bindDn alongside the masked password on every save; without
-      // also clearing bindDn here, the paired-validation below would reject the request when
-      // the operator intentionally avoided re-typing the secret. Operators who actually want
-      // to rotate bindDn must also re-enter bindPassword (i.e. supply a non-mask value).
+      // bindPassword === MASKED_SECRET means "preserve the stored secret" (the UI round-trips
+      // the masked value when the operator did not edit the field). To satisfy the paired
+      // validation below, bindDn is also dropped from the patch, but only when the client's
+      // bindDn matches what is currently stored - otherwise a request that changes bindDn
+      // while keeping the masked password would silently swallow the DN edit and return 200.
+      // To actually rotate bindDn, the operator must re-enter bindPassword (supply a non-mask
+      // value) so the credentials are updated together.
       const isBindPasswordMasked = body.bindPassword === MASKED_SECRET;
-      const bindDn = isBindPasswordMasked ? undefined : body.bindDn;
-      const bindPassword = isBindPasswordMasked ? undefined : body.bindPassword;
+      let bindDn: string | undefined;
+      let bindPassword: string | undefined;
+      if (isBindPasswordMasked) {
+        const storedConfig = (await ldapRepo.get()) ?? ldapRepo.DEFAULT_CONFIG;
+        if (body.bindDn !== undefined && body.bindDn !== storedConfig.bindDn) {
+          return badRequest(
+            reply,
+            'bindDn cannot be changed while bindPassword is masked; re-enter bindPassword to rotate credentials',
+          );
+        }
+        bindDn = undefined;
+        bindPassword = undefined;
+      } else {
+        bindDn = body.bindDn;
+        bindPassword = body.bindPassword;
+      }
       const enabledValue = parseBoolean(enabled);
       const tlsCaResult = parseTlsCaForPatch(body.tlsCaCertificate);
       if (!tlsCaResult.ok) {

--- a/server/routes/ldap.ts
+++ b/server/routes/ldap.ts
@@ -6,6 +6,7 @@ import * as rolesRepo from '../repositories/rolesRepo.ts';
 import { standardRateLimitedErrorResponses } from '../schemas/common.ts';
 import { DEFAULT_ROLE_ID } from '../services/external-auth.ts';
 import { getAuditCounts, logAudit } from '../utils/audit.ts';
+import { MASKED_SECRET } from '../utils/crypto.ts';
 import { validateGroupFilterTemplate, validateUserFilterTemplate } from '../utils/ldap-filter.ts';
 import { badRequest, parseBoolean, requireNonEmptyString } from '../utils/validation.ts';
 
@@ -14,17 +15,15 @@ import { badRequest, parseBoolean, requireNonEmptyString } from '../utils/valida
 const TLS_CA_MAX_LENGTH = 65536;
 const PEM_BLOCK_REGEX = /-----BEGIN CERTIFICATE-----[\s\S]+?-----END CERTIFICATE-----/g;
 
-// Sentinel returned in place of the stored bindPassword on GET /config so the
-// secret never leaves the server. The UI round-trips this sentinel back on save
-// when the operator did not edit the field, and PUT /config drops it from the
-// patch so the existing column value is preserved.
+// bindPassword is masked on GET so the secret never leaves the server, and PUT
+// treats the same sentinel as "no change" so a round-tripped form save preserves
+// the stored value. The sentinel matches the repo-wide MASKED_SECRET convention
+// already used by smtpPassword, clientSecret, privateKey, and API keys.
 // (tlsCaCertificate is a public CA certificate, not a private key, so it is
 // returned as-is.)
-const BIND_PASSWORD_MASK = '***';
-
 const maskBindPassword = (config: ldapRepo.LdapConfig): ldapRepo.LdapConfig => ({
   ...config,
-  bindPassword: config.bindPassword ? BIND_PASSWORD_MASK : '',
+  bindPassword: config.bindPassword ? MASKED_SECRET : '',
 });
 
 // Returns the patch fragment to merge into ldapRepo.update():
@@ -208,13 +207,13 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         roleMappings,
         autoProvisionAll,
       } = body;
-      // When the client round-trips the masking sentinel returned by GET /config, treat the
+      // When the client round-trips the MASKED_SECRET sentinel returned by GET /config, treat the
       // whole bindDn/bindPassword pair as "no change" so the stored secret is preserved. The
       // UI re-sends the existing bindDn alongside the masked password on every save; without
       // also clearing bindDn here, the paired-validation below would reject the request when
       // the operator intentionally avoided re-typing the secret. Operators who actually want
       // to rotate bindDn must also re-enter bindPassword (i.e. supply a non-mask value).
-      const isBindPasswordMasked = body.bindPassword === BIND_PASSWORD_MASK;
+      const isBindPasswordMasked = body.bindPassword === MASKED_SECRET;
       const bindDn = isBindPasswordMasked ? undefined : body.bindDn;
       const bindPassword = isBindPasswordMasked ? undefined : body.bindPassword;
       const enabledValue = parseBoolean(enabled);

--- a/server/test/routes/ldap.test.ts
+++ b/server/test/routes/ldap.test.ts
@@ -8,6 +8,7 @@ import * as realRolesRepo from '../../repositories/rolesRepo.ts';
 import * as realUsersRepo from '../../repositories/usersRepo.ts';
 import * as realLdapService from '../../services/ldap.ts';
 import * as realAudit from '../../utils/audit.ts';
+import { MASKED_SECRET } from '../../utils/crypto.ts';
 import * as realPermissions from '../../utils/permissions.ts';
 import {
   installAuthMiddlewareMock,
@@ -186,7 +187,7 @@ describe('GET /api/ldap/config', () => {
     expect(JSON.parse(response.body).tlsCaCertificate).toBe(validPemCert);
   });
 
-  test('masks a stored bindPassword as "***" so the secret never leaves the server', async () => {
+  test('masks a stored bindPassword with MASKED_SECRET so the secret never leaves the server', async () => {
     ldapGetMock.mockResolvedValue({ ...BASE_CONFIG, bindPassword: 'super-secret-bind-pw' });
     const response = await testApp.inject({
       method: 'GET',
@@ -195,7 +196,7 @@ describe('GET /api/ldap/config', () => {
     });
     expect(response.statusCode).toBe(200);
     const body = JSON.parse(response.body);
-    expect(body.bindPassword).toBe('***');
+    expect(body.bindPassword).toBe(MASKED_SECRET);
     expect(response.body).not.toContain('super-secret-bind-pw');
   });
 
@@ -245,11 +246,11 @@ describe('GET /api/ldap/config', () => {
 });
 
 describe('PUT /api/ldap/config - bindPassword masking', () => {
-  test('bindPassword="***" is dropped from the patch so the stored secret is preserved', async () => {
+  test('bindPassword=MASKED_SECRET is dropped from the patch so the stored secret is preserved', async () => {
     const response = await putConfig({
       enabled: false,
       bindDn: 'cn=admin,dc=example,dc=com',
-      bindPassword: '***',
+      bindPassword: MASKED_SECRET,
     });
     expect(response.statusCode).toBe(200);
     const patch = ldapUpdateMock.mock.calls[0][0] as Partial<realLdapRepo.LdapConfig>;
@@ -284,7 +285,7 @@ describe('PUT /api/ldap/config - bindPassword masking', () => {
     });
     expect(response.statusCode).toBe(200);
     const body = JSON.parse(response.body);
-    expect(body.bindPassword).toBe('***');
+    expect(body.bindPassword).toBe(MASKED_SECRET);
     expect(response.body).not.toContain('a-new-secret');
   });
 });

--- a/server/test/routes/ldap.test.ts
+++ b/server/test/routes/ldap.test.ts
@@ -247,6 +247,9 @@ describe('GET /api/ldap/config', () => {
 
 describe('PUT /api/ldap/config - bindPassword masking', () => {
   test('bindPassword=MASKED_SECRET is dropped from the patch so the stored secret is preserved', async () => {
+    // The client must round-trip the SAME bindDn it received from GET when keeping the
+    // mask sentinel - otherwise the request is rejected to prevent a silent DN edit.
+    ldapGetMock.mockResolvedValue({ ...BASE_CONFIG, bindDn: 'cn=admin,dc=example,dc=com' });
     const response = await putConfig({
       enabled: false,
       bindDn: 'cn=admin,dc=example,dc=com',
@@ -258,6 +261,18 @@ describe('PUT /api/ldap/config - bindPassword masking', () => {
     // bindDn must also be dropped (paired with bindPassword) so the stored credential survives
     // unchanged; otherwise the COALESCE-on-undefined trick can't preserve the pair atomically.
     expect(patch.bindDn).toBeUndefined();
+  });
+
+  test('rejects a bindDn change when bindPassword is masked (no silent DN swap)', async () => {
+    ldapGetMock.mockResolvedValue({ ...BASE_CONFIG, bindDn: 'cn=admin,dc=example,dc=com' });
+    const response = await putConfig({
+      enabled: false,
+      bindDn: 'cn=rotated,dc=example,dc=com',
+      bindPassword: MASKED_SECRET,
+    });
+    expect(response.statusCode).toBe(400);
+    expect(JSON.parse(response.body).error).toContain('bindDn cannot be changed');
+    expect(ldapUpdateMock).not.toHaveBeenCalled();
   });
 
   test('a real new bindPassword (non-mask) is forwarded to ldapRepo.update', async () => {

--- a/server/test/routes/ldap.test.ts
+++ b/server/test/routes/ldap.test.ts
@@ -186,6 +186,30 @@ describe('GET /api/ldap/config', () => {
     expect(JSON.parse(response.body).tlsCaCertificate).toBe(validPemCert);
   });
 
+  test('masks a stored bindPassword as "***" so the secret never leaves the server', async () => {
+    ldapGetMock.mockResolvedValue({ ...BASE_CONFIG, bindPassword: 'super-secret-bind-pw' });
+    const response = await testApp.inject({
+      method: 'GET',
+      url: '/api/ldap/config',
+      headers: authHeader(),
+    });
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body.bindPassword).toBe('***');
+    expect(response.body).not.toContain('super-secret-bind-pw');
+  });
+
+  test('returns empty bindPassword when none is stored (no spurious mask)', async () => {
+    ldapGetMock.mockResolvedValue({ ...BASE_CONFIG, bindPassword: '' });
+    const response = await testApp.inject({
+      method: 'GET',
+      url: '/api/ldap/config',
+      headers: authHeader(),
+    });
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body).bindPassword).toBe('');
+  });
+
   test('returns DEFAULT_CONFIG (with empty tlsCaCertificate) when no row exists', async () => {
     ldapGetMock.mockResolvedValue(null);
     const response = await testApp.inject({
@@ -217,6 +241,51 @@ describe('GET /api/ldap/config', () => {
     });
     expect(response.statusCode).toBe(200);
     expect(JSON.parse(response.body).autoProvisionAll).toBe(true);
+  });
+});
+
+describe('PUT /api/ldap/config - bindPassword masking', () => {
+  test('bindPassword="***" is dropped from the patch so the stored secret is preserved', async () => {
+    const response = await putConfig({
+      enabled: false,
+      bindDn: 'cn=admin,dc=example,dc=com',
+      bindPassword: '***',
+    });
+    expect(response.statusCode).toBe(200);
+    const patch = ldapUpdateMock.mock.calls[0][0] as Partial<realLdapRepo.LdapConfig>;
+    expect(patch.bindPassword).toBeUndefined();
+    // bindDn must also be dropped (paired with bindPassword) so the stored credential survives
+    // unchanged; otherwise the COALESCE-on-undefined trick can't preserve the pair atomically.
+    expect(patch.bindDn).toBeUndefined();
+  });
+
+  test('a real new bindPassword (non-mask) is forwarded to ldapRepo.update', async () => {
+    const response = await putConfig({
+      enabled: false,
+      bindDn: 'cn=admin,dc=example,dc=com',
+      bindPassword: 'a-new-secret',
+    });
+    expect(response.statusCode).toBe(200);
+    const patch = ldapUpdateMock.mock.calls[0][0] as Partial<realLdapRepo.LdapConfig>;
+    expect(patch.bindPassword).toBe('a-new-secret');
+    expect(patch.bindDn).toBe('cn=admin,dc=example,dc=com');
+  });
+
+  test('PUT response masks bindPassword in the returned config', async () => {
+    ldapUpdateMock.mockImplementation(async () => ({
+      ...BASE_CONFIG,
+      bindDn: 'cn=admin,dc=example,dc=com',
+      bindPassword: 'a-new-secret',
+    }));
+    const response = await putConfig({
+      enabled: false,
+      bindDn: 'cn=admin,dc=example,dc=com',
+      bindPassword: 'a-new-secret',
+    });
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body.bindPassword).toBe('***');
+    expect(response.body).not.toContain('a-new-secret');
   });
 });
 


### PR DESCRIPTION
## Summary
- `GET /api/ldap/config` was returning the stored LDAP bind password in plaintext to any holder of `administration.authentication.view`. The response now replaces `bindPassword` with the repo-wide `MASKED_SECRET` (`'********'`) sentinel when a secret is stored (empty string otherwise) so the secret never leaves the server.
- `PUT /api/ldap/config` now treats `bindPassword === MASKED_SECRET` as "no change" and drops the field (along with `bindDn`, which is paired-validated) from the patch, so re-saving the form without re-typing the password preserves the stored credential instead of clobbering it.
- The sentinel is the same one already used by `smtpPassword`, `clientSecret`, `privateKey`, and the general-settings API keys, so the masking convention is now uniform across the codebase.
- `tlsCaCertificate` is a public CA certificate (no private key material), so it remains unmasked.

## Manual verification
1. Configure LDAP with a `bindPassword` and save.
2. Re-open Settings -> LDAP -- verify the bindPassword field shows `'********'`.
3. Click Save without changing it -- verify LDAP authentication still works.

## Test plan
- [x] `bun test server/test/routes/ldap.test.ts` (24/24 pass, includes new GET-masking, PUT-preserves-on-mask, and PUT-forwards-real-password tests)
- [x] `bun run test` repo-wide (962 pass)
- [x] `bun run lint` (Biome clean for the files in this PR)
- [x] `cd server && bun run build` (TypeScript clean)

Generated with [Claude Code](https://claude.com/claude-code)