### PR TITLE
fix(ldap): surface 503 on LDAP outage + fail sync loudly on search errors (#368)

### DIFF
--- a/components/Login.tsx
+++ b/components/Login.tsx
@@ -1,7 +1,7 @@
 import type React from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import api from '../services/api';
+import api, { ApiError } from '../services/api';
 import type { PublicSsoProvider, User } from '../types';
 
 export interface LoginProps {
@@ -84,6 +84,13 @@ const Login: React.FC<LoginProps> = ({
     };
   }, []);
 
+  const messageForLoginError = (err: unknown): string => {
+    if (err instanceof ApiError && err.errorCode === 'ldap_unavailable') {
+      return t('auth:login.errors.ldapUnavailable');
+    }
+    return (err as Error).message || t('auth:login.errors.invalidCredentials');
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setFieldErrors({});
@@ -104,7 +111,7 @@ const Login: React.FC<LoginProps> = ({
       const response = await api.auth.login(username, password);
       onLogin(response.user, response.token);
     } catch (err) {
-      setError((err as Error).message || t('auth:login.errors.invalidCredentials'));
+      setError(messageForLoginError(err));
     } finally {
       setIsLoading(false);
     }

--- a/locales/en/auth.json
+++ b/locales/en/auth.json
@@ -15,7 +15,8 @@
       "networkError": "Network error. Please try again.",
       "unknownError": "An error occurred. Please try again.",
       "accountDisabled": "Your account has been disabled.",
-      "sessionExpired": "Your session has expired. Please sign in again."
+      "sessionExpired": "Your session has expired. Please sign in again.",
+      "ldapUnavailable": "Authentication service is temporarily unavailable. Please try again in a moment or contact your administrator."
     }
   },
   "session": {

--- a/locales/it/auth.json
+++ b/locales/it/auth.json
@@ -15,7 +15,8 @@
       "networkError": "Errore di rete. Riprova.",
       "unknownError": "Si è verificato un errore. Riprova.",
       "accountDisabled": "Il tuo account è stato disabilitato.",
-      "sessionExpired": "La tua sessione è scaduta. Accedi nuovamente."
+      "sessionExpired": "La tua sessione è scaduta. Accedi nuovamente.",
+      "ldapUnavailable": "Servizio di autenticazione temporaneamente non disponibile. Riprova tra poco o contatta l'amministratore."
     }
   },
   "session": {

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -62,6 +62,11 @@ const loginResponseSchema = {
   required: ['token', 'user'],
 } as const;
 
+const LDAP_UNAVAILABLE_BODY = {
+  error: 'Authentication service temporarily unavailable',
+  errorCode: 'ldap_unavailable',
+} as const;
+
 export default async function (fastify: FastifyInstance, _opts: unknown) {
   // POST /login
   fastify.post(
@@ -109,11 +114,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
             ldapAutoProvisioned = !!provision.created;
           }
         } catch (err) {
-          const errorMessage = err instanceof Error ? err.message : 'Unknown error';
-          fastify.log.warn(
-            { username: usernameResult.value, errorMessage },
+          fastify.log.error(
+            { err, username: usernameResult.value },
             'LDAP auto-provision attempt failed',
           );
+          return reply.code(503).send(LDAP_UNAVAILABLE_BODY);
         }
         if (!user) {
           return reply.code(401).send({ error: 'Invalid username or password' });
@@ -141,11 +146,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           ldapMatchedRoleIds = ldapAuthResult.matchedRoleIds;
           ldapGroups = ldapAuthResult.groups;
         } catch (err) {
-          const errorMessage = err instanceof Error ? err.message : 'Unknown error';
-          fastify.log.warn(
-            { username: usernameResult.value, errorMessage },
+          fastify.log.error(
+            { err, username: usernameResult.value },
             'LDAP auth attempt failed',
           );
+          return reply.code(503).send(LDAP_UNAVAILABLE_BODY);
         }
       }
 

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -146,10 +146,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           ldapMatchedRoleIds = ldapAuthResult.matchedRoleIds;
           ldapGroups = ldapAuthResult.groups;
         } catch (err) {
-          fastify.log.error(
-            { err, username: usernameResult.value },
-            'LDAP auth attempt failed',
-          );
+          fastify.log.error({ err, username: usernameResult.value }, 'LDAP auth attempt failed');
           return reply.code(503).send(LDAP_UNAVAILABLE_BODY);
         }
       }

--- a/server/routes/ldap.ts
+++ b/server/routes/ldap.ts
@@ -367,10 +367,26 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       if (!passwordResult.ok) return badRequest(reply, passwordResult.message);
 
       const ldapService = (await import('../services/ldap.ts')).default;
-      const result = await ldapService.authenticateWithProfile(
-        usernameResult.value,
-        passwordResult.value,
-      );
+      let result: Awaited<ReturnType<typeof ldapService.authenticateWithProfile>>;
+      try {
+        result = await ldapService.authenticateWithProfile(
+          usernameResult.value,
+          passwordResult.value,
+        );
+      } catch (err) {
+        // Admin diagnostic — surface the outage in the response body instead of a 500
+        // so the LDAP-config screen can render a clear "server unreachable" message.
+        const message = err instanceof Error ? err.message : 'Unknown error';
+        request.log.warn({ err, username: usernameResult.value }, 'LDAP test failed');
+        return {
+          success: false,
+          authenticated: false,
+          username: usernameResult.value,
+          message: `LDAP server unreachable: ${message}`,
+          groups: [],
+          roleIds: [],
+        };
+      }
       const authenticated = result.authenticated;
 
       return {

--- a/server/schemas/common.ts
+++ b/server/schemas/common.ts
@@ -35,6 +35,7 @@ export const standardErrorResponses = {
   403: errorResponseSchema,
   404: errorResponseSchema,
   409: errorResponseSchema,
+  503: errorResponseSchema,
 } as const;
 
 export const standardRateLimitedErrorResponses = {

--- a/server/services/ldap.ts
+++ b/server/services/ldap.ts
@@ -203,7 +203,8 @@ class LDAPService {
         return { authenticated: false, groups: [], matchedRoleIds: [] };
       }
 
-      // Bind with service account first to find the user's DN
+      // Bind with service account first to find the user's DN. A failure here is a system
+      // problem (bad service creds, network), not a user-credential issue — propagate.
       await new Promise<void>((resolve, reject) => {
         ldapClient.bind(config.bindDn, config.bindPassword, (err) => {
           if (err) reject(err);
@@ -219,20 +220,30 @@ class LDAPService {
       const userDn = userEntry.dn;
       const canonicalUsername = deriveCanonicalUsername(userEntry.attributes, username);
 
+      // Re-bind as the user to verify the supplied password before doing any further
+      // (potentially N+1) work. A failure here means wrong credentials — return
+      // `authenticated: false` and let the caller surface 401. We do NOT widen this to
+      // swallow other errors above: an LDAP outage must propagate so the route can
+      // return 503 instead of misreporting "Invalid username or password".
+      try {
+        await new Promise<void>((resolve, reject) => {
+          ldapClient.bind(userDn, password, (err) => {
+            if (err) reject(err);
+            else resolve();
+          });
+        });
+      } catch (err) {
+        logger.warn(
+          { err: serializeError(err), username },
+          'LDAP user bind failed (treated as invalid credentials)',
+        );
+        return { authenticated: false, groups: [], matchedRoleIds: [] };
+      }
+
       // Search groups under both the canonical and typed identifiers so configs whose
       // groupFilter expects e.g. `memberUid={0}` work even when the user typed an alias
       // (email/UPN) that userFilter accepted.
       const groups = await this.findUserGroups(ldapClient, userDn, [canonicalUsername, username]);
-
-      // Try to bind as the user
-      // We need a new client for this to verify credentials safely without messing up the service connection state
-      // or we can just re-bind. Re-binding on the same client is standard.
-      await new Promise<void>((resolve, reject) => {
-        ldapClient.bind(userDn, password, (err) => {
-          if (err) reject(err);
-          else resolve();
-        });
-      });
 
       return {
         authenticated: true,
@@ -242,9 +253,6 @@ class LDAPService {
         canonicalUsername,
         displayName: deriveDisplayName(userEntry.attributes, canonicalUsername),
       };
-    } catch (err) {
-      logger.error({ err: serializeError(err), username }, 'LDAP auth error');
-      return { authenticated: false, groups: [], matchedRoleIds: [] };
     } finally {
       if (client) {
         client.unbind((err) => {
@@ -584,12 +592,16 @@ class LDAPService {
             });
           });
 
-          res.on('error', (err: Error) => {
-            logger.error({ err: serializeError(err) }, 'LDAP search error');
-          });
+          // Reject (rather than swallow) so partial syncs fail loudly instead of being
+          // reported as success with a truncated count. The outer catch handles logging.
+          res.on('error', (err: Error) => reject(err));
 
-          res.on('end', () => {
-            resolve();
+          res.on('end', (result: { status: number }) => {
+            if (result.status !== 0) {
+              reject(new Error(`LDAP search failed status: ${result.status}`));
+            } else {
+              resolve();
+            }
           });
         });
       });

--- a/server/test/routes/auth.test.ts
+++ b/server/test/routes/auth.test.ts
@@ -302,7 +302,7 @@ describe('POST /api/auth/login', () => {
     expect(bcryptCompareMock).toHaveBeenCalledTimes(1);
   });
 
-  test('401: LDAP user does not fall back to local password when LDAP fails', async () => {
+  test('503: LDAP user login returns ldap_unavailable when LDAP throws (regression #368)', async () => {
     findLoginUserByUsernameMock.mockResolvedValue({ ...LOGIN_USER, authMethod: 'ldap' });
     ldapAuthenticateWithProfileMock.mockRejectedValue(new Error('LDAP server unreachable'));
     bcryptCompareMock.mockResolvedValue(true);
@@ -313,8 +313,30 @@ describe('POST /api/auth/login', () => {
       payload: { username: 'alice', password: 'secret' },
     });
 
-    expect(res.statusCode).toBe(401);
+    expect(res.statusCode).toBe(503);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'Authentication service temporarily unavailable',
+      errorCode: 'ldap_unavailable',
+    });
     expect(bcryptCompareMock).not.toHaveBeenCalled();
+  });
+
+  test('503: unknown-user LDAP auto-provision returns ldap_unavailable when LDAP throws (regression #368)', async () => {
+    findLoginUserByUsernameMock.mockResolvedValue(null);
+    ldapAuthenticateAndProvisionMock.mockRejectedValue(new Error('connect ECONNREFUSED'));
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/auth/login',
+      payload: { username: 'ghost', password: 'whatever' },
+    });
+
+    expect(res.statusCode).toBe(503);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'Authentication service temporarily unavailable',
+      errorCode: 'ldap_unavailable',
+    });
+    expect(logAuditMock).not.toHaveBeenCalled();
   });
 
   test('401: SSO-only user cannot sign in with local password', async () => {

--- a/server/test/services/ldap.test.ts
+++ b/server/test/services/ldap.test.ts
@@ -445,6 +445,22 @@ describe('authenticate', () => {
     );
     expect(lastClientStats?.unbindCalls).toBe(1);
   });
+
+  test('skips findUserGroups when user-bind fails (regression: avoid N+1 on wrong password)', async () => {
+    nextFixture = {
+      bindResponses: [null, new Error('invalid credentials')],
+      searchResponses: [
+        {
+          entries: [{ objectName: 'uid=alice,dc=test,dc=com', object: { uid: 'alice' } }],
+          status: 0,
+        },
+      ],
+    };
+    const result = await ldapService.authenticateWithProfile('alice', 'pw');
+    expect(result.authenticated).toBe(false);
+    // Only the user-lookup search runs; the group search must NOT have been issued.
+    expect(lastClientStats?.searchCalls).toHaveLength(1);
+  });
 });
 
 describe('findUserDn (direct, with config preloaded)', () => {

--- a/server/test/services/ldap.test.ts
+++ b/server/test/services/ldap.test.ts
@@ -344,10 +344,9 @@ describe('authenticate', () => {
     expect(ok).toBe(false);
   });
 
-  test('returns false when service-account bind errors; unbind still called', async () => {
+  test('rejects when service-account bind errors; unbind still called', async () => {
     nextFixture = { bindResponses: [new Error('bad creds')] };
-    const ok = await ldapService.authenticate('alice', 'pw');
-    expect(ok).toBe(false);
+    await expect(ldapService.authenticate('alice', 'pw')).rejects.toThrow('bad creds');
     expect(lastClientStats?.unbindCalls).toBe(1);
   });
 
@@ -434,6 +433,17 @@ describe('authenticate', () => {
     expect(result.authenticated).toBe(true);
     expect(result.groups).toEqual([]);
     expect(result.matchedRoleIds).toEqual([]);
+  });
+
+  test('rejects when the user-search stream emits an error (LDAP outage during search)', async () => {
+    nextFixture = {
+      bindResponses: [null],
+      searchResponses: [{ errorEvent: new Error('connection reset') }],
+    };
+    await expect(ldapService.authenticateWithProfile('alice', 'pw')).rejects.toThrow(
+      'connection reset',
+    );
+    expect(lastClientStats?.unbindCalls).toBe(1);
   });
 });
 
@@ -724,6 +734,32 @@ describe('syncUsers', () => {
     await expect(ldapService.syncUsers()).rejects.toThrow('bind failed in sync');
     expect(lastClientStats?.unbindCalls).toBe(1);
   });
+
+  test('rejects when the search stream emits an error (no silent partial sync)', async () => {
+    nextFixture = {
+      bindResponses: [null],
+      searchResponses: [
+        {
+          entries: [{ objectName: 'uid=alice,dc=x', object: { uid: 'alice', cn: 'Alice' } }],
+          errorEvent: new Error('search aborted by server'),
+          status: 0,
+        },
+      ],
+    };
+    await expect(ldapService.syncUsers()).rejects.toThrow('search aborted by server');
+    expect(lastClientStats?.unbindCalls).toBe(1);
+    expect(createUserMock).not.toHaveBeenCalled();
+    expect(updateNameByUsernameMock).not.toHaveBeenCalled();
+  });
+
+  test('rejects when search end yields a non-zero status', async () => {
+    nextFixture = {
+      bindResponses: [null],
+      searchResponses: [{ entries: [], status: 1 }],
+    };
+    await expect(ldapService.syncUsers()).rejects.toThrow('LDAP search failed status: 1');
+    expect(lastClientStats?.unbindCalls).toBe(1);
+  });
 });
 
 describe('lookupUserGroups', () => {
@@ -806,11 +842,25 @@ describe('lookupUserGroups', () => {
 });
 
 describe('authenticateAndProvision', () => {
-  test('returns { authenticated: false } when LDAP rejects credentials', async () => {
-    // service-account bind fails → authenticateWithProfile returns false
-    nextFixture = { bindResponses: [new Error('bad creds')] };
+  test('returns { authenticated: false } when LDAP rejects user credentials', async () => {
+    // user-bind fails → authenticateWithProfile returns { authenticated: false } (wrong password)
+    nextFixture = {
+      bindResponses: [null, new Error('invalid credentials')],
+      searchResponses: [
+        {
+          entries: [{ objectName: 'uid=alice,dc=test,dc=com', object: { uid: 'alice' } }],
+          status: 0,
+        },
+      ],
+    };
     const result = await ldapService.authenticateAndProvision('alice', 'pw');
     expect(result).toEqual({ authenticated: false });
+    expect(createUserMock).not.toHaveBeenCalled();
+  });
+
+  test('rejects when LDAP service-account bind fails (system error, not wrong password)', async () => {
+    nextFixture = { bindResponses: [new Error('bad creds')] };
+    await expect(ldapService.authenticateAndProvision('alice', 'pw')).rejects.toThrow('bad creds');
     expect(createUserMock).not.toHaveBeenCalled();
   });
 

--- a/services/api/client.ts
+++ b/services/api/client.ts
@@ -21,12 +21,14 @@ export const getApiBase = () => API_BASE;
 export class ApiError extends Error {
   public readonly status: number;
   public readonly isNetworkError: boolean;
+  public readonly errorCode?: string;
 
-  constructor(message: string, status: number, isNetworkError = false) {
+  constructor(message: string, status: number, isNetworkError = false, errorCode?: string) {
     super(message);
     this.name = 'ApiError';
     this.status = status;
     this.isNetworkError = isNetworkError;
+    this.errorCode = errorCode;
   }
 }
 
@@ -56,7 +58,12 @@ export const fetchApi = async <T>(endpoint: string, options: RequestInit = {}): 
 
   if (!response.ok) {
     const error = await response.json().catch(() => ({ error: 'Request failed' }));
-    throw new ApiError(error.message || error.error || `HTTP ${response.status}`, response.status);
+    throw new ApiError(
+      error.message || error.error || `HTTP ${response.status}`,
+      response.status,
+      false,
+      typeof error.errorCode === 'string' ? error.errorCode : undefined,
+    );
   }
 
   if (response.status === 204) {

--- a/test/components/Login.test.tsx
+++ b/test/components/Login.test.tsx
@@ -123,6 +123,32 @@ describe('<Login />', () => {
     expect(screen.getByText('Bad credentials')).toBeInTheDocument();
   });
 
+  test('503 ldap_unavailable shows specific i18n message instead of server text', async () => {
+    apiAuthLogin.mockImplementation(() =>
+      Promise.reject(
+        new ApiErrorStub(
+          'Authentication service temporarily unavailable',
+          503,
+          false,
+          'ldap_unavailable',
+        ),
+      ),
+    );
+
+    render(<Login onLogin={() => {}} />);
+    fireEvent.change(screen.getByPlaceholderText('auth:login.username'), {
+      target: { value: 'admin' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('auth:login.password'), {
+      target: { value: 'secret' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /auth:login.signIn/ }));
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(screen.getByText('auth:login.errors.ldapUnavailable')).toBeInTheDocument();
+  });
+
   test('password toggle flips input type between password and text', () => {
     render(<Login onLogin={() => {}} />);
     const passwordInput = screen.getByPlaceholderText('auth:login.password') as HTMLInputElement;

--- a/test/helpers/apiErrorStub.ts
+++ b/test/helpers/apiErrorStub.ts
@@ -6,11 +6,13 @@
 export class ApiErrorStub extends Error {
   public readonly status: number;
   public readonly isNetworkError: boolean;
+  public readonly errorCode?: string;
 
-  constructor(message: string, status: number, isNetworkError = false) {
+  constructor(message: string, status: number, isNetworkError = false, errorCode?: string) {
     super(message);
     this.name = 'ApiError';
     this.status = status;
     this.isNetworkError = isNetworkError;
+    this.errorCode = errorCode;
   }
 }


### PR DESCRIPTION
## Summary
Closes #368. Two LDAP reliability bugs:

- **Login lockout during LDAP outage.** `authenticateWithProfile` was catching every error and returning `{ authenticated: false }`, so `/login` answered `401 Invalid username or password` during an outage and every user without a local account got locked out. Now: only the user-bind step (wrong password) returns false; service-bind, search, and group-lookup errors propagate and the route replies `503 { errorCode: 'ldap_unavailable' }`, logged at ERROR.
- **`syncUsers` silently dropping users.** The search stream's `error` event only logged and the subsequent `end` event resolved with whatever partial entries had accumulated. Now both `error` and non-zero `end` status reject the promise — matches the existing pattern in `findUserEntry` / `findUserGroups`.

Side win: user-bind now runs before `findUserGroups`, so wrong-password attempts no longer pay for the N+1 group lookup.

## Test plan
- [x] `cd server && bun test test/services/ldap.test.ts` — 56 pass (4 new tests, 2 updated)
- [x] `cd server && bun test test/routes/auth.test.ts` — 26 pass (2 new 503 tests, 1 updated)
- [x] `cd server && bun test` — full server suite 2291 pass / 0 fail
- [x] `cd server && bun run build` — tsc clean
- [ ] Manual: black-hole `LDAP_HOST`, attempt login → expect `503 ldap_unavailable` and an ERROR log; restore LDAP → expect normal 200/401

🤖 Generated with [Claude Code](https://claude.com/claude-code)