### PR TITLE
fix(reports): SSE backpressure + atomic AI edit-stream (#413)

### DIFF
--- a/server/routes/reports.ts
+++ b/server/routes/reports.ts
@@ -1,7 +1,7 @@
 import { AsyncLocalStorage } from 'async_hooks';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
-import type { DbExecutor } from '../db/drizzle.ts';
+import { type DbExecutor, withDbTransaction } from '../db/drizzle.ts';
 import pool from '../db/index.ts';
 import * as schema from '../db/schema/index.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
@@ -1223,11 +1223,58 @@ const startSseResponse = (reply: FastifyReply) => {
   if (typeof reply.raw.flushHeaders === 'function') reply.raw.flushHeaders();
 };
 
-const writeSseEvent = (reply: FastifyReply, event: string, payload: unknown) => {
+// Writes a single chunk to the underlying response socket and waits for downstream
+// readiness before resolving. If `reply.raw.write` returns false (Node stream buffer full),
+// we await a `'drain'` event so the AI provider stream can pause feeding bytes — without
+// this, a slow SSE client would let Node buffer unbounded data and risk OOM. Resolves to
+// `false` if the socket closes or errors before draining so callers can abort the stream.
+export const writeSseChunk = (
+  raw: Pick<FastifyReply['raw'], 'write' | 'once' | 'off'>,
+  chunk: string,
+): Promise<boolean> =>
+  new Promise<boolean>((resolve) => {
+    let ok: boolean;
+    try {
+      ok = raw.write(chunk);
+    } catch {
+      resolve(false);
+      return;
+    }
+    if (ok) {
+      resolve(true);
+      return;
+    }
+    const cleanup = () => {
+      raw.off('drain', onDrain);
+      raw.off('close', onClose);
+      raw.off('error', onError);
+    };
+    const onDrain = () => {
+      cleanup();
+      resolve(true);
+    };
+    const onClose = () => {
+      cleanup();
+      resolve(false);
+    };
+    const onError = () => {
+      cleanup();
+      resolve(false);
+    };
+    raw.once('drain', onDrain);
+    raw.once('close', onClose);
+    raw.once('error', onError);
+  });
+
+export const writeSseEvent = async (
+  reply: FastifyReply,
+  event: string,
+  payload: unknown,
+): Promise<boolean> => {
   if (reply.raw.destroyed || reply.raw.writableEnded) return false;
   try {
-    reply.raw.write(`event: ${event}\n`);
-    reply.raw.write(`data: ${JSON.stringify(payload)}\n\n`);
+    if (!(await writeSseChunk(reply.raw, `event: ${event}\n`))) return false;
+    if (!(await writeSseChunk(reply.raw, `data: ${JSON.stringify(payload)}\n\n`))) return false;
     return true;
   } catch {
     return false;
@@ -1305,14 +1352,14 @@ const createSseStreamHandlers = (
     onThoughtDelta: async (delta: string) => {
       if (abortController.signal.aborted) return;
       accumulated.thoughtContent += delta;
-      if (!writeSseEvent(reply, 'thought_delta', { delta })) {
+      if (!(await writeSseEvent(reply, 'thought_delta', { delta }))) {
         abortController.abort();
       }
     },
     onAnswerDelta: async (delta: string) => {
       if (abortController.signal.aborted) return;
       accumulated.text += delta;
-      if (!writeSseEvent(reply, 'answer_delta', { delta })) {
+      if (!(await writeSseEvent(reply, 'answer_delta', { delta }))) {
         abortController.abort();
       }
     },
@@ -1629,10 +1676,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         startSseResponse(reply);
         streamStarted = true;
         if (
-          !writeSseEvent(reply, 'start', {
+          !(await writeSseEvent(reply, 'start', {
             sessionId: resolvedSessionId,
             messageId: assistantMessageId,
-          })
+          }))
         ) {
           streamAbortController.abort();
           return;
@@ -1641,7 +1688,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         const emitThoughtDone = async () => {
           if (thoughtDoneSent || streamAbortController.signal.aborted) return;
           thoughtDoneSent = true;
-          if (!writeSseEvent(reply, 'thought_done', {})) {
+          if (!(await writeSseEvent(reply, 'thought_done', {}))) {
             streamAbortController.abort();
           }
         };
@@ -1717,11 +1764,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         );
 
         if (
-          !writeSseEvent(reply, 'done', {
+          !(await writeSseEvent(reply, 'done', {
             sessionId: resolvedSessionId,
             text: assistantText,
             thoughtContent: assistantThoughtContent || undefined,
-          })
+          }))
         ) {
           streamAbortController.abort();
         }
@@ -1733,7 +1780,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         }
         const msg = err instanceof Error ? err.message : 'AI request failed';
         if (!streamStarted) return reply.code(502).send({ error: msg });
-        writeSseEvent(reply, 'error', { message: msg });
+        await writeSseEvent(reply, 'error', { message: msg });
         endSseResponse(reply);
       } finally {
         request.raw.removeListener('aborted', handleClientDisconnect);
@@ -1820,14 +1867,14 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         userMsgCreatedAt,
       );
 
-      let savedAssistantCreatedAt: Date;
-      if (pairedAssistant) {
-        savedAssistantCreatedAt = new Date(pairedAssistant.createdAt);
-        await reportsAiChatRepo.deleteMessage(pairedAssistant.id);
-      } else {
-        savedAssistantCreatedAt = new Date(new Date(userMsgCreatedAt).getTime() + 1000);
-      }
+      const savedAssistantCreatedAt = pairedAssistant
+        ? new Date(pairedAssistant.createdAt)
+        : new Date(new Date(userMsgCreatedAt).getTime() + 1000);
 
+      // Persist the user's edited content immediately so the edit is visible even if the AI
+      // stream subsequently fails. The old paired assistant message is NOT deleted here —
+      // deletion is deferred until the atomic swap below, so a streaming failure leaves the
+      // previous assistant response intact.
       await reportsAiChatRepo.updateMessageContent(messageIdResult.value, contentResult.value);
 
       const assistantMessageId = generatePrefixedId(reportsAiChatRepo.RPT_MSG_ID_PREFIX);
@@ -1858,10 +1905,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         startSseResponse(reply);
         streamStarted = true;
         if (
-          !writeSseEvent(reply, 'start', {
+          !(await writeSseEvent(reply, 'start', {
             sessionId: sessionIdResult.value,
             messageId: assistantMessageId,
-          })
+          }))
         ) {
           streamAbortController.abort();
           return;
@@ -1870,7 +1917,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         const emitThoughtDone = async () => {
           if (thoughtDoneSent || streamAbortController.signal.aborted) return;
           thoughtDoneSent = true;
-          if (!writeSseEvent(reply, 'thought_done', {})) {
+          if (!(await writeSseEvent(reply, 'thought_done', {}))) {
             streamAbortController.abort();
           }
         };
@@ -1914,22 +1961,33 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           generatedThought || streamHandlers.accumulated.thoughtContent.trim();
         if (streamAbortController.signal.aborted) return;
 
-        await reportsAiChatRepo.insertAssistantMessage({
-          id: assistantMessageId,
-          sessionId: sessionIdResult.value,
-          content: assistantText,
-          thoughtContent: assistantThoughtContent || null,
-          createdAt: savedAssistantCreatedAt.toISOString(),
+        // Atomic swap: delete the old paired assistant (if any) and insert the new one in
+        // a single transaction. Deferring the delete until here means a mid-stream failure
+        // leaves the previous assistant response intact (the swap simply never runs).
+        await withDbTransaction(async (tx) => {
+          if (pairedAssistant) {
+            await reportsAiChatRepo.deleteMessage(pairedAssistant.id, tx);
+          }
+          await reportsAiChatRepo.insertAssistantMessage(
+            {
+              id: assistantMessageId,
+              sessionId: sessionIdResult.value,
+              content: assistantText,
+              thoughtContent: assistantThoughtContent || null,
+              createdAt: savedAssistantCreatedAt.toISOString(),
+            },
+            tx,
+          );
         });
 
         await reportsAiChatRepo.touchSession(sessionIdResult.value, userId);
 
         if (
-          !writeSseEvent(reply, 'done', {
+          !(await writeSseEvent(reply, 'done', {
             sessionId: sessionIdResult.value,
             text: assistantText,
             thoughtContent: assistantThoughtContent || undefined,
-          })
+          }))
         ) {
           streamAbortController.abort();
         }
@@ -1941,7 +1999,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         }
         const msg = err instanceof Error ? err.message : 'AI request failed';
         if (!streamStarted) return reply.code(502).send({ error: msg });
-        writeSseEvent(reply, 'error', { message: msg });
+        await writeSseEvent(reply, 'error', { message: msg });
         endSseResponse(reply);
       } finally {
         request.raw.removeListener('aborted', handleClientDisconnect);

--- a/server/test/routes/reports-sse-backpressure.test.ts
+++ b/server/test/routes/reports-sse-backpressure.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from 'bun:test';
+import { EventEmitter } from 'node:events';
+import type { FastifyReply } from 'fastify';
+import { writeSseChunk, writeSseEvent } from '../../routes/reports.ts';
+
+// Minimal fake of `reply.raw` that mimics Node's `http.ServerResponse` surface
+// touched by `writeSseChunk` / `writeSseEvent`: `write(chunk)` plus EventEmitter
+// methods for `'drain' | 'close' | 'error'`. The `write` impl is controllable so
+// tests can simulate a full internal buffer (return false) and trigger drain/close.
+class FakeRaw extends EventEmitter {
+  destroyed = false;
+  writableEnded = false;
+  writes: string[] = [];
+  // When false, every `.write` returns false (buffer "full") until `drain` is emitted.
+  // When true (default), writes succeed synchronously.
+  writeReturns = true;
+  // When true, `.write` throws — exercises the catch path in writeSseChunk.
+  throwOnWrite = false;
+
+  write(chunk: string): boolean {
+    if (this.throwOnWrite) throw new Error('mock write failure');
+    this.writes.push(chunk);
+    return this.writeReturns;
+  }
+}
+
+// Cast through `unknown` because Node's `ServerResponse.once` returns `this`, which TS
+// resolves as `ServerResponse` (not `FakeRaw`); the structural shape needed by
+// writeSseChunk (write + once/off for drain/close/error) is satisfied either way.
+type RawArg = Parameters<typeof writeSseChunk>[0];
+const asRaw = (raw: FakeRaw): RawArg => raw as unknown as RawArg;
+const fakeReply = (raw: FakeRaw): FastifyReply => ({ raw }) as unknown as FastifyReply;
+
+describe('writeSseChunk backpressure', () => {
+  test('resolves immediately to true when write returns true', async () => {
+    const raw = new FakeRaw();
+    const result = await writeSseChunk(asRaw(raw), 'hello');
+    expect(result).toBe(true);
+    expect(raw.writes).toEqual(['hello']);
+  });
+
+  test('waits for drain when write returns false', async () => {
+    const raw = new FakeRaw();
+    raw.writeReturns = false;
+
+    let resolved = false;
+    const pending = writeSseChunk(asRaw(raw), 'slow-chunk').then((v) => {
+      resolved = true;
+      return v;
+    });
+
+    // Yield once so the chunk write executes and listeners attach.
+    await new Promise((r) => setImmediate(r));
+    expect(resolved).toBe(false);
+    expect(raw.listenerCount('drain')).toBe(1);
+    expect(raw.listenerCount('close')).toBe(1);
+    expect(raw.listenerCount('error')).toBe(1);
+
+    raw.emit('drain');
+    expect(await pending).toBe(true);
+    // Listeners removed on resolution.
+    expect(raw.listenerCount('drain')).toBe(0);
+    expect(raw.listenerCount('close')).toBe(0);
+    expect(raw.listenerCount('error')).toBe(0);
+  });
+
+  test('resolves to false when close fires before drain (client disconnect mid-buffer)', async () => {
+    const raw = new FakeRaw();
+    raw.writeReturns = false;
+
+    const pending = writeSseChunk(asRaw(raw), 'doomed-chunk');
+    await new Promise((r) => setImmediate(r));
+
+    raw.emit('close');
+    expect(await pending).toBe(false);
+    expect(raw.listenerCount('drain')).toBe(0);
+    expect(raw.listenerCount('close')).toBe(0);
+    expect(raw.listenerCount('error')).toBe(0);
+  });
+
+  test('resolves to false when error fires before drain', async () => {
+    const raw = new FakeRaw();
+    raw.writeReturns = false;
+
+    const pending = writeSseChunk(asRaw(raw), 'will-error');
+    await new Promise((r) => setImmediate(r));
+
+    raw.emit('error', new Error('socket hangup'));
+    expect(await pending).toBe(false);
+  });
+
+  test('resolves to false when write throws', async () => {
+    const raw = new FakeRaw();
+    raw.throwOnWrite = true;
+    const result = await writeSseChunk(asRaw(raw), 'thrower');
+    expect(result).toBe(false);
+  });
+});
+
+describe('writeSseEvent backpressure', () => {
+  test('returns false immediately when raw.destroyed', async () => {
+    const raw = new FakeRaw();
+    raw.destroyed = true;
+    const result = await writeSseEvent(fakeReply(raw), 'msg', { x: 1 });
+    expect(result).toBe(false);
+    expect(raw.writes).toHaveLength(0);
+  });
+
+  test('returns false immediately when raw.writableEnded', async () => {
+    const raw = new FakeRaw();
+    raw.writableEnded = true;
+    const result = await writeSseEvent(fakeReply(raw), 'msg', { x: 1 });
+    expect(result).toBe(false);
+    expect(raw.writes).toHaveLength(0);
+  });
+
+  test('writes both event and data chunks in SSE wire format', async () => {
+    const raw = new FakeRaw();
+    const result = await writeSseEvent(fakeReply(raw), 'answer_delta', { delta: 'hi' });
+    expect(result).toBe(true);
+    expect(raw.writes).toEqual(['event: answer_delta\n', 'data: {"delta":"hi"}\n\n']);
+  });
+
+  test('does not resolve until drain when write returns false (regression for #413)', async () => {
+    const raw = new FakeRaw();
+    raw.writeReturns = false;
+
+    let resolved = false;
+    const pending = writeSseEvent(fakeReply(raw), 'answer_delta', { delta: 'hi' }).then((v) => {
+      resolved = true;
+      return v;
+    });
+
+    await new Promise((r) => setImmediate(r));
+    expect(resolved).toBe(false);
+    // First chunk written but write returned false, so we're parked on drain.
+    expect(raw.writes).toEqual(['event: answer_delta\n']);
+
+    // Simulate buffer flush by allowing further writes to succeed, then emit drain.
+    raw.writeReturns = true;
+    raw.emit('drain');
+    expect(await pending).toBe(true);
+    expect(raw.writes).toEqual(['event: answer_delta\n', 'data: {"delta":"hi"}\n\n']);
+  });
+
+  test('returns false when client disconnects (close fires) mid-event', async () => {
+    const raw = new FakeRaw();
+    raw.writeReturns = false;
+
+    const pending = writeSseEvent(fakeReply(raw), 'answer_delta', { delta: 'hi' });
+    await new Promise((r) => setImmediate(r));
+    raw.emit('close');
+    expect(await pending).toBe(false);
+  });
+});

--- a/server/test/routes/reports.test.ts
+++ b/server/test/routes/reports.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
 import type { FastifyInstance, FastifyPluginAsync } from 'fastify';
+import * as realDrizzle from '../../db/drizzle.ts';
 import * as realGeneralSettingsRepo from '../../repositories/generalSettingsRepo.ts';
 import * as realReportsAiChatRepo from '../../repositories/reportsAiChatRepo.ts';
 import * as realReportsCatalogRepo from '../../repositories/reportsCatalogRepo.ts';
@@ -16,6 +17,8 @@ import {
 } from '../helpers/authMiddlewareMock.ts';
 import { buildRouteTestApp } from '../helpers/buildRouteTestApp.ts';
 import { signToken } from '../helpers/jwt.ts';
+import { TX_SENTINEL } from '../helpers/txSentinel.ts';
+import { makeWithDbTransactionMock } from '../helpers/withDbTransactionMock.ts';
 
 const usersRepoSnap = { ...realUsersRepo };
 const rolesRepoSnap = { ...realRolesRepo };
@@ -27,6 +30,9 @@ const reportsClientsSnap = { ...realReportsClientsRepo };
 const reportsHoursSnap = { ...realReportsHoursRepo };
 const reportsRevenueSnap = { ...realReportsRevenueRepo };
 const workUnitsSnap = { ...realWorkUnitsRepo };
+const drizzleSnap = { ...realDrizzle };
+
+const { withDbTransactionMock, resetWithDbTransactionMock } = makeWithDbTransactionMock();
 
 const findAuthUserByIdMock = mock();
 const userHasRoleMock = mock();
@@ -131,6 +137,10 @@ beforeAll(async () => {
     ...workUnitsSnap,
     listManagedUserIds: listManagedUserIdsMock,
   }));
+  mock.module('../../db/drizzle.ts', () => ({
+    ...drizzleSnap,
+    withDbTransaction: withDbTransactionMock,
+  }));
 
   routePlugin = (await import('../../routes/reports.ts')).default as FastifyPluginAsync;
 
@@ -150,6 +160,7 @@ afterAll(() => {
   mock.module('../../repositories/reportsHoursRepo.ts', () => reportsHoursSnap);
   mock.module('../../repositories/reportsRevenueRepo.ts', () => reportsRevenueSnap);
   mock.module('../../repositories/workUnitsRepo.ts', () => workUnitsSnap);
+  mock.module('../../db/drizzle.ts', () => drizzleSnap);
   globalThis.fetch = originalFetch;
 });
 
@@ -208,12 +219,14 @@ const allMocks = [
   getCatalogSectionMock,
   listManagedUserIdsMock,
   fetchMock,
+  withDbTransactionMock,
 ];
 
 let testApp: FastifyInstance;
 
 beforeEach(async () => {
   for (const m of allMocks) m.mockReset();
+  resetWithDbTransactionMock();
   findAuthUserByIdMock.mockResolvedValue(HAPPY_USER);
   userHasRoleMock.mockResolvedValue(true);
   getRolePermissionsMock.mockResolvedValue(FULL_PERMS);
@@ -844,5 +857,118 @@ describe('POST /api/reports/ai-reporting/chat/edit-stream', () => {
 
     expect(res.statusCode).toBe(404);
     expect(JSON.parse(res.body)).toEqual({ error: 'User message not found' });
+  });
+
+  // Regression for issue #413: previously the route deleted the old paired assistant
+  // BEFORE starting the AI stream, so a streaming failure permanently lost that response.
+  // Now deletion is deferred until the atomic swap that also inserts the new assistant.
+  test('preserves old paired assistant when AI provider fetch fails (deferred deletion)', async () => {
+    getActiveSessionForUserMock.mockResolvedValue({ id: 'rpt-chat-1', title: 'Existing' });
+    findUserMessageMock.mockResolvedValue({ id: 'm-user', createdAt: new Date(1000) });
+    findFirstAssistantAfterMock.mockResolvedValue({
+      id: 'm-old-assistant',
+      createdAt: new Date(2000),
+    });
+    listRecentMessagesMock.mockResolvedValue([]);
+    updateMessageContentMock.mockResolvedValue(undefined);
+    fetchMock.mockRejectedValue(new Error('provider unreachable'));
+
+    await testApp.inject({
+      method: 'POST',
+      url: '/api/reports/ai-reporting/chat/edit-stream',
+      headers: authHeader(),
+      payload: { sessionId: 'rpt-chat-1', messageId: 'm-user', content: 'edited' },
+    });
+
+    // The user's edit is persisted immediately (visible regardless of stream outcome).
+    expect(updateMessageContentMock).toHaveBeenCalledWith('m-user', 'edited');
+    // Old assistant message must NOT be deleted when streaming fails — this is the
+    // core regression assertion for #413. Old code deleted it before the stream even
+    // began, so the previous assistant response was permanently lost on any failure.
+    expect(deleteMessageMock).not.toHaveBeenCalled();
+    // No new assistant inserted either — the atomic swap never ran.
+    expect(insertAssistantMessageMock).not.toHaveBeenCalled();
+    // And the swap transaction wrapper was never invoked.
+    expect(withDbTransactionMock).not.toHaveBeenCalled();
+  });
+
+  test('wraps delete-old + insert-new in a single transaction on stream success', async () => {
+    getActiveSessionForUserMock.mockResolvedValue({ id: 'rpt-chat-1', title: 'Existing' });
+    findUserMessageMock.mockResolvedValue({ id: 'm-user', createdAt: new Date(1000) });
+    findFirstAssistantAfterMock.mockResolvedValue({
+      id: 'm-old-assistant',
+      createdAt: new Date(2000),
+    });
+    listRecentMessagesMock.mockResolvedValue([]);
+    updateMessageContentMock.mockResolvedValue(undefined);
+    deleteMessageMock.mockResolvedValue(undefined);
+    insertAssistantMessageMock.mockResolvedValue(undefined);
+    touchSessionMock.mockResolvedValue(undefined);
+
+    // Streaming SSE body with a single Gemini text chunk so the stream succeeds.
+    const geminiChunk = `data: ${JSON.stringify({
+      candidates: [{ content: { parts: [{ text: 'new answer' }] } }],
+    })}\n\n`;
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      body: new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(geminiChunk));
+          controller.close();
+        },
+      }),
+    } as unknown as Response);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/reports/ai-reporting/chat/edit-stream',
+      headers: authHeader(),
+      payload: { sessionId: 'rpt-chat-1', messageId: 'm-user', content: 'edited' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(withDbTransactionMock).toHaveBeenCalledTimes(1);
+    // Both repo writes happened inside the tx callback (TX_SENTINEL is passed as exec).
+    expect(deleteMessageMock).toHaveBeenCalledWith('m-old-assistant', TX_SENTINEL);
+    expect(insertAssistantMessageMock).toHaveBeenCalledTimes(1);
+    expect(insertAssistantMessageMock.mock.calls[0]?.[1]).toBe(TX_SENTINEL);
+  });
+
+  test('skips deleteMessage in transaction when no paired assistant exists', async () => {
+    getActiveSessionForUserMock.mockResolvedValue({ id: 'rpt-chat-1', title: 'Existing' });
+    findUserMessageMock.mockResolvedValue({ id: 'm-user', createdAt: new Date(1000) });
+    findFirstAssistantAfterMock.mockResolvedValue(null);
+    listRecentMessagesMock.mockResolvedValue([]);
+    updateMessageContentMock.mockResolvedValue(undefined);
+    insertAssistantMessageMock.mockResolvedValue(undefined);
+    touchSessionMock.mockResolvedValue(undefined);
+
+    const geminiChunk = `data: ${JSON.stringify({
+      candidates: [{ content: { parts: [{ text: 'first answer' }] } }],
+    })}\n\n`;
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      body: new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(geminiChunk));
+          controller.close();
+        },
+      }),
+    } as unknown as Response);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/reports/ai-reporting/chat/edit-stream',
+      headers: authHeader(),
+      payload: { sessionId: 'rpt-chat-1', messageId: 'm-user', content: 'edited' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(withDbTransactionMock).toHaveBeenCalledTimes(1);
+    expect(deleteMessageMock).not.toHaveBeenCalled();
+    expect(insertAssistantMessageMock).toHaveBeenCalledTimes(1);
+    expect(insertAssistantMessageMock.mock.calls[0]?.[1]).toBe(TX_SENTINEL);
   });
 });


### PR DESCRIPTION
## Summary

Fixes [#413](https://github.com/xBounceIT/praetor/issues/413) — two correctness bugs in the AI Reporting SSE handlers in `server/routes/reports.ts`.

### 1. SSE backpressure (OOM risk)

`writeSseEvent` ignored the return value of `reply.raw.write()`. When the AI provider stream pushed data faster than a slow SSE client could read it, Node's internal stream buffer grew unbounded — a single slow client could OOM-crash the entire server.

`writeSseEvent` is now `async` and awaits `'drain'` when `write()` reports the buffer is full, or resolves to `false` if `'close'`/`'error'` fire first so callers can abort the stream. All ten callsites in the two streaming route handlers (`/ai-reporting/chat/stream` and `/ai-reporting/chat/edit-stream`) now `await` it. A small `writeSseChunk` helper isolates the drain/cleanup logic and is exported for unit testing.

### 2. Atomic edit-stream

`/ai-reporting/chat/edit-stream` deleted the old paired assistant message **before** the AI stream started, then inserted the new assistant many seconds later (after the stream completed). Any failure between those two points — network blip, provider timeout, client disconnect, crash — permanently lost the previous response with no recovery.

The fix:
- The early `deleteMessage(pairedAssistant.id)` is removed.
- The user-message content update still happens immediately so the edit is visible.
- After the AI stream succeeds, a single `withDbTransaction` atomically deletes the old paired assistant (if any) and inserts the new one.

Properties of the new flow:
- AI stream errors → old assistant survives intact, user edit preserved.
- Swap transaction fails → both delete and insert roll back atomically.
- Client disconnects mid-stream → swap never runs, old assistant survives.

## Test plan

- [x] `cd server && bun run build` — TypeScript compile clean
- [x] `bun run typecheck` — full project typecheck clean
- [x] `bun run test:server` — 2328 server tests pass (0 failures)
- [x] `bun run test:frontend` — 1012 frontend tests pass (0 failures)
- [x] `biome check` on changed files — clean

New tests:
- `server/test/routes/reports-sse-backpressure.test.ts` — 10 unit tests covering `writeSseChunk` (drain wait, close/error cleanup, listener leak prevention, throw path) and `writeSseEvent` (early-bail on destroyed/writableEnded, SSE wire format, the #413 regression: does not resolve until drain).
- `server/test/routes/reports.test.ts` — 3 new integration tests for `/ai-reporting/chat/edit-stream`:
  - Preserves the old paired assistant when the AI provider fetch fails (deferred deletion regression).
  - Wraps delete-old + insert-new in a single `withDbTransaction` on stream success.
  - Skips `deleteMessage` in the transaction when no paired assistant exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)