### PR TITLE
fix(auth): sanitize 500 errors, configurable session max, JWT algorithm allowlist

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -58,6 +58,23 @@ const parseTrustProxyEnv = (value: string | undefined): boolean | string | numbe
   return value.trim();
 };
 
+// Exported for testing. In production, sanitize 5xx response bodies so internal error details
+// (stack traces, DB column names, etc.) never reach API clients. The full error is still
+// recorded server-side via request.log.error. 4xx responses pass through unchanged so
+// validation/auth/etc. messages remain useful to API clients in every environment.
+export const buildErrorResponseMessage = (
+  error: Error & { statusCode?: number },
+  env: NodeJS.ProcessEnv = process.env,
+): { statusCode: number; message: string } => {
+  const statusCode = error.statusCode || 500;
+  const isProduction = env.NODE_ENV === 'production';
+  const shouldMaskMessage = isProduction && statusCode >= 500;
+  const message = shouldMaskMessage
+    ? 'Internal server error'
+    : error.message || 'Internal server error';
+  return { statusCode, message };
+};
+
 export const buildApp = async () => {
   const fastify = Fastify({
     logger: loggerOptions,
@@ -168,9 +185,8 @@ export const buildApp = async () => {
       'Unhandled request error',
     );
 
-    reply.code(error.statusCode || 500).send({
-      error: error.message || 'Internal server error',
-    });
+    const { statusCode, message } = buildErrorResponseMessage(error);
+    reply.code(statusCode).send({ error: message });
   });
 
   return fastify;

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -30,6 +30,40 @@ const resolveJwtSecret = () => {
 
 const JWT_SECRET = resolveJwtSecret();
 
+// JWT signing algorithm. `jwt.sign` (see generateToken below) defaults to HS256, so we pin
+// verification to the same algorithm to prevent algorithm-confusion attacks (e.g. forged
+// tokens using `alg: 'none'` or asymmetric algorithms abusing the HMAC secret as a public key).
+const JWT_ALGORITHM = 'HS256' as const;
+
+const DEFAULT_SESSION_MAX_DURATION_MS = 8 * 60 * 60 * 1000; // 8 hours
+
+const resolveSessionMaxDurationMs = (): number => {
+  const raw = process.env.SESSION_MAX_DURATION_MS?.trim();
+  if (!raw) return DEFAULT_SESSION_MAX_DURATION_MS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_SESSION_MAX_DURATION_MS;
+  }
+  return parsed;
+};
+
+// Resolved lazily on the first authenticated request and cached for the lifetime of the
+// process, so we avoid re-parsing env on every request without forcing tests to set
+// SESSION_MAX_DURATION_MS before the very first `import './middleware/auth.ts'` runs.
+let cachedSessionMaxDurationMs: number | null = null;
+const getSessionMaxDurationMs = (): number => {
+  if (cachedSessionMaxDurationMs === null) {
+    cachedSessionMaxDurationMs = resolveSessionMaxDurationMs();
+  }
+  return cachedSessionMaxDurationMs;
+};
+
+// Test-only escape hatch: forces re-reading SESSION_MAX_DURATION_MS from env on the next
+// authenticated request. Not part of the public production API.
+export const __resetSessionMaxDurationCacheForTests = () => {
+  cachedSessionMaxDurationMs = null;
+};
+
 type SessionJwtPayload = JwtPayload & {
   userId: string;
   sessionStart?: number;
@@ -93,14 +127,16 @@ export const authenticateToken = async (request: FastifyRequest, reply: FastifyR
   }
 
   try {
-    const decoded = jwt.verify(token, JWT_SECRET) as SessionJwtPayload;
+    const decoded = jwt.verify(token, JWT_SECRET, {
+      algorithms: [JWT_ALGORITHM],
+    }) as SessionJwtPayload;
     const sessionStart = decoded.sessionStart ?? Date.now();
 
-    // Check for max session duration (8 hours)
-    const SESSION_MAX_DURATION = 8 * 60 * 60 * 1000; // 8 hours in ms
+    // Check for max session duration (configurable via SESSION_MAX_DURATION_MS env var,
+    // default 8 hours). Resolved once per process — see getSessionMaxDurationMs above.
     const now = Date.now();
 
-    if (now - sessionStart > SESSION_MAX_DURATION) {
+    if (now - sessionStart > getSessionMaxDurationMs()) {
       return reply.code(401).send({ error: 'Session expired (max duration exceeded)' });
     }
 
@@ -199,8 +235,11 @@ export const generateToken = (
   activeRole?: string,
 ) => {
   // Token expires in 30 minutes (idle timeout)
-  // sessionStart tracks the absolute start of the session (max 8 hours)
-  return jwt.sign({ userId, sessionStart, activeRole }, JWT_SECRET, { expiresIn: '30m' });
+  // sessionStart tracks the absolute start of the session (SESSION_MAX_DURATION_MS, default 8h)
+  return jwt.sign({ userId, sessionStart, activeRole }, JWT_SECRET, {
+    expiresIn: '30m',
+    algorithm: JWT_ALGORITHM,
+  });
 };
 
 export default {

--- a/server/test/app.test.ts
+++ b/server/test/app.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from 'bun:test';
+import Fastify from 'fastify';
+import { buildErrorResponseMessage } from '../app.ts';
+import { serializeError } from '../utils/logger.ts';
+
+// Lightweight harness that mirrors app.ts's setErrorHandler. We don't call buildApp() here
+// because it registers every domain route, opens the DB pool, and requires real LDAP/SSO
+// config — none of which the error-handling contract depends on.
+const buildTestApp = (env: NodeJS.ProcessEnv) => {
+  // Capture log lines for assertions about server-side error visibility. Pino accepts a
+  // raw stream destination, so we write each JSON log line into an array we can inspect.
+  const logLines: string[] = [];
+  const captureStream = {
+    write(chunk: string) {
+      logLines.push(chunk);
+    },
+  };
+  const fastify = Fastify({
+    logger: {
+      level: 'error',
+      stream: captureStream as never,
+    },
+  });
+
+  fastify.setErrorHandler((error: Error & { statusCode?: number }, request, reply) => {
+    request.log.error(
+      {
+        err: serializeError(error),
+        statusCode: error.statusCode,
+      },
+      'Unhandled request error',
+    );
+
+    const { statusCode, message } = buildErrorResponseMessage(error, env);
+    reply.code(statusCode).send({ error: message });
+  });
+
+  fastify.get('/boom-500', async () => {
+    throw new Error('Database password is hunter2');
+  });
+
+  fastify.get('/boom-400', async () => {
+    const err = new Error('Missing required field: email') as Error & { statusCode?: number };
+    err.statusCode = 400;
+    throw err;
+  });
+
+  fastify.get('/boom-503', async () => {
+    const err = new Error('Upstream OAuth token leaked') as Error & { statusCode?: number };
+    err.statusCode = 503;
+    throw err;
+  });
+
+  return { fastify, logLines };
+};
+
+describe('buildErrorResponseMessage', () => {
+  test('production + 500: masks message to "Internal server error"', () => {
+    const result = buildErrorResponseMessage(new Error('SQL near "FROM" failed'), {
+      NODE_ENV: 'production',
+    } as NodeJS.ProcessEnv);
+    expect(result).toEqual({ statusCode: 500, message: 'Internal server error' });
+  });
+
+  test('production + 5xx (503): also masks', () => {
+    const err = new Error('Sensitive upstream detail') as Error & { statusCode?: number };
+    err.statusCode = 503;
+    const result = buildErrorResponseMessage(err, {
+      NODE_ENV: 'production',
+    } as NodeJS.ProcessEnv);
+    expect(result).toEqual({ statusCode: 503, message: 'Internal server error' });
+  });
+
+  test('production + 4xx: original message passes through', () => {
+    const err = new Error('Invalid email') as Error & { statusCode?: number };
+    err.statusCode = 400;
+    const result = buildErrorResponseMessage(err, {
+      NODE_ENV: 'production',
+    } as NodeJS.ProcessEnv);
+    expect(result).toEqual({ statusCode: 400, message: 'Invalid email' });
+  });
+
+  test('non-production + 500: original message passes through (developer ergonomics)', () => {
+    const result = buildErrorResponseMessage(new Error('SQL near "FROM" failed'), {
+      NODE_ENV: 'development',
+    } as NodeJS.ProcessEnv);
+    expect(result).toEqual({ statusCode: 500, message: 'SQL near "FROM" failed' });
+  });
+
+  test('falls back to "Internal server error" when the Error has no message', () => {
+    const err = new Error('') as Error & { statusCode?: number };
+    err.statusCode = 500;
+    const result = buildErrorResponseMessage(err, {
+      NODE_ENV: 'development',
+    } as NodeJS.ProcessEnv);
+    expect(result).toEqual({ statusCode: 500, message: 'Internal server error' });
+  });
+});
+
+describe('Fastify error handler integration', () => {
+  test('production: a 500 returns the generic message but the real error reaches the log', async () => {
+    const { fastify, logLines } = buildTestApp({
+      NODE_ENV: 'production',
+    } as NodeJS.ProcessEnv);
+
+    const response = await fastify.inject({ method: 'GET', url: '/boom-500' });
+
+    expect(response.statusCode).toBe(500);
+    expect(JSON.parse(response.body)).toEqual({ error: 'Internal server error' });
+    // The original message must still be visible to operators via the server log.
+    const allLogs = logLines.join('\n');
+    expect(allLogs).toContain('Database password is hunter2');
+    expect(allLogs).toContain('Unhandled request error');
+
+    await fastify.close();
+  });
+
+  test('production: a 503 also gets the generic message', async () => {
+    const { fastify } = buildTestApp({
+      NODE_ENV: 'production',
+    } as NodeJS.ProcessEnv);
+
+    const response = await fastify.inject({ method: 'GET', url: '/boom-503' });
+
+    expect(response.statusCode).toBe(503);
+    expect(JSON.parse(response.body)).toEqual({ error: 'Internal server error' });
+
+    await fastify.close();
+  });
+
+  test('production: a 4xx keeps its original message', async () => {
+    const { fastify } = buildTestApp({
+      NODE_ENV: 'production',
+    } as NodeJS.ProcessEnv);
+
+    const response = await fastify.inject({ method: 'GET', url: '/boom-400' });
+
+    expect(response.statusCode).toBe(400);
+    expect(JSON.parse(response.body)).toEqual({ error: 'Missing required field: email' });
+
+    await fastify.close();
+  });
+
+  test('non-production: 5xx error messages still pass through to the client', async () => {
+    const { fastify } = buildTestApp({
+      NODE_ENV: 'development',
+    } as NodeJS.ProcessEnv);
+
+    const response = await fastify.inject({ method: 'GET', url: '/boom-500' });
+
+    expect(response.statusCode).toBe(500);
+    expect(JSON.parse(response.body)).toEqual({ error: 'Database password is hunter2' });
+
+    await fastify.close();
+  });
+});

--- a/server/test/middleware/auth-session-max.test.ts
+++ b/server/test/middleware/auth-session-max.test.ts
@@ -1,0 +1,151 @@
+// Isolated test for SESSION_MAX_DURATION_MS configuration. The auth middleware caches the
+// env var on first use, so each test sets process.env.SESSION_MAX_DURATION_MS and invokes
+// the cache-reset hook so the next request re-resolves the configured window.
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import {
+  __resetSessionMaxDurationCacheForTests,
+  authenticateToken,
+} from '../../middleware/auth.ts';
+import * as realRolesRepo from '../../repositories/rolesRepo.ts';
+import * as realUsersRepo from '../../repositories/usersRepo.ts';
+import * as realPermissions from '../../utils/permissions.ts';
+import { signToken } from '../helpers/jwt.ts';
+
+const usersRepoSnapshot = { ...realUsersRepo };
+const rolesRepoSnapshot = { ...realRolesRepo };
+const permissionsSnapshot = { ...realPermissions };
+
+const findAuthUserByIdMock = mock();
+const userHasRoleMock = mock();
+const getRolePermissionsMock = mock();
+
+const HAPPY_USER = {
+  id: 'u1',
+  name: 'Alice',
+  username: 'alice',
+  role: 'manager',
+  avatarInitials: 'AL',
+  isDisabled: false,
+};
+
+const HAPPY_PERMISSIONS = ['timesheets.tracker.view'];
+
+const ORIGINAL_SESSION_MAX = process.env.SESSION_MAX_DURATION_MS;
+
+beforeAll(() => {
+  mock.module('../../repositories/usersRepo.ts', () => ({
+    ...usersRepoSnapshot,
+    findAuthUserById: findAuthUserByIdMock,
+  }));
+  mock.module('../../repositories/rolesRepo.ts', () => ({
+    ...rolesRepoSnapshot,
+    userHasRole: userHasRoleMock,
+  }));
+  mock.module('../../utils/permissions.ts', () => ({
+    ...permissionsSnapshot,
+    getRolePermissions: getRolePermissionsMock,
+  }));
+});
+
+afterAll(() => {
+  if (ORIGINAL_SESSION_MAX === undefined) {
+    delete process.env.SESSION_MAX_DURATION_MS;
+  } else {
+    process.env.SESSION_MAX_DURATION_MS = ORIGINAL_SESSION_MAX;
+  }
+  // Restore the default cache value for any subsequent tests.
+  __resetSessionMaxDurationCacheForTests();
+  mock.module('../../repositories/usersRepo.ts', () => usersRepoSnapshot);
+  mock.module('../../repositories/rolesRepo.ts', () => rolesRepoSnapshot);
+  mock.module('../../utils/permissions.ts', () => permissionsSnapshot);
+});
+
+type FakeReply = {
+  statusCode: number;
+  body: unknown;
+  headers: Record<string, string>;
+  code(c: number): FakeReply;
+  send(body: unknown): FakeReply;
+  header(name: string, value: string): FakeReply;
+};
+
+const buildFakeReply = (): FakeReply => {
+  const reply: FakeReply = {
+    statusCode: 0,
+    body: undefined,
+    headers: {},
+    code(c: number) {
+      reply.statusCode = c;
+      return reply;
+    },
+    send(body: unknown) {
+      reply.body = body;
+      return reply;
+    },
+    header(name: string, value: string) {
+      reply.headers[name.toLowerCase()] = value;
+      return reply;
+    },
+  };
+  return reply;
+};
+
+type FakeRequest = { headers: Record<string, string | undefined> };
+const buildFakeRequest = (token: string): FakeRequest => ({
+  headers: { authorization: `Bearer ${token}` },
+});
+
+beforeEach(() => {
+  findAuthUserByIdMock.mockReset();
+  userHasRoleMock.mockReset();
+  getRolePermissionsMock.mockReset();
+  findAuthUserByIdMock.mockResolvedValue(HAPPY_USER);
+  userHasRoleMock.mockResolvedValue(true);
+  getRolePermissionsMock.mockResolvedValue(HAPPY_PERMISSIONS);
+  // Apply our overridden window and reset the cached value so the next request re-resolves.
+  process.env.SESSION_MAX_DURATION_MS = '1000';
+  __resetSessionMaxDurationCacheForTests();
+});
+
+describe('SESSION_MAX_DURATION_MS env override', () => {
+  test('rejects a session older than the configured max (1s) with 401', async () => {
+    // sessionStart 2 seconds ago should exceed our 1s SESSION_MAX_DURATION_MS.
+    const sessionStart = Date.now() - 2_000;
+    const token = signToken({ userId: 'u1', sessionStart });
+    const reply = buildFakeReply();
+
+    await authenticateToken(buildFakeRequest(token) as never, reply as never);
+
+    expect(reply.statusCode).toBe(401);
+    expect(reply.body).toEqual({ error: 'Session expired (max duration exceeded)' });
+    // The handler short-circuits before loading the user.
+    expect(findAuthUserByIdMock).not.toHaveBeenCalled();
+  });
+
+  test('a fresh session (sessionStart = now) is still accepted', async () => {
+    const token = signToken({ userId: 'u1', sessionStart: Date.now() });
+    const reply = buildFakeReply();
+
+    await authenticateToken(buildFakeRequest(token) as never, reply as never);
+
+    expect(reply.statusCode).toBe(0);
+    expect(reply.body).toBeUndefined();
+    expect(findAuthUserByIdMock).toHaveBeenCalledWith('u1');
+  });
+
+  test('non-positive values fall back to the default 8h window', async () => {
+    process.env.SESSION_MAX_DURATION_MS = 'not-a-number';
+    __resetSessionMaxDurationCacheForTests();
+
+    // A session 10s old would have been rejected under the 1s override but must be accepted
+    // when we fall back to the 8h default.
+    const sessionStart = Date.now() - 10_000;
+    const token = signToken({ userId: 'u1', sessionStart });
+    const reply = buildFakeReply();
+
+    await authenticateToken(buildFakeRequest(token) as never, reply as never);
+
+    expect(reply.statusCode).toBe(0);
+    expect(reply.body).toBeUndefined();
+  });
+});

--- a/server/test/middleware/auth.test.ts
+++ b/server/test/middleware/auth.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
-import type jwt from 'jsonwebtoken';
+import jwt from 'jsonwebtoken';
 import {
   authenticateToken,
   generateToken,
@@ -165,6 +165,40 @@ describe('authenticateToken', () => {
     await authenticateToken(request as never, reply as never);
     expect(reply.statusCode).toBe(403);
     expect(reply.body).toEqual({ error: 'Invalid or expired token' });
+  });
+
+  test('403 when token is signed with alg=none (algorithm-confusion attack)', async () => {
+    // Forge an unsigned token: jwt.sign with algorithm 'none' produces a token whose signature
+    // is empty. If the server accepts `alg: 'none'`, anyone can forge an authenticated request.
+    // The algorithm allowlist ({ algorithms: ['HS256'] }) must reject this token.
+    const forgedToken = jwt.sign(
+      { userId: 'u1', sessionStart: Date.now() },
+      // jsonwebtoken requires `null` as the secret when using alg=none.
+      null as unknown as string,
+      { algorithm: 'none' as jwt.Algorithm, expiresIn: '30m' },
+    );
+    const request = buildFakeRequest(forgedToken);
+    const reply = buildFakeReply();
+    await authenticateToken(request as never, reply as never);
+    expect(reply.statusCode).toBe(403);
+    expect(reply.body).toEqual({ error: 'Invalid or expired token' });
+    expect(findAuthUserByIdMock).not.toHaveBeenCalled();
+  });
+
+  test('403 when token uses a different HMAC algorithm than the verifier allows', async () => {
+    // A token signed with HS512 (still using our shared secret) must be rejected because
+    // the allowlist is HS256-only. This guards against future drift between sign/verify.
+    const TEST_JWT_SECRET = process.env.JWT_SECRET || 'praetor-test-jwt-secret';
+    const wrongAlgToken = jwt.sign({ userId: 'u1', sessionStart: Date.now() }, TEST_JWT_SECRET, {
+      algorithm: 'HS512',
+      expiresIn: '30m',
+    });
+    const request = buildFakeRequest(wrongAlgToken);
+    const reply = buildFakeReply();
+    await authenticateToken(request as never, reply as never);
+    expect(reply.statusCode).toBe(403);
+    expect(reply.body).toEqual({ error: 'Invalid or expired token' });
+    expect(findAuthUserByIdMock).not.toHaveBeenCalled();
   });
 
   test('403 when token is idle-expired', async () => {


### PR DESCRIPTION
## Summary

- **Critical #5 (error message leak):** in production, replace 5xx response bodies with a generic `'Internal server error'`. 4xx messages pass through unchanged; the full error is still recorded server-side via `request.log.error`.
- **Medium B16 (hardcoded session length):** make the max-session window configurable via `SESSION_MAX_DURATION_MS` (default `8 * 60 * 60 * 1000`). Resolved lazily and cached for the process lifetime so the env var is parsed once, not per request; invalid/non-positive values fall back to the 8h default.
- **Medium B16 (JWT algorithm):** restrict `jwt.verify` to `{ algorithms: ['HS256'] }` and pass `algorithm: 'HS256'` explicitly to `jwt.sign`, preventing algorithm-confusion attacks (forged `alg: 'none'` tokens, or asymmetric algorithms abusing the HMAC secret).

## Test plan

- [x] `bun test ./test/middleware/auth.test.ts` (31 tests) — including two new tests that confirm tokens signed with `alg=none` or `HS512` are rejected with 403 before any user lookup.
- [x] `bun test ./test/middleware/auth-session-max.test.ts` (3 tests) — `SESSION_MAX_DURATION_MS=1000` rejects a 2s-old session with 401; fresh sessions still pass; invalid values fall back to the 8h default.
- [x] `bun test ./test/app.test.ts` (9 tests) — `buildErrorResponseMessage` masks 5xx in production / passes 4xx and dev 5xx through, plus a Fastify-`inject` integration test that confirms the real error reaches `request.log.error` even when the response body is generic.
- [x] `cd server && bun test ./test` — all 2086 server tests pass.
- [x] `bun run lint` and `cd server && bun run build`.

## Manual verification

1. Set `NODE_ENV=production` and force any 500 from a backend route — verify the response body is `{ error: 'Internal server error' }` and that the real error still appears in the server log under `'Unhandled request error'`.
2. Set `SESSION_MAX_DURATION_MS=60000` in env, log in, wait 65s — the next API call should return 401 with `{ error: 'Session expired (max duration exceeded)' }`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)