### PR TITLE
fix(security): wire ADMIN_DEFAULT_PASSWORD into bootstrap admin (#410)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,7 +36,10 @@ LOG_LEVEL=info
 # demo business dataset. Intended for demo/test Docker stacks and reused volumes.
 DEMO_SEEDING=false
 
-# Initial password for bootstrap admin user (username: admin)
-# Used only when the admin user does not already exist.
+# Initial password for the bootstrap admin user (username: admin).
+# Applied only on first start, when the admin user does not yet exist; leaving this
+# variable unset falls back to the literal password "password". Leaving the
+# placeholder value below in place is treated as insecure and triggers an in-app
+# warning until the admin password is changed.
 # Generate with: openssl rand -base64 24
 ADMIN_DEFAULT_PASSWORD=change-me-strong-admin-password

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The workflow runs on `v*` git tags and can also be run manually.
 ## Usage Guide
 
 - **Login**:
-  - Bootstrap Admin: `admin` / `password`
+  - Bootstrap Admin: `admin` / value of `ADMIN_DEFAULT_PASSWORD` (falls back to `password` when the env var is unset; an in-app warning surfaces until the admin password is changed away from any insecure default)
   - Demo Manager: `manager` / `password` when `DEMO_SEEDING=true`
   - Demo User: `user` / `password` when `DEMO_SEEDING=true`
   

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -19,8 +19,10 @@ Set at least:
 - `ENCRYPTION_KEY`
 - `FRONTEND_URL`
 
-Fresh installs create the bootstrap admin as `admin` / `password`. Change that password after
-the first login.
+Fresh installs create the bootstrap admin as `admin` with the password from the
+`ADMIN_DEFAULT_PASSWORD` env var (falls back to `password` when unset). The app surfaces an
+in-app warning until the admin password is changed away from any insecure default; change it
+after the first login.
 
 ## 2) Authenticate to Registry (if private)
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -26,8 +26,11 @@ JWT_SECRET=change-me-long-random-jwt-secret
 # demo business dataset. Intended for demo/test environments and reused demo volumes.
 DEMO_SEEDING=false
 
-# Initial password for bootstrap admin user (username: admin)
-# Used only when the admin user does not already exist.
+# Initial password for the bootstrap admin user (username: admin).
+# Applied only on first start, when the admin user does not yet exist; leaving this
+# variable unset falls back to the literal password "password". Leaving the
+# placeholder value below in place is treated as insecure and triggers an in-app
+# warning until the admin password is changed.
 # Generate with: openssl rand -base64 24
 ADMIN_DEFAULT_PASSWORD=change-me-strong-admin-password
 

--- a/server/db/bootstrapAdmin.ts
+++ b/server/db/bootstrapAdmin.ts
@@ -8,18 +8,33 @@ import { query } from './index.ts';
 export const ADMIN_USERNAME = 'admin';
 export const DEFAULT_ADMIN_USER_ID = 'u1';
 export const DEFAULT_BOOTSTRAP_ADMIN_PASSWORD = 'password';
+const INSECURE_BOOTSTRAP_ADMIN_PASSWORDS = [
+  DEFAULT_BOOTSTRAP_ADMIN_PASSWORD,
+  'change-me-strong-admin-password',
+] as const;
 
 const logger = createChildLogger({ module: 'db:bootstrap-admin' });
+
+const resolveBootstrapAdminPassword = (): string => {
+  const fromEnv = process.env.ADMIN_DEFAULT_PASSWORD?.trim();
+  return fromEnv && fromEnv.length > 0 ? fromEnv : DEFAULT_BOOTSTRAP_ADMIN_PASSWORD;
+};
+
+const matchesInsecureBootstrapPassword = async (passwordHash: string): Promise<boolean> => {
+  for (const candidate of INSECURE_BOOTSTRAP_ADMIN_PASSWORDS) {
+    if (await bcrypt.compare(candidate, passwordHash)) return true;
+  }
+  return false;
+};
 
 export const syncDefaultAdminPasswordWarning = async (
   adminId: string,
   passwordHash: string | null | undefined,
 ) => {
-  const usesDefaultPassword =
-    typeof passwordHash === 'string' &&
-    (await bcrypt.compare(DEFAULT_BOOTSTRAP_ADMIN_PASSWORD, passwordHash));
+  const usesInsecurePassword =
+    typeof passwordHash === 'string' && (await matchesInsecureBootstrapPassword(passwordHash));
 
-  if (usesDefaultPassword) {
+  if (usesInsecurePassword) {
     await notificationsRepo.upsertAdminPasswordWarning(adminId);
   } else {
     await notificationsRepo.deleteAdminPasswordWarning();
@@ -44,7 +59,7 @@ export const ensureBootstrapAdmin = async () => {
     ]);
     adminId = defaultIdCheck.rows.length === 0 ? DEFAULT_ADMIN_USER_ID : generatePrefixedId('u');
 
-    adminPasswordHash = await bcrypt.hash(DEFAULT_BOOTSTRAP_ADMIN_PASSWORD, 12);
+    adminPasswordHash = await bcrypt.hash(resolveBootstrapAdminPassword(), 12);
 
     await usersRepo.createUser({
       id: adminId,

--- a/server/test/db/bootstrapAdmin.test.ts
+++ b/server/test/db/bootstrapAdmin.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
 import * as realBcrypt from 'bcryptjs';
 import * as realDbIndex from '../../db/index.ts';
 import * as realNotificationsRepo from '../../repositories/notificationsRepo.ts';
@@ -59,11 +59,23 @@ const allMocks = [
   bcryptCompareMock,
 ];
 
+const ADMIN_PASSWORD_ENV = 'ADMIN_DEFAULT_PASSWORD';
+const originalAdminPasswordEnv = process.env[ADMIN_PASSWORD_ENV];
+
 beforeEach(() => {
   for (const mockedFn of allMocks) mockedFn.mockReset();
   createUserMock.mockResolvedValue(undefined);
   upsertAdminPasswordWarningMock.mockResolvedValue(undefined);
   deleteAdminPasswordWarningMock.mockResolvedValue(undefined);
+  delete process.env[ADMIN_PASSWORD_ENV];
+});
+
+afterEach(() => {
+  if (originalAdminPasswordEnv === undefined) {
+    delete process.env[ADMIN_PASSWORD_ENV];
+  } else {
+    process.env[ADMIN_PASSWORD_ENV] = originalAdminPasswordEnv;
+  }
 });
 
 describe('ensureBootstrapAdmin', () => {
@@ -116,7 +128,61 @@ describe('ensureBootstrapAdmin', () => {
     expect(adminId).toBe('u1');
     expect(createUserMock).not.toHaveBeenCalled();
     expect(bcryptCompareMock).toHaveBeenCalledWith('password', '$2a$changed');
+    expect(bcryptCompareMock).toHaveBeenCalledWith(
+      'change-me-strong-admin-password',
+      '$2a$changed',
+    );
     expect(upsertAdminPasswordWarningMock).not.toHaveBeenCalled();
     expect(deleteAdminPasswordWarningMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('fresh admin uses ADMIN_DEFAULT_PASSWORD when set', async () => {
+    process.env[ADMIN_PASSWORD_ENV] = 'op-chosen-strong-pw';
+    queryMock
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 });
+    bcryptHashMock.mockResolvedValue('$2a$op-hash');
+    bcryptCompareMock.mockResolvedValue(false);
+
+    await bootstrapAdmin.ensureBootstrapAdmin();
+
+    expect(bcryptHashMock).toHaveBeenCalledWith('op-chosen-strong-pw', 12);
+    expect(bcryptHashMock).not.toHaveBeenCalledWith('password', 12);
+    expect(createUserMock).toHaveBeenCalledWith(
+      expect.objectContaining({ passwordHash: '$2a$op-hash' }),
+    );
+    expect(upsertAdminPasswordWarningMock).not.toHaveBeenCalled();
+    expect(deleteAdminPasswordWarningMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('fresh admin falls back to literal default when env var is whitespace', async () => {
+    process.env[ADMIN_PASSWORD_ENV] = '   ';
+    queryMock
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 });
+    bcryptHashMock.mockResolvedValue('$2a$password-hash');
+    bcryptCompareMock.mockResolvedValue(true);
+
+    await bootstrapAdmin.ensureBootstrapAdmin();
+
+    expect(bcryptHashMock).toHaveBeenCalledWith('password', 12);
+  });
+
+  test('existing admin still using the .env.example placeholder gets the warning', async () => {
+    queryMock
+      .mockResolvedValueOnce({ rows: [{ id: 'u1', password_hash: '$2a$placeholder' }] })
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 });
+    bcryptCompareMock.mockImplementation(
+      async (candidate: string) => candidate === 'change-me-strong-admin-password',
+    );
+
+    const adminId = await bootstrapAdmin.ensureBootstrapAdmin();
+
+    expect(adminId).toBe('u1');
+    expect(createUserMock).not.toHaveBeenCalled();
+    expect(upsertAdminPasswordWarningMock).toHaveBeenCalledWith('u1');
+    expect(deleteAdminPasswordWarningMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #410.

## Summary
- The `ADMIN_DEFAULT_PASSWORD` env var was documented in both `.env.example` files and even overridden in CI, but `ensureBootstrapAdmin` always hashed the hard-coded literal `'password'`. Operators relying on the variable to secure the first-run admin account were silently shipping the default.
- `server/db/bootstrapAdmin.ts` now reads `process.env.ADMIN_DEFAULT_PASSWORD` (trimmed, non-empty) when creating the admin, falling back to the legacy `'password'` literal so existing deployments don't change behavior on upgrade.
- The "default admin password" in-app warning now also fires when the admin still uses the `.env.example` placeholder `change-me-strong-admin-password`, so deployers who copy the file verbatim still get nagged until they change the password.
- README, `deploy/README.md`, and both `.env.example` comments updated to describe the actual behavior.

## Why
Documented behavior didn't match runtime behavior — a security risk: a deployer who set `ADMIN_DEFAULT_PASSWORD=<strong>` and walked away thinking they had a hardened bootstrap admin actually had `admin / password`.

## Approach
Chose the issue's first suggested fix (wire the var in) over the second (remove from docs). The variable was already plumbed through CI and deploy docs assume it works; honoring the contract is the smaller surprise. No startup hard-fail — leaving the var unset still produces a working bootstrap admin (preserves current behavior); the in-app warning surfaces the insecure state until the admin changes the password.

## Test plan
- [x] `cd server && bun test test/db/bootstrapAdmin.test.ts` — 6 pass (3 existing + 3 new: env-var honored, whitespace falls back, placeholder triggers warning).
- [x] `cd server && bun test` — full backend suite: 2318 pass, 28 skip, 0 fail.
- [ ] Smoke test in the CI Docker stack: `ADMIN_DEFAULT_PASSWORD=ci-docker-stack-admin-password` (already set in `.github/workflows/ci.yml:368`) — login as `admin` with that value should succeed; login with `password` should fail.
- [ ] In-app warning UX: with `ADMIN_DEFAULT_PASSWORD` unset (or set to the placeholder), confirm the admin-password warning notification appears after first login and clears once the admin changes the password.

🤖 Generated with [Claude Code](https://claude.com/claude-code)