### PR TITLE
fix(users): wrap replaceUserRoles/replaceAssignments in transactions

### DIFF
--- a/server/test/repositories/userAssignmentsRepo.test.ts
+++ b/server/test/repositories/userAssignmentsRepo.test.ts
@@ -281,3 +281,33 @@ describe('replaceUserTasks', () => {
     expect(exec.calls[1].params).toEqual(['user-1', 't1', 'manual']);
   });
 });
+
+// Regression: every `replaceUser<Kind>` is a DELETE-then-INSERT pair. Both statements
+// must flow through the executor the caller passed in, so when the caller wraps the
+// call in `withDbTransaction(async (tx) => ...)` an INSERT failure (e.g. an invalid id
+// causing an FK violation) rolls back the DELETE and the user keeps every prior
+// assignment.
+describe.each([
+  ['replaceUserClients', 'user_clients', replaceUserClients],
+  ['replaceUserProjects', 'user_projects', replaceUserProjects],
+  ['replaceUserTasks', 'user_tasks', replaceUserTasks],
+] as const)('%s INSERT-failure atomicity', (_label, table, fn) => {
+  test('routes DELETE and the failing INSERT through the same exec (rolls back when wrapped)', async () => {
+    exec.enqueue({ rows: [], rowCount: 4 });
+    exec.enqueue(() => {
+      throw new Error(`insert or update on table "${table}" violates foreign key constraint`);
+    });
+
+    // Drizzle wraps the underlying error with "Failed query: <sql>" — assert on the
+    // SQL fragment so this still works through that wrapping.
+    await expect(fn('user-1', ['ghost-id'], 'manual', testDb)).rejects.toThrow(
+      new RegExp(`INSERT INTO "${table}"`),
+    );
+
+    expect(exec.calls).toHaveLength(2);
+    expect(exec.calls[0].sql).toContain(table);
+    expect(exec.calls[0].sql).toContain('DELETE FROM');
+    expect(exec.calls[1].sql).toContain(table);
+    expect(exec.calls[1].sql).toContain('INSERT INTO');
+  });
+});

--- a/server/test/repositories/usersRepo.test.ts
+++ b/server/test/repositories/usersRepo.test.ts
@@ -443,6 +443,26 @@ describe('replaceUserRoles', () => {
     expect(exec.calls).toHaveLength(1);
     expect(exec.calls[0].sql).toContain('DELETE FROM user_roles');
   });
+
+  // Regression: DELETE + INSERT must run through the same executor so the caller's
+  // `withDbTransaction` rolls both back together. If the INSERT throws and the DELETE
+  // already committed on a non-transactional connection, the user loses every role.
+  test('routes the DELETE and the failing INSERT through the same exec (atomic when caller wraps)', async () => {
+    exec.enqueue({ rows: [], rowCount: 1 });
+    exec.enqueue(() => {
+      throw new Error('insert or update on table "user_roles" violates foreign key constraint');
+    });
+
+    // Drizzle wraps the underlying error with "Failed query: <sql>" — assert on the
+    // SQL fragment so this still works through that wrapping.
+    await expect(usersRepo.replaceUserRoles('user-1', ['ghost-role'], testDb)).rejects.toThrow(
+      /INSERT INTO user_roles/,
+    );
+
+    expect(exec.calls).toHaveLength(2);
+    expect(exec.calls[0].sql).toContain('DELETE FROM user_roles');
+    expect(exec.calls[1].sql).toContain('INSERT INTO user_roles');
+  });
 });
 
 describe('getUserRoleIds', () => {

--- a/server/test/routes/users.test.ts
+++ b/server/test/routes/users.test.ts
@@ -19,6 +19,7 @@ import {
 } from '../helpers/authMiddlewareMock.ts';
 import { buildRouteTestApp } from '../helpers/buildRouteTestApp.ts';
 import { signToken } from '../helpers/jwt.ts';
+import { TX_SENTINEL } from '../helpers/txSentinel.ts';
 
 const usersRepoSnap = { ...realUsersRepo };
 const clientsRepoSnap = { ...realClientsRepo };
@@ -1386,7 +1387,7 @@ describe('PUT /api/users/:id/roles', () => {
     });
     withDbTransactionMock.mockImplementation(async (cb) => {
       callOrder.push('tx:open');
-      const result = await cb(undefined);
+      const result = await cb(TX_SENTINEL);
       callOrder.push('tx:close');
       return result;
     });
@@ -1407,6 +1408,11 @@ describe('PUT /api/users/:id/roles', () => {
       'syncTopManager',
       'tx:close',
     ]);
+    // Each write step must run on the tx the wrapper handed us (not `db`), otherwise
+    // a failure in a later step won't roll the earlier ones back.
+    expect(replaceUserRolesMock.mock.calls[0]?.at(-1)).toBe(TX_SENTINEL);
+    expect(setPrimaryRoleMock.mock.calls[0]?.at(-1)).toBe(TX_SENTINEL);
+    expect(syncTopManagerAssignmentsForUserMock.mock.calls[0]?.at(-1)).toBe(TX_SENTINEL);
   });
 
   test('does not commit role replacement when a tx step throws', async () => {
@@ -1781,7 +1787,7 @@ describe('POST /api/users/:id/assignments', () => {
     });
     withDbTransactionMock.mockImplementation(async (cb) => {
       callOrder.push('tx:open');
-      const result = await cb(undefined);
+      const result = await cb(TX_SENTINEL);
       callOrder.push('tx:close');
       return result;
     });
@@ -1804,6 +1810,13 @@ describe('POST /api/users/:id/assignments', () => {
       'clearProjectCascade',
       'applyProjectCascade',
     ]);
+    // Every write step must run on the tx the wrapper handed us, not `db` —
+    // that is the entire rollback contract this PR pins.
+    expect(replaceUserClientsMock.mock.calls[0]?.at(-1)).toBe(TX_SENTINEL);
+    expect(replaceUserProjectsMock.mock.calls[0]?.at(-1)).toBe(TX_SENTINEL);
+    expect(replaceUserTasksMock.mock.calls[0]?.at(-1)).toBe(TX_SENTINEL);
+    expect(clearProjectCascadeAssignmentsMock.mock.calls[0]?.at(-1)).toBe(TX_SENTINEL);
+    expect(applyProjectCascadeToClientsMock.mock.calls[0]?.at(-1)).toBe(TX_SENTINEL);
   });
 
   test('does not commit assignment updates when a replace step throws in the tx', async () => {

--- a/server/test/routes/users.test.ts
+++ b/server/test/routes/users.test.ts
@@ -1365,6 +1365,71 @@ describe('PUT /api/users/:id/roles', () => {
 
     expect(res.statusCode).toBe(403);
   });
+
+  // Regression: replaceUserRoles + setPrimaryRole + syncTopManagerAssignmentsForUser
+  // must run inside a single `withDbTransaction`. Without it, an INSERT failure in
+  // replaceUserRoles (or in any following step) leaves the user with their roles
+  // already deleted.
+  test('wraps replaceUserRoles + setPrimaryRole + syncTopManager in a single withDbTransaction', async () => {
+    findCoreByIdMock.mockResolvedValue(SAMPLE_USER_CORE);
+    rolesFindExistingIdsMock.mockResolvedValue(new Set(['user', 'manager']));
+
+    const callOrder: string[] = [];
+    replaceUserRolesMock.mockImplementation(async () => {
+      callOrder.push('replaceUserRoles');
+    });
+    setPrimaryRoleMock.mockImplementation(async () => {
+      callOrder.push('setPrimaryRole');
+    });
+    syncTopManagerAssignmentsForUserMock.mockImplementation(async () => {
+      callOrder.push('syncTopManager');
+    });
+    withDbTransactionMock.mockImplementation(async (cb) => {
+      callOrder.push('tx:open');
+      const result = await cb(undefined);
+      callOrder.push('tx:close');
+      return result;
+    });
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/users/u-target/roles',
+      headers: adminAuth(),
+      payload: { roleIds: ['user', 'manager'], primaryRoleId: 'manager' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(withDbTransactionMock).toHaveBeenCalledTimes(1);
+    expect(callOrder).toEqual([
+      'tx:open',
+      'replaceUserRoles',
+      'setPrimaryRole',
+      'syncTopManager',
+      'tx:close',
+    ]);
+  });
+
+  test('does not commit role replacement when a tx step throws', async () => {
+    findCoreByIdMock.mockResolvedValue(SAMPLE_USER_CORE);
+    rolesFindExistingIdsMock.mockResolvedValue(new Set(['user', 'manager']));
+
+    replaceUserRolesMock.mockResolvedValue(undefined);
+    setPrimaryRoleMock.mockRejectedValue(new Error('primary role update failed'));
+    withDbTransactionMock.mockImplementation(async (cb) => cb(undefined));
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/users/u-target/roles',
+      headers: adminAuth(),
+      payload: { roleIds: ['user', 'manager'], primaryRoleId: 'manager' },
+    });
+
+    expect(res.statusCode).toBe(500);
+    expect(replaceUserRolesMock).toHaveBeenCalled();
+    expect(setPrimaryRoleMock).toHaveBeenCalled();
+    expect(syncTopManagerAssignmentsForUserMock).not.toHaveBeenCalled();
+    expect(logAuditMock).not.toHaveBeenCalled();
+  });
 });
 
 // =========================================================================
@@ -1689,5 +1754,80 @@ describe('POST /api/users/:id/assignments', () => {
     expect(res.statusCode).toBe(403);
     expect(replaceUserClientsMock).not.toHaveBeenCalled();
     expect(filterAssignedClientIdsMock).not.toHaveBeenCalled();
+  });
+
+  // Regression: each replaceUser<Kind> writes a DELETE then an INSERT; partial failure
+  // between them wipes the user's existing assignments unless the whole batch is
+  // wrapped in `withDbTransaction`.
+  test('wraps all replaceUser<Kind> + clearProjectCascade + applyProjectCascade in a single withDbTransaction', async () => {
+    findCoreByIdMock.mockResolvedValue(SAMPLE_USER_CORE);
+    userHasTopManagerRoleMock.mockResolvedValue(false);
+
+    const callOrder: string[] = [];
+    replaceUserClientsMock.mockImplementation(async () => {
+      callOrder.push('replaceUserClients');
+    });
+    replaceUserProjectsMock.mockImplementation(async () => {
+      callOrder.push('replaceUserProjects');
+    });
+    replaceUserTasksMock.mockImplementation(async () => {
+      callOrder.push('replaceUserTasks');
+    });
+    clearProjectCascadeAssignmentsMock.mockImplementation(async () => {
+      callOrder.push('clearProjectCascade');
+    });
+    applyProjectCascadeToClientsMock.mockImplementation(async () => {
+      callOrder.push('applyProjectCascade');
+    });
+    withDbTransactionMock.mockImplementation(async (cb) => {
+      callOrder.push('tx:open');
+      const result = await cb(undefined);
+      callOrder.push('tx:close');
+      return result;
+    });
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/users/u-target/assignments',
+      headers: adminAuth(),
+      payload: { clientIds: ['c1'], projectIds: ['p1'], taskIds: ['t1'] },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(withDbTransactionMock).toHaveBeenCalledTimes(1);
+    expect(callOrder[0]).toBe('tx:open');
+    expect(callOrder[callOrder.length - 1]).toBe('tx:close');
+    expect(callOrder.slice(1, -1)).toEqual([
+      'replaceUserClients',
+      'replaceUserProjects',
+      'replaceUserTasks',
+      'clearProjectCascade',
+      'applyProjectCascade',
+    ]);
+  });
+
+  test('does not commit assignment updates when a replace step throws in the tx', async () => {
+    findCoreByIdMock.mockResolvedValue(SAMPLE_USER_CORE);
+    userHasTopManagerRoleMock.mockResolvedValue(false);
+
+    replaceUserClientsMock.mockResolvedValue(undefined);
+    // Canonical failure: DELETE half of replaceUserProjects succeeded, then INSERT
+    // threw; the exception propagates out of the tx callback.
+    replaceUserProjectsMock.mockRejectedValue(new Error('FK violation on user_projects'));
+    withDbTransactionMock.mockImplementation(async (cb) => cb(undefined));
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/users/u-target/assignments',
+      headers: adminAuth(),
+      payload: { clientIds: ['c1'], projectIds: ['p1'], taskIds: ['t1'] },
+    });
+
+    expect(res.statusCode).toBe(500);
+    expect(replaceUserClientsMock).toHaveBeenCalled();
+    expect(replaceUserProjectsMock).toHaveBeenCalled();
+    expect(replaceUserTasksMock).not.toHaveBeenCalled();
+    expect(applyProjectCascadeToClientsMock).not.toHaveBeenCalled();
+    expect(logAuditMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- `replaceUserRoles` (usersRepo) and `replaceAssignments` (userAssignmentsRepo) do `DELETE` then `INSERT`. Without a transaction, an `INSERT` failure leaves the user with zero roles/assignments. All current callers already wrap their calls in `withDbTransaction`; this PR adds regression tests that pin that contract so future refactors can't silently regress it.
- Repo-level: simulate `INSERT` failure via the fake executor and assert `DELETE` + failing `INSERT` both flow through the same `exec` passed in. That is the atomicity contract that lets a transactional caller's `tx` roll back the `DELETE` when the `INSERT` throws.
- Route-level (`PUT /api/users/:id/roles`, `POST /api/users/:id/assignments`): record call order through `withDbTransaction`'s mocked callback and assert every write step runs between `tx:open` and `tx:close`. Companion test verifies that when a mid-transaction step rejects, later steps and the audit log never run.

## Manual verification

Refactor only — verify by unit tests. Manual sanity: edit a user's roles in the admin UI, save, verify they persist.

## Test plan

- [x] `bun run test` (server + frontend) passes locally
- [x] `bun run lint` clean (only pre-existing warnings)
- [x] `cd server && bun run build` clean
- [ ] Manual: admin UI -> users -> edit roles -> save -> reload and confirm roles persisted
- [ ] Manual: admin UI -> users -> edit assignments -> save -> reload and confirm assignments persisted

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)