### PR TITLE
fix(frontend): recurring-entry race + stale closures in supplierQuote/client handlers

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -634,6 +634,12 @@ const App: React.FC = () => {
   const [entries, setEntries] = useState<TimeEntry[]>([]);
   // Bumped on logout/role-switch so in-flight cursor streams stop appending stale rows.
   const entriesStreamTokenRef = useRef(0);
+  // Flips to true once the initial entries page resolves; the recurring-entry
+  // generator effect waits on this rather than relying on a setTimeout
+  // heuristic to guess when entries are loaded. Reset to false on
+  // logout/role-switch alongside `setEntries([])`. We use state (not a ref) so
+  // the dependent effect re-runs when the flag changes.
+  const [entriesLoaded, setEntriesLoaded] = useState(false);
   const [ldapConfig, setLdapConfig] = useState<LdapConfig>({
     enabled: false,
     serverUrl: 'ldap://ldap.example.com:389',
@@ -795,13 +801,16 @@ const App: React.FC = () => {
   const [supplierQuoteFilterId, setSupplierQuoteFilterId] = useState<string | null>(null);
   const [clientsOrderFilterId, setClientsOrderFilterId] = useState<string | null>(null);
 
-  // Latest-value refs for the quote handler factory. The handlers read these
-  // BEFORE and AFTER awaited API calls; getters backed by refs let the memoized
-  // factory observe up-to-date state once promises resolve (a navigation can
-  // clear `clientQuoteFilterId` mid-await, for example).
+  // Latest-value refs for handler factories. The handlers read these BEFORE
+  // and AFTER awaited API calls; getters backed by refs let the memoized
+  // factories observe up-to-date state once promises resolve (a navigation can
+  // clear `clientQuoteFilterId` mid-await, or a new project can land between
+  // factory creation and a `clients.remove()` call, for example).
   const quotesRef = useRef(quotes);
   const clientQuoteFilterIdRef = useRef(clientQuoteFilterId);
   const clientOfferFilterIdRef = useRef(clientOfferFilterId);
+  const supplierQuoteFilterIdRef = useRef(supplierQuoteFilterId);
+  const projectsRef = useRef(projects);
   // Sync in render rather than a passive effect: an in-flight promise can
   // resume between commit and useEffect (microtask vs effect-task), reading
   // a stale ref. React allows writing to refs during render as long as the
@@ -809,6 +818,8 @@ const App: React.FC = () => {
   quotesRef.current = quotes;
   clientQuoteFilterIdRef.current = clientQuoteFilterId;
   clientOfferFilterIdRef.current = clientOfferFilterId;
+  supplierQuoteFilterIdRef.current = supplierQuoteFilterId;
+  projectsRef.current = projects;
 
   const clearAuthScopedAppState = useCallback(() => {
     resetModuleLoader();
@@ -834,6 +845,7 @@ const App: React.FC = () => {
     setSupplierInvoices([]);
     setEntries([]);
     entriesStreamTokenRef.current++;
+    setEntriesLoaded(false);
     setWorkUnits([]);
     setViewingUserAssignmentState({
       userId: '',
@@ -889,14 +901,16 @@ const App: React.FC = () => {
   const supplierQuoteHandlers = useMemo(
     () =>
       makeSupplierQuoteHandlers({
-        supplierQuoteFilterId,
+        // Getter backed by a ref so reads after awaited API calls see the
+        // latest value instead of the snapshot captured at factory creation.
+        getSupplierQuoteFilterId: () => supplierQuoteFilterIdRef.current,
         setSupplierQuotes,
         setSupplierOrders,
         setSupplierInvoices,
         setSupplierQuoteFilterId,
         setActiveView,
       }),
-    [supplierQuoteFilterId],
+    [],
   );
 
   const quoteHandlers = useMemo(
@@ -922,12 +936,14 @@ const App: React.FC = () => {
   const clientHandlers = useMemo(
     () =>
       makeClientHandlers({
-        projects,
+        // Getter backed by a ref so the post-await read of `projects` sees the
+        // latest snapshot rather than the one captured at factory creation.
+        getProjects: () => projectsRef.current,
         setClients,
         setProjects,
         setProjectTasks,
       }),
-    [projects],
+    [],
   );
 
   const productHandlers = useMemo(() => makeProductHandlers({ setProducts }), []);
@@ -1141,6 +1157,7 @@ const App: React.FC = () => {
       entries: () => {
         entriesStreamTokenRef.current++;
         setEntries([]);
+        setEntriesLoaded(false);
       },
       workUnits: () => setWorkUnits([]),
       users: () => setUsers([]),
@@ -1408,6 +1425,13 @@ const App: React.FC = () => {
                 apply: (page) => {
                   const token = ++entriesStreamTokenRef.current;
                   setEntries(page.entries);
+                  // Signal that the initial page of entries is in state. The
+                  // recurring-entries generator effect gates on this so it
+                  // never runs against the empty-array initial state (which
+                  // used to be papered over with a setTimeout(100) heuristic
+                  // and could miss/duplicate entries under varying API
+                  // latency).
+                  setEntriesLoaded(true);
                   if (page.nextCursor) void streamRemainingEntries(page.nextCursor, token);
                 },
               },
@@ -1871,13 +1895,19 @@ const App: React.FC = () => {
     [clients, projects, projectTasks, currentUser, viewingUserId, viewingUserAssignmentState],
   );
 
+  // Generate recurring entries once the initial entries page is in state.
+  // Previously this used a setTimeout(100) heuristic to guess when the
+  // entries fetch had resolved — that race was visible under slow APIs
+  // (could miss new recurring rows) and could double-fire on fast ones.
+  // Sequencing on `entriesLoaded` makes the ordering deterministic: the
+  // generator inspects the real `entries` state, and `setEntriesLoaded` is
+  // flipped to false on logout/role-switch/module-clear, so a subsequent
+  // entries refetch will re-trigger generation exactly once.
   useEffect(() => {
     if (!currentUser) return;
-    const timer = setTimeout(() => {
-      generateRecurringEntries();
-    }, 100);
-    return () => clearTimeout(timer);
-  }, [generateRecurringEntries, currentUser]);
+    if (!entriesLoaded) return;
+    generateRecurringEntries();
+  }, [generateRecurringEntries, currentUser, entriesLoaded]);
 
   const taskHandlers = useMemo(
     () =>

--- a/hooks/handlers/clientHandlers.ts
+++ b/hooks/handlers/clientHandlers.ts
@@ -8,15 +8,24 @@ import type {
   ProjectTask,
 } from '../../types';
 
+/**
+ * Client handlers read `projects` AFTER an awaited delete to compute which
+ * project tasks to drop. Capturing the array from the deps closure would
+ * surface a stale-closure bug: between the time `makeClientHandlers` runs and
+ * the time `remove()` awaits the API, the user may have added or deleted a
+ * project. Using a getter that reads from a ref in `App.tsx` keeps the read
+ * fresh — we filter against the latest `projects` snapshot at invocation
+ * time. See `quoteHandlers.ts` for the canonical example of the pattern.
+ */
 export type ClientHandlersDeps = {
-  projects: Project[];
+  getProjects: () => Project[];
   setClients: React.Dispatch<React.SetStateAction<Client[]>>;
   setProjects: React.Dispatch<React.SetStateAction<Project[]>>;
   setProjectTasks: React.Dispatch<React.SetStateAction<ProjectTask[]>>;
 };
 
 export const makeClientHandlers = (deps: ClientHandlersDeps) => {
-  const { projects, setClients, setProjects, setProjectTasks } = deps;
+  const { getProjects, setClients, setProjects, setProjectTasks } = deps;
 
   const add = async (clientData: Partial<Client>) => {
     try {
@@ -41,7 +50,12 @@ export const makeClientHandlers = (deps: ClientHandlersDeps) => {
   const remove = async (id: string) => {
     try {
       await api.clients.delete(id);
-      const projectIdsForClient = projects.filter((p) => p.clientId === id).map((p) => p.id);
+      // Read `projects` via the getter so we observe the latest array, not the
+      // one captured at factory creation. Any project added/removed during the
+      // delete round-trip would otherwise be missed when filtering tasks.
+      const projectIdsForClient = getProjects()
+        .filter((p) => p.clientId === id)
+        .map((p) => p.id);
       setClients((prev) => prev.filter((c) => c.id !== id));
       setProjects((prev) => prev.filter((p) => p.clientId !== id));
       setProjectTasks((prev) => prev.filter((t) => !projectIdsForClient.includes(t.projectId)));

--- a/hooks/handlers/supplierQuoteHandlers.ts
+++ b/hooks/handlers/supplierQuoteHandlers.ts
@@ -3,8 +3,21 @@ import api from '../../services/api';
 import type { SupplierInvoice, SupplierQuote, SupplierSaleOrder, View } from '../../types';
 import { makeTempId } from '../../utils/tempId';
 
+/**
+ * Supplier-quote handlers read `supplierQuoteFilterId` both before and AFTER
+ * awaited network calls. Capturing the raw value via the deps closure would
+ * surface a stale-closure bug: the handler factory is memoized with the value
+ * at the time of the surrounding `useMemo` render, but an awaited API call can
+ * outlive that render. While the await is pending the user can navigate or
+ * clear the filter, which mutates the underlying state. Reading the captured
+ * value after the await would then act on out-of-date data (for example, the
+ * `supplierQuoteFilterId === id` branch could re-apply a filter the user just
+ * cleared). Callers pass a getter that closes over the latest React state via
+ * a ref in `App.tsx`, so reads inside the handler always see the current value
+ * — even across awaits. See `quoteHandlers.ts` for the canonical example.
+ */
 export type SupplierQuoteHandlersDeps = {
-  supplierQuoteFilterId: string | null;
+  getSupplierQuoteFilterId: () => string | null;
   setSupplierQuotes: React.Dispatch<React.SetStateAction<SupplierQuote[]>>;
   setSupplierOrders: React.Dispatch<React.SetStateAction<SupplierSaleOrder[]>>;
   setSupplierInvoices: React.Dispatch<React.SetStateAction<SupplierInvoice[]>>;
@@ -14,7 +27,7 @@ export type SupplierQuoteHandlersDeps = {
 
 export const makeSupplierQuoteHandlers = (deps: SupplierQuoteHandlersDeps) => {
   const {
-    supplierQuoteFilterId,
+    getSupplierQuoteFilterId,
     setSupplierQuotes,
     setSupplierOrders,
     setSupplierInvoices,
@@ -52,7 +65,10 @@ export const makeSupplierQuoteHandlers = (deps: SupplierQuoteHandlersDeps) => {
   const updateSupplierQuote = async (id: string, updates: Partial<SupplierQuote>) => {
     try {
       const updated = await api.supplierQuotes.update(id, updates);
-      if (supplierQuoteFilterId === id) {
+      // Re-read the filter via the getter so we observe the latest value, not
+      // the one captured when this handler was created. A navigation effect in
+      // App.tsx can clear the filter while the API call is in flight.
+      if (getSupplierQuoteFilterId() === id) {
         setSupplierQuoteFilterId(updated.id);
       }
       await refreshSupplierQuoteFlow();

--- a/test/handlers/clientHandlers.test.ts
+++ b/test/handlers/clientHandlers.test.ts
@@ -78,7 +78,7 @@ describe('makeClientHandlers', () => {
     );
     const clients = makeStubSetter<ClientLike>([{ id: 'c1' }]);
     const handlers = makeClientHandlers({
-      projects: [],
+      getProjects: () => [],
       setClients: clients.setter,
       setProjects: makeStubSetter<ProjectLike>([]).setter,
       setProjectTasks: makeStubSetter<TaskLike>([]).setter,
@@ -93,7 +93,7 @@ describe('makeClientHandlers', () => {
   test('add rethrows on api error', async () => {
     apiMocks.clientsCreate.mockImplementation(() => Promise.reject(new Error('boom')));
     const handlers = makeClientHandlers({
-      projects: [],
+      getProjects: () => [],
       setClients: makeStubSetter<ClientLike>([]).setter,
       setProjects: makeStubSetter<ProjectLike>([]).setter,
       setProjectTasks: makeStubSetter<TaskLike>([]).setter,
@@ -110,7 +110,7 @@ describe('makeClientHandlers', () => {
       { id: 'c2', name: 'Beta' },
     ]);
     const handlers = makeClientHandlers({
-      projects: [],
+      getProjects: () => [],
       setClients: clients.setter,
       setProjects: makeStubSetter<ProjectLike>([]).setter,
       setProjectTasks: makeStubSetter<TaskLike>([]).setter,
@@ -136,7 +136,7 @@ describe('makeClientHandlers', () => {
     ]);
 
     const handlers = makeClientHandlers({
-      projects: projects.get() as never,
+      getProjects: (() => projects.get()) as never,
       setClients: clients.setter,
       setProjects: projects.setter,
       setProjectTasks: tasks.setter,
@@ -150,6 +150,40 @@ describe('makeClientHandlers', () => {
     expect(tasks.get()).toEqual([{ id: 't2', projectId: 'p3' }]);
   });
 
+  test('delete reads latest projects via getter (not capture-time snapshot)', async () => {
+    // At factory creation, the user has one project; after the factory is
+    // built they add a second one before clicking delete. The buggy version
+    // captured the initial array and missed the second project's tasks.
+    apiMocks.clientsDelete.mockImplementation(() => Promise.resolve());
+    let projectsState: ProjectLike[] = [{ id: 'p1', clientId: 'c1' }];
+    const clients = makeStubSetter<ClientLike>([{ id: 'c1' }, { id: 'c2' }]);
+    const projectsSetter = makeStubSetter<ProjectLike>(projectsState);
+    const tasks = makeStubSetter<TaskLike>([
+      { id: 't1', projectId: 'p1' },
+      { id: 't2', projectId: 'p2' }, // task for the late-added project
+      { id: 't3', projectId: 'pX' }, // unrelated
+    ]);
+    const handlers = makeClientHandlers({
+      // Getter reads the LATEST `projectsState` at invocation time.
+      getProjects: (() => projectsState) as never,
+      setClients: clients.setter,
+      setProjects: projectsSetter.setter,
+      setProjectTasks: tasks.setter,
+    });
+
+    // Second project for c1 added after factory creation.
+    projectsState = [
+      { id: 'p1', clientId: 'c1' },
+      { id: 'p2', clientId: 'c1' },
+    ];
+
+    await handlers.delete('c1');
+
+    // Both t1 (for p1) and t2 (for p2) must have been pruned — proof the
+    // getter saw the post-factory project list.
+    expect(tasks.get().map((t) => t.id)).toEqual(['t3']);
+  });
+
   test('updateProfileOption refetches and replaces clients', async () => {
     apiMocks.clientsUpdateProfileOption.mockImplementation(() =>
       Promise.resolve({ id: 'po-1', value: 'updated' }),
@@ -159,7 +193,7 @@ describe('makeClientHandlers', () => {
     );
     const clients = makeStubSetter<ClientLike>([{ id: 'c-old' }]);
     const handlers = makeClientHandlers({
-      projects: [],
+      getProjects: () => [],
       setClients: clients.setter,
       setProjects: makeStubSetter<ProjectLike>([]).setter,
       setProjectTasks: makeStubSetter<TaskLike>([]).setter,
@@ -177,7 +211,7 @@ describe('makeClientHandlers', () => {
   test('createProfileOption rethrows on api error', async () => {
     apiMocks.clientsCreateProfileOption.mockImplementation(() => Promise.reject(new Error('nope')));
     const handlers = makeClientHandlers({
-      projects: [],
+      getProjects: () => [],
       setClients: makeStubSetter<ClientLike>([]).setter,
       setProjects: makeStubSetter<ProjectLike>([]).setter,
       setProjectTasks: makeStubSetter<TaskLike>([]).setter,
@@ -190,7 +224,7 @@ describe('makeClientHandlers', () => {
   test('deleteProfileOption awaits api call', async () => {
     apiMocks.clientsDeleteProfileOption.mockImplementation(() => Promise.resolve());
     const handlers = makeClientHandlers({
-      projects: [],
+      getProjects: () => [],
       setClients: makeStubSetter<ClientLike>([]).setter,
       setProjects: makeStubSetter<ProjectLike>([]).setter,
       setProjectTasks: makeStubSetter<TaskLike>([]).setter,

--- a/test/handlers/supplierQuoteHandlers.test.ts
+++ b/test/handlers/supplierQuoteHandlers.test.ts
@@ -85,14 +85,19 @@ const buildHandlers = (overrides: Record<string, unknown> = {}) => {
       : null;
   const supplierQuoteFilterId = makeStubScalar<string | null>(initialFilterId);
   const setActiveView = mock(() => {});
+  // Pull out raw-value override (test-only convenience) before spreading so it
+  // does not leak into the factory deps shape.
+  const { supplierQuoteFilterId: _initial, ...factoryOverrides } = overrides;
   const handlers = makeSupplierQuoteHandlers({
-    supplierQuoteFilterId: supplierQuoteFilterId.get(),
+    // Backed by a closure over the stub so tests can mutate the value mid-test
+    // and observe the getter pattern (mirrors the ref-backed App.tsx getter).
+    getSupplierQuoteFilterId: () => supplierQuoteFilterId.get(),
     setSupplierQuotes: supplierQuotes.setter as never,
     setSupplierOrders: supplierOrders.setter as never,
     setSupplierInvoices: supplierInvoices.setter as never,
     setSupplierQuoteFilterId: supplierQuoteFilterId.setter as never,
     setActiveView: setActiveView as never,
-    ...overrides,
+    ...(factoryOverrides as Record<string, never>),
   });
   return {
     handlers,
@@ -201,6 +206,54 @@ describe('makeSupplierQuoteHandlers', () => {
     } finally {
       restore();
     }
+  });
+
+  test('updateSupplierQuote reads filter via getter at call time, not capture time', async () => {
+    // Factory is created with filter=null. The buggy version captured that
+    // null value and would never re-apply the filter even after the user
+    // navigated to a filtered view. The getter must observe the current value
+    // at invocation time.
+    apiMocks.supplierQuotesUpdate.mockImplementation((id: string, updates: unknown) =>
+      Promise.resolve({ id: `${id}-v2`, ...(updates as object) }),
+    );
+    apiMocks.supplierQuotesList.mockImplementation(() => Promise.resolve([]));
+    apiMocks.supplierOrdersList.mockImplementation(() => Promise.resolve([]));
+    const ctx = buildHandlers({ supplierQuoteFilterId: null });
+
+    // After factory creation, user pins the filter to the quote we'll update.
+    ctx.supplierQuoteFilterId.setter('sq-1' as never);
+
+    await ctx.handlers.updateSupplierQuote('sq-1', { status: 'sent' } as never);
+
+    // Filter must have followed the new id — proof the getter was read at
+    // invocation time, not at factory creation.
+    expect(ctx.supplierQuoteFilterId.get()).toBe('sq-1-v2');
+  });
+
+  test('updateSupplierQuote does NOT re-apply filter that was cleared during await', async () => {
+    let resolver: () => void = () => {};
+    apiMocks.supplierQuotesUpdate.mockImplementation(
+      (id: string, updates: unknown) =>
+        new Promise((resolve) => {
+          resolver = () => resolve({ id: `${id}-v2`, ...(updates as object) } as never);
+        }),
+    );
+    apiMocks.supplierQuotesList.mockImplementation(() => Promise.resolve([]));
+    apiMocks.supplierOrdersList.mockImplementation(() => Promise.resolve([]));
+    const ctx = buildHandlers({ supplierQuoteFilterId: 'sq-1' });
+
+    // Kick off the update; do NOT await yet.
+    const pending = ctx.handlers.updateSupplierQuote('sq-1', { status: 'sent' } as never);
+
+    // Simulate the user navigating away mid-await (App.tsx clears filter).
+    ctx.supplierQuoteFilterId.setter(null as never);
+
+    resolver();
+    await pending;
+
+    // The handler must respect the cleared filter. The buggy version would
+    // have re-applied 'sq-1-v2'.
+    expect(ctx.supplierQuoteFilterId.get()).toBe(null);
   });
 
   test('deleteSupplierQuote removes from list', async () => {


### PR DESCRIPTION
## Summary
- Remove the `setTimeout(100)` heuristic before `generateRecurringEntries()`; gate the effect on a new `entriesLoaded` flag that flips true once the initial entries page resolves and false on logout/role-switch/module-clear, so generation runs deterministically once per load.
- Mirror the ref-backed getter pattern from `quoteHandlers` in `supplierQuoteHandlers` (`getSupplierQuoteFilterId`) and `clientHandlers` (`getProjects`), with new refs in `App.tsx` synced in render so reads after awaited API calls see the latest state.
- Add unit tests in `test/handlers/{client,supplierQuote}Handlers.test.ts` proving the getter is read at invocation time (filter follows the new id, deletes pick up post-factory projects) and respects mid-flight clears.

## Manual verification
- [ ] 1) Open the app, wait for entries to load. Verify recurring entries are generated once (no duplicates) regardless of API latency.
- [ ] 2) Delete a client; verify projects belonging to it disappear immediately even if you've recently added a new project (no stale closure).
- [ ] 3) Edit a supplier quote that is currently filtered to — verify the filter follows the new id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)