### PR TITLE
fix(crypto): decrypt throws on parse/auth failure

### DIFF
--- a/server/test/utils/crypto.test.ts
+++ b/server/test/utils/crypto.test.ts
@@ -74,15 +74,22 @@ describe('decrypt', () => {
     expect(decrypt(encrypt(plaintext))).toBe(plaintext);
   });
 
-  test('returns input unchanged when it does not look like encrypted format (legacy plaintext)', () => {
-    expect(decrypt('legacy-plaintext-no-colons')).toBe('legacy-plaintext-no-colons');
+  test('throws when input does not match the iv:authTag:encrypted format', () => {
+    expect(() => decrypt('plaintext-no-colons')).toThrow(/Invalid encrypted value format/);
   });
 
-  test('returns ciphertext unchanged when iv/authTag/encrypted decode but auth tag fails (treats as legacy)', () => {
-    // Three colon-separated base64 parts that aren't a valid GCM ciphertext should
-    // hit the catch branch and be returned as-is rather than throwing.
+  test('throws when ciphertext parses but GCM auth tag verification fails', () => {
     const fakeCiphertext = `${Buffer.from('iv').toString('base64')}:${Buffer.from('tag').toString('base64')}:${Buffer.from('data').toString('base64')}`;
-    expect(decrypt(fakeCiphertext)).toBe(fakeCiphertext);
+    expect(() => decrypt(fakeCiphertext)).toThrow();
+  });
+
+  test('throws when a real ciphertext has a tampered auth tag', () => {
+    const real = encrypt('a real secret');
+    const [iv, tag, data] = real.split(':');
+    const tagBytes = Buffer.from(tag, 'base64');
+    tagBytes[0] ^= 0xff;
+    const tampered = `${iv}:${tagBytes.toString('base64')}:${data}`;
+    expect(() => decrypt(tampered)).toThrow();
   });
 });
 

--- a/server/utils/crypto.ts
+++ b/server/utils/crypto.ts
@@ -27,21 +27,15 @@ export function encrypt(plaintext: string): string {
 
 export function decrypt(ciphertext: string): string {
   if (!ciphertext) return '';
-  const key = getEncryptionKey();
   const [ivB64, authTagB64, encryptedB64] = ciphertext.split(':');
   if (!ivB64 || !authTagB64 || !encryptedB64) {
-    // Not encrypted (legacy plaintext) - return as-is
-    return ciphertext;
+    throw new Error('Invalid encrypted value format');
   }
-  try {
-    const iv = Buffer.from(ivB64, 'base64');
-    const authTag = Buffer.from(authTagB64, 'base64');
-    const encrypted = Buffer.from(encryptedB64, 'base64');
-    const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
-    decipher.setAuthTag(authTag);
-    return decipher.update(encrypted) + decipher.final('utf8');
-  } catch {
-    // Decryption failed (likely legacy plaintext containing colons) - return as-is
-    return ciphertext;
-  }
+  const key = getEncryptionKey();
+  const iv = Buffer.from(ivB64, 'base64');
+  const authTag = Buffer.from(authTagB64, 'base64');
+  const encrypted = Buffer.from(encryptedB64, 'base64');
+  const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(authTag);
+  return decipher.update(encrypted) + decipher.final('utf8');
 }


### PR DESCRIPTION
## Summary

- Removes the two silent fallbacks in `decrypt()` that returned the raw input on parse failure (line 34) or GCM auth-tag failure (catch block at line 45). Both defeated AES-256-GCM's tamper detection and could feed corrupted ciphertext to `nodemailer` / `openid-client` as if it were the plaintext SMTP password or OAuth client secret.
- Reorders the function so format validation runs **before** `getEncryptionKey()` — no SHA-256 work on inputs that will immediately throw.
- Adds a regression test that flips one byte of the auth tag on a real ciphertext and confirms `decrypt` throws (this test fails on the old code, passes on the fix).

Closes #365.

## Test plan

- [x] `bun test test/utils/crypto.test.ts` — 12 pass / 0 fail
- [x] `bun test` (full backend suite) — 2287 pass / 28 skip / 0 fail
- [x] `bun run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)