### PR TITLE
fix(tests): add toHaveBeenCalled guards; remove vacuous assertions; fix module-scope state

### DIFF
--- a/server/services/email.ts
+++ b/server/services/email.ts
@@ -167,6 +167,13 @@ class EmailService {
     }
   }
 
+  // Invalidates the in-memory config cache so the next operation re-reads from the repo.
+  // Mirrors `LDAPService.invalidateConfig()` — exposed publicly so tests do not have to
+  // reach into the private `config` field via type casts.
+  invalidateConfig(): void {
+    this.config = null;
+  }
+
   async sendTestEmail(recipientEmail: string): Promise<{
     success: boolean;
     code: string;

--- a/server/test/routes/clients.test.ts
+++ b/server/test/routes/clients.test.ts
@@ -364,6 +364,7 @@ describe('POST /api/clients', () => {
     });
 
     expect(res.statusCode).toBe(201);
+    expect(createClientMock).toHaveBeenCalledTimes(1);
     const id = createClientMock.mock.calls[0][0].id as string;
     expect(id).toMatch(/^c-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
   });
@@ -398,6 +399,9 @@ describe('POST /api/clients', () => {
     ]);
 
     for (const r of results) expect(r.statusCode).toBe(201);
+    // Guard the Set/array length check below: without this, `new Set([]).size === [].length`
+    // would pass vacuously if the mock was never called.
+    expect(createClientMock).toHaveBeenCalledTimes(3);
     const ids = createClientMock.mock.calls.map((c) => (c[0] as { id: string }).id);
     expect(new Set(ids).size).toBe(ids.length);
   });

--- a/server/test/routes/entries.test.ts
+++ b/server/test/routes/entries.test.ts
@@ -673,6 +673,7 @@ describe('PUT /api/entries/:id', () => {
     });
 
     expect(res.statusCode).toBe(200);
+    expect(entriesUpdateMock).toHaveBeenCalledTimes(1);
     const patch = entriesUpdateMock.mock.calls[0][1] as Record<string, unknown>;
     expect(patch.location).toBeUndefined();
   });
@@ -694,6 +695,7 @@ describe('PUT /api/entries/:id', () => {
     });
 
     expect(res.statusCode).toBe(200);
+    expect(entriesUpdateMock).toHaveBeenCalledTimes(1);
     const patch = entriesUpdateMock.mock.calls[0][1] as Record<string, unknown>;
     expect(patch.location).toBeUndefined();
   });
@@ -715,6 +717,7 @@ describe('PUT /api/entries/:id', () => {
     });
 
     expect(res.statusCode).toBe(200);
+    expect(entriesUpdateMock).toHaveBeenCalledTimes(1);
     const patch = entriesUpdateMock.mock.calls[0][1] as Record<string, unknown>;
     expect(patch.location).toBe('office');
   });
@@ -838,6 +841,7 @@ describe('DELETE /api/entries (bulk)', () => {
     });
 
     expect(res.statusCode).toBe(200);
+    expect(entriesBulkDeleteMock).toHaveBeenCalledTimes(1);
     const callArgs = entriesBulkDeleteMock.mock.calls[0][0];
     expect(callArgs.fromDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
   });

--- a/server/test/routes/ldap.test.ts
+++ b/server/test/routes/ldap.test.ts
@@ -224,6 +224,7 @@ describe('PUT /api/ldap/config - autoProvisionAll', () => {
   test('omitting autoProvisionAll does not pass the key to ldapRepo.update', async () => {
     const response = await putConfig({ enabled: false });
     expect(response.statusCode).toBe(200);
+    expect(ldapUpdateMock).toHaveBeenCalledTimes(1);
     const patch = ldapUpdateMock.mock.calls[0][0] as Partial<realLdapRepo.LdapConfig>;
     expect(patch.autoProvisionAll).toBeUndefined();
   });
@@ -231,6 +232,7 @@ describe('PUT /api/ldap/config - autoProvisionAll', () => {
   test('passing autoProvisionAll=true forwards it to ldapRepo.update', async () => {
     const response = await putConfig({ enabled: false, autoProvisionAll: true });
     expect(response.statusCode).toBe(200);
+    expect(ldapUpdateMock).toHaveBeenCalledTimes(1);
     const patch = ldapUpdateMock.mock.calls[0][0] as Partial<realLdapRepo.LdapConfig>;
     expect(patch.autoProvisionAll).toBe(true);
   });
@@ -239,6 +241,7 @@ describe('PUT /api/ldap/config - autoProvisionAll', () => {
     ldapGetMock.mockResolvedValue({ ...BASE_CONFIG, autoProvisionAll: true });
     const response = await putConfig({ enabled: false, autoProvisionAll: false });
     expect(response.statusCode).toBe(200);
+    expect(ldapUpdateMock).toHaveBeenCalledTimes(1);
     const patch = ldapUpdateMock.mock.calls[0][0] as Partial<realLdapRepo.LdapConfig>;
     expect(patch.autoProvisionAll).toBe(false);
   });
@@ -257,6 +260,7 @@ describe('PUT /api/ldap/config - tlsCaCertificate', () => {
     const messy = `\n\n${validPemCert.replace(/\n/g, '\r\n')}\n\n`;
     const response = await putConfig({ enabled: false, tlsCaCertificate: messy });
     expect(response.statusCode).toBe(200);
+    expect(ldapUpdateMock).toHaveBeenCalledTimes(1);
     const patch = ldapUpdateMock.mock.calls[0][0] as Partial<realLdapRepo.LdapConfig>;
     expect(patch.tlsCaCertificate).not.toContain('\r');
     expect(patch.tlsCaCertificate?.endsWith('\n')).toBe(true);
@@ -266,6 +270,7 @@ describe('PUT /api/ldap/config - tlsCaCertificate', () => {
   test('empty string clears the field (passes "" to repo.update)', async () => {
     const response = await putConfig({ enabled: false, tlsCaCertificate: '' });
     expect(response.statusCode).toBe(200);
+    expect(ldapUpdateMock).toHaveBeenCalledTimes(1);
     const patch = ldapUpdateMock.mock.calls[0][0] as Partial<realLdapRepo.LdapConfig>;
     expect(patch.tlsCaCertificate).toBe('');
   });
@@ -273,6 +278,7 @@ describe('PUT /api/ldap/config - tlsCaCertificate', () => {
   test('null clears the field (treated like empty)', async () => {
     const response = await putConfig({ enabled: false, tlsCaCertificate: null });
     expect(response.statusCode).toBe(200);
+    expect(ldapUpdateMock).toHaveBeenCalledTimes(1);
     const patch = ldapUpdateMock.mock.calls[0][0] as Partial<realLdapRepo.LdapConfig>;
     expect(patch.tlsCaCertificate).toBe('');
   });
@@ -280,6 +286,7 @@ describe('PUT /api/ldap/config - tlsCaCertificate', () => {
   test('whitespace-only string is treated as clear', async () => {
     const response = await putConfig({ enabled: false, tlsCaCertificate: '   \n\t  ' });
     expect(response.statusCode).toBe(200);
+    expect(ldapUpdateMock).toHaveBeenCalledTimes(1);
     const patch = ldapUpdateMock.mock.calls[0][0] as Partial<realLdapRepo.LdapConfig>;
     expect(patch.tlsCaCertificate).toBe('');
   });

--- a/server/test/routes/projects.test.ts
+++ b/server/test/routes/projects.test.ts
@@ -986,6 +986,9 @@ describe('PUT /api/projects/:id', () => {
     });
 
     expect(res.statusCode).toBe(200);
+    // Guard the optional-chained access below: without this, a missing call would make
+    // `updateArgs?.orderId` collapse to `undefined` and the assertion would pass vacuously.
+    expect(updateMock).toHaveBeenCalled();
     const updateArgs = updateMock.mock.calls.at(-1)?.[1] as Record<string, unknown> | undefined;
     expect(updateArgs?.orderId).toBeUndefined();
   });

--- a/server/test/routes/tasks.test.ts
+++ b/server/test/routes/tasks.test.ts
@@ -381,6 +381,7 @@ describe('POST /api/tasks', () => {
     });
 
     expect(res.statusCode).toBe(201);
+    expect(createMock).toHaveBeenCalledTimes(1);
     const call = createMock.mock.calls[0][0] as { recurrenceStart: string };
     expect(call.recurrenceStart).toBe(expectedToday);
     // No client → no client cascades

--- a/server/test/services/email.test.ts
+++ b/server/test/services/email.test.ts
@@ -61,7 +61,7 @@ const buildEnabledConfig = (overrides: Partial<typeof DEFAULT_REPO_CONFIG> = {})
 });
 
 const resetSingleton = () => {
-  (emailService as unknown as { config: unknown }).config = null;
+  emailService.invalidateConfig();
 };
 
 beforeEach(() => {

--- a/server/test/services/ldap.test.ts
+++ b/server/test/services/ldap.test.ts
@@ -190,7 +190,8 @@ const LDAP_LOGIN_USER = {
 };
 
 const resetService = () => {
-  (ldapService as unknown as { config: unknown }).config = null;
+  // Use the public cache-invalidation hook rather than reaching into the private field.
+  ldapService.invalidateConfig();
 };
 
 const ENV_KEYS = [

--- a/server/test/utils/crypto.test.ts
+++ b/server/test/utils/crypto.test.ts
@@ -31,15 +31,26 @@ describe('encrypt', () => {
     const b = encrypt('same-plaintext');
     expect(a).not.toBe(b);
   });
+});
+
+// Isolated in its own describe block so the missing-key state is set up in beforeAll
+// and restored in afterAll. Keeping the deletion out of the test body removes the
+// risk that a thrown assertion would leak the unset env var into later tests.
+describe('encrypt without ENCRYPTION_KEY', () => {
+  let savedKey: string | undefined;
+
+  beforeAll(() => {
+    savedKey = process.env.ENCRYPTION_KEY;
+    delete process.env.ENCRYPTION_KEY;
+  });
+
+  afterAll(() => {
+    if (savedKey === undefined) delete process.env.ENCRYPTION_KEY;
+    else process.env.ENCRYPTION_KEY = savedKey;
+  });
 
   test('throws when ENCRYPTION_KEY is missing', () => {
-    const saved = process.env.ENCRYPTION_KEY;
-    delete process.env.ENCRYPTION_KEY;
-    try {
-      expect(() => encrypt('whatever')).toThrow(/ENCRYPTION_KEY/);
-    } finally {
-      process.env.ENCRYPTION_KEY = saved;
-    }
+    expect(() => encrypt('whatever')).toThrow(/ENCRYPTION_KEY/);
   });
 });
 

--- a/server/test/utils/ssl.test.ts
+++ b/server/test/utils/ssl.test.ts
@@ -2,9 +2,10 @@ import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from 'b
 import realFs from 'fs';
 import realSelfsigned from 'selfsigned';
 
-// Suppress the "Generated self-signed SSL certificate" log line so test output stays clean.
+// We suppress the "Generated self-signed SSL certificate" log line so test output stays
+// clean, but the override is installed in beforeAll and restored in afterAll so a thrown
+// error during module load (or between files) cannot leave console.log silenced globally.
 const ORIGINAL_CONSOLE_LOG = console.log;
-console.log = () => undefined;
 
 // Snapshot real exports before installing mocks (mock.module inside beforeAll is not hoisted).
 const fsSnapshot = { ...realFs };
@@ -19,6 +20,7 @@ const generateMock = mock<(attrs: unknown, opts: unknown) => { private: string; 
 );
 
 beforeAll(() => {
+  console.log = () => undefined;
   // ssl.ts only consumes these four named exports from `fs`; preserve the rest verbatim
   // so any other module loaded by the test harness keeps working.
   mock.module('fs', () => ({

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -10,30 +10,39 @@ type AssertEqual<T, U> =
 
 const trueValue: true = true;
 
+// Each test in this file is a pure type-level check: the typed variable assignments
+// below either compile or trigger a `@ts-expect-error`, and `tsc --noEmit` is what
+// makes the test "fail" by breaking the build. The runtime `expect(true).toBe(true)`
+// is just a placeholder so Bun's reporter shows the spec as executed — comparing the
+// typed literals to themselves would pass vacuously regardless of the type definitions.
 describe('UserRole literal union', () => {
   test('accepts the four built-in role ids', () => {
     const admin: UserRole = 'admin';
     const manager: UserRole = 'manager';
     const user: UserRole = 'user';
     const topManager: UserRole = 'top_manager';
-    expect([admin, manager, user, topManager]).toEqual(['admin', 'manager', 'user', 'top_manager']);
+    void [admin, manager, user, topManager];
+    expect(true).toBe(true);
   });
 
   test('KnownUserRole rejects typos like "amdin"', () => {
     // @ts-expect-error - 'amdin' is not a built-in role id
     const typo: KnownUserRole = 'amdin';
-    void typo;
     // The valid spelling compiles without error.
     const valid: KnownUserRole = 'admin';
-    expect(valid).toBe('admin');
+    void [typo, valid];
+    expect(true).toBe(true);
   });
 
   test('UserRole still accepts arbitrary strings (custom DB-defined roles)', () => {
     // The `string & {}` escape hatch keeps `UserRole` assignable from any string so
     // custom role ids stored in the `roles` table continue to work.
     const custom: UserRole = 'custom_role_from_db';
-    expect(custom).toBe('custom_role_from_db');
+    void custom;
     const knownExtendsUserRole: AssertExtends<KnownUserRole, UserRole> = trueValue;
+    // trueValue's type is the literal `true`; this assertion verifies the compile-time
+    // relationship (KnownUserRole extends UserRole) rather than the runtime value, which
+    // is trivially true by construction.
     expect(knownExtendsUserRole).toBe(true);
   });
 });
@@ -42,27 +51,28 @@ describe('Permission literal union', () => {
   test('accepts well-formed known permissions', () => {
     const view: Permission = 'crm.clients.view';
     const update: Permission = 'administration.roles.update';
-    expect([view, update]).toEqual(['crm.clients.view', 'administration.roles.update']);
+    void [view, update];
+    expect(true).toBe(true);
   });
 
   test('KnownPermission rejects typos in the resource/action segments', () => {
     // @ts-expect-error - 'crm.clinets.view' has a misspelled resource
     const typo: KnownPermission = 'crm.clinets.view';
-    void typo;
     // @ts-expect-error - 'view2' is not a known action
     const badAction: KnownPermission = 'crm.clients.view2';
-    void badAction;
     const valid: KnownPermission = 'crm.clients.view';
-    expect(valid).toBe('crm.clients.view');
+    void [typo, badAction, valid];
+    expect(true).toBe(true);
   });
 
   test('Permission still accepts arbitrary strings (DB-driven extensibility)', () => {
     const custom: Permission = 'custom.module.view';
-    expect(custom).toBe('custom.module.view');
+    void custom;
     const knownExtendsPermission: AssertEqual<
       Permission extends string ? true : false,
       true
     > = trueValue;
+    // Compile-time assertion of a type relationship; runtime value is trivially true.
     expect(knownExtendsPermission).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Add `expect(mock).toHaveBeenCalledTimes(N)` guards before every `mock.calls[0][0]` read in `clients`, `projects`, `ldap`, `tasks`, and `entries` route tests so an uninvoked mock no longer silently passes via `undefined?.field` or `new Set([]).size === [].length`.
- Replace tautological string-literal `expect(x).toBe(x)` assertions in `test/types.test.ts` with a single placeholder; that file's real contract is compile-time type assertions, not runtime checks.
- Expose `EmailService.invalidateConfig()` (mirroring the existing `LDAPService.invalidateConfig()`) and use it from the test instead of casting `emailService as unknown as { config: unknown }`. Same fix applied to the ldap service test, which now calls the existing public hook.
- Move `console.log = () => undefined` in `ssl.test.ts` out of module scope into `beforeAll`/`afterAll` so a throw during module load cannot leave logs silenced globally across the rest of the suite.
- Hoist the missing-`ENCRYPTION_KEY` setup in `crypto.test.ts` into its own `describe` block with `beforeAll`/`afterAll`, removing the `try/finally` env mutation from the test body.

## Manual verification
Test-only change — no production behavior change (the new `EmailService.invalidateConfig()` is a pure cache-busting helper that mirrors LDAPService).

To prove the new guards catch the bugs they claim to detect, I temporarily short-circuited `POST /api/clients` to return `201` before `clientsRepo.create` was called. With the old code, `expect(new Set([]).size).toBe([].length)` would have passed (`0 === 0`); with the new `expect(createClientMock).toHaveBeenCalledTimes(3)` guard the test now correctly fails:

```
error: expect(received).toHaveBeenCalledTimes(expected)
  Expected number of calls: 3
  Received number of calls: 0
(fail) POST /api/clients > 201 back-to-back creates produce unique ids
```

The injection was then reverted.

## Test plan
- [x] `cd server && bun test ./test` — 2072 pass / 0 fail / 28 skip
- [x] `bun test ./test` (frontend) — 962 pass / 0 fail
- [x] `bun run lint` — passes (4 pre-existing warnings in `quoteHandlers.test.ts` unrelated to this change)
- [x] `cd server && bun run build` — clean tsc compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)