### PR TITLE
fix(admin): validate startOfWeek/defaultLocation, rate-limit settings/email/ai routes (#411)

### DIFF
--- a/server/routes/ai.ts
+++ b/server/routes/ai.ts
@@ -3,6 +3,7 @@ import { authenticateToken, requirePermission } from '../middleware/auth.ts';
 import * as generalSettingsRepo from '../repositories/generalSettingsRepo.ts';
 import { standardRateLimitedErrorResponses } from '../schemas/common.ts';
 import { normalizeGeminiModelPath } from '../utils/ai-models.ts';
+import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import { badRequest, optionalNonEmptyString, validateEnum } from '../utils/validation.ts';
 
 const googleModelExists = async (apiKey: string, modelPath: string): Promise<boolean> => {
@@ -43,7 +44,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.post(
     '/validate-model',
     {
-      onRequest: [authenticateToken, requirePermission('administration.general.update')],
+      onRequest: [
+        fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
+        authenticateToken,
+        requirePermission('administration.general.update'),
+      ],
       schema: {
         tags: ['ai'],
         summary: 'Validate that a model exists on the selected provider',

--- a/server/routes/email.ts
+++ b/server/routes/email.ts
@@ -1,10 +1,11 @@
-import type { FastifyInstance, FastifyRequest } from 'fastify';
+import type { FastifyInstance } from 'fastify';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
 import * as emailRepo from '../repositories/emailRepo.ts';
 import { errorResponseSchema, standardRateLimitedErrorResponses } from '../schemas/common.ts';
 import emailService, { type EmailConfigInput } from '../services/email.ts';
 import { logAudit } from '../utils/audit.ts';
 import { MASKED_SECRET } from '../utils/crypto.ts';
+import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 
 const sharedConfigProperties = {
   enabled: { type: 'boolean' },
@@ -80,7 +81,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/config',
     {
-      onRequest: [authenticateToken, requirePermission('administration.email.view')],
+      onRequest: [
+        fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
+        authenticateToken,
+        requirePermission('administration.email.view'),
+      ],
       schema: {
         tags: ['email'],
         summary: 'Get email configuration',
@@ -98,7 +103,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.put(
     '/config',
     {
-      onRequest: [authenticateToken, requirePermission('administration.email.update')],
+      onRequest: [
+        fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
+        authenticateToken,
+        requirePermission('administration.email.update'),
+      ],
       schema: {
         tags: ['email'],
         summary: 'Update email configuration',
@@ -109,7 +118,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         },
       },
     },
-    async (request: FastifyRequest, _reply) => {
+    async (request, _reply) => {
       const updated = await emailService.saveConfig(request.body as EmailConfigInput);
 
       await logAudit({
@@ -127,7 +136,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.post(
     '/test',
     {
-      onRequest: [authenticateToken, requirePermission('administration.email.update')],
+      onRequest: [
+        fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
+        authenticateToken,
+        requirePermission('administration.email.update'),
+      ],
       schema: {
         tags: ['email'],
         summary: 'Send test email',
@@ -169,7 +182,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.post(
     '/test-connection',
     {
-      onRequest: [authenticateToken, requirePermission('administration.email.update')],
+      onRequest: [
+        fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
+        authenticateToken,
+        requirePermission('administration.email.update'),
+      ],
       schema: {
         tags: ['email'],
         summary: 'Test SMTP connection',

--- a/server/routes/general-settings.ts
+++ b/server/routes/general-settings.ts
@@ -2,9 +2,11 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
 import * as generalSettingsRepo from '../repositories/generalSettingsRepo.ts';
 import { standardRateLimitedErrorResponses } from '../schemas/common.ts';
+import { VALID_LOCATIONS } from '../services/timeEntries.ts';
 import { logAudit } from '../utils/audit.ts';
 import { MASKED_SECRET } from '../utils/crypto.ts';
 import { requestHasPermission as hasPermission } from '../utils/permissions.ts';
+import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
   optionalEnum,
@@ -100,7 +102,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.get(
     '/',
     {
-      onRequest: [authenticateToken],
+      onRequest: [fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT), authenticateToken],
       schema: {
         tags: ['general-settings'],
         summary: 'Get global settings',
@@ -122,7 +124,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.put(
     '/',
     {
-      onRequest: [authenticateToken, requirePermission('administration.general.update')],
+      onRequest: [
+        fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
+        authenticateToken,
+        requirePermission('administration.general.update'),
+      ],
       schema: {
         tags: ['general-settings'],
         summary: 'Update global settings',
@@ -170,6 +176,16 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const aiProviderResult = optionalEnum(aiProvider, ['gemini', 'openrouter'], 'aiProvider');
       if (!aiProviderResult.ok) return badRequest(reply, aiProviderResult.message);
 
+      const startOfWeekResult = optionalEnum(startOfWeek, ['Monday', 'Sunday'], 'startOfWeek');
+      if (!startOfWeekResult.ok) return badRequest(reply, startOfWeekResult.message);
+
+      const defaultLocationResult = optionalEnum(
+        defaultLocation,
+        VALID_LOCATIONS,
+        'defaultLocation',
+      );
+      if (!defaultLocationResult.ok) return badRequest(reply, defaultLocationResult.message);
+
       if (
         geminiModelId !== undefined &&
         geminiModelId !== null &&
@@ -198,7 +214,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const settings = await generalSettingsRepo.update({
         currency: currencyResult.value,
         dailyLimit: dailyLimitResult.value,
-        startOfWeek,
+        startOfWeek: startOfWeekResult.value,
         treatSaturdayAsHoliday: treatSaturdayAsHolidayValue,
         enableAiReporting: enableAiReportingValue,
         geminiApiKey,
@@ -207,7 +223,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         geminiModelId,
         openrouterModelId,
         allowWeekendSelection: allowWeekendSelectionValue,
-        defaultLocation,
+        defaultLocation: defaultLocationResult.value,
       });
 
       await logAudit({

--- a/server/routes/settings.ts
+++ b/server/routes/settings.ts
@@ -18,7 +18,7 @@ import {
   getPersonalAccessTokenDisplayPrefix,
   hashPersonalAccessToken,
 } from '../utils/personal-access-token.ts';
-import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
+import { LOGIN_RATE_LIMIT, STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
   forbidden,
@@ -290,11 +290,13 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
     },
   );
 
-  // PUT /password - Update user password
+  // PUT /password - Update user password. LOGIN_RATE_LIMIT (not the standard
+  // per-route limit) because this verifies the current password — same threat
+  // model as login, so it gets the same anti-brute-force budget.
   fastify.put(
     '/password',
     {
-      onRequest: [authenticateToken],
+      onRequest: [fastify.rateLimit(LOGIN_RATE_LIMIT), authenticateToken],
       schema: {
         tags: ['settings'],
         summary: 'Update password',

--- a/server/services/timeEntries.ts
+++ b/server/services/timeEntries.ts
@@ -27,8 +27,9 @@ export type AuthenticatedActor = {
   permissions: string[];
 };
 
-// Mirrors the DB check constraint on time_entries.location.
-const VALID_LOCATIONS = ['remote', 'office', 'customer_premise', 'transfer'] as const;
+// Mirrors the DB check constraint on time_entries.location. Also reused by
+// `PUT /api/general-settings` to validate the `defaultLocation` field.
+export const VALID_LOCATIONS = ['remote', 'office', 'customer_premise', 'transfer'] as const;
 type ValidLocation = (typeof VALID_LOCATIONS)[number];
 
 const parseOptionalLocation = (

--- a/server/test/routes/general-settings.test.ts
+++ b/server/test/routes/general-settings.test.ts
@@ -240,6 +240,58 @@ describe('PUT /api/general-settings', () => {
     expect(JSON.parse(res.body).error).toMatch(/aiProvider must be one of/);
   });
 
+  test('400 invalid startOfWeek enum, repo not called', async () => {
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/general-settings',
+      headers: authHeader(),
+      payload: { startOfWeek: 'Tuesday' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/startOfWeek must be one of/);
+    expect(settingsUpdateMock).not.toHaveBeenCalled();
+  });
+
+  test('400 invalid defaultLocation enum, repo not called', async () => {
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/general-settings',
+      headers: authHeader(),
+      payload: { defaultLocation: 'space_station' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/defaultLocation must be one of/);
+    expect(settingsUpdateMock).not.toHaveBeenCalled();
+  });
+
+  test('200 accepts valid Sunday + customer_premise round-trip', async () => {
+    settingsUpdateMock.mockResolvedValue({
+      ...SETTINGS_WITH_KEYS,
+      startOfWeek: 'Sunday',
+      defaultLocation: 'customer_premise',
+    });
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/general-settings',
+      headers: authHeader(),
+      payload: { startOfWeek: 'Sunday', defaultLocation: 'customer_premise' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(settingsUpdateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        startOfWeek: 'Sunday',
+        defaultLocation: 'customer_premise',
+      }),
+    );
+    const body = JSON.parse(res.body);
+    expect(body.startOfWeek).toBe('Sunday');
+    expect(body.defaultLocation).toBe('customer_premise');
+  });
+
   test('403 missing administration.general.update', async () => {
     getRolePermissionsMock.mockResolvedValue([]); // no perm
 


### PR DESCRIPTION
Closes #411.

## Summary

- `PUT /api/general-settings` now validates `startOfWeek` (`'Monday' | 'Sunday'`) and `defaultLocation` (`'office' | 'customer_premise' | 'remote' | 'transfer'`) via the existing `optionalEnum` helper, returning **400** with a clear message instead of letting the request 500 against the `general_settings_start_of_week_check` DB constraint — or silently persisting an arbitrary `defaultLocation` (the column has no DB CHECK, only `varchar(20)`).
- Eight admin endpoints that previously had no per-route rate limit now get one:
  - `general-settings` GET/PUT, `email` GET/PUT `/config` + POST `/test` + POST `/test-connection`, `ai` POST `/validate-model` → `STANDARD_ROUTE_RATE_LIMIT` (600/min).
  - `settings` PUT `/password` → **`LOGIN_RATE_LIMIT`** (30 per 15 min). The issue suggested the standard limit, but this endpoint verifies the current password under a valid session — same threat model as login, so it shares the same anti-brute-force budget as `auth.ts` and `sso-auth.ts`.
- Deduplicates the locations list: `VALID_LOCATIONS` in [server/services/timeEntries.ts](server/services/timeEntries.ts) is now exported and reused, instead of repeating the literal in the route.

## Why

Two real defects:
- Invalid `startOfWeek` surfaced as **HTTP 500** with no actionable error for the admin UI; invalid `defaultLocation` persisted silently and could break the frontend, which only renders the four `TimeEntryLocation` values.
- `PUT /api/settings/password` and the email-test endpoints were unrate-limited inside a valid session, allowing unbounded brute-force / SMTP attempts. Peer routes (LDAP, user roles) already apply `STANDARD_ROUTE_RATE_LIMIT`, so this brings the admin surface to parity.

## Notes for reviewers

- The `request: FastifyRequest` annotation on `PUT /api/email/config` was removed because adding `fastify.rateLimit(...)` to `onRequest` caused a TS inference conflict with the route's `as const`-narrowed body schema. Other handlers in the same file already omit the annotation; runtime behavior is unchanged.
- One judgment call worth flagging: `LOGIN_RATE_LIMIT` (30 / 15 min) on password change is stricter than what the issue suggested. Happy to fall back to `STANDARD_ROUTE_RATE_LIMIT` if you'd rather match the issue verbatim, but the brute-force argument felt strong enough to deviate.

## Test plan

- [x] Existing 70 tests across `general-settings`, `email`, `ai`, `settings` route suites still pass.
- [x] 3 new tests in `server/test/routes/general-settings.test.ts` cover: invalid `startOfWeek` → 400 (repo not called), invalid `defaultLocation` → 400 (repo not called), valid `Sunday` + `customer_premise` round-trip.
- [x] `bun run lint` clean (4 pre-existing warnings in unrelated `quoteHandlers.test.ts`).
- [ ] Reviewer: confirm `LOGIN_RATE_LIMIT` is acceptable for password change (see "Notes for reviewers").

🤖 Generated with [Claude Code](https://claude.com/claude-code)