### PR TITLE
feat(settings): lock profile + password forms for non-local auth users

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2658,6 +2658,8 @@ const App: React.FC = () => {
             {activeView === 'settings' && (
               <UserSettings
                 settings={userSettings}
+                authMethod={currentUser.authMethod ?? 'local'}
+                authProviderName={currentUser.authProviderName ?? null}
                 onUpdate={handleUpdateUserSettings}
                 onUpdatePassword={handleUpdateUserPassword}
                 onListMcpTokens={handleListMcpTokens}

--- a/components/UserSettings.tsx
+++ b/components/UserSettings.tsx
@@ -47,11 +47,14 @@ import { Textarea } from '@/components/ui/textarea';
 import { cn } from '@/lib/utils';
 import praetorFaviconUrl from '../praetor-favicon.png';
 import type { CreatedMcpToken, McpToken, PersonalAccessToken, Settings } from '../services/api';
+import type { UserAuthMethod } from '../types';
 import { applyLanguagePreference } from '../utils/language';
 import { applyTheme, getTheme, THEMES, type Theme } from '../utils/theme';
 
 export interface UserSettingsProps {
   settings: Settings;
+  authMethod?: UserAuthMethod;
+  authProviderName?: string | null;
   isLoading?: boolean;
   onUpdate: (updates: Partial<Settings>) => void;
   onUpdatePassword: (currentPassword: string, newPassword: string) => Promise<void>;
@@ -168,6 +171,8 @@ const LANGUAGE_OPTIONS: ReadonlyArray<{
 
 const UserSettings: React.FC<UserSettingsProps> = ({
   settings,
+  authMethod = 'local',
+  authProviderName = null,
   isLoading = false,
   onUpdate,
   onUpdatePassword,
@@ -179,6 +184,10 @@ const UserSettings: React.FC<UserSettingsProps> = ({
 }) => {
   const { t } = useTranslation(['settings', 'common']);
   const translateRef = useRef(t);
+  const isLocalAuth = authMethod === 'local';
+  const identityProviderLabel = isLocalAuth
+    ? ''
+    : authProviderName || t(`settings:identityProviders.${authMethod}`);
 
   // Initialize the editable fields from `settings` once at mount. We deliberately
   // do not re-sync on later `settings` prop changes: the parent re-creates the
@@ -276,6 +285,8 @@ const UserSettings: React.FC<UserSettingsProps> = ({
 
   const handleSave = async (e: React.FormEvent) => {
     e.preventDefault();
+    // Profile fields are mastered by the identity provider for non-local users.
+    if (!isLocalAuth) return;
     // Prevent double-submission when the user mashes Enter / clicks Save twice
     // in quick succession — `onUpdate` is async and a second call would race.
     if (isSaving) return;
@@ -301,7 +312,9 @@ const UserSettings: React.FC<UserSettingsProps> = ({
     applyLanguagePreference(lang);
     setLanguage(lang);
     try {
-      await onUpdate({ fullName, email, language: lang });
+      // Send only the language so this still works for non-local users
+      // (the backend rejects fullName/email updates for them).
+      await onUpdate({ language: lang });
     } catch (err) {
       console.error('Failed to update language:', err);
       // Roll the optimistic update back so the user can retry the same option.
@@ -505,6 +518,16 @@ const UserSettings: React.FC<UserSettingsProps> = ({
           </div>
           <form onSubmit={handleSave}>
             <div className="p-6 space-y-6">
+              {!isLocalAuth && (
+                <div
+                  role="status"
+                  aria-live="polite"
+                  className="flex items-center gap-2 rounded-md border border-zinc-200 bg-zinc-50 p-4 text-sm font-medium text-zinc-700"
+                >
+                  <Lock aria-hidden="true" className="size-4" />
+                  {t('userProfile.lockedBanner', { provider: identityProviderLabel })}
+                </div>
+              )}
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                 <div>
                   <label className="block text-xs font-bold text-zinc-400 uppercase tracking-wider mb-2">
@@ -514,7 +537,13 @@ const UserSettings: React.FC<UserSettingsProps> = ({
                     type="text"
                     value={fullName}
                     onChange={(e) => setFullName(e.target.value)}
-                    className="w-full px-4 py-2 bg-zinc-50 border border-zinc-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none transition-all text-sm font-semibold"
+                    disabled={!isLocalAuth}
+                    readOnly={!isLocalAuth}
+                    aria-readonly={!isLocalAuth}
+                    className={cn(
+                      'w-full px-4 py-2 bg-zinc-50 border border-zinc-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none transition-all text-sm font-semibold',
+                      !isLocalAuth && 'cursor-not-allowed opacity-60',
+                    )}
                   />
                 </div>
                 <div>
@@ -525,37 +554,45 @@ const UserSettings: React.FC<UserSettingsProps> = ({
                     type="email"
                     value={email}
                     onChange={(e) => setEmail(e.target.value)}
-                    className="w-full px-4 py-2 bg-zinc-50 border border-zinc-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none transition-all text-sm font-semibold"
+                    disabled={!isLocalAuth}
+                    readOnly={!isLocalAuth}
+                    aria-readonly={!isLocalAuth}
+                    className={cn(
+                      'w-full px-4 py-2 bg-zinc-50 border border-zinc-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none transition-all text-sm font-semibold',
+                      !isLocalAuth && 'cursor-not-allowed opacity-60',
+                    )}
                   />
                 </div>
               </div>
             </div>
-            <div className="px-6 py-4 border-t border-zinc-200 flex justify-end">
-              <button
-                type="submit"
-                disabled={isSaving || !hasChanges}
-                className={`px-8 py-3 rounded-xl font-bold text-sm transition-all duration-300 ease-in-out active:scale-95 flex items-center gap-2 ${
-                  isSaved
-                    ? 'bg-emerald-500 text-white shadow-lg shadow-emerald-100'
-                    : isSaving || !hasChanges
-                      ? 'bg-zinc-100 text-zinc-400 cursor-not-allowed border border-zinc-200'
-                      : 'bg-praetor text-white shadow-lg shadow-zinc-200 hover:bg-zinc-700'
-                }`}
-              >
-                {isSaving ? (
-                  <i className="fa-solid fa-circle-notch fa-spin"></i>
-                ) : isSaved ? (
-                  <i className="fa-solid fa-check"></i>
-                ) : (
-                  <i className="fa-solid fa-save"></i>
-                )}
-                {isSaving
-                  ? t('general.saving')
-                  : isSaved
-                    ? t('general.changesSaved')
-                    : t('general.saveChanges')}
-              </button>
-            </div>
+            {isLocalAuth && (
+              <div className="px-6 py-4 border-t border-zinc-200 flex justify-end">
+                <button
+                  type="submit"
+                  disabled={isSaving || !hasChanges}
+                  className={`px-8 py-3 rounded-xl font-bold text-sm transition-all duration-300 ease-in-out active:scale-95 flex items-center gap-2 ${
+                    isSaved
+                      ? 'bg-emerald-500 text-white shadow-lg shadow-emerald-100'
+                      : isSaving || !hasChanges
+                        ? 'bg-zinc-100 text-zinc-400 cursor-not-allowed border border-zinc-200'
+                        : 'bg-praetor text-white shadow-lg shadow-zinc-200 hover:bg-zinc-700'
+                  }`}
+                >
+                  {isSaving ? (
+                    <i className="fa-solid fa-circle-notch fa-spin"></i>
+                  ) : isSaved ? (
+                    <i className="fa-solid fa-check"></i>
+                  ) : (
+                    <i className="fa-solid fa-save"></i>
+                  )}
+                  {isSaving
+                    ? t('general.saving')
+                    : isSaved
+                      ? t('general.changesSaved')
+                      : t('general.saveChanges')}
+                </button>
+              </div>
+            )}
           </form>
         </section>
       )}
@@ -687,82 +724,99 @@ const UserSettings: React.FC<UserSettingsProps> = ({
               </CardTitle>
               <CardDescription>{t('password.description')}</CardDescription>
             </CardHeader>
-            <form onSubmit={handlePasswordUpdate}>
-              <CardContent className="space-y-6 p-6">
-                {passwordError && (
-                  <div className="flex items-center gap-2 rounded-md border border-destructive/20 bg-destructive/10 p-4 text-sm font-medium text-destructive animate-in fade-in slide-in-from-top-2">
-                    <AlertCircle aria-hidden="true" className="size-4" />
-                    {passwordError}
-                  </div>
-                )}
+            {isLocalAuth ? (
+              <form onSubmit={handlePasswordUpdate}>
+                <CardContent className="space-y-6 p-6">
+                  {passwordError && (
+                    <div className="flex items-center gap-2 rounded-md border border-destructive/20 bg-destructive/10 p-4 text-sm font-medium text-destructive animate-in fade-in slide-in-from-top-2">
+                      <AlertCircle aria-hidden="true" className="size-4" />
+                      {passwordError}
+                    </div>
+                  )}
 
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                  <Field>
-                    <FieldLabel htmlFor="security-current-password">
-                      {t('password.currentPassword')}
-                    </FieldLabel>
-                    <Input
-                      id="security-current-password"
-                      type="password"
-                      value={currentPassword}
-                      onChange={(e) => setCurrentPassword(e.target.value)}
-                      placeholder="••••••••"
-                      required
-                    />
-                  </Field>
-                  <Field className="md:col-start-1">
-                    <FieldLabel htmlFor="security-new-password">
-                      {t('password.newPassword')}
-                    </FieldLabel>
-                    <Input
-                      id="security-new-password"
-                      type="password"
-                      value={newPassword}
-                      onChange={(e) => setNewPassword(e.target.value)}
-                      placeholder="••••••••"
-                      required
-                    />
-                  </Field>
-                  <Field>
-                    <FieldLabel htmlFor="security-confirm-password">
-                      {t('password.confirmNewPassword')}
-                    </FieldLabel>
-                    <Input
-                      id="security-confirm-password"
-                      type="password"
-                      value={confirmPassword}
-                      onChange={(e) => setConfirmPassword(e.target.value)}
-                      placeholder="••••••••"
-                      required
-                    />
-                  </Field>
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                    <Field>
+                      <FieldLabel htmlFor="security-current-password">
+                        {t('password.currentPassword')}
+                      </FieldLabel>
+                      <Input
+                        id="security-current-password"
+                        type="password"
+                        value={currentPassword}
+                        onChange={(e) => setCurrentPassword(e.target.value)}
+                        placeholder="••••••••"
+                        required
+                      />
+                    </Field>
+                    <Field className="md:col-start-1">
+                      <FieldLabel htmlFor="security-new-password">
+                        {t('password.newPassword')}
+                      </FieldLabel>
+                      <Input
+                        id="security-new-password"
+                        type="password"
+                        value={newPassword}
+                        onChange={(e) => setNewPassword(e.target.value)}
+                        placeholder="••••••••"
+                        required
+                      />
+                    </Field>
+                    <Field>
+                      <FieldLabel htmlFor="security-confirm-password">
+                        {t('password.confirmNewPassword')}
+                      </FieldLabel>
+                      <Input
+                        id="security-confirm-password"
+                        type="password"
+                        value={confirmPassword}
+                        onChange={(e) => setConfirmPassword(e.target.value)}
+                        placeholder="••••••••"
+                        required
+                      />
+                    </Field>
+                  </div>
+                </CardContent>
+                <CardFooter className="justify-end border-t border-border px-6 py-4 [.border-t]:pt-4">
+                  {(() => {
+                    const { Icon, iconClass, label } = isSavingPassword
+                      ? { Icon: Loader2, iconClass: 'animate-spin', label: t('password.updating') }
+                      : passwordSuccess
+                        ? {
+                            Icon: Check,
+                            iconClass: undefined,
+                            label: t('password.passwordUpdated'),
+                          }
+                        : {
+                            Icon: KeyRound,
+                            iconClass: undefined,
+                            label: t('password.updatePassword'),
+                          };
+                    return (
+                      <Button
+                        type="submit"
+                        disabled={
+                          isSavingPassword || !currentPassword || !newPassword || !confirmPassword
+                        }
+                      >
+                        <Icon aria-hidden="true" className={iconClass} />
+                        {label}
+                      </Button>
+                    );
+                  })()}
+                </CardFooter>
+              </form>
+            ) : (
+              <CardContent className="p-6">
+                <div
+                  role="status"
+                  aria-live="polite"
+                  className="flex items-center gap-2 rounded-md border border-border bg-muted/40 p-4 text-sm font-medium text-muted-foreground"
+                >
+                  <Lock aria-hidden="true" className="size-4" />
+                  {t('password.lockedBanner', { provider: identityProviderLabel })}
                 </div>
               </CardContent>
-              <CardFooter className="justify-end border-t border-border px-6 py-4 [.border-t]:pt-4">
-                {(() => {
-                  const { Icon, iconClass, label } = isSavingPassword
-                    ? { Icon: Loader2, iconClass: 'animate-spin', label: t('password.updating') }
-                    : passwordSuccess
-                      ? { Icon: Check, iconClass: undefined, label: t('password.passwordUpdated') }
-                      : {
-                          Icon: KeyRound,
-                          iconClass: undefined,
-                          label: t('password.updatePassword'),
-                        };
-                  return (
-                    <Button
-                      type="submit"
-                      disabled={
-                        isSavingPassword || !currentPassword || !newPassword || !confirmPassword
-                      }
-                    >
-                      <Icon aria-hidden="true" className={iconClass} />
-                      {label}
-                    </Button>
-                  );
-                })()}
-              </CardFooter>
-            </form>
+            )}
           </Card>
 
           <Card className="gap-0 overflow-hidden rounded-lg border-border bg-background py-0">

--- a/locales/en/settings.json
+++ b/locales/en/settings.json
@@ -5,7 +5,8 @@
     "title": "User Profile",
     "fullName": "Full Name",
     "email": "Email Address",
-    "updateProfile": "Update Profile"
+    "updateProfile": "Update Profile",
+    "lockedBanner": "Your profile is managed by {{provider}} and cannot be edited here."
   },
   "language": {
     "title": "Language",
@@ -53,7 +54,13 @@
     "passwordsDoNotMatch": "New passwords do not match",
     "passwordMinLength": "New password must be at least 8 characters long",
     "sameAsCurrent": "New password must be different from the current password",
-    "incorrectPassword": "Incorrect current password"
+    "incorrectPassword": "Incorrect current password",
+    "lockedBanner": "Your password is managed by {{provider}}. Change it there."
+  },
+  "identityProviders": {
+    "ldap": "LDAP",
+    "oidc": "OIDC",
+    "saml": "SAML"
   },
   "mcp": {
     "title": "MCP Tokens",

--- a/locales/it/settings.json
+++ b/locales/it/settings.json
@@ -5,7 +5,8 @@
     "title": "Profilo Utente",
     "fullName": "Nome Completo",
     "email": "Indirizzo Email",
-    "updateProfile": "Aggiorna Profilo"
+    "updateProfile": "Aggiorna Profilo",
+    "lockedBanner": "Il tuo profilo è gestito da {{provider}} e non può essere modificato qui."
   },
   "language": {
     "title": "Lingua",
@@ -53,7 +54,13 @@
     "passwordsDoNotMatch": "Le nuove password non corrispondono",
     "passwordMinLength": "La nuova password deve avere almeno 8 caratteri",
     "sameAsCurrent": "La nuova password deve essere diversa da quella attuale",
-    "incorrectPassword": "Password attuale non corretta"
+    "incorrectPassword": "Password attuale non corretta",
+    "lockedBanner": "La tua password è gestita da {{provider}}. Modificala lì."
+  },
+  "identityProviders": {
+    "ldap": "LDAP",
+    "oidc": "OIDC",
+    "saml": "SAML"
   },
   "mcp": {
     "title": "Token MCP",

--- a/server/routes/settings.ts
+++ b/server/routes/settings.ts
@@ -21,6 +21,7 @@ import {
 import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
+  forbidden,
   optionalEmail,
   optionalEnum,
   optionalNonEmptyString,
@@ -181,6 +182,15 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const languageResult = optionalEnum(language, settingsRepo.LANGUAGES, 'language');
       if (!languageResult.ok) return badRequest(reply, languageResult.message);
 
+      // Identity fields (name, email) are mastered by the upstream IdP for
+      // non-local users; only the UI-preference `language` field stays editable.
+      if (fullNameResult.value !== null || emailResult.value !== null) {
+        const userCore = await usersRepo.findCoreById(request.user.id);
+        if (userCore && userCore.authMethod !== 'local') {
+          return forbidden(reply, 'Profile is managed by the identity provider');
+        }
+      }
+
       return settingsRepo.upsertForUser(request.user.id, {
         fullName: fullNameResult.value,
         email: emailResult.value,
@@ -314,6 +324,13 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
 
       if (currentPasswordResult.value === newPasswordResult.value) {
         return badRequest(reply, 'New password must be different from the current password');
+      }
+
+      // The password lives in the upstream IdP for non-local users; reject before
+      // bcrypt so we surface a clear error instead of "Incorrect current password".
+      const userCore = await usersRepo.findCoreById(request.user.id);
+      if (userCore && userCore.authMethod !== 'local') {
+        return forbidden(reply, 'Password is managed by the identity provider');
       }
 
       const passwordHash = await usersRepo.getPasswordHash(request.user.id);

--- a/server/test/routes/settings.test.ts
+++ b/server/test/routes/settings.test.ts
@@ -25,6 +25,7 @@ const personalAccessTokensRepoSnap = { ...realPersonalAccessTokensRepo };
 const bcryptSnap = { ...(realBcrypt as Record<string, unknown>) };
 
 const findAuthUserByIdMock = mock();
+const findCoreByIdMock = mock();
 const userHasRoleMock = mock();
 const getRolePermissionsMock = mock();
 const getOrCreateForUserMock = mock();
@@ -51,6 +52,7 @@ beforeAll(async () => {
   mock.module('../../repositories/usersRepo.ts', () => ({
     ...usersRepoSnap,
     findAuthUserById: findAuthUserByIdMock,
+    findCoreById: findCoreByIdMock,
     getPasswordHash: getPasswordHashMock,
     updatePasswordHash: updatePasswordHashMock,
   }));
@@ -134,6 +136,7 @@ const HAPPY_PERSONAL_ACCESS_TOKEN = {
 
 const allMocks = [
   findAuthUserByIdMock,
+  findCoreByIdMock,
   userHasRoleMock,
   getRolePermissionsMock,
   getOrCreateForUserMock,
@@ -155,9 +158,20 @@ const allMocks = [
 
 let testApp: FastifyInstance;
 
+const LOCAL_CORE_USER = {
+  id: 'u1',
+  name: 'Alice',
+  username: 'alice',
+  role: 'user',
+  employeeType: 'app_user',
+  authMethod: 'local',
+  authProviderId: null,
+};
+
 beforeEach(async () => {
   for (const m of allMocks) m.mockReset();
   findAuthUserByIdMock.mockResolvedValue(HAPPY_USER);
+  findCoreByIdMock.mockResolvedValue(LOCAL_CORE_USER);
   userHasRoleMock.mockResolvedValue(true);
   getRolePermissionsMock.mockResolvedValue([]);
   upsertAdminPasswordWarningMock.mockResolvedValue(undefined);
@@ -292,6 +306,54 @@ describe('PUT /api/settings', () => {
       payload: { fullName: 'X' },
     });
     expect(res.statusCode).toBe(401);
+  });
+
+  test('403 non-local user cannot update fullName', async () => {
+    findCoreByIdMock.mockResolvedValue({ ...LOCAL_CORE_USER, authMethod: 'ldap' });
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/settings',
+      headers: authHeader(),
+      payload: { fullName: 'Alice B' },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body).error).toMatch(/identity provider/);
+    expect(upsertForUserMock).not.toHaveBeenCalled();
+  });
+
+  test('403 non-local user cannot update email', async () => {
+    findCoreByIdMock.mockResolvedValue({ ...LOCAL_CORE_USER, authMethod: 'oidc' });
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/settings',
+      headers: authHeader(),
+      payload: { email: 'alice@new.com' },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(upsertForUserMock).not.toHaveBeenCalled();
+  });
+
+  test('200 non-local user can still change language', async () => {
+    findCoreByIdMock.mockResolvedValue({ ...LOCAL_CORE_USER, authMethod: 'saml' });
+    upsertForUserMock.mockResolvedValue({ ...HAPPY_SETTINGS, language: 'it' });
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/settings',
+      headers: authHeader(),
+      payload: { language: 'it' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(upsertForUserMock).toHaveBeenCalledWith('u1', {
+      fullName: null,
+      email: null,
+      language: 'it',
+    });
   });
 });
 
@@ -547,6 +609,23 @@ describe('PUT /api/settings/password', () => {
       payload: { currentPassword: 'a', newPassword: 'b' },
     });
     expect(res.statusCode).toBe(401);
+  });
+
+  test('403 non-local user cannot change password', async () => {
+    findCoreByIdMock.mockResolvedValue({ ...LOCAL_CORE_USER, authMethod: 'ldap' });
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/settings/password',
+      headers: authHeader(),
+      payload: { currentPassword: 'old-pw1', newPassword: 'new-secure-pw' },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body).error).toMatch(/identity provider/);
+    expect(getPasswordHashMock).not.toHaveBeenCalled();
+    expect(bcryptCompareMock).not.toHaveBeenCalled();
+    expect(updatePasswordHashMock).not.toHaveBeenCalled();
   });
 });
 

--- a/server/utils/validation.ts
+++ b/server/utils/validation.ts
@@ -452,6 +452,13 @@ export function badRequest(reply: FastifyReply, message: string): FastifyReply {
 }
 
 /**
+ * Send a 403 Forbidden response with error message
+ */
+export function forbidden(reply: FastifyReply, message: string): FastifyReply {
+  return reply.code(403).send({ error: message });
+}
+
+/**
  * Validate email format (basic regex)
  */
 export function isValidEmail(value: string): boolean {

--- a/test/components/UserSettings.test.tsx
+++ b/test/components/UserSettings.test.tsx
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { PersonalAccessToken, Settings } from '../../services/api';
+import type { UserAuthMethod } from '../../types';
 import { installI18nMock } from '../helpers/i18n';
 
 installI18nMock();
@@ -57,6 +58,9 @@ const onRenewPersonalAccessToken = mock(() =>
 
 const renderSettings = (
   overrides: {
+    authMethod?: UserAuthMethod;
+    authProviderName?: string | null;
+    onUpdate?: (updates: Partial<Settings>) => Promise<void>;
     onGetPersonalAccessToken?: () => Promise<PersonalAccessToken>;
     onRenewPersonalAccessToken?: () => Promise<PersonalAccessToken>;
   } = {},
@@ -64,7 +68,9 @@ const renderSettings = (
   render(
     <UserSettings
       settings={settings}
-      onUpdate={onUpdate}
+      authMethod={overrides.authMethod}
+      authProviderName={overrides.authProviderName}
+      onUpdate={overrides.onUpdate ?? onUpdate}
       onUpdatePassword={onUpdatePassword}
       onListMcpTokens={onListMcpTokens}
       onCreateMcpToken={onCreateMcpToken}
@@ -388,5 +394,75 @@ describe('<UserSettings /> MCP tokens', () => {
 
     await waitFor(() => expect(onRevokeMcpToken).toHaveBeenCalledWith('mcp-token-1'));
     await waitFor(() => expect(screen.queryByText('Agent')).not.toBeInTheDocument());
+  });
+});
+
+describe('<UserSettings /> non-local auth', () => {
+  beforeEach(() => {
+    for (const m of [
+      onUpdate,
+      onUpdatePassword,
+      onListMcpTokens,
+      onCreateMcpToken,
+      onRevokeMcpToken,
+      onGetPersonalAccessToken,
+      onRenewPersonalAccessToken,
+    ]) {
+      m.mockClear();
+    }
+  });
+
+  test('Profile tab: shows lock banner and disables identity inputs for LDAP users', () => {
+    renderSettings({ authMethod: 'ldap', authProviderName: null });
+
+    expect(screen.getByText('userProfile.lockedBanner')).toBeInTheDocument();
+
+    const fullNameInput = screen.getByDisplayValue('Alice') as HTMLInputElement;
+    const emailInput = screen.getByDisplayValue('alice@example.com') as HTMLInputElement;
+
+    expect(fullNameInput.disabled).toBe(true);
+    expect(fullNameInput.readOnly).toBe(true);
+    expect(emailInput.disabled).toBe(true);
+    expect(emailInput.readOnly).toBe(true);
+
+    expect(screen.queryByRole('button', { name: /general.saveChanges/ })).not.toBeInTheDocument();
+  });
+
+  test('Profile tab: submitting the form is a no-op for non-local users', async () => {
+    const { container } = renderSettings({ authMethod: 'oidc', authProviderName: 'Acme SSO' });
+
+    const form = container.querySelector('form');
+    expect(form).not.toBeNull();
+    fireEvent.submit(form as HTMLFormElement);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  test('Security tab: replaces the password card with a lock banner; PAT card still renders', async () => {
+    renderSettings({ authMethod: 'saml', authProviderName: 'Corporate SSO' });
+
+    fireEvent.click(screen.getByText('security.title'));
+
+    expect(await screen.findByText('password.lockedBanner')).toBeInTheDocument();
+
+    expect(screen.queryByLabelText('password.currentPassword')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('password.newPassword')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('password.confirmNewPassword')).not.toBeInTheDocument();
+
+    await waitFor(() => expect(onGetPersonalAccessToken).toHaveBeenCalled());
+    expect(screen.getByText('security.personalAccessToken.title')).toBeInTheDocument();
+  });
+
+  test('Language change for non-local users only sends the language field', async () => {
+    renderSettings({ authMethod: 'ldap' });
+
+    fireEvent.click(screen.getByRole('button', { name: /language.title/ }));
+    fireEvent.click(screen.getByText('language.italian'));
+
+    await waitFor(() => expect(onUpdate).toHaveBeenCalled());
+    expect(onUpdate).toHaveBeenCalledWith({ language: 'it' });
   });
 });


### PR DESCRIPTION
## Summary

For LDAP/OIDC/SAML users, identity fields (name, email) and the password live in the upstream identity provider. Allowing local edits in the user-preferences screen was misleading — profile changes landed in a per-user `settings` row that diverged from the IdP, and password change attempts failed with a confusing _"Incorrect current password"_ error (because no local password hash exists).

This PR locks both forms for non-local users and enforces the same constraint server-side.

### UI changes (`components/UserSettings.tsx`)

- **Profile tab**: Full Name / Email inputs are `disabled` + `readOnly`, the Save button is hidden, and an explanatory banner names the upstream provider.
- **Security tab**: the password card body is replaced by the same banner; PAT and MCP cards are untouched.
- `handleLanguageChange` now sends a language-only payload so the language tab still works for non-local users under the new server guard.

### Server changes (`server/routes/settings.ts`)

- `PUT /settings` returns **403** when a non-local user supplies `fullName` or `email`. Pure language updates still pass through.
- `PUT /settings/password` returns **403** before bcrypt for non-local users with a clear `Password is managed by the identity provider` message.
- Added a `forbidden(reply, message)` helper next to the existing `badRequest` in `server/utils/validation.ts`.

### i18n

New keys in `locales/{en,it}/settings.json`: `userProfile.lockedBanner`, `password.lockedBanner`, `identityProviders.{ldap,oidc,saml}`.

## Test plan

- [x] `bun test test/components/UserSettings.test.tsx` — 16 pass (4 new cases: banner + disabled inputs, submit no-op, password lock + PAT card still rendered, language-only payload)
- [x] `cd server && bun test test/routes/settings.test.ts` — 32 pass (4 new cases: 403 on fullName, 403 on email, 200 on language-only, 403 on password change)
- [x] Full backend suite (2209 pass, 0 fail) and full frontend suite (3187 pass, 0 fail)
- [x] `bun run lint` clean
- [ ] Manual: log in as a local user → Profile/Security work as before; log in as an LDAP user → both forms locked with banner, Language tab still saves

🤖 Generated with [Claude Code](https://claude.com/claude-code)