### PR TITLE
feat(time-entries): server-side recurring entry generation

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -79,14 +79,9 @@ import type {
   View,
   WorkUnit,
 } from './types';
-import {
-  dateOnlyStringToLocalDate,
-  formatDateOnlyForLocale,
-  getLocalDateString,
-} from './utils/date';
+import { formatDateOnlyForLocale, getLocalDateString } from './utils/date';
 import { getTechnicalDocsViewFromPathname } from './utils/docsRoutes';
 import { getErrorMessage } from './utils/errors';
-import { isItalianHoliday } from './utils/holidays';
 import {
   clearStaleModuleScopedState,
   getStaleModulesAfterNavigation,
@@ -1842,120 +1837,33 @@ const App: React.FC = () => {
   }, [users, currentUser]);
 
   const generateRecurringEntries = useCallback(
-    async (tasksOverride?: ProjectTask[]) => {
-      const tasksToUse = tasksOverride ?? projectTasks;
+    async (_tasksOverride?: ProjectTask[]) => {
+      // Server-side generation via `POST /api/entries/recurring/generate`. The legacy
+      // client-side implementation walked each recurring task and inserted one entry at a
+      // time for a rolling 14-day window (or up to the task's `recurrenceEnd`). The server
+      // applies the same matching rules + idempotency, so the rolling-window UX is preserved
+      // while pushing the per-row inserts off the main thread.
+      if (!currentUser) return;
+
       const today = new Date();
-      // Default future limit for entries without an end date
-      const defaultFutureLimit = new Date();
-      defaultFutureLimit.setDate(today.getDate() + 14);
+      const fromDate = getLocalDateString(today);
+      const future = new Date(today);
+      future.setDate(today.getDate() + 14);
+      const toDate = getLocalDateString(future);
 
-      const newEntries: TimeEntry[] = [];
-
-      for (const task of tasksToUse.filter((t) => t.isRecurring)) {
-        const project = projects.find((p) => p.id === task.projectId);
-        const client = project ? clients.find((c) => c.id === project.clientId) : null;
-        if (!project || !client) continue;
-
-        const startDate = task.recurrenceStart
-          ? dateOnlyStringToLocalDate(task.recurrenceStart)
-          : new Date();
-        // Use recurrence end date if specified, otherwise use default 14-day limit
-        const taskEndDate = task.recurrenceEnd
-          ? dateOnlyStringToLocalDate(task.recurrenceEnd)
-          : null;
-        const futureLimit =
-          taskEndDate && taskEndDate > defaultFutureLimit ? taskEndDate : defaultFutureLimit;
-
-        for (let d = new Date(startDate); d <= futureLimit; d.setDate(d.getDate() + 1)) {
-          if (taskEndDate && d > taskEndDate) break;
-
-          // Skip disabled days: Sundays, Saturdays (if configured), and holidays
-          const isSunday = d.getDay() === 0;
-          const isSaturday = d.getDay() === 6;
-          const holidayName = isItalianHoliday(d);
-          const isDisabledDay =
-            isSunday || (generalSettings.treatSaturdayAsHoliday && isSaturday) || !!holidayName;
-          if (isDisabledDay) continue;
-
-          const dateStr = getLocalDateString(d);
-
-          let matches = false;
-          if (task.recurrencePattern === 'daily') matches = true;
-          if (task.recurrencePattern === 'weekly' && d.getDay() === startDate.getDay())
-            matches = true;
-          if (task.recurrencePattern === 'monthly' && d.getDate() === startDate.getDate())
-            matches = true;
-
-          // Custom patterns: monthly:first:X or monthly:last:X
-          if (
-            typeof task.recurrencePattern === 'string' &&
-            task.recurrencePattern.startsWith('monthly:')
-          ) {
-            const parts = task.recurrencePattern.split(':');
-            if (parts.length === 3) {
-              const type = parts[1]; // 'first' or 'last'
-              const targetDay = parseInt(parts[2], 10); // 0-6 (Sun-Sat) or 1-7 depending on UI, my modal uses 0=Sun, 1=Mon... match JS getDay()
-
-              // Adjust for UI mapping: My modal uses 0=Sun, 1=Mon...6=Sat which matches getDay() perfectly.
-              // Wait, in modal I used 0=Sunday, 1=Monday. JS getDay() returns 0=Sunday, 1=Monday. So it matches.
-
-              if (d.getDay() === targetDay) {
-                if (type === 'first') {
-                  // First: dates 1-7
-                  if (d.getDate() <= 7) matches = true;
-                } else if (type === 'second') {
-                  // Second: dates 8-14
-                  if (d.getDate() > 7 && d.getDate() <= 14) matches = true;
-                } else if (type === 'third') {
-                  // Third: dates 15-21
-                  if (d.getDate() > 14 && d.getDate() <= 21) matches = true;
-                } else if (type === 'fourth') {
-                  // Fourth: dates 22-28
-                  if (d.getDate() > 21 && d.getDate() <= 28) matches = true;
-                } else if (type === 'last') {
-                  // Last: adding 7 days puts us next month
-                  const nextWeek = new Date(d);
-                  nextWeek.setDate(d.getDate() + 7);
-                  if (nextWeek.getMonth() !== d.getMonth()) matches = true;
-                }
-              }
-            }
-          }
-          if (matches) {
-            const exists = entries.some(
-              (e) => e.date === dateStr && e.projectId === task.projectId && e.task === task.name,
-            );
-            if (!exists) {
-              try {
-                const entry = await api.entries.create({
-                  date: dateStr,
-                  userId: currentUser?.id || '',
-                  clientId: client.id,
-                  clientName: client.name,
-                  projectId: task.projectId,
-                  projectName: project.name,
-                  task: task.name,
-                  duration: task.recurrenceDuration || 0,
-                  isPlaceholder: true,
-                  hourlyCost: currentUser?.costPerHour || 0,
-                });
-                newEntries.push(entry);
-              } catch (err) {
-                console.error('Failed to create recurring entry:', err);
-              }
-            }
-          }
+      try {
+        const result = await api.entries.generateRecurring({ fromDate, toDate });
+        if (result.generated.length > 0) {
+          setEntries((prev) =>
+            [...result.generated, ...prev].sort((a, b) => b.createdAt - a.createdAt),
+          );
         }
-      }
-
-      if (newEntries.length > 0) {
-        setEntries((prev) => [...newEntries, ...prev].sort((a, b) => b.createdAt - a.createdAt));
+      } catch (err) {
+        console.error('Failed to generate recurring entries:', err);
       }
     },
-    [projectTasks, entries, projects, clients, currentUser, generalSettings],
+    [currentUser],
   );
-
-  // ... (rest of the logic remains validation which we don't need to change but need for context)
 
   const trackerCatalogs = useMemo(
     () =>

--- a/App.tsx
+++ b/App.tsx
@@ -1836,34 +1836,26 @@ const App: React.FC = () => {
     return [currentUser];
   }, [users, currentUser]);
 
-  const generateRecurringEntries = useCallback(
-    async (_tasksOverride?: ProjectTask[]) => {
-      // Server-side generation via `POST /api/entries/recurring/generate`. The legacy
-      // client-side implementation walked each recurring task and inserted one entry at a
-      // time for a rolling 14-day window (or up to the task's `recurrenceEnd`). The server
-      // applies the same matching rules + idempotency, so the rolling-window UX is preserved
-      // while pushing the per-row inserts off the main thread.
-      if (!currentUser) return;
+  const generateRecurringEntries = useCallback(async () => {
+    if (!currentUser) return;
 
-      const today = new Date();
-      const fromDate = getLocalDateString(today);
-      const future = new Date(today);
-      future.setDate(today.getDate() + 14);
-      const toDate = getLocalDateString(future);
+    const today = new Date();
+    const fromDate = getLocalDateString(today);
+    const future = new Date(today);
+    future.setDate(today.getDate() + 14);
+    const toDate = getLocalDateString(future);
 
-      try {
-        const result = await api.entries.generateRecurring({ fromDate, toDate });
-        if (result.generated.length > 0) {
-          setEntries((prev) =>
-            [...result.generated, ...prev].sort((a, b) => b.createdAt - a.createdAt),
-          );
-        }
-      } catch (err) {
-        console.error('Failed to generate recurring entries:', err);
+    try {
+      const result = await api.entries.generateRecurring({ fromDate, toDate });
+      if (result.generated.length > 0) {
+        setEntries((prev) =>
+          [...result.generated, ...prev].sort((a, b) => b.createdAt - a.createdAt),
+        );
       }
-    },
-    [currentUser],
-  );
+    } catch (err) {
+      console.error('Failed to generate recurring entries:', err);
+    }
+  }, [currentUser]);
 
   const trackerCatalogs = useMemo(
     () =>

--- a/docs-site/src/content/docs/en/time-tracking.md
+++ b/docs-site/src/content/docs/en/time-tracking.md
@@ -20,3 +20,31 @@ The weekly view helps you quickly review hours across days. Use it to find missi
 Recurring tasks generate repeated entries, such as weekly meetings or periodic administrative work.
 
 When configuring a recurrence, check frequency, start date, optional end date, and description. If a recurrence is no longer needed, disable it instead of creating duplicate manual entries.
+
+### Template model
+
+Each recurring template is defined on a project task and includes:
+
+- `recurrencePattern`: `daily`, `weekly`, `monthly`, or the custom patterns `monthly:first:<dow>`, `monthly:second:<dow>`, `monthly:third:<dow>`, `monthly:fourth:<dow>`, `monthly:last:<dow>` (with `<dow>` = 0 Sunday … 6 Saturday).
+- `recurrenceStart`: the date occurrences begin from.
+- `recurrenceEnd` (optional): when set, generation stops on this date.
+- `recurrenceDuration`: the default duration (in hours) of each generated entry.
+
+Sundays, Saturdays (when the _Treat Saturday as holiday_ setting is enabled), and Italian holidays are always skipped.
+
+### Server-side generation
+
+Recurring entries are materialized on the server via `POST /api/entries/recurring/generate`. The body requires `fromDate` and `toDate` in `YYYY-MM-DD` format; an optional `userId` can be supplied (it requires the work-unit management link or the `timesheets.tracker_all.create` permission for the target user).
+
+```json
+{
+  "fromDate": "2026-01-01",
+  "toDate": "2026-01-14"
+}
+```
+
+The endpoint is idempotent: re-running it with the same window does not create duplicates, since existing `(date, project, task)` tuples are skipped. The response reports `generatedCount`, `skippedExistingCount`, and the list of created entries.
+
+To prevent accidentally huge generations, the server caps the window at 366 days per call.
+
+The required permission is `timesheets.recurring.create`.

--- a/docs-site/src/content/docs/time-tracking.md
+++ b/docs-site/src/content/docs/time-tracking.md
@@ -20,3 +20,31 @@ La vista settimanale aiuta a controllare rapidamente le ore distribuite sui gior
 Le attività ricorrenti permettono di generare registrazioni ripetitive, per esempio riunioni settimanali o attività amministrative periodiche.
 
 Quando configuri una ricorrenza, controlla frequenza, data di inizio, eventuale data di fine e descrizione. Se una ricorrenza non serve più, disattivala invece di creare registrazioni manuali duplicate.
+
+### Modello del template
+
+Ogni template ricorrente è definito sull'attività di progetto e include:
+
+- `recurrencePattern`: `daily`, `weekly`, `monthly`, oppure i pattern personalizzati `monthly:first:<dow>`, `monthly:second:<dow>`, `monthly:third:<dow>`, `monthly:fourth:<dow>`, `monthly:last:<dow>` (con `<dow>` = 0 domenica … 6 sabato).
+- `recurrenceStart`: data da cui partono le occorrenze.
+- `recurrenceEnd` (opzionale): se valorizzata, blocca la generazione oltre tale data.
+- `recurrenceDuration`: ore di default per ciascuna registrazione generata.
+
+I giorni che cadono di domenica, di sabato (se l'impostazione _Tratta il sabato come festivo_ è attiva) e quelli che coincidono con festività italiane vengono sempre saltati.
+
+### Generazione lato server
+
+La materializzazione delle registrazioni ricorrenti avviene sul server tramite l'endpoint `POST /api/entries/recurring/generate`. Il body richiede `fromDate` e `toDate` in formato `YYYY-MM-DD`; opzionalmente è possibile passare `userId` (richiede il permesso di gestione dell'utente o `timesheets.tracker_all.create`).
+
+```json
+{
+  "fromDate": "2026-01-01",
+  "toDate": "2026-01-14"
+}
+```
+
+L'endpoint è idempotente: rieseguirlo con la stessa finestra non crea duplicati, perché le coppie già presenti `(data, progetto, attività)` vengono saltate. La risposta include `generatedCount`, `skippedExistingCount` e l'elenco delle registrazioni create.
+
+Per evitare generazioni accidentalmente troppo ampie, il server limita la finestra a 366 giorni per chiamata.
+
+Il permesso richiesto è `timesheets.recurring.create`.

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -135,6 +135,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -152,6 +155,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -171,6 +177,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -188,6 +197,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -207,6 +219,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -224,6 +239,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -321,6 +339,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -338,6 +359,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -357,6 +381,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -374,6 +401,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -393,6 +423,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -410,6 +443,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -537,6 +573,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -554,6 +593,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -573,6 +615,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -590,6 +635,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -609,6 +657,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -626,6 +677,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -666,6 +720,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -683,6 +740,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -702,6 +762,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -719,6 +782,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -738,6 +804,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -755,6 +824,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -979,6 +1051,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -996,6 +1071,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -1015,6 +1093,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -1032,6 +1113,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -1051,6 +1135,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -1068,6 +1155,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -1152,6 +1242,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -1169,6 +1262,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -1188,6 +1284,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -1205,6 +1304,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -1224,6 +1326,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -1241,6 +1346,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -1302,6 +1410,35 @@
                           "external"
                         ]
                       },
+                      "authMethod": {
+                        "type": "string",
+                        "enum": [
+                          "local",
+                          "ldap",
+                          "oidc",
+                          "saml"
+                        ]
+                      },
+                      "authProviderId": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "authProviderName": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
                       "hasTopManagerRole": {
                         "type": "boolean"
                       },
@@ -1319,6 +1456,9 @@
                       "costPerHour",
                       "isDisabled",
                       "employeeType",
+                      "authMethod",
+                      "authProviderId",
+                      "authProviderName",
                       "hasTopManagerRole",
                       "isAdminOnly"
                     ]
@@ -1335,6 +1475,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -1354,6 +1497,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -1371,6 +1517,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -1390,6 +1539,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -1408,6 +1560,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -1425,6 +1580,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -1523,6 +1681,35 @@
                         "external"
                       ]
                     },
+                    "authMethod": {
+                      "type": "string",
+                      "enum": [
+                        "local",
+                        "ldap",
+                        "oidc",
+                        "saml"
+                      ]
+                    },
+                    "authProviderId": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "authProviderName": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
                     "hasTopManagerRole": {
                       "type": "boolean"
                     },
@@ -1540,6 +1727,9 @@
                     "costPerHour",
                     "isDisabled",
                     "employeeType",
+                    "authMethod",
+                    "authProviderId",
+                    "authProviderName",
                     "hasTopManagerRole",
                     "isAdminOnly"
                   ]
@@ -1555,6 +1745,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -1574,6 +1767,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -1591,6 +1787,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -1610,6 +1809,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -1627,6 +1829,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -1684,6 +1889,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -1701,6 +1909,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -1720,6 +1931,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -1738,6 +1952,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -1755,6 +1972,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -1849,6 +2069,35 @@
                         "external"
                       ]
                     },
+                    "authMethod": {
+                      "type": "string",
+                      "enum": [
+                        "local",
+                        "ldap",
+                        "oidc",
+                        "saml"
+                      ]
+                    },
+                    "authProviderId": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "authProviderName": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
                     "hasTopManagerRole": {
                       "type": "boolean"
                     },
@@ -1866,6 +2115,9 @@
                     "costPerHour",
                     "isDisabled",
                     "employeeType",
+                    "authMethod",
+                    "authProviderId",
+                    "authProviderName",
                     "hasTopManagerRole",
                     "isAdminOnly"
                   ]
@@ -1881,6 +2133,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -1900,6 +2155,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -1917,6 +2175,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -1936,6 +2197,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -1953,6 +2217,263 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/users/{id}/auth-method": {
+      "put": {
+        "summary": "Change user authentication method",
+        "tags": [
+          "users"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "authMethod": {
+                    "type": "string",
+                    "enum": [
+                      "local",
+                      "ldap",
+                      "oidc",
+                      "saml"
+                    ]
+                  },
+                  "authProviderId": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "authMethod"
+                ]
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "username": {
+                      "type": "string"
+                    },
+                    "email": {
+                      "type": "string"
+                    },
+                    "role": {
+                      "type": "string"
+                    },
+                    "avatarInitials": {
+                      "type": "string"
+                    },
+                    "costPerHour": {
+                      "type": "number"
+                    },
+                    "isDisabled": {
+                      "type": "boolean"
+                    },
+                    "employeeType": {
+                      "type": "string",
+                      "enum": [
+                        "app_user",
+                        "internal",
+                        "external"
+                      ]
+                    },
+                    "authMethod": {
+                      "type": "string",
+                      "enum": [
+                        "local",
+                        "ldap",
+                        "oidc",
+                        "saml"
+                      ]
+                    },
+                    "authProviderId": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "authProviderName": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "hasTopManagerRole": {
+                      "type": "boolean"
+                    },
+                    "isAdminOnly": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "name",
+                    "username",
+                    "email",
+                    "role",
+                    "avatarInitials",
+                    "costPerHour",
+                    "isDisabled",
+                    "employeeType",
+                    "authMethod",
+                    "authProviderId",
+                    "authProviderName",
+                    "hasTopManagerRole",
+                    "isAdminOnly"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -2017,6 +2538,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -2034,6 +2558,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -2053,6 +2580,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -2071,6 +2601,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -2088,6 +2621,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -2175,6 +2711,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -2192,6 +2731,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -2211,6 +2753,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -2229,6 +2774,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -2246,6 +2794,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -2320,6 +2871,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -2337,6 +2891,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -2356,6 +2913,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -2374,6 +2934,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -2391,6 +2954,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -2476,6 +3042,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -2493,6 +3062,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -2512,6 +3084,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -2530,6 +3105,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -2547,6 +3125,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -2689,6 +3270,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -2706,6 +3290,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -2725,6 +3312,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -2743,6 +3333,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -2760,6 +3353,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -2787,191 +3383,217 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "string"
-                      },
-                      "name": {
-                        "type": "string"
-                      },
-                      "description": {
-                        "type": [
-                          "null",
-                          "string"
-                        ]
-                      },
-                      "isDisabled": {
-                        "type": "boolean"
-                      },
-                      "type": {
-                        "type": "string"
-                      },
-                      "contacts": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "fullName": {
-                              "type": "string"
-                            },
-                            "role": {
-                              "type": [
-                                "null",
-                                "string"
-                              ]
-                            },
-                            "email": {
-                              "type": [
-                                "null",
-                                "string"
-                              ]
-                            },
-                            "phone": {
-                              "type": [
-                                "null",
-                                "string"
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "isDisabled": {
+                            "type": "boolean"
+                          },
+                          "type": {
+                            "type": "string"
+                          },
+                          "contacts": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "fullName": {
+                                  "type": "string"
+                                },
+                                "role": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "email": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                },
+                                "phone": {
+                                  "type": [
+                                    "null",
+                                    "string"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "fullName"
                               ]
                             }
                           },
-                          "required": [
-                            "fullName"
-                          ]
-                        }
-                      },
-                      "contactName": {
-                        "type": [
-                          "null",
-                          "string"
+                          "contactName": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "clientCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "email": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "phone": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "address": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "addressCountry": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "addressState": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "addressCap": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "addressProvince": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "addressCivicNumber": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "addressLine": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "atecoCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "website": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "sector": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "numberOfEmployees": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "revenue": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "fiscalCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "officeCountRange": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "vatNumber": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "taxCode": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "createdAt": {
+                            "type": "number"
+                          },
+                          "totalSentQuotes": {
+                            "type": "number"
+                          },
+                          "totalAcceptedOrders": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name"
                         ]
                       },
-                      "clientCode": {
-                        "type": [
-                          "null",
-                          "string"
-                        ]
-                      },
-                      "email": {
-                        "type": [
-                          "null",
-                          "string"
-                        ]
-                      },
-                      "phone": {
-                        "type": [
-                          "null",
-                          "string"
-                        ]
-                      },
-                      "address": {
-                        "type": [
-                          "null",
-                          "string"
-                        ]
-                      },
-                      "addressCountry": {
-                        "type": [
-                          "null",
-                          "string"
-                        ]
-                      },
-                      "addressState": {
-                        "type": [
-                          "null",
-                          "string"
-                        ]
-                      },
-                      "addressCap": {
-                        "type": [
-                          "null",
-                          "string"
-                        ]
-                      },
-                      "addressProvince": {
-                        "type": [
-                          "null",
-                          "string"
-                        ]
-                      },
-                      "addressCivicNumber": {
-                        "type": [
-                          "null",
-                          "string"
-                        ]
-                      },
-                      "addressLine": {
-                        "type": [
-                          "null",
-                          "string"
-                        ]
-                      },
-                      "atecoCode": {
-                        "type": [
-                          "null",
-                          "string"
-                        ]
-                      },
-                      "website": {
-                        "type": [
-                          "null",
-                          "string"
-                        ]
-                      },
-                      "sector": {
-                        "type": [
-                          "null",
-                          "string"
-                        ]
-                      },
-                      "numberOfEmployees": {
-                        "type": [
-                          "null",
-                          "string"
-                        ]
-                      },
-                      "revenue": {
-                        "type": [
-                          "null",
-                          "string"
-                        ]
-                      },
-                      "fiscalCode": {
-                        "type": [
-                          "null",
-                          "string"
-                        ]
-                      },
-                      "officeCountRange": {
-                        "type": [
-                          "null",
-                          "string"
-                        ]
-                      },
-                      "vatNumber": {
-                        "type": [
-                          "null",
-                          "string"
-                        ]
-                      },
-                      "taxCode": {
-                        "type": [
-                          "null",
-                          "string"
-                        ]
-                      },
-                      "createdAt": {
-                        "type": "number"
-                      },
-                      "totalSentQuotes": {
-                        "type": "number"
-                      },
-                      "totalAcceptedOrders": {
-                        "type": "number"
+                      {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name"
+                        ],
+                        "additionalProperties": false
                       }
-                    },
-                    "required": [
-                      "id",
-                      "name"
                     ]
                   }
                 }
@@ -2986,6 +3608,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -3005,6 +3630,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -3022,6 +3650,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -3041,6 +3672,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -3059,6 +3693,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -3076,6 +3713,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -3414,6 +4054,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -3431,6 +4074,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -3450,6 +4096,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -3468,6 +4117,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -3485,6 +4137,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -3904,6 +4559,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -3921,6 +4579,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -3940,6 +4601,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -3958,6 +4622,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -3975,6 +4642,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -4030,6 +4700,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -4047,6 +4720,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -4066,6 +4742,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -4084,6 +4763,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -4101,6 +4783,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -4201,6 +4886,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -4218,6 +4906,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -4237,6 +4928,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -4255,6 +4949,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -4272,6 +4969,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -4388,6 +5088,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -4405,6 +5108,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -4424,6 +5130,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -4442,6 +5151,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -4459,6 +5171,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -4585,6 +5300,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -4602,6 +5320,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -4621,6 +5342,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -4639,6 +5363,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -4656,6 +5383,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -4725,6 +5455,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -4742,6 +5475,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -4761,6 +5497,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -4779,6 +5518,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -4796,6 +5538,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -4855,6 +5600,30 @@
                           "string"
                         ]
                       },
+                      "offerId": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "startDate": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "endDate": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "revenue": {
+                        "type": [
+                          "null",
+                          "number"
+                        ]
+                      },
                       "billingType": {
                         "type": "string",
                         "enum": [
@@ -4894,6 +5663,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -4911,6 +5683,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -4930,6 +5705,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -4947,6 +5725,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -4966,6 +5747,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -4983,6 +5767,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -5022,6 +5809,27 @@
                   "orderId": {
                     "type": "string"
                   },
+                  "offerId": {
+                    "type": "string"
+                  },
+                  "startDate": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "endDate": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "revenue": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
+                  },
                   "billingType": {
                     "type": "string",
                     "enum": [
@@ -5039,7 +5847,8 @@
                 },
                 "required": [
                   "name",
-                  "clientId"
+                  "clientId",
+                  "offerId"
                 ]
               }
             }
@@ -5083,6 +5892,30 @@
                         "string"
                       ]
                     },
+                    "offerId": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "startDate": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "endDate": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "revenue": {
+                      "type": [
+                        "null",
+                        "number"
+                      ]
+                    },
                     "billingType": {
                       "type": "string",
                       "enum": [
@@ -5121,6 +5954,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -5138,6 +5974,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -5157,6 +5996,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -5175,6 +6017,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -5192,6 +6037,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -5249,6 +6097,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -5266,6 +6117,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -5285,6 +6139,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -5303,6 +6160,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -5320,6 +6180,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -5358,6 +6221,36 @@
                   },
                   "isDisabled": {
                     "type": "boolean"
+                  },
+                  "orderId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "offerId": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "startDate": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "endDate": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "revenue": {
+                    "type": [
+                      "number",
+                      "null"
+                    ]
                   },
                   "billingType": {
                     "type": "string",
@@ -5426,6 +6319,30 @@
                         "string"
                       ]
                     },
+                    "offerId": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "startDate": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "endDate": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "revenue": {
+                      "type": [
+                        "null",
+                        "number"
+                      ]
+                    },
                     "billingType": {
                       "type": "string",
                       "enum": [
@@ -5464,6 +6381,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -5481,6 +6401,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -5500,6 +6423,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -5518,6 +6444,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -5535,6 +6464,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -5587,6 +6519,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -5604,6 +6539,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -5623,6 +6561,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -5641,6 +6582,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -5658,6 +6602,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -5734,6 +6681,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -5751,6 +6701,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -5770,6 +6723,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -5788,6 +6744,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -5805,6 +6764,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -5931,6 +6893,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -5948,6 +6913,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -5967,6 +6935,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -5984,6 +6955,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -6003,6 +6977,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -6020,6 +6997,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -6204,6 +7184,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -6221,6 +7204,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -6240,6 +7226,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -6258,6 +7247,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -6275,6 +7267,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -6330,6 +7325,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -6347,6 +7345,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -6366,6 +7367,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -6384,6 +7388,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -6401,6 +7408,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -6453,6 +7463,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -6470,6 +7483,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -6489,6 +7505,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -6507,6 +7526,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -6524,6 +7546,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -6719,6 +7744,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -6736,6 +7764,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -6755,6 +7786,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -6773,6 +7807,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -6790,6 +7827,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -6845,6 +7885,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -6862,6 +7905,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -6881,6 +7927,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -6899,6 +7948,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -6916,6 +7968,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -6968,6 +8023,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -6985,6 +8043,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -7004,6 +8065,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -7022,6 +8086,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -7039,6 +8106,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -7115,6 +8185,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -7132,6 +8205,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -7151,6 +8227,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -7169,6 +8248,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -7186,6 +8268,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -7340,6 +8425,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -7357,6 +8445,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -7376,6 +8467,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -7393,6 +8487,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -7412,6 +8509,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -7429,6 +8529,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -7589,6 +8692,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -7606,6 +8712,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -7625,6 +8734,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -7643,6 +8755,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -7660,6 +8775,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -7739,6 +8857,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -7756,6 +8877,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -7775,6 +8899,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -7792,6 +8919,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -7811,6 +8941,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -7828,6 +8961,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -7970,6 +9106,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -7987,6 +9126,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -8006,6 +9148,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -8024,6 +9169,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -8041,6 +9189,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -8096,6 +9247,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -8113,6 +9267,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -8132,6 +9289,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -8150,6 +9310,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -8167,6 +9330,289 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/entries/recurring/generate": {
+      "post": {
+        "summary": "Generate time entries from recurring templates",
+        "tags": [
+          "entries"
+        ],
+        "description": "Walks the active recurring task templates assigned to the target user (or the authenticated user if `userId` is omitted) and inserts a placeholder time entry for every matching day in `[fromDate, toDate]` that does not already have an entry for the same (date, project, task) tuple. Idempotent.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "fromDate": {
+                    "type": "string",
+                    "format": "date"
+                  },
+                  "toDate": {
+                    "type": "string",
+                    "format": "date"
+                  },
+                  "userId": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "fromDate",
+                  "toDate"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "generated": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "userId": {
+                            "type": "string"
+                          },
+                          "date": {
+                            "type": "string",
+                            "format": "date"
+                          },
+                          "clientId": {
+                            "type": "string"
+                          },
+                          "clientName": {
+                            "type": "string"
+                          },
+                          "projectId": {
+                            "type": "string"
+                          },
+                          "projectName": {
+                            "type": "string"
+                          },
+                          "task": {
+                            "type": "string"
+                          },
+                          "taskId": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "notes": {
+                            "type": [
+                              "null",
+                              "string"
+                            ]
+                          },
+                          "duration": {
+                            "type": "number"
+                          },
+                          "hourlyCost": {
+                            "type": "number"
+                          },
+                          "isPlaceholder": {
+                            "type": "boolean"
+                          },
+                          "location": {
+                            "type": "string"
+                          },
+                          "createdAt": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "userId",
+                          "date",
+                          "clientId",
+                          "clientName",
+                          "projectId",
+                          "projectName",
+                          "task",
+                          "duration",
+                          "hourlyCost",
+                          "isPlaceholder",
+                          "location",
+                          "createdAt"
+                        ]
+                      }
+                    },
+                    "generatedCount": {
+                      "type": "integer"
+                    },
+                    "skippedExistingCount": {
+                      "type": "integer"
+                    },
+                    "range": {
+                      "type": "object",
+                      "properties": {
+                        "fromDate": {
+                          "type": "string",
+                          "format": "date"
+                        },
+                        "toDate": {
+                          "type": "string",
+                          "format": "date"
+                        }
+                      },
+                      "required": [
+                        "fromDate",
+                        "toDate"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "generated",
+                    "generatedCount",
+                    "skippedExistingCount",
+                    "range"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -8227,6 +9673,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -8244,6 +9693,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -8263,6 +9715,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -8280,6 +9735,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -8299,6 +9757,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -8316,6 +9777,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -8400,6 +9864,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -8417,6 +9884,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -8436,6 +9906,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -8454,6 +9927,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -8471,6 +9947,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -8540,6 +10019,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -8557,6 +10039,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -8576,6 +10061,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -8593,6 +10081,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -8612,6 +10103,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -8629,6 +10123,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -8723,6 +10220,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -8740,6 +10240,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -8759,6 +10262,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -8776,6 +10282,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -8795,6 +10304,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -8812,6 +10324,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -8869,6 +10384,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -8886,6 +10404,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -8905,6 +10426,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -8922,6 +10446,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -8941,6 +10468,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -8958,6 +10488,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -9027,6 +10560,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -9044,6 +10580,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -9063,6 +10602,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -9081,6 +10623,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -9098,6 +10643,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -9164,6 +10712,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -9181,6 +10732,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -9200,6 +10754,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -9218,6 +10775,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -9235,6 +10795,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -9301,6 +10864,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -9318,6 +10884,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -9337,6 +10906,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -9355,6 +10927,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -9372,6 +10947,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -9435,6 +11013,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -9452,6 +11033,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -9471,6 +11055,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -9488,6 +11075,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -9507,6 +11097,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -9524,6 +11117,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -9661,6 +11257,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -9678,6 +11277,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -9697,6 +11299,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -9714,6 +11319,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -9733,6 +11341,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -9750,6 +11361,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -9979,6 +11593,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -9996,6 +11613,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -10015,6 +11635,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -10032,6 +11655,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -10051,6 +11677,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -10068,6 +11697,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -10309,6 +11941,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -10326,6 +11961,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -10345,6 +11983,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -10362,6 +12003,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -10381,6 +12025,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -10398,6 +12045,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -10438,6 +12088,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -10455,6 +12108,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -10474,6 +12130,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -10491,6 +12150,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -10510,6 +12172,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -10527,6 +12192,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -10598,6 +12266,9 @@
                     },
                     "tlsCaCertificate": {
                       "type": "string"
+                    },
+                    "autoProvisionAll": {
+                      "type": "boolean"
                     }
                   },
                   "required": [
@@ -10610,7 +12281,8 @@
                     "groupBaseDn",
                     "groupFilter",
                     "roleMappings",
-                    "tlsCaCertificate"
+                    "tlsCaCertificate",
+                    "autoProvisionAll"
                   ]
                 }
               }
@@ -10624,6 +12296,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -10643,6 +12318,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -10660,6 +12338,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -10679,6 +12360,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -10697,6 +12381,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -10714,6 +12401,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -10786,6 +12476,9 @@
                       "null"
                     ],
                     "maxLength": 65536
+                  },
+                  "autoProvisionAll": {
+                    "type": "boolean"
                   }
                 }
               }
@@ -10844,6 +12537,9 @@
                     },
                     "tlsCaCertificate": {
                       "type": "string"
+                    },
+                    "autoProvisionAll": {
+                      "type": "boolean"
                     }
                   },
                   "required": [
@@ -10856,7 +12552,8 @@
                     "groupBaseDn",
                     "groupFilter",
                     "roleMappings",
-                    "tlsCaCertificate"
+                    "tlsCaCertificate",
+                    "autoProvisionAll"
                   ]
                 }
               }
@@ -10870,6 +12567,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -10889,6 +12589,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -10906,6 +12609,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -10925,6 +12631,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -10943,6 +12652,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -10960,6 +12672,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -11058,6 +12773,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -11075,6 +12793,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -11094,6 +12815,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -11111,6 +12835,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -11130,6 +12857,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -11147,6 +12877,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -11195,6 +12928,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -11212,6 +12948,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -11231,6 +12970,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -11248,6 +12990,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -11267,6 +13012,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -11284,6 +13032,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -11375,6 +13126,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -11392,6 +13146,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -11411,6 +13168,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -11428,6 +13188,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -11447,6 +13210,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -11464,6 +13230,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -11601,6 +13370,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -11618,6 +13390,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -11637,6 +13412,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -11654,6 +13432,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -11673,6 +13454,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -11690,6 +13474,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -11807,6 +13594,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -11824,6 +13614,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -11843,6 +13636,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -11860,6 +13656,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -11879,6 +13678,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -11896,6 +13698,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -12061,6 +13866,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -12078,6 +13886,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -12097,6 +13908,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -12115,6 +13929,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -12132,6 +13949,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -12305,6 +14125,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -12322,6 +14145,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -12341,6 +14167,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -12359,6 +14188,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -12376,6 +14208,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -12416,6 +14251,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -12433,6 +14271,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -12452,6 +14293,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -12470,6 +14314,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -12487,6 +14334,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -12576,6 +14426,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -12593,6 +14446,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -12612,6 +14468,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -12630,6 +14489,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -12647,6 +14509,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -12743,6 +14608,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -12760,6 +14628,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -12779,6 +14650,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -12797,6 +14671,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -12814,6 +14691,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -12915,6 +14795,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -12932,6 +14815,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -12951,6 +14837,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -12969,6 +14858,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -12986,6 +14878,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -13026,6 +14921,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -13043,6 +14941,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -13062,6 +14963,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -13080,6 +14984,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -13097,6 +15004,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -13173,6 +15083,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -13190,6 +15103,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -13209,6 +15125,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -13227,6 +15146,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -13244,6 +15166,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -13323,6 +15248,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -13340,6 +15268,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -13359,6 +15290,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -13377,6 +15311,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -13394,6 +15331,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -13485,6 +15425,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -13502,6 +15445,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -13521,6 +15467,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -13539,6 +15488,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -13556,6 +15508,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -13612,6 +15567,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -13629,6 +15587,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -13648,6 +15609,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -13666,6 +15630,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -13683,6 +15650,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -13757,6 +15727,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -13774,6 +15747,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -13793,6 +15769,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -13811,6 +15790,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -13828,6 +15810,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -13923,6 +15908,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -13940,6 +15928,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -13959,6 +15950,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -13977,6 +15971,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -13994,6 +15991,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -14097,6 +16097,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -14114,6 +16117,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -14133,6 +16139,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -14151,6 +16160,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -14168,6 +16180,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -14208,6 +16223,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -14225,6 +16243,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -14244,6 +16265,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -14262,6 +16286,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -14279,6 +16306,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -14477,6 +16507,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -14494,6 +16527,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -14513,6 +16549,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -14530,6 +16569,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -14549,6 +16591,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -14566,6 +16611,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -14862,6 +16910,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -14879,6 +16930,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -14898,6 +16952,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -14916,6 +16973,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -14933,6 +16993,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -15237,6 +17300,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -15254,6 +17320,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -15273,6 +17342,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -15291,6 +17363,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -15308,6 +17383,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -15348,6 +17426,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -15365,6 +17446,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -15384,6 +17468,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -15402,6 +17489,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -15419,6 +17509,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -15501,6 +17594,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -15518,6 +17614,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -15537,6 +17636,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -15554,6 +17656,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -15573,6 +17678,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -15590,6 +17698,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -15679,6 +17790,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -15696,6 +17810,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -15715,6 +17832,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -15732,6 +17852,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -15751,6 +17874,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -15768,6 +17894,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -15981,6 +18110,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -15998,6 +18130,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -16017,6 +18152,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -16035,6 +18173,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -16052,6 +18193,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -16246,6 +18390,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -16263,6 +18410,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -16282,6 +18432,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -16299,6 +18452,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -16318,6 +18474,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -16335,6 +18494,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -16639,6 +18801,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -16656,6 +18821,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -16675,6 +18843,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -16693,6 +18864,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -16710,6 +18884,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -17015,6 +19192,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -17032,6 +19212,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -17051,6 +19234,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -17069,6 +19255,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -17086,6 +19275,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -17126,6 +19318,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -17143,6 +19338,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -17162,6 +19360,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -17180,6 +19381,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -17197,6 +19401,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -17279,6 +19486,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -17296,6 +19506,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -17315,6 +19528,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -17332,6 +19548,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -17351,6 +19570,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -17368,6 +19590,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -17457,6 +19682,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -17474,6 +19702,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -17493,6 +19724,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -17510,6 +19744,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -17529,6 +19766,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -17546,6 +19786,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -17755,6 +19998,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -17772,6 +20018,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -17791,6 +20040,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -17809,6 +20061,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -17826,6 +20081,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -17913,6 +20171,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -17930,6 +20191,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -17949,6 +20213,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -17966,6 +20233,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -17985,6 +20255,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -18002,6 +20275,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -18112,6 +20388,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -18129,6 +20408,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -18148,6 +20430,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -18165,6 +20450,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -18184,6 +20472,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -18201,6 +20492,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -18322,6 +20616,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -18339,6 +20636,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -18358,6 +20658,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -18375,6 +20678,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -18394,6 +20700,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -18411,6 +20720,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -18466,6 +20778,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -18483,6 +20798,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -18502,6 +20820,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -18519,6 +20840,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -18538,6 +20862,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -18555,6 +20882,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -18607,6 +20937,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -18624,6 +20957,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -18643,6 +20979,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -18660,6 +20999,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -18679,6 +21021,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -18696,6 +21041,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -18772,6 +21120,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -18789,6 +21140,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -18808,6 +21162,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -18825,6 +21182,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -18844,6 +21204,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -18861,6 +21224,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -19080,6 +21446,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -19097,6 +21466,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -19116,6 +21488,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -19133,6 +21508,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -19152,6 +21530,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -19169,6 +21550,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -19504,6 +21888,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -19521,6 +21908,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -19540,6 +21930,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -19558,6 +21951,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -19575,6 +21971,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -19914,6 +22313,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -19931,6 +22333,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -19950,6 +22355,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -19968,6 +22376,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -19985,6 +22396,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -20025,6 +22439,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -20042,6 +22459,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -20061,6 +22481,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -20079,6 +22502,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -20096,6 +22522,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -20178,6 +22607,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -20195,6 +22627,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -20214,6 +22649,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -20231,6 +22669,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -20250,6 +22691,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -20267,6 +22711,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -20356,6 +22803,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -20373,6 +22823,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -20392,6 +22845,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -20409,6 +22865,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -20428,6 +22887,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -20445,6 +22907,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -20679,6 +23144,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -20696,6 +23164,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -20715,6 +23186,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -20733,6 +23207,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -20750,6 +23227,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -20903,6 +23383,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -20920,6 +23403,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -20939,6 +23425,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -20956,6 +23445,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -20975,6 +23467,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -20992,6 +23487,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -21224,6 +23722,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -21241,6 +23742,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -21260,6 +23764,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -21278,6 +23785,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -21295,6 +23805,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -21529,6 +24042,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -21546,6 +24062,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -21565,6 +24084,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -21583,6 +24105,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -21600,6 +24125,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -21640,6 +24168,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -21657,6 +24188,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -21676,6 +24210,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -21694,6 +24231,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -21711,6 +24251,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -21826,6 +24369,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -21843,6 +24389,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -21862,6 +24411,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -21879,6 +24431,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -21898,6 +24453,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -21915,6 +24473,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -22071,6 +24632,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -22088,6 +24652,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -22107,6 +24674,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -22125,6 +24695,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -22142,6 +24715,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -22309,6 +24885,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -22326,6 +24905,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -22345,6 +24927,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -22363,6 +24948,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -22380,6 +24968,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -22420,6 +25011,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -22437,6 +25031,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -22456,6 +25053,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -22474,6 +25074,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -22491,6 +25094,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -22637,6 +25243,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -22654,6 +25263,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -22673,6 +25285,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -22690,6 +25305,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -22709,6 +25327,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -22726,6 +25347,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -22944,6 +25568,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -22961,6 +25588,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -22980,6 +25610,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -22998,6 +25631,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -23015,6 +25651,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -23238,6 +25877,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -23255,6 +25897,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -23274,6 +25919,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -23292,6 +25940,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -23309,6 +25960,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -23349,6 +26003,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -23366,6 +26023,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -23385,6 +26045,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -23403,6 +26066,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -23420,6 +26086,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -23502,6 +26171,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -23519,6 +26191,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -23538,6 +26213,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -23555,6 +26233,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -23574,6 +26255,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -23591,6 +26275,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -23680,6 +26367,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -23697,6 +26387,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -23716,6 +26409,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -23733,6 +26429,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -23752,6 +26451,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -23769,6 +26471,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -23930,6 +26635,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -23947,6 +26655,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -23966,6 +26677,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -23984,6 +26698,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -24001,6 +26718,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -24087,6 +26807,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -24104,6 +26827,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -24123,6 +26849,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -24140,6 +26869,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -24159,6 +26891,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -24176,6 +26911,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -24257,6 +26995,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -24274,6 +27015,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -24293,6 +27037,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -24311,6 +27058,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -24328,6 +27078,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -24411,6 +27164,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -24428,6 +27184,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -24447,6 +27206,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -24464,6 +27226,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -24483,6 +27248,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -24500,6 +27268,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -24550,6 +27321,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -24567,6 +27341,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -24586,6 +27363,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -24604,6 +27384,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -24621,6 +27404,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -24773,6 +27559,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -24790,6 +27579,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -24809,6 +27601,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -24826,6 +27621,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -24845,6 +27643,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -24862,6 +27663,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -25093,6 +27897,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -25110,6 +27917,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -25129,6 +27939,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -25147,6 +27960,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -25164,6 +27980,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -25398,6 +28217,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -25415,6 +28237,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -25434,6 +28259,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -25452,6 +28280,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -25469,6 +28300,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -25509,6 +28343,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -25526,6 +28363,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -25545,6 +28385,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -25563,6 +28406,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -25580,6 +28426,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -25662,6 +28511,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -25679,6 +28531,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -25698,6 +28553,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -25715,6 +28573,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -25734,6 +28595,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -25751,6 +28615,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -25840,6 +28707,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -25857,6 +28727,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -25876,6 +28749,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -25893,6 +28769,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -25912,6 +28791,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -25929,6 +28811,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -26096,6 +28981,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -26113,6 +29001,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -26132,6 +29023,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -26150,6 +29044,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -26167,6 +29064,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -26312,6 +29212,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -26329,6 +29232,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -26348,6 +29254,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -26365,6 +29274,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -26384,6 +29296,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -26401,6 +29316,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -26623,6 +29541,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -26640,6 +29561,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -26659,6 +29583,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -26677,6 +29604,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -26694,6 +29624,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -26918,6 +29851,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -26935,6 +29871,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -26954,6 +29893,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -26972,6 +29914,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -26989,6 +29934,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -27029,222 +29977,8 @@
                   "properties": {
                     "error": {
                       "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/supplier-quotes/": {
-      "get": {
-        "summary": "List supplier quotes",
-        "tags": [
-          "supplier-quotes"
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "string"
-                      },
-                      "supplierId": {
-                        "type": "string"
-                      },
-                      "supplierName": {
-                        "type": "string"
-                      },
-                      "paymentTerms": {
-                        "type": [
-                          "null",
-                          "string"
-                        ]
-                      },
-                      "status": {
-                        "type": "string"
-                      },
-                      "expirationDate": {
-                        "type": [
-                          "null",
-                          "string"
-                        ],
-                        "format": "date"
-                      },
-                      "linkedOrderId": {
-                        "type": [
-                          "null",
-                          "string"
-                        ]
-                      },
-                      "notes": {
-                        "type": [
-                          "null",
-                          "string"
-                        ]
-                      },
-                      "createdAt": {
-                        "type": "number"
-                      },
-                      "updatedAt": {
-                        "type": "number"
-                      },
-                      "items": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "id": {
-                              "type": "string"
-                            },
-                            "quoteId": {
-                              "type": "string"
-                            },
-                            "productId": {
-                              "type": [
-                                "null",
-                                "string"
-                              ]
-                            },
-                            "productName": {
-                              "type": "string"
-                            },
-                            "quantity": {
-                              "type": "number"
-                            },
-                            "unitPrice": {
-                              "type": "number"
-                            },
-                            "note": {
-                              "type": [
-                                "null",
-                                "string"
-                              ]
-                            },
-                            "unitType": {
-                              "type": "string",
-                              "enum": [
-                                "hours",
-                                "days",
-                                "unit"
-                              ]
-                            }
-                          },
-                          "required": [
-                            "id",
-                            "quoteId",
-                            "productName",
-                            "quantity",
-                            "unitPrice"
-                          ]
-                        }
-                      }
                     },
-                    "required": [
-                      "id",
-                      "supplierId",
-                      "supplierName",
-                      "status",
-                      "createdAt",
-                      "updatedAt",
-                      "items"
-                    ]
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -27264,312 +29998,8 @@
                   "properties": {
                     "error": {
                       "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "summary": "Create supplier quote",
-        "tags": [
-          "supplier-quotes"
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "string"
-                  },
-                  "supplierId": {
-                    "type": "string"
-                  },
-                  "supplierName": {
-                    "type": "string"
-                  },
-                  "items": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "productId": {
-                          "type": "string"
-                        },
-                        "productName": {
-                          "type": "string"
-                        },
-                        "quantity": {
-                          "type": "number"
-                        },
-                        "unitPrice": {
-                          "type": "number"
-                        },
-                        "note": {
-                          "type": "string"
-                        },
-                        "unitType": {
-                          "type": "string",
-                          "enum": [
-                            "hours",
-                            "days",
-                            "unit"
-                          ]
-                        }
-                      },
-                      "required": [
-                        "productName",
-                        "quantity",
-                        "unitPrice"
-                      ]
-                    }
-                  },
-                  "paymentTerms": {
-                    "type": "string"
-                  },
-                  "status": {
-                    "type": "string"
-                  },
-                  "expirationDate": {
-                    "type": "string",
-                    "format": "date"
-                  },
-                  "notes": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "id",
-                  "supplierId",
-                  "supplierName",
-                  "items",
-                  "expirationDate"
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
                     },
-                    "supplierId": {
-                      "type": "string"
-                    },
-                    "supplierName": {
-                      "type": "string"
-                    },
-                    "paymentTerms": {
-                      "type": [
-                        "null",
-                        "string"
-                      ]
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "expirationDate": {
-                      "type": [
-                        "null",
-                        "string"
-                      ],
-                      "format": "date"
-                    },
-                    "linkedOrderId": {
-                      "type": [
-                        "null",
-                        "string"
-                      ]
-                    },
-                    "notes": {
-                      "type": [
-                        "null",
-                        "string"
-                      ]
-                    },
-                    "createdAt": {
-                      "type": "number"
-                    },
-                    "updatedAt": {
-                      "type": "number"
-                    },
-                    "items": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string"
-                          },
-                          "quoteId": {
-                            "type": "string"
-                          },
-                          "productId": {
-                            "type": [
-                              "null",
-                              "string"
-                            ]
-                          },
-                          "productName": {
-                            "type": "string"
-                          },
-                          "quantity": {
-                            "type": "number"
-                          },
-                          "unitPrice": {
-                            "type": "number"
-                          },
-                          "note": {
-                            "type": [
-                              "null",
-                              "string"
-                            ]
-                          },
-                          "unitType": {
-                            "type": "string",
-                            "enum": [
-                              "hours",
-                              "days",
-                              "unit"
-                            ]
-                          }
-                        },
-                        "required": [
-                          "id",
-                          "quoteId",
-                          "productName",
-                          "quantity",
-                          "unitPrice"
-                        ]
-                      }
-                    }
-                  },
-                  "required": [
-                    "id",
-                    "supplierId",
-                    "supplierName",
-                    "status",
-                    "createdAt",
-                    "updatedAt",
-                    "items"
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -27589,299 +30019,8 @@
                   "properties": {
                     "error": {
                       "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/supplier-quotes/{id}": {
-      "put": {
-        "summary": "Update supplier quote",
-        "tags": [
-          "supplier-quotes"
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "id": {
-                    "type": "string"
-                  },
-                  "supplierId": {
-                    "type": "string"
-                  },
-                  "supplierName": {
-                    "type": "string"
-                  },
-                  "items": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "productId": {
-                          "type": "string"
-                        },
-                        "productName": {
-                          "type": "string"
-                        },
-                        "quantity": {
-                          "type": "number"
-                        },
-                        "unitPrice": {
-                          "type": "number"
-                        },
-                        "note": {
-                          "type": "string"
-                        },
-                        "unitType": {
-                          "type": "string",
-                          "enum": [
-                            "hours",
-                            "days",
-                            "unit"
-                          ]
-                        }
-                      },
-                      "required": [
-                        "productName",
-                        "quantity",
-                        "unitPrice"
-                      ]
-                    }
-                  },
-                  "paymentTerms": {
-                    "type": "string"
-                  },
-                  "status": {
-                    "type": "string"
-                  },
-                  "expirationDate": {
-                    "type": "string",
-                    "format": "date"
-                  },
-                  "notes": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "id",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
                     },
-                    "supplierId": {
-                      "type": "string"
-                    },
-                    "supplierName": {
-                      "type": "string"
-                    },
-                    "paymentTerms": {
-                      "type": [
-                        "null",
-                        "string"
-                      ]
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "expirationDate": {
-                      "type": [
-                        "null",
-                        "string"
-                      ],
-                      "format": "date"
-                    },
-                    "linkedOrderId": {
-                      "type": [
-                        "null",
-                        "string"
-                      ]
-                    },
-                    "notes": {
-                      "type": [
-                        "null",
-                        "string"
-                      ]
-                    },
-                    "createdAt": {
-                      "type": "number"
-                    },
-                    "updatedAt": {
-                      "type": "number"
-                    },
-                    "items": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string"
-                          },
-                          "quoteId": {
-                            "type": "string"
-                          },
-                          "productId": {
-                            "type": [
-                              "null",
-                              "string"
-                            ]
-                          },
-                          "productName": {
-                            "type": "string"
-                          },
-                          "quantity": {
-                            "type": "number"
-                          },
-                          "unitPrice": {
-                            "type": "number"
-                          },
-                          "note": {
-                            "type": [
-                              "null",
-                              "string"
-                            ]
-                          },
-                          "unitType": {
-                            "type": "string",
-                            "enum": [
-                              "hours",
-                              "days",
-                              "unit"
-                            ]
-                          }
-                        },
-                        "required": [
-                          "id",
-                          "quoteId",
-                          "productName",
-                          "quantity",
-                          "unitPrice"
-                        ]
-                      }
-                    }
-                  },
-                  "required": [
-                    "id",
-                    "supplierId",
-                    "supplierName",
-                    "status",
-                    "createdAt",
-                    "updatedAt",
-                    "items"
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -27901,116 +30040,8 @@
                   "properties": {
                     "error": {
                       "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "summary": "Delete supplier quote",
-        "tags": [
-          "supplier-quotes"
-        ],
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "id",
-            "required": true
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Default Response"
-          },
-          "400": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -28030,1206 +30061,8 @@
                   "properties": {
                     "error": {
                       "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/supplier-quotes/{id}/versions": {
-      "get": {
-        "summary": "List versions for a supplier quote",
-        "tags": [
-          "supplier-quotes"
-        ],
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "id",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "string"
-                      },
-                      "quoteId": {
-                        "type": "string"
-                      },
-                      "reason": {
-                        "type": "string",
-                        "enum": [
-                          "update",
-                          "restore"
-                        ]
-                      },
-                      "createdByUserId": {
-                        "type": [
-                          "null",
-                          "string"
-                        ]
-                      },
-                      "createdAt": {
-                        "type": "number"
-                      }
                     },
-                    "required": [
-                      "id",
-                      "quoteId",
-                      "reason",
-                      "createdAt"
-                    ]
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/supplier-quotes/{id}/versions/{versionId}": {
-      "get": {
-        "summary": "Get a single supplier quote version",
-        "tags": [
-          "supplier-quotes"
-        ],
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "id",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "versionId",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    },
-                    "quoteId": {
-                      "type": "string"
-                    },
-                    "reason": {
-                      "type": "string",
-                      "enum": [
-                        "update",
-                        "restore"
-                      ]
-                    },
-                    "createdByUserId": {
-                      "type": [
-                        "null",
-                        "string"
-                      ]
-                    },
-                    "createdAt": {
-                      "type": "number"
-                    },
-                    "snapshot": {}
-                  },
-                  "required": [
-                    "id",
-                    "quoteId",
-                    "reason",
-                    "createdAt",
-                    "snapshot"
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/supplier-quotes/{id}/versions/{versionId}/restore": {
-      "post": {
-        "summary": "Restore a supplier quote to a prior version",
-        "tags": [
-          "supplier-quotes"
-        ],
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "id",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "versionId",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    },
-                    "supplierId": {
-                      "type": "string"
-                    },
-                    "supplierName": {
-                      "type": "string"
-                    },
-                    "paymentTerms": {
-                      "type": [
-                        "null",
-                        "string"
-                      ]
-                    },
-                    "status": {
-                      "type": "string"
-                    },
-                    "expirationDate": {
-                      "type": [
-                        "null",
-                        "string"
-                      ],
-                      "format": "date"
-                    },
-                    "linkedOrderId": {
-                      "type": [
-                        "null",
-                        "string"
-                      ]
-                    },
-                    "notes": {
-                      "type": [
-                        "null",
-                        "string"
-                      ]
-                    },
-                    "createdAt": {
-                      "type": "number"
-                    },
-                    "updatedAt": {
-                      "type": "number"
-                    },
-                    "items": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string"
-                          },
-                          "quoteId": {
-                            "type": "string"
-                          },
-                          "productId": {
-                            "type": [
-                              "null",
-                              "string"
-                            ]
-                          },
-                          "productName": {
-                            "type": "string"
-                          },
-                          "quantity": {
-                            "type": "number"
-                          },
-                          "unitPrice": {
-                            "type": "number"
-                          },
-                          "note": {
-                            "type": [
-                              "null",
-                              "string"
-                            ]
-                          },
-                          "unitType": {
-                            "type": "string",
-                            "enum": [
-                              "hours",
-                              "days",
-                              "unit"
-                            ]
-                          }
-                        },
-                        "required": [
-                          "id",
-                          "quoteId",
-                          "productName",
-                          "quantity",
-                          "unitPrice"
-                        ]
-                      }
-                    }
-                  },
-                  "required": [
-                    "id",
-                    "supplierId",
-                    "supplierName",
-                    "status",
-                    "createdAt",
-                    "updatedAt",
-                    "items"
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/supplier-quotes/{id}/attachments": {
-      "get": {
-        "summary": "List attachments for a supplier quote",
-        "tags": [
-          "supplier-quotes"
-        ],
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "id",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "string"
-                      },
-                      "quoteId": {
-                        "type": "string"
-                      },
-                      "fileName": {
-                        "type": "string"
-                      },
-                      "mimeType": {
-                        "type": "string"
-                      },
-                      "fileSize": {
-                        "type": "number"
-                      },
-                      "uploadedByUserId": {
-                        "type": [
-                          "null",
-                          "string"
-                        ]
-                      },
-                      "createdAt": {
-                        "type": "number"
-                      }
-                    },
-                    "required": [
-                      "id",
-                      "quoteId",
-                      "fileName",
-                      "mimeType",
-                      "fileSize",
-                      "createdAt"
-                    ]
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "summary": "Upload an attachment to a supplier quote",
-        "tags": [
-          "supplier-quotes"
-        ],
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "id",
-            "required": true
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    },
-                    "quoteId": {
-                      "type": "string"
-                    },
-                    "fileName": {
-                      "type": "string"
-                    },
-                    "mimeType": {
-                      "type": "string"
-                    },
-                    "fileSize": {
-                      "type": "number"
-                    },
-                    "uploadedByUserId": {
-                      "type": [
-                        "null",
-                        "string"
-                      ]
-                    },
-                    "createdAt": {
-                      "type": "number"
-                    }
-                  },
-                  "required": [
-                    "id",
-                    "quoteId",
-                    "fileName",
-                    "mimeType",
-                    "fileSize",
-                    "createdAt"
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "413": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "415": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/supplier-quotes/{id}/attachments/{attachmentId}/download": {
-      "get": {
-        "summary": "Download a supplier-quote attachment",
-        "tags": [
-          "supplier-quotes"
-        ],
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "id",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "attachmentId",
-            "required": true
-          }
-        ],
-        "responses": {
-          "400": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/supplier-quotes/{id}/attachments/{attachmentId}": {
-      "delete": {
-        "summary": "Delete a supplier-quote attachment",
-        "tags": [
-          "supplier-quotes"
-        ],
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "id",
-            "required": true
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "in": "path",
-            "name": "attachmentId",
-            "required": true
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Default Response"
-          },
-          "400": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -29323,6 +30156,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -29340,6 +30176,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -29359,6 +30198,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -29376,6 +30218,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -29395,6 +30240,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -29412,6 +30260,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -29469,6 +30320,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -29486,6 +30340,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -29505,6 +30362,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -29523,6 +30383,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -29540,6 +30403,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -29587,6 +30453,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -29604,6 +30473,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -29623,6 +30495,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -29641,6 +30516,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -29658,6 +30536,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -29700,6 +30581,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -29717,6 +30601,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -29736,6 +30623,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -29754,6 +30644,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -29771,6 +30664,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -29850,6 +30746,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -29867,6 +30766,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -29886,6 +30788,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -29903,6 +30808,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -29922,6 +30830,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -29939,6 +30850,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -30060,6 +30974,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -30077,6 +30994,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -30096,6 +31016,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -30113,6 +31036,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -30132,6 +31058,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -30149,6 +31078,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -30228,6 +31160,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -30246,6 +31181,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -30263,6 +31201,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -30321,6 +31262,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -30338,6 +31282,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -30407,6 +31354,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -30424,6 +31374,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -30443,6 +31396,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -30460,6 +31416,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -30479,6 +31438,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -30496,6 +31458,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -30584,6 +31549,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -30601,6 +31569,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -30620,6 +31591,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -30637,6 +31611,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -30656,6 +31633,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -30673,6 +31653,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -30767,6 +31750,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -30784,6 +31770,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -30803,6 +31792,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -30820,6 +31812,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -30839,6 +31834,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -30856,6 +31854,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -30911,6 +31912,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -30928,6 +31932,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -30947,6 +31954,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -30964,6 +31974,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -30983,6 +31996,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -31000,6 +32016,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -31097,6 +32116,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -31114,6 +32136,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -31133,6 +32158,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -31150,6 +32178,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -31169,6 +32200,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -31186,6 +32220,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -31248,6 +32285,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -31265,6 +32305,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -31284,6 +32327,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -31301,6 +32347,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -31320,6 +32369,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -31337,6 +32389,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -31397,6 +32452,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -31414,6 +32472,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -31433,6 +32494,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -31451,6 +32515,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -31468,6 +32535,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -31563,6 +32633,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -31580,6 +32653,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -31599,6 +32675,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -31617,6 +32696,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -31634,6 +32716,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -31691,6 +32776,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -31708,6 +32796,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -31727,6 +32818,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -31745,6 +32839,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -31762,6 +32859,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -31815,6 +32915,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -31832,6 +32935,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -31851,6 +32957,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -31869,6 +32978,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -31886,6 +32998,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -31944,6 +33059,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -31961,6 +33079,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -31980,6 +33101,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -31998,6 +33122,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -32015,6 +33142,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -32093,6 +33223,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -32110,6 +33243,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -32129,6 +33265,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -32147,6 +33286,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -32164,6 +33306,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -32307,6 +33452,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -32324,6 +33472,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -32343,6 +33494,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -32360,6 +33514,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },
@@ -32379,6 +33536,9 @@
                   "properties": {
                     "error": {
                       "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
                     }
                   },
                   "required": [
@@ -32396,6 +33556,9 @@
                   "type": "object",
                   "properties": {
                     "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
                       "type": "string"
                     }
                   },

--- a/hooks/handlers/taskHandlers.ts
+++ b/hooks/handlers/taskHandlers.ts
@@ -7,7 +7,7 @@ export type TaskHandlersDeps = {
   projectTasks: ProjectTask[];
   setProjectTasks: React.Dispatch<React.SetStateAction<ProjectTask[]>>;
   setEntries: React.Dispatch<React.SetStateAction<TimeEntry[]>>;
-  generateRecurringEntries: (tasks?: ProjectTask[]) => Promise<void> | void;
+  generateRecurringEntries: () => Promise<void> | void;
 };
 
 export const makeTaskHandlers = (deps: TaskHandlersDeps) => {
@@ -54,16 +54,10 @@ export const makeTaskHandlers = (deps: TaskHandlersDeps) => {
         recurrenceEnd: endDate,
         recurrenceDuration: duration,
       });
-      // Use a functional updater so a concurrent task edit/add during the
-      // awaited api.tasks.update above is not clobbered by a stale snapshot.
-      // Side-channel the resulting list out so generateRecurringEntries sees
-      // the freshly-updated task without relying on closed-over state.
-      let nextTasks: ProjectTask[] = [];
-      setProjectTasks((prev) => {
-        nextTasks = prev.map((t) => (t.id === taskId ? updated : t));
-        return nextTasks;
-      });
-      await generateRecurringEntries(nextTasks);
+      // Functional updater so a concurrent task edit/add during the awaited
+      // api.tasks.update above is not clobbered by a stale snapshot.
+      setProjectTasks((prev) => prev.map((t) => (t.id === taskId ? updated : t)));
+      await generateRecurringEntries();
     } catch (err) {
       console.error('Failed to make task recurring:', err);
     }

--- a/server/repositories/entriesRepo.ts
+++ b/server/repositories/entriesRepo.ts
@@ -1,4 +1,4 @@
-import { and, eq, gte, type SQL, sql } from 'drizzle-orm';
+import { and, eq, gte, lte, type SQL, sql } from 'drizzle-orm';
 import { type DbExecutor, db, executeRows } from '../db/drizzle.ts';
 import { timeEntries } from '../db/schema/timeEntries.ts';
 import { normalizeNullableDateOnly } from '../utils/date.ts';
@@ -209,6 +209,34 @@ export const decodeCursor = (raw: string): EntriesCursor | null => {
   }
 };
 
+/**
+ * Returns the set of `${date}|${projectId}|${task}` keys for entries owned by `userId`
+ * whose date falls in [fromDate, toDate] inclusive. Used by the recurring-entry generator
+ * to skip days that already have a matching entry (idempotent runs).
+ */
+export const findExistingRecurringKeys = async (
+  userId: string,
+  fromDate: string,
+  toDate: string,
+  exec: DbExecutor = db,
+): Promise<Set<string>> => {
+  const rows = await exec
+    .select({
+      date: timeEntries.date,
+      projectId: timeEntries.projectId,
+      task: timeEntries.task,
+    })
+    .from(timeEntries)
+    .where(
+      and(
+        eq(timeEntries.userId, userId),
+        gte(timeEntries.date, fromDate),
+        lte(timeEntries.date, toDate),
+      ),
+    );
+  return new Set(rows.map((row) => `${row.date}|${row.projectId}|${row.task}`));
+};
+
 export const findOwner = async (id: string, exec: DbExecutor = db): Promise<string | null> => {
   const rows = await exec
     .select({ userId: timeEntries.userId })
@@ -278,6 +306,39 @@ export const create = async (entry: NewEntry, exec: DbExecutor = db): Promise<Ti
     })
     .returning();
   return mapBuilderRow(row);
+};
+
+/**
+ * Bulk insert variant used by the recurring-entry generator. Returns the inserted rows in
+ * the same order they were supplied. Empty input is a no-op.
+ */
+export const createMany = async (
+  entries: NewEntry[],
+  exec: DbExecutor = db,
+): Promise<TimeEntry[]> => {
+  if (entries.length === 0) return [];
+  const rows = await exec
+    .insert(timeEntries)
+    .values(
+      entries.map((entry) => ({
+        id: entry.id,
+        userId: entry.userId,
+        date: entry.date,
+        clientId: entry.clientId,
+        clientName: entry.clientName,
+        projectId: entry.projectId,
+        projectName: entry.projectName,
+        task: entry.task,
+        taskId: entry.taskId,
+        notes: entry.notes,
+        duration: numericForDb(entry.duration),
+        hourlyCost: numericForDb(entry.hourlyCost),
+        isPlaceholder: entry.isPlaceholder,
+        location: entry.location,
+      })),
+    )
+    .returning();
+  return rows.map(mapBuilderRow);
 };
 
 export type EntryUpdate = {

--- a/server/repositories/entriesRepo.ts
+++ b/server/repositories/entriesRepo.ts
@@ -308,6 +308,11 @@ export const create = async (entry: NewEntry, exec: DbExecutor = db): Promise<Ti
   return mapBuilderRow(row);
 };
 
+// Postgres caps bind parameters at 65,535 per statement. With 14 columns per row a single
+// INSERT can safely carry ~4,600 rows; we chunk at 1,000 for a comfortable margin and to
+// keep individual statements bounded in size.
+const CREATE_MANY_CHUNK_SIZE = 1000;
+
 /**
  * Bulk insert variant used by the recurring-entry generator. Returns the inserted rows in
  * the same order they were supplied. Empty input is a no-op.
@@ -317,28 +322,33 @@ export const createMany = async (
   exec: DbExecutor = db,
 ): Promise<TimeEntry[]> => {
   if (entries.length === 0) return [];
-  const rows = await exec
-    .insert(timeEntries)
-    .values(
-      entries.map((entry) => ({
-        id: entry.id,
-        userId: entry.userId,
-        date: entry.date,
-        clientId: entry.clientId,
-        clientName: entry.clientName,
-        projectId: entry.projectId,
-        projectName: entry.projectName,
-        task: entry.task,
-        taskId: entry.taskId,
-        notes: entry.notes,
-        duration: numericForDb(entry.duration),
-        hourlyCost: numericForDb(entry.hourlyCost),
-        isPlaceholder: entry.isPlaceholder,
-        location: entry.location,
-      })),
-    )
-    .returning();
-  return rows.map(mapBuilderRow);
+  const result: TimeEntry[] = [];
+  for (let i = 0; i < entries.length; i += CREATE_MANY_CHUNK_SIZE) {
+    const chunk = entries.slice(i, i + CREATE_MANY_CHUNK_SIZE);
+    const rows = await exec
+      .insert(timeEntries)
+      .values(
+        chunk.map((entry) => ({
+          id: entry.id,
+          userId: entry.userId,
+          date: entry.date,
+          clientId: entry.clientId,
+          clientName: entry.clientName,
+          projectId: entry.projectId,
+          projectName: entry.projectName,
+          task: entry.task,
+          taskId: entry.taskId,
+          notes: entry.notes,
+          duration: numericForDb(entry.duration),
+          hourlyCost: numericForDb(entry.hourlyCost),
+          isPlaceholder: entry.isPlaceholder,
+          location: entry.location,
+        })),
+      )
+      .returning();
+    for (const row of rows) result.push(mapBuilderRow(row));
+  }
+  return result;
 };
 
 export type EntryUpdate = {

--- a/server/repositories/projectsRepo.ts
+++ b/server/repositories/projectsRepo.ts
@@ -150,6 +150,36 @@ export const listByIds = async (ids: string[], exec: DbExecutor = db): Promise<P
   return rows.map(mapRawRow);
 };
 
+/**
+ * Resolve project + client display tuples for a set of project ids in one query.
+ * Used by the recurring time-entry generator to populate the denormalized `client_name`
+ * / `project_name` columns on `time_entries` without N round-trips.
+ */
+export const listNamesByIds = async (
+  ids: string[],
+  exec: DbExecutor = db,
+): Promise<Map<string, { projectName: string; clientId: string; clientName: string }>> => {
+  if (ids.length === 0) return new Map();
+  const rows = await executeRows<{
+    id: string;
+    name: string;
+    client_id: string;
+    client_name: string;
+  }>(
+    exec,
+    sql`SELECT p.id, p.name, p.client_id, c.name AS client_name
+          FROM projects p
+          INNER JOIN clients c ON c.id = p.client_id
+         WHERE p.id = ANY(${ids})`,
+  );
+  return new Map(
+    rows.map((row) => [
+      row.id,
+      { projectName: row.name, clientId: row.client_id, clientName: row.client_name },
+    ]),
+  );
+};
+
 export const findClientId = async (id: string, exec: DbExecutor = db): Promise<string | null> => {
   const rows = await exec
     .select({ clientId: projects.clientId })

--- a/server/repositories/tasksRepo.ts
+++ b/server/repositories/tasksRepo.ts
@@ -61,34 +61,32 @@ export const listAll = async (exec: DbExecutor = db): Promise<Task[]> => {
   return rows.map(mapRow);
 };
 
-/**
- * List recurring tasks (is_recurring = true, is_disabled = false) assigned to a user.
- * Used by the recurring time-entry generator to discover which templates apply.
- */
+const taskSelectFields = {
+  id: tasks.id,
+  name: tasks.name,
+  projectId: tasks.projectId,
+  description: tasks.description,
+  isRecurring: tasks.isRecurring,
+  recurrencePattern: tasks.recurrencePattern,
+  recurrenceStart: tasks.recurrenceStart,
+  recurrenceEnd: tasks.recurrenceEnd,
+  recurrenceDuration: tasks.recurrenceDuration,
+  expectedEffort: tasks.expectedEffort,
+  monthlyEffort: tasks.monthlyEffort,
+  revenue: tasks.revenue,
+  notes: tasks.notes,
+  isDisabled: tasks.isDisabled,
+  createdAt: tasks.createdAt,
+  billingType: tasks.billingType,
+  billingFrequency: tasks.billingFrequency,
+} as const;
+
 export const listRecurringForUser = async (
   userId: string,
   exec: DbExecutor = db,
 ): Promise<Task[]> => {
   const rows = await exec
-    .select({
-      id: tasks.id,
-      name: tasks.name,
-      projectId: tasks.projectId,
-      description: tasks.description,
-      isRecurring: tasks.isRecurring,
-      recurrencePattern: tasks.recurrencePattern,
-      recurrenceStart: tasks.recurrenceStart,
-      recurrenceEnd: tasks.recurrenceEnd,
-      recurrenceDuration: tasks.recurrenceDuration,
-      expectedEffort: tasks.expectedEffort,
-      monthlyEffort: tasks.monthlyEffort,
-      revenue: tasks.revenue,
-      notes: tasks.notes,
-      isDisabled: tasks.isDisabled,
-      createdAt: tasks.createdAt,
-      billingType: tasks.billingType,
-      billingFrequency: tasks.billingFrequency,
-    })
+    .select(taskSelectFields)
     .from(tasks)
     .innerJoin(userTasks, eq(userTasks.taskId, tasks.id))
     .where(
@@ -100,25 +98,7 @@ export const listRecurringForUser = async (
 
 export const listForUser = async (userId: string, exec: DbExecutor = db): Promise<Task[]> => {
   const rows = await exec
-    .select({
-      id: tasks.id,
-      name: tasks.name,
-      projectId: tasks.projectId,
-      description: tasks.description,
-      isRecurring: tasks.isRecurring,
-      recurrencePattern: tasks.recurrencePattern,
-      recurrenceStart: tasks.recurrenceStart,
-      recurrenceEnd: tasks.recurrenceEnd,
-      recurrenceDuration: tasks.recurrenceDuration,
-      expectedEffort: tasks.expectedEffort,
-      monthlyEffort: tasks.monthlyEffort,
-      revenue: tasks.revenue,
-      notes: tasks.notes,
-      isDisabled: tasks.isDisabled,
-      createdAt: tasks.createdAt,
-      billingType: tasks.billingType,
-      billingFrequency: tasks.billingFrequency,
-    })
+    .select(taskSelectFields)
     .from(tasks)
     .innerJoin(userTasks, eq(userTasks.taskId, tasks.id))
     .where(eq(userTasks.userId, userId))

--- a/server/repositories/tasksRepo.ts
+++ b/server/repositories/tasksRepo.ts
@@ -61,6 +61,43 @@ export const listAll = async (exec: DbExecutor = db): Promise<Task[]> => {
   return rows.map(mapRow);
 };
 
+/**
+ * List recurring tasks (is_recurring = true, is_disabled = false) assigned to a user.
+ * Used by the recurring time-entry generator to discover which templates apply.
+ */
+export const listRecurringForUser = async (
+  userId: string,
+  exec: DbExecutor = db,
+): Promise<Task[]> => {
+  const rows = await exec
+    .select({
+      id: tasks.id,
+      name: tasks.name,
+      projectId: tasks.projectId,
+      description: tasks.description,
+      isRecurring: tasks.isRecurring,
+      recurrencePattern: tasks.recurrencePattern,
+      recurrenceStart: tasks.recurrenceStart,
+      recurrenceEnd: tasks.recurrenceEnd,
+      recurrenceDuration: tasks.recurrenceDuration,
+      expectedEffort: tasks.expectedEffort,
+      monthlyEffort: tasks.monthlyEffort,
+      revenue: tasks.revenue,
+      notes: tasks.notes,
+      isDisabled: tasks.isDisabled,
+      createdAt: tasks.createdAt,
+      billingType: tasks.billingType,
+      billingFrequency: tasks.billingFrequency,
+    })
+    .from(tasks)
+    .innerJoin(userTasks, eq(userTasks.taskId, tasks.id))
+    .where(
+      and(eq(userTasks.userId, userId), eq(tasks.isRecurring, true), eq(tasks.isDisabled, false)),
+    )
+    .orderBy(tasks.name);
+  return rows.map(mapRow);
+};
+
 export const listForUser = async (userId: string, exec: DbExecutor = db): Promise<Task[]> => {
   const rows = await exec
     .select({

--- a/server/routes/entries.ts
+++ b/server/routes/entries.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import {
   authenticateToken,
   requireAnyPermission,
+  requirePermission,
   requireScopedPermission,
 } from '../middleware/auth.ts';
 import {
@@ -13,6 +14,7 @@ import {
   bulkDeleteTimeEntries,
   createTimeEntry,
   deleteTimeEntry,
+  generateRecurringEntries,
   listTimeEntries,
   TimeEntryServiceError,
   updateTimeEntry,
@@ -108,6 +110,34 @@ const entriesListResponseSchema = {
     nextCursor: { type: ['string', 'null'] },
   },
   required: ['entries', 'nextCursor'],
+} as const;
+
+const recurringGenerateBodySchema = {
+  type: 'object',
+  properties: {
+    fromDate: { type: 'string', format: 'date' },
+    toDate: { type: 'string', format: 'date' },
+    userId: { type: 'string' },
+  },
+  required: ['fromDate', 'toDate'],
+} as const;
+
+const recurringGenerateResponseSchema = {
+  type: 'object',
+  properties: {
+    generated: { type: 'array', items: entrySchema },
+    generatedCount: { type: 'integer' },
+    skippedExistingCount: { type: 'integer' },
+    range: {
+      type: 'object',
+      properties: {
+        fromDate: { type: 'string', format: 'date' },
+        toDate: { type: 'string', format: 'date' },
+      },
+      required: ['fromDate', 'toDate'],
+    },
+  },
+  required: ['generated', 'generatedCount', 'skippedExistingCount', 'range'],
 } as const;
 
 const entriesBulkDeleteQuerySchema = {
@@ -245,6 +275,41 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const { id } = request.params as { id: string };
       try {
         return await deleteTimeEntry(actorFromRequest(request), id);
+      } catch (err) {
+        return handleTimeEntryServiceError(err, reply);
+      }
+    },
+  );
+
+  // POST /recurring/generate - Materialize recurring templates into time entries
+  fastify.post(
+    '/recurring/generate',
+    {
+      onRequest: [
+        fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
+        authenticateToken,
+        requirePermission('timesheets.recurring.create'),
+      ],
+      schema: {
+        tags: ['entries'],
+        summary: 'Generate time entries from recurring templates',
+        description:
+          'Walks the active recurring task templates assigned to the target user (or the ' +
+          'authenticated user if `userId` is omitted) and inserts a placeholder time entry ' +
+          'for every matching day in `[fromDate, toDate]` that does not already have an ' +
+          'entry for the same (date, project, task) tuple. Idempotent.',
+        body: recurringGenerateBodySchema,
+        response: {
+          200: recurringGenerateResponseSchema,
+          ...standardRateLimitedErrorResponses,
+        },
+      },
+    },
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      if (!assertAuthenticated(request, reply)) return;
+
+      try {
+        return await generateRecurringEntries(actorFromRequest(request), request.body ?? {});
       } catch (err) {
         return handleTimeEntryServiceError(err, reply);
       }

--- a/server/services/timeEntries.ts
+++ b/server/services/timeEntries.ts
@@ -362,9 +362,48 @@ export const generateRecurringEntries = async (
   const uniqueProjectIds = Array.from(new Set(recurringTasks.map((t) => t.projectId)));
   const projectsByProjectId = await projectsRepo.listNamesByIds(uniqueProjectIds);
 
+  // `listRecurringForUser` already gates on `user_tasks`, but a stale `user_tasks` row can
+  // outlive a revoked client/project assignment. Re-apply the same per-row checks
+  // `createTimeEntry` runs so the recurring path can't escape an assignment downgrade.
+  let allowedTasks = recurringTasks;
+  if (!hasPermission(actor, 'timesheets.tracker_all.create')) {
+    const uniqueClientIds = Array.from(
+      new Set(
+        recurringTasks
+          .map((t) => projectsByProjectId.get(t.projectId)?.clientId)
+          .filter((id): id is string => id !== undefined),
+      ),
+    );
+    const [assignedClients, assignedProjects, assignedTasks] = await Promise.all([
+      userAssignmentsRepo.filterAssignedClientIds(targetUserId, uniqueClientIds),
+      userAssignmentsRepo.filterAssignedProjectIds(targetUserId, uniqueProjectIds),
+      userAssignmentsRepo.filterAssignedTaskIds(
+        targetUserId,
+        recurringTasks.map((t) => t.id),
+      ),
+    ]);
+    allowedTasks = recurringTasks.filter((t) => {
+      const clientId = projectsByProjectId.get(t.projectId)?.clientId;
+      return (
+        clientId !== undefined &&
+        assignedClients.has(clientId) &&
+        assignedProjects.has(t.projectId) &&
+        assignedTasks.has(t.id)
+      );
+    });
+  }
+  if (allowedTasks.length === 0) {
+    return {
+      generated: [],
+      generatedCount: 0,
+      skippedExistingCount: 0,
+      range: { fromDate, toDate },
+    };
+  }
+
   type PendingEntry = ReturnType<typeof buildPendingEntry>;
   const buildPendingEntry = (
-    task: (typeof recurringTasks)[number],
+    task: (typeof allowedTasks)[number],
     project: NonNullable<ReturnType<typeof projectsByProjectId.get>>,
     dateStr: string,
   ) => ({
@@ -390,7 +429,7 @@ export const generateRecurringEntries = async (
   // task) tuple don't insert duplicate rows in a single generation pass.
   const stagedKeys = new Set<string>();
 
-  for (const task of recurringTasks) {
+  for (const task of allowedTasks) {
     if (!task.recurrencePattern) continue;
     const project = projectsByProjectId.get(task.projectId);
     if (!project) continue;

--- a/server/services/timeEntries.ts
+++ b/server/services/timeEntries.ts
@@ -7,7 +7,7 @@ import * as tasksRepo from '../repositories/tasksRepo.ts';
 import * as userAssignmentsRepo from '../repositories/userAssignmentsRepo.ts';
 import * as usersRepo from '../repositories/usersRepo.ts';
 import * as workUnitsRepo from '../repositories/workUnitsRepo.ts';
-import { formatLocalDateOnly, todayLocalDateOnly } from '../utils/date.ts';
+import { formatLocalDateOnly, parseLocalDateOnly, todayLocalDateOnly } from '../utils/date.ts';
 import { isItalianHoliday } from '../utils/holidays.ts';
 import { generatePrefixedId } from '../utils/order-ids.ts';
 import { hasScopedActionPermission } from '../utils/permissions.ts';
@@ -254,25 +254,16 @@ export const deleteTimeEntry = async (
   return { message: 'Entry deleted' };
 };
 
-// Recurring time-entry generation.
+// Recurring time-entry generation. Supported patterns:
+//   - 'daily'                : every weekday in the window
+//   - 'weekly'               : same weekday as `recurrence_start`
+//   - 'monthly'              : same day-of-month as `recurrence_start`
+//   - 'monthly:<nth>:<dow>'  : Nth (first/second/third/fourth/last) weekday of the month;
+//                              `dow` is 0=Sun..6=Sat (matches JS `Date.getDay()`)
 //
-// Supported recurrence patterns (matching rules mirrored from the legacy client-side path
-// so existing templates keep producing the same days):
-//
-//   - 'daily'                : every weekday in the window.
-//   - 'weekly'               : same weekday as `recurrence_start`.
-//   - 'monthly'              : same day-of-month as `recurrence_start`.
-//   - 'monthly:<nth>:<dow>'  : Nth (`first`/`second`/`third`/`fourth`/`last`) weekday of
-//                              the month. `dow` is 0=Sun..6=Sat (matches JS `Date.getDay()`).
-//
-// Sundays, configured Saturdays, and Italian holidays are always skipped. Days outside the
-// template's `[recurrence_start, recurrence_end]` window are skipped. Existing entries
-// (matched by date + projectId + task name) are skipped, so re-running is a no-op.
-
-const dateOnlyToLocal = (dateOnly: string): Date => {
-  const [year, month, day] = dateOnly.split('-').map(Number);
-  return new Date(year, month - 1, day);
-};
+// Sundays, configured Saturdays, Italian holidays, and days outside the template's
+// `[recurrence_start, recurrence_end]` window are skipped. Existing entries (date +
+// projectId + task name) are skipped, so re-running is idempotent.
 
 const recurrenceMatches = (day: Date, pattern: string, start: Date): boolean => {
   if (pattern === 'daily') return true;
@@ -319,9 +310,6 @@ export type GenerateRecurringResult = {
   range: { fromDate: string; toDate: string };
 };
 
-// Hard cap on the window to avoid pathological generation (the legacy client-side limit
-// extended the window per-template only up to the recurrence end-date; the explicit API
-// makes the caller responsible for the range, so we cap it server-side).
 const MAX_RECURRING_DAYS = 366;
 
 export const generateRecurringEntries = async (
@@ -336,8 +324,8 @@ export const generateRecurringEntries = async (
   const toDate = requireValid(parseDateString(input.toDate, 'toDate'));
   if (fromDate > toDate) badRequest('fromDate must be on or before toDate');
 
-  const fromLocal = dateOnlyToLocal(fromDate);
-  const toLocal = dateOnlyToLocal(toDate);
+  const fromLocal = parseLocalDateOnly(fromDate);
+  const toLocal = parseLocalDateOnly(toDate);
   const windowDays =
     Math.round((toLocal.getTime() - fromLocal.getTime()) / (24 * 60 * 60 * 1000)) + 1;
   if (windowDays > MAX_RECURRING_DAYS) {
@@ -407,15 +395,17 @@ export const generateRecurringEntries = async (
     const project = projectsByProjectId.get(task.projectId);
     if (!project) continue;
 
-    const templateStart = task.recurrenceStart ? dateOnlyToLocal(task.recurrenceStart) : fromLocal;
-    const templateEnd = task.recurrenceEnd ? dateOnlyToLocal(task.recurrenceEnd) : null;
+    const templateStart = task.recurrenceStart
+      ? parseLocalDateOnly(task.recurrenceStart)
+      : fromLocal;
+    const templateEnd = task.recurrenceEnd ? parseLocalDateOnly(task.recurrenceEnd) : null;
 
     const iterStart = templateStart > fromLocal ? templateStart : fromLocal;
     const iterEnd = templateEnd && templateEnd < toLocal ? templateEnd : toLocal;
     if (iterStart > iterEnd) continue;
 
     for (
-      const cursor = new Date(iterStart);
+      let cursor = new Date(iterStart);
       cursor <= iterEnd;
       cursor.setDate(cursor.getDate() + 1)
     ) {

--- a/server/services/timeEntries.ts
+++ b/server/services/timeEntries.ts
@@ -1,3 +1,4 @@
+import { withDbTransaction } from '../db/drizzle.ts';
 import type { TimeEntry } from '../repositories/entriesRepo.ts';
 import * as entriesRepo from '../repositories/entriesRepo.ts';
 import * as generalSettingsRepo from '../repositories/generalSettingsRepo.ts';
@@ -6,7 +7,8 @@ import * as tasksRepo from '../repositories/tasksRepo.ts';
 import * as userAssignmentsRepo from '../repositories/userAssignmentsRepo.ts';
 import * as usersRepo from '../repositories/usersRepo.ts';
 import * as workUnitsRepo from '../repositories/workUnitsRepo.ts';
-import { todayLocalDateOnly } from '../utils/date.ts';
+import { formatLocalDateOnly, todayLocalDateOnly } from '../utils/date.ts';
+import { isItalianHoliday } from '../utils/holidays.ts';
 import { generatePrefixedId } from '../utils/order-ids.ts';
 import { hasScopedActionPermission } from '../utils/permissions.ts';
 import {
@@ -250,6 +252,207 @@ export const deleteTimeEntry = async (
 
   await entriesRepo.deleteById(entryId);
   return { message: 'Entry deleted' };
+};
+
+// Recurring time-entry generation.
+//
+// Supported recurrence patterns (matching rules mirrored from the legacy client-side path
+// so existing templates keep producing the same days):
+//
+//   - 'daily'                : every weekday in the window.
+//   - 'weekly'               : same weekday as `recurrence_start`.
+//   - 'monthly'              : same day-of-month as `recurrence_start`.
+//   - 'monthly:<nth>:<dow>'  : Nth (`first`/`second`/`third`/`fourth`/`last`) weekday of
+//                              the month. `dow` is 0=Sun..6=Sat (matches JS `Date.getDay()`).
+//
+// Sundays, configured Saturdays, and Italian holidays are always skipped. Days outside the
+// template's `[recurrence_start, recurrence_end]` window are skipped. Existing entries
+// (matched by date + projectId + task name) are skipped, so re-running is a no-op.
+
+const dateOnlyToLocal = (dateOnly: string): Date => {
+  const [year, month, day] = dateOnly.split('-').map(Number);
+  return new Date(year, month - 1, day);
+};
+
+const recurrenceMatches = (day: Date, pattern: string, start: Date): boolean => {
+  if (pattern === 'daily') return true;
+  if (pattern === 'weekly') return day.getDay() === start.getDay();
+  if (pattern === 'monthly') return day.getDate() === start.getDate();
+  if (pattern.startsWith('monthly:')) {
+    const parts = pattern.split(':');
+    if (parts.length !== 3) return false;
+    const occurrence = parts[1];
+    const targetDow = Number.parseInt(parts[2], 10);
+    if (!Number.isInteger(targetDow) || day.getDay() !== targetDow) return false;
+    const dom = day.getDate();
+    switch (occurrence) {
+      case 'first':
+        return dom <= 7;
+      case 'second':
+        return dom > 7 && dom <= 14;
+      case 'third':
+        return dom > 14 && dom <= 21;
+      case 'fourth':
+        return dom > 21 && dom <= 28;
+      case 'last': {
+        const nextWeek = new Date(day);
+        nextWeek.setDate(day.getDate() + 7);
+        return nextWeek.getMonth() !== day.getMonth();
+      }
+      default:
+        return false;
+    }
+  }
+  return false;
+};
+
+export type GenerateRecurringInput = {
+  fromDate?: unknown;
+  toDate?: unknown;
+  userId?: unknown;
+};
+
+export type GenerateRecurringResult = {
+  generated: TimeEntry[];
+  generatedCount: number;
+  skippedExistingCount: number;
+  range: { fromDate: string; toDate: string };
+};
+
+// Hard cap on the window to avoid pathological generation (the legacy client-side limit
+// extended the window per-template only up to the recurrence end-date; the explicit API
+// makes the caller responsible for the range, so we cap it server-side).
+const MAX_RECURRING_DAYS = 366;
+
+export const generateRecurringEntries = async (
+  actor: AuthenticatedActor,
+  input: GenerateRecurringInput,
+): Promise<GenerateRecurringResult> => {
+  if (!hasPermission(actor, 'timesheets.recurring.create')) {
+    fail(403, 'Insufficient permissions');
+  }
+
+  const fromDate = requireValid(parseDateString(input.fromDate, 'fromDate'));
+  const toDate = requireValid(parseDateString(input.toDate, 'toDate'));
+  if (fromDate > toDate) badRequest('fromDate must be on or before toDate');
+
+  const fromLocal = dateOnlyToLocal(fromDate);
+  const toLocal = dateOnlyToLocal(toDate);
+  const windowDays =
+    Math.round((toLocal.getTime() - fromLocal.getTime()) / (24 * 60 * 60 * 1000)) + 1;
+  if (windowDays > MAX_RECURRING_DAYS) {
+    badRequest(`Date range too large (max ${MAX_RECURRING_DAYS} days)`);
+  }
+
+  const providedUserId = requireValid(optionalNonEmptyString(input.userId, 'userId'));
+  let targetUserId = actor.id;
+  if (providedUserId) {
+    targetUserId = providedUserId;
+    if (targetUserId !== actor.id && !hasPermission(actor, 'timesheets.tracker_all.create')) {
+      const allowed = await workUnitsRepo.isUserManagedBy(actor.id, targetUserId);
+      if (!allowed) fail(403, 'Not authorized to generate entries for this user');
+    }
+  }
+
+  const [recurringTasks, settings, hourlyCost, existingKeys] = await Promise.all([
+    tasksRepo.listRecurringForUser(targetUserId),
+    generalSettingsRepo.get(),
+    usersRepo.findCostPerHour(targetUserId),
+    entriesRepo.findExistingRecurringKeys(targetUserId, fromDate, toDate),
+  ]);
+  if (recurringTasks.length === 0) {
+    return {
+      generated: [],
+      generatedCount: 0,
+      skippedExistingCount: 0,
+      range: { fromDate, toDate },
+    };
+  }
+
+  const treatSaturdayAsHoliday = settings?.treatSaturdayAsHoliday ?? true;
+
+  const uniqueProjectIds = Array.from(new Set(recurringTasks.map((t) => t.projectId)));
+  const projectsByProjectId = await projectsRepo.listNamesByIds(uniqueProjectIds);
+
+  type PendingEntry = ReturnType<typeof buildPendingEntry>;
+  const buildPendingEntry = (
+    task: (typeof recurringTasks)[number],
+    project: NonNullable<ReturnType<typeof projectsByProjectId.get>>,
+    dateStr: string,
+  ) => ({
+    id: generatePrefixedId('te'),
+    userId: targetUserId,
+    date: dateStr,
+    clientId: project.clientId,
+    clientName: project.clientName,
+    projectId: task.projectId,
+    projectName: project.projectName,
+    task: task.name,
+    taskId: task.id,
+    notes: null,
+    duration: task.recurrenceDuration ?? 0,
+    hourlyCost,
+    isPlaceholder: true,
+    location: settings?.defaultLocation ?? 'remote',
+  });
+
+  const pending: PendingEntry[] = [];
+  let skippedExistingCount = 0;
+  // Track keys staged in this run so two recurring templates with the same (date, projectId,
+  // task) tuple don't insert duplicate rows in a single generation pass.
+  const stagedKeys = new Set<string>();
+
+  for (const task of recurringTasks) {
+    if (!task.recurrencePattern) continue;
+    const project = projectsByProjectId.get(task.projectId);
+    if (!project) continue;
+
+    const templateStart = task.recurrenceStart ? dateOnlyToLocal(task.recurrenceStart) : fromLocal;
+    const templateEnd = task.recurrenceEnd ? dateOnlyToLocal(task.recurrenceEnd) : null;
+
+    const iterStart = templateStart > fromLocal ? templateStart : fromLocal;
+    const iterEnd = templateEnd && templateEnd < toLocal ? templateEnd : toLocal;
+    if (iterStart > iterEnd) continue;
+
+    for (
+      const cursor = new Date(iterStart);
+      cursor <= iterEnd;
+      cursor.setDate(cursor.getDate() + 1)
+    ) {
+      const dow = cursor.getDay();
+      if (dow === 0) continue;
+      if (dow === 6 && treatSaturdayAsHoliday) continue;
+      if (isItalianHoliday(cursor)) continue;
+      if (!recurrenceMatches(cursor, task.recurrencePattern, templateStart)) continue;
+
+      const dateStr = formatLocalDateOnly(cursor);
+      const key = `${dateStr}|${task.projectId}|${task.name}`;
+      if (existingKeys.has(key)) {
+        skippedExistingCount += 1;
+        continue;
+      }
+      if (stagedKeys.has(key)) continue;
+      stagedKeys.add(key);
+      pending.push(buildPendingEntry(task, project, dateStr));
+    }
+  }
+
+  if (pending.length === 0) {
+    return {
+      generated: [],
+      generatedCount: 0,
+      skippedExistingCount,
+      range: { fromDate, toDate },
+    };
+  }
+
+  const inserted = await withDbTransaction((tx) => entriesRepo.createMany(pending, tx));
+  return {
+    generated: inserted,
+    generatedCount: inserted.length,
+    skippedExistingCount,
+    range: { fromDate, toDate },
+  };
 };
 
 export const bulkDeleteTimeEntries = async (

--- a/server/test/repositories/entriesRepo.test.ts
+++ b/server/test/repositories/entriesRepo.test.ts
@@ -369,6 +369,39 @@ describe('createMany', () => {
     expect(result[0].id).toBe('e-1');
     expect(result[1].id).toBe('e-2');
   });
+
+  test('chunks inserts at 1000 rows to stay under PG bind-parameter limits', async () => {
+    // 2500 entries -> 3 chunks: 1000 + 1000 + 500.
+    const inputs = Array.from({ length: 2500 }, (_, i) => ({
+      id: `e-${i}`,
+      userId: 'u-1',
+      date: '2026-04-30',
+      clientId: 'c-1',
+      clientName: 'Acme',
+      projectId: 'p-1',
+      projectName: 'Alpha',
+      task: 'Dev',
+      taskId: 't-1',
+      notes: null,
+      duration: 1,
+      hourlyCost: 100,
+      isPlaceholder: true,
+      location: 'remote',
+    }));
+    exec.enqueue({ rows: inputs.slice(0, 1000).map((i) => entryRow({ 0: i.id })) });
+    exec.enqueue({ rows: inputs.slice(1000, 2000).map((i) => entryRow({ 0: i.id })) });
+    exec.enqueue({ rows: inputs.slice(2000, 2500).map((i) => entryRow({ 0: i.id })) });
+
+    const result = await entriesRepo.createMany(inputs, testDb);
+
+    expect(exec.calls).toHaveLength(3);
+    expect(exec.calls[0].params).toHaveLength(14_000);
+    expect(exec.calls[1].params).toHaveLength(14_000);
+    expect(exec.calls[2].params).toHaveLength(7_000);
+    expect(result).toHaveLength(2500);
+    expect(result[0].id).toBe('e-0');
+    expect(result[2499].id).toBe('e-2499');
+  });
 });
 
 describe('findExistingRecurringKeys', () => {

--- a/server/test/repositories/entriesRepo.test.ts
+++ b/server/test/repositories/entriesRepo.test.ts
@@ -313,6 +313,102 @@ describe('create', () => {
   });
 });
 
+describe('createMany', () => {
+  test('returns an empty array without issuing a query for empty input', async () => {
+    const result = await entriesRepo.createMany([], testDb);
+    expect(result).toEqual([]);
+    expect(exec.calls).toHaveLength(0);
+  });
+
+  test('inserts multiple rows in a single query and returns mapped rows', async () => {
+    exec.enqueue({
+      rows: [entryRow(), entryRow({ 0: 'e-2', 2: '2026-05-01' })],
+    });
+    const result = await entriesRepo.createMany(
+      [
+        {
+          id: 'e-1',
+          userId: 'u-1',
+          date: '2026-04-30',
+          clientId: 'c-1',
+          clientName: 'Acme',
+          projectId: 'p-1',
+          projectName: 'Alpha',
+          task: 'Dev',
+          taskId: 't-1',
+          notes: null,
+          duration: 1.5,
+          hourlyCost: 100,
+          isPlaceholder: true,
+          location: 'remote',
+        },
+        {
+          id: 'e-2',
+          userId: 'u-1',
+          date: '2026-05-01',
+          clientId: 'c-1',
+          clientName: 'Acme',
+          projectId: 'p-1',
+          projectName: 'Alpha',
+          task: 'Dev',
+          taskId: 't-1',
+          notes: null,
+          duration: 2,
+          hourlyCost: 100,
+          isPlaceholder: true,
+          location: 'remote',
+        },
+      ],
+      testDb,
+    );
+    // Single INSERT with two value-tuples => 14 params per row * 2 rows.
+    expect(exec.calls).toHaveLength(1);
+    expect(exec.calls[0].params).toHaveLength(28);
+    expect(exec.calls[0].sql).toContain('returning');
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe('e-1');
+    expect(result[1].id).toBe('e-2');
+  });
+});
+
+describe('findExistingRecurringKeys', () => {
+  test('returns a Set keyed by date|projectId|task for matching rows', async () => {
+    // Drizzle returns SELECT rows as positional arrays in projection order:
+    // [date, projectId, task] for our select.
+    exec.enqueue({
+      rows: [
+        ['2026-04-30', 'p-1', 'Dev'],
+        ['2026-05-01', 'p-1', 'Dev'],
+        ['2026-05-02', 'p-2', 'Review'],
+      ],
+    });
+    const result = await entriesRepo.findExistingRecurringKeys(
+      'u-1',
+      '2026-04-30',
+      '2026-05-02',
+      testDb,
+    );
+    expect(result).toEqual(
+      new Set(['2026-04-30|p-1|Dev', '2026-05-01|p-1|Dev', '2026-05-02|p-2|Review']),
+    );
+    expect(exec.calls[0].params).toEqual(['u-1', '2026-04-30', '2026-05-02']);
+    const sql = exec.calls[0].sql;
+    expect(sql).toContain('user_id');
+    expect(sql).toContain('date');
+  });
+
+  test('returns an empty Set when no rows match', async () => {
+    exec.enqueue({ rows: [] });
+    const result = await entriesRepo.findExistingRecurringKeys(
+      'u-1',
+      '2026-04-30',
+      '2026-05-02',
+      testDb,
+    );
+    expect(result.size).toBe(0);
+  });
+});
+
 const newEntry = {
   id: 'e-1',
   userId: 'u-1',

--- a/server/test/repositories/tasksRepo.test.ts
+++ b/server/test/repositories/tasksRepo.test.ts
@@ -87,6 +87,20 @@ describe('listForUser', () => {
   });
 });
 
+describe('listRecurringForUser', () => {
+  test('filters by user_id, is_recurring = true, and is_disabled = false', async () => {
+    exec.enqueue({ rows: [taskRow({ 4: true })] });
+    const result = await tasksRepo.listRecurringForUser('u-1', testDb);
+    expect(result).toHaveLength(1);
+    const sql = exec.calls[0].sql.toLowerCase();
+    expect(sql).toContain('inner join "user_tasks"');
+    expect(sql).toContain('is_recurring');
+    expect(sql).toContain('is_disabled');
+    // user_id is one of the params.
+    expect(exec.calls[0].params).toContain('u-1');
+  });
+});
+
 describe('create', () => {
   test('inserts and returns the mapped row', async () => {
     exec.enqueue({ rows: [taskRow()] });

--- a/server/test/routes/entries.test.ts
+++ b/server/test/routes/entries.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
 import type { FastifyInstance, FastifyPluginAsync } from 'fastify';
+import * as realDrizzle from '../../db/drizzle.ts';
 import * as realEntriesRepo from '../../repositories/entriesRepo.ts';
 import * as realGeneralSettingsRepo from '../../repositories/generalSettingsRepo.ts';
 import * as realProjectsRepo from '../../repositories/projectsRepo.ts';
@@ -25,6 +26,7 @@ const tasksRepoSnap = { ...realTasksRepo };
 const projectsRepoSnap = { ...realProjectsRepo };
 const userAssignmentsRepoSnap = { ...realUserAssignmentsRepo };
 const workUnitsRepoSnap = { ...realWorkUnitsRepo };
+const drizzleSnap = { ...realDrizzle };
 
 // Auth-middleware deps (real authenticateToken runs)
 const findAuthUserByIdMock = mock();
@@ -34,23 +36,28 @@ const getRolePermissionsMock = mock();
 // Route deps
 const findCostPerHourMock = mock();
 const findIdByProjectAndNameMock = mock();
+const listRecurringForUserMock = mock();
 const isUserManagedByMock = mock();
 const generalSettingsGetMock = mock();
 const entriesListAllMock = mock();
 const entriesListForUserMock = mock();
 const entriesListForManagerViewMock = mock();
 const entriesCreateMock = mock();
+const entriesCreateManyMock = mock();
 const entriesUpdateMock = mock();
 const entriesDeleteByIdMock = mock();
 const entriesBulkDeleteMock = mock();
 const entriesFindContextMock = mock();
 const entriesFindOwnerMock = mock();
+const entriesFindExistingRecurringKeysMock = mock();
 const entriesDecodeCursorMock = mock();
 const entriesEncodeCursorMock = mock((c: unknown) => `enc:${JSON.stringify(c)}`);
 const projectsFindClientIdMock = mock();
+const projectsListNamesByIdsMock = mock();
 const isClientAssignedToUserMock = mock();
 const isProjectAssignedToUserMock = mock();
 const isTaskAssignedToUserMock = mock();
+const withDbTransactionMock = mock(async (cb: (tx: unknown) => unknown) => cb(undefined));
 
 let entriesRoutePlugin: FastifyPluginAsync;
 
@@ -75,11 +82,13 @@ beforeAll(async () => {
     listForUser: entriesListForUserMock,
     listForManagerView: entriesListForManagerViewMock,
     create: entriesCreateMock,
+    createMany: entriesCreateManyMock,
     update: entriesUpdateMock,
     deleteById: entriesDeleteByIdMock,
     bulkDelete: entriesBulkDeleteMock,
     findContext: entriesFindContextMock,
     findOwner: entriesFindOwnerMock,
+    findExistingRecurringKeys: entriesFindExistingRecurringKeysMock,
     decodeCursor: entriesDecodeCursorMock,
     encodeCursor: entriesEncodeCursorMock,
   }));
@@ -90,10 +99,16 @@ beforeAll(async () => {
   mock.module('../../repositories/tasksRepo.ts', () => ({
     ...tasksRepoSnap,
     findIdByProjectAndName: findIdByProjectAndNameMock,
+    listRecurringForUser: listRecurringForUserMock,
   }));
   mock.module('../../repositories/projectsRepo.ts', () => ({
     ...projectsRepoSnap,
     findClientId: projectsFindClientIdMock,
+    listNamesByIds: projectsListNamesByIdsMock,
+  }));
+  mock.module('../../db/drizzle.ts', () => ({
+    ...drizzleSnap,
+    withDbTransaction: withDbTransactionMock,
   }));
   mock.module('../../repositories/userAssignmentsRepo.ts', () => ({
     ...userAssignmentsRepoSnap,
@@ -120,6 +135,7 @@ afterAll(() => {
   mock.module('../../repositories/projectsRepo.ts', () => projectsRepoSnap);
   mock.module('../../repositories/userAssignmentsRepo.ts', () => userAssignmentsRepoSnap);
   mock.module('../../repositories/workUnitsRepo.ts', () => workUnitsRepoSnap);
+  mock.module('../../db/drizzle.ts', () => drizzleSnap);
 });
 
 const HAPPY_USER = {
@@ -164,22 +180,27 @@ const allMocks = [
   getRolePermissionsMock,
   findCostPerHourMock,
   findIdByProjectAndNameMock,
+  listRecurringForUserMock,
   isUserManagedByMock,
   generalSettingsGetMock,
   entriesListAllMock,
   entriesListForUserMock,
   entriesListForManagerViewMock,
   entriesCreateMock,
+  entriesCreateManyMock,
   entriesUpdateMock,
   entriesDeleteByIdMock,
   entriesBulkDeleteMock,
   entriesFindContextMock,
   entriesFindOwnerMock,
+  entriesFindExistingRecurringKeysMock,
   entriesDecodeCursorMock,
   projectsFindClientIdMock,
+  projectsListNamesByIdsMock,
   isClientAssignedToUserMock,
   isProjectAssignedToUserMock,
   isTaskAssignedToUserMock,
+  withDbTransactionMock,
 ];
 
 let testApp: FastifyInstance;
@@ -188,6 +209,11 @@ beforeEach(async () => {
   for (const m of allMocks) m.mockReset();
   // encodeCursor remains stable across tests
   entriesEncodeCursorMock.mockImplementation((c: unknown) => `enc:${JSON.stringify(c)}`);
+  // Pass-through transaction by default so service-level `withDbTransaction` invocations
+  // forward to the (mocked) repo without trying to open a real DB connection.
+  withDbTransactionMock.mockImplementation(
+    async (cb: (tx: unknown) => unknown) => await cb(undefined),
+  );
 
   findAuthUserByIdMock.mockResolvedValue(HAPPY_USER);
   userHasRoleMock.mockResolvedValue(true);
@@ -784,6 +810,376 @@ describe('DELETE /api/entries/:id', () => {
 
     expect(res.statusCode).toBe(403);
     expect(JSON.parse(res.body)).toEqual({ error: 'Not authorized to delete this entry' });
+  });
+});
+
+describe('POST /api/entries/recurring/generate', () => {
+  const RECURRING_PERMS = [
+    'timesheets.tracker.view',
+    'timesheets.recurring.view',
+    'timesheets.recurring.create',
+  ];
+
+  // Sample template: a daily recurring task assigned to u1 with no end date.
+  const dailyTask = {
+    id: 't1',
+    name: 'Daily standup',
+    projectId: 'p1',
+    description: null,
+    isRecurring: true,
+    recurrencePattern: 'daily',
+    recurrenceStart: '2025-06-02', // Monday
+    recurrenceEnd: undefined,
+    recurrenceDuration: 0.5,
+    expectedEffort: undefined,
+    monthlyEffort: undefined,
+    revenue: undefined,
+    notes: undefined,
+    isDisabled: false,
+    createdAt: 1_700_000_000_000,
+    billingType: 'time_and_materials',
+    billingFrequency: 'monthly',
+  };
+
+  const weeklyTask = {
+    ...dailyTask,
+    id: 't2',
+    name: 'Weekly review',
+    recurrencePattern: 'weekly',
+    recurrenceStart: '2025-06-02', // Monday -> only Mondays match
+  };
+
+  const monthlyFirstMondayTask = {
+    ...dailyTask,
+    id: 't3',
+    name: 'Monthly kickoff',
+    recurrencePattern: 'monthly:first:1', // first Monday of the month
+    recurrenceStart: '2025-06-01',
+  };
+
+  const endedTask = {
+    ...dailyTask,
+    id: 't4',
+    name: 'Sunsetting task',
+    recurrencePattern: 'daily',
+    recurrenceStart: '2025-06-02',
+    recurrenceEnd: '2025-06-04', // Mon..Wed only
+  };
+
+  const happyProjectsMap = new Map([
+    ['p1', { projectName: 'Project One', clientId: 'c1', clientName: 'Client One' }],
+  ]);
+
+  const setupHappyPath = () => {
+    getRolePermissionsMock.mockResolvedValue(RECURRING_PERMS);
+    findCostPerHourMock.mockResolvedValue(40);
+    generalSettingsGetMock.mockResolvedValue({
+      treatSaturdayAsHoliday: true,
+      defaultLocation: 'remote',
+    });
+    listRecurringForUserMock.mockResolvedValue([dailyTask]);
+    projectsListNamesByIdsMock.mockResolvedValue(happyProjectsMap);
+    entriesFindExistingRecurringKeysMock.mockResolvedValue(new Set<string>());
+    entriesCreateManyMock.mockImplementation(async (rows: Array<Record<string, unknown>>) =>
+      rows.map((r) => ({ ...r, createdAt: 1_700_000_000_000 })),
+    );
+  };
+
+  test('200: generates a daily template across a Mon-Fri window', async () => {
+    setupHappyPath();
+
+    // Use 2025-06-09..2025-06-13 (Mon..Fri, no Italian holidays in this range).
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/entries/recurring/generate',
+      headers: authHeader(),
+      payload: { fromDate: '2025-06-09', toDate: '2025-06-13' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.generatedCount).toBe(5);
+    expect(body.skippedExistingCount).toBe(0);
+    expect(body.range).toEqual({ fromDate: '2025-06-09', toDate: '2025-06-13' });
+    expect(entriesCreateManyMock).toHaveBeenCalledTimes(1);
+
+    const inserted = entriesCreateManyMock.mock.calls[0][0] as Array<Record<string, unknown>>;
+    expect(inserted.map((e) => e.date)).toEqual([
+      '2025-06-09',
+      '2025-06-10',
+      '2025-06-11',
+      '2025-06-12',
+      '2025-06-13',
+    ]);
+    for (const entry of inserted) {
+      expect(entry).toMatchObject({
+        userId: 'u1',
+        clientId: 'c1',
+        clientName: 'Client One',
+        projectId: 'p1',
+        projectName: 'Project One',
+        task: 'Daily standup',
+        taskId: 't1',
+        duration: 0.5,
+        hourlyCost: 40,
+        isPlaceholder: true,
+        location: 'remote',
+      });
+    }
+  });
+
+  test('200: skips Saturdays/Sundays and Italian holidays', async () => {
+    setupHappyPath();
+    // 2025-06-02 (Mon, Festa della Repubblica - Italian holiday) is skipped.
+    // 2025-06-07 (Sat) and 2025-06-08 (Sun) are skipped.
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/entries/recurring/generate',
+      headers: authHeader(),
+      payload: { fromDate: '2025-06-02', toDate: '2025-06-08' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const inserted = entriesCreateManyMock.mock.calls[0][0] as Array<Record<string, unknown>>;
+    // Holiday on 06-02 (Repubblica), then Tue-Fri (06-03..06-06) = 4 days
+    expect(inserted.map((e) => e.date)).toEqual([
+      '2025-06-03',
+      '2025-06-04',
+      '2025-06-05',
+      '2025-06-06',
+    ]);
+  });
+
+  test('200: is idempotent - existing keys are skipped', async () => {
+    setupHappyPath();
+    // Pretend 06-10 and 06-11 already exist.
+    entriesFindExistingRecurringKeysMock.mockResolvedValue(
+      new Set(['2025-06-10|p1|Daily standup', '2025-06-11|p1|Daily standup']),
+    );
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/entries/recurring/generate',
+      headers: authHeader(),
+      payload: { fromDate: '2025-06-09', toDate: '2025-06-13' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    // 5 weekdays total, 2 existing -> 3 new
+    expect(body.generatedCount).toBe(3);
+    expect(body.skippedExistingCount).toBe(2);
+    const inserted = entriesCreateManyMock.mock.calls[0][0] as Array<Record<string, unknown>>;
+    expect(inserted.map((e) => e.date)).toEqual(['2025-06-09', '2025-06-12', '2025-06-13']);
+  });
+
+  test('200: weekly pattern only matches the start weekday', async () => {
+    setupHappyPath();
+    listRecurringForUserMock.mockResolvedValue([weeklyTask]);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/entries/recurring/generate',
+      headers: authHeader(),
+      payload: { fromDate: '2025-06-02', toDate: '2025-06-15' }, // 2 Mondays
+    });
+
+    expect(res.statusCode).toBe(200);
+    const inserted = entriesCreateManyMock.mock.calls[0][0] as Array<Record<string, unknown>>;
+    // Mondays in window: 06-02 (holiday, skipped), 06-09. 06-15 is Sunday.
+    expect(inserted.map((e) => e.date)).toEqual(['2025-06-09']);
+  });
+
+  test('200: monthly:first:1 only matches the first Monday', async () => {
+    setupHappyPath();
+    listRecurringForUserMock.mockResolvedValue([monthlyFirstMondayTask]);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/entries/recurring/generate',
+      headers: authHeader(),
+      payload: { fromDate: '2025-06-01', toDate: '2025-08-31' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const inserted = entriesCreateManyMock.mock.calls[0][0] as Array<Record<string, unknown>>;
+    // First Mondays of Jun/Jul/Aug 2025: 06-02 (Repubblica holiday -> skipped), 07-07, 08-04.
+    expect(inserted.map((e) => e.date)).toEqual(['2025-07-07', '2025-08-04']);
+  });
+
+  test('200: respects recurrenceEnd', async () => {
+    setupHappyPath();
+    listRecurringForUserMock.mockResolvedValue([endedTask]);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/entries/recurring/generate',
+      headers: authHeader(),
+      payload: { fromDate: '2025-06-02', toDate: '2025-06-10' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const inserted = entriesCreateManyMock.mock.calls[0][0] as Array<Record<string, unknown>>;
+    // recurrenceEnd is 2025-06-04. 06-02 is a holiday, so only 06-03 and 06-04 remain.
+    expect(inserted.map((e) => e.date)).toEqual(['2025-06-03', '2025-06-04']);
+  });
+
+  test('200: empty when no recurring templates exist', async () => {
+    setupHappyPath();
+    listRecurringForUserMock.mockResolvedValue([]);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/entries/recurring/generate',
+      headers: authHeader(),
+      payload: { fromDate: '2025-06-02', toDate: '2025-06-06' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({
+      generated: [],
+      generatedCount: 0,
+      skippedExistingCount: 0,
+      range: { fromDate: '2025-06-02', toDate: '2025-06-06' },
+    });
+    expect(entriesCreateManyMock).not.toHaveBeenCalled();
+  });
+
+  test('400: fromDate after toDate', async () => {
+    setupHappyPath();
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/entries/recurring/generate',
+      headers: authHeader(),
+      payload: { fromDate: '2025-06-10', toDate: '2025-06-02' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({ error: 'fromDate must be on or before toDate' });
+    expect(entriesCreateManyMock).not.toHaveBeenCalled();
+  });
+
+  test('400: rejects an oversized window', async () => {
+    setupHappyPath();
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/entries/recurring/generate',
+      headers: authHeader(),
+      payload: { fromDate: '2024-01-01', toDate: '2026-12-31' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/Date range too large/);
+  });
+
+  test('403: missing timesheets.recurring.create permission', async () => {
+    getRolePermissionsMock.mockResolvedValue(['timesheets.tracker.view']);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/entries/recurring/generate',
+      headers: authHeader(),
+      payload: { fromDate: '2025-06-02', toDate: '2025-06-06' },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Insufficient permissions' });
+    expect(listRecurringForUserMock).not.toHaveBeenCalled();
+  });
+
+  test('403: cross-user generation without manager link or tracker_all.create', async () => {
+    getRolePermissionsMock.mockResolvedValue(RECURRING_PERMS);
+    isUserManagedByMock.mockResolvedValue(false);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/entries/recurring/generate',
+      headers: authHeader(),
+      payload: { fromDate: '2025-06-02', toDate: '2025-06-06', userId: 'u2' },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'Not authorized to generate entries for this user',
+    });
+    expect(listRecurringForUserMock).not.toHaveBeenCalled();
+  });
+
+  test('200: cross-user generation as manager of the target', async () => {
+    setupHappyPath();
+    isUserManagedByMock.mockResolvedValue(true);
+    listRecurringForUserMock.mockResolvedValue([dailyTask]);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/entries/recurring/generate',
+      headers: authHeader(),
+      payload: { fromDate: '2025-06-03', toDate: '2025-06-03', userId: 'u2' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(listRecurringForUserMock).toHaveBeenCalledWith('u2');
+    expect(findCostPerHourMock).toHaveBeenCalledWith('u2');
+    const inserted = entriesCreateManyMock.mock.calls[0][0] as Array<Record<string, unknown>>;
+    expect(inserted[0].userId).toBe('u2');
+  });
+
+  test('400: invalid YYYY-MM-DD body is rejected by the schema layer', async () => {
+    setupHappyPath();
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/entries/recurring/generate',
+      headers: authHeader(),
+      payload: { fromDate: 'not-a-date', toDate: '2025-06-06' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(entriesCreateManyMock).not.toHaveBeenCalled();
+  });
+
+  test('200: re-running the same window is a no-op (idempotent end-to-end)', async () => {
+    setupHappyPath();
+
+    // First call - generate 5 entries.
+    const first = await testApp.inject({
+      method: 'POST',
+      url: '/api/entries/recurring/generate',
+      headers: authHeader(),
+      payload: { fromDate: '2025-06-09', toDate: '2025-06-13' }, // Mon..Fri (no holidays)
+    });
+    expect(first.statusCode).toBe(200);
+    expect(JSON.parse(first.body).generatedCount).toBe(5);
+
+    // Second call - the keys repo now returns the previously inserted set.
+    entriesCreateManyMock.mockReset();
+    entriesCreateManyMock.mockImplementation(async (rows: Array<Record<string, unknown>>) =>
+      rows.map((r) => ({ ...r, createdAt: 1_700_000_000_000 })),
+    );
+    entriesFindExistingRecurringKeysMock.mockResolvedValue(
+      new Set([
+        '2025-06-09|p1|Daily standup',
+        '2025-06-10|p1|Daily standup',
+        '2025-06-11|p1|Daily standup',
+        '2025-06-12|p1|Daily standup',
+        '2025-06-13|p1|Daily standup',
+      ]),
+    );
+
+    const second = await testApp.inject({
+      method: 'POST',
+      url: '/api/entries/recurring/generate',
+      headers: authHeader(),
+      payload: { fromDate: '2025-06-09', toDate: '2025-06-13' },
+    });
+    expect(second.statusCode).toBe(200);
+    const body = JSON.parse(second.body);
+    expect(body.generatedCount).toBe(0);
+    expect(body.skippedExistingCount).toBe(5);
+    expect(entriesCreateManyMock).not.toHaveBeenCalled();
   });
 });
 

--- a/server/test/routes/entries.test.ts
+++ b/server/test/routes/entries.test.ts
@@ -57,6 +57,9 @@ const projectsListNamesByIdsMock = mock();
 const isClientAssignedToUserMock = mock();
 const isProjectAssignedToUserMock = mock();
 const isTaskAssignedToUserMock = mock();
+const filterAssignedClientIdsMock = mock();
+const filterAssignedProjectIdsMock = mock();
+const filterAssignedTaskIdsMock = mock();
 const withDbTransactionMock = mock(async (cb: (tx: unknown) => unknown) => cb(undefined));
 
 let entriesRoutePlugin: FastifyPluginAsync;
@@ -115,6 +118,9 @@ beforeAll(async () => {
     isClientAssignedToUser: isClientAssignedToUserMock,
     isProjectAssignedToUser: isProjectAssignedToUserMock,
     isTaskAssignedToUser: isTaskAssignedToUserMock,
+    filterAssignedClientIds: filterAssignedClientIdsMock,
+    filterAssignedProjectIds: filterAssignedProjectIdsMock,
+    filterAssignedTaskIds: filterAssignedTaskIdsMock,
   }));
   mock.module('../../repositories/workUnitsRepo.ts', () => ({
     ...workUnitsRepoSnap,
@@ -200,6 +206,9 @@ const allMocks = [
   isClientAssignedToUserMock,
   isProjectAssignedToUserMock,
   isTaskAssignedToUserMock,
+  filterAssignedClientIdsMock,
+  filterAssignedProjectIdsMock,
+  filterAssignedTaskIdsMock,
   withDbTransactionMock,
 ];
 
@@ -222,6 +231,16 @@ beforeEach(async () => {
   isClientAssignedToUserMock.mockResolvedValue(true);
   isProjectAssignedToUserMock.mockResolvedValue(true);
   isTaskAssignedToUserMock.mockResolvedValue(true);
+  // Bulk filters default to "everything is assigned" so happy-path recurring tests pass.
+  filterAssignedClientIdsMock.mockImplementation(
+    async (_userId: string, ids: string[]) => new Set(ids),
+  );
+  filterAssignedProjectIdsMock.mockImplementation(
+    async (_userId: string, ids: string[]) => new Set(ids),
+  );
+  filterAssignedTaskIdsMock.mockImplementation(
+    async (_userId: string, ids: string[]) => new Set(ids),
+  );
 
   testApp = await buildRouteTestApp(entriesRoutePlugin, '/api/entries');
 });
@@ -1180,6 +1199,70 @@ describe('POST /api/entries/recurring/generate', () => {
     expect(body.generatedCount).toBe(0);
     expect(body.skippedExistingCount).toBe(5);
     expect(entriesCreateManyMock).not.toHaveBeenCalled();
+  });
+
+  test('200: filters out a recurring task whose client assignment was revoked', async () => {
+    setupHappyPath();
+    // `listRecurringForUser` still returns the task (stale user_tasks row), but the
+    // user no longer has the client assignment - the recurring path must re-apply the
+    // same checks `createTimeEntry` runs and skip this template.
+    filterAssignedClientIdsMock.mockResolvedValue(new Set<string>());
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/entries/recurring/generate',
+      headers: authHeader(),
+      payload: { fromDate: '2025-06-09', toDate: '2025-06-13' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.generatedCount).toBe(0);
+    expect(body.skippedExistingCount).toBe(0);
+    expect(entriesCreateManyMock).not.toHaveBeenCalled();
+    expect(filterAssignedClientIdsMock).toHaveBeenCalledWith('u1', ['c1']);
+    expect(filterAssignedProjectIdsMock).toHaveBeenCalledWith('u1', ['p1']);
+    expect(filterAssignedTaskIdsMock).toHaveBeenCalledWith('u1', ['t1']);
+  });
+
+  test('200: filters out a recurring task whose project assignment was revoked', async () => {
+    setupHappyPath();
+    filterAssignedProjectIdsMock.mockResolvedValue(new Set<string>());
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/entries/recurring/generate',
+      headers: authHeader(),
+      payload: { fromDate: '2025-06-09', toDate: '2025-06-13' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).generatedCount).toBe(0);
+    expect(entriesCreateManyMock).not.toHaveBeenCalled();
+  });
+
+  test('200: tracker_all.create bypasses the per-assignment filter', async () => {
+    setupHappyPath();
+    getRolePermissionsMock.mockResolvedValue([...RECURRING_PERMS, 'timesheets.tracker_all.create']);
+    // Even with all bulk filters returning empty, an admin-scope actor should still
+    // generate entries because the filter step is skipped.
+    filterAssignedClientIdsMock.mockResolvedValue(new Set<string>());
+    filterAssignedProjectIdsMock.mockResolvedValue(new Set<string>());
+    filterAssignedTaskIdsMock.mockResolvedValue(new Set<string>());
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/entries/recurring/generate',
+      headers: authHeader(),
+      payload: { fromDate: '2025-06-09', toDate: '2025-06-13' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).generatedCount).toBe(5);
+    expect(entriesCreateManyMock).toHaveBeenCalledTimes(1);
+    expect(filterAssignedClientIdsMock).not.toHaveBeenCalled();
+    expect(filterAssignedProjectIdsMock).not.toHaveBeenCalled();
+    expect(filterAssignedTaskIdsMock).not.toHaveBeenCalled();
   });
 });
 

--- a/server/test/utils/holidays.test.ts
+++ b/server/test/utils/holidays.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'bun:test';
+import { getEaster, isItalianHoliday } from '../../utils/holidays.ts';
+
+describe('server isItalianHoliday', () => {
+  test('Capodanno (January 1)', () => {
+    expect(isItalianHoliday(new Date(2025, 0, 1))).toBe('Capodanno');
+  });
+
+  test('Festa della Repubblica (June 2)', () => {
+    expect(isItalianHoliday(new Date(2025, 5, 2))).toBe('Repubblica');
+  });
+
+  test('Natale (December 25)', () => {
+    expect(isItalianHoliday(new Date(2025, 11, 25))).toBe('Natale');
+  });
+
+  test('non-holiday weekday returns null', () => {
+    // 2025-06-10 is a Tuesday, no Italian holiday
+    expect(isItalianHoliday(new Date(2025, 5, 10))).toBeNull();
+  });
+
+  test("computes Easter and Lunedì dell'Angelo correctly for 2025", () => {
+    // Easter 2025 is April 20
+    const easter = getEaster(2025);
+    expect(easter.getFullYear()).toBe(2025);
+    expect(easter.getMonth()).toBe(3);
+    expect(easter.getDate()).toBe(20);
+
+    expect(isItalianHoliday(new Date(2025, 3, 20))).toBe('Pasqua');
+    expect(isItalianHoliday(new Date(2025, 3, 21))).toBe("Lunedì dell'Angelo");
+  });
+});

--- a/server/utils/date.ts
+++ b/server/utils/date.ts
@@ -12,6 +12,11 @@ export const formatLocalDateOnly = (date: Date) => {
   return `${year}-${month}-${day}`;
 };
 
+export const parseLocalDateOnly = (dateOnly: string): Date => {
+  const [year, month, day] = dateOnly.split('-').map(Number);
+  return new Date(year, month - 1, day);
+};
+
 export const normalizeNullableDateOnly = (value: unknown, fieldName: string) => {
   if (value === undefined || value === null) return null;
   if (value instanceof Date) return formatLocalDateOnly(value);

--- a/server/utils/holidays.ts
+++ b/server/utils/holidays.ts
@@ -1,0 +1,56 @@
+/**
+ * Italian Holiday Logic (Anonymous Algorithm for Easter)
+ *
+ * Server-side mirror of the frontend `utils/holidays.ts`. The recurring-entry
+ * generator skips fixed and dynamic Italian holidays the same way the timesheet
+ * UI does, so the two implementations must stay in sync.
+ */
+
+export const getEaster = (year: number): Date => {
+  const floor = Math.floor;
+  const G = year % 19;
+  const C = floor(year / 100);
+  const H = (C - floor(C / 4) - floor((8 * C + 13) / 25) + 19 * G + 15) % 30;
+  const I = H - floor(H / 28) * (1 - floor(29 / (H + 1)) * floor((21 - G) / 11));
+  const J = (year + floor(year / 4) + I + 2 - C + floor(C / 4)) % 7;
+  const L = I - J;
+  const month = 3 + floor((L + 40) / 44);
+  const day = L + 28 - 31 * floor(month / 4);
+  return new Date(year, month - 1, day);
+};
+
+const FIXED_HOLIDAYS: Record<string, string> = {
+  '1-1': 'Capodanno',
+  '1-6': 'Epifania',
+  '4-25': 'Liberazione',
+  '5-1': 'Lavoro',
+  '6-2': 'Repubblica',
+  '8-15': 'Ferragosto',
+  '11-1': 'Ognissanti',
+  '12-8': 'Immacolata',
+  '12-25': 'Natale',
+  '12-26': 'S. Stefano',
+};
+
+const isSameDay = (a: Date, b: Date) =>
+  a.getFullYear() === b.getFullYear() &&
+  a.getMonth() === b.getMonth() &&
+  a.getDate() === b.getDate();
+
+export const isItalianHoliday = (date: Date): string | null => {
+  const d = date.getDate();
+  const m = date.getMonth() + 1;
+  const y = date.getFullYear();
+
+  const fixedKey = `${m}-${d}`;
+  if (FIXED_HOLIDAYS[fixedKey]) return FIXED_HOLIDAYS[fixedKey];
+
+  const easter = getEaster(y);
+  if (isSameDay(date, easter)) return 'Pasqua';
+
+  const easterMonday = new Date(easter);
+  easterMonday.setDate(easter.getDate() + 1);
+  if (isSameDay(date, easterMonday)) return "Lunedì dell'Angelo";
+
+  return null;
+};

--- a/services/api/entries.ts
+++ b/services/api/entries.ts
@@ -7,6 +7,13 @@ export type EntriesPage = {
   nextCursor: string | null;
 };
 
+export type GenerateRecurringResponse = {
+  generated: TimeEntry[];
+  generatedCount: number;
+  skippedExistingCount: number;
+  range: { fromDate: string; toDate: string };
+};
+
 export const entriesApi = {
   listPage: async (
     options: { userId?: string; cursor?: string | null; limit?: number } = {},
@@ -42,5 +49,21 @@ export const entriesApi = {
     if (options?.futureOnly) params.append('futureOnly', 'true');
     if (options?.placeholderOnly) params.append('placeholderOnly', 'true');
     return fetchApi(`/entries?${params.toString()}`, { method: 'DELETE' });
+  },
+
+  /**
+   * Materialize recurring task templates into placeholder time entries server-side.
+   * Idempotent: re-running with the same window does not create duplicates.
+   */
+  generateRecurring: async (input: {
+    fromDate: string;
+    toDate: string;
+    userId?: string;
+  }): Promise<GenerateRecurringResponse> => {
+    const result = await fetchApi<GenerateRecurringResponse>('/entries/recurring/generate', {
+      method: 'POST',
+      body: JSON.stringify(input),
+    });
+    return { ...result, generated: result.generated.map(normalizeTimeEntry) };
   },
 };

--- a/test/handlers/taskHandlers.test.ts
+++ b/test/handlers/taskHandlers.test.ts
@@ -93,13 +93,6 @@ describe('makeTaskHandlers.makeRecurring', () => {
     expect(updates.recurrenceEnd).toBe('2026-12-01');
     expect(updates.recurrenceDuration).toBe(8);
     expect(generateSpy).toHaveBeenCalledTimes(1);
-    // The recurring generator must receive the freshly-updated task list, not a
-    // stale snapshot — otherwise the just-made-recurring task is invisible.
-    const passedTasks = generateSpy.mock.calls[0]?.[0] as TaskLike[] | undefined;
-    expect(passedTasks).toBeDefined();
-    const updatedTask = passedTasks?.find((t) => t.id === 't1');
-    expect(updatedTask?.isRecurring).toBe(true);
-    expect(updatedTask?.recurrencePattern).toBe('weekly');
   });
 
   test('regenerates synchronously without a setTimeout race', async () => {
@@ -124,46 +117,6 @@ describe('makeTaskHandlers.makeRecurring', () => {
 
     // After the awaited makeRecurring resolves, regeneration must have already fired.
     expect(generateSpy).toHaveBeenCalledTimes(1);
-  });
-
-  test('passes the updated task list (not stale closure) to generateRecurringEntries', async () => {
-    // Regression: when makeTaskHandlers is built from a snapshot of projectTasks that
-    // lacks the new task, the old code relied on closure and used the stale list.
-    // The fix passes the explicit `nextTasks` array, so the just-updated task is visible.
-    apiMocks.tasksUpdate.mockImplementation((id: string, updates: unknown) =>
-      Promise.resolve({
-        id,
-        name: 'fresh-task',
-        projectId: 'p1',
-        isRecurring: true,
-        ...(updates as object),
-      }),
-    );
-    // Simulate: handlers were built while only an older task existed; the fresh task
-    // (`fresh-task`) was just added to state but the closure here still sees it because
-    // makeRecurring uses the deps snapshot. After updating `fresh-task` to recurring,
-    // the generator must see the updated version.
-    const tasksList: TaskLike[] = [
-      { id: 't-old', name: 'old', projectId: 'p1', isRecurring: false },
-      { id: 't-new', name: 'fresh-task', projectId: 'p1', isRecurring: false },
-    ];
-    const tasks = makeStubSetter<TaskLike>(tasksList);
-    const generateSpy = mock((_tasks?: unknown) => Promise.resolve());
-    const handlers = makeTaskHandlers({
-      projectTasks: tasks.get() as never,
-      setProjectTasks: tasks.setter,
-      setEntries: makeStubSetter<EntryLike>([]).setter,
-      generateRecurringEntries: generateSpy as never,
-    });
-
-    await handlers.makeRecurring('t-new', 'weekly', '2026-05-01');
-
-    const passedTasks = generateSpy.mock.calls[0]?.[0] as TaskLike[] | undefined;
-    expect(passedTasks).toBeDefined();
-    expect(passedTasks?.length).toBe(2);
-    const newTask = passedTasks?.find((t) => t.id === 't-new');
-    expect(newTask?.isRecurring).toBe(true);
-    expect(newTask?.recurrencePattern).toBe('weekly');
   });
 
   test('does not clobber a concurrent task add that lands during the api update await', async () => {
@@ -216,10 +169,7 @@ describe('makeTaskHandlers.makeRecurring', () => {
     expect(finalTasks.find((t) => t.id === 't1')?.isRecurring).toBe(true);
     expect(finalTasks.find((t) => t.id === 't2')?.name).toBe('added-concurrently');
 
-    // generateRecurringEntries should still receive the full list (both tasks).
-    const passedTasks = generateSpy.mock.calls[0]?.[0] as TaskLike[] | undefined;
-    expect(passedTasks?.length).toBe(2);
-    expect(passedTasks?.find((t) => t.id === 't2')).toBeDefined();
+    expect(generateSpy).toHaveBeenCalledTimes(1);
   });
 
   test('editing already-recurring task: clears placeholder entries before update', async () => {


### PR DESCRIPTION
## Summary
- Introduces a new server-side endpoint `POST /api/entries/recurring/generate` that materializes recurring task templates into placeholder time entries. The legacy client-side loop in `App.tsx` (one create per matching day, repeated every login) is replaced by a single server call that batches inserts in a single transaction and skips already-generated days.
- Matching rules are preserved 1:1 (daily / weekly / monthly / `monthly:<nth>:<dow>`), as is the holiday/weekend filtering (Sundays, Saturdays when `treatSaturdayAsHoliday` is set, Italian holidays).
- Guarded by `timesheets.recurring.create`. Cross-user generation requires either the work-unit management link or `timesheets.tracker_all.create`.

## Implementation notes
- New service: `server/services/timeEntries.ts#generateRecurringEntries` — validates input, fetches recurring templates + project metadata + existing keys in parallel, builds the pending rows, and inserts them inside `withDbTransaction`.
- New repo helpers: `tasksRepo.listRecurringForUser`, `projectsRepo.listNamesByIds`, `entriesRepo.findExistingRecurringKeys`, `entriesRepo.createMany`.
- Server-side mirror of the frontend Italian-holiday calendar (`server/utils/holidays.ts`) keeps the skip logic consistent without cross-importing across the frontend/backend boundary.
- Window capped at 366 days per call.
- Idempotency is enforced via `(date, projectId, task)` keys looked up once and de-duplicated within a single run.
- Frontend `App.tsx#generateRecurringEntries` and the `services/api/entries.ts` client now delegate to the new endpoint.

## Manual verification
1) Create a recurring task (daily, Mon-Fri).
2) Hit `POST /api/entries/recurring/generate` with `{ "fromDate": "2026-01-05", "toDate": "2026-01-16" }`.
3) Verify the expected `time_entries` rows are created in `/api/entries` and visible in the tracker (weekdays only).
4) Re-hit the same endpoint with the same range — verify `generatedCount: 0`, `skippedExistingCount > 0`, no duplicates.

## Test plan
- [x] `bun run test` (frontend + backend, 3086 tests, 0 fail)
- [x] `bun run lint` (only pre-existing warnings)
- [x] `cd server && bun run build` (clean)
- [x] New tests cover: happy-path generation, idempotency, day-mask (weekly), monthly:first:1 pattern, recurrenceEnd respected, holiday skip, permission gating, cross-user manager case, oversize-window rejection.

Closes Unit 16 of the codebase-issue parallel rollout (Medium B8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)