### PR TITLE
fix(timesheet): persist WeeklyView clears and await all submit mutations (#364)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -456,6 +456,7 @@ const TrackerView: React.FC<{
           onAddCustomTask={onAddCustomTask}
           onAddBulkEntries={onAddBulkEntries}
           onUpdateEntry={onUpdateEntry}
+          onDeleteEntry={onDeleteEntry}
           viewingUserId={viewingUserId}
           selectedDate={selectedDate}
           onSelectedDateChange={setSelectedDate}

--- a/components/timesheet/WeeklyView.tsx
+++ b/components/timesheet/WeeklyView.tsx
@@ -43,7 +43,8 @@ export interface WeeklyViewProps {
     >,
   ) => Promise<ProjectTask>;
   onAddBulkEntries: (entries: Omit<TimeEntry, 'id' | 'createdAt' | 'userId'>[]) => Promise<void>;
-  onUpdateEntry: (id: string, updates: Partial<TimeEntry>) => void;
+  onUpdateEntry: (id: string, updates: Partial<TimeEntry>) => void | Promise<void>;
+  onDeleteEntry: (id: string) => void | Promise<void>;
   viewingUserId: string;
   selectedDate: string;
   onSelectedDateChange: (date: string) => void;
@@ -88,6 +89,20 @@ const parseDuration = (raw: string): number => {
   return Number.isFinite(parsed) ? parsed : 0;
 };
 
+type EditClassification = 'add' | 'update' | 'delete' | 'noop';
+
+const classifyEdit = (base: DayCell | undefined, edit: DayCell): EditClassification => {
+  const newDuration = parseDuration(edit.duration);
+  const baseDuration = base ? parseDuration(base.duration) : 0;
+  const noteChanged = (edit.note ?? '') !== (base?.note ?? '');
+  if (base?.entryId) {
+    if (newDuration === 0) return 'delete';
+    if (newDuration !== baseDuration || noteChanged) return 'update';
+    return 'noop';
+  }
+  return newDuration > 0 ? 'add' : 'noop';
+};
+
 const WeeklyView: React.FC<WeeklyViewProps> = ({
   entries,
   clients,
@@ -98,6 +113,7 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
   onAddCustomTask,
   onAddBulkEntries,
   onUpdateEntry,
+  onDeleteEntry,
   viewingUserId,
   selectedDate,
   onSelectedDateChange,
@@ -366,6 +382,9 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
     const newErrors: WeeklyEntryFormErrors = {};
     const formEdits = pendingEdits[FORM_ROW_KEY] ?? {};
     const hasFormHours = Object.values(formEdits).some((cell) => parseDuration(cell.duration) > 0);
+    const hasFormChanges = Object.entries(formEdits).some(
+      ([dateStr, cell]) => classifyEdit(formRowBaseDays[dateStr], cell) !== 'noop',
+    );
 
     if (hasFormHours) {
       if (!selection.clientId) newErrors.clientId = t('common:validation.clientRequired');
@@ -387,6 +406,8 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
     }
 
     const entriesToAdd: Omit<TimeEntry, 'id' | 'createdAt' | 'userId'>[] = [];
+    const entriesToUpdate: Array<{ id: string; updates: Partial<TimeEntry> }> = [];
+    const entriesToDelete: string[] = [];
 
     const submitRow = (
       rowKey: string,
@@ -405,14 +426,17 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
         const base = meta.baseDays[day.dateStr];
         const edit = rowEdits[day.dateStr];
         if (!edit) continue;
-        const newDuration = parseDuration(edit.duration);
-        const baseDuration = base ? parseDuration(base.duration) : 0;
-        const noteChanged = (edit.note ?? '') !== (base?.note ?? '');
-        if (base?.entryId) {
-          if (newDuration > 0 && (newDuration !== baseDuration || noteChanged)) {
-            // `edit.note` directly so a user can clear a previously-set note.
-            onUpdateEntry(base.entryId, {
-              duration: newDuration,
+        const action = classifyEdit(base, edit);
+        if (action === 'noop') continue;
+        if (action === 'delete' && base?.entryId) {
+          entriesToDelete.push(base.entryId);
+          continue;
+        }
+        if (action === 'update' && base?.entryId) {
+          entriesToUpdate.push({
+            id: base.entryId,
+            updates: {
+              duration: parseDuration(edit.duration),
               notes: edit.note,
               task: meta.taskName,
               projectId: meta.projectId,
@@ -420,28 +444,26 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
               clientName: client?.name || 'Unknown',
               projectName: project?.name || 'General',
               location: meta.location,
-            });
-          }
+            },
+          });
           continue;
         }
-        if (newDuration > 0) {
-          entriesToAdd.push({
-            date: day.dateStr,
-            clientId: meta.clientId,
-            clientName: client?.name || 'Unknown',
-            projectId: meta.projectId,
-            projectName: project?.name || 'General',
-            task: meta.taskName,
-            duration: newDuration,
-            notes: edit.note || weekNote,
-            hourlyCost: 0,
-            location: meta.location,
-          });
-        }
+        entriesToAdd.push({
+          date: day.dateStr,
+          clientId: meta.clientId,
+          clientName: client?.name || 'Unknown',
+          projectId: meta.projectId,
+          projectName: project?.name || 'General',
+          task: meta.taskName,
+          duration: parseDuration(edit.duration),
+          notes: edit.note || weekNote,
+          hourlyCost: 0,
+          location: meta.location,
+        });
       }
     };
 
-    if (hasFormHours) {
+    if (hasFormChanges) {
       submitRow(FORM_ROW_KEY, {
         clientId: selection.clientId,
         projectId: selection.projectId,
@@ -462,9 +484,15 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
     }
 
     try {
-      if (entriesToAdd.length > 0) {
-        await onAddBulkEntries(entriesToAdd);
+      const pending: Promise<void>[] = [];
+      if (entriesToAdd.length > 0) pending.push(onAddBulkEntries(entriesToAdd));
+      for (const { id, updates } of entriesToUpdate) {
+        pending.push(Promise.resolve(onUpdateEntry(id, updates)));
       }
+      for (const id of entriesToDelete) {
+        pending.push(Promise.resolve(onDeleteEntry(id)));
+      }
+      await Promise.all(pending);
       setPendingEdits({});
       setWeekNote('');
       setShowSuccess(true);
@@ -548,29 +576,14 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
     );
   };
 
-  // True when at least one pending edit would actually change state on
-  // submit — i.e. a non-zero new value on a fresh cell, or an existing entry
-  // whose duration / note differs from its baseline. Mirrors submitRow's
-  // gating so the button stays disabled when the user types a value and then
-  // clears it (net zero change).
   const hasPendingEdits = useMemo(() => {
     const rowHasChange = (rowKey: string, baseDays: DayMap) => {
       const edits = pendingEdits[rowKey];
       if (!edits) return false;
-      for (const [dateStr, edit] of Object.entries(edits)) {
-        const base = baseDays[dateStr];
-        const newDuration = parseDuration(edit.duration);
-        const baseDuration = base ? parseDuration(base.duration) : 0;
-        const noteChanged = (edit.note ?? '') !== (base?.note ?? '');
-        if (base?.entryId) {
-          if (newDuration > 0 && (newDuration !== baseDuration || noteChanged)) return true;
-        } else if (newDuration > 0) {
-          return true;
-        }
-      }
-      return false;
+      return Object.entries(edits).some(
+        ([dateStr, edit]) => classifyEdit(baseDays[dateStr], edit) !== 'noop',
+      );
     };
-
     if (rowHasChange(FORM_ROW_KEY, formRowBaseDays)) return true;
     return entryRows.some((row) => rowHasChange(row.key, row.baseDays));
   }, [pendingEdits, formRowBaseDays, entryRows]);

--- a/test/components/WeeklyView.test.tsx
+++ b/test/components/WeeklyView.test.tsx
@@ -32,6 +32,7 @@ const baseProps = {
     ({ id: 'task-new', name: 'new', projectId: 'project-new' }) as ProjectTask,
   onAddBulkEntries: async () => {},
   onUpdateEntry: () => {},
+  onDeleteEntry: () => {},
   viewingUserId: 'u-1',
   selectedDate: todayDateOnly(),
   onSelectedDateChange: () => {},

--- a/test/components/timesheet/WeeklyView.test.tsx
+++ b/test/components/timesheet/WeeklyView.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { waitFor } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 import type { Client, Project, ProjectTask, TimeEntry } from '../../../types';
 import { installI18nMock } from '../../helpers/i18n';
 import { render } from '../../helpers/render';
@@ -42,6 +42,7 @@ const sharedProps = {
     ({ id: 'task-new', name: 'new', projectId: 'project-new' }) as ProjectTask,
   onAddBulkEntries: async () => {},
   onUpdateEntry: () => {},
+  onDeleteEntry: () => {},
   viewingUserId: 'user-a',
   selectedDate: todayDateOnly(),
   onSelectedDateChange: () => {},
@@ -110,6 +111,146 @@ describe('<WeeklyView /> RBAC catalog scoping', () => {
       const inputs = document.body.querySelectorAll<HTMLInputElement>('input[inputmode="decimal"]');
       const prefilled = Array.from(inputs).some((input) => input.value === '3.5');
       expect(prefilled).toBe(true);
+    });
+  });
+});
+
+// Catalog with two distinct (client, project, task) combos. The catalog
+// selection auto-picks the first combo for the form row, so any entry that
+// uses the *second* combo stays in the entryRows section — exactly the place
+// where the bug manifested before the fix.
+const twoComboCatalog = {
+  clients: [
+    { id: 'client-a', name: 'Client A' },
+    { id: 'client-b', name: 'Client B' },
+  ] satisfies Client[],
+  projects: [
+    { id: 'project-a', name: 'Project A', clientId: 'client-a', color: '#111111' },
+    { id: 'project-b', name: 'Project B', clientId: 'client-b', color: '#222222' },
+  ] satisfies Project[],
+  projectTasks: [
+    { id: 'task-a', name: 'Task A', projectId: 'project-a' },
+    { id: 'task-b', name: 'Task B', projectId: 'project-b' },
+  ] satisfies ProjectTask[],
+};
+
+const entryBOn = (date: string): TimeEntry => ({
+  id: 'entry-b',
+  userId: 'user-a',
+  date,
+  clientId: 'client-b',
+  clientName: 'Client B',
+  projectId: 'project-b',
+  projectName: 'Project B',
+  task: 'Task B',
+  duration: 3.5,
+  hourlyCost: 0,
+  createdAt: 1700000000,
+  location: 'remote',
+});
+
+const findDurationInputWithValue = (value: string): HTMLInputElement | undefined => {
+  const inputs = document.body.querySelectorAll<HTMLInputElement>('input[inputmode="decimal"]');
+  return Array.from(inputs).find((input) => input.value === value);
+};
+
+const clickSubmit = () => {
+  const buttons = document.body.querySelectorAll('button');
+  const submit = Array.from(buttons).find((b) => b.textContent?.includes('weekly.submitTime'));
+  if (!submit) throw new Error('submit button not found');
+  fireEvent.click(submit);
+  return submit as HTMLButtonElement;
+};
+
+describe('<WeeklyView /> submit mutations', () => {
+  test('clearing an existing entry calls onDeleteEntry and not onUpdateEntry', async () => {
+    // Regression for issue #364 bug 1: prior to the fix, setting duration to 0
+    // on an existing entry hit `continue` without calling onUpdateEntry OR
+    // onDeleteEntry, so the cell looked cleared in the UI but the entry
+    // survived on refresh.
+    const today = todayDateOnly();
+    const updateCalls: Array<{ id: string; updates: unknown }> = [];
+    const deleteCalls: string[] = [];
+
+    render(
+      <WeeklyView
+        entries={[entryBOn(today)]}
+        {...twoComboCatalog}
+        {...sharedProps}
+        onUpdateEntry={(id, updates) => {
+          updateCalls.push({ id, updates });
+        }}
+        onDeleteEntry={(id) => {
+          deleteCalls.push(id);
+        }}
+      />,
+    );
+
+    const durationInput = await waitFor(() => {
+      const input = findDurationInputWithValue('3.5');
+      if (!input) throw new Error('pre-filled 3.5 input not found');
+      return input;
+    });
+
+    fireEvent.focus(durationInput);
+    fireEvent.change(durationInput, { target: { value: '' } });
+    fireEvent.blur(durationInput);
+
+    clickSubmit();
+
+    await waitFor(() => {
+      expect(deleteCalls).toEqual(['entry-b']);
+    });
+    expect(updateCalls).toEqual([]);
+  });
+
+  test('handleSubmit awaits onUpdateEntry before flashing success', async () => {
+    // Regression for issue #364 bug 2: onUpdateEntry was previously invoked
+    // without await, so setShowSuccess(true) fired before the PATCH resolved.
+    // We expose this by holding the update promise pending and asserting the
+    // success state has not been reached.
+    const today = todayDateOnly();
+    let resolveUpdate: () => void = () => {
+      throw new Error('updatePromise executor did not assign resolve');
+    };
+    const updatePromise = new Promise<void>((resolve) => {
+      resolveUpdate = resolve;
+    });
+
+    render(
+      <WeeklyView
+        entries={[entryBOn(today)]}
+        {...twoComboCatalog}
+        {...sharedProps}
+        onUpdateEntry={() => updatePromise}
+      />,
+    );
+
+    const durationInput = await waitFor(() => {
+      const input = findDurationInputWithValue('3.5');
+      if (!input) throw new Error('pre-filled 3.5 input not found');
+      return input;
+    });
+
+    fireEvent.focus(durationInput);
+    fireEvent.change(durationInput, { target: { value: '5' } });
+    fireEvent.blur(durationInput);
+
+    const submit = clickSubmit();
+
+    // While the update is pending: button disabled and still labelled with
+    // `weekly.submitTime` (not the `weekly.success` flash).
+    expect(submit.hasAttribute('disabled')).toBe(true);
+    expect(submit.textContent).toContain('weekly.submitTime');
+    expect(submit.textContent).not.toContain('weekly.success');
+
+    resolveUpdate();
+
+    await waitFor(() => {
+      const refreshed = Array.from(document.body.querySelectorAll('button')).find((b) =>
+        b.textContent?.includes('weekly.success'),
+      );
+      expect(refreshed).toBeTruthy();
     });
   });
 });

--- a/test/components/timesheet/WeeklyView.test.tsx
+++ b/test/components/timesheet/WeeklyView.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { fireEvent, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import type { Client, Project, ProjectTask, TimeEntry } from '../../../types';
 import { installI18nMock } from '../../helpers/i18n';
 import { render } from '../../helpers/render';
@@ -115,10 +115,9 @@ describe('<WeeklyView /> RBAC catalog scoping', () => {
   });
 });
 
-// Catalog with two distinct (client, project, task) combos. The catalog
-// selection auto-picks the first combo for the form row, so any entry that
-// uses the *second* combo stays in the entryRows section — exactly the place
-// where the bug manifested before the fix.
+// Two distinct (client, project, task) combos. The form auto-selects the first
+// combo, so an entry referencing the *second* combo lands in entryRows rather
+// than collapsing into the form row.
 const twoComboCatalog = {
   clients: [
     { id: 'client-a', name: 'Client A' },
@@ -154,20 +153,31 @@ const findDurationInputWithValue = (value: string): HTMLInputElement | undefined
   return Array.from(inputs).find((input) => input.value === value);
 };
 
+const getSubmitButton = () => screen.getByRole('button', { name: /weekly\.(submitTime|success)/ });
+
 const clickSubmit = () => {
-  const buttons = document.body.querySelectorAll('button');
-  const submit = Array.from(buttons).find((b) => b.textContent?.includes('weekly.submitTime'));
-  if (!submit) throw new Error('submit button not found');
+  const submit = getSubmitButton();
   fireEvent.click(submit);
   return submit as HTMLButtonElement;
 };
 
+const setDurationInput = (input: HTMLInputElement, value: string) => {
+  fireEvent.focus(input);
+  fireEvent.change(input, { target: { value } });
+  fireEvent.blur(input);
+};
+
+const waitForDurationInputs = async (predicate: (inputs: HTMLInputElement[]) => boolean) =>
+  waitFor(() => {
+    const inputs = Array.from(
+      document.body.querySelectorAll<HTMLInputElement>('input[inputmode="decimal"]'),
+    );
+    if (!predicate(inputs)) throw new Error('expected duration inputs not yet rendered');
+    return inputs;
+  });
+
 describe('<WeeklyView /> submit mutations', () => {
-  test('clearing an existing entry calls onDeleteEntry and not onUpdateEntry', async () => {
-    // Regression for issue #364 bug 1: prior to the fix, setting duration to 0
-    // on an existing entry hit `continue` without calling onUpdateEntry OR
-    // onDeleteEntry, so the cell looked cleared in the UI but the entry
-    // survived on refresh.
+  test('clearing an existing entry-row cell calls onDeleteEntry and not onUpdateEntry', async () => {
     const today = todayDateOnly();
     const updateCalls: Array<{ id: string; updates: unknown }> = [];
     const deleteCalls: string[] = [];
@@ -192,10 +202,7 @@ describe('<WeeklyView /> submit mutations', () => {
       return input;
     });
 
-    fireEvent.focus(durationInput);
-    fireEvent.change(durationInput, { target: { value: '' } });
-    fireEvent.blur(durationInput);
-
+    setDurationInput(durationInput, '');
     clickSubmit();
 
     await waitFor(() => {
@@ -204,11 +211,111 @@ describe('<WeeklyView /> submit mutations', () => {
     expect(updateCalls).toEqual([]);
   });
 
+  test('clearing a form-row cell that maps to an existing entry calls onDeleteEntry', async () => {
+    // The single-combo catalog auto-selects, collapsing the matching entry
+    // into the form row. Clearing it must still flow through submitRow so
+    // hasFormChanges triggers the delete instead of dropping the edit.
+    const today = todayDateOnly();
+    const deleteCalls: string[] = [];
+
+    render(
+      <WeeklyView
+        entries={[
+          {
+            ...entryBOn(today),
+            id: 'entry-a',
+            clientId: 'client-a',
+            clientName: 'Client A',
+            projectId: 'project-a',
+            projectName: 'Project A',
+            task: 'Task A',
+          },
+        ]}
+        clients={[{ id: 'client-a', name: 'Client A' }]}
+        projects={[{ id: 'project-a', name: 'Project A', clientId: 'client-a', color: '#111' }]}
+        projectTasks={[{ id: 'task-a', name: 'Task A', projectId: 'project-a' }]}
+        {...sharedProps}
+        onDeleteEntry={(id) => {
+          deleteCalls.push(id);
+        }}
+      />,
+    );
+
+    const durationInput = await waitFor(() => {
+      const input = findDurationInputWithValue('3.5');
+      if (!input) throw new Error('pre-filled 3.5 input not found');
+      return input;
+    });
+
+    setDurationInput(durationInput, '');
+    clickSubmit();
+
+    await waitFor(() => {
+      expect(deleteCalls).toEqual(['entry-a']);
+    });
+  });
+
+  test('one submit dispatches mixed add, update, and delete batches', async () => {
+    // Row with two existing entries on two different days: clear one (delete),
+    // change the other (update), and fill an empty day (add). All three batches
+    // must fire from the same submit and resolve before success flashes.
+    const today = todayDateOnly();
+    const previousDay = (() => {
+      const d = new Date(today);
+      d.setDate(d.getDate() - 1);
+      return d.toISOString().slice(0, 10);
+    })();
+    const addCalls: unknown[][] = [];
+    const updateCalls: Array<{ id: string; updates: unknown }> = [];
+    const deleteCalls: string[] = [];
+
+    render(
+      <WeeklyView
+        entries={[
+          { ...entryBOn(today), id: 'entry-today', duration: 2 },
+          { ...entryBOn(previousDay), id: 'entry-prev', duration: 4 },
+        ]}
+        {...twoComboCatalog}
+        {...sharedProps}
+        onAddBulkEntries={async (entries) => {
+          addCalls.push(entries);
+        }}
+        onUpdateEntry={(id, updates) => {
+          updateCalls.push({ id, updates });
+        }}
+        onDeleteEntry={(id) => {
+          deleteCalls.push(id);
+        }}
+      />,
+    );
+
+    const inputs = await waitForDurationInputs(
+      (xs) => xs.some((i) => i.value === '2') && xs.some((i) => i.value === '4'),
+    );
+    const todayInput = inputs.find((i) => i.value === '2');
+    const prevInput = inputs.find((i) => i.value === '4');
+    if (!todayInput || !prevInput) throw new Error('expected both pre-filled inputs');
+
+    setDurationInput(prevInput, '');
+    setDurationInput(todayInput, '6');
+
+    const emptyInput = Array.from(
+      document.body.querySelectorAll<HTMLInputElement>('input[inputmode="decimal"]'),
+    ).find((i) => i.value === '' && !i.disabled && i !== prevInput);
+    if (!emptyInput) throw new Error('no empty day-cell input available');
+    setDurationInput(emptyInput, '1.5');
+
+    clickSubmit();
+
+    await waitFor(() => {
+      expect(deleteCalls).toEqual(['entry-prev']);
+      expect(updateCalls.map((c) => c.id)).toEqual(['entry-today']);
+      expect(addCalls).toHaveLength(1);
+      expect(addCalls[0]).toHaveLength(1);
+    });
+  });
+
   test('handleSubmit awaits onUpdateEntry before flashing success', async () => {
-    // Regression for issue #364 bug 2: onUpdateEntry was previously invoked
-    // without await, so setShowSuccess(true) fired before the PATCH resolved.
-    // We expose this by holding the update promise pending and asserting the
-    // success state has not been reached.
     const today = todayDateOnly();
     let resolveUpdate: () => void = () => {
       throw new Error('updatePromise executor did not assign resolve');
@@ -232,14 +339,10 @@ describe('<WeeklyView /> submit mutations', () => {
       return input;
     });
 
-    fireEvent.focus(durationInput);
-    fireEvent.change(durationInput, { target: { value: '5' } });
-    fireEvent.blur(durationInput);
+    setDurationInput(durationInput, '5');
 
     const submit = clickSubmit();
 
-    // While the update is pending: button disabled and still labelled with
-    // `weekly.submitTime` (not the `weekly.success` flash).
     expect(submit.hasAttribute('disabled')).toBe(true);
     expect(submit.textContent).toContain('weekly.submitTime');
     expect(submit.textContent).not.toContain('weekly.success');
@@ -247,10 +350,7 @@ describe('<WeeklyView /> submit mutations', () => {
     resolveUpdate();
 
     await waitFor(() => {
-      const refreshed = Array.from(document.body.querySelectorAll('button')).find((b) =>
-        b.textContent?.includes('weekly.success'),
-      );
-      expect(refreshed).toBeTruthy();
+      expect(getSubmitButton().textContent).toContain('weekly.success');
     });
   });
 });


### PR DESCRIPTION
## Summary

Closes #364. `components/timesheet/WeeklyView.tsx` had two related bugs causing silent partial saves:

- **Bug 1** — clearing the duration on an existing entry hit `continue` without calling `onUpdateEntry` or `onDeleteEntry`, so the cell looked cleared in the UI but the entry survived on refresh.
- **Bug 2** — `onUpdateEntry` was fired without `await` inside `submitRow`; only `onAddBulkEntries` was awaited before `setPendingEdits({})` and `setShowSuccess(true)` ran, so users saw the "saved" banner while their PATCHes were still in flight.

## Changes

- Added `onDeleteEntry: (id) => void | Promise<void>` to `WeeklyViewProps` and wired `handleDeleteEntry` through `App.tsx`. Widened `onUpdateEntry` to `void | Promise<void>` so `handleSubmit` can `await` it.
- Introduced a `classifyEdit(base, edit)` helper that returns `'add' | 'update' | 'delete' | 'noop'`. Both `submitRow` and `hasPendingEdits` now consume it, keeping submit-side batching and the submit-button enable gating in lockstep.
- `handleSubmit` now collects `entriesToAdd` / `entriesToUpdate` / `entriesToDelete`, fires them via `Promise.all`, then clears pending edits and flashes success only after all mutations resolve.
- Form-row submit gate is now `hasFormChanges` (any classification ≠ noop) instead of `hasFormHours`, so clearing the last populated form-row cell still flows through `submitRow`.

## Test plan

- [x] `bun test test/components/timesheet/WeeklyView.test.tsx` — two new regression tests:
  - Clearing a populated entry-row cell calls `onDeleteEntry` with the entry id and does not call `onUpdateEntry`.
  - With a deferred `onUpdateEntry`, the submit button stays disabled and non-success until the promise resolves, then transitions to the success state.
- [x] `bun test test/components/` — full frontend component suite (390 pass / 0 fail).
- [x] `bunx biome check` clean on changed files.
- [x] `bunx tsc --noEmit` clean on changed files.
- [ ] Manual smoke on the remote container: create entry → clear → save → refresh shows entry gone; mixed add/edit/clear in one submit reconciles correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)