### PR TITLE
fix(settings): normalize USD currency in update path (#370)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -87,6 +87,7 @@ import {
   clearStaleModuleScopedState,
   getStaleModulesAfterNavigation,
 } from './utils/moduleScopedState';
+import { normalizeCurrency } from './utils/normalizeCurrency';
 import {
   buildPermission,
   equivalentPermissionsFor,
@@ -1186,11 +1187,9 @@ const AppContent: React.FC = () => {
     const loadGeneralSettings = async () => {
       if (hasLoadedGeneralSettings) return;
       const genSettings = await api.generalSettings.get();
-      if (genSettings.currency === 'USD') {
-        genSettings.currency = '$';
-      }
       setGeneralSettings({
         ...genSettings,
+        currency: normalizeCurrency(genSettings.currency),
         geminiApiKey: genSettings.geminiApiKey || '',
         aiProvider: genSettings.aiProvider || 'gemini',
         openrouterApiKey: genSettings.openrouterApiKey || '',
@@ -2033,6 +2032,7 @@ const AppContent: React.FC = () => {
       const updated = await api.generalSettings.update(updates);
       setGeneralSettings({
         ...updated,
+        currency: normalizeCurrency(updated.currency),
         geminiApiKey: updated.geminiApiKey || '',
         aiProvider: updated.aiProvider || 'gemini',
         openrouterApiKey: updated.openrouterApiKey || '',

--- a/test/utils/normalizeCurrency.test.ts
+++ b/test/utils/normalizeCurrency.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'bun:test';
+import { normalizeCurrency } from '../../utils/normalizeCurrency';
+
+describe('normalizeCurrency', () => {
+  test('maps the legacy "USD" code to the "$" symbol', () => {
+    expect(normalizeCurrency('USD')).toBe('$');
+  });
+
+  test('is idempotent on "$"', () => {
+    expect(normalizeCurrency('$')).toBe('$');
+  });
+
+  test('leaves the euro symbol untouched', () => {
+    expect(normalizeCurrency('€')).toBe('€');
+  });
+
+  test('leaves multi-character symbols like "CHF" untouched', () => {
+    expect(normalizeCurrency('CHF')).toBe('CHF');
+  });
+});

--- a/utils/normalizeCurrency.ts
+++ b/utils/normalizeCurrency.ts
@@ -1,0 +1,2 @@
+export const normalizeCurrency = (currency: string): string =>
+  currency === 'USD' ? '$' : currency;


### PR DESCRIPTION
## Summary

- Fixes #370. The general-settings **load** path normalizes legacy `'USD'` to `'$'` before writing to `generalSettings` state, but the **update** handler (`App.tsx:2031-2047`) writes the API response directly. After saving any field, accounts with the legacy code see currency flip from `$50.00` to `USD 50.00` across the 14+ views that consume `generalSettings.currency` as a display string.
- Extract `normalizeCurrency` into `utils/normalizeCurrency.ts` and apply it on both the load and update paths.
- Scope intentionally narrow: only the legacy `'USD' → '$'` mapping that the load path already performed. EUR/GBP code-to-symbol mapping is a display concern (handled by the existing `getCurrencySymbol` in `App.tsx`) and is left untouched to avoid silently rewriting persisted state for currencies not mentioned in the issue.

## Test plan

- [x] `bun test test/utils/normalizeCurrency.test.ts` — new helper unit test (4 assertions: `USD→$`, idempotent `$`, passthrough `€`, passthrough `CHF`).
- [x] Frontend `tsc -p tsconfig.json --noEmit` — clean.
- [x] `biome check` on the touched files — clean.
- [ ] Manual smoke (remote DB): seed `general_settings.currency = 'USD'`, open the app, save another field in General Settings → cost amounts continue to render as `$N.NN` and not `USD N.NN`.

No docs changes: this is a bug fix with no API or UX-surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)