### PR TITLE
fix(repos): ORDER BY + locking semantics + safe mapping + DELETE 204 + AJV formats

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -32,6 +32,7 @@ import suppliersRoutes from './routes/suppliers.ts';
 import tasksRoutes from './routes/tasks.ts';
 import usersRoutes from './routes/users.ts';
 import workUnitsRoutes from './routes/work-units.ts';
+import { ajvFormatsPlugin, ajvFormatsPluginOptions } from './utils/ajv-formats.ts';
 import { loggerOptions, serializeError } from './utils/logger.ts';
 import { GLOBAL_RATE_LIMIT } from './utils/rate-limit.ts';
 
@@ -79,6 +80,13 @@ export const buildApp = async () => {
   const fastify = Fastify({
     logger: loggerOptions,
     trustProxy: parseTrustProxyEnv(process.env.TRUST_PROXY),
+    // Register `ajv-formats` so JSON-schema `format` keywords (`date-time`, `date`, `email`, ...)
+    // are actually validated. Without this, schemas like `{ type: 'string', format: 'date-time' }`
+    // silently accept any string. See server/utils/ajv-formats.ts for the plugin wiring.
+    ajv: {
+      customOptions: {},
+      plugins: [[ajvFormatsPlugin, ajvFormatsPluginOptions]],
+    },
   });
 
   await fastify.register(cors, {

--- a/server/bun.lock
+++ b/server/bun.lock
@@ -13,6 +13,7 @@
         "@modelcontextprotocol/node": "^2.0.0-alpha.2",
         "@modelcontextprotocol/server": "^2.0.0-alpha.2",
         "@node-saml/node-saml": "^5.1.0",
+        "ajv-formats": "^3.0.1",
         "bcryptjs": "^3.0.3",
         "dotenv": "^17.4.2",
         "drizzle-orm": "^0.45.2",

--- a/server/package.json
+++ b/server/package.json
@@ -26,6 +26,7 @@
     "@modelcontextprotocol/node": "^2.0.0-alpha.2",
     "@modelcontextprotocol/server": "^2.0.0-alpha.2",
     "@node-saml/node-saml": "^5.1.0",
+    "ajv-formats": "^3.0.1",
     "bcryptjs": "^3.0.3",
     "dotenv": "^17.4.2",
     "drizzle-orm": "^0.45.2",

--- a/server/repositories/clientOffersRepo.ts
+++ b/server/repositories/clientOffersRepo.ts
@@ -82,7 +82,7 @@ export const listAllItems = async (exec: DbExecutor = db): Promise<ClientOfferIt
   const rows = await exec
     .select()
     .from(customerOfferItems)
-    .orderBy(asc(customerOfferItems.createdAt));
+    .orderBy(asc(customerOfferItems.createdAt), asc(customerOfferItems.id));
   return rows.map(mapItem);
 };
 

--- a/server/repositories/clientOffersRepo.ts
+++ b/server/repositories/clientOffersRepo.ts
@@ -114,7 +114,11 @@ export type ExistingOffer = {
   status: string;
 };
 
-export const findForUpdate = async (
+// Reads the minimal set of fields needed to gate updates / restores. Named `findExisting`
+// (not `findForUpdate`) because it does not acquire a row lock - callers run the read,
+// validate, and then issue a separate UPDATE outside any locking scope. If you need true
+// SELECT ... FOR UPDATE semantics, wrap in `withDbTransaction` and add `.for('update')`.
+export const findExisting = async (
   id: string,
   exec: DbExecutor = db,
 ): Promise<ExistingOffer | null> => {
@@ -184,7 +188,8 @@ export const findItemsForOffer = async (
   const rows = await exec
     .select()
     .from(customerOfferItems)
-    .where(eq(customerOfferItems.offerId, offerId));
+    .where(eq(customerOfferItems.offerId, offerId))
+    .orderBy(asc(customerOfferItems.createdAt), asc(customerOfferItems.id));
   return rows.map(mapItem);
 };
 

--- a/server/repositories/clientQuotesRepo.ts
+++ b/server/repositories/clientQuotesRepo.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, ne, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, ne, sql } from 'drizzle-orm';
 import { type DbExecutor, db } from '../db/drizzle.ts';
 import { customerOffers } from '../db/schema/customerOffers.ts';
 import { quoteItems, quotes } from '../db/schema/quotes.ts';
@@ -161,7 +161,11 @@ export const findIdConflict = async (
   return rows.length > 0;
 };
 
-export const findCurrentForUpdate = async (
+// Reads the minimal set of fields needed to gate updates / restores. Named `findCurrent`
+// (not `findCurrentForUpdate`) because it does not acquire a row lock - callers run the read,
+// validate, and then issue a separate UPDATE outside any locking scope. If you need true
+// SELECT ... FOR UPDATE semantics, wrap in `withDbTransaction` and add `.for('update')`.
+export const findCurrent = async (
   id: string,
   exec: DbExecutor = db,
 ): Promise<{
@@ -305,7 +309,11 @@ export const findItemsForQuote = async (
   quoteId: string,
   exec: DbExecutor = db,
 ): Promise<ClientQuoteItem[]> => {
-  const rows = await exec.select().from(quoteItems).where(eq(quoteItems.quoteId, quoteId));
+  const rows = await exec
+    .select()
+    .from(quoteItems)
+    .where(eq(quoteItems.quoteId, quoteId))
+    .orderBy(asc(quoteItems.createdAt), asc(quoteItems.id));
   return rows.map(mapItem);
 };
 

--- a/server/repositories/clientsOrdersRepo.ts
+++ b/server/repositories/clientsOrdersRepo.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, ne, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, ne, sql } from 'drizzle-orm';
 import { type DbExecutor, db } from '../db/drizzle.ts';
 import { customerOffers } from '../db/schema/customerOffers.ts';
 import { saleItems, sales } from '../db/schema/sales.ts';
@@ -127,7 +127,11 @@ export type ExistingClientOrder = {
   notes: string | null;
 };
 
-export const findForUpdate = async (
+// Reads the minimal set of fields needed to gate updates / restores. Named `findExisting`
+// (not `findForUpdate`) because it does not acquire a row lock - callers run the read,
+// validate, and then issue a separate UPDATE outside any locking scope. If you need true
+// SELECT ... FOR UPDATE semantics, wrap in `withDbTransaction` and add `.for('update')`.
+export const findExisting = async (
   id: string,
   exec: DbExecutor = db,
 ): Promise<ExistingClientOrder | null> => {
@@ -221,7 +225,7 @@ export const findItemsForOrder = async (
     .select()
     .from(saleItems)
     .where(eq(saleItems.saleId, orderId))
-    .orderBy(saleItems.createdAt);
+    .orderBy(asc(saleItems.createdAt), asc(saleItems.id));
   return rows.map(mapItem);
 };
 

--- a/server/repositories/clientsRepo.ts
+++ b/server/repositories/clientsRepo.ts
@@ -91,21 +91,38 @@ const formatAddress = ({
     .join(', ');
 };
 
+// Safely coerce a raw column value to `string | null`. Anything that is not a string
+// becomes null, which is preferable to the legacy `as string | null` casts that could
+// surface `undefined` or non-string DB types as the literal `"undefined"` downstream.
+const stringOrNull = (value: unknown): string | null => (typeof value === 'string' ? value : null);
+
+const parseCreatedAt = (value: unknown): number | undefined => {
+  if (value instanceof Date) {
+    const t = value.getTime();
+    return Number.isFinite(t) ? t : undefined;
+  }
+  if (typeof value === 'string' || typeof value === 'number') {
+    const t = new Date(value).getTime();
+    return Number.isFinite(t) ? t : undefined;
+  }
+  return undefined;
+};
+
 export const mapClientRow = (c: Record<string, unknown>): Client => {
-  const fiscalCode = (c.fiscal_code as string | null) || null;
-  const createdAt = c.created_at ? new Date(c.created_at as string).getTime() : undefined;
+  const fiscalCode = stringOrNull(c.fiscal_code);
+  const createdAt = parseCreatedAt(c.created_at);
   const contacts = parseContactsFromDb(c.contacts);
   const primary = contacts[0] ?? null;
 
-  const addressCountry = (c.address_country as string | null) || null;
-  const addressState = (c.address_state as string | null) || null;
-  const addressCap = (c.address_cap as string | null) || null;
-  const addressProvince = (c.address_province as string | null) || null;
-  const addressCivicNumber = (c.address_civic_number as string | null) || null;
-  const addressLine = (c.address_line as string | null) || null;
+  const addressCountry = stringOrNull(c.address_country);
+  const addressState = stringOrNull(c.address_state);
+  const addressCap = stringOrNull(c.address_cap);
+  const addressProvince = stringOrNull(c.address_province);
+  const addressCivicNumber = stringOrNull(c.address_civic_number);
+  const addressLine = stringOrNull(c.address_line);
 
   const address =
-    (c.address as string | null) ||
+    stringOrNull(c.address) ||
     formatAddress({
       civicNumber: addressCivicNumber,
       line: addressLine,
@@ -117,16 +134,16 @@ export const mapClientRow = (c: Record<string, unknown>): Client => {
     null;
 
   return {
-    id: c.id as string,
-    name: c.name as string,
-    description: (c.description as string | null) ?? null,
-    isDisabled: c.is_disabled as boolean,
-    type: c.type as string,
+    id: typeof c.id === 'string' ? c.id : '',
+    name: typeof c.name === 'string' ? c.name : '',
+    description: stringOrNull(c.description),
+    isDisabled: c.is_disabled === true,
+    type: typeof c.type === 'string' ? c.type : '',
     contacts,
-    contactName: (c.contact_name as string | null) || primary?.fullName || null,
-    clientCode: (c.client_code as string | null) ?? null,
-    email: (c.email as string | null) || primary?.email || null,
-    phone: (c.phone as string | null) || primary?.phone || null,
+    contactName: stringOrNull(c.contact_name) || primary?.fullName || null,
+    clientCode: stringOrNull(c.client_code),
+    email: stringOrNull(c.email) || primary?.email || null,
+    phone: stringOrNull(c.phone) || primary?.phone || null,
     address,
     addressCountry,
     addressState,
@@ -134,16 +151,23 @@ export const mapClientRow = (c: Record<string, unknown>): Client => {
     addressProvince,
     addressCivicNumber,
     addressLine,
-    atecoCode: (c.ateco_code as string | null) ?? null,
-    website: (c.website as string | null) ?? null,
-    sector: (c.sector as string | null) ?? null,
-    numberOfEmployees: (c.number_of_employees as string | null) ?? null,
-    revenue: (c.revenue as string | null) ?? null,
+    atecoCode: stringOrNull(c.ateco_code),
+    website: stringOrNull(c.website),
+    sector: stringOrNull(c.sector),
+    numberOfEmployees: stringOrNull(c.number_of_employees),
+    revenue: stringOrNull(c.revenue),
     fiscalCode,
-    officeCountRange: (c.office_count_range as string | null) ?? null,
-    totalSentQuotes: parseDbNumber(c.total_sent_quotes as string | number | null, undefined),
+    officeCountRange: stringOrNull(c.office_count_range),
+    totalSentQuotes: parseDbNumber(
+      typeof c.total_sent_quotes === 'string' || typeof c.total_sent_quotes === 'number'
+        ? c.total_sent_quotes
+        : null,
+      undefined,
+    ),
     totalAcceptedOrders: parseDbNumber(
-      c.total_accepted_orders as string | number | null,
+      typeof c.total_accepted_orders === 'string' || typeof c.total_accepted_orders === 'number'
+        ? c.total_accepted_orders
+        : null,
       undefined,
     ),
     vatNumber: fiscalCode,

--- a/server/repositories/invoicesRepo.ts
+++ b/server/repositories/invoicesRepo.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, ne, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, ne, sql } from 'drizzle-orm';
 import { type DbExecutor, db, executeRows, runAtomically } from '../db/drizzle.ts';
 import { invoiceItems, invoices } from '../db/schema/invoices.ts';
 import { requireDateOnly } from '../utils/date.ts';
@@ -152,7 +152,11 @@ export const findItemsForInvoice = async (
   invoiceId: string,
   exec: DbExecutor = db,
 ): Promise<InvoiceItem[]> => {
-  const rows = await exec.select().from(invoiceItems).where(eq(invoiceItems.invoiceId, invoiceId));
+  const rows = await exec
+    .select()
+    .from(invoiceItems)
+    .where(eq(invoiceItems.invoiceId, invoiceId))
+    .orderBy(asc(invoiceItems.createdAt), asc(invoiceItems.id));
   return rows.map(mapItem);
 };
 

--- a/server/repositories/supplierInvoicesRepo.ts
+++ b/server/repositories/supplierInvoicesRepo.ts
@@ -84,7 +84,8 @@ export const findItemsForInvoice = async (
   const rows = await exec
     .select()
     .from(supplierInvoiceItems)
-    .where(eq(supplierInvoiceItems.invoiceId, invoiceId));
+    .where(eq(supplierInvoiceItems.invoiceId, invoiceId))
+    .orderBy(asc(supplierInvoiceItems.createdAt), asc(supplierInvoiceItems.id));
   return rows.map(mapItem);
 };
 
@@ -100,7 +101,11 @@ export const findInvoiceForLinkedSale = async (
   return rows[0]?.id ?? null;
 };
 
-export const findExistingForUpdate = async (
+// Reads the minimal set of fields needed to gate updates / restores. Named `findExisting`
+// (not `findExistingForUpdate`) because it does not acquire a row lock - callers run the read,
+// validate, and then issue a separate UPDATE outside any locking scope. If you need true
+// SELECT ... FOR UPDATE semantics, wrap in `withDbTransaction` and add `.for('update')`.
+export const findExisting = async (
   id: string,
   exec: DbExecutor = db,
 ): Promise<{

--- a/server/repositories/supplierInvoicesRepo.ts
+++ b/server/repositories/supplierInvoicesRepo.ts
@@ -65,7 +65,7 @@ export const listAllItems = async (exec: DbExecutor = db): Promise<SupplierInvoi
   const rows = await exec
     .select()
     .from(supplierInvoiceItems)
-    .orderBy(asc(supplierInvoiceItems.createdAt));
+    .orderBy(asc(supplierInvoiceItems.createdAt), asc(supplierInvoiceItems.id));
   return rows.map(mapItem);
 };
 

--- a/server/repositories/supplierOrdersRepo.ts
+++ b/server/repositories/supplierOrdersRepo.ts
@@ -63,7 +63,7 @@ export const listAllItems = async (exec: DbExecutor = db): Promise<SupplierOrder
   const rows = await exec
     .select()
     .from(supplierSaleItems)
-    .orderBy(asc(supplierSaleItems.createdAt));
+    .orderBy(asc(supplierSaleItems.createdAt), asc(supplierSaleItems.id));
   return rows.map(mapItem);
 };
 

--- a/server/repositories/supplierOrdersRepo.ts
+++ b/server/repositories/supplierOrdersRepo.ts
@@ -103,7 +103,8 @@ export const findItemsForOrder = async (
   const rows = await exec
     .select()
     .from(supplierSaleItems)
-    .where(eq(supplierSaleItems.saleId, orderId));
+    .where(eq(supplierSaleItems.saleId, orderId))
+    .orderBy(asc(supplierSaleItems.createdAt), asc(supplierSaleItems.id));
   return rows.map(mapItem);
 };
 
@@ -131,7 +132,11 @@ export const findExistingByLinkedQuote = async (
   return rows[0]?.id ?? null;
 };
 
-export const findExistingForUpdate = async (
+// Reads the minimal set of fields needed to gate updates / restores. Named `findExisting`
+// (not `findExistingForUpdate`) because it does not acquire a row lock - callers run the read,
+// validate, and then issue a separate UPDATE outside any locking scope. If you need true
+// SELECT ... FOR UPDATE semantics, wrap in `withDbTransaction` and add `.for('update')`.
+export const findExisting = async (
   id: string,
   exec: DbExecutor = db,
 ): Promise<{

--- a/server/repositories/supplierQuotesRepo.ts
+++ b/server/repositories/supplierQuotesRepo.ts
@@ -74,7 +74,7 @@ export const listAllItems = async (exec: DbExecutor = db): Promise<SupplierQuote
   const rows = await exec
     .select()
     .from(supplierQuoteItems)
-    .orderBy(asc(supplierQuoteItems.createdAt));
+    .orderBy(asc(supplierQuoteItems.createdAt), asc(supplierQuoteItems.id));
   return rows.map(mapItem);
 };
 

--- a/server/repositories/supplierQuotesRepo.ts
+++ b/server/repositories/supplierQuotesRepo.ts
@@ -101,7 +101,8 @@ export const findItemsForQuote = async (
   const rows = await exec
     .select()
     .from(supplierQuoteItems)
-    .where(eq(supplierQuoteItems.quoteId, quoteId));
+    .where(eq(supplierQuoteItems.quoteId, quoteId))
+    .orderBy(asc(supplierQuoteItems.createdAt), asc(supplierQuoteItems.id));
   return rows.map(mapItem);
 };
 

--- a/server/routes/client-offers.ts
+++ b/server/routes/client-offers.ts
@@ -513,7 +513,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
 
-      const existingOffer = await clientOffersRepo.findForUpdate(idResult.value);
+      const existingOffer = await clientOffersRepo.findExisting(idResult.value);
       if (!existingOffer) {
         return reply.code(404).send({ error: 'Offer not found' });
       }
@@ -871,7 +871,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       // would need SELECT ... FOR UPDATE here AND matching locking in the sale-create path.
       const result: RestoreOutcome = await withDbTransaction(async (tx) => {
         const [current, linkedSaleId, version] = await Promise.all([
-          clientOffersRepo.findForUpdate(idResult.value, tx),
+          clientOffersRepo.findExisting(idResult.value, tx),
           clientOffersRepo.findLinkedSaleId(idResult.value, tx),
           offerVersionsRepo.findById(idResult.value, versionIdResult.value, tx),
         ]);

--- a/server/routes/client-quotes.ts
+++ b/server/routes/client-quotes.ts
@@ -693,7 +693,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         return reply.code(409).send({ error: 'Quotes become read-only once an offer exists' });
       }
 
-      const current = await clientQuotesRepo.findCurrentForUpdate(idResult.value);
+      const current = await clientQuotesRepo.findCurrent(idResult.value);
       if (!current) {
         return reply.code(404).send({ error: 'Quote not found' });
       }
@@ -1036,7 +1036,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       // Same read-only rules as PUT.
       const [linkedOfferId, current, nonDraftLinkedSale, version] = await Promise.all([
         clientQuotesRepo.findLinkedOfferId(idResult.value),
-        clientQuotesRepo.findCurrentForUpdate(idResult.value),
+        clientQuotesRepo.findCurrent(idResult.value),
         clientQuotesRepo.findNonDraftLinkedSale(idResult.value),
         quoteVersionsRepo.findById(idResult.value, versionIdResult.value),
       ]);

--- a/server/routes/clients-orders.ts
+++ b/server/routes/clients-orders.ts
@@ -783,7 +783,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         if (!normalizedItems) return;
       }
 
-      const existingOrder = await clientsOrdersRepo.findForUpdate(idResult.value);
+      const existingOrder = await clientsOrdersRepo.findExisting(idResult.value);
       if (!existingOrder) {
         return reply.code(404).send({ error: 'Order not found' });
       }
@@ -1136,7 +1136,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       if (!versionIdResult.ok) return badRequest(reply, versionIdResult.message);
 
       const [current, version] = await Promise.all([
-        clientsOrdersRepo.findForUpdate(idResult.value),
+        clientsOrdersRepo.findExisting(idResult.value),
         orderVersionsRepo.findById(idResult.value, versionIdResult.value),
       ]);
 

--- a/server/routes/clients.ts
+++ b/server/routes/clients.ts
@@ -8,11 +8,7 @@ import {
 import * as clientProfileOptionsRepo from '../repositories/clientProfileOptionsRepo.ts';
 import * as clientsRepo from '../repositories/clientsRepo.ts';
 import * as userAssignmentsRepo from '../repositories/userAssignmentsRepo.ts';
-import {
-  messageResponseSchema,
-  standardErrorResponses,
-  standardRateLimitedErrorResponses,
-} from '../schemas/common.ts';
+import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
 import { logAudit } from '../utils/audit.ts';
 import { assertAuthenticated } from '../utils/auth-assert.ts';
 import { getUniqueViolation } from '../utils/db-errors.ts';
@@ -839,7 +835,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         summary: 'Delete client',
         params: idParamSchema,
         response: {
-          200: messageResponseSchema,
+          204: { type: 'null' },
           ...standardErrorResponses,
         },
       },
@@ -868,7 +864,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           secondaryLabel: deleted.clientCode ?? undefined,
         },
       });
-      return { message: 'Client deleted' };
+      return reply.code(204).send();
     },
   );
 
@@ -1064,7 +1060,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           required: ['category', 'id'],
         },
         response: {
-          200: messageResponseSchema,
+          204: { type: 'null' },
           ...standardErrorResponses,
         },
       },
@@ -1108,7 +1104,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         },
       });
 
-      return { message: 'Profile option deleted' };
+      return reply.code(204).send();
     },
   );
 }

--- a/server/routes/entries.ts
+++ b/server/routes/entries.ts
@@ -6,11 +6,7 @@ import {
   requireScopedPermission,
 } from '../middleware/auth.ts';
 import type { TimeEntry } from '../repositories/entriesRepo.ts';
-import {
-  messageResponseSchema,
-  standardErrorResponses,
-  standardRateLimitedErrorResponses,
-} from '../schemas/common.ts';
+import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
 import {
   bulkDeleteTimeEntries,
   createTimeEntry,
@@ -295,7 +291,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         summary: 'Delete time entry',
         params: idParamSchema,
         response: {
-          200: messageResponseSchema,
+          204: { type: 'null' },
           ...standardErrorResponses,
         },
       },
@@ -305,7 +301,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
 
       const { id } = request.params as { id: string };
       try {
-        return await deleteTimeEntry(actorFromRequest(request), id);
+        // Service still returns `{ message }` because the MCP tool surface relays it back to
+        // the client; the REST route discards it and returns 204-no-body per REST norms.
+        await deleteTimeEntry(actorFromRequest(request), id);
+        return reply.code(204).send();
       } catch (err) {
         return handleTimeEntryServiceError(err, reply);
       }
@@ -365,7 +364,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         summary: 'Bulk delete time entries',
         querystring: entriesBulkDeleteQuerySchema,
         response: {
-          200: messageResponseSchema,
+          204: { type: 'null' },
           ...standardRateLimitedErrorResponses,
         },
       },
@@ -380,12 +379,13 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         placeholderOnly?: string;
       };
       try {
-        return await bulkDeleteTimeEntries(actorFromRequest(request), {
+        await bulkDeleteTimeEntries(actorFromRequest(request), {
           projectId,
           task,
           futureOnly,
           placeholderOnly,
         });
+        return reply.code(204).send();
       } catch (err) {
         return handleTimeEntryServiceError(err, reply);
       }

--- a/server/routes/projects.ts
+++ b/server/routes/projects.ts
@@ -327,7 +327,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         summary: 'Delete project',
         params: idParamSchema,
         response: {
-          200: messageResponseSchema,
+          204: { type: 'null' },
           ...standardErrorResponses,
         },
       },
@@ -376,7 +376,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           secondaryLabel: deletedProject.clientId,
         },
       });
-      return { message: 'Project deleted' };
+      return reply.code(204).send();
     },
   );
 

--- a/server/routes/roles.ts
+++ b/server/routes/roles.ts
@@ -2,7 +2,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { withDbTransaction } from '../db/drizzle.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
 import * as rolesRepo from '../repositories/rolesRepo.ts';
-import { messageResponseSchema, standardRateLimitedErrorResponses } from '../schemas/common.ts';
+import { standardRateLimitedErrorResponses } from '../schemas/common.ts';
 import { logAudit } from '../utils/audit.ts';
 import { generatePrefixedId } from '../utils/order-ids.ts';
 import {
@@ -273,7 +273,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         summary: 'Delete role',
         params: idParamSchema,
         response: {
-          200: messageResponseSchema,
+          204: { type: 'null' },
           ...standardRateLimitedErrorResponses,
         },
       },
@@ -306,7 +306,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           targetLabel: roleRow.name,
         },
       });
-      return { message: 'Role deleted' };
+      return reply.code(204).send();
     },
   );
 

--- a/server/routes/settings.ts
+++ b/server/routes/settings.ts
@@ -262,7 +262,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           required: ['id'],
         },
         response: {
-          200: messageResponseSchema,
+          204: { type: 'null' },
           ...standardRateLimitedErrorResponses,
         },
       },
@@ -276,7 +276,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const revoked = await mcpTokensRepo.revokeForUser(idResult.value, request.user.id);
       if (!revoked) return reply.code(404).send({ error: 'MCP token not found' });
 
-      return { message: 'MCP token revoked' };
+      return reply.code(204).send();
     },
   );
 

--- a/server/routes/supplier-invoices.ts
+++ b/server/routes/supplier-invoices.ts
@@ -494,7 +494,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       }
 
       const [existingInvoice, idConflict] = await Promise.all([
-        supplierInvoicesRepo.findExistingForUpdate(idResult.value),
+        supplierInvoicesRepo.findExisting(idResult.value),
         nextIdValue
           ? supplierInvoicesRepo.findIdConflict(nextIdValue, idResult.value)
           : Promise.resolve(false),

--- a/server/routes/supplier-orders.ts
+++ b/server/routes/supplier-orders.ts
@@ -445,7 +445,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       }
 
       const [existingOrder, idConflict] = await Promise.all([
-        supplierOrdersRepo.findExistingForUpdate(idResult.value),
+        supplierOrdersRepo.findExisting(idResult.value),
         nextIdValue
           ? supplierOrdersRepo.findIdConflict(nextIdValue, idResult.value)
           : Promise.resolve(false),
@@ -704,7 +704,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
 
       const [linkedInvoiceId, current, version] = await Promise.all([
         supplierOrdersRepo.findLinkedInvoiceId(idResult.value),
-        supplierOrdersRepo.findExistingForUpdate(idResult.value),
+        supplierOrdersRepo.findExisting(idResult.value),
         supplierOrderVersionsRepo.findById(idResult.value, versionIdResult.value),
       ]);
 

--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -616,7 +616,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         summary: 'Delete task',
         params: idParamSchema,
         response: {
-          200: messageResponseSchema,
+          204: { type: 'null' },
           ...standardErrorResponses,
         },
       },
@@ -644,7 +644,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           secondaryLabel: deleted.projectId,
         },
       });
-      return { message: 'Task deleted' };
+      return reply.code(204).send();
     },
   );
 

--- a/server/routes/users.ts
+++ b/server/routes/users.ts
@@ -555,7 +555,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         summary: 'Delete user',
         params: idParamSchema,
         response: {
-          200: messageResponseSchema,
+          204: { type: 'null' },
           ...standardErrorResponses,
         },
       },
@@ -592,7 +592,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           secondaryLabel: user.username,
         },
       });
-      return { message: 'User deleted' };
+      return reply.code(204).send();
     },
   );
 

--- a/server/routes/work-units.ts
+++ b/server/routes/work-units.ts
@@ -257,7 +257,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         summary: 'Delete work unit',
         params: idParamSchema,
         response: {
-          200: messageResponseSchema,
+          204: { type: 'null' },
           ...standardRateLimitedErrorResponses,
         },
       },
@@ -281,7 +281,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           targetLabel: deleted.name,
         },
       });
-      return { message: 'Work unit deleted' };
+      return reply.code(204).send();
     },
   );
 

--- a/server/test/helpers/buildRouteTestApp.ts
+++ b/server/test/helpers/buildRouteTestApp.ts
@@ -1,13 +1,23 @@
 import Fastify, { type FastifyInstance, type FastifyPluginAsync } from 'fastify';
+import { ajvFormatsPlugin, ajvFormatsPluginOptions } from '../../utils/ajv-formats.ts';
 
 // Why no `@fastify/rate-limit`: the plugin's onResponse hook double-writes after
 // `authMiddlewareMock` hijacks an early-401/403 reply. Decorating `rateLimit` as a no-op gives
 // route files the decorator they expect without that hook.
+//
+// AJV is wired with the same `ajv-formats` plugin/options as the real app (server/app.ts) so
+// route schemas using `format: 'date-time'` etc. validate identically under test.
 export const buildRouteTestApp = async (
   routePlugin: FastifyPluginAsync,
   prefix: string,
 ): Promise<FastifyInstance> => {
-  const app = Fastify({ logger: false });
+  const app = Fastify({
+    logger: false,
+    ajv: {
+      customOptions: {},
+      plugins: [[ajvFormatsPlugin, ajvFormatsPluginOptions]],
+    },
+  });
   app.decorate('rateLimit', () => async () => {});
   await app.register(routePlugin, { prefix });
   await app.ready();

--- a/server/test/repositories/clientOffersRepo.test.ts
+++ b/server/test/repositories/clientOffersRepo.test.ts
@@ -86,17 +86,17 @@ describe('existsById / findIdConflict', () => {
   });
 });
 
-describe('findForUpdate', () => {
+describe('findExisting', () => {
   test('returns existing offer fields needed for permission checks', async () => {
     exec.enqueue({ rows: [['co-1', 'cq-1', 'c-1', 'Acme', 'draft']] });
-    const result = await clientOffersRepo.findForUpdate('co-1', testDb);
+    const result = await clientOffersRepo.findExisting('co-1', testDb);
     expect(result?.linkedQuoteId).toBe('cq-1');
     expect(result?.status).toBe('draft');
   });
 
   test('returns null when not found', async () => {
     exec.enqueue({ rows: [] });
-    expect(await clientOffersRepo.findForUpdate('co-x', testDb)).toBeNull();
+    expect(await clientOffersRepo.findExisting('co-x', testDb)).toBeNull();
   });
 });
 
@@ -135,6 +135,14 @@ describe('findItemsForOffer', () => {
     expect(exec.calls[0].params).toEqual(['co-1']);
     expect(result.map((i) => i.id)).toEqual(['coi-1', 'coi-2']);
     expect(result[1].quantity).toBe(3);
+  });
+
+  test('orders rows deterministically by created_at then id', async () => {
+    exec.enqueue({ rows: [] });
+    await clientOffersRepo.findItemsForOffer('co-1', testDb);
+    const sql = exec.calls[0].sql.toLowerCase();
+    expect(sql).toContain('order by');
+    expect(sql).toMatch(/"created_at".*,.*"id"/);
   });
 
   test('returns [] when no items for offer', async () => {

--- a/server/test/repositories/clientQuotesRepo.test.ts
+++ b/server/test/repositories/clientQuotesRepo.test.ts
@@ -96,22 +96,22 @@ describe('existsById / findIdConflict', () => {
   });
 });
 
-describe('findCurrentForUpdate', () => {
+describe('findCurrent', () => {
   test('returns parsed status and discount fields', async () => {
     exec.enqueue({ rows: [['sent', '15.5', 'currency']] });
-    const result = await clientQuotesRepo.findCurrentForUpdate('cq-1', testDb);
+    const result = await clientQuotesRepo.findCurrent('cq-1', testDb);
     expect(result).toEqual({ status: 'sent', discount: 15.5, discountType: 'currency' });
   });
 
   test('defaults discountType to percentage when null', async () => {
     exec.enqueue({ rows: [['draft', 0, null]] });
-    const result = await clientQuotesRepo.findCurrentForUpdate('cq-1', testDb);
+    const result = await clientQuotesRepo.findCurrent('cq-1', testDb);
     expect(result?.discountType).toBe('percentage');
   });
 
   test('returns null when not found', async () => {
     exec.enqueue({ rows: [] });
-    expect(await clientQuotesRepo.findCurrentForUpdate('cq-x', testDb)).toBeNull();
+    expect(await clientQuotesRepo.findCurrent('cq-x', testDb)).toBeNull();
   });
 });
 
@@ -356,6 +356,14 @@ describe('findItemsForQuote', () => {
     expect(exec.calls[0].params).toContain('cq-1');
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe('qi-1');
+  });
+
+  test('orders rows deterministically by created_at then id', async () => {
+    exec.enqueue({ rows: [] });
+    await clientQuotesRepo.findItemsForQuote('cq-1', testDb);
+    const sql = exec.calls[0].sql.toLowerCase();
+    expect(sql).toContain('order by');
+    expect(sql).toMatch(/"created_at".*,.*"id"/);
   });
 });
 

--- a/server/test/repositories/clientsOrdersRepo.test.ts
+++ b/server/test/repositories/clientsOrdersRepo.test.ts
@@ -343,12 +343,12 @@ describe('findIdConflict', () => {
   });
 });
 
-describe('findForUpdate', () => {
+describe('findExisting', () => {
   test('returns mapped existing order when found', async () => {
     exec.enqueue({
       rows: [['co-1', null, null, 'c-1', 'Acme', 'net30', '5', 'currency', 'draft', null]],
     });
-    const result = await repo.findForUpdate('co-1', testDb);
+    const result = await repo.findExisting('co-1', testDb);
     expect(result).toEqual({
       id: 'co-1',
       linkedQuoteId: null,
@@ -367,13 +367,13 @@ describe('findForUpdate', () => {
     exec.enqueue({
       rows: [['co-1', null, null, 'c-1', 'Acme', 'net30', '0', 'weird', 'draft', null]],
     });
-    const result = await repo.findForUpdate('co-1', testDb);
+    const result = await repo.findExisting('co-1', testDb);
     expect(result?.discountType).toBe('percentage');
   });
 
   test('returns null when not found', async () => {
     exec.enqueue({ rows: [] });
-    expect(await repo.findForUpdate('co-x', testDb)).toBeNull();
+    expect(await repo.findExisting('co-x', testDb)).toBeNull();
   });
 });
 
@@ -400,6 +400,14 @@ describe('findItemsForOrder', () => {
     expect(exec.calls[0].params).toContain('co-1');
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe('si-1');
+  });
+
+  test('orders rows deterministically by created_at then id', async () => {
+    exec.enqueue({ rows: [] });
+    await repo.findItemsForOrder('co-1', testDb);
+    const sql = exec.calls[0].sql.toLowerCase();
+    expect(sql).toContain('order by');
+    expect(sql).toMatch(/"created_at".*,.*"id"/);
   });
 });
 

--- a/server/test/repositories/clientsRepo.test.ts
+++ b/server/test/repositories/clientsRepo.test.ts
@@ -126,6 +126,52 @@ describe('mapClientRow', () => {
     expect(result.vatNumber).toBe('IT12345');
     expect(result.taxCode).toBe('IT12345');
   });
+
+  test('coerces missing string columns to null (no "undefined" leakage)', () => {
+    // Row has *no* address_* columns at all; legacy `as string` casts would surface them as
+    // the string `"undefined"`. Guarded mapping must produce nulls instead.
+    const minimalRow = {
+      id: 'c-2',
+      name: 'Minimal',
+      is_disabled: false,
+      type: 'company',
+      contacts: null,
+    };
+    const result = clientsRepo.mapClientRow(minimalRow);
+    expect(result.description).toBeNull();
+    expect(result.clientCode).toBeNull();
+    expect(result.email).toBeNull();
+    expect(result.phone).toBeNull();
+    expect(result.address).toBeNull();
+    expect(result.addressCountry).toBeNull();
+    expect(result.addressState).toBeNull();
+    expect(result.addressCap).toBeNull();
+    expect(result.addressProvince).toBeNull();
+    expect(result.addressCivicNumber).toBeNull();
+    expect(result.addressLine).toBeNull();
+    expect(result.atecoCode).toBeNull();
+    expect(result.website).toBeNull();
+    expect(result.sector).toBeNull();
+    expect(result.numberOfEmployees).toBeNull();
+    expect(result.revenue).toBeNull();
+    expect(result.fiscalCode).toBeNull();
+    expect(result.officeCountRange).toBeNull();
+    // None of these should ever be the literal string "undefined".
+    for (const value of Object.values(result)) {
+      expect(value).not.toBe('undefined');
+    }
+  });
+
+  test('coerces non-string column values to null instead of casting through', () => {
+    // Numeric column where a string is expected - shouldn't crash, just becomes null.
+    const result = clientsRepo.mapClientRow({
+      ...baseRow,
+      description: 12345,
+      website: { url: 'x' },
+    });
+    expect(result.description).toBeNull();
+    expect(result.website).toBeNull();
+  });
 });
 
 describe('list', () => {

--- a/server/test/repositories/invoicesRepo.test.ts
+++ b/server/test/repositories/invoicesRepo.test.ts
@@ -310,4 +310,12 @@ describe('findItemsForInvoice', () => {
     expect(exec.calls[0].params).toContain('INV-1');
     expect(result[0].id).toBe('inv-item-1');
   });
+
+  test('orders rows deterministically by created_at then id', async () => {
+    exec.enqueue({ rows: [] });
+    await invoicesRepo.findItemsForInvoice('INV-1', testDb);
+    const sql = exec.calls[0].sql.toLowerCase();
+    expect(sql).toContain('order by');
+    expect(sql).toMatch(/"created_at".*,.*"id"/);
+  });
 });

--- a/server/test/repositories/supplierInvoicesRepo.test.ts
+++ b/server/test/repositories/supplierInvoicesRepo.test.ts
@@ -79,6 +79,23 @@ describe('listAllItems', () => {
   });
 });
 
+describe('findItemsForInvoice', () => {
+  test('filters by invoice_id and maps rows', async () => {
+    exec.enqueue({ rows: [itemRow()] });
+    const result = await supplierInvoicesRepo.findItemsForInvoice('SINV-2026-0001', testDb);
+    expect(exec.calls[0].params).toContain('SINV-2026-0001');
+    expect(result[0].id).toBe('sinv-item-1');
+  });
+
+  test('orders rows deterministically by created_at then id', async () => {
+    exec.enqueue({ rows: [] });
+    await supplierInvoicesRepo.findItemsForInvoice('SINV-2026-0001', testDb);
+    const sql = exec.calls[0].sql.toLowerCase();
+    expect(sql).toContain('order by');
+    expect(sql).toMatch(/"created_at".*,.*"id"/);
+  });
+});
+
 describe('findInvoiceForLinkedSale', () => {
   test('returns id when found', async () => {
     exec.enqueue({ rows: [['SINV-2026-0001']] });
@@ -93,10 +110,10 @@ describe('findInvoiceForLinkedSale', () => {
   });
 });
 
-describe('findExistingForUpdate', () => {
+describe('findExisting', () => {
   test('returns id, status, issueDate, dueDate', async () => {
     exec.enqueue({ rows: [['SINV-2026-0001', 'draft', '2026-04-01', '2026-04-30']] });
-    expect(await supplierInvoicesRepo.findExistingForUpdate('SINV-2026-0001', testDb)).toEqual({
+    expect(await supplierInvoicesRepo.findExisting('SINV-2026-0001', testDb)).toEqual({
       id: 'SINV-2026-0001',
       status: 'draft',
       issueDate: '2026-04-01',

--- a/server/test/repositories/supplierOrdersRepo.test.ts
+++ b/server/test/repositories/supplierOrdersRepo.test.ts
@@ -72,10 +72,10 @@ describe('findById', () => {
   });
 });
 
-describe('findExistingForUpdate', () => {
+describe('findExisting', () => {
   test('returns mapped object with linkedQuoteId', async () => {
     exec.enqueue({ rows: [['so-1', 'q-1', 's-1', 'Acme', 'draft']] });
-    expect(await supplierOrdersRepo.findExistingForUpdate('so-1', testDb)).toEqual({
+    expect(await supplierOrdersRepo.findExisting('so-1', testDb)).toEqual({
       id: 'so-1',
       linkedQuoteId: 'q-1',
       supplierId: 's-1',
@@ -86,7 +86,7 @@ describe('findExistingForUpdate', () => {
 
   test('returns null when not found', async () => {
     exec.enqueue({ rows: [] });
-    expect(await supplierOrdersRepo.findExistingForUpdate('so-x', testDb)).toBeNull();
+    expect(await supplierOrdersRepo.findExisting('so-x', testDb)).toBeNull();
   });
 });
 
@@ -229,6 +229,14 @@ describe('findItemsForOrder', () => {
     expect(exec.calls[0].params).toContain('so-1');
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe('ssi-1');
+  });
+
+  test('orders rows deterministically by created_at then id', async () => {
+    exec.enqueue({ rows: [] });
+    await supplierOrdersRepo.findItemsForOrder('so-1', testDb);
+    const sql = exec.calls[0].sql.toLowerCase();
+    expect(sql).toContain('order by');
+    expect(sql).toMatch(/"created_at".*,.*"id"/);
   });
 });
 

--- a/server/test/repositories/supplierQuotesRepo.test.ts
+++ b/server/test/repositories/supplierQuotesRepo.test.ts
@@ -249,6 +249,14 @@ describe('findItemsForQuote', () => {
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe('sqi-1');
   });
+
+  test('orders rows deterministically by created_at then id', async () => {
+    exec.enqueue({ rows: [] });
+    await supplierQuotesRepo.findItemsForQuote('q-1', testDb);
+    const sql = exec.calls[0].sql.toLowerCase();
+    expect(sql).toContain('order by');
+    expect(sql).toMatch(/"created_at".*,.*"id"/);
+  });
 });
 
 describe('findFullForSnapshot', () => {

--- a/server/test/routes/client-offers-versions.test.ts
+++ b/server/test/routes/client-offers-versions.test.ts
@@ -34,7 +34,7 @@ const userHasRoleMock = mock();
 const getRolePermissionsMock = mock();
 
 const coExistsByIdMock = mock();
-const coFindForUpdateMock = mock();
+const coFindExistingMock = mock();
 const coFindLinkedSaleIdMock = mock();
 const coFindFullForSnapshotMock = mock();
 const coFindItemsForOfferMock = mock();
@@ -78,7 +78,7 @@ beforeAll(async () => {
   mock.module('../../repositories/clientOffersRepo.ts', () => ({
     ...clientOffersRepoSnap,
     existsById: coExistsByIdMock,
-    findForUpdate: coFindForUpdateMock,
+    findExisting: coFindExistingMock,
     findLinkedSaleId: coFindLinkedSaleIdMock,
     findFullForSnapshot: coFindFullForSnapshotMock,
     findItemsForOffer: coFindItemsForOfferMock,
@@ -197,7 +197,7 @@ const allMocks = [
   userHasRoleMock,
   getRolePermissionsMock,
   coExistsByIdMock,
-  coFindForUpdateMock,
+  coFindExistingMock,
   coFindLinkedSaleIdMock,
   coFindFullForSnapshotMock,
   coFindItemsForOfferMock,
@@ -314,7 +314,7 @@ describe('GET /api/sales/client-offers/:id/versions/:versionId', () => {
 
 describe('POST /api/sales/client-offers/:id/versions/:versionId/restore', () => {
   const setupHappyPath = () => {
-    coFindForUpdateMock.mockResolvedValue({
+    coFindExistingMock.mockResolvedValue({
       id: 'off-1',
       linkedQuoteId: 'q-1',
       clientId: 'c1',
@@ -383,7 +383,7 @@ describe('POST /api/sales/client-offers/:id/versions/:versionId/restore', () => 
   });
 
   test('404 when current offer does not exist', async () => {
-    coFindForUpdateMock.mockResolvedValue(null);
+    coFindExistingMock.mockResolvedValue(null);
 
     const res = await testApp.inject({
       method: 'POST',
@@ -397,7 +397,7 @@ describe('POST /api/sales/client-offers/:id/versions/:versionId/restore', () => 
   });
 
   test('409 when offer is not draft', async () => {
-    coFindForUpdateMock.mockResolvedValue({
+    coFindExistingMock.mockResolvedValue({
       id: 'off-1',
       linkedQuoteId: 'q-1',
       clientId: 'c1',
@@ -416,7 +416,7 @@ describe('POST /api/sales/client-offers/:id/versions/:versionId/restore', () => 
   });
 
   test('409 when any linked sale exists (draft or otherwise)', async () => {
-    coFindForUpdateMock.mockResolvedValue({
+    coFindExistingMock.mockResolvedValue({
       id: 'off-1',
       linkedQuoteId: 'q-1',
       clientId: 'c1',
@@ -467,7 +467,7 @@ describe('POST /api/sales/client-offers/:id/versions/:versionId/restore', () => 
   });
 
   test('404 when version not found (and no cross-offer leak)', async () => {
-    coFindForUpdateMock.mockResolvedValue({
+    coFindExistingMock.mockResolvedValue({
       id: 'off-1',
       linkedQuoteId: 'q-1',
       clientId: 'c1',
@@ -521,7 +521,7 @@ describe('POST /api/sales/client-offers/:id/versions/:versionId/restore', () => 
 
 describe('PUT /api/sales/client-offers/:id snapshots pre-update state', () => {
   test('PUT with content changes inserts a snapshot inside the transaction', async () => {
-    coFindForUpdateMock.mockResolvedValue({
+    coFindExistingMock.mockResolvedValue({
       id: 'off-1',
       linkedQuoteId: 'q-1',
       clientId: 'c1',
@@ -550,7 +550,7 @@ describe('PUT /api/sales/client-offers/:id snapshots pre-update state', () => {
   });
 
   test('PUT with id-only rename does NOT snapshot (no content change)', async () => {
-    coFindForUpdateMock.mockResolvedValue({
+    coFindExistingMock.mockResolvedValue({
       id: 'off-1',
       linkedQuoteId: 'q-1',
       clientId: 'c1',

--- a/server/test/routes/client-offers-versions.test.ts
+++ b/server/test/routes/client-offers-versions.test.ts
@@ -572,7 +572,7 @@ describe('PUT /api/sales/client-offers/:id snapshots pre-update state', () => {
   });
 
   test('PUT items: replaceItems failure rolls back (no audit, no success)', async () => {
-    coFindForUpdateMock.mockResolvedValue({
+    coFindExistingMock.mockResolvedValue({
       id: 'off-1',
       linkedQuoteId: null,
       clientId: 'c1',

--- a/server/test/routes/client-quotes-versions.test.ts
+++ b/server/test/routes/client-quotes-versions.test.ts
@@ -35,7 +35,7 @@ const getRolePermissionsMock = mock();
 
 const cqExistsByIdMock = mock();
 const cqFindLinkedOfferIdMock = mock();
-const cqFindCurrentForUpdateMock = mock();
+const cqFindCurrentMock = mock();
 const cqFindNonDraftLinkedSaleMock = mock();
 const cqFindAnyLinkedSaleMock = mock();
 const cqDeleteDraftSalesForQuoteMock = mock();
@@ -82,7 +82,7 @@ beforeAll(async () => {
     ...clientQuotesRepoSnap,
     existsById: cqExistsByIdMock,
     findLinkedOfferId: cqFindLinkedOfferIdMock,
-    findCurrentForUpdate: cqFindCurrentForUpdateMock,
+    findCurrent: cqFindCurrentMock,
     findNonDraftLinkedSale: cqFindNonDraftLinkedSaleMock,
     findAnyLinkedSale: cqFindAnyLinkedSaleMock,
     deleteDraftSalesForQuote: cqDeleteDraftSalesForQuoteMock,
@@ -204,7 +204,7 @@ const allMocks = [
   getRolePermissionsMock,
   cqExistsByIdMock,
   cqFindLinkedOfferIdMock,
-  cqFindCurrentForUpdateMock,
+  cqFindCurrentMock,
   cqFindNonDraftLinkedSaleMock,
   cqFindAnyLinkedSaleMock,
   cqDeleteDraftSalesForQuoteMock,
@@ -326,7 +326,7 @@ describe('GET /api/sales/client-quotes/:id/versions/:versionId', () => {
 describe('POST /api/sales/client-quotes/:id/versions/:versionId/restore', () => {
   const setupHappyPath = () => {
     cqFindLinkedOfferIdMock.mockResolvedValue(null);
-    cqFindCurrentForUpdateMock.mockResolvedValue({
+    cqFindCurrentMock.mockResolvedValue({
       status: 'draft',
       discount: 0,
       discountType: 'percentage',
@@ -404,7 +404,7 @@ describe('POST /api/sales/client-quotes/:id/versions/:versionId/restore', () => 
 
   test('404 when current quote does not exist', async () => {
     cqFindLinkedOfferIdMock.mockResolvedValue(null);
-    cqFindCurrentForUpdateMock.mockResolvedValue(null);
+    cqFindCurrentMock.mockResolvedValue(null);
 
     const res = await testApp.inject({
       method: 'POST',
@@ -418,7 +418,7 @@ describe('POST /api/sales/client-quotes/:id/versions/:versionId/restore', () => 
 
   test('409 when quote is confirmed', async () => {
     cqFindLinkedOfferIdMock.mockResolvedValue(null);
-    cqFindCurrentForUpdateMock.mockResolvedValue({
+    cqFindCurrentMock.mockResolvedValue({
       status: 'confirmed',
       discount: 0,
       discountType: 'percentage',
@@ -436,7 +436,7 @@ describe('POST /api/sales/client-quotes/:id/versions/:versionId/restore', () => 
 
   test('409 when non-draft linked sale exists', async () => {
     cqFindLinkedOfferIdMock.mockResolvedValue(null);
-    cqFindCurrentForUpdateMock.mockResolvedValue({
+    cqFindCurrentMock.mockResolvedValue({
       status: 'draft',
       discount: 0,
       discountType: 'percentage',
@@ -488,7 +488,7 @@ describe('POST /api/sales/client-quotes/:id/versions/:versionId/restore', () => 
 
   test('404 when version not found (and no cross-quote leak)', async () => {
     cqFindLinkedOfferIdMock.mockResolvedValue(null);
-    cqFindCurrentForUpdateMock.mockResolvedValue({
+    cqFindCurrentMock.mockResolvedValue({
       status: 'draft',
       discount: 0,
       discountType: 'percentage',
@@ -540,7 +540,7 @@ describe('POST /api/sales/client-quotes/:id/versions/:versionId/restore', () => 
 describe('PUT /api/sales/client-quotes/:id snapshots pre-update state', () => {
   test('PUT with content changes inserts a snapshot inside the transaction', async () => {
     cqFindLinkedOfferIdMock.mockResolvedValue(null);
-    cqFindCurrentForUpdateMock.mockResolvedValue({
+    cqFindCurrentMock.mockResolvedValue({
       status: 'draft',
       discount: 0,
       discountType: 'percentage',
@@ -569,7 +569,7 @@ describe('PUT /api/sales/client-quotes/:id snapshots pre-update state', () => {
 
   test('PUT with id-only rename does NOT snapshot (no content change)', async () => {
     cqFindLinkedOfferIdMock.mockResolvedValue(null);
-    cqFindCurrentForUpdateMock.mockResolvedValue({
+    cqFindCurrentMock.mockResolvedValue({
       status: 'draft',
       discount: 0,
       discountType: 'percentage',

--- a/server/test/routes/clients-orders-versions.test.ts
+++ b/server/test/routes/clients-orders-versions.test.ts
@@ -34,7 +34,7 @@ const userHasRoleMock = mock();
 const getRolePermissionsMock = mock();
 
 const coExistsByIdMock = mock();
-const coFindForUpdateMock = mock();
+const coFindExistingMock = mock();
 const coFindFullForSnapshotMock = mock();
 const coFindItemsForOrderMock = mock();
 const coFindIdConflictMock = mock();
@@ -77,7 +77,7 @@ beforeAll(async () => {
   mock.module('../../repositories/clientsOrdersRepo.ts', () => ({
     ...clientsOrdersRepoSnap,
     existsById: coExistsByIdMock,
-    findForUpdate: coFindForUpdateMock,
+    findExisting: coFindExistingMock,
     findFullForSnapshot: coFindFullForSnapshotMock,
     findItemsForOrder: coFindItemsForOrderMock,
     findIdConflict: coFindIdConflictMock,
@@ -198,7 +198,7 @@ const allMocks = [
   userHasRoleMock,
   getRolePermissionsMock,
   coExistsByIdMock,
-  coFindForUpdateMock,
+  coFindExistingMock,
   coFindFullForSnapshotMock,
   coFindItemsForOrderMock,
   coFindIdConflictMock,
@@ -314,7 +314,7 @@ describe('GET /api/clients-orders/:id/versions/:versionId', () => {
 
 describe('POST /api/clients-orders/:id/versions/:versionId/restore', () => {
   const setupHappyPath = () => {
-    coFindForUpdateMock.mockResolvedValue({
+    coFindExistingMock.mockResolvedValue({
       id: 'o-1',
       linkedQuoteId: null,
       linkedOfferId: null,
@@ -382,7 +382,7 @@ describe('POST /api/clients-orders/:id/versions/:versionId/restore', () => {
   });
 
   test('404 when current order does not exist', async () => {
-    coFindForUpdateMock.mockResolvedValue(null);
+    coFindExistingMock.mockResolvedValue(null);
     ovFindByIdMock.mockResolvedValue(SAMPLE_VERSION);
 
     const res = await testApp.inject({
@@ -397,7 +397,7 @@ describe('POST /api/clients-orders/:id/versions/:versionId/restore', () => {
   });
 
   test('409 when order has linkedOfferId', async () => {
-    coFindForUpdateMock.mockResolvedValue({
+    coFindExistingMock.mockResolvedValue({
       id: 'o-1',
       linkedQuoteId: null,
       linkedOfferId: 'off-1',
@@ -423,7 +423,7 @@ describe('POST /api/clients-orders/:id/versions/:versionId/restore', () => {
   });
 
   test('409 when order has linkedQuoteId', async () => {
-    coFindForUpdateMock.mockResolvedValue({
+    coFindExistingMock.mockResolvedValue({
       id: 'o-1',
       linkedQuoteId: 'q-1',
       linkedOfferId: null,
@@ -449,7 +449,7 @@ describe('POST /api/clients-orders/:id/versions/:versionId/restore', () => {
   });
 
   test('409 when order is non-draft', async () => {
-    coFindForUpdateMock.mockResolvedValue({
+    coFindExistingMock.mockResolvedValue({
       id: 'o-1',
       linkedQuoteId: null,
       linkedOfferId: null,
@@ -504,7 +504,7 @@ describe('POST /api/clients-orders/:id/versions/:versionId/restore', () => {
   });
 
   test('404 when version not found (and no cross-order leak)', async () => {
-    coFindForUpdateMock.mockResolvedValue({
+    coFindExistingMock.mockResolvedValue({
       id: 'o-1',
       linkedQuoteId: null,
       linkedOfferId: null,
@@ -582,7 +582,7 @@ describe('POST /api/clients-orders/:id/versions/:versionId/restore', () => {
 
 describe('PUT /api/clients-orders/:id snapshots pre-update state', () => {
   test('PUT with content changes inserts a snapshot inside the transaction', async () => {
-    coFindForUpdateMock.mockResolvedValue({
+    coFindExistingMock.mockResolvedValue({
       id: 'o-1',
       linkedQuoteId: null,
       linkedOfferId: null,
@@ -617,7 +617,7 @@ describe('PUT /api/clients-orders/:id snapshots pre-update state', () => {
   });
 
   test('PUT with status-only update does NOT snapshot (no locked field changes)', async () => {
-    coFindForUpdateMock.mockResolvedValue({
+    coFindExistingMock.mockResolvedValue({
       id: 'o-1',
       linkedQuoteId: null,
       linkedOfferId: null,
@@ -644,7 +644,7 @@ describe('PUT /api/clients-orders/:id snapshots pre-update state', () => {
   });
 
   test('PUT on source-linked order does NOT snapshot (status-only edit)', async () => {
-    coFindForUpdateMock.mockResolvedValue({
+    coFindExistingMock.mockResolvedValue({
       id: 'o-1',
       linkedQuoteId: 'q-1',
       linkedOfferId: null,
@@ -670,7 +670,7 @@ describe('PUT /api/clients-orders/:id snapshots pre-update state', () => {
   });
 
   test('PUT with field present but value unchanged does NOT snapshot', async () => {
-    coFindForUpdateMock.mockResolvedValue({
+    coFindExistingMock.mockResolvedValue({
       id: 'o-1',
       linkedQuoteId: null,
       linkedOfferId: null,
@@ -717,7 +717,7 @@ describe('PUT /api/clients-orders/:id snapshots pre-update state', () => {
   });
 
   test('PUT changing only an item productCost snapshots (regression)', async () => {
-    coFindForUpdateMock.mockResolvedValue({
+    coFindExistingMock.mockResolvedValue({
       id: 'o-1',
       linkedQuoteId: null,
       linkedOfferId: null,
@@ -764,7 +764,7 @@ describe('PUT /api/clients-orders/:id snapshots pre-update state', () => {
   });
 
   test('PUT changing only an item unitType snapshots', async () => {
-    coFindForUpdateMock.mockResolvedValue({
+    coFindExistingMock.mockResolvedValue({
       id: 'o-1',
       linkedQuoteId: null,
       linkedOfferId: null,

--- a/server/test/routes/clients-orders-versions.test.ts
+++ b/server/test/routes/clients-orders-versions.test.ts
@@ -809,7 +809,7 @@ describe('PUT /api/clients-orders/:id snapshots pre-update state', () => {
   });
 
   test('PUT items: replaceItems failure rolls back (no audit, no success)', async () => {
-    coFindForUpdateMock.mockResolvedValue({
+    coFindExistingMock.mockResolvedValue({
       id: 'o-1',
       linkedQuoteId: null,
       linkedOfferId: null,

--- a/server/test/routes/clients.test.ts
+++ b/server/test/routes/clients.test.ts
@@ -658,7 +658,7 @@ describe('PUT /api/clients/:id', () => {
 });
 
 describe('DELETE /api/clients/:id', () => {
-  test('200 happy + audit', async () => {
+  test('204 happy + audit', async () => {
     deleteClientByIdMock.mockResolvedValue({ id: 'c-1', name: 'ACME', clientCode: 'ACME-01' });
 
     const res = await testApp.inject({
@@ -667,14 +667,14 @@ describe('DELETE /api/clients/:id', () => {
       headers: authHeader(),
     });
 
-    expect(res.statusCode).toBe(200);
-    expect(JSON.parse(res.body)).toEqual({ message: 'Client deleted' });
+    expect(res.statusCode).toBe(204);
+    expect(res.body).toBe('');
     expect(logAuditMock).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'client.deleted', entityId: 'c-1' }),
     );
   });
 
-  test('200 crm.clients_all.delete bypasses assigned-client check', async () => {
+  test('204 crm.clients_all.delete bypasses assigned-client check', async () => {
     getRolePermissionsMock.mockResolvedValue(['crm.clients_all.delete']);
     isClientAssignedToUserMock.mockResolvedValue(false);
     deleteClientByIdMock.mockResolvedValue({ id: 'c-1', name: 'ACME', clientCode: 'ACME-01' });
@@ -685,7 +685,7 @@ describe('DELETE /api/clients/:id', () => {
       headers: authHeader(),
     });
 
-    expect(res.statusCode).toBe(200);
+    expect(res.statusCode).toBe(204);
     expect(isClientAssignedToUserMock).not.toHaveBeenCalled();
     expect(deleteClientByIdMock).toHaveBeenCalledWith('c-1');
   });
@@ -913,7 +913,7 @@ describe('PUT /api/clients/profile-options/:category/:id', () => {
 });
 
 describe('DELETE /api/clients/profile-options/:category/:id', () => {
-  test('200 deletes profile option when unused', async () => {
+  test('204 deletes profile option when unused', async () => {
     cpoFindByCategoryAndIdMock.mockResolvedValue({ id: 'cpo-1', value: 'Tech' });
     cpoGetUsageCountMock.mockResolvedValue(0);
     cpoDeleteByIdMock.mockResolvedValue(true);
@@ -924,8 +924,8 @@ describe('DELETE /api/clients/profile-options/:category/:id', () => {
       headers: authHeader(),
     });
 
-    expect(res.statusCode).toBe(200);
-    expect(JSON.parse(res.body)).toEqual({ message: 'Profile option deleted' });
+    expect(res.statusCode).toBe(204);
+    expect(res.body).toBe('');
     expect(logAuditMock).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'client.profile_option.deleted' }),
     );

--- a/server/test/routes/entries.test.ts
+++ b/server/test/routes/entries.test.ts
@@ -793,7 +793,7 @@ describe('PUT /api/entries/:id', () => {
 });
 
 describe('DELETE /api/entries/:id', () => {
-  test('200 own entry', async () => {
+  test('204 own entry', async () => {
     entriesFindOwnerMock.mockResolvedValue('u1');
     entriesDeleteByIdMock.mockResolvedValue(undefined);
 
@@ -803,8 +803,8 @@ describe('DELETE /api/entries/:id', () => {
       headers: authHeader(),
     });
 
-    expect(res.statusCode).toBe(200);
-    expect(JSON.parse(res.body)).toEqual({ message: 'Entry deleted' });
+    expect(res.statusCode).toBe(204);
+    expect(res.body).toBe('');
     expect(entriesDeleteByIdMock).toHaveBeenCalledWith('te-1');
   });
 
@@ -1271,7 +1271,7 @@ describe('POST /api/entries/recurring/generate', () => {
 });
 
 describe('DELETE /api/entries (bulk)', () => {
-  test('200 manager-scoped restricts to viewer', async () => {
+  test('204 manager-scoped restricts to viewer', async () => {
     entriesBulkDeleteMock.mockResolvedValue(3);
 
     const res = await testApp.inject({
@@ -1280,8 +1280,8 @@ describe('DELETE /api/entries (bulk)', () => {
       headers: authHeader(),
     });
 
-    expect(res.statusCode).toBe(200);
-    expect(JSON.parse(res.body)).toEqual({ message: 'Deleted 3 entries' });
+    expect(res.statusCode).toBe(204);
+    expect(res.body).toBe('');
     expect(entriesBulkDeleteMock).toHaveBeenCalledWith(
       expect.objectContaining({
         projectId: 'p1',
@@ -1292,7 +1292,7 @@ describe('DELETE /api/entries (bulk)', () => {
     );
   });
 
-  test('200 admin scope deletes across all users', async () => {
+  test('204 admin scope deletes across all users', async () => {
     getRolePermissionsMock.mockResolvedValue([
       ...TRACKER_ALL_PERMS,
       'timesheets.tracker_all.delete',
@@ -1305,13 +1305,13 @@ describe('DELETE /api/entries (bulk)', () => {
       headers: authHeader(),
     });
 
-    expect(res.statusCode).toBe(200);
+    expect(res.statusCode).toBe(204);
     expect(entriesBulkDeleteMock).toHaveBeenCalledWith(
       expect.objectContaining({ restrictToManagerScopeOf: undefined }),
     );
   });
 
-  test('200 futureOnly=true sets fromDate to today', async () => {
+  test('204 futureOnly=true sets fromDate to today', async () => {
     entriesBulkDeleteMock.mockResolvedValue(1);
 
     const res = await testApp.inject({
@@ -1320,7 +1320,7 @@ describe('DELETE /api/entries (bulk)', () => {
       headers: authHeader(),
     });
 
-    expect(res.statusCode).toBe(200);
+    expect(res.statusCode).toBe(204);
     expect(entriesBulkDeleteMock).toHaveBeenCalledTimes(1);
     const callArgs = entriesBulkDeleteMock.mock.calls[0][0];
     expect(callArgs.fromDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
@@ -1349,7 +1349,7 @@ describe('DELETE /api/entries (bulk)', () => {
     expect(JSON.parse(res.body)).toEqual({ error: 'Insufficient permissions' });
   });
 
-  test('200 with only timesheets.tracker_all.delete widens scope across users', async () => {
+  test('204 with only timesheets.tracker_all.delete widens scope across users', async () => {
     getRolePermissionsMock.mockResolvedValue(['timesheets.tracker_all.delete']);
     entriesBulkDeleteMock.mockResolvedValue(5);
 
@@ -1359,8 +1359,8 @@ describe('DELETE /api/entries (bulk)', () => {
       headers: authHeader(),
     });
 
-    expect(res.statusCode).toBe(200);
-    expect(JSON.parse(res.body)).toEqual({ message: 'Deleted 5 entries' });
+    expect(res.statusCode).toBe(204);
+    expect(res.body).toBe('');
     expect(entriesBulkDeleteMock).toHaveBeenCalledWith(
       expect.objectContaining({
         projectId: 'p1',
@@ -1370,7 +1370,7 @@ describe('DELETE /api/entries (bulk)', () => {
     );
   });
 
-  test('200 with only timesheets.recurring.delete stays restricted to actor', async () => {
+  test('204 with only timesheets.recurring.delete stays restricted to actor', async () => {
     getRolePermissionsMock.mockResolvedValue(['timesheets.recurring.delete']);
     entriesBulkDeleteMock.mockResolvedValue(2);
 
@@ -1380,8 +1380,8 @@ describe('DELETE /api/entries (bulk)', () => {
       headers: authHeader(),
     });
 
-    expect(res.statusCode).toBe(200);
-    expect(JSON.parse(res.body)).toEqual({ message: 'Deleted 2 entries' });
+    expect(res.statusCode).toBe(204);
+    expect(res.body).toBe('');
     expect(entriesBulkDeleteMock).toHaveBeenCalledWith(
       expect.objectContaining({
         projectId: 'p1',

--- a/server/test/routes/projects.test.ts
+++ b/server/test/routes/projects.test.ts
@@ -678,8 +678,8 @@ describe('DELETE /api/projects/:id', () => {
       headers: authHeader(),
     });
 
-    expect(res.statusCode).toBe(200);
-    expect(JSON.parse(res.body)).toEqual({ message: 'Project deleted' });
+    expect(res.statusCode).toBe(204);
+    expect(res.body).toBe('');
     expect(deleteByIdMock).toHaveBeenCalledWith('p-1', undefined);
     expect(logAuditMock).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'project.deleted', entityId: 'p-1' }),

--- a/server/test/routes/roles.test.ts
+++ b/server/test/routes/roles.test.ts
@@ -469,8 +469,8 @@ describe('DELETE /api/roles/:id', () => {
       headers: adminAuth(),
     });
 
-    expect(res.statusCode).toBe(200);
-    expect(JSON.parse(res.body)).toEqual({ message: 'Role deleted' });
+    expect(res.statusCode).toBe(204);
+    expect(res.body).toBe('');
     expect(deleteRoleMock).toHaveBeenCalledWith('role-x');
     expect(logAuditMock).toHaveBeenCalledWith(expect.objectContaining({ action: 'role.deleted' }));
   });

--- a/server/test/routes/settings.test.ts
+++ b/server/test/routes/settings.test.ts
@@ -386,8 +386,8 @@ describe('MCP token settings routes', () => {
       headers: authHeader(),
     });
 
-    expect(res.statusCode).toBe(200);
-    expect(JSON.parse(res.body)).toEqual({ message: 'MCP token revoked' });
+    expect(res.statusCode).toBe(204);
+    expect(res.body).toBe('');
     expect(revokeMcpTokenForUserMock).toHaveBeenCalledWith('mcp-token-1', 'u1');
   });
 

--- a/server/test/routes/supplier-invoices.test.ts
+++ b/server/test/routes/supplier-invoices.test.ts
@@ -33,7 +33,7 @@ const findInvoiceForLinkedSaleMock = mock();
 const maxSequenceForYearMock = mock();
 const createMock = mock();
 const insertItemsMock = mock();
-const findExistingForUpdateMock = mock();
+const findExistingMock = mock();
 const findIdConflictMock = mock();
 const updateMock = mock();
 const replaceItemsMock = mock();
@@ -71,7 +71,7 @@ beforeAll(async () => {
     maxSequenceForYear: maxSequenceForYearMock,
     create: createMock,
     insertItems: insertItemsMock,
-    findExistingForUpdate: findExistingForUpdateMock,
+    findExisting: findExistingMock,
     findIdConflict: findIdConflictMock,
     update: updateMock,
     replaceItems: replaceItemsMock,
@@ -158,7 +158,7 @@ const allMocks = [
   maxSequenceForYearMock,
   createMock,
   insertItemsMock,
-  findExistingForUpdateMock,
+  findExistingMock,
   findIdConflictMock,
   updateMock,
   replaceItemsMock,
@@ -423,7 +423,7 @@ describe('POST /api/supplier-invoices', () => {
 
 describe('PUT /api/supplier-invoices/:id', () => {
   test('200 partial update on draft invoice', async () => {
-    findExistingForUpdateMock.mockResolvedValue({
+    findExistingMock.mockResolvedValue({
       id: 'SINV-2025-0001',
       status: 'draft',
       issueDate: '2025-06-01',
@@ -448,7 +448,7 @@ describe('PUT /api/supplier-invoices/:id', () => {
   });
 
   test('200 update with new items uses replaceItems', async () => {
-    findExistingForUpdateMock.mockResolvedValue({
+    findExistingMock.mockResolvedValue({
       id: 'SINV-2025-0001',
       status: 'draft',
       issueDate: '2025-06-01',
@@ -471,7 +471,7 @@ describe('PUT /api/supplier-invoices/:id', () => {
   });
 
   test('404 invoice not found', async () => {
-    findExistingForUpdateMock.mockResolvedValue(null);
+    findExistingMock.mockResolvedValue(null);
 
     const res = await testApp.inject({
       method: 'PUT',
@@ -485,7 +485,7 @@ describe('PUT /api/supplier-invoices/:id', () => {
   });
 
   test('409 non-draft invoice with locked field updates is read-only', async () => {
-    findExistingForUpdateMock.mockResolvedValue({
+    findExistingMock.mockResolvedValue({
       id: 'SINV-2025-0001',
       status: 'sent',
       issueDate: '2025-06-01',
@@ -505,7 +505,7 @@ describe('PUT /api/supplier-invoices/:id', () => {
   });
 
   test('409 id conflict on rename', async () => {
-    findExistingForUpdateMock.mockResolvedValue({
+    findExistingMock.mockResolvedValue({
       id: 'SINV-2025-0001',
       status: 'draft',
       issueDate: '2025-06-01',
@@ -525,7 +525,7 @@ describe('PUT /api/supplier-invoices/:id', () => {
   });
 
   test('400 dueDate before issueDate using effective dates', async () => {
-    findExistingForUpdateMock.mockResolvedValue({
+    findExistingMock.mockResolvedValue({
       id: 'SINV-2025-0001',
       status: 'draft',
       issueDate: '2025-06-01',
@@ -546,7 +546,7 @@ describe('PUT /api/supplier-invoices/:id', () => {
   });
 
   test('400 empty items array on update', async () => {
-    findExistingForUpdateMock.mockResolvedValue({
+    findExistingMock.mockResolvedValue({
       id: 'SINV-2025-0001',
       status: 'draft',
       issueDate: '2025-06-01',
@@ -565,7 +565,7 @@ describe('PUT /api/supplier-invoices/:id', () => {
   });
 
   test('404 update returns null after transaction', async () => {
-    findExistingForUpdateMock.mockResolvedValue({
+    findExistingMock.mockResolvedValue({
       id: 'SINV-2025-0001',
       status: 'draft',
       issueDate: '2025-06-01',

--- a/server/test/routes/supplier-orders-versions.test.ts
+++ b/server/test/routes/supplier-orders-versions.test.ts
@@ -33,7 +33,7 @@ const userHasRoleMock = mock();
 const getRolePermissionsMock = mock();
 
 const soExistsByIdMock = mock();
-const soFindExistingForUpdateMock = mock();
+const soFindExistingMock = mock();
 const soFindLinkedInvoiceIdMock = mock();
 const soFindFullForSnapshotMock = mock();
 const soFindItemsForOrderMock = mock();
@@ -73,7 +73,7 @@ beforeAll(async () => {
   mock.module('../../repositories/supplierOrdersRepo.ts', () => ({
     ...supplierOrdersRepoSnap,
     existsById: soExistsByIdMock,
-    findExistingForUpdate: soFindExistingForUpdateMock,
+    findExisting: soFindExistingMock,
     findLinkedInvoiceId: soFindLinkedInvoiceIdMock,
     findFullForSnapshot: soFindFullForSnapshotMock,
     findItemsForOrder: soFindItemsForOrderMock,
@@ -191,7 +191,7 @@ const allMocks = [
   userHasRoleMock,
   getRolePermissionsMock,
   soExistsByIdMock,
-  soFindExistingForUpdateMock,
+  soFindExistingMock,
   soFindLinkedInvoiceIdMock,
   soFindFullForSnapshotMock,
   soFindItemsForOrderMock,
@@ -310,7 +310,7 @@ describe('GET /api/accounting/supplier-orders/:id/versions/:versionId', () => {
 describe('POST /api/accounting/supplier-orders/:id/versions/:versionId/restore', () => {
   const setupHappyPath = () => {
     soFindLinkedInvoiceIdMock.mockResolvedValue(null);
-    soFindExistingForUpdateMock.mockResolvedValue({
+    soFindExistingMock.mockResolvedValue({
       id: 'so-1',
       linkedQuoteId: null,
       supplierId: 's-1',
@@ -389,7 +389,7 @@ describe('POST /api/accounting/supplier-orders/:id/versions/:versionId/restore',
 
   test('404 when current order does not exist', async () => {
     soFindLinkedInvoiceIdMock.mockResolvedValue(null);
-    soFindExistingForUpdateMock.mockResolvedValue(null);
+    soFindExistingMock.mockResolvedValue(null);
 
     const res = await testApp.inject({
       method: 'POST',
@@ -403,7 +403,7 @@ describe('POST /api/accounting/supplier-orders/:id/versions/:versionId/restore',
 
   test('409 when order is non-draft', async () => {
     soFindLinkedInvoiceIdMock.mockResolvedValue(null);
-    soFindExistingForUpdateMock.mockResolvedValue({
+    soFindExistingMock.mockResolvedValue({
       id: 'so-1',
       linkedQuoteId: null,
       supplierId: 's-1',
@@ -453,7 +453,7 @@ describe('POST /api/accounting/supplier-orders/:id/versions/:versionId/restore',
 
   test('404 when version not found (and no cross-order leak)', async () => {
     soFindLinkedInvoiceIdMock.mockResolvedValue(null);
-    soFindExistingForUpdateMock.mockResolvedValue({
+    soFindExistingMock.mockResolvedValue({
       id: 'so-1',
       linkedQuoteId: null,
       supplierId: 's-1',
@@ -511,7 +511,7 @@ describe('POST /api/accounting/supplier-orders/:id/versions/:versionId/restore',
 
 describe('PUT /api/accounting/supplier-orders/:id snapshots pre-update state', () => {
   test('PUT with content changes inserts a snapshot inside the transaction', async () => {
-    soFindExistingForUpdateMock.mockResolvedValue({
+    soFindExistingMock.mockResolvedValue({
       id: 'so-1',
       linkedQuoteId: null,
       supplierId: 's-1',
@@ -540,7 +540,7 @@ describe('PUT /api/accounting/supplier-orders/:id snapshots pre-update state', (
   });
 
   test('PUT with id-only rename does NOT snapshot (no content change)', async () => {
-    soFindExistingForUpdateMock.mockResolvedValue({
+    soFindExistingMock.mockResolvedValue({
       id: 'so-1',
       linkedQuoteId: null,
       supplierId: 's-1',

--- a/server/test/routes/tasks.test.ts
+++ b/server/test/routes/tasks.test.ts
@@ -804,7 +804,7 @@ describe('PUT /api/tasks/:id', () => {
 });
 
 describe('DELETE /api/tasks/:id', () => {
-  test('200: happy delete with audit', async () => {
+  test('204: happy delete with audit', async () => {
     deleteByIdMock.mockResolvedValue({ name: 'Implement feature', projectId: 'p-1' });
 
     const res = await testApp.inject({
@@ -813,8 +813,8 @@ describe('DELETE /api/tasks/:id', () => {
       headers: authHeader(),
     });
 
-    expect(res.statusCode).toBe(200);
-    expect(JSON.parse(res.body)).toEqual({ message: 'Task deleted' });
+    expect(res.statusCode).toBe(204);
+    expect(res.body).toBe('');
     expect(logAuditMock).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'task.deleted', entityId: 't-1' }),
     );

--- a/server/test/routes/users.test.ts
+++ b/server/test/routes/users.test.ts
@@ -622,7 +622,7 @@ describe('POST /api/users', () => {
 // =========================================================================
 
 describe('DELETE /api/users/:id', () => {
-  test('200 admin deletes app_user', async () => {
+  test('204 admin deletes app_user', async () => {
     findCoreByIdMock.mockResolvedValue(SAMPLE_USER_CORE);
     deleteByIdMock.mockResolvedValue(true);
 
@@ -632,8 +632,8 @@ describe('DELETE /api/users/:id', () => {
       headers: adminAuth(),
     });
 
-    expect(res.statusCode).toBe(200);
-    expect(JSON.parse(res.body)).toEqual({ message: 'User deleted' });
+    expect(res.statusCode).toBe(204);
+    expect(res.body).toBe('');
     expect(deleteByIdMock).toHaveBeenCalledWith('u-target');
     expect(logAuditMock).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'user.deleted', entityId: 'u-target' }),

--- a/server/test/routes/work-units.test.ts
+++ b/server/test/routes/work-units.test.ts
@@ -352,7 +352,7 @@ describe('PUT /api/work-units/:id', () => {
 });
 
 describe('DELETE /api/work-units/:id', () => {
-  test('200 happy + audit', async () => {
+  test('204 happy + audit', async () => {
     deleteByIdMock.mockResolvedValue({ id: 'wu-1', name: 'Engineering' });
 
     const res = await testApp.inject({
@@ -361,8 +361,8 @@ describe('DELETE /api/work-units/:id', () => {
       headers: authHeader(),
     });
 
-    expect(res.statusCode).toBe(200);
-    expect(JSON.parse(res.body)).toEqual({ message: 'Work unit deleted' });
+    expect(res.statusCode).toBe(204);
+    expect(res.body).toBe('');
     expect(logAuditMock).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'work_unit.deleted', entityId: 'wu-1' }),
     );

--- a/server/utils/ajv-formats.ts
+++ b/server/utils/ajv-formats.ts
@@ -1,0 +1,26 @@
+// Registers `ajv-formats` with Fastify's AJV instance so JSON-schema `format` keywords
+// (`date-time`, `date`, `email`, ...) are actually validated.
+//
+// @fastify/ajv-compiler auto-registers `ajv-formats` with default options when no explicit
+// formats plugin is supplied. Wiring it ourselves makes the configuration explicit (we choose
+// which formats are active) and protects against silent breakage if the upstream default ever
+// changes. The compiler dedupes by checking `plugin.name === 'formatsPlugin'`, so we keep the
+// underlying function reference (whose `.name` is `formatsPlugin`) - any wrapper would break
+// the dedupe and double-register the plugin.
+
+import type { Plugin } from 'ajv';
+import addFormats, { type FormatsPluginOptions } from 'ajv-formats';
+
+// Re-typed as a generic AJV `Plugin` so it fits Fastify's `ajv.plugins` array signature
+// (Fastify expects `Plugin<unknown>`, while ajv-formats's own signature is `Plugin<FormatsPluginOptions>`).
+// The default-import shape from `ajv-formats` also loses the callable type after TS module-interop
+// translation, so we cast here once instead of at every call site.
+export const ajvFormatsPlugin = addFormats as unknown as Plugin<unknown>;
+
+export const ajvFormatsPluginOptions: FormatsPluginOptions = {
+  mode: 'full',
+  // Limit registration to the formats we actually use in route schemas - keeps the keyword set
+  // tight. `date-time` is the load-bearing one (logs.ts startDate/endDate, others).
+  formats: ['date-time', 'date', 'time', 'email', 'uri', 'uuid'],
+  keywords: true,
+};

--- a/services/api/roles.ts
+++ b/services/api/roles.ts
@@ -18,7 +18,7 @@ export const rolesApi = {
       method: 'PUT',
       body: JSON.stringify({ permissions }),
     }),
-  delete: (id: string): Promise<{ message: string }> =>
+  delete: (id: string): Promise<void> =>
     fetchApi(`/roles/${id}`, {
       method: 'DELETE',
     }),


### PR DESCRIPTION
## Summary

Unit 14 of the codebase logical-issue cleanup. Five repo/route hardening passes bundled together because they all touch the same files:

- **B4 — deterministic `ORDER BY`** on the seven `findItemsFor*` repo functions (client+supplier offers, quotes, orders, invoices). All now `ORDER BY created_at, id` so the items table doesn't reorder between reloads.
- **B5 — misnamed `*ForUpdate`**: renamed `findForUpdate`, `findCurrentForUpdate`, `findExistingForUpdate` (5 functions across `clientOffersRepo`, `clientQuotesRepo`, `clientsOrdersRepo`, `supplierInvoicesRepo`, `supplierOrdersRepo`) to `findExisting` / `findCurrent`. Audit of every caller showed none actually run inside `withDbTransaction` (one comment in `client-offers.ts:874` already notes this limitation), so adding `.for('update')` would just be theatre. Doc comments explain how to upgrade to true row-locking later.
- **B10 — `mapClientRow` unsafe casts**: replaced the `as string | null` / `as boolean` casts on `Record<string, unknown>` with explicit `typeof` guards. New helpers `stringOrNull` and `parseCreatedAt` keep the call sites readable. Adds a regression test that a row missing every address column maps to `null` instead of the literal `"undefined"`.
- **B18 — DELETE response shape**: standardised every DELETE handler that returned `200 { message: ... }` to `204` with no body (clients, profile options, projects, roles, tasks, users, work units, MCP tokens, time entries delete + bulk). The `time-entries` service still returns `{ message }` because the MCP tool surface relays it back; the REST route just discards it. Frontend client `rolesApi.delete` typing changed from `Promise<{ message: string }>` to `Promise<void>` (no other clients consumed the body). All 10 corresponding tests updated to assert 204 + empty body.
- **B19 — AJV `date-time` format**: `@fastify/ajv-compiler@4` auto-registers `ajv-formats` with defaults, but wired it explicitly through `server/utils/ajv-formats.ts` so the active formats are pinned to `[date-time, date, time, email, uri, uuid]`. The test helper `buildRouteTestApp` was also updated to mirror the production wiring so the existing logs.ts `400 on invalid startDate` test actually exercises the real validator.

## Test plan

- [x] `bun run test` (2110 server tests, 962 frontend tests — all pass)
- [x] `bun run lint` (clean — 4 pre-existing warnings unrelated to this change)
- [x] `cd server && bun run build` (clean)

## Manual verification

1) Edit an item-bearing document (offer/quote/order) and reload — verify item order is stable across reloads.
2) Send an invalid timestamp to `GET /api/logs/audit?startDate=not-a-date` — verify 400 response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)