### PR TITLE
refactor(settings): restyle Profile tab with shadcn Card + tokens

### DIFF
--- a/components/UserSettings.tsx
+++ b/components/UserSettings.tsx
@@ -11,10 +11,12 @@ import {
   Moon,
   Palette,
   RefreshCw,
+  Save,
   Shield,
   Sun,
   SunMoon,
   Trash2,
+  User,
 } from 'lucide-react';
 import type React from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -498,66 +500,56 @@ const UserSettings: React.FC<UserSettingsProps> = ({
       </div>
 
       {activeTab === 'profile' && (
-        <section className="bg-white rounded-2xl border border-zinc-200 shadow-sm overflow-hidden animate-in fade-in slide-in-from-left-4 duration-300">
-          <div className="px-6 py-4 bg-zinc-50 border-b border-zinc-200 flex items-center gap-3 rounded-t-2xl">
-            <i className="fa-solid fa-user text-praetor"></i>
-            <h3 className="font-semibold text-zinc-800">{t('userProfile.title')}</h3>
-          </div>
+        <Card className="gap-0 overflow-hidden rounded-lg border-border bg-background py-0 animate-in fade-in slide-in-from-left-4 duration-300">
+          <CardHeader className="border-b border-border bg-muted/40 px-6 py-4 [.border-b]:pb-4">
+            <CardTitle className="flex items-center gap-3 text-base">
+              <User aria-hidden="true" className="size-4 text-praetor" />
+              {t('userProfile.title')}
+            </CardTitle>
+            <CardDescription>{t('userProfile.description')}</CardDescription>
+          </CardHeader>
           <form onSubmit={handleSave}>
-            <div className="p-6 space-y-6">
+            <CardContent className="space-y-6 p-6">
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <div>
-                  <label className="block text-xs font-bold text-zinc-400 uppercase tracking-wider mb-2">
-                    {t('userProfile.fullName')}
-                  </label>
-                  <input
+                <Field>
+                  <FieldLabel htmlFor="profile-full-name">{t('userProfile.fullName')}</FieldLabel>
+                  <Input
+                    id="profile-full-name"
                     type="text"
                     value={fullName}
                     onChange={(e) => setFullName(e.target.value)}
-                    className="w-full px-4 py-2 bg-zinc-50 border border-zinc-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none transition-all text-sm font-semibold"
+                    required
                   />
-                </div>
-                <div>
-                  <label className="block text-xs font-bold text-zinc-400 uppercase tracking-wider mb-2">
-                    {t('userProfile.email')}
-                  </label>
-                  <input
+                </Field>
+                <Field>
+                  <FieldLabel htmlFor="profile-email">{t('userProfile.email')}</FieldLabel>
+                  <Input
+                    id="profile-email"
                     type="email"
                     value={email}
                     onChange={(e) => setEmail(e.target.value)}
-                    className="w-full px-4 py-2 bg-zinc-50 border border-zinc-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none transition-all text-sm font-semibold"
+                    required
                   />
-                </div>
+                </Field>
               </div>
-            </div>
-            <div className="px-6 py-4 border-t border-zinc-200 flex justify-end">
-              <button
-                type="submit"
-                disabled={isSaving || !hasChanges}
-                className={`px-8 py-3 rounded-xl font-bold text-sm transition-all duration-300 ease-in-out active:scale-95 flex items-center gap-2 ${
-                  isSaved
-                    ? 'bg-emerald-500 text-white shadow-lg shadow-emerald-100'
-                    : isSaving || !hasChanges
-                      ? 'bg-zinc-100 text-zinc-400 cursor-not-allowed border border-zinc-200'
-                      : 'bg-praetor text-white shadow-lg shadow-zinc-200 hover:bg-zinc-700'
-                }`}
-              >
-                {isSaving ? (
-                  <i className="fa-solid fa-circle-notch fa-spin"></i>
-                ) : isSaved ? (
-                  <i className="fa-solid fa-check"></i>
-                ) : (
-                  <i className="fa-solid fa-save"></i>
-                )}
-                {isSaving
-                  ? t('general.saving')
+            </CardContent>
+            <CardFooter className="justify-end border-t border-border px-6 py-4 [.border-t]:pt-4">
+              {(() => {
+                const { Icon, iconClass, label } = isSaving
+                  ? { Icon: Loader2, iconClass: 'animate-spin', label: t('general.saving') }
                   : isSaved
-                    ? t('general.changesSaved')
-                    : t('general.saveChanges')}
-              </button>
-            </div>
+                    ? { Icon: Check, iconClass: undefined, label: t('general.changesSaved') }
+                    : { Icon: Save, iconClass: undefined, label: t('general.saveChanges') };
+                return (
+                  <Button type="submit" disabled={isSaving || !hasChanges}>
+                    <Icon aria-hidden="true" className={iconClass} />
+                    {label}
+                  </Button>
+                );
+              })()}
+            </CardFooter>
           </form>
-        </section>
+        </Card>
       )}
 
       {activeTab === 'appearance' && (

--- a/docs-site/src/content/docs/ai-reporting.md
+++ b/docs-site/src/content/docs/ai-reporting.md
@@ -36,7 +36,7 @@ Per concedere o revocare la visibilità dei costi, modifica il ruolo in Amminist
 
 ## Accesso MCP per agenti esterni
 
-Praetor espone un endpoint MCP remoto su `/api/mcp` per agenti compatibili con Model Context Protocol. Gli agenti devono autenticarsi con un token MCP personale, creato da Impostazioni > Token MCP.
+Praetor espone un endpoint MCP remoto su `/api/mcp` per agenti compatibili con Model Context Protocol. Gli agenti devono autenticarsi con un token MCP personale, creato da Impostazioni > MCP.
 
 Il token viene mostrato una sola volta al momento della creazione. Praetor conserva solo un hash, quindi revoca e ricrea il token se viene perso.
 
@@ -50,13 +50,13 @@ Authorization: Bearer praetor_mcp_...
 
 Per collegare un agente esterno:
 
-1. Apri Impostazioni > Token MCP.
+1. Apri Impostazioni > MCP.
 2. Crea un token con un nome riconoscibile, ad esempio il nome dell'agente o del dispositivo.
 3. Copia subito il token; non verrà più mostrato.
 4. Usa il campo URL server MCP mostrato nella pagina per l'endpoint esatto, di solito `https://host-praetor/api/mcp`.
 5. Copia il prompt di configurazione agente se vuoi far configurare automaticamente il server a un agente AI.
 6. Configura il client MCP con l'URL dell'endpoint e l'header bearer indicato sopra.
-7. Revoca i token vecchi o inutilizzati da Impostazioni > Token MCP.
+7. Revoca i token vecchi o inutilizzati da Impostazioni > MCP.
 
 Strumenti supportati:
 

--- a/docs-site/src/content/docs/en/ai-reporting.md
+++ b/docs-site/src/content/docs/en/ai-reporting.md
@@ -36,7 +36,7 @@ To grant or revoke cost visibility, edit the role in Administration > Roles and 
 
 ## MCP Access For External Agents
 
-Praetor exposes a remote MCP endpoint at `/api/mcp` for Model Context Protocol compatible agents. Agents must authenticate with a personal MCP token created from Settings > MCP Tokens.
+Praetor exposes a remote MCP endpoint at `/api/mcp` for Model Context Protocol compatible agents. Agents must authenticate with a personal MCP token created from Settings > MCP.
 
 The token is shown only once when it is created. Praetor stores only a hash, so revoke and recreate the token if it is lost.
 
@@ -50,13 +50,13 @@ Authorization: Bearer praetor_mcp_...
 
 Use these steps to connect an external agent:
 
-1. Open Settings > MCP Tokens.
+1. Open Settings > MCP.
 2. Create a token with a recognizable name, such as the agent or device name.
 3. Copy the token immediately; it will not be shown again.
 4. Use the displayed MCP Server URL field for the exact endpoint, usually `https://your-praetor-host/api/mcp`.
 5. Copy the Agent Setup Prompt if you want an AI agent to configure the server automatically.
 6. Configure the MCP client with the endpoint URL and bearer token header above.
-7. Revoke old or unused tokens from Settings > MCP Tokens.
+7. Revoke old or unused tokens from Settings > MCP.
 
 Supported tools:
 

--- a/locales/en/settings.json
+++ b/locales/en/settings.json
@@ -2,7 +2,8 @@
   "title": "Settings",
   "subtitle": "Manage your personal preferences",
   "userProfile": {
-    "title": "User Profile",
+    "title": "Profile",
+    "description": "Update your name and email address.",
     "fullName": "Full Name",
     "email": "Email Address",
     "updateProfile": "Update Profile"
@@ -56,7 +57,7 @@
     "incorrectPassword": "Incorrect current password"
   },
   "mcp": {
-    "title": "MCP Tokens",
+    "title": "MCP",
     "description": "Create tokens that let AI agents access Praetor over the MCP protocol.",
     "urlLabel": "MCP Server URL",
     "urlDescription": "Use this Streamable HTTP endpoint when adding Praetor to an external MCP client.",

--- a/locales/it/settings.json
+++ b/locales/it/settings.json
@@ -2,7 +2,8 @@
   "title": "Impostazioni",
   "subtitle": "Gestisci le tue preferenze personali",
   "userProfile": {
-    "title": "Profilo Utente",
+    "title": "Profilo",
+    "description": "Aggiorna nome e indirizzo email.",
     "fullName": "Nome Completo",
     "email": "Indirizzo Email",
     "updateProfile": "Aggiorna Profilo"
@@ -56,7 +57,7 @@
     "incorrectPassword": "Password attuale non corretta"
   },
   "mcp": {
-    "title": "Token MCP",
+    "title": "MCP",
     "description": "Crea token per consentire agli agenti AI di accedere a Praetor tramite il protocollo MCP.",
     "urlLabel": "URL server MCP",
     "urlDescription": "Usa questo endpoint Streamable HTTP quando aggiungi Praetor a un client MCP esterno.",


### PR DESCRIPTION
## Summary

- Replace the bespoke `<section>` + raw `<input>` + custom button in the Profile tab of `components/UserSettings.tsx` with the same shadcn primitives the other settings tabs already use (`Card`, `CardHeader`, `CardContent`, `CardFooter`, `Field`, `FieldLabel`, `Input`, `Button`) + lucide icons, so theme tokens (dark/zebra/praetor) render correctly. Mirrors prior tab migrations (#327, #330).
- Tighten two tab labels to match their concise siblings: `userProfile.title` "User Profile"/"Profilo Utente" → "Profile"/"Profilo", `mcp.title` "MCP Tokens"/"Token MCP" → "MCP" in both locales. Add `userProfile.description` for the new card subtitle. Update six "Settings > MCP Tokens" references in the user docs to "Settings > MCP" so they stay accurate after the rename.
- Add `required` to both Profile inputs to match the Security tab's pattern — prevents blank-name/blank-email submits.

## Notes for reviewers

- Behavior: form submit logic (`handleSave`, `fullName`/`email` state, `hasChanges` gating) is unchanged — only JSX and tab labels.
- Test impact: the existing UserSettings test at [`test/components/UserSettings.test.tsx:278`](https://github.com/xBounceIT/praetor/blob/main/test/components/UserSettings.test.tsx#L278) clicks `screen.getByText('userProfile.title')`, which matches the raw key (i18n is stubbed in tests), so the rename does not break it.
- Out of scope but flagged during review: the new submit-button IIFE shares structure with three other tri-state save buttons in the codebase (Security tab in this file, plus `GeneralSettings.tsx` and `EmailSettings.tsx` still on FontAwesome). A shared `<StatusSubmitButton>` would unlock migrating those last two off legacy styling; not done here to keep this PR scoped to the Profile tab.

## Test plan

- [x] `bun run lint` — clean (4 pre-existing warnings in `test/hooks/handlers/quoteHandlers.test.ts`, unrelated)
- [x] `bun test test/components/UserSettings.test.tsx` — 12/12 pass
- [x] Manual: open Settings as any user and confirm the Profile tab visually matches the Security password card (header band, Field/Input look, Save button placement and `idle → spinner → check` states).
- [x] Manual: switch through Light / Dark / Zebra / Praetor themes and confirm the Profile card respects each theme.
- [x] Manual: confirm the tab labels read "Profile" / "MCP" in both EN and IT.
- [x] Manual: confirm blank-name and blank-email submits are now rejected by the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)