### PR TITLE
fix(security): separate HMAC key from AES key (#416)

### DIFF
--- a/docs-site/src/content/docs/ai-reporting.md
+++ b/docs-site/src/content/docs/ai-reporting.md
@@ -40,6 +40,8 @@ Praetor espone un endpoint MCP remoto su `/api/mcp` per agenti compatibili con M
 
 Il token viene mostrato una sola volta al momento della creazione. Praetor conserva solo un hash, quindi revoca e ricrea il token se viene perso.
 
+> Nota di aggiornamento: la release che introduce la separazione delle chiavi crittografiche (issue #416) cambia la chiave HMAC usata per gli hash dei token MCP. Dopo l'aggiornamento i token MCP esistenti smettono di funzionare e vanno rigenerati da Impostazioni > MCP.
+
 Gli strumenti MCP rispettano sempre i permessi del tuo ruolo corrente. La prima versione include strumenti per utente corrente, utenti e gerarchie, clienti, fornitori, progetti, attività, preventivi, offerte, ordini, fatture, consuntivi e notifiche.
 
 Configura il client MCP con l'URL dell'endpoint e l'header:

--- a/docs-site/src/content/docs/en/ai-reporting.md
+++ b/docs-site/src/content/docs/en/ai-reporting.md
@@ -40,6 +40,8 @@ Praetor exposes a remote MCP endpoint at `/api/mcp` for Model Context Protocol c
 
 The token is shown only once when it is created. Praetor stores only a hash, so revoke and recreate the token if it is lost.
 
+> Upgrade note: the release that introduces cryptographic key separation (issue #416) changes the HMAC key used for MCP-token hashes. After the upgrade, existing MCP tokens stop working and must be regenerated from Settings > MCP.
+
 MCP tools always respect the permissions of your current role. The first release includes tools for the current user, users and hierarchy, clients, suppliers, projects, tasks, quotes, offers, orders, invoices, time entries, and notifications.
 
 Configure the MCP client with the endpoint URL and this header:

--- a/server/repositories/mcpTokensRepo.ts
+++ b/server/repositories/mcpTokensRepo.ts
@@ -2,7 +2,7 @@ import crypto from 'node:crypto';
 import { and, desc, eq, isNull, sql } from 'drizzle-orm';
 import { type DbExecutor, db } from '../db/drizzle.ts';
 import { mcpTokens } from '../db/schema/mcpTokens.ts';
-import { getEncryptionKey } from '../utils/crypto.ts';
+import { getHmacKey } from '../utils/crypto.ts';
 
 export const MCP_TOKEN_PREFIX = 'praetor_mcp_';
 
@@ -24,7 +24,7 @@ export const generateRawToken = (): string =>
   `${MCP_TOKEN_PREFIX}${crypto.randomBytes(32).toString('base64url')}`;
 
 export const hashToken = (rawToken: string): string =>
-  crypto.createHmac('sha256', getEncryptionKey()).update(rawToken).digest('hex');
+  crypto.createHmac('sha256', getHmacKey()).update(rawToken).digest('hex');
 
 const displayPrefix = (rawToken: string): string => rawToken.slice(0, 24);
 

--- a/server/test/utils/crypto.test.ts
+++ b/server/test/utils/crypto.test.ts
@@ -1,8 +1,11 @@
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import {
   __resetEncryptionKeyCacheForTests,
+  __resetHmacKeyCacheForTests,
   decrypt,
   encrypt,
+  getEncryptionKey,
+  getHmacKey,
   MASKED_SECRET,
 } from '../../utils/crypto.ts';
 
@@ -11,12 +14,14 @@ const ORIGINAL_KEY = process.env.ENCRYPTION_KEY;
 beforeAll(() => {
   process.env.ENCRYPTION_KEY = 'test-encryption-key-for-unit-tests';
   __resetEncryptionKeyCacheForTests();
+  __resetHmacKeyCacheForTests();
 });
 
 afterAll(() => {
   if (ORIGINAL_KEY === undefined) delete process.env.ENCRYPTION_KEY;
   else process.env.ENCRYPTION_KEY = ORIGINAL_KEY;
   __resetEncryptionKeyCacheForTests();
+  __resetHmacKeyCacheForTests();
 });
 
 describe('encrypt', () => {
@@ -50,16 +55,60 @@ describe('encrypt without ENCRYPTION_KEY', () => {
     savedKey = process.env.ENCRYPTION_KEY;
     delete process.env.ENCRYPTION_KEY;
     __resetEncryptionKeyCacheForTests();
+    __resetHmacKeyCacheForTests();
   });
 
   afterAll(() => {
     if (savedKey === undefined) delete process.env.ENCRYPTION_KEY;
     else process.env.ENCRYPTION_KEY = savedKey;
     __resetEncryptionKeyCacheForTests();
+    __resetHmacKeyCacheForTests();
   });
 
   test('throws when ENCRYPTION_KEY is missing', () => {
     expect(() => encrypt('whatever')).toThrow(/ENCRYPTION_KEY/);
+  });
+
+  test('getHmacKey throws when ENCRYPTION_KEY is missing', () => {
+    expect(() => getHmacKey()).toThrow(/ENCRYPTION_KEY/);
+  });
+});
+
+describe('getHmacKey', () => {
+  test('returns a 32-byte Buffer', () => {
+    const k = getHmacKey();
+    expect(Buffer.isBuffer(k)).toBe(true);
+    expect(k.length).toBe(32);
+  });
+
+  test('is deterministic across calls (cache hit)', () => {
+    const a = getHmacKey();
+    const b = getHmacKey();
+    expect(a.equals(b)).toBe(true);
+  });
+
+  test('produces the same bytes after a cache reset with the same ENCRYPTION_KEY', () => {
+    const before = Buffer.from(getHmacKey());
+    __resetHmacKeyCacheForTests();
+    const after = getHmacKey();
+    expect(before.equals(after)).toBe(true);
+  });
+
+  test('differs from the AES key derived by getEncryptionKey (key separation, issue #416)', () => {
+    expect(getHmacKey().equals(getEncryptionKey())).toBe(false);
+  });
+
+  test('produces different output when ENCRYPTION_KEY changes', () => {
+    const original = Buffer.from(getHmacKey());
+    const savedKey = process.env.ENCRYPTION_KEY;
+    process.env.ENCRYPTION_KEY = `${savedKey}-rotated`;
+    __resetHmacKeyCacheForTests();
+    try {
+      expect(getHmacKey().equals(original)).toBe(false);
+    } finally {
+      process.env.ENCRYPTION_KEY = savedKey;
+      __resetHmacKeyCacheForTests();
+    }
   });
 });
 

--- a/server/test/utils/crypto.test.ts
+++ b/server/test/utils/crypto.test.ts
@@ -101,9 +101,9 @@ describe('getHmacKey', () => {
   test('produces different output when ENCRYPTION_KEY changes', () => {
     const original = Buffer.from(getHmacKey());
     const savedKey = process.env.ENCRYPTION_KEY;
-    process.env.ENCRYPTION_KEY = `${savedKey}-rotated`;
-    __resetHmacKeyCacheForTests();
     try {
+      process.env.ENCRYPTION_KEY = `${savedKey}-rotated`;
+      __resetHmacKeyCacheForTests();
       expect(getHmacKey().equals(original)).toBe(false);
     } finally {
       process.env.ENCRYPTION_KEY = savedKey;

--- a/server/utils/crypto.ts
+++ b/server/utils/crypto.ts
@@ -5,9 +5,9 @@ const IV_LENGTH = 16;
 
 export const MASKED_SECRET = '********';
 
-// SHA-256 of ENCRYPTION_KEY: a stable 32-byte buffer used as the AES-256 key for
-// encrypt/decrypt and as the HMAC key for PAT / MCP-token hashing. Memoized because PAT auth
-// runs on every authenticated request; ENCRYPTION_KEY is process-stable so this is safe.
+// AES-256 key for encrypt/decrypt: SHA-256 of ENCRYPTION_KEY. Kept as a plain SHA-256
+// derivation (rather than HKDF) for backward-compat with secrets already encrypted at rest
+// (SMTP / LDAP / SSO). Memoized because ENCRYPTION_KEY is process-stable.
 let cachedEncryptionKey: Buffer | null = null;
 export function getEncryptionKey(): Buffer {
   if (cachedEncryptionKey !== null) return cachedEncryptionKey;
@@ -21,6 +21,32 @@ export function getEncryptionKey(): Buffer {
 
 export const __resetEncryptionKeyCacheForTests = () => {
   cachedEncryptionKey = null;
+};
+
+// HMAC key for PAT / MCP-token hashing: HKDF-derived from ENCRYPTION_KEY with a
+// domain-separation label, independent from the AES key (issue #416). Memoized because PAT/MCP
+// auth runs on every authenticated request.
+const HMAC_HKDF_INFO = 'praetor:hmac-token-hashing:v1';
+let cachedHmacKey: Buffer | null = null;
+export function getHmacKey(): Buffer {
+  if (cachedHmacKey !== null) return cachedHmacKey;
+  const key = process.env.ENCRYPTION_KEY;
+  if (!key) {
+    throw new Error('ENCRYPTION_KEY environment variable is required');
+  }
+  const derived = crypto.hkdfSync(
+    'sha256',
+    Buffer.from(key, 'utf8'),
+    Buffer.alloc(0),
+    HMAC_HKDF_INFO,
+    32,
+  );
+  cachedHmacKey = Buffer.from(derived);
+  return cachedHmacKey;
+}
+
+export const __resetHmacKeyCacheForTests = () => {
+  cachedHmacKey = null;
 };
 
 // Heuristic test for `encrypt()`'s output shape. Validates the IV and auth-tag base64

--- a/server/utils/crypto.ts
+++ b/server/utils/crypto.ts
@@ -8,6 +8,10 @@ export const MASKED_SECRET = '********';
 // AES-256 key for encrypt/decrypt: SHA-256 of ENCRYPTION_KEY. Kept as a plain SHA-256
 // derivation (rather than HKDF) for backward-compat with secrets already encrypted at rest
 // (SMTP / LDAP / SSO). Memoized because ENCRYPTION_KEY is process-stable.
+//
+// Do NOT use this key for HMAC or other non-AES primitives — use `getHmacKey()` for
+// HMAC-keyed hashing (issue #416). Reusing the same key across primitives couples
+// otherwise-independent security boundaries.
 let cachedEncryptionKey: Buffer | null = null;
 export function getEncryptionKey(): Buffer {
   if (cachedEncryptionKey !== null) return cachedEncryptionKey;

--- a/server/utils/personal-access-token.ts
+++ b/server/utils/personal-access-token.ts
@@ -1,5 +1,5 @@
 import crypto from 'crypto';
-import { getEncryptionKey } from './crypto.ts';
+import { getHmacKey } from './crypto.ts';
 
 export const PERSONAL_ACCESS_TOKEN_PREFIX = 'praetor_pat_';
 const RANDOM_BYTES = 32;
@@ -8,9 +8,10 @@ const DISPLAY_PREFIX_LENGTH = 20;
 export const generatePersonalAccessToken = () =>
   `${PERSONAL_ACCESS_TOKEN_PREFIX}${crypto.randomBytes(RANDOM_BYTES).toString('base64url')}`;
 
-// HMAC-keyed by ENCRYPTION_KEY so a DB-read leak alone can't brute-force token values offline.
+// HMAC-keyed by an HKDF-derived sub-key of ENCRYPTION_KEY (domain-separated from the AES key,
+// issue #416) so a DB-read leak alone can't brute-force token values offline.
 export const hashPersonalAccessToken = (token: string) =>
-  crypto.createHmac('sha256', getEncryptionKey()).update(token).digest('hex');
+  crypto.createHmac('sha256', getHmacKey()).update(token).digest('hex');
 
 export const getPersonalAccessTokenDisplayPrefix = (token: string) =>
   token.slice(0, DISPLAY_PREFIX_LENGTH);


### PR DESCRIPTION
## Summary

Fixes [#416](https://github.com/xBounceIT/praetor/issues/416). The same key derived from `ENCRYPTION_KEY` was used both as the AES-256-GCM key (for SMTP / LDAP / SSO secrets at rest) and as the HMAC-SHA256 key (for PAT and MCP token hashes), violating cryptographic key separation.

- Adds `getHmacKey()` in `server/utils/crypto.ts` that derives a 32-byte HMAC key via `crypto.hkdfSync` from `ENCRYPTION_KEY` with the domain-separation label `praetor:hmac-token-hashing:v1`. Memoized to match the existing AES key cache (PAT/MCP auth runs per-request).
- Switches `hashPersonalAccessToken` (`server/utils/personal-access-token.ts`) and `hashToken` (`server/repositories/mcpTokensRepo.ts`) to key their HMACs with `getHmacKey()` instead of the AES key.
- Leaves `getEncryptionKey()` (the AES side) unchanged so already-encrypted secrets at rest keep decrypting — full HKDF on both sides would have required a startup decrypt-then-reencrypt migration and was deferred per scoping discussion.

The two derived keys are now independent buffers (HKDF output vs. SHA-256 output), which is the property the issue asks for. A unit test asserts `getHmacKey().equals(getEncryptionKey()) === false`.

## Operational impact (please flag in release notes)

Every existing PAT and MCP token hash in the DB becomes unmatchable after this deploys — the new HMAC key won't reproduce the old digests. **Users must regenerate their PATs and MCP tokens after the upgrade.** Existing rows aren't deleted; they just stop authenticating until rotated. Encrypted SMTP / LDAP / SSO secrets are unaffected.

Docs updated in [docs-site/src/content/docs/ai-reporting.md](docs-site/src/content/docs/ai-reporting.md) (Italian) and the English mirror with a one-line upgrade note pointing users to Settings > MCP to regenerate.

## Test plan

- [x] `cd server && bun test test/utils/crypto.test.ts` — new `describe('getHmacKey')` block covers length, determinism, cache-reset round-trip, inequality vs. AES key, rotation sensitivity, and missing-`ENCRYPTION_KEY` throw path (18 pass / 0 fail).
- [x] `cd server && bun test test/middleware/auth.test.ts test/middleware/mcpAuth.test.ts test/routes/auth.test.ts test/routes/settings.test.ts test/routes/mcp.test.ts test/repositories/personalAccessTokensRepo.test.ts` — 124 / 0. All existing token tests pass because they re-derive hashes through the helpers rather than hard-coding digests.
- [x] `cd server && bun test` — full backend suite: 2321 pass / 28 skip / 0 fail.
- [ ] Reviewer: confirm the deploy plan accounts for prompting users to regenerate PAT / MCP tokens (release notes, in-app banner, or similar — out of scope for this PR but worth tracking).

## Out of scope

- Re-deriving the AES key via HKDF as well. That would require decrypting every secret with the current key and re-encrypting with the new key at startup — deferred to a future change if/when the cipher itself is rotated.
- Versioning the encrypted-value format (`v1:iv:tag:ct`). Not needed for the HMAC-only scope; the HKDF label is already `:v1`-suffixed for future HMAC-key rotations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)