### PR TITLE
fix(sso): harden host/redirect/SSRF, mask provider secrets, validate state before consume

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -3,6 +3,9 @@
 # These values OVERRIDE the docker-compose defaults for local testing.
 PORT=3001
 FRONTEND_URL=http://localhost:5173
+# Public base URL the IdP will redirect back to (e.g. https://praetor.example.com).
+# Required for SSO when the backend is reachable on a different host than FRONTEND_URL.
+# SSO_CALLBACK_BASE_URL=
 # Leave unset for direct local backend runs. Set to `1` only when the backend
 # is behind a local reverse proxy and should trust forwarded client IP headers.
 # TRUST_PROXY=1

--- a/server/routes/sso-auth.ts
+++ b/server/routes/sso-auth.ts
@@ -53,20 +53,6 @@ const loginResponseSchema = {
   required: ['token', 'user'],
 } as const;
 
-const getHeaderValue = (value: string | string[] | undefined): string => {
-  if (Array.isArray(value)) return value[0] ?? '';
-  return value ?? '';
-};
-
-const getRequestOrigin = (request: FastifyRequest): string => {
-  const proto = getHeaderValue(request.headers['x-forwarded-proto']).split(',')[0] || 'http';
-  const host =
-    getHeaderValue(request.headers['x-forwarded-host']).split(',')[0] ||
-    getHeaderValue(request.headers.host) ||
-    'localhost:3001';
-  return `${proto}://${host}`;
-};
-
 const buildFrontendErrorUrl = (message: string): string => {
   const configured = process.env.FRONTEND_URL?.trim();
   const fallback = `/?sso_error=${encodeURIComponent(message)}`;
@@ -105,7 +91,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
     },
     async (request: FastifyRequest, reply: FastifyReply) => {
       const { slug } = request.params as { slug: string };
-      const redirectUrl = await ssoService.startOidcLogin(slug, getRequestOrigin(request));
+      const redirectUrl = await ssoService.startOidcLogin(slug);
       return reply.redirect(redirectUrl, 302);
     },
   );
@@ -123,12 +109,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
     async (request: FastifyRequest, reply: FastifyReply) => {
       const { slug } = request.params as { slug: string };
       try {
-        const currentUrl = new URL(request.url, getRequestOrigin(request));
-        const redirectUrl = await ssoService.completeOidcLogin(
-          slug,
-          currentUrl,
-          getRequestOrigin(request),
-        );
+        // We only need the search params from the inbound URL — never construct an
+        // origin from request headers. The service builds the public callback URL from
+        // server config (SSO_CALLBACK_BASE_URL / FRONTEND_URL).
+        const currentUrl = new URL(request.url, 'http://internal.invalid');
+        const redirectUrl = await ssoService.completeOidcLogin(slug, currentUrl);
         return reply.redirect(redirectUrl, 302);
       } catch (err) {
         const message = err instanceof Error ? err.message : 'SSO login failed';
@@ -151,7 +136,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
     },
     async (request: FastifyRequest, reply: FastifyReply) => {
       const { slug } = request.params as { slug: string };
-      const redirectUrl = await ssoService.startSamlLogin(slug, getRequestOrigin(request));
+      const redirectUrl = await ssoService.startSamlLogin(slug);
       return reply.redirect(redirectUrl, 302);
     },
   );
@@ -172,7 +157,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         const redirectUrl = await ssoService.completeSamlLogin(
           slug,
           request.body as Record<string, string>,
-          getRequestOrigin(request),
         );
         return reply.redirect(redirectUrl, 302);
       } catch (err) {
@@ -195,7 +179,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
     },
     async (request: FastifyRequest, reply: FastifyReply) => {
       const { slug } = request.params as { slug: string };
-      const metadata = await ssoService.getSamlMetadata(slug, getRequestOrigin(request));
+      const metadata = await ssoService.getSamlMetadata(slug);
       return reply.type('application/samlmetadata+xml').send(metadata);
     },
   );

--- a/server/routes/sso.ts
+++ b/server/routes/sso.ts
@@ -4,6 +4,7 @@ import * as rolesRepo from '../repositories/rolesRepo.ts';
 import { standardRateLimitedErrorResponses } from '../schemas/common.ts';
 import * as ssoService from '../services/sso.ts';
 import { logAudit } from '../utils/audit.ts';
+import { MASKED_SECRET } from '../utils/crypto.ts';
 import { badRequest, parseBoolean, requireNonEmptyString } from '../utils/validation.ts';
 
 const roleMappingSchema = {
@@ -124,9 +125,13 @@ const validateProviderBody = async (
     }
   }
 
-  if (input.enabled && input.protocol === 'saml') {
-    const hasMetadata = !!input.metadataUrl?.trim() || !!input.metadataXml?.trim();
-    const hasManual = !!input.entryPoint?.trim() && !!input.idpCert?.trim();
+  if (input.enabled && input.protocol === 'saml' && options.isCreate) {
+    // A masked sentinel never counts as "present" — the service preserves the existing value
+    // on update, but it can't satisfy a fresh create where there is nothing to preserve.
+    const hasMetadataXml = !!input.metadataXml?.trim() && input.metadataXml !== MASKED_SECRET;
+    const hasMetadata = !!input.metadataUrl?.trim() || hasMetadataXml;
+    const hasIdpCert = !!input.idpCert?.trim() && input.idpCert !== MASKED_SECRET;
+    const hasManual = !!input.entryPoint?.trim() && hasIdpCert;
     if (!hasMetadata && !hasManual) {
       badRequest(reply, 'SAML requires metadata URL/XML or manual entryPoint and idpCert');
       return null;

--- a/server/services/sso.ts
+++ b/server/services/sso.ts
@@ -1,3 +1,4 @@
+import dns from 'node:dns/promises';
 import {
   type CacheItem,
   type CacheProvider,
@@ -20,6 +21,8 @@ import { resolveExternalIdentity } from './external-auth.ts';
 const OIDC_STATE_TTL_MS = 10 * 60 * 1000;
 const SAML_REQUEST_TTL_MS = 10 * 60 * 1000;
 const LOGIN_TICKET_TTL_MS = 2 * 60 * 1000;
+const REMOTE_FETCH_TIMEOUT_MS = 5_000;
+const REMOTE_FETCH_REDIRECT_LIMIT = 3;
 
 export type AdminSsoProvider = ssoProvidersRepo.SsoProvider;
 export type PublicSsoProvider = ssoProvidersRepo.PublicSsoProvider;
@@ -41,6 +44,9 @@ const maskProvider = (provider: ssoProvidersRepo.SsoProvider): AdminSsoProvider 
   ...provider,
   clientSecret: provider.clientSecret ? MASKED_SECRET : '',
   privateKey: provider.privateKey ? MASKED_SECRET : '',
+  // metadataXml and idpCert can embed signing/certificate material; mask the same way.
+  metadataXml: provider.metadataXml ? MASKED_SECRET : '',
+  idpCert: provider.idpCert ? MASKED_SECRET : '',
 });
 
 const getProviderSecrets = (provider: ssoProvidersRepo.SsoProvider) => ({
@@ -72,16 +78,28 @@ const readClaimArray = (claims: Record<string, unknown>, name: string): string[]
   return coerceStringArray(claims[name]);
 };
 
-const buildPublicSsoUrl = (path: string, requestOrigin: string): string => {
-  const base = process.env.SSO_CALLBACK_BASE_URL?.trim() || requestOrigin;
-  return new URL(path, base).href;
+/**
+ * Resolves the public base URL used to build callback / metadata / redirect URLs.
+ *
+ * We refuse to read `Host` / `x-forwarded-host` headers — those are attacker-controlled and
+ * have caused host header injection vulnerabilities in similar flows. Instead, the base URL
+ * MUST come from configuration: `SSO_CALLBACK_BASE_URL` (preferred) or `FRONTEND_URL`.
+ */
+export const resolvePublicBaseUrl = (): string => {
+  const explicit = process.env.SSO_CALLBACK_BASE_URL?.trim();
+  if (explicit) return explicit;
+  const frontend = process.env.FRONTEND_URL?.trim();
+  if (frontend) return frontend;
+  throw new Error('SSO_CALLBACK_BASE_URL or FRONTEND_URL must be configured for SSO');
 };
 
-const buildCallbackUrl = (protocol: 'oidc' | 'saml', slug: string, requestOrigin: string): string =>
-  buildPublicSsoUrl(`/api/auth/sso/${protocol}/${slug}/callback`, requestOrigin);
+const buildPublicSsoUrl = (path: string, baseUrl: string): string => new URL(path, baseUrl).href;
 
-const buildSamlMetadataUrl = (slug: string, requestOrigin: string): string =>
-  buildPublicSsoUrl(`/api/auth/sso/saml/${slug}/metadata`, requestOrigin);
+const buildCallbackUrl = (protocol: 'oidc' | 'saml', slug: string, baseUrl: string): string =>
+  buildPublicSsoUrl(`/api/auth/sso/${protocol}/${slug}/callback`, baseUrl);
+
+const buildSamlMetadataUrl = (slug: string, baseUrl: string): string =>
+  buildPublicSsoUrl(`/api/auth/sso/saml/${slug}/metadata`, baseUrl);
 
 const buildFrontendTicketUrl = (ticket: string): string => {
   const configured = process.env.FRONTEND_URL?.trim();
@@ -108,6 +126,10 @@ const prepareProviderValues = (
   } else {
     patch.privateKey = input.privateKey ? encrypt(input.privateKey) : '';
   }
+  // Treat metadataXml / idpCert the same way as secrets: a '***' echo on PUT should preserve
+  // the stored value rather than overwriting it with the mask.
+  if (input.metadataXml === MASKED_SECRET) delete patch.metadataXml;
+  if (input.idpCert === MASKED_SECRET) delete patch.idpCert;
   if (!existing && patch.protocol === 'saml') {
     patch.scopes = patch.scopes || ssoProvidersRepo.DEFAULT_OIDC_FIELDS.scopes;
     patch.usernameAttribute =
@@ -184,12 +206,96 @@ const parseSamlMetadata = (xml: string) => {
   };
 };
 
+/**
+ * Returns true when `ip` is in an IPv4 / IPv6 private, loopback, or link-local range that a
+ * server-side fetch should NEVER target. Blocks the standard SSRF egress targets:
+ *   - 127.0.0.0/8 (loopback)
+ *   - 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 (RFC1918 private)
+ *   - 169.254.0.0/16 (link-local incl. cloud metadata 169.254.169.254)
+ *   - 0.0.0.0/8
+ *   - ::1 (IPv6 loopback)
+ *   - fc00::/7 (IPv6 unique-local)
+ *   - fe80::/10 (IPv6 link-local)
+ */
+export const isPrivateIp = (ip: string): boolean => {
+  const v4 = ip.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (v4) {
+    const [a, b] = [Number(v4[1]), Number(v4[2])];
+    if (a === 10) return true;
+    if (a === 127) return true;
+    if (a === 0) return true;
+    if (a === 172 && b >= 16 && b <= 31) return true;
+    if (a === 192 && b === 168) return true;
+    if (a === 169 && b === 254) return true;
+    return false;
+  }
+  // IPv6 — normalise to lower-case, strip zone id.
+  const v6 = ip.toLowerCase().split('%')[0];
+  if (v6 === '::1') return true;
+  if (v6 === '::') return true;
+  if (v6.startsWith('fc') || v6.startsWith('fd')) return true; // fc00::/7
+  if (v6.startsWith('fe8') || v6.startsWith('fe9') || v6.startsWith('fea') || v6.startsWith('feb'))
+    return true; // fe80::/10
+  // IPv4-mapped IPv6 — recursively check the embedded v4.
+  const mapped = v6.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
+  if (mapped) return isPrivateIp(mapped[1]);
+  return false;
+};
+
+/**
+ * Throws if `url` is non-HTTPS or its hostname resolves to a private / loopback / link-local
+ * address. Shared by the SSRF-fetch loop and the OIDC issuer pre-flight so the two cannot drift.
+ */
+const assertSafeRemoteUrl = async (url: URL): Promise<void> => {
+  if (url.protocol !== 'https:') {
+    throw new Error(`Refusing to fetch non-HTTPS URL: ${url.protocol}//...`);
+  }
+  const addresses = await dns.lookup(url.hostname, { all: true });
+  if (addresses.length === 0) {
+    throw new Error(`Could not resolve host ${url.hostname}`);
+  }
+  if (addresses.some((a) => isPrivateIp(a.address))) {
+    throw new Error(`Refusing to fetch URL with private/loopback host: ${url.hostname}`);
+  }
+};
+
+/**
+ * SSRF-hardened fetch for IdP-supplied URLs (SAML metadata, OIDC discovery).
+ *
+ * Guarantees:
+ *   - HTTPS only (no http:, file:, gopher:, etc).
+ *   - Host resolved via DNS; rejects if any resolved address is private/loopback/link-local.
+ *   - 5-second total timeout via AbortController.
+ *   - Bounded follows: each redirect target is re-validated identically.
+ */
+const safeFetchRemoteUrl = async (url: string): Promise<Response> => {
+  let current = url;
+  for (let hops = 0; hops <= REMOTE_FETCH_REDIRECT_LIMIT; hops++) {
+    await assertSafeRemoteUrl(new URL(current));
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), REMOTE_FETCH_TIMEOUT_MS);
+    try {
+      const response = await fetch(current, { signal: controller.signal, redirect: 'manual' });
+      if (response.status >= 300 && response.status < 400) {
+        const next = response.headers.get('location');
+        if (!next) return response;
+        current = new URL(next, current).href;
+        continue;
+      }
+      return response;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+  throw new Error('Exceeded redirect limit while fetching remote URL');
+};
+
 const resolveSamlIdpConfig = async (provider: ssoProvidersRepo.SsoProvider) => {
   if (provider.metadataXml.trim()) {
     return { ...parseSamlMetadata(provider.metadataXml), source: 'metadataXml' };
   }
   if (provider.metadataUrl.trim()) {
-    const response = await fetch(provider.metadataUrl);
+    const response = await safeFetchRemoteUrl(provider.metadataUrl);
     if (!response.ok) throw new Error(`Failed to fetch SAML metadata: HTTP ${response.status}`);
     return { ...parseSamlMetadata(await response.text()), source: 'metadataUrl' };
   }
@@ -249,6 +355,17 @@ const getEnabledProviderBySlug = async (
   return provider;
 };
 
+const getEnabledProviderById = async (
+  protocol: 'oidc' | 'saml',
+  id: string,
+): Promise<ssoProvidersRepo.SsoProvider> => {
+  const provider = await ssoProvidersRepo.findById(id);
+  if (!provider || provider.protocol !== protocol || !provider.enabled) {
+    throw new Error('SSO provider is not enabled');
+  }
+  return provider;
+};
+
 const getProviderBySlug = async (
   protocol: 'oidc' | 'saml',
   slug: string,
@@ -265,17 +382,22 @@ const createOidcConfig = async (provider: ssoProvidersRepo.SsoProvider) => {
   if (!provider.issuerUrl || !provider.clientId) {
     throw new Error('OIDC provider is missing issuer URL or client ID');
   }
-  return oidc.discovery(new URL(provider.issuerUrl), provider.clientId, clientSecret || undefined);
+  // Reuse the same SSRF pre-flight as the SAML metadata fetch. openid-client.discovery does its
+  // own HTTPS fetch internally, but our pre-flight catches the obvious cases (http://, private
+  // IP) before we hand control to the library.
+  const issuerUrl = new URL(provider.issuerUrl);
+  await assertSafeRemoteUrl(issuerUrl);
+  return oidc.discovery(issuerUrl, provider.clientId, clientSecret || undefined);
 };
 
 const createSamlClient = async (
   provider: ssoProvidersRepo.SsoProvider,
-  requestOrigin: string,
+  baseUrl: string,
 ): Promise<SAML> => {
   const idp = await resolveSamlIdpConfig(provider);
   const { privateKey } = getProviderSecrets(provider);
-  const callbackUrl = buildCallbackUrl('saml', provider.slug, requestOrigin);
-  const issuer = provider.spIssuer || buildSamlMetadataUrl(provider.slug, requestOrigin);
+  const callbackUrl = buildCallbackUrl('saml', provider.slug, baseUrl);
+  const issuer = provider.spIssuer || buildSamlMetadataUrl(provider.slug, baseUrl);
   const entryPoint = idp.entryPoint || provider.entryPoint;
   const idpCert = normalizeCertificate(idp.idpCert || provider.idpCert);
   if (!entryPoint || !idpCert) {
@@ -366,7 +488,8 @@ export const updateProvider = async (
 export const deleteProvider = async (id: string): Promise<boolean> =>
   ssoProvidersRepo.deleteById(id);
 
-export const startOidcLogin = async (slug: string, requestOrigin: string): Promise<string> => {
+export const startOidcLogin = async (slug: string): Promise<string> => {
+  const baseUrl = resolvePublicBaseUrl();
   const provider = await getEnabledProviderBySlug('oidc', slug);
   const config = await createOidcConfig(provider);
   const codeVerifier = oidc.randomPKCECodeVerifier();
@@ -381,7 +504,7 @@ export const startOidcLogin = async (slug: string, requestOrigin: string): Promi
     expiresAt: new Date(Date.now() + OIDC_STATE_TTL_MS),
   });
   return oidc.buildAuthorizationUrl(config, {
-    redirect_uri: buildCallbackUrl('oidc', provider.slug, requestOrigin),
+    redirect_uri: buildCallbackUrl('oidc', provider.slug, baseUrl),
     scope: provider.scopes || ssoProvidersRepo.DEFAULT_OIDC_FIELDS.scopes,
     code_challenge: codeChallenge,
     code_challenge_method: 'S256',
@@ -389,17 +512,21 @@ export const startOidcLogin = async (slug: string, requestOrigin: string): Promi
   }).href;
 };
 
-export const completeOidcLogin = async (
-  slug: string,
-  callbackUrl: URL,
-  requestOrigin: string,
-): Promise<string> => {
-  const provider = await getEnabledProviderBySlug('oidc', slug);
+export const completeOidcLogin = async (slug: string, callbackUrl: URL): Promise<string> => {
+  const baseUrl = resolvePublicBaseUrl();
+  // Consume the state first, then resolve the provider FROM state.providerId — never from the
+  // URL slug. This blocks a slug-mismatch attack where the caller hits /oidc/<other>/callback
+  // with a code+state bound to a different provider, hoping to trade it for the wrong
+  // provider's tokens. The slug is only used as a defence-in-depth cross-check below.
   const stateValue = callbackUrl.searchParams.get('state') || '';
   const state = await ssoStatesRepo.consume(stateValue, 'oidc');
-  if (!state || state.providerId !== provider.id) throw new Error('Invalid or expired SSO state');
+  if (!state) throw new Error('Invalid or expired SSO state');
+  const provider = await getEnabledProviderById('oidc', state.providerId);
+  if (provider.slug !== normalizeSlug(slug)) {
+    throw new Error('Invalid or expired SSO state');
+  }
   const config = await createOidcConfig(provider);
-  const publicCallbackUrl = new URL(buildCallbackUrl('oidc', provider.slug, requestOrigin));
+  const publicCallbackUrl = new URL(buildCallbackUrl('oidc', provider.slug, baseUrl));
   publicCallbackUrl.search = callbackUrl.search;
   publicCallbackUrl.hash = callbackUrl.hash;
   const tokens = await oidc.authorizationCodeGrant(config, publicCallbackUrl, {
@@ -427,19 +554,20 @@ export const completeOidcLogin = async (
   });
 };
 
-export const startSamlLogin = async (slug: string, requestOrigin: string): Promise<string> => {
+export const startSamlLogin = async (slug: string): Promise<string> => {
+  const baseUrl = resolvePublicBaseUrl();
   const provider = await getEnabledProviderBySlug('saml', slug);
-  const saml = await createSamlClient(provider, requestOrigin);
+  const saml = await createSamlClient(provider, baseUrl);
   return saml.getAuthorizeUrlAsync('', undefined, {});
 };
 
 export const completeSamlLogin = async (
   slug: string,
   formBody: Record<string, string>,
-  requestOrigin: string,
 ): Promise<string> => {
+  const baseUrl = resolvePublicBaseUrl();
   const provider = await getEnabledProviderBySlug('saml', slug);
-  const saml = await createSamlClient(provider, requestOrigin);
+  const saml = await createSamlClient(provider, baseUrl);
   const result = await saml.validatePostResponseAsync(formBody);
   if (!result.profile || result.loggedOut) throw new Error('SAML response did not include a login');
   const profile = result.profile as Profile & Record<string, unknown>;
@@ -456,13 +584,14 @@ export const completeSamlLogin = async (
   });
 };
 
-export const getSamlMetadata = async (slug: string, requestOrigin: string): Promise<string> => {
+export const getSamlMetadata = async (slug: string): Promise<string> => {
+  const baseUrl = resolvePublicBaseUrl();
   const provider = await getProviderBySlug('saml', slug);
   const { privateKey } = getProviderSecrets(provider);
-  const issuer = provider.spIssuer || buildSamlMetadataUrl(provider.slug, requestOrigin);
+  const issuer = provider.spIssuer || buildSamlMetadataUrl(provider.slug, baseUrl);
   return generateServiceProviderMetadata({
     issuer,
-    callbackUrl: buildCallbackUrl('saml', provider.slug, requestOrigin),
+    callbackUrl: buildCallbackUrl('saml', provider.slug, baseUrl),
     privateKey: privateKey || undefined,
     publicCerts: provider.publicCert || undefined,
     signatureAlgorithm: 'sha256',

--- a/server/services/sso.ts
+++ b/server/services/sso.ts
@@ -23,6 +23,9 @@ const SAML_REQUEST_TTL_MS = 10 * 60 * 1000;
 const LOGIN_TICKET_TTL_MS = 2 * 60 * 1000;
 const REMOTE_FETCH_TIMEOUT_MS = 5_000;
 const REMOTE_FETCH_REDIRECT_LIMIT = 3;
+// SAML metadata documents are typically a few KB. 1 MiB is well above any legitimate payload
+// and keeps a hostile IdP from sending multi-GB junk that would OOM the backend.
+const REMOTE_FETCH_MAX_BYTES = 1 * 1024 * 1024;
 
 export type AdminSsoProvider = ssoProvidersRepo.SsoProvider;
 export type PublicSsoProvider = ssoProvidersRepo.PublicSsoProvider;
@@ -78,19 +81,39 @@ const readClaimArray = (claims: Record<string, unknown>, name: string): string[]
   return coerceStringArray(claims[name]);
 };
 
+const isLocalLoopbackHostname = (hostname: string): boolean =>
+  hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
+
 /**
  * Resolves the public base URL used to build callback / metadata / redirect URLs.
  *
  * We refuse to read `Host` / `x-forwarded-host` headers — those are attacker-controlled and
  * have caused host header injection vulnerabilities in similar flows. Instead, the base URL
  * MUST come from configuration: `SSO_CALLBACK_BASE_URL` (preferred) or `FRONTEND_URL`.
+ *
+ * The configured URL must parse and use https://, except for loopback hosts where http:// is
+ * allowed for local development. An http:// base URL on a public host would put the SSO ticket
+ * (transported via redirect to the configured FRONTEND_URL) at risk of network interception.
  */
 export const resolvePublicBaseUrl = (): string => {
   const explicit = process.env.SSO_CALLBACK_BASE_URL?.trim();
-  if (explicit) return explicit;
-  const frontend = process.env.FRONTEND_URL?.trim();
-  if (frontend) return frontend;
-  throw new Error('SSO_CALLBACK_BASE_URL or FRONTEND_URL must be configured for SSO');
+  const raw = explicit || process.env.FRONTEND_URL?.trim();
+  if (!raw) {
+    throw new Error('SSO_CALLBACK_BASE_URL or FRONTEND_URL must be configured for SSO');
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new Error('SSO public base URL is not a valid URL');
+  }
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    throw new Error(`SSO public base URL must use http(s) (got ${parsed.protocol})`);
+  }
+  if (parsed.protocol === 'http:' && !isLocalLoopbackHostname(parsed.hostname)) {
+    throw new Error('SSO public base URL must use https:// for non-loopback hosts');
+  }
+  return raw;
 };
 
 const buildPublicSsoUrl = (path: string, baseUrl: string): string => new URL(path, baseUrl).href;
@@ -212,6 +235,7 @@ const parseSamlMetadata = (xml: string) => {
  *   - 127.0.0.0/8 (loopback)
  *   - 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 (RFC1918 private)
  *   - 169.254.0.0/16 (link-local incl. cloud metadata 169.254.169.254)
+ *   - 100.64.0.0/10 (carrier-grade NAT — non-routable on the public internet)
  *   - 0.0.0.0/8
  *   - ::1 (IPv6 loopback)
  *   - fc00::/7 (IPv6 unique-local)
@@ -227,6 +251,7 @@ export const isPrivateIp = (ip: string): boolean => {
     if (a === 172 && b >= 16 && b <= 31) return true;
     if (a === 192 && b === 168) return true;
     if (a === 169 && b === 254) return true;
+    if (a === 100 && b >= 64 && b <= 127) return true;
     return false;
   }
   // IPv6 — normalise to lower-case, strip zone id.
@@ -260,6 +285,32 @@ const assertSafeRemoteUrl = async (url: URL): Promise<void> => {
 };
 
 /**
+ * Reads a response body as text, refusing to buffer more than REMOTE_FETCH_MAX_BYTES. Guards
+ * against a hostile IdP that returns a huge metadata document hoping to OOM the backend.
+ */
+const readBoundedText = async (response: Response): Promise<string> => {
+  const declared = Number(response.headers.get('content-length'));
+  if (Number.isFinite(declared) && declared > REMOTE_FETCH_MAX_BYTES) {
+    throw new Error(`Remote response too large (${declared} bytes)`);
+  }
+  if (!response.body) return '';
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > REMOTE_FETCH_MAX_BYTES) {
+      await reader.cancel();
+      throw new Error(`Remote response exceeded ${REMOTE_FETCH_MAX_BYTES} bytes`);
+    }
+    chunks.push(value);
+  }
+  return Buffer.concat(chunks, total).toString('utf-8');
+};
+
+/**
  * SSRF-hardened fetch for IdP-supplied URLs (SAML metadata, OIDC discovery).
  *
  * Guarantees:
@@ -278,7 +329,9 @@ const safeFetchRemoteUrl = async (url: string): Promise<Response> => {
       const response = await fetch(current, { signal: controller.signal, redirect: 'manual' });
       if (response.status >= 300 && response.status < 400) {
         const next = response.headers.get('location');
-        if (!next) return response;
+        if (!next) {
+          throw new Error(`Redirect response without Location header from ${current}`);
+        }
         current = new URL(next, current).href;
         continue;
       }
@@ -297,7 +350,7 @@ const resolveSamlIdpConfig = async (provider: ssoProvidersRepo.SsoProvider) => {
   if (provider.metadataUrl.trim()) {
     const response = await safeFetchRemoteUrl(provider.metadataUrl);
     if (!response.ok) throw new Error(`Failed to fetch SAML metadata: HTTP ${response.status}`);
-    return { ...parseSamlMetadata(await response.text()), source: 'metadataUrl' };
+    return { ...parseSamlMetadata(await readBoundedText(response)), source: 'metadataUrl' };
   }
   return {
     idpIssuer: provider.idpIssuer,

--- a/server/test/integration/sso-keycloak.integration.test.ts
+++ b/server/test/integration/sso-keycloak.integration.test.ts
@@ -253,6 +253,9 @@ describe.skipIf(SHOULD_SKIP_SSO)('SSO integration: Keycloak OIDC and SAML', () =
   let ssoService: SsoServiceModule;
 
   beforeAll(async () => {
+    // The service now reads the public base URL from env, not request headers. The integration
+    // tests need an explicit SSO_CALLBACK_BASE_URL set to the Keycloak-facing origin.
+    process.env.SSO_CALLBACK_BASE_URL = REQUEST_ORIGIN;
     mock.module('../../db/drizzle.ts', () => ({
       withDbTransaction: async <T>(fn: (tx: unknown) => Promise<T>) => fn({}),
       db: {},
@@ -367,7 +370,7 @@ describe.skipIf(SHOULD_SKIP_SSO)('SSO integration: Keycloak OIDC and SAML', () =
   });
 
   test('OIDC authorization code flow binds an existing local user and maps Keycloak groups', async () => {
-    const authorizationUrl = await ssoService.startOidcLogin(OIDC_PROVIDER_SLUG, REQUEST_ORIGIN);
+    const authorizationUrl = await ssoService.startOidcLogin(OIDC_PROVIDER_SLUG);
     const loginResult = await loginThroughKeycloak(
       authorizationUrl,
       ALICE_USERNAME,
@@ -376,11 +379,7 @@ describe.skipIf(SHOULD_SKIP_SSO)('SSO integration: Keycloak OIDC and SAML', () =
     expect(loginResult.type).toBe('redirect');
     if (loginResult.type !== 'redirect') throw new Error('Expected OIDC redirect callback');
 
-    const frontendUrl = await ssoService.completeOidcLogin(
-      OIDC_PROVIDER_SLUG,
-      loginResult.url,
-      REQUEST_ORIGIN,
-    );
+    const frontendUrl = await ssoService.completeOidcLogin(OIDC_PROVIDER_SLUG, loginResult.url);
     const ticket = new URL(frontendUrl, 'http://localhost').searchParams.get('sso_ticket');
 
     expect(ticket).toBeTruthy();
@@ -398,17 +397,13 @@ describe.skipIf(SHOULD_SKIP_SSO)('SSO integration: Keycloak OIDC and SAML', () =
   });
 
   test('SAML POST flow creates an unknown Keycloak user with mapped roles', async () => {
-    const authorizationUrl = await ssoService.startSamlLogin(SAML_PROVIDER_SLUG, REQUEST_ORIGIN);
+    const authorizationUrl = await ssoService.startSamlLogin(SAML_PROVIDER_SLUG);
     const loginResult = await loginThroughKeycloak(authorizationUrl, BOB_USERNAME, BOB_PASSWORD);
     expect(loginResult.type).toBe('saml-post');
     if (loginResult.type !== 'saml-post') throw new Error('Expected SAML POST callback');
     expect(loginResult.fields.SAMLResponse).toBeTruthy();
 
-    const frontendUrl = await ssoService.completeSamlLogin(
-      SAML_PROVIDER_SLUG,
-      loginResult.fields,
-      REQUEST_ORIGIN,
-    );
+    const frontendUrl = await ssoService.completeSamlLogin(SAML_PROVIDER_SLUG, loginResult.fields);
     const ticket = new URL(frontendUrl, 'http://localhost').searchParams.get('sso_ticket');
     const createdBob = [...users.values()].find((user) => user.username === BOB_USERNAME);
 

--- a/server/test/routes/sso.test.ts
+++ b/server/test/routes/sso.test.ts
@@ -1,0 +1,258 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { FastifyInstance, FastifyPluginAsync } from 'fastify';
+import * as realRolesRepo from '../../repositories/rolesRepo.ts';
+import * as realSsoProvidersRepo from '../../repositories/ssoProvidersRepo.ts';
+import * as realUsersRepo from '../../repositories/usersRepo.ts';
+import * as realAudit from '../../utils/audit.ts';
+import { MASKED_SECRET } from '../../utils/crypto.ts';
+import * as realPermissions from '../../utils/permissions.ts';
+import {
+  installAuthMiddlewareMock,
+  restoreAuthMiddlewareMock,
+} from '../helpers/authMiddlewareMock.ts';
+import { buildRouteTestApp } from '../helpers/buildRouteTestApp.ts';
+import { signToken } from '../helpers/jwt.ts';
+
+const usersRepoSnap = { ...realUsersRepo };
+const rolesRepoSnap = { ...realRolesRepo };
+const permissionsSnap = { ...realPermissions };
+const ssoProvidersRepoSnap = { ...realSsoProvidersRepo };
+const auditSnap = { ...realAudit };
+
+const findAuthUserByIdMock = mock();
+const userHasRoleMock = mock();
+const getRolePermissionsMock = mock();
+const findExistingIdsMock = mock();
+const listMock = mock();
+const findByIdMock = mock();
+const updateMock = mock();
+const logAuditMock = mock(async () => undefined);
+
+let routePlugin: FastifyPluginAsync;
+
+// Required by utils/crypto.ts for the encrypt path exercised when a non-masked secret is PUT.
+process.env.ENCRYPTION_KEY = process.env.ENCRYPTION_KEY || 'test-encryption-key-32-bytes-long!!';
+
+beforeAll(async () => {
+  installAuthMiddlewareMock();
+
+  mock.module('../../repositories/usersRepo.ts', () => ({
+    ...usersRepoSnap,
+    findAuthUserById: findAuthUserByIdMock,
+  }));
+  mock.module('../../repositories/rolesRepo.ts', () => ({
+    ...rolesRepoSnap,
+    findExistingIds: findExistingIdsMock,
+    userHasRole: userHasRoleMock,
+  }));
+  mock.module('../../utils/permissions.ts', () => ({
+    ...permissionsSnap,
+    getRolePermissions: getRolePermissionsMock,
+  }));
+  mock.module('../../repositories/ssoProvidersRepo.ts', () => ({
+    ...ssoProvidersRepoSnap,
+    list: listMock,
+    findById: findByIdMock,
+    update: updateMock,
+  }));
+  mock.module('../../utils/audit.ts', () => ({
+    ...auditSnap,
+    logAudit: logAuditMock,
+  }));
+
+  routePlugin = (await import('../../routes/sso.ts')).default as FastifyPluginAsync;
+});
+
+afterAll(() => {
+  restoreAuthMiddlewareMock();
+  mock.module('../../repositories/usersRepo.ts', () => usersRepoSnap);
+  mock.module('../../repositories/rolesRepo.ts', () => rolesRepoSnap);
+  mock.module('../../utils/permissions.ts', () => permissionsSnap);
+  mock.module('../../repositories/ssoProvidersRepo.ts', () => ssoProvidersRepoSnap);
+  mock.module('../../utils/audit.ts', () => auditSnap);
+});
+
+const HAPPY_USER = {
+  id: 'u1',
+  name: 'Alice',
+  username: 'alice',
+  role: 'admin',
+  avatarInitials: 'AL',
+  isDisabled: false,
+};
+
+const baseProvider: realSsoProvidersRepo.SsoProvider = {
+  id: 'sso-1',
+  protocol: 'oidc',
+  slug: 'google',
+  name: 'Google',
+  enabled: true,
+  issuerUrl: 'https://accounts.google.com',
+  clientId: 'client-123',
+  // Stored ciphertext — not the plaintext. The masking logic only cares whether non-empty.
+  clientSecret: 'iv:tag:ciphertext',
+  scopes: 'openid profile email',
+  metadataUrl: '',
+  metadataXml: '',
+  entryPoint: '',
+  idpIssuer: '',
+  idpCert: '',
+  spIssuer: '',
+  privateKey: 'iv:tag:pkcipher',
+  publicCert: '',
+  usernameAttribute: 'preferred_username',
+  nameAttribute: 'name',
+  emailAttribute: 'email',
+  groupsAttribute: 'groups',
+  roleMappings: [],
+};
+
+let testApp: FastifyInstance;
+
+const allMocks = [
+  findAuthUserByIdMock,
+  userHasRoleMock,
+  getRolePermissionsMock,
+  findExistingIdsMock,
+  listMock,
+  findByIdMock,
+  updateMock,
+  logAuditMock,
+];
+
+beforeEach(async () => {
+  for (const m of allMocks) m.mockReset();
+  findAuthUserByIdMock.mockResolvedValue(HAPPY_USER);
+  userHasRoleMock.mockResolvedValue(true);
+  getRolePermissionsMock.mockResolvedValue([
+    'administration.authentication.view',
+    'administration.authentication.update',
+  ]);
+  findExistingIdsMock.mockResolvedValue(new Set<string>());
+  logAuditMock.mockImplementation(async () => undefined);
+  testApp = await buildRouteTestApp(routePlugin, '/api/sso');
+});
+
+afterEach(async () => {
+  await testApp.close();
+});
+
+const authHeader = () => ({ authorization: `Bearer ${signToken({ userId: 'u1' })}` });
+
+describe('GET /api/sso/providers — secret masking', () => {
+  test('clientSecret and privateKey are returned as MASKED_SECRET when set', async () => {
+    listMock.mockResolvedValue([baseProvider]);
+    const response = await testApp.inject({
+      method: 'GET',
+      url: '/api/sso/providers',
+      headers: authHeader(),
+    });
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body).toHaveLength(1);
+    expect(body[0].clientSecret).toBe(MASKED_SECRET);
+    expect(body[0].privateKey).toBe(MASKED_SECRET);
+  });
+
+  test('empty secrets stay empty (no spurious mask)', async () => {
+    listMock.mockResolvedValue([{ ...baseProvider, clientSecret: '', privateKey: '' }]);
+    const response = await testApp.inject({
+      method: 'GET',
+      url: '/api/sso/providers',
+      headers: authHeader(),
+    });
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body[0].clientSecret).toBe('');
+    expect(body[0].privateKey).toBe('');
+  });
+
+  test('metadataXml and idpCert are masked when set', async () => {
+    listMock.mockResolvedValue([
+      {
+        ...baseProvider,
+        protocol: 'saml',
+        metadataXml: '<EntityDescriptor>...</EntityDescriptor>',
+        idpCert: 'MIIDxx...',
+      },
+    ]);
+    const response = await testApp.inject({
+      method: 'GET',
+      url: '/api/sso/providers',
+      headers: authHeader(),
+    });
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body);
+    expect(body[0].metadataXml).toBe(MASKED_SECRET);
+    expect(body[0].idpCert).toBe(MASKED_SECRET);
+  });
+});
+
+describe('PUT /api/sso/providers/:id — masked sentinel preserves existing secrets', () => {
+  test('clientSecret === MASKED_SECRET is dropped from patch (existing value preserved)', async () => {
+    findByIdMock.mockResolvedValue(baseProvider);
+    updateMock.mockImplementation(
+      async (_id: string, patch: realSsoProvidersRepo.SsoProviderPatch) => ({
+        ...baseProvider,
+        ...patch,
+      }),
+    );
+    const response = await testApp.inject({
+      method: 'PUT',
+      url: '/api/sso/providers/sso-1',
+      headers: { ...authHeader(), 'content-type': 'application/json' },
+      payload: {
+        clientSecret: MASKED_SECRET,
+        privateKey: MASKED_SECRET,
+        name: 'Google (renamed)',
+      },
+    });
+    expect(response.statusCode).toBe(200);
+    const [, patch] = updateMock.mock.calls[0];
+    expect(patch).not.toHaveProperty('clientSecret');
+    expect(patch).not.toHaveProperty('privateKey');
+    expect(patch.name).toBe('Google (renamed)');
+  });
+
+  test('a new (non-masked) clientSecret IS encrypted and persisted', async () => {
+    findByIdMock.mockResolvedValue(baseProvider);
+    updateMock.mockImplementation(
+      async (_id: string, patch: realSsoProvidersRepo.SsoProviderPatch) => ({
+        ...baseProvider,
+        ...patch,
+      }),
+    );
+    const response = await testApp.inject({
+      method: 'PUT',
+      url: '/api/sso/providers/sso-1',
+      headers: { ...authHeader(), 'content-type': 'application/json' },
+      payload: { clientSecret: 'a-real-new-secret' },
+    });
+    expect(response.statusCode).toBe(200);
+    const [, patch] = updateMock.mock.calls[0];
+    expect(typeof patch.clientSecret).toBe('string');
+    // Should be encrypted ciphertext, not the raw plaintext.
+    expect(patch.clientSecret).not.toBe('a-real-new-secret');
+    expect(patch.clientSecret).not.toBe('');
+  });
+
+  test('metadataXml === MASKED_SECRET is dropped from patch', async () => {
+    findByIdMock.mockResolvedValue({ ...baseProvider, protocol: 'saml' });
+    updateMock.mockImplementation(
+      async (_id: string, patch: realSsoProvidersRepo.SsoProviderPatch) => ({
+        ...baseProvider,
+        ...patch,
+      }),
+    );
+    const response = await testApp.inject({
+      method: 'PUT',
+      url: '/api/sso/providers/sso-1',
+      headers: { ...authHeader(), 'content-type': 'application/json' },
+      payload: { metadataXml: MASKED_SECRET, idpCert: MASKED_SECRET },
+    });
+    expect(response.statusCode).toBe(200);
+    const [, patch] = updateMock.mock.calls[0];
+    expect(patch).not.toHaveProperty('metadataXml');
+    expect(patch).not.toHaveProperty('idpCert');
+  });
+});

--- a/server/test/services/sso.test.ts
+++ b/server/test/services/sso.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
 import * as realDns from 'node:dns/promises';
 import * as realSsoProvidersRepo from '../../repositories/ssoProvidersRepo.ts';
 import * as realSsoStatesRepo from '../../repositories/ssoStatesRepo.ts';
@@ -81,6 +81,14 @@ describe('isPrivateIp', () => {
     expect(sso.isPrivateIp('::ffff:127.0.0.1')).toBe(true);
     expect(sso.isPrivateIp('::ffff:10.0.0.1')).toBe(true);
   });
+
+  test('detects 100.64.0.0/10 (carrier-grade NAT)', () => {
+    expect(sso.isPrivateIp('100.64.0.1')).toBe(true);
+    expect(sso.isPrivateIp('100.127.255.254')).toBe(true);
+    // Just below and just above the CGN range stay public.
+    expect(sso.isPrivateIp('100.63.255.255')).toBe(false);
+    expect(sso.isPrivateIp('100.128.0.1')).toBe(false);
+  });
 });
 
 describe('resolvePublicBaseUrl', () => {
@@ -114,6 +122,28 @@ describe('resolvePublicBaseUrl', () => {
   test('falls back to FRONTEND_URL', () => {
     process.env.FRONTEND_URL = 'https://app.example.com';
     expect(sso.resolvePublicBaseUrl()).toBe('https://app.example.com');
+  });
+
+  test('rejects an unparseable URL', () => {
+    process.env.SSO_CALLBACK_BASE_URL = 'not a url';
+    expect(() => sso.resolvePublicBaseUrl()).toThrow(/not a valid URL/);
+  });
+
+  test('rejects non-http(s) schemes', () => {
+    process.env.SSO_CALLBACK_BASE_URL = 'javascript:alert(1)';
+    expect(() => sso.resolvePublicBaseUrl()).toThrow(/must use http/);
+  });
+
+  test('allows http:// for localhost (dev mode)', () => {
+    process.env.SSO_CALLBACK_BASE_URL = 'http://localhost:3001';
+    expect(sso.resolvePublicBaseUrl()).toBe('http://localhost:3001');
+    process.env.SSO_CALLBACK_BASE_URL = 'http://127.0.0.1:3001';
+    expect(sso.resolvePublicBaseUrl()).toBe('http://127.0.0.1:3001');
+  });
+
+  test('rejects http:// for non-loopback hosts', () => {
+    process.env.SSO_CALLBACK_BASE_URL = 'http://praetor.example.com';
+    expect(() => sso.resolvePublicBaseUrl()).toThrow(/https:\/\/ for non-loopback/);
   });
 });
 
@@ -176,6 +206,106 @@ describe('startSamlLogin SSRF protections', () => {
     });
     dnsLookupMock.mockResolvedValue([{ address: '169.254.169.254', family: 4 }]);
     await expect(sso.startSamlLogin('okta')).rejects.toThrow(/private\/loopback/);
+  });
+});
+
+describe('safeFetchRemoteUrl behavior (exercised via SAML metadata fetch)', () => {
+  const realFetch = globalThis.fetch;
+  const originalSsoBase = process.env.SSO_CALLBACK_BASE_URL;
+  const fetchMock = mock();
+
+  beforeEach(() => {
+    process.env.SSO_CALLBACK_BASE_URL = 'https://app.example.com';
+    fetchMock.mockReset();
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+    findBySlugMock.mockResolvedValue({
+      ...SAML_PROVIDER,
+      metadataUrl: 'https://idp.example.com/metadata',
+    });
+    // Default: every DNS lookup resolves to a benign public IP.
+    dnsLookupMock.mockResolvedValue([{ address: '203.0.113.10', family: 4 }]);
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  afterAll(() => {
+    if (originalSsoBase === undefined) delete process.env.SSO_CALLBACK_BASE_URL;
+    else process.env.SSO_CALLBACK_BASE_URL = originalSsoBase;
+  });
+
+  test('follows a single 302 redirect and re-validates the target', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: { location: 'https://idp2.example.com/metadata' },
+        }),
+      )
+      .mockResolvedValueOnce(new Response('<EntityDescriptor entityID="x"/>', { status: 200 }));
+    // The redirect should be followed all the way through to SAML client construction; that
+    // construction then fails with a domain-specific error proving safeFetchRemoteUrl returned
+    // the post-redirect response successfully.
+    await expect(sso.startSamlLogin('okta')).rejects.toThrow(/missing entry point/);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // assertSafeRemoteUrl runs dns.lookup once per hop.
+    expect(dnsLookupMock).toHaveBeenCalledTimes(2);
+  });
+
+  test('throws when a redirect response is missing the Location header', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 302 }));
+    await expect(sso.startSamlLogin('okta')).rejects.toThrow(/Location header/);
+  });
+
+  test('rejects when a redirect target resolves to a private IP (per-hop revalidation)', async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { location: 'https://internal.example/m' },
+      }),
+    );
+    dnsLookupMock
+      .mockResolvedValueOnce([{ address: '203.0.113.10', family: 4 }])
+      .mockResolvedValueOnce([{ address: '10.0.0.1', family: 4 }]);
+    await expect(sso.startSamlLogin('okta')).rejects.toThrow(/private\/loopback/);
+  });
+
+  test('rejects after exceeding the redirect limit', async () => {
+    // Same Location each time — drives the loop to its bound.
+    fetchMock.mockResolvedValue(
+      new Response(null, {
+        status: 302,
+        headers: { location: 'https://idp.example.com/metadata' },
+      }),
+    );
+    await expect(sso.startSamlLogin('okta')).rejects.toThrow(/redirect limit/);
+  });
+
+  test('rejects when Content-Length declares a body larger than the cap', async () => {
+    // No body, but the declared content-length is enough to fail the pre-stream check.
+    fetchMock.mockResolvedValueOnce(
+      new Response(null, {
+        status: 200,
+        headers: { 'content-length': String(2 * 1024 * 1024) },
+      }),
+    );
+    await expect(sso.startSamlLogin('okta')).rejects.toThrow(/too large/);
+  });
+
+  test('rejects when the streamed body exceeds the cap', async () => {
+    // Build a Response with a streaming body bigger than the cap, without a Content-Length so
+    // the size check happens during the read loop.
+    const oneMb = new Uint8Array(1024 * 1024).fill(65); // 1 MiB of 'A'
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(oneMb);
+        controller.enqueue(oneMb); // 2 MiB total — over the cap
+        controller.close();
+      },
+    });
+    fetchMock.mockResolvedValueOnce(new Response(stream, { status: 200 }));
+    await expect(sso.startSamlLogin('okta')).rejects.toThrow(/exceeded/);
   });
 });
 

--- a/server/test/services/sso.test.ts
+++ b/server/test/services/sso.test.ts
@@ -1,0 +1,250 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as realDns from 'node:dns/promises';
+import * as realSsoProvidersRepo from '../../repositories/ssoProvidersRepo.ts';
+import * as realSsoStatesRepo from '../../repositories/ssoStatesRepo.ts';
+
+const dnsSnap = { ...realDns };
+const ssoProvidersRepoSnap = { ...realSsoProvidersRepo };
+const ssoStatesRepoSnap = { ...realSsoStatesRepo };
+
+const dnsLookupMock = mock();
+const findBySlugMock = mock();
+const findByIdMock = mock();
+const statesConsumeMock = mock();
+
+let sso: typeof import('../../services/sso.ts');
+
+beforeAll(async () => {
+  mock.module('node:dns/promises', () => ({
+    ...dnsSnap,
+    default: { ...dnsSnap, lookup: dnsLookupMock },
+    lookup: dnsLookupMock,
+  }));
+  mock.module('../../repositories/ssoProvidersRepo.ts', () => ({
+    ...ssoProvidersRepoSnap,
+    findBySlug: findBySlugMock,
+    findById: findByIdMock,
+  }));
+  mock.module('../../repositories/ssoStatesRepo.ts', () => ({
+    ...ssoStatesRepoSnap,
+    consume: statesConsumeMock,
+  }));
+
+  sso = await import('../../services/sso.ts');
+});
+
+afterAll(() => {
+  mock.module('node:dns/promises', () => dnsSnap);
+  mock.module('../../repositories/ssoProvidersRepo.ts', () => ssoProvidersRepoSnap);
+  mock.module('../../repositories/ssoStatesRepo.ts', () => ssoStatesRepoSnap);
+});
+
+beforeEach(() => {
+  for (const m of [dnsLookupMock, findBySlugMock, findByIdMock, statesConsumeMock]) m.mockReset();
+});
+
+describe('isPrivateIp', () => {
+  test('detects IPv4 loopback', () => {
+    expect(sso.isPrivateIp('127.0.0.1')).toBe(true);
+    expect(sso.isPrivateIp('127.255.255.254')).toBe(true);
+  });
+
+  test('detects RFC1918 private ranges', () => {
+    expect(sso.isPrivateIp('10.0.0.1')).toBe(true);
+    expect(sso.isPrivateIp('172.16.5.6')).toBe(true);
+    expect(sso.isPrivateIp('172.31.255.255')).toBe(true);
+    expect(sso.isPrivateIp('192.168.1.1')).toBe(true);
+  });
+
+  test('detects link-local (cloud metadata)', () => {
+    expect(sso.isPrivateIp('169.254.169.254')).toBe(true);
+  });
+
+  test('detects IPv6 loopback and unique-local', () => {
+    expect(sso.isPrivateIp('::1')).toBe(true);
+    expect(sso.isPrivateIp('fc00::1')).toBe(true);
+    expect(sso.isPrivateIp('fd12:3456:789a::1')).toBe(true);
+    expect(sso.isPrivateIp('fe80::1')).toBe(true);
+  });
+
+  test('does NOT match public IPv4', () => {
+    expect(sso.isPrivateIp('8.8.8.8')).toBe(false);
+    expect(sso.isPrivateIp('172.32.0.1')).toBe(false); // 172.32 is public
+    expect(sso.isPrivateIp('11.0.0.1')).toBe(false);
+  });
+
+  test('does NOT match public IPv6', () => {
+    expect(sso.isPrivateIp('2606:4700:4700::1111')).toBe(false);
+  });
+
+  test('detects IPv4-mapped IPv6 loopback', () => {
+    expect(sso.isPrivateIp('::ffff:127.0.0.1')).toBe(true);
+    expect(sso.isPrivateIp('::ffff:10.0.0.1')).toBe(true);
+  });
+});
+
+describe('resolvePublicBaseUrl', () => {
+  const originalSsoBase = process.env.SSO_CALLBACK_BASE_URL;
+  const originalFrontend = process.env.FRONTEND_URL;
+
+  beforeEach(() => {
+    process.env.SSO_CALLBACK_BASE_URL = '';
+    process.env.FRONTEND_URL = '';
+  });
+
+  afterAll(() => {
+    if (originalSsoBase === undefined) delete process.env.SSO_CALLBACK_BASE_URL;
+    else process.env.SSO_CALLBACK_BASE_URL = originalSsoBase;
+    if (originalFrontend === undefined) delete process.env.FRONTEND_URL;
+    else process.env.FRONTEND_URL = originalFrontend;
+  });
+
+  test('throws when both env vars are unset', () => {
+    expect(() => sso.resolvePublicBaseUrl()).toThrow(
+      'SSO_CALLBACK_BASE_URL or FRONTEND_URL must be configured for SSO',
+    );
+  });
+
+  test('prefers SSO_CALLBACK_BASE_URL over FRONTEND_URL', () => {
+    process.env.SSO_CALLBACK_BASE_URL = 'https://sso.example.com';
+    process.env.FRONTEND_URL = 'https://app.example.com';
+    expect(sso.resolvePublicBaseUrl()).toBe('https://sso.example.com');
+  });
+
+  test('falls back to FRONTEND_URL', () => {
+    process.env.FRONTEND_URL = 'https://app.example.com';
+    expect(sso.resolvePublicBaseUrl()).toBe('https://app.example.com');
+  });
+});
+
+const SAML_PROVIDER: realSsoProvidersRepo.SsoProvider = {
+  id: 'sso-1',
+  protocol: 'saml',
+  slug: 'okta',
+  name: 'Okta',
+  enabled: true,
+  issuerUrl: '',
+  clientId: '',
+  clientSecret: '',
+  scopes: '',
+  metadataUrl: 'http://10.0.0.1/metadata', // intentionally non-HTTPS + private
+  metadataXml: '',
+  entryPoint: '',
+  idpIssuer: '',
+  idpCert: '',
+  spIssuer: '',
+  privateKey: '',
+  publicCert: '',
+  usernameAttribute: 'nameID',
+  nameAttribute: 'name',
+  emailAttribute: 'email',
+  groupsAttribute: 'groups',
+  roleMappings: [],
+};
+
+describe('startSamlLogin SSRF protections', () => {
+  const originalSsoBase = process.env.SSO_CALLBACK_BASE_URL;
+  beforeEach(() => {
+    process.env.SSO_CALLBACK_BASE_URL = 'https://app.example.com';
+  });
+  afterAll(() => {
+    if (originalSsoBase === undefined) delete process.env.SSO_CALLBACK_BASE_URL;
+    else process.env.SSO_CALLBACK_BASE_URL = originalSsoBase;
+  });
+
+  test('rejects http:// metadataUrl', async () => {
+    findBySlugMock.mockResolvedValue({
+      ...SAML_PROVIDER,
+      metadataUrl: 'http://idp.example.com/metadata',
+    });
+    await expect(sso.startSamlLogin('okta')).rejects.toThrow(/non-HTTPS/);
+  });
+
+  test('rejects metadataUrl that resolves to a private IP', async () => {
+    findBySlugMock.mockResolvedValue({
+      ...SAML_PROVIDER,
+      metadataUrl: 'https://internal.example.com/metadata',
+    });
+    dnsLookupMock.mockResolvedValue([{ address: '10.0.0.5', family: 4 }]);
+    await expect(sso.startSamlLogin('okta')).rejects.toThrow(/private\/loopback/);
+  });
+
+  test('rejects metadataUrl host that resolves to 169.254.169.254 (cloud metadata)', async () => {
+    findBySlugMock.mockResolvedValue({
+      ...SAML_PROVIDER,
+      metadataUrl: 'https://metadata.example.com/metadata',
+    });
+    dnsLookupMock.mockResolvedValue([{ address: '169.254.169.254', family: 4 }]);
+    await expect(sso.startSamlLogin('okta')).rejects.toThrow(/private\/loopback/);
+  });
+});
+
+describe('completeOidcLogin state-before-provider ordering', () => {
+  const originalSsoBase = process.env.SSO_CALLBACK_BASE_URL;
+  beforeEach(() => {
+    process.env.SSO_CALLBACK_BASE_URL = 'https://app.example.com';
+  });
+  afterAll(() => {
+    if (originalSsoBase === undefined) delete process.env.SSO_CALLBACK_BASE_URL;
+    else process.env.SSO_CALLBACK_BASE_URL = originalSsoBase;
+  });
+
+  test('rejects when state cannot be consumed', async () => {
+    statesConsumeMock.mockResolvedValue(null);
+    const callbackUrl = new URL(
+      'http://internal.invalid/api/auth/sso/oidc/google/callback?state=missing&code=abc',
+    );
+    await expect(sso.completeOidcLogin('google', callbackUrl)).rejects.toThrow(
+      'Invalid or expired SSO state',
+    );
+    expect(findBySlugMock).not.toHaveBeenCalled();
+    expect(findByIdMock).not.toHaveBeenCalled();
+  });
+
+  test('looks up the provider FROM state.providerId, not the URL slug', async () => {
+    // The state was created for provider sso-1 ('google'); but the caller hits a
+    // /oidc/<other>/callback path. The service must resolve the provider via the
+    // state, then reject because the slugs do not match — never trade for a
+    // different provider's tokens.
+    statesConsumeMock.mockResolvedValue({
+      state: 's',
+      providerId: 'sso-1',
+      protocol: 'oidc',
+      codeVerifier: 'v',
+      relayState: '',
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    findByIdMock.mockResolvedValue({
+      ...SAML_PROVIDER,
+      id: 'sso-1',
+      protocol: 'oidc',
+      slug: 'google',
+      issuerUrl: 'https://accounts.google.com',
+      clientId: 'cid',
+    });
+    const callbackUrl = new URL(
+      'http://internal.invalid/api/auth/sso/oidc/other/callback?state=s&code=abc',
+    );
+    await expect(sso.completeOidcLogin('other', callbackUrl)).rejects.toThrow(
+      'Invalid or expired SSO state',
+    );
+    // Provider was fetched by id, not slug.
+    expect(findByIdMock).toHaveBeenCalledWith('sso-1');
+    expect(findBySlugMock).not.toHaveBeenCalled();
+  });
+
+  test('consume happens before any provider lookup', async () => {
+    // Even when the state is invalid, we should consume the state (which atomically
+    // burns it) before doing slug → provider lookups. This means a bogus state value
+    // doesn't leak information about which providers are configured.
+    statesConsumeMock.mockResolvedValue(null);
+    findBySlugMock.mockResolvedValue(null);
+    const callbackUrl = new URL(
+      'http://internal.invalid/api/auth/sso/oidc/anything/callback?state=x',
+    );
+    await expect(sso.completeOidcLogin('anything', callbackUrl)).rejects.toThrow(
+      'Invalid or expired SSO state',
+    );
+    expect(statesConsumeMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Replace request-header-based origin resolution with a strict `SSO_CALLBACK_BASE_URL` / `FRONTEND_URL` allowlist (never read `Host` / `x-forwarded-host` for URL construction)
- Mask `clientSecret`, `privateKey`, `metadataXml`, and `idpCert` in admin GETs; a `'***'` echo on PUT preserves the stored value
- Validate / consume the OIDC state atomically before any provider lookup, and resolve the provider from `state.providerId` rather than the URL slug — a slug-mismatch attack can no longer trade a state for the wrong provider's tokens
- Add a shared SSRF pre-flight (HTTPS-only, DNS lookup, private/loopback IP rejection) plus a 5 s timeout and bounded-redirect cap to SAML metadata fetch and OIDC discovery

Covers Critical issues #1, #2, #4, #12 and Medium B6 from the SSO security review. Documents the new `SSO_CALLBACK_BASE_URL` env var in `server/.env.example`.

## Manual verification

1. Log in as admin → Settings → SSO. Verify `clientSecret`, `privateKey`, `metadataXml`, and `idpCert` fields render as `***` for any saved provider.
2. Edit an existing provider, leave the secret as `***`, and save. Then attempt a real login through that provider — it should still succeed (the stored secret was preserved, not overwritten).
3. Try to add a SAML provider with `metadataUrl=http://10.0.0.1/metadata`. Expect a clear rejection: non-HTTPS and/or private-host error.
4. Verify the `Host` header can no longer be used to forge a callback URL: set `SSO_CALLBACK_BASE_URL=https://praetor.example.com` and curl `/api/auth/sso/oidc/<slug>/start` with `Host: attacker.example`. The 302 `Location` should still point at `praetor.example.com`.

## Test plan

- [x] `cd server && bun run build` — typecheck passes
- [x] `bun run lint` — no new lint errors
- [x] `cd server && bun test` — full backend suite passes (2094 / 0 fail)
- [x] New unit tests cover state-before-provider ordering, private-IP / non-HTTPS SSRF rejection, GET secret masking, and PUT `'***'` preservation