### PR TITLE
fix(seed): add demo tasks for dm_proj_01/02 to prevent NULL task_id (#423)

### DIFF
--- a/server/db/seed.sql
+++ b/server/db/seed.sql
@@ -989,6 +989,20 @@ ON CONFLICT (id) DO UPDATE SET
     is_disabled = EXCLUDED.is_disabled,
     created_at = EXCLUDED.created_at;
 
+-- Tasks for the demo projects above. Without these rows the second time_entries block
+-- below resolves task_id to NULL because it looks up tasks by (project_id, name). See
+-- GitHub issue #423.
+INSERT INTO tasks (id, name, project_id, description) VALUES
+    ('dm_task_01', 'Security audit review',    'dm_proj_01', 'Pen-test findings walkthrough with the client.'),
+    ('dm_task_02', 'Assessment report draft',  'dm_proj_01', 'Executive summary and remediation roadmap.'),
+    ('dm_task_03', 'Final review sign-off',    'dm_proj_01', 'Client sign-off and deliverable handoff.'),
+    ('dm_task_04', 'Deployment configuration', 'dm_proj_02', 'CI pipeline and staging environment setup.'),
+    ('dm_task_05', 'Infra provisioning',       'dm_proj_02', 'Cloud resources for the first deployment wave.')
+ON CONFLICT (id) DO UPDATE SET
+    name = EXCLUDED.name,
+    project_id = EXCLUDED.project_id,
+    description = EXCLUDED.description;
+
 INSERT INTO notifications (
     id,
     user_id,
@@ -1145,7 +1159,12 @@ INSERT INTO user_tasks (user_id, task_id, assignment_source) VALUES
     ('u6', 't2', 'manual'),
     ('u6', 't3', 'manual'),
     ('u7', 't4', 'manual'),
-    ('u8', 't4', 'manual')
+    ('u8', 't4', 'manual'),
+    ('u2', 'dm_task_01', 'manual'),
+    ('u6', 'dm_task_02', 'manual'),
+    ('u2', 'dm_task_03', 'manual'),
+    ('u5', 'dm_task_04', 'manual'),
+    ('u3', 'dm_task_05', 'manual')
 ON CONFLICT (user_id, task_id) DO NOTHING;
 
 INSERT INTO time_entries (

--- a/server/test/db/seedTaskReferences.test.ts
+++ b/server/test/db/seedTaskReferences.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Regression: GitHub issue #423. The second `INSERT INTO time_entries` block in seed.sql
+// resolves task_id via `(SELECT t.id FROM tasks t WHERE t.project_id = v.project_id AND
+// t.name = v.task ...)`. If no row in any `INSERT INTO tasks` block has a matching
+// (project_id, name) pair, the lookup returns NULL and the demo dataset ships incomplete
+// time entries. We assert here that every (project_id, task) referenced by that block
+// resolves to a real task row in seed.sql.
+
+const SERVER_ROOT = join(import.meta.dirname, '..', '..');
+const SEED_SQL = readFileSync(join(SERVER_ROOT, 'db', 'seed.sql'), 'utf-8');
+
+type TopLevelEvent = { type: 'comma' | 'open' | 'close'; index: number };
+
+// Walk a SQL fragment yielding top-level commas and the outer `(...)` boundaries while
+// respecting `'…''…'` strings and nested parens. The two parsers below build on this so
+// the string/paren state machine lives in one place.
+function* walkSqlTopLevel(input: string): Generator<TopLevelEvent> {
+  let depth = 0;
+  let inString = false;
+  for (let i = 0; i < input.length; i += 1) {
+    const c = input[i];
+    if (inString) {
+      if (c === "'") {
+        if (input[i + 1] === "'") {
+          i += 1;
+          continue;
+        }
+        inString = false;
+      }
+      continue;
+    }
+    if (c === "'") {
+      inString = true;
+      continue;
+    }
+    if (c === '(') {
+      if (depth === 0) yield { type: 'open', index: i };
+      depth += 1;
+    } else if (c === ')') {
+      depth -= 1;
+      if (depth === 0) yield { type: 'close', index: i };
+    } else if (c === ',' && depth === 0) {
+      yield { type: 'comma', index: i };
+    }
+  }
+}
+
+const splitTopLevelCommas = (input: string): string[] => {
+  const parts: string[] = [];
+  let start = 0;
+  for (const evt of walkSqlTopLevel(input)) {
+    if (evt.type !== 'comma') continue;
+    parts.push(input.slice(start, evt.index));
+    start = evt.index + 1;
+  }
+  parts.push(input.slice(start));
+  return parts.map((s) => s.trim());
+};
+
+const unquote = (value: string): string => {
+  const trimmed = value.trim();
+  const m = trimmed.match(/^'((?:''|[^'])*)'$/);
+  return m ? m[1].replace(/''/g, "'") : trimmed;
+};
+
+const extractTopLevelTuples = (body: string): string[][] => {
+  const tuples: string[][] = [];
+  let start = -1;
+  for (const evt of walkSqlTopLevel(body)) {
+    if (evt.type === 'open') {
+      start = evt.index + 1;
+    } else if (evt.type === 'close' && start !== -1) {
+      tuples.push(splitTopLevelCommas(body.slice(start, evt.index)));
+      start = -1;
+    }
+  }
+  return tuples;
+};
+
+const collectTaskKeys = (sql: string): Set<string> => {
+  const keys = new Set<string>();
+  const blockRe =
+    /INSERT\s+INTO\s+tasks\s*\(([^)]+)\)\s*VALUES\s*([\s\S]+?)(?=\s*ON\s+CONFLICT|\s*;)/gi;
+  let match: RegExpExecArray | null = blockRe.exec(sql);
+  while (match !== null) {
+    const columns = match[1].split(',').map((s) => s.trim());
+    const projIdx = columns.indexOf('project_id');
+    const nameIdx = columns.indexOf('name');
+    if (projIdx !== -1 && nameIdx !== -1) {
+      for (const tuple of extractTopLevelTuples(match[2])) {
+        if (tuple.length > Math.max(projIdx, nameIdx)) {
+          keys.add(`${unquote(tuple[projIdx])}::${unquote(tuple[nameIdx])}`);
+        }
+      }
+    }
+    match = blockRe.exec(sql);
+  }
+  return keys;
+};
+
+type DemoTimeEntry = { id: string; projectId: string; task: string };
+
+const requirePosition = (label: string, idx: number): number => {
+  if (idx === -1) throw new Error(`seed.sql: failed to locate ${label}`);
+  return idx;
+};
+
+// Locate the time_entries INSERT block that resolves project_name via
+// `JOIN projects p ON p.id = v.project_id` — the block reported in issue #423 — and
+// return one record per tuple with (id, project_id, task).
+const parseDmJoinTimeEntries = (sql: string): DemoTimeEntry[] => {
+  const joinIdx = requirePosition(
+    'JOIN-projects time_entries block',
+    sql.indexOf('JOIN projects p ON p.id = v.project_id'),
+  );
+  const insertIdx = requirePosition(
+    'INSERT INTO time_entries preceding the JOIN block',
+    sql.lastIndexOf('INSERT INTO time_entries', joinIdx),
+  );
+  const valuesHeader = 'FROM (VALUES';
+  const valuesStart = requirePosition('FROM (VALUES header', sql.indexOf(valuesHeader, insertIdx));
+  const aliasHeader = ') AS v(';
+  const aliasMarker = requirePosition(aliasHeader, sql.indexOf(aliasHeader, valuesStart));
+  const aliasColsStart = aliasMarker + aliasHeader.length;
+  const aliasClose = requirePosition("')' closing AS v(...)", sql.indexOf(')', aliasColsStart));
+
+  const aliasCols = sql
+    .slice(aliasColsStart, aliasClose)
+    .split(',')
+    .map((s) => s.trim());
+  const idIdx = requirePosition("column 'id'", aliasCols.indexOf('id'));
+  const projIdx = requirePosition("column 'project_id'", aliasCols.indexOf('project_id'));
+  const taskIdx = requirePosition("column 'task'", aliasCols.indexOf('task'));
+
+  const body = sql.slice(valuesStart + valuesHeader.length, aliasMarker);
+  return extractTopLevelTuples(body).map((parts) => ({
+    id: unquote(parts[idIdx]),
+    projectId: unquote(parts[projIdx]),
+    task: unquote(parts[taskIdx]),
+  }));
+};
+
+describe('seed.sql demo time entries (issue #423)', () => {
+  const taskKeys = collectTaskKeys(SEED_SQL);
+  const entries = parseDmJoinTimeEntries(SEED_SQL);
+
+  test('parses exactly dm_te_21..dm_te_25 from the JOIN-projects block', () => {
+    expect(entries.map((entry) => entry.id).sort()).toEqual([
+      'dm_te_21',
+      'dm_te_22',
+      'dm_te_23',
+      'dm_te_24',
+      'dm_te_25',
+    ]);
+  });
+
+  test.each(entries)('time entry $id resolves task_id (project=$projectId, task="$task")', ({
+    projectId,
+    task,
+  }) => {
+    expect(taskKeys.has(`${projectId}::${task}`)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds five `dm_task_*` rows in `server/db/seed.sql` for projects `dm_proj_01`/`dm_proj_02` whose `name` columns exactly match the values referenced by demo time entries `dm_te_21`–`dm_te_25`, plus matching `user_tasks` assignments mirroring the existing `user_projects` pattern.
- Adds `server/test/db/seedTaskReferences.test.ts` to lock the invariant: it statically parses `seed.sql`, extracts every `(project_id, task)` pair from the JOIN-projects `time_entries` block, and asserts each resolves to a real `tasks` row.

## Why

Fixes [#423](https://github.com/xBounceIT/praetor/issues/423). The five `dm_te_21`–`dm_te_25` demo time entries resolved `task_id` via a `(project_id, task name)` lookup against `tasks`, but no task rows existed for `dm_proj_01`/`dm_proj_02` — only the legacy `t1`–`t4` rows on `p1`–`p3`. The entries shipped with `task_id = NULL` despite having a free-text `task` field, breaking task-filtering, task-hour reporting, and the "Unknown Task" rendering path in the demo. Adding tasks (rather than rewriting the time entries to point at legacy projects) preserves the demo narrative — client `dm_cli_01` → sale `dm_so_04` → projects `dm_proj_01/02` → time entries on those projects — which is already wired through notifications and project assignments.

## Notes for reviewers

- Cleanup is already covered: [`server/db/demoSeed.ts:483-489`](https://github.com/xBounceIT/praetor/blob/main/server/db/demoSeed.ts#L483-L489) deletes `tasks WHERE project_id IN DEMO_IDS.projects`, so the new `dm_task_*` rows are removed cleanly on each demo reseed.
- The regression test parses `seed.sql` statically (no DB required). It fails on `main` with 5 unresolved `(project_id, task)` pairs and passes on this branch.
- During implementation I noticed a separate but related bug: three entries in the FIRST `time_entries` block (`dm_te_08`, `dm_te_13`, `dm_te_18`) reference a `'Market Analysis'` task on `p3` that doesn't exist either. Out of scope for this PR — to be handled in a follow-up.

## Test plan

- [x] `cd server && bun test test/db/seedTaskReferences.test.ts` — 6 pass / 0 fail
- [x] `cd server && bun test` — 2321 pass / 0 fail / 28 skip
- [x] `bun run test:frontend` (from repo root) — 1012 pass / 0 fail
- [ ] On the remote Docker demo environment: `SELECT id, task_id FROM time_entries WHERE id LIKE 'dm_te_2_';` should now show non-NULL `task_id` for every row after a demo reseed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)