### PR TITLE
feat(reports): time-entry cost calculation + report aggregations

### DIFF
--- a/docs-site/src/content/docs/ai-reporting.md
+++ b/docs-site/src/content/docs/ai-reporting.md
@@ -23,6 +23,17 @@ Usa i risultati come supporto all'analisi, non come sostituto dei dati ufficiali
 - Controlla sempre importi, date e riferimenti citati nella risposta.
 - Riformula la domanda se la risposta è troppo generica.
 
+## Costi nei report
+
+Praetor calcola il costo di ogni voce di consuntivo come `durata * costo orario` con la stessa precisione decimale usata per le fatture. Il costo orario salvato sulla voce è quello in vigore al momento dell'inserimento, quindi le modifiche retroattive al costo orario di un dipendente non riscrivono lo storico.
+
+Gli aggregati di costo per progetto, cliente, utente e periodo sono inclusi nei dataset di AI reporting solo se il tuo ruolo ha il permesso `reports.cost`. Senza questo permesso:
+
+- Il campo `cost` viene rimosso dalle voci di consuntivo restituite dall'API.
+- I totali e i top per costo vengono omessi dai dataset di AI reporting; restano disponibili le ore e il numero di voci.
+
+Per concedere o revocare la visibilità dei costi, modifica il ruolo in Amministrazione > Ruoli e abilita o disabilita la voce "Reports > Cost reports".
+
 ## Accesso MCP per agenti esterni
 
 Praetor espone un endpoint MCP remoto su `/api/mcp` per agenti compatibili con Model Context Protocol. Gli agenti devono autenticarsi con un token MCP personale, creato da Impostazioni > Token MCP.

--- a/docs-site/src/content/docs/en/ai-reporting.md
+++ b/docs-site/src/content/docs/en/ai-reporting.md
@@ -23,6 +23,17 @@ Use results as analytical support, not as a replacement for official data. Befor
 - Always verify amounts, dates, and references mentioned in the answer.
 - Rephrase the question if the answer is too generic.
 
+## Cost in reports
+
+Praetor computes the cost of each time entry as `duration * hourly cost`, using the same currency precision as invoices. The hourly cost stored on the entry is the rate that was in effect when the entry was logged, so retroactive changes to a user's hourly cost do not rewrite history.
+
+Cost aggregates per project, client, user, and period are included in AI reporting datasets only when your role has the `reports.cost` permission. Without it:
+
+- The `cost` field is stripped from time entries returned by the API.
+- Cost totals and "top by cost" lists are omitted from AI reporting datasets; hours and entry counts remain available.
+
+To grant or revoke cost visibility, edit the role in Administration > Roles and toggle the "Reports > Cost reports" entry.
+
 ## MCP Access For External Agents
 
 Praetor exposes a remote MCP endpoint at `/api/mcp` for Model Context Protocol compatible agents. Agents must authenticate with a personal MCP token created from Settings > MCP Tokens.

--- a/locales/en/administration.json
+++ b/locales/en/administration.json
@@ -62,7 +62,8 @@
       "work_units_all": "Work Units (All)"
     },
     "reports": {
-      "ai_reporting": "AI Reporting"
+      "ai_reporting": "AI Reporting",
+      "cost": "Cost reports"
     },
     "configuration": {
       "authentication": "Authentication",

--- a/locales/en/reports.json
+++ b/locales/en/reports.json
@@ -1,4 +1,8 @@
 {
+  "cost": "Cost",
+  "costTotal": "Total cost",
+  "costPerHour": "Hourly cost",
+  "costPermissionRequired": "Cost data is hidden because your role does not have the 'reports.cost' permission.",
   "aiReporting": {
     "newChat": "New Chat",
     "session": "Session",

--- a/locales/it/administration.json
+++ b/locales/it/administration.json
@@ -62,7 +62,8 @@
       "work_units_all": "Unità di Lavoro (Tutte)"
     },
     "reports": {
-      "ai_reporting": "Reportistica IA"
+      "ai_reporting": "Reportistica IA",
+      "cost": "Report costi"
     },
     "configuration": {
       "authentication": "Autenticazione",

--- a/locales/it/reports.json
+++ b/locales/it/reports.json
@@ -1,4 +1,8 @@
 {
+  "cost": "Costo",
+  "costTotal": "Costo totale",
+  "costPerHour": "Costo orario",
+  "costPermissionRequired": "I dati di costo sono nascosti perche' il tuo ruolo non ha il permesso 'reports.cost'.",
   "aiReporting": {
     "newChat": "Nuova Chat",
     "session": "Sessione",

--- a/locales/it/reports.json
+++ b/locales/it/reports.json
@@ -2,7 +2,7 @@
   "cost": "Costo",
   "costTotal": "Costo totale",
   "costPerHour": "Costo orario",
-  "costPermissionRequired": "I dati di costo sono nascosti perche' il tuo ruolo non ha il permesso 'reports.cost'.",
+  "costPermissionRequired": "I dati di costo sono nascosti perché il tuo ruolo non ha il permesso 'reports.cost'.",
   "aiReporting": {
     "newChat": "Nuova Chat",
     "session": "Sessione",

--- a/server/repositories/entriesRepo.ts
+++ b/server/repositories/entriesRepo.ts
@@ -1,6 +1,7 @@
 import { and, eq, gte, type SQL, sql } from 'drizzle-orm';
 import { type DbExecutor, db, executeRows } from '../db/drizzle.ts';
 import { timeEntries } from '../db/schema/timeEntries.ts';
+import { computeEntryCost } from '../utils/billing.ts';
 import { normalizeNullableDateOnly } from '../utils/date.ts';
 import { numericForDb, parseDbNumber } from '../utils/parse.ts';
 import { managedUserIdsSubquerySql } from './workUnitsRepo.ts';
@@ -18,6 +19,11 @@ export type TimeEntry = {
   notes: string | null;
   duration: number;
   hourlyCost: number;
+  // `cost` is computed on read as `duration * hourlyCost` (rounded to currency precision)
+  // so retroactive `hourly_cost` changes never rewrite historical entry costs - the per-row
+  // `hourly_cost` we already store on insert is the "as of the day the entry was logged"
+  // rate that we want to preserve here.
+  cost: number;
   isPlaceholder: boolean;
   location: string;
   createdAt: number;
@@ -56,6 +62,8 @@ const ENTRY_COLUMNS_SQL = sql`id, user_id, date, client_id, client_name, project
 const mapRawRow = (row: TimeEntryRow): TimeEntry => {
   const date = normalizeNullableDateOnly(row.date, 'entry.date');
   if (!date) throw new TypeError('Invalid date value for entry.date');
+  const duration = parseDbNumber(row.duration, 0);
+  const hourlyCost = parseDbNumber(row.hourly_cost, 0);
   return {
     id: row.id,
     userId: row.user_id,
@@ -67,8 +75,9 @@ const mapRawRow = (row: TimeEntryRow): TimeEntry => {
     task: row.task,
     taskId: row.task_id,
     notes: row.notes,
-    duration: parseDbNumber(row.duration, 0),
-    hourlyCost: parseDbNumber(row.hourly_cost, 0),
+    duration,
+    hourlyCost,
+    cost: computeEntryCost(duration, hourlyCost),
     isPlaceholder: !!row.is_placeholder,
     location: row.location || 'remote',
     createdAt: row.created_at ? new Date(row.created_at).getTime() : 0,
@@ -81,6 +90,8 @@ const mapRawRow = (row: TimeEntryRow): TimeEntry => {
 const mapBuilderRow = (row: typeof timeEntries.$inferSelect): TimeEntry => {
   const date = normalizeNullableDateOnly(row.date, 'entry.date');
   if (!date) throw new TypeError('Invalid date value for entry.date');
+  const duration = parseDbNumber(row.duration, 0);
+  const hourlyCost = parseDbNumber(row.hourlyCost, 0);
   return {
     id: row.id,
     userId: row.userId,
@@ -92,8 +103,9 @@ const mapBuilderRow = (row: typeof timeEntries.$inferSelect): TimeEntry => {
     task: row.task,
     taskId: row.taskId,
     notes: row.notes,
-    duration: parseDbNumber(row.duration, 0),
-    hourlyCost: parseDbNumber(row.hourlyCost, 0),
+    duration,
+    hourlyCost,
+    cost: computeEntryCost(duration, hourlyCost),
     isPlaceholder: !!row.isPlaceholder,
     location: row.location || 'remote',
     createdAt: row.createdAt?.getTime() ?? 0,

--- a/server/repositories/reportsHoursRepo.ts
+++ b/server/repositories/reportsHoursRepo.ts
@@ -1,7 +1,11 @@
 import { sql } from 'drizzle-orm';
 import { type DbExecutor, db, executeRows } from '../db/drizzle.ts';
+import { roundCurrency } from '../utils/invoice-math.ts';
 import { parseDbNumber, toDbText } from '../utils/parse.ts';
 import { tasksT, timeEntriesTasksJoin } from './tasksRepo.ts';
+
+const parseCost = (value: string | number | null | undefined): number =>
+  roundCurrency(parseDbNumber(value, 0));
 
 // Raw SQL via `executeRows` bypasses Drizzle's typed null-handling - `toDbText` (trim + ''
 // fallback) is applied manually so stray whitespace doesn't render awkward cells in the UI.
@@ -159,14 +163,14 @@ export const getTimesheetsSection = async (
     totals: {
       hours: totalHours,
       entryCount: totalEntries,
-      cost: parseDbNumber(totals[0]?.total_cost, 0),
+      cost: parseCost(totals[0]?.total_cost),
       avgEntryHours: totalEntries > 0 ? totalHours / totalEntries : 0,
     },
     byMonth: byMonth.map((r) => ({
       label: toDbText(r.label),
       hours: parseDbNumber(r.hours, 0),
       entryCount: parseDbNumber(r.entry_count, 0),
-      cost: parseDbNumber(r.total_cost, 0),
+      cost: parseCost(r.total_cost),
     })),
     byLocation: byLocation.map((r) => ({
       location: toDbText(r.location),
@@ -314,7 +318,7 @@ export const getProjectsSection = async (
     ? hoursRows.map((r) => ({
         label: toDbText(r.label),
         hours: parseDbNumber(r.hours, 0),
-        cost: parseDbNumber(r.cost, 0),
+        cost: parseCost(r.cost),
       }))
     : [];
   const topByHours = [...projectStats]

--- a/server/routes/entries.ts
+++ b/server/routes/entries.ts
@@ -130,21 +130,21 @@ const actorFromRequest = (request: FastifyRequest) => ({
   permissions: request.user?.permissions ?? [],
 });
 
+type SanitizedEntry = TimeEntry | Omit<TimeEntry, 'cost' | 'hourlyCost'>;
+
 // Strip `cost` / `hourlyCost` from outgoing entry payloads when the caller lacks
 // `reports.cost.view`. Computed cost reveals per-user pay rates, so the API enforces the
 // gate even when the UI happens to hide the column.
-const sanitizeEntry = (entry: TimeEntry, includeCost: boolean): Partial<TimeEntry> => {
+const sanitizeEntry = (entry: TimeEntry, includeCost: boolean): SanitizedEntry => {
   if (includeCost) return entry;
   const { cost: _cost, hourlyCost: _hourlyCost, ...rest } = entry;
   return rest;
 };
 
-// `nextCursor` here is the already-encoded cursor string returned by the service
-// (`listTimeEntries`), distinct from the raw `EntriesCursor` object exposed by the repo.
 const sanitizeListResult = (
   result: { entries: TimeEntry[]; nextCursor: string | null },
   includeCost: boolean,
-): { entries: Partial<TimeEntry>[]; nextCursor: string | null } => ({
+): { entries: SanitizedEntry[]; nextCursor: string | null } => ({
   entries: result.entries.map((e) => sanitizeEntry(e, includeCost)),
   nextCursor: result.nextCursor,
 });

--- a/server/routes/entries.ts
+++ b/server/routes/entries.ts
@@ -4,6 +4,7 @@ import {
   requireAnyPermission,
   requireScopedPermission,
 } from '../middleware/auth.ts';
+import type { TimeEntry } from '../repositories/entriesRepo.ts';
 import {
   messageResponseSchema,
   standardErrorResponses,
@@ -18,6 +19,7 @@ import {
   updateTimeEntry,
 } from '../services/timeEntries.ts';
 import { assertAuthenticated } from '../utils/auth-assert.ts';
+import { requestHasPermission } from '../utils/permissions.ts';
 import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 
 const idParamSchema = {
@@ -43,10 +45,13 @@ const entrySchema = {
     notes: { type: ['string', 'null'] },
     duration: { type: 'number' },
     hourlyCost: { type: 'number' },
+    cost: { type: 'number' },
     isPlaceholder: { type: 'boolean' },
     location: { type: 'string' },
     createdAt: { type: 'number' },
   },
+  // `cost` and `hourlyCost` stay out of `required` because they are stripped at response
+  // time when the caller lacks `reports.cost.view`. Everything else is always present.
   required: [
     'id',
     'userId',
@@ -57,7 +62,6 @@ const entrySchema = {
     'projectName',
     'task',
     'duration',
-    'hourlyCost',
     'isPlaceholder',
     'location',
     'createdAt',
@@ -126,6 +130,25 @@ const actorFromRequest = (request: FastifyRequest) => ({
   permissions: request.user?.permissions ?? [],
 });
 
+// Strip `cost` / `hourlyCost` from outgoing entry payloads when the caller lacks
+// `reports.cost.view`. Computed cost reveals per-user pay rates, so the API enforces the
+// gate even when the UI happens to hide the column.
+const sanitizeEntry = (entry: TimeEntry, includeCost: boolean): Partial<TimeEntry> => {
+  if (includeCost) return entry;
+  const { cost: _cost, hourlyCost: _hourlyCost, ...rest } = entry;
+  return rest;
+};
+
+// `nextCursor` here is the already-encoded cursor string returned by the service
+// (`listTimeEntries`), distinct from the raw `EntriesCursor` object exposed by the repo.
+const sanitizeListResult = (
+  result: { entries: TimeEntry[]; nextCursor: string | null },
+  includeCost: boolean,
+): { entries: Partial<TimeEntry>[]; nextCursor: string | null } => ({
+  entries: result.entries.map((e) => sanitizeEntry(e, includeCost)),
+  nextCursor: result.nextCursor,
+});
+
 const handleTimeEntryServiceError = (err: unknown, reply: FastifyReply) => {
   if (err instanceof TimeEntryServiceError) {
     return reply.code(err.statusCode).send({ error: err.message });
@@ -162,7 +185,12 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         cursor?: string;
       };
       try {
-        return await listTimeEntries(actorFromRequest(request), { userId, limit, cursor });
+        const result = await listTimeEntries(actorFromRequest(request), {
+          userId,
+          limit,
+          cursor,
+        });
+        return sanitizeListResult(result, requestHasPermission(request, 'reports.cost.view'));
       } catch (err) {
         return handleTimeEntryServiceError(err, reply);
       }
@@ -189,7 +217,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
 
       try {
         const created = await createTimeEntry(actorFromRequest(request), request.body ?? {});
-        return reply.code(201).send(created);
+        return reply
+          .code(201)
+          .send(sanitizeEntry(created, requestHasPermission(request, 'reports.cost.view')));
       } catch (err) {
         return handleTimeEntryServiceError(err, reply);
       }
@@ -217,7 +247,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
 
       const { id } = request.params as { id: string };
       try {
-        return await updateTimeEntry(actorFromRequest(request), id, request.body ?? {});
+        const updated = await updateTimeEntry(actorFromRequest(request), id, request.body ?? {});
+        return sanitizeEntry(updated, requestHasPermission(request, 'reports.cost.view'));
       } catch (err) {
         return handleTimeEntryServiceError(err, reply);
       }

--- a/server/routes/reports.ts
+++ b/server/routes/reports.ts
@@ -865,9 +865,14 @@ export const buildBusinessDataset = async (
       top: 50,
     };
 
+    const canViewCost = hasPermission(request, 'reports.cost.view');
+    if (canViewCost) {
+      addGrantedPermissions(request, ['reports.cost.view'], permissionsApplied);
+    }
+
     if (canViewTimesheets && shouldIncludeDatasetSection(requestedSections, 'timesheets')) {
       includedSections.add('timesheets');
-      dataset.timesheets = await reportsHoursRepo.getTimesheetsSection(
+      const timesheets = await reportsHoursRepo.getTimesheetsSection(
         {
           fromDate,
           toDate,
@@ -876,6 +881,19 @@ export const buildBusinessDataset = async (
         },
         datasetDb,
       );
+      // Strip cost numbers for callers without `reports.cost.view` - they may still see
+      // hours and entry counts, but not the cost roll-ups that reveal hourly rates.
+      dataset.timesheets = canViewCost
+        ? timesheets
+        : {
+            ...timesheets,
+            totals: {
+              hours: timesheets.totals.hours,
+              entryCount: timesheets.totals.entryCount,
+              avgEntryHours: timesheets.totals.avgEntryHours,
+            },
+            byMonth: timesheets.byMonth.map(({ cost: _c, ...rest }) => rest),
+          };
     }
 
     const supplierWorkflowViewPermissions = [
@@ -975,7 +993,7 @@ export const buildBusinessDataset = async (
       );
 
       const canViewAllProjects = hasPermission(request, 'projects.manage_all.view');
-      dataset.projects = await reportsHoursRepo.getProjectsSection(
+      const projects = await reportsHoursRepo.getProjectsSection(
         {
           viewerId,
           fromDate,
@@ -989,6 +1007,15 @@ export const buildBusinessDataset = async (
         },
         datasetDb,
       );
+      // `topByCost` and the per-row `cost` on `topByHours` both reveal cost numbers, so
+      // both go behind `reports.cost.view`.
+      dataset.projects = canViewCost
+        ? projects
+        : {
+            ...projects,
+            topByHours: projects.topByHours.map(({ cost: _c, ...rest }) => rest),
+            topByCost: [],
+          };
     }
 
     const canListTasks = [

--- a/server/test/repositories/entriesRepo.test.ts
+++ b/server/test/repositories/entriesRepo.test.ts
@@ -206,6 +206,22 @@ describe('mapRawRow (exercised via listAll return path)', () => {
     const result = await entriesRepo.listAll({}, testDb);
     expect(result.entries[0].createdAt).toBe(0);
   });
+
+  test('cost is surfaced on the raw-SQL read path (duration * hourly_cost, rounded)', async () => {
+    // 1.5h * $100 = $150
+    exec.enqueue({ rows: [rawRow] });
+    const result = await entriesRepo.listAll({}, testDb);
+    expect(result.entries[0].duration).toBe(1.5);
+    expect(result.entries[0].hourlyCost).toBe(100);
+    expect(result.entries[0].cost).toBe(150);
+  });
+
+  test('cost is 0 when hourly_cost is null on a raw row', async () => {
+    exec.enqueue({ rows: [{ ...rawRow, hourly_cost: null }] });
+    const result = await entriesRepo.listAll({}, testDb);
+    expect(result.entries[0].hourlyCost).toBe(0);
+    expect(result.entries[0].cost).toBe(0);
+  });
 });
 
 describe('findOwner', () => {
@@ -283,6 +299,7 @@ describe('create', () => {
     expect(exec.calls[0].sql).toContain('returning');
     expect(result.duration).toBe(1.5);
     expect(result.hourlyCost).toBe(100);
+    expect(result.cost).toBe(150);
     expect(result.userId).toBe('u-1');
     expect(result.taskId).toBe('t-1');
   });
@@ -341,6 +358,24 @@ describe('mapBuilderRow (exercised via create return path)', () => {
     exec.enqueue({ rows: [entryRow({ 11: null })] });
     const result = await entriesRepo.create(newEntry, testDb);
     expect(result.hourlyCost).toBe(0);
+    // cost = duration * hourlyCost — when hourlyCost falls back to 0, cost is also 0
+    expect(result.cost).toBe(0);
+  });
+
+  test('cost is computed on read as duration * hourly_cost (rounded)', async () => {
+    // duration=2.5h, hourly_cost=$73.20 -> 183.00
+    exec.enqueue({ rows: [entryRow({ 10: '2.5', 11: '73.20' })] });
+    const result = await entriesRepo.create(newEntry, testDb);
+    expect(result.duration).toBe(2.5);
+    expect(result.hourlyCost).toBe(73.2);
+    expect(result.cost).toBe(183);
+  });
+
+  test('cost rounds to currency precision', async () => {
+    // 1h * 0.015 = 0.015 -> rounds half-up to 0.02
+    exec.enqueue({ rows: [entryRow({ 10: '1', 11: '0.015' })] });
+    const result = await entriesRepo.create(newEntry, testDb);
+    expect(result.cost).toBe(0.02);
   });
 
   test('null is_placeholder coerces to false', async () => {

--- a/server/test/repositories/entriesRepo.test.ts
+++ b/server/test/repositories/entriesRepo.test.ts
@@ -358,7 +358,6 @@ describe('mapBuilderRow (exercised via create return path)', () => {
     exec.enqueue({ rows: [entryRow({ 11: null })] });
     const result = await entriesRepo.create(newEntry, testDb);
     expect(result.hourlyCost).toBe(0);
-    // cost = duration * hourlyCost — when hourlyCost falls back to 0, cost is also 0
     expect(result.cost).toBe(0);
   });
 

--- a/server/test/repositories/reportsHoursRepo.test.ts
+++ b/server/test/repositories/reportsHoursRepo.test.ts
@@ -67,6 +67,26 @@ describe('getTimesheetsSection', () => {
     });
   });
 
+  test('cost values are rounded to 2 decimals to match invoice currency precision', async () => {
+    // SUM(duration * hourly_cost) can emit long-tail floats; rounding aligns with
+    // computeEntryCost so per-entry rollups equal the sum of per-entry costs.
+    exec.enqueue({ rows: [{ hours: '10', entry_count: '1', total_cost: '306.675' }] });
+    exec.enqueue({ rows: [] });
+    exec.enqueue({ rows: [] });
+    exec.enqueue({ rows: [] });
+    exec.enqueue({ rows: [] });
+    exec.enqueue({
+      rows: [{ label: '2026-01', hours: '10', entry_count: '1', total_cost: '306.675' }],
+    });
+    exec.enqueue({ rows: [] });
+    const result = await repo.getTimesheetsSection(
+      { fromDate: FROM, toDate: TO, allowedTimesheetUserIds: null, topLimit: 10 },
+      testDb,
+    );
+    expect(result.totals.cost).toBe(306.68);
+    expect(result.byMonth[0].cost).toBe(306.68);
+  });
+
   test('avgEntryHours is 0 when no entries', async () => {
     exec.enqueue({ rows: [{ hours: '0', entry_count: '0', total_cost: '0' }] });
     enqueueEmptyN(6);

--- a/server/test/routes/entries.test.ts
+++ b/server/test/routes/entries.test.ts
@@ -153,6 +153,7 @@ const SAMPLE_ENTRY = {
   notes: null,
   duration: 4,
   hourlyCost: 50,
+  cost: 200, // mapBuilderRow surfaces duration * hourlyCost
   isPlaceholder: false,
   location: 'remote',
   createdAt: 1_700_000_000_000,

--- a/server/test/utils/billing.test.ts
+++ b/server/test/utils/billing.test.ts
@@ -29,18 +29,11 @@ describe('computeEntryCost', () => {
   });
 
   test('matches duration * hourlyCost rounded to currency precision', () => {
-    // Bank-of-half-cents picked specifically so the IEEE-754 round-trip lands
-    // strictly above 306.675 - using 7.25 * 42.30 would underflow to 306.67 in
-    // JS floats, so we use values where the round target is unambiguous.
-    // 6.50 * 12.50 = 81.25 (exact in floats) → stays at 81.25
     expect(computeEntryCost(6.5, 12.5)).toBe(81.25);
-    // 1 * 0.015 = 0.015 → 0.02 (halves up via Math.round)
     expect(computeEntryCost(1, 0.015)).toBe(0.02);
   });
 
   test('handles negative duration as math allows (caller is responsible for validation)', () => {
-    // Computation should not mask validation errors; we rely on input validation upstream
-    // to reject negative durations and hourly costs at the request layer.
     expect(computeEntryCost(-2, 50)).toBe(-100);
   });
 });

--- a/server/test/utils/billing.test.ts
+++ b/server/test/utils/billing.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'bun:test';
+import { computeEntryCost } from '../../utils/billing.ts';
+
+describe('computeEntryCost', () => {
+  test('returns 0 when duration is 0', () => {
+    expect(computeEntryCost(0, 100)).toBe(0);
+  });
+
+  test('returns 0 when hourly cost is 0', () => {
+    expect(computeEntryCost(5, 0)).toBe(0);
+  });
+
+  test('multiplies duration by hourly cost', () => {
+    expect(computeEntryCost(2, 50)).toBe(100);
+  });
+
+  test('handles fractional hours', () => {
+    expect(computeEntryCost(1.5, 100)).toBe(150);
+  });
+
+  test('rounds to 2 decimals (down)', () => {
+    // 0.1 * 0.2 = 0.020000000000000004 in JS floats; rounding pins it to 0.02
+    expect(computeEntryCost(0.1, 0.2)).toBe(0.02);
+  });
+
+  test('rounds halves up', () => {
+    // 1 * 0.005 = 0.005 → 0.01
+    expect(computeEntryCost(1, 0.005)).toBe(0.01);
+  });
+
+  test('matches duration * hourlyCost rounded to currency precision', () => {
+    // Bank-of-half-cents picked specifically so the IEEE-754 round-trip lands
+    // strictly above 306.675 - using 7.25 * 42.30 would underflow to 306.67 in
+    // JS floats, so we use values where the round target is unambiguous.
+    // 6.50 * 12.50 = 81.25 (exact in floats) → stays at 81.25
+    expect(computeEntryCost(6.5, 12.5)).toBe(81.25);
+    // 1 * 0.015 = 0.015 → 0.02 (halves up via Math.round)
+    expect(computeEntryCost(1, 0.015)).toBe(0.02);
+  });
+
+  test('handles negative duration as math allows (caller is responsible for validation)', () => {
+    // Computation should not mask validation errors; we rely on input validation upstream
+    // to reject negative durations and hourly costs at the request layer.
+    expect(computeEntryCost(-2, 50)).toBe(-100);
+  });
+});

--- a/server/utils/billing.ts
+++ b/server/utils/billing.ts
@@ -1,3 +1,5 @@
+import { roundCurrency } from './invoice-math.ts';
+
 export const STORED_BILLING_TYPES = ['retainer', 'time_and_materials'] as const;
 export const BILLING_TYPES = [...STORED_BILLING_TYPES, 'mixed'] as const;
 export const BILLING_FREQUENCIES = ['monthly', 'one_time'] as const;
@@ -20,3 +22,12 @@ export const normalizeBillingFrequency = (
 export const normalizeStoredBillingType = (
   billingType: BillingType | null | undefined,
 ): StoredBillingType => (billingType === 'retainer' ? 'retainer' : DEFAULT_BILLING_TYPE);
+
+// Compute the cost of a single time entry as `duration * hourlyCost`, rounded to the
+// invoice currency precision so totals line up with what the UI renders. Used by
+// `entriesRepo.mapBuilderRow` / `mapRawRow` to surface `cost` on read instead of storing
+// it - hourly_cost can move retroactively (HR cost changes) but historical entries should
+// keep showing the cost at the time the entry was logged, which is what we already store
+// per row in `time_entries.hourly_cost`.
+export const computeEntryCost = (durationHours: number, hourlyCost: number): number =>
+  roundCurrency(durationHours * hourlyCost);

--- a/server/utils/permissions.ts
+++ b/server/utils/permissions.ts
@@ -61,6 +61,11 @@ export const PERMISSION_DEFINITIONS: PermissionDefinition[] = [
 
   // Reports
   { id: 'reports.ai_reporting', actions: ['view', 'create'] },
+  // `reports.cost.view` gates exposure of per-entry / aggregated *cost* numbers
+  // (duration * hourly_cost) - kept separate from `hr.costs` because someone can be
+  // allowed to read cost roll-ups in reports without being trusted to set per-user
+  // hourly cost rates.
+  { id: 'reports.cost', actions: ['view'] },
 
   // Administration
   { id: 'administration.authentication', actions: VIEW_UPDATE },
@@ -138,6 +143,7 @@ export const DEFAULT_ROLE_PERMISSIONS: Record<string, Permission[]> = {
     buildPermission('hr.employee_assignments', 'update'),
     buildPermission('reports.ai_reporting', 'view'),
     buildPermission('reports.ai_reporting', 'create'),
+    buildPermission('reports.cost', 'view'),
     buildPermission('settings', 'view'),
     buildPermission('settings', 'update'),
     buildPermission('docs.api', 'view'),
@@ -175,6 +181,7 @@ export const DEFAULT_ROLE_PERMISSIONS: Record<string, Permission[]> = {
     buildPermission('hr.work_units_all', 'view'),
     buildPermission('reports.ai_reporting', 'view'),
     buildPermission('reports.ai_reporting', 'create'),
+    buildPermission('reports.cost', 'view'),
     buildPermission('settings', 'view'),
     buildPermission('settings', 'update'),
     buildPermission('docs.api', 'view'),

--- a/services/api/normalizers.ts
+++ b/services/api/normalizers.ts
@@ -238,11 +238,23 @@ export const normalizeClientsOrder = (o: ClientsOrder): ClientsOrder => ({
   items: (o.items || []).map(normalizeClientsOrderItem),
 });
 
-export const normalizeTimeEntry = (e: TimeEntry): TimeEntry => ({
-  ...e,
-  duration: Number(e.duration || 0),
-  hourlyCost: Number(e.hourlyCost || 0),
-});
+export const normalizeTimeEntry = (e: TimeEntry): TimeEntry => {
+  // `hourlyCost` / `cost` are gated behind `reports.cost.view` server-side and may be
+  // entirely absent from the payload. Preserve the absence (rather than coercing to 0)
+  // so the UI can branch on permission visibility instead of getting a misleading zero.
+  const normalized: TimeEntry = { ...e, duration: Number(e.duration || 0) };
+  if (e.hourlyCost !== undefined && e.hourlyCost !== null) {
+    normalized.hourlyCost = Number(e.hourlyCost);
+  } else {
+    delete normalized.hourlyCost;
+  }
+  if (e.cost !== undefined && e.cost !== null) {
+    normalized.cost = Number(e.cost);
+  } else {
+    delete normalized.cost;
+  }
+  return normalized;
+};
 
 export const normalizeTask = (t: ProjectTask): ProjectTask => ({
   ...t,

--- a/test/services/normalizers.test.ts
+++ b/test/services/normalizers.test.ts
@@ -646,18 +646,31 @@ describe('normalizeClientsOrder', () => {
 });
 
 describe('normalizeTimeEntry', () => {
-  test('parses duration and hourlyCost as numbers', () => {
-    const entry = make<TimeEntry>(baseTimeEntry, { duration: '2.5', hourlyCost: '50' });
+  test('parses duration, hourlyCost, and cost as numbers', () => {
+    const entry = make<TimeEntry>(baseTimeEntry, {
+      duration: '2.5',
+      hourlyCost: '50',
+      cost: '125',
+    });
     const result = normalizeTimeEntry(entry);
     expect(result.duration).toBe(2.5);
     expect(result.hourlyCost).toBe(50);
+    expect(result.cost).toBe(125);
   });
 
-  test('defaults missing duration and hourlyCost to 0', () => {
-    const entry = make<TimeEntry>(baseTimeEntry, { duration: undefined, hourlyCost: undefined });
+  test('defaults missing duration to 0; keeps hourlyCost/cost absent when stripped server-side', () => {
+    // The server omits hourlyCost / cost entirely when the caller lacks
+    // `reports.cost.view`. The normalizer must preserve that absence so callers can
+    // branch on permission visibility instead of misreading a 0 as "no cost".
+    const entry = make<TimeEntry>(baseTimeEntry, {
+      duration: undefined,
+      hourlyCost: undefined,
+      cost: undefined,
+    });
     const result = normalizeTimeEntry(entry);
     expect(result.duration).toBe(0);
-    expect(result.hourlyCost).toBe(0);
+    expect(result.hourlyCost).toBeUndefined();
+    expect(result.cost).toBeUndefined();
   });
 });
 

--- a/types.ts
+++ b/types.ts
@@ -243,7 +243,11 @@ export interface TimeEntry {
   taskId?: string | null;
   notes?: string;
   duration: number;
-  hourlyCost: number;
+  // `hourlyCost` and `cost` are stripped server-side when the caller lacks
+  // `reports.cost.view` - components must treat them as optional and fall back when
+  // missing rather than assuming both are always present.
+  hourlyCost?: number;
+  cost?: number;
   createdAt: number;
   isPlaceholder?: boolean;
   location?: TimeEntryLocation;

--- a/utils/permissions.ts
+++ b/utils/permissions.ts
@@ -66,8 +66,6 @@ export const PERMISSION_DEFINITIONS: PermissionDefinition[] = [
 
   // Reports
   { id: 'reports.ai_reporting', actions: ['view', 'create'], module: 'reports' },
-  // Mirrors backend's `reports.cost.view` - gates the Cost column / totals in any view
-  // that surfaces per-entry or aggregated cost numbers (timesheet lists, reports).
   { id: 'reports.cost', actions: ['view'], module: 'reports' },
 
   // Administration

--- a/utils/permissions.ts
+++ b/utils/permissions.ts
@@ -66,6 +66,9 @@ export const PERMISSION_DEFINITIONS: PermissionDefinition[] = [
 
   // Reports
   { id: 'reports.ai_reporting', actions: ['view', 'create'], module: 'reports' },
+  // Mirrors backend's `reports.cost.view` - gates the Cost column / totals in any view
+  // that surfaces per-entry or aggregated cost numbers (timesheet lists, reports).
+  { id: 'reports.cost', actions: ['view'], module: 'reports' },
 
   // Administration
   { id: 'administration.authentication', actions: VIEW_UPDATE, module: 'administration' },


### PR DESCRIPTION
## Summary
- Compute per-entry `cost` as `duration * hourly_cost` on read (rounded to invoice precision) so retroactive hourly-cost changes don't rewrite history.
- Round cost aggregations in `reportsHoursRepo` (timesheets totals/byMonth, projects topByHours/topByCost) so roll-ups equal the sum of per-entry costs.
- Add a new `reports.cost.view` permission and strip `cost` / `hourlyCost` from entries responses and AI-reporting dataset (timesheets totals/byMonth, projects topByCost) when callers lack it.

## Manual verification
- [ ] As a user with `reports.cost.view` (manager, top_manager, or admin), GET `/api/entries` and verify each entry includes `cost` equal to `duration * hourlyCost`.
- [ ] As a user without `reports.cost.view` (e.g. default `user` role), GET `/api/entries` and verify `cost` and `hourlyCost` are absent on every entry.
- [ ] Open an AI Reporting chat as a user with the permission and confirm the dataset includes `timesheets.totals.cost` and `projects.topByCost`.
- [ ] Repeat without the permission and confirm those cost fields/sections are omitted while hours/entry counts remain.
- [ ] Verify totals match: pick a date range and check that `timesheets.totals.cost` equals `SUM(duration * hourly_cost)` over the entries in the range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)