### PR TITLE
refactor(routes): dedup canAccess* and clients unique-violation handler

### DIFF
--- a/server/repositories/clientsRepo.ts
+++ b/server/repositories/clientsRepo.ts
@@ -43,10 +43,10 @@ export type Client = {
   createdAt: number | undefined;
 };
 
-// Domain enum so callers can map unique-constraint violations to user-facing messages
-// without coupling to the raw Postgres index names.
 export type ClientUniqueViolationKind = 'fiscal_code' | 'client_code';
 
+// Maps Postgres unique-constraint violations to a domain kind so callers can surface
+// user-facing messages without depending on raw index names.
 export const classifyUniqueViolation = (err: unknown): ClientUniqueViolationKind | null => {
   const dup = getUniqueViolation(err);
   if (!dup) return null;

--- a/server/repositories/clientsRepo.ts
+++ b/server/repositories/clientsRepo.ts
@@ -45,8 +45,7 @@ export type Client = {
 
 export type ClientUniqueViolationKind = 'fiscal_code' | 'client_code';
 
-// Maps Postgres unique-constraint violations to a domain kind so callers can surface
-// user-facing messages without depending on raw index names.
+// Decouples callers from raw Postgres index names.
 export const classifyUniqueViolation = (err: unknown): ClientUniqueViolationKind | null => {
   const dup = getUniqueViolation(err);
   if (!dup) return null;

--- a/server/repositories/clientsRepo.ts
+++ b/server/repositories/clientsRepo.ts
@@ -43,8 +43,8 @@ export type Client = {
   createdAt: number | undefined;
 };
 
-// Classify a thrown error from a clients insert/update as a known unique-constraint violation
-// so callers can surface a domain-level message without coupling to raw Postgres index names.
+// Domain enum so callers can map unique-constraint violations to user-facing messages
+// without coupling to the raw Postgres index names.
 export type ClientUniqueViolationKind = 'fiscal_code' | 'client_code';
 
 export const classifyUniqueViolation = (err: unknown): ClientUniqueViolationKind | null => {

--- a/server/repositories/clientsRepo.ts
+++ b/server/repositories/clientsRepo.ts
@@ -1,6 +1,7 @@
 import { and, eq, ne, sql } from 'drizzle-orm';
 import { type DbExecutor, db, executeRows } from '../db/drizzle.ts';
 import { clients } from '../db/schema/clients.ts';
+import { getUniqueViolation } from '../utils/db-errors.ts';
 import { parseDbNumber } from '../utils/parse.ts';
 
 export type ClientContact = {
@@ -40,6 +41,19 @@ export type Client = {
   vatNumber: string | null;
   taxCode: string | null;
   createdAt: number | undefined;
+};
+
+// Classify a thrown error from a clients insert/update as a known unique-constraint violation
+// so callers can surface a domain-level message without coupling to raw Postgres index names.
+export type ClientUniqueViolationKind = 'fiscal_code' | 'client_code';
+
+export const classifyUniqueViolation = (err: unknown): ClientUniqueViolationKind | null => {
+  const dup = getUniqueViolation(err);
+  if (!dup) return null;
+  if (dup.constraint === 'idx_clients_client_code_unique') return 'client_code';
+  if (dup.constraint === 'idx_clients_fiscal_code_unique') return 'fiscal_code';
+  if (dup.detail?.includes('client_code')) return 'client_code';
+  return 'fiscal_code';
 };
 
 const parseContactsFromDb = (value: unknown): ClientContact[] => {

--- a/server/routes/clients.ts
+++ b/server/routes/clients.ts
@@ -312,17 +312,16 @@ const canAccessClient = makeAccessChecker(
   'crm.clients_all.view',
 );
 
+const CLIENT_UNIQUE_VIOLATION_MESSAGES: Record<clientsRepo.ClientUniqueViolationKind, string> = {
+  client_code: 'Client ID already exists',
+  fiscal_code: 'Fiscal code already exists',
+};
+
 const handleClientUniqueViolation = (err: unknown, reply: FastifyReply): boolean => {
   const kind = clientsRepo.classifyUniqueViolation(err);
-  if (kind === 'client_code') {
-    badRequest(reply, 'Client ID already exists');
-    return true;
-  }
-  if (kind === 'fiscal_code') {
-    badRequest(reply, 'Fiscal code already exists');
-    return true;
-  }
-  return false;
+  if (!kind) return false;
+  badRequest(reply, CLIENT_UNIQUE_VIOLATION_MESSAGES[kind]);
+  return true;
 };
 
 export default async function (fastify: FastifyInstance, _opts: unknown) {

--- a/server/routes/clients.ts
+++ b/server/routes/clients.ts
@@ -11,9 +11,9 @@ import * as userAssignmentsRepo from '../repositories/userAssignmentsRepo.ts';
 import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
 import { logAudit } from '../utils/audit.ts';
 import { assertAuthenticated } from '../utils/auth-assert.ts';
-import { getForeignKeyViolation, getUniqueViolation } from '../utils/db-errors.ts';
+import { getForeignKeyViolation } from '../utils/db-errors.ts';
 import { generatePrefixedId } from '../utils/order-ids.ts';
-import { requestHasPermission as hasPermission } from '../utils/permissions.ts';
+import { requestHasPermission as hasPermission, makeAccessChecker } from '../utils/permissions.ts';
 import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
@@ -307,15 +307,18 @@ const buildPrimaryFieldsFromContacts = (contacts: ClientContact[]) => {
   };
 };
 
-const canAccessClient = (
-  request: FastifyRequest,
-  clientId: string,
-  allScopePermission = 'crm.clients_all.view',
-) => {
-  if (hasPermission(request, allScopePermission)) return Promise.resolve(true);
-  const userId = request.user?.id;
-  if (!userId) return Promise.resolve(false);
-  return userAssignmentsRepo.isClientAssignedToUser(userId, clientId);
+// Pass a forwarding arrow rather than a direct reference so test `mock.module` replacements
+// of `userAssignmentsRepo.*` resolve at call time, not module-load time.
+const canAccessClient = makeAccessChecker(
+  (userId, clientId) => userAssignmentsRepo.isClientAssignedToUser(userId, clientId),
+  'crm.clients_all.view',
+);
+
+const handleClientUniqueViolation = (err: unknown, reply: FastifyReply): FastifyReply | null => {
+  const kind = clientsRepo.classifyUniqueViolation(err);
+  if (kind === 'client_code') return badRequest(reply, 'Client ID already exists');
+  if (kind === 'fiscal_code') return badRequest(reply, 'Fiscal code already exists');
+  return null;
 };
 
 export default async function (fastify: FastifyInstance, _opts: unknown) {
@@ -571,19 +574,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         });
         return reply.code(201).send(client);
       } catch (err) {
-        const dup = getUniqueViolation(err);
-        if (dup) {
-          if (dup.constraint === 'idx_clients_fiscal_code_unique') {
-            return badRequest(reply, 'Fiscal code already exists');
-          }
-          if (dup.constraint === 'idx_clients_client_code_unique') {
-            return badRequest(reply, 'Client ID already exists');
-          }
-          if (dup.detail?.includes('client_code')) {
-            return badRequest(reply, 'Client ID already exists');
-          }
-          return badRequest(reply, 'Fiscal code already exists');
-        }
+        const handled = handleClientUniqueViolation(err, reply);
+        if (handled) return handled;
         throw err;
       }
     },
@@ -821,19 +813,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         });
         return client;
       } catch (err) {
-        const dup = getUniqueViolation(err);
-        if (dup) {
-          if (dup.constraint === 'idx_clients_fiscal_code_unique') {
-            return badRequest(reply, 'Fiscal code already exists');
-          }
-          if (dup.constraint === 'idx_clients_client_code_unique') {
-            return badRequest(reply, 'Client ID already exists');
-          }
-          if (dup.detail?.includes('client_code')) {
-            return badRequest(reply, 'Client ID already exists');
-          }
-          return badRequest(reply, 'Fiscal code already exists');
-        }
+        const handled = handleClientUniqueViolation(err, reply);
+        if (handled) return handled;
         throw err;
       }
     },

--- a/server/routes/clients.ts
+++ b/server/routes/clients.ts
@@ -307,18 +307,22 @@ const buildPrimaryFieldsFromContacts = (contacts: ClientContact[]) => {
   };
 };
 
-// Pass a forwarding arrow rather than a direct reference so test `mock.module` replacements
-// of `userAssignmentsRepo.*` resolve at call time, not module-load time.
 const canAccessClient = makeAccessChecker(
   (userId, clientId) => userAssignmentsRepo.isClientAssignedToUser(userId, clientId),
   'crm.clients_all.view',
 );
 
-const handleClientUniqueViolation = (err: unknown, reply: FastifyReply): FastifyReply | null => {
+const handleClientUniqueViolation = (err: unknown, reply: FastifyReply): boolean => {
   const kind = clientsRepo.classifyUniqueViolation(err);
-  if (kind === 'client_code') return badRequest(reply, 'Client ID already exists');
-  if (kind === 'fiscal_code') return badRequest(reply, 'Fiscal code already exists');
-  return null;
+  if (kind === 'client_code') {
+    badRequest(reply, 'Client ID already exists');
+    return true;
+  }
+  if (kind === 'fiscal_code') {
+    badRequest(reply, 'Fiscal code already exists');
+    return true;
+  }
+  return false;
 };
 
 export default async function (fastify: FastifyInstance, _opts: unknown) {
@@ -574,8 +578,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         });
         return reply.code(201).send(client);
       } catch (err) {
-        const handled = handleClientUniqueViolation(err, reply);
-        if (handled) return handled;
+        if (handleClientUniqueViolation(err, reply)) return reply;
         throw err;
       }
     },
@@ -813,8 +816,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         });
         return client;
       } catch (err) {
-        const handled = handleClientUniqueViolation(err, reply);
-        if (handled) return handled;
+        if (handleClientUniqueViolation(err, reply)) return reply;
         throw err;
       }
     },

--- a/server/routes/projects.ts
+++ b/server/routes/projects.ts
@@ -118,8 +118,6 @@ class OrderClientMismatchError extends Error {}
 class OfferClientMismatchError extends Error {}
 class DateRangeError extends Error {}
 
-// Pass forwarding arrows rather than direct references so test `mock.module` replacements
-// of `userAssignmentsRepo.*` resolve at call time, not module-load time.
 const canAccessClient = makeAccessChecker(
   (userId, clientId) => userAssignmentsRepo.isClientAssignedToUser(userId, clientId),
   'crm.clients_all.view',

--- a/server/routes/projects.ts
+++ b/server/routes/projects.ts
@@ -27,7 +27,7 @@ import {
 } from '../utils/billing.ts';
 import { ForeignKeyError, NotFoundError } from '../utils/http-errors.ts';
 import { generatePrefixedId } from '../utils/order-ids.ts';
-import { requestHasPermission as hasPermission } from '../utils/permissions.ts';
+import { requestHasPermission as hasPermission, makeAccessChecker } from '../utils/permissions.ts';
 import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
@@ -118,27 +118,17 @@ class OrderClientMismatchError extends Error {}
 class OfferClientMismatchError extends Error {}
 class DateRangeError extends Error {}
 
-const canAccessClient = (
-  request: FastifyRequest,
-  clientId: string,
-  allScopePermission = 'crm.clients_all.view',
-) => {
-  if (hasPermission(request, allScopePermission)) return Promise.resolve(true);
-  const userId = request.user?.id;
-  if (!userId) return Promise.resolve(false);
-  return userAssignmentsRepo.isClientAssignedToUser(userId, clientId);
-};
+// Pass forwarding arrows rather than direct references so test `mock.module` replacements
+// of `userAssignmentsRepo.*` resolve at call time, not module-load time.
+const canAccessClient = makeAccessChecker(
+  (userId, clientId) => userAssignmentsRepo.isClientAssignedToUser(userId, clientId),
+  'crm.clients_all.view',
+);
 
-const canAccessProject = (
-  request: FastifyRequest,
-  projectId: string,
-  allScopePermission = 'projects.manage_all.view',
-) => {
-  if (hasPermission(request, allScopePermission)) return Promise.resolve(true);
-  const userId = request.user?.id;
-  if (!userId) return Promise.resolve(false);
-  return userAssignmentsRepo.isProjectAssignedToUser(userId, projectId);
-};
+const canAccessProject = makeAccessChecker(
+  (userId, projectId) => userAssignmentsRepo.isProjectAssignedToUser(userId, projectId),
+  'projects.manage_all.view',
+);
 
 export default async function (fastify: FastifyInstance, _opts: unknown) {
   // GET / - List all projects

--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -26,7 +26,7 @@ import {
 import { todayLocalDateOnly } from '../utils/date.ts';
 import { ForeignKeyError } from '../utils/http-errors.ts';
 import { generatePrefixedId } from '../utils/order-ids.ts';
-import { requestHasPermission as hasPermission } from '../utils/permissions.ts';
+import { requestHasPermission as hasPermission, makeAccessChecker } from '../utils/permissions.ts';
 import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
@@ -119,27 +119,17 @@ const userIdsSchema = {
   required: ['userIds'],
 } as const;
 
-const canAccessProject = (
-  request: FastifyRequest,
-  projectId: string,
-  allScopePermission = 'projects.manage_all.view',
-) => {
-  if (hasPermission(request, allScopePermission)) return Promise.resolve(true);
-  const userId = request.user?.id;
-  if (!userId) return Promise.resolve(false);
-  return userAssignmentsRepo.isProjectAssignedToUser(userId, projectId);
-};
+// Pass forwarding arrows rather than direct references so test `mock.module` replacements
+// of `userAssignmentsRepo.*` resolve at call time, not module-load time.
+const canAccessProject = makeAccessChecker(
+  (userId, projectId) => userAssignmentsRepo.isProjectAssignedToUser(userId, projectId),
+  'projects.manage_all.view',
+);
 
-const canAccessTask = (
-  request: FastifyRequest,
-  taskId: string,
-  allScopePermission = 'projects.tasks_all.view',
-) => {
-  if (hasPermission(request, allScopePermission)) return Promise.resolve(true);
-  const userId = request.user?.id;
-  if (!userId) return Promise.resolve(false);
-  return userAssignmentsRepo.isTaskAssignedToUser(userId, taskId);
-};
+const canAccessTask = makeAccessChecker(
+  (userId, taskId) => userAssignmentsRepo.isTaskAssignedToUser(userId, taskId),
+  'projects.tasks_all.view',
+);
 
 export default async function (fastify: FastifyInstance, _opts: unknown) {
   // GET / - List all tasks

--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -119,8 +119,6 @@ const userIdsSchema = {
   required: ['userIds'],
 } as const;
 
-// Pass forwarding arrows rather than direct references so test `mock.module` replacements
-// of `userAssignmentsRepo.*` resolve at call time, not module-load time.
 const canAccessProject = makeAccessChecker(
   (userId, projectId) => userAssignmentsRepo.isProjectAssignedToUser(userId, projectId),
   'projects.manage_all.view',

--- a/server/test/repositories/clientsRepo.test.ts
+++ b/server/test/repositories/clientsRepo.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
 import type { DbExecutor } from '../../db/drizzle.ts';
 import * as clientsRepo from '../../repositories/clientsRepo.ts';
+import { makeDbError } from '../helpers/dbErrors.ts';
 import { type FakeExecutor, makeRow, setupTestDb } from '../helpers/fakeExecutor.ts';
 
 let exec: FakeExecutor;
@@ -453,5 +454,38 @@ describe('deleteById', () => {
   test('returns null when no row deleted', async () => {
     exec.enqueue({ rows: [] });
     expect(await clientsRepo.deleteById('c-x', testDb)).toBeNull();
+  });
+});
+
+describe('classifyUniqueViolation', () => {
+  test('returns "fiscal_code" for idx_clients_fiscal_code_unique', () => {
+    expect(
+      clientsRepo.classifyUniqueViolation(makeDbError('23505', 'idx_clients_fiscal_code_unique')),
+    ).toBe('fiscal_code');
+  });
+
+  test('returns "client_code" for idx_clients_client_code_unique', () => {
+    expect(
+      clientsRepo.classifyUniqueViolation(makeDbError('23505', 'idx_clients_client_code_unique')),
+    ).toBe('client_code');
+  });
+
+  test('falls back to detail-text match when constraint name is missing', () => {
+    const err = makeDbError('23505');
+    err.detail = 'Key (client_code)=(AC-1) already exists.';
+    expect(clientsRepo.classifyUniqueViolation(err)).toBe('client_code');
+  });
+
+  test('catches all other 23505 violations as "fiscal_code" (legacy fallback)', () => {
+    expect(clientsRepo.classifyUniqueViolation(makeDbError('23505', 'some_other_unique'))).toBe(
+      'fiscal_code',
+    );
+  });
+
+  test('returns null when the error is not a unique violation', () => {
+    expect(clientsRepo.classifyUniqueViolation(makeDbError('23503'))).toBeNull();
+    expect(clientsRepo.classifyUniqueViolation(new Error('boom'))).toBeNull();
+    expect(clientsRepo.classifyUniqueViolation(null)).toBeNull();
+    expect(clientsRepo.classifyUniqueViolation(undefined)).toBeNull();
   });
 });

--- a/server/test/utils/permissions.test.ts
+++ b/server/test/utils/permissions.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, mock, test } from 'bun:test';
 import {
   ADMIN_BASE_PERMISSIONS,
   ADMINISTRATION_PERMISSIONS,
@@ -12,6 +12,7 @@ import {
   hasScopedActionPermission,
   isPermissionKnown,
   isTopManagerOnlyPermission,
+  makeAccessChecker,
   normalizePermission,
   PERMISSION_DEFINITIONS,
   requestHasPermission,
@@ -226,6 +227,76 @@ describe('hasPermission', () => {
 
   test('returns false for empty array', () => {
     expect(hasPermission([], 'crm.clients.view')).toBe(false);
+  });
+});
+
+describe('makeAccessChecker', () => {
+  const ENTITY_ID = 'entity-1';
+  const DEFAULT_SCOPE = 'crm.clients_all.view';
+
+  test('short-circuits true when the request has the default *_all scope permission', async () => {
+    const repoFn = mock(async () => false);
+    const canAccess = makeAccessChecker(repoFn, DEFAULT_SCOPE);
+
+    const request = { user: { id: 'u1', permissions: [DEFAULT_SCOPE] } };
+    expect(await canAccess(request, ENTITY_ID)).toBe(true);
+    expect(repoFn).not.toHaveBeenCalled();
+  });
+
+  test('short-circuits true when the request has a caller-supplied scope override', async () => {
+    const repoFn = mock(async () => false);
+    const canAccess = makeAccessChecker(repoFn, DEFAULT_SCOPE);
+
+    const request = { user: { id: 'u1', permissions: ['crm.clients_all.delete'] } };
+    // Caller asked us to gate on the *.delete variant rather than the default *.view.
+    expect(await canAccess(request, ENTITY_ID, 'crm.clients_all.delete')).toBe(true);
+    expect(repoFn).not.toHaveBeenCalled();
+  });
+
+  test('falls back to the repo lookup when the request lacks the *_all scope permission', async () => {
+    const repoFn = mock(async () => true);
+    const canAccess = makeAccessChecker(repoFn, DEFAULT_SCOPE);
+
+    const request = { user: { id: 'u1', permissions: ['crm.clients.view'] } };
+    expect(await canAccess(request, ENTITY_ID)).toBe(true);
+    expect(repoFn).toHaveBeenCalledTimes(1);
+    expect(repoFn).toHaveBeenCalledWith('u1', ENTITY_ID);
+  });
+
+  test('returns the repo verdict — false when the user is not assigned to the entity', async () => {
+    const repoFn = mock(async () => false);
+    const canAccess = makeAccessChecker(repoFn, DEFAULT_SCOPE);
+
+    const request = { user: { id: 'u1', permissions: ['crm.clients.view'] } };
+    expect(await canAccess(request, ENTITY_ID)).toBe(false);
+    expect(repoFn).toHaveBeenCalledWith('u1', ENTITY_ID);
+  });
+
+  test('returns false without hitting the repo when the request has no user', async () => {
+    const repoFn = mock(async () => true);
+    const canAccess = makeAccessChecker(repoFn, DEFAULT_SCOPE);
+
+    expect(await canAccess({}, ENTITY_ID)).toBe(false);
+    expect(repoFn).not.toHaveBeenCalled();
+  });
+
+  test('returns false without hitting the repo when the user has no id', async () => {
+    const repoFn = mock(async () => true);
+    const canAccess = makeAccessChecker(repoFn, DEFAULT_SCOPE);
+
+    const request = { user: { permissions: ['crm.clients.view'] } };
+    expect(await canAccess(request, ENTITY_ID)).toBe(false);
+    expect(repoFn).not.toHaveBeenCalled();
+  });
+
+  test('propagates repo errors to the caller', async () => {
+    const repoFn = mock(async () => {
+      throw new Error('repo boom');
+    });
+    const canAccess = makeAccessChecker(repoFn, DEFAULT_SCOPE);
+
+    const request = { user: { id: 'u1', permissions: ['crm.clients.view'] } };
+    await expect(canAccess(request, ENTITY_ID)).rejects.toThrow('repo boom');
   });
 });
 

--- a/server/utils/permissions.ts
+++ b/server/utils/permissions.ts
@@ -267,15 +267,14 @@ export const requestHasPermission = (
   permission: Permission | string,
 ) => !!request.user?.permissions?.includes(permission);
 
-// Duck-typed shape the access checker reads off the Fastify request. Kept local so this module
-// doesn't pull in `fastify` and create an import cycle.
+// Duck-typed locally so this module doesn't pull in `fastify` and create an import cycle.
 type RequestWithUser = { user?: { id?: string; permissions?: string[] } };
 
 type AssignmentCheck = (userId: string, entityId: string) => Promise<boolean>;
 
-// Build a request-scoped access checker that grants access either via the wide "*_all" scope
-// permission or via an explicit per-entity assignment lookup. Lets routes collapse the
-// "scope-permission OR repo lookup" pattern to a single line.
+// Grants access either via the wide "*_all" scope permission or via a per-entity assignment
+// lookup. Pass `repoFn` as a forwarding arrow (not a direct module reference) so test
+// `mock.module` replacements resolve at call time, not at factory-invocation time.
 export const makeAccessChecker = (
   repoFn: AssignmentCheck,
   defaultAllScopePermission: Permission | string,

--- a/server/utils/permissions.ts
+++ b/server/utils/permissions.ts
@@ -266,3 +266,28 @@ export const requestHasPermission = (
   request: { user?: { permissions?: string[] } },
   permission: Permission | string,
 ) => !!request.user?.permissions?.includes(permission);
+
+// Duck-typed shape the access checker reads off the Fastify request. Kept local so this module
+// doesn't pull in `fastify` and create an import cycle.
+type RequestWithUser = { user?: { id?: string; permissions?: string[] } };
+
+type AssignmentCheck = (userId: string, entityId: string) => Promise<boolean>;
+
+// Build a request-scoped access checker that grants access either via the wide "*_all" scope
+// permission or via an explicit per-entity assignment lookup. Lets routes collapse the
+// "scope-permission OR repo lookup" pattern to a single line.
+export const makeAccessChecker = (
+  repoFn: AssignmentCheck,
+  defaultAllScopePermission: Permission | string,
+) => {
+  return (
+    request: RequestWithUser,
+    entityId: string,
+    allScopePermission: Permission | string = defaultAllScopePermission,
+  ): Promise<boolean> => {
+    if (requestHasPermission(request, allScopePermission)) return Promise.resolve(true);
+    const userId = request.user?.id;
+    if (!userId) return Promise.resolve(false);
+    return repoFn(userId, entityId);
+  };
+};


### PR DESCRIPTION
## Summary
- Extract a single `makeAccessChecker(repoFn, defaultAllScopePermission)` factory in `server/utils/permissions.ts` and collapse the three duplicated 8-line `canAccess*` helpers in `clients.ts`, `projects.ts`, and `tasks.ts` into thin one-liners. (`clients.ts` had `canAccessClient`; `projects.ts` had both `canAccessClient` and `canAccessProject`; `tasks.ts` had both `canAccessProject` and `canAccessTask`.)
- Move the 11-line Postgres-index-name match for client unique violations (`idx_clients_fiscal_code_unique` / `idx_clients_client_code_unique`) out of the route layer into `clientsRepo.classifyUniqueViolation` (returns a domain enum `'fiscal_code' | 'client_code' | null`). The two verbatim catch-blocks in the POST and PUT handlers of `clients.ts` now share a small local `handleClientUniqueViolation(err, reply)` that maps the enum to a `badRequest` reply.
- Pure refactor — no behavior changes. Surfaced from PR #352 review as out-of-scope cleanup.

## Notes
- The route helpers pass forwarding arrows (e.g. `(userId, clientId) => userAssignmentsRepo.isClientAssignedToUser(userId, clientId)`) instead of the bare function reference. This keeps `userAssignmentsRepo.*` late-bound so `mock.module` replacements in route tests resolve at call time — matching the previous namespace-import behavior. Without this, the full server test run shows 70+ unrelated route test failures.

## Test plan
- [x] `bunx --bun biome check` clean on all touched files
- [x] `bun test server/test/utils/permissions.test.ts server/test/repositories/clientsRepo.test.ts server/test/routes/clients.test.ts server/test/routes/projects.test.ts server/test/routes/tasks.test.ts` → 245 pass, 0 fail
- [x] Full `bun test server/test` → 2242 pass, 28 skip, 0 fail (matches baseline on main)
- [x] `cd server && bun run build` → clean
- [x] New tests:
  - `makeAccessChecker` behavior matrix (scope hit, scope override, falls back to repo, returns repo verdict, no user, no user id, propagates errors)
  - `classifyUniqueViolation` (each index name, detail-text fallback, legacy catchall, non-violations return null)

🤖 Generated with [Claude Code](https://claude.com/claude-code)