### PR TITLE
fix(api): make fetchApiStream throw ApiError on network/HTTP errors

### DIFF
--- a/services/api/client.ts
+++ b/services/api/client.ts
@@ -75,14 +75,25 @@ export const fetchApiStream = async (
     ...options.headers,
   };
 
-  const response = await fetch(`${API_BASE}${endpoint}`, {
-    ...options,
-    headers,
-  });
+  let response: Response;
+  try {
+    response = await fetch(`${API_BASE}${endpoint}`, {
+      ...options,
+      headers,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Network request failed';
+    throw new ApiError(message, 0, true);
+  }
 
   const newToken = response.headers.get('x-auth-token');
   if (newToken) {
     setAuthToken(newToken);
+  }
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: 'Request failed' }));
+    throw new ApiError(error.message || error.error || `HTTP ${response.status}`, response.status);
   }
 
   return response;

--- a/services/api/reports.ts
+++ b/services/api/reports.ts
@@ -59,13 +59,6 @@ const parseReportStream = async (
   response: Response,
   handlers: ReportChatStreamHandlers = {},
 ): Promise<ReportChatStreamDoneEvent> => {
-  if (!response.ok) {
-    const jsonError = await response.json().catch(() => null);
-    const message =
-      typeof jsonError?.error === 'string' ? jsonError.error : `HTTP ${response.status}`;
-    throw new Error(message);
-  }
-
   if (!response.body) {
     throw new Error('Streaming response body is missing');
   }

--- a/services/api/supplierQuotes.ts
+++ b/services/api/supplierQuotes.ts
@@ -51,10 +51,6 @@ export const supplierQuotesApi = {
       method: 'POST',
       body: formData,
     });
-    if (!response.ok) {
-      const errorBody = await response.json().catch(() => ({ error: 'Upload failed' }));
-      throw new Error(errorBody.error || `HTTP ${response.status}`);
-    }
     return (await response.json()) as SupplierQuoteAttachment;
   },
 
@@ -62,10 +58,6 @@ export const supplierQuotesApi = {
     const response = await fetchApiStream(
       `/sales/supplier-quotes/${id}/attachments/${attachmentId}/download`,
     );
-    if (!response.ok) {
-      const errorBody = await response.json().catch(() => ({ error: 'Download failed' }));
-      throw new Error(errorBody.error || `HTTP ${response.status}`);
-    }
     return await response.blob();
   },
 

--- a/test/services/client.test.ts
+++ b/test/services/client.test.ts
@@ -213,12 +213,36 @@ describe('services/api/client', () => {
       await fetchApiStream('/stream');
     });
 
-    test('does not throw on non-ok stream responses; caller handles them', async () => {
+    test('throws ApiError carrying the HTTP status on non-ok stream responses', async () => {
       fetchMock.mockImplementationOnce(async () =>
-        buildResponse({ status: 500, json: () => ({}) }),
+        buildResponse({ status: 500, json: () => ({ message: 'boom' }) }),
       );
-      const response = await fetchApiStream('/bad-stream');
-      expect((response as { status: number }).status).toBe(500);
+      await expect(fetchApiStream('/bad-stream')).rejects.toMatchObject({
+        name: 'ApiError',
+        status: 500,
+        message: 'boom',
+      });
+    });
+
+    test('non-ok stream with unparseable body falls back to "Request failed"', async () => {
+      fetchMock.mockImplementationOnce(async () =>
+        buildResponse({
+          status: 503,
+          json: () => Promise.reject(new Error('not json')),
+        }),
+      );
+      await expect(fetchApiStream('/crash-stream')).rejects.toThrow('Request failed');
+    });
+
+    test('network error from fetch surfaces as ApiError with isNetworkError=true', async () => {
+      fetchMock.mockImplementationOnce(async () => {
+        throw new TypeError('Failed to fetch');
+      });
+      await expect(fetchApiStream('/down-stream')).rejects.toMatchObject({
+        name: 'ApiError',
+        status: 0,
+        isNetworkError: true,
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary
- `fetchApiStream` now mirrors `fetchApi`: throws `ApiError(msg, 0, true)` on network failure and `ApiError(msg, status)` on `!response.ok` (after token rotation, so 401 rotations still apply). Closes #372.
- Removed the now-unreachable `!response.ok` branches in the three callers (`supplierQuotes.uploadAttachment` / `downloadAttachment`, `parseReportStream`).
- Three new tests assert non-ok → `ApiError` with status, unparseable-body fallback, and network-error → `ApiError` with `isNetworkError=true` — using `rejects.toMatchObject` to stay consistent with the rest of the suite.

## Test plan
- [x] `bun test test/services/client.test.ts` — 23/23 pass
- [x] `bun run test:frontend` — 999/999 pass
- [x] `bunx biome check` on touched files — clean
- [ ] Manual smoke: trigger a 500 from `/reports/ai-reporting/chat/stream` and confirm the UI surfaces an `ApiError` rather than a malformed-SSE error

🤖 Generated with [Claude Code](https://claude.com/claude-code)