### PR TITLE
fix(auth): reset settings state on logout to prevent cross-user leak (#371)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -827,14 +827,14 @@ const AppContent: React.FC = () => {
   const clearAuthScopedAppState = useCallback(() => {
     resetModuleLoader();
     setHasLoadedGeneralSettings(false);
-    setHasLoadedLdapConfig(false);
-    setHasLoadedSsoProviders(false);
-    setHasLoadedEmailConfig(false);
-    setHasLoadedRoles(false);
     setGeneralSettings(INITIAL_GENERAL_SETTINGS);
+    setHasLoadedLdapConfig(false);
     setLdapConfig(INITIAL_LDAP_CONFIG);
+    setHasLoadedEmailConfig(false);
     setEmailConfig(INITIAL_EMAIL_CONFIG);
+    setHasLoadedSsoProviders(false);
     setSsoProviders([]);
+    setHasLoadedRoles(false);
     setRoles([]);
     setUsers([]);
     setClients([]);

--- a/App.tsx
+++ b/App.tsx
@@ -3,6 +3,12 @@ import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { FieldLabel } from '@/components/ui/field';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import {
+  type GeneralSettingsState,
+  INITIAL_EMAIL_CONFIG,
+  INITIAL_GENERAL_SETTINGS,
+  INITIAL_LDAP_CONFIG,
+} from './authScopedDefaults';
 import ClientsInvoicesView from './components/accounting/ClientsInvoicesView';
 import ClientsOrdersView from './components/accounting/ClientsOrdersView';
 import SupplierInvoicesView from './components/accounting/SupplierInvoicesView';
@@ -641,33 +647,9 @@ const AppContent: React.FC = () => {
   // logout/role-switch alongside `setEntries([])`. We use state (not a ref) so
   // the dependent effect re-runs when the flag changes.
   const [entriesLoaded, setEntriesLoaded] = useState(false);
-  const [ldapConfig, setLdapConfig] = useState<LdapConfig>({
-    enabled: false,
-    serverUrl: 'ldap://ldap.example.com:389',
-    baseDn: 'dc=example,dc=com',
-    bindDn: 'cn=read-only-admin,dc=example,dc=com',
-    bindPassword: '',
-    userFilter: '(uid={0})',
-    groupBaseDn: 'ou=groups,dc=example,dc=com',
-    groupFilter: '(member={0})',
-    roleMappings: [],
-    tlsCaCertificate: '',
-    autoProvisionAll: false,
-  });
-  const [generalSettings, setGeneralSettings] = useState({
-    currency: '€',
-    dailyLimit: 8,
-    startOfWeek: 'Monday' as 'Monday' | 'Sunday',
-    treatSaturdayAsHoliday: true,
-    allowWeekendSelection: true,
-    enableAiReporting: false,
-    geminiApiKey: '',
-    aiProvider: 'gemini' as 'gemini' | 'openrouter',
-    openrouterApiKey: '',
-    geminiModelId: '',
-    openrouterModelId: '',
-    defaultLocation: 'remote' as TimeEntryLocation,
-  });
+  const [ldapConfig, setLdapConfig] = useState<LdapConfig>(INITIAL_LDAP_CONFIG);
+  const [generalSettings, setGeneralSettings] =
+    useState<GeneralSettingsState>(INITIAL_GENERAL_SETTINGS);
   const {
     loadedModules,
     moduleLoadErrors,
@@ -683,17 +665,7 @@ const AppContent: React.FC = () => {
   const [hasLoadedSsoProviders, setHasLoadedSsoProviders] = useState(false);
   const [ssoProviders, setSsoProviders] = useState<SsoProvider[]>([]);
   const [hasLoadedEmailConfig, setHasLoadedEmailConfig] = useState(false);
-  const [emailConfig, setEmailConfig] = useState<EmailConfig>({
-    enabled: false,
-    smtpHost: '',
-    smtpPort: 587,
-    smtpEncryption: 'tls',
-    smtpRejectUnauthorized: true,
-    smtpUser: '',
-    smtpPassword: '',
-    fromEmail: '',
-    fromName: 'Praetor',
-  });
+  const [emailConfig, setEmailConfig] = useState<EmailConfig>(INITIAL_EMAIL_CONFIG);
 
   const [workUnits, setWorkUnits] = useState<WorkUnit[]>([]);
   const [roles, setRoles] = useState<Role[]>([]);
@@ -859,6 +831,9 @@ const AppContent: React.FC = () => {
     setHasLoadedSsoProviders(false);
     setHasLoadedEmailConfig(false);
     setHasLoadedRoles(false);
+    setGeneralSettings(INITIAL_GENERAL_SETTINGS);
+    setLdapConfig(INITIAL_LDAP_CONFIG);
+    setEmailConfig(INITIAL_EMAIL_CONFIG);
     setSsoProviders([]);
     setRoles([]);
     setUsers([]);

--- a/authScopedDefaults.ts
+++ b/authScopedDefaults.ts
@@ -4,7 +4,21 @@ import type { EmailConfig, GeneralSettings, LdapConfig } from './types';
 // a concrete value (empty string / default) so consumers never see `undefined`.
 export type GeneralSettingsState = Required<GeneralSettings>;
 
-export const INITIAL_LDAP_CONFIG: LdapConfig = {
+// Defaults are shared module-level references reused by every reset; an
+// in-place mutation by any consumer would silently re-introduce the leak
+// these constants exist to prevent. Freeze recursively so dev-mode catches
+// the mistake.
+const deepFreeze = <T>(value: T): T => {
+  if (value !== null && typeof value === 'object' && !Object.isFrozen(value)) {
+    Object.freeze(value);
+    for (const key of Object.keys(value) as (keyof T)[]) {
+      deepFreeze(value[key]);
+    }
+  }
+  return value;
+};
+
+export const INITIAL_LDAP_CONFIG: LdapConfig = deepFreeze({
   enabled: false,
   serverUrl: 'ldap://ldap.example.com:389',
   baseDn: 'dc=example,dc=com',
@@ -16,9 +30,9 @@ export const INITIAL_LDAP_CONFIG: LdapConfig = {
   roleMappings: [],
   tlsCaCertificate: '',
   autoProvisionAll: false,
-};
+});
 
-export const INITIAL_GENERAL_SETTINGS: GeneralSettingsState = {
+export const INITIAL_GENERAL_SETTINGS: GeneralSettingsState = deepFreeze({
   currency: '€',
   dailyLimit: 8,
   startOfWeek: 'Monday',
@@ -31,9 +45,9 @@ export const INITIAL_GENERAL_SETTINGS: GeneralSettingsState = {
   geminiModelId: '',
   openrouterModelId: '',
   defaultLocation: 'remote',
-};
+});
 
-export const INITIAL_EMAIL_CONFIG: EmailConfig = {
+export const INITIAL_EMAIL_CONFIG: EmailConfig = deepFreeze({
   enabled: false,
   smtpHost: '',
   smtpPort: 587,
@@ -43,4 +57,4 @@ export const INITIAL_EMAIL_CONFIG: EmailConfig = {
   smtpPassword: '',
   fromEmail: '',
   fromName: 'Praetor',
-};
+});

--- a/authScopedDefaults.ts
+++ b/authScopedDefaults.ts
@@ -1,0 +1,46 @@
+import type { EmailConfig, GeneralSettings, LdapConfig } from './types';
+
+// State variant: every optional field on the API-response type is present as
+// a concrete value (empty string / default) so consumers never see `undefined`.
+export type GeneralSettingsState = Required<GeneralSettings>;
+
+export const INITIAL_LDAP_CONFIG: LdapConfig = {
+  enabled: false,
+  serverUrl: 'ldap://ldap.example.com:389',
+  baseDn: 'dc=example,dc=com',
+  bindDn: 'cn=read-only-admin,dc=example,dc=com',
+  bindPassword: '',
+  userFilter: '(uid={0})',
+  groupBaseDn: 'ou=groups,dc=example,dc=com',
+  groupFilter: '(member={0})',
+  roleMappings: [],
+  tlsCaCertificate: '',
+  autoProvisionAll: false,
+};
+
+export const INITIAL_GENERAL_SETTINGS: GeneralSettingsState = {
+  currency: '€',
+  dailyLimit: 8,
+  startOfWeek: 'Monday',
+  treatSaturdayAsHoliday: true,
+  allowWeekendSelection: true,
+  enableAiReporting: false,
+  geminiApiKey: '',
+  aiProvider: 'gemini',
+  openrouterApiKey: '',
+  geminiModelId: '',
+  openrouterModelId: '',
+  defaultLocation: 'remote',
+};
+
+export const INITIAL_EMAIL_CONFIG: EmailConfig = {
+  enabled: false,
+  smtpHost: '',
+  smtpPort: 587,
+  smtpEncryption: 'tls',
+  smtpRejectUnauthorized: true,
+  smtpUser: '',
+  smtpPassword: '',
+  fromEmail: '',
+  fromName: 'Praetor',
+};

--- a/authScopedDefaults.ts
+++ b/authScopedDefaults.ts
@@ -6,19 +6,20 @@ export type GeneralSettingsState = Required<GeneralSettings>;
 
 // Defaults are shared module-level references reused by every reset; an
 // in-place mutation by any consumer would silently re-introduce the leak
-// these constants exist to prevent. Freeze recursively so dev-mode catches
-// the mistake.
-const deepFreeze = <T>(value: T): T => {
+// these constants exist to prevent. Freeze recursively (Object.isFrozen
+// guards against cycles) and return Readonly so the compiler flags writes
+// before runtime does.
+const deepFreeze = <T>(value: T): Readonly<T> => {
   if (value !== null && typeof value === 'object' && !Object.isFrozen(value)) {
     Object.freeze(value);
-    for (const key of Object.keys(value) as (keyof T)[]) {
-      deepFreeze(value[key]);
+    for (const child of Object.values(value)) {
+      deepFreeze(child);
     }
   }
   return value;
 };
 
-export const INITIAL_LDAP_CONFIG: LdapConfig = deepFreeze({
+export const INITIAL_LDAP_CONFIG = deepFreeze<LdapConfig>({
   enabled: false,
   serverUrl: 'ldap://ldap.example.com:389',
   baseDn: 'dc=example,dc=com',
@@ -32,7 +33,7 @@ export const INITIAL_LDAP_CONFIG: LdapConfig = deepFreeze({
   autoProvisionAll: false,
 });
 
-export const INITIAL_GENERAL_SETTINGS: GeneralSettingsState = deepFreeze({
+export const INITIAL_GENERAL_SETTINGS = deepFreeze<GeneralSettingsState>({
   currency: '€',
   dailyLimit: 8,
   startOfWeek: 'Monday',
@@ -47,7 +48,7 @@ export const INITIAL_GENERAL_SETTINGS: GeneralSettingsState = deepFreeze({
   defaultLocation: 'remote',
 });
 
-export const INITIAL_EMAIL_CONFIG: EmailConfig = deepFreeze({
+export const INITIAL_EMAIL_CONFIG = deepFreeze<EmailConfig>({
   enabled: false,
   smtpHost: '',
   smtpPort: 587,

--- a/test/App.clearAuthScopedState.test.ts
+++ b/test/App.clearAuthScopedState.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  INITIAL_EMAIL_CONFIG,
+  INITIAL_GENERAL_SETTINGS,
+  INITIAL_LDAP_CONFIG,
+} from '../authScopedDefaults';
+
+// Issue #371: defaults must wipe sensitive credentials and disable AI reporting
+// so one user's settings do not survive into the next session after logout.
+describe('App.tsx auth-scoped reset defaults', () => {
+  test('LDAP defaults wipe bind credentials', () => {
+    expect(INITIAL_LDAP_CONFIG.enabled).toBe(false);
+    expect(INITIAL_LDAP_CONFIG.bindPassword).toBe('');
+    expect(INITIAL_LDAP_CONFIG.tlsCaCertificate).toBe('');
+    expect(INITIAL_LDAP_CONFIG.roleMappings).toEqual([]);
+  });
+
+  test('email defaults wipe SMTP credentials', () => {
+    expect(INITIAL_EMAIL_CONFIG.enabled).toBe(false);
+    expect(INITIAL_EMAIL_CONFIG.smtpHost).toBe('');
+    expect(INITIAL_EMAIL_CONFIG.smtpUser).toBe('');
+    expect(INITIAL_EMAIL_CONFIG.smtpPassword).toBe('');
+    expect(INITIAL_EMAIL_CONFIG.fromEmail).toBe('');
+  });
+
+  test('general-settings defaults wipe AI keys and disable AI reporting', () => {
+    expect(INITIAL_GENERAL_SETTINGS.enableAiReporting).toBe(false);
+    expect(INITIAL_GENERAL_SETTINGS.geminiApiKey).toBe('');
+    expect(INITIAL_GENERAL_SETTINGS.openrouterApiKey).toBe('');
+    expect(INITIAL_GENERAL_SETTINGS.geminiModelId).toBe('');
+    expect(INITIAL_GENERAL_SETTINGS.openrouterModelId).toBe('');
+  });
+
+  test('clearAuthScopedAppState body resets all three settings objects', () => {
+    // Source-text assertion: pins that the reset *path* actually runs, not
+    // just that the safe defaults exist. The bug was that the helper updated
+    // `hasLoaded*` flags but never invoked the setters for the data itself.
+    const source = readFileSync(join(import.meta.dir, '..', 'App.tsx'), 'utf8');
+    const start = source.indexOf('const clearAuthScopedAppState = useCallback(');
+    expect(start).toBeGreaterThan(-1);
+    const end = source.indexOf('}, [resetModuleLoader]);', start);
+    expect(end).toBeGreaterThan(start);
+    const body = source.slice(start, end);
+    expect(body).toContain('setGeneralSettings(INITIAL_GENERAL_SETTINGS)');
+    expect(body).toContain('setLdapConfig(INITIAL_LDAP_CONFIG)');
+    expect(body).toContain('setEmailConfig(INITIAL_EMAIL_CONFIG)');
+  });
+});


### PR DESCRIPTION
## Summary
- `clearAuthScopedAppState` in `App.tsx` was resetting the `hasLoaded*` flags but never the underlying state objects, so `generalSettings`, `ldapConfig`, and `emailConfig` (including LDAP bind credentials and SMTP passwords) persisted in React state across logouts — a cross-user data-exposure risk on shared workstations and a brief UI flicker (e.g. AI Reporting sidebar) when a different user logged in next.
- Extracted the initial defaults into a dedicated `authScopedDefaults.ts` module (separate file so `App.tsx` stays Fast-Refresh-clean for Biome's `useComponentExportOnlyModules`) and reset all three settings on login/logout alongside the existing data clears.
- Defaults are deep-frozen so any future in-place mutation by a consumer fails fast in dev instead of silently re-introducing the leak.

Other auth-scoped state was already reset elsewhere and is unaffected by this PR: `notifications` / `unreadNotificationCount` reset in an effect on `currentUser` change; `viewingUserId` reset in `useAuth.onLogin`/`onLogout`; `userSettings` owned and reset by `useAuth`.

Closes #371.

## Test plan
- [x] `bun test test/App.clearAuthScopedState.test.ts` — new regression test (4/4 pass; verified fails on unfixed source).
- [x] `bun test ./test` — 1001/1001 pass.
- [x] `bunx tsc -p tsconfig.json --noEmit` — clean.
- [x] `bunx biome check` on changed files — clean.
- [ ] Manual smoke: log in as admin A with LDAP/SMTP configured and `enableAiReporting: true`, log out, log in as user B without those settings; confirm no flicker of A's data and React DevTools shows the three objects cleared to defaults immediately on logout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)