### PR TITLE
fix(tasks): validate recurrence range; harden addBulk against partial failure (#409)

### DIFF
--- a/hooks/handlers/entryHandlers.ts
+++ b/hooks/handlers/entryHandlers.ts
@@ -36,20 +36,30 @@ export const makeEntryHandlers = (deps: EntryHandlersDeps) => {
 
   const addBulk = async (newEntries: Omit<TimeEntry, 'id' | 'createdAt' | 'userId'>[]) => {
     if (!currentUser) return;
-    try {
-      const targetUserId = viewingUserId || currentUser.id;
-      const createdEntries = await Promise.all(
-        newEntries.map((entry) =>
-          api.entries.create({
-            ...entry,
-            userId: targetUserId,
-            hourlyCost: currentUser?.costPerHour || 0,
-          } as TimeEntry),
-        ),
-      );
-      setEntries((prev) => [...createdEntries, ...prev].sort((a, b) => b.createdAt - a.createdAt));
-    } catch (err) {
-      console.error('Failed to add bulk entries:', err);
+    const targetUserId = viewingUserId || currentUser.id;
+    const results = await Promise.allSettled(
+      newEntries.map((entry) =>
+        api.entries.create({
+          ...entry,
+          userId: targetUserId,
+          hourlyCost: currentUser?.costPerHour || 0,
+        } as TimeEntry),
+      ),
+    );
+
+    const created: TimeEntry[] = [];
+    const failures: unknown[] = [];
+    for (const r of results) {
+      if (r.status === 'fulfilled') created.push(r.value);
+      else failures.push(r.reason);
+    }
+
+    if (created.length > 0) {
+      setEntries((prev) => [...created, ...prev].sort((a, b) => b.createdAt - a.createdAt));
+    }
+
+    if (failures.length > 0) {
+      for (const err of failures) console.error('Failed to add bulk entry:', err);
       alert('Failed to add some time entries');
     }
   };

--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -554,6 +554,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         if (!endResult.ok) return badRequest(reply, endResult.message);
       }
 
+      if (recurrenceStart && recurrenceEnd && recurrenceStart > recurrenceEnd) {
+        return badRequest(reply, 'recurrenceStart must be on or before recurrenceEnd');
+      }
+
       const isRecurringValue =
         isRecurring === undefined || isRecurring === null ? undefined : parseBoolean(isRecurring);
 

--- a/server/test/routes/tasks.test.ts
+++ b/server/test/routes/tasks.test.ts
@@ -776,6 +776,21 @@ describe('PUT /api/tasks/:id', () => {
     expect(JSON.parse(res.body).error).toMatch(/recurrenceEnd must be in YYYY-MM-DD format/);
   });
 
+  test('400: recurrenceStart after recurrenceEnd', async () => {
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/tasks/t-1',
+      headers: authHeader(),
+      payload: { recurrenceStart: '2026-12-31', recurrenceEnd: '2025-01-01' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(
+      /recurrenceStart must be on or before recurrenceEnd/,
+    );
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
   test('400: invalid recurrenceDuration', async () => {
     const res = await testApp.inject({
       method: 'PUT',

--- a/test/handlers/entryHandlers.test.ts
+++ b/test/handlers/entryHandlers.test.ts
@@ -192,6 +192,38 @@ describe('makeEntryHandlers', () => {
     }
   });
 
+  test('addBulk merges successfully created entries even if some fail', async () => {
+    let counter = 0;
+    apiMocks.entriesCreate.mockImplementation((_data: unknown) => {
+      counter += 1;
+      if (counter === 2) return Promise.reject(new Error('boom'));
+      return Promise.resolve({ id: `e-new-${counter}`, createdAt: counter * 100 });
+    });
+    const entries = makeStubSetter<EntryLike>([{ id: 'e0', createdAt: 50 }]);
+    const handlers = makeEntryHandlers({
+      currentUser: { id: 'u1', costPerHour: 25 } as never,
+      viewingUserId: 'u2',
+      setEntries: entries.setter,
+    });
+
+    const restore = silenceConsole();
+    try {
+      await handlers.addBulk([
+        { task: 'a' } as never,
+        { task: 'b' } as never,
+        { task: 'c' } as never,
+      ]);
+      expect(apiMocks.entriesCreate).toHaveBeenCalledTimes(3);
+      const ids = entries.get().map((e) => e.id);
+      expect(ids).toContain('e-new-1');
+      expect(ids).toContain('e-new-3');
+      expect(ids).toContain('e0');
+      expect(ids).not.toContain('e-new-2');
+    } finally {
+      restore();
+    }
+  });
+
   test('delete removes matching entry', async () => {
     apiMocks.entriesDelete.mockImplementation(() => Promise.resolve());
     const entries = makeStubSetter<EntryLike>([


### PR DESCRIPTION
## Summary

Closes #409. Two related bug fixes:

- **Server**: `PUT /api/tasks/:id` now rejects payloads where `recurrenceStart > recurrenceEnd`. Previously each date was validated independently, so an inverted range (e.g. `start=2026-12-31`, `end=2025-01-01`) was accepted and silently produced a recurring task that would never generate entries.
- **Frontend**: `entryHandlers.addBulk` switches from `Promise.all` to `Promise.allSettled`. Successfully created entries are now merged into local state even when a sibling create fails, fixing the orphan-on-UI bug where the WeeklyView showed "saved" while server-side rows existed that the UI didn't display. Failures still surface via `console.error` + `alert`.

The `addBulk` rewrite intentionally preserves the existing swallow-and-alert contract (no re-throw), since the caller in `WeeklyView.handleSubmit` has no catch and re-throwing would cause an unhandled rejection. Documented by the existing `addBulk swallows errors` test.

## Test plan

- [x] `bun run test:server` — 2316 pass / 0 fail (new test: `400: recurrenceStart after recurrenceEnd` in `server/test/routes/tasks.test.ts`)
- [x] `bun run test:frontend` — 1013 pass / 0 fail (new test: `addBulk merges successfully created entries even if some fail` in `test/handlers/entryHandlers.test.ts`)
- [x] `bun run lint` — 0 errors (4 pre-existing warnings in unrelated `quoteHandlers.test.ts`)
- [ ] Manual: in WeeklyView submit a week containing multiple new entries with one that will fail server-side; confirm the successful entries appear in the timesheet (no orphans) and the failure alert still fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)