### PR TITLE
fix(auth): bump sessionVersion on password change (#400)

### DIFF
--- a/docs-site/src/content/docs/en/getting-started.md
+++ b/docs-site/src/content/docs/en/getting-started.md
@@ -29,6 +29,6 @@ The sidebar groups the main modules. Available items depend on your role:
 
 From the user menu you can open settings, switch role when multiple profiles are available, open this documentation, and log out.
 
-The **Security** tab contains password changes and your personal access token for API use. The token inherits your user permissions; copy it when it is created or renewed, because it is shown only in masked form afterward. The token is also rejected after 30 days without use — renew it before it goes idle, or have an administrator adjust the idle window via the `PAT_IDLE_TIMEOUT_MS` server environment variable.
+The **Security** tab contains password changes and your personal access token for API use. Changing your password immediately revokes every other active session for your account: only the device you used to make the change stays signed in. The token inherits your user permissions; copy it when it is created or renewed, because it is shown only in masked form afterward. The token is also rejected after 30 days without use — renew it before it goes idle, or have an administrator adjust the idle window via the `PAT_IDLE_TIMEOUT_MS` server environment variable.
 
 Always check that you are using the right role before changing administrative or accounting data.

--- a/docs-site/src/content/docs/getting-started.md
+++ b/docs-site/src/content/docs/getting-started.md
@@ -29,6 +29,6 @@ La barra laterale raggruppa i moduli principali. Le voci disponibili dipendono d
 
 Dal menu utente puoi aprire le impostazioni, cambiare ruolo se hai più profili disponibili, consultare questa documentazione e uscire dall'applicazione.
 
-La scheda **Sicurezza** contiene il cambio password e il token di accesso personale per usare le API. Il token eredita i permessi del tuo utente; copialo quando viene creato o rinnovato, perché in seguito verrà mostrato solo in forma mascherata. Il token viene inoltre rifiutato dopo 30 giorni di inattività — rinnovalo prima che scada o chiedi a un amministratore di regolare la finestra di inattività tramite la variabile d'ambiente `PAT_IDLE_TIMEOUT_MS` lato server.
+La scheda **Sicurezza** contiene il cambio password e il token di accesso personale per usare le API. Quando cambi la password, tutte le altre sessioni attive del tuo utente vengono revocate immediatamente: solo il dispositivo da cui hai effettuato il cambio resta connesso. Il token eredita i permessi del tuo utente; copialo quando viene creato o rinnovato, perché in seguito verrà mostrato solo in forma mascherata. Il token viene inoltre rifiutato dopo 30 giorni di inattività — rinnovalo prima che scada o chiedi a un amministratore di regolare la finestra di inattività tramite la variabile d'ambiente `PAT_IDLE_TIMEOUT_MS` lato server.
 
 Controlla sempre di lavorare con il ruolo corretto prima di modificare dati amministrativi o contabili.

--- a/server/repositories/usersRepo.ts
+++ b/server/repositories/usersRepo.ts
@@ -166,14 +166,6 @@ export const getPasswordHash = async (
   return rows[0]?.passwordHash ?? null;
 };
 
-export const updatePasswordHash = async (
-  userId: string,
-  passwordHash: string,
-  exec: DbExecutor = db,
-): Promise<void> => {
-  await exec.update(users).set({ passwordHash }).where(eq(users.id, userId));
-};
-
 export const findCostPerHour = async (userId: string, exec: DbExecutor = db): Promise<number> => {
   const rows = await exec
     .select({ costPerHour: users.costPerHour })

--- a/server/repositories/usersRepo.ts
+++ b/server/repositories/usersRepo.ts
@@ -2,6 +2,7 @@ import { eq, sql } from 'drizzle-orm';
 import { type DbExecutor, db, executeRows } from '../db/drizzle.ts';
 import type { UserAuthMethod } from '../db/schema/users.ts';
 import { users } from '../db/schema/users.ts';
+import { NotFoundError } from '../utils/http-errors.ts';
 import { parseDbNumber } from '../utils/parse.ts';
 import { ADMIN_ROLE_ID, TOP_MANAGER_ROLE_ID } from '../utils/permissions.ts';
 
@@ -102,6 +103,24 @@ export const bumpSessionVersion = async (userId: string, exec: DbExecutor = db):
     .update(users)
     .set({ sessionVersion: sql`${users.sessionVersion} + 1` })
     .where(eq(users.id, userId));
+};
+
+// Atomic credential rotation: bumping `session_version` in the same UPDATE that
+// stores the new hash guarantees no window in which the new password is live but
+// stolen tokens still validate. Returns the new session_version so the caller
+// can re-sign their own x-auth-token and stay logged in.
+export const rotatePasswordAndBumpSession = async (
+  userId: string,
+  passwordHash: string,
+  exec: DbExecutor = db,
+): Promise<number> => {
+  const rows = await exec
+    .update(users)
+    .set({ passwordHash, sessionVersion: sql`${users.sessionVersion} + 1` })
+    .where(eq(users.id, userId))
+    .returning({ sessionVersion: users.sessionVersion });
+  if (!rows[0]) throw new NotFoundError('User');
+  return rows[0].sessionVersion;
 };
 
 export const findLoginUserByUsername = async (

--- a/server/routes/settings.ts
+++ b/server/routes/settings.ts
@@ -350,18 +350,12 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         newHash,
       );
 
-      if (request.user.username === ADMIN_USERNAME) {
-        if (newPasswordResult.value === DEFAULT_ADMIN_PASSWORD) {
-          await notificationsRepo.upsertAdminPasswordWarning(request.user.id);
-        } else {
-          await notificationsRepo.deleteAdminPasswordWarning();
-        }
-      }
-
-      // authenticateToken's sliding-window refresh already wrote an x-auth-token
-      // signed with the pre-bump sessionVersion; overwrite it so the current
-      // device stays logged in while other live sessions get "Session revoked"
-      // on their next request. PAT callers have nothing to rotate.
+      // Re-sign x-auth-token before the admin-warning side effects below: the
+      // password is already rotated, and authenticateToken's sliding-window
+      // refresh wrote a pre-bump token in onRequest. If a downstream side
+      // effect throws, Fastify's 500 response still carries this rotated
+      // header — without it, the admin would be force-logged-out by their own
+      // password change. PAT callers have nothing to rotate.
       if (request.auth?.source === 'session' && request.auth.sessionStart !== undefined) {
         const refreshedToken = generateToken(
           request.user.id,
@@ -370,6 +364,14 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           newSessionVersion,
         );
         reply.header('x-auth-token', refreshedToken);
+      }
+
+      if (request.user.username === ADMIN_USERNAME) {
+        if (newPasswordResult.value === DEFAULT_ADMIN_PASSWORD) {
+          await notificationsRepo.upsertAdminPasswordWarning(request.user.id);
+        } else {
+          await notificationsRepo.deleteAdminPasswordWarning();
+        }
       }
 
       return { message: 'Password updated successfully' };

--- a/server/routes/settings.ts
+++ b/server/routes/settings.ts
@@ -1,6 +1,6 @@
 import bcrypt from 'bcryptjs';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
-import { authenticateToken } from '../middleware/auth.ts';
+import { authenticateToken, generateToken } from '../middleware/auth.ts';
 import * as mcpTokensRepo from '../repositories/mcpTokensRepo.ts';
 import * as notificationsRepo from '../repositories/notificationsRepo.ts';
 import * as personalAccessTokensRepo from '../repositories/personalAccessTokensRepo.ts';
@@ -345,13 +345,31 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
 
       const newHash = await bcrypt.hash(newPasswordResult.value, 12);
 
-      await usersRepo.updatePasswordHash(request.user.id, newHash);
+      const newSessionVersion = await usersRepo.rotatePasswordAndBumpSession(
+        request.user.id,
+        newHash,
+      );
+
       if (request.user.username === ADMIN_USERNAME) {
         if (newPasswordResult.value === DEFAULT_ADMIN_PASSWORD) {
           await notificationsRepo.upsertAdminPasswordWarning(request.user.id);
         } else {
           await notificationsRepo.deleteAdminPasswordWarning();
         }
+      }
+
+      // authenticateToken's sliding-window refresh already wrote an x-auth-token
+      // signed with the pre-bump sessionVersion; overwrite it so the current
+      // device stays logged in while other live sessions get "Session revoked"
+      // on their next request. PAT callers have nothing to rotate.
+      if (request.auth?.source === 'session' && request.auth.sessionStart !== undefined) {
+        const refreshedToken = generateToken(
+          request.user.id,
+          request.auth.sessionStart,
+          request.user.role,
+          newSessionVersion,
+        );
+        reply.header('x-auth-token', refreshedToken);
       }
 
       return { message: 'Password updated successfully' };

--- a/server/test/repositories/usersRepo.test.ts
+++ b/server/test/repositories/usersRepo.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
 import type { DbExecutor } from '../../db/drizzle.ts';
 import * as usersRepo from '../../repositories/usersRepo.ts';
+import { NotFoundError } from '../../utils/http-errors.ts';
 import { type FakeExecutor, setupTestDb } from '../helpers/fakeExecutor.ts';
 
 let exec: FakeExecutor;
@@ -101,18 +102,20 @@ describe('findLoginUserByUsername', () => {
   });
 });
 
-describe('updatePasswordHash', () => {
-  test('passes the hash and userId in params', async () => {
-    exec.enqueue({ rows: [], rowCount: 1 });
-    await usersRepo.updatePasswordHash('user-1', 'new-hash', testDb);
+describe('rotatePasswordAndBumpSession', () => {
+  test('passes the hash and userId, returns the new session_version from RETURNING', async () => {
+    exec.enqueue({ rows: [[5]], rowCount: 1 });
+    const result = await usersRepo.rotatePasswordAndBumpSession('user-1', 'new-hash', testDb);
+    expect(result).toBe(5);
     expect(exec.calls[0].params).toContain('new-hash');
     expect(exec.calls[0].params).toContain('user-1');
   });
 
-  test('resolves to undefined', async () => {
-    exec.enqueue({ rows: [], rowCount: 1 });
-    const result = await usersRepo.updatePasswordHash('user-1', 'new-hash', testDb);
-    expect(result).toBeUndefined();
+  test('throws NotFoundError when no row matched the userId', async () => {
+    exec.enqueue({ rows: [], rowCount: 0 });
+    await expect(
+      usersRepo.rotatePasswordAndBumpSession('user-missing', 'new-hash', testDb),
+    ).rejects.toBeInstanceOf(NotFoundError);
   });
 });
 

--- a/server/test/routes/settings.test.ts
+++ b/server/test/routes/settings.test.ts
@@ -13,7 +13,7 @@ import {
   restoreAuthMiddlewareMock,
 } from '../helpers/authMiddlewareMock.ts';
 import { buildRouteTestApp } from '../helpers/buildRouteTestApp.ts';
-import { signToken } from '../helpers/jwt.ts';
+import { decodeForAssertion, signToken } from '../helpers/jwt.ts';
 
 // hashPersonalAccessToken (HMAC-keyed, exercised via the settings routes) requires
 // ENCRYPTION_KEY at call time.
@@ -35,7 +35,7 @@ const getRolePermissionsMock = mock();
 const getOrCreateForUserMock = mock();
 const upsertForUserMock = mock();
 const getPasswordHashMock = mock();
-const updatePasswordHashMock = mock();
+const rotatePasswordAndBumpSessionMock = mock();
 const upsertAdminPasswordWarningMock = mock();
 const deleteAdminPasswordWarningMock = mock();
 const listMcpTokensForUserMock = mock();
@@ -58,7 +58,7 @@ beforeAll(async () => {
     findAuthUserById: findAuthUserByIdMock,
     findCoreById: findCoreByIdMock,
     getPasswordHash: getPasswordHashMock,
-    updatePasswordHash: updatePasswordHashMock,
+    rotatePasswordAndBumpSession: rotatePasswordAndBumpSessionMock,
   }));
   mock.module('../../repositories/rolesRepo.ts', () => ({
     ...rolesRepoSnap,
@@ -147,7 +147,7 @@ const allMocks = [
   getOrCreateForUserMock,
   upsertForUserMock,
   getPasswordHashMock,
-  updatePasswordHashMock,
+  rotatePasswordAndBumpSessionMock,
   upsertAdminPasswordWarningMock,
   deleteAdminPasswordWarningMock,
   listMcpTokensForUserMock,
@@ -472,11 +472,11 @@ describe('MCP token settings routes', () => {
 });
 
 describe('PUT /api/settings/password', () => {
-  test('200 happy password change', async () => {
+  test('200 happy password change bumps sessionVersion and rotates x-auth-token', async () => {
     getPasswordHashMock.mockResolvedValue('$2a$existing');
     bcryptCompareMock.mockResolvedValue(true);
     bcryptHashMock.mockResolvedValue('$2a$newhash');
-    updatePasswordHashMock.mockResolvedValue(undefined);
+    rotatePasswordAndBumpSessionMock.mockResolvedValue(2);
 
     const res = await testApp.inject({
       method: 'PUT',
@@ -489,7 +489,14 @@ describe('PUT /api/settings/password', () => {
     expect(JSON.parse(res.body)).toEqual({ message: 'Password updated successfully' });
     expect(bcryptCompareMock).toHaveBeenCalledWith('old-pw1', '$2a$existing');
     expect(bcryptHashMock).toHaveBeenCalledWith('new-secure-pw', 12);
-    expect(updatePasswordHashMock).toHaveBeenCalledWith('u1', '$2a$newhash');
+    expect(rotatePasswordAndBumpSessionMock).toHaveBeenCalledWith('u1', '$2a$newhash');
+
+    const rotated = res.headers['x-auth-token'];
+    expect(typeof rotated).toBe('string');
+    const decoded = decodeForAssertion(rotated as string);
+    expect(decoded.sessionVersion).toBe(2);
+    expect(decoded.userId).toBe('u1');
+
     expect(upsertAdminPasswordWarningMock).not.toHaveBeenCalled();
     expect(deleteAdminPasswordWarningMock).not.toHaveBeenCalled();
   });
@@ -499,7 +506,7 @@ describe('PUT /api/settings/password', () => {
     getPasswordHashMock.mockResolvedValue('$2a$existing');
     bcryptCompareMock.mockResolvedValue(true);
     bcryptHashMock.mockResolvedValue('$2a$newhash');
-    updatePasswordHashMock.mockResolvedValue(undefined);
+    rotatePasswordAndBumpSessionMock.mockResolvedValue(2);
 
     const res = await testApp.inject({
       method: 'PUT',
@@ -518,7 +525,7 @@ describe('PUT /api/settings/password', () => {
     getPasswordHashMock.mockResolvedValue('$2a$existing');
     bcryptCompareMock.mockResolvedValue(true);
     bcryptHashMock.mockResolvedValue('$2a$newhash');
-    updatePasswordHashMock.mockResolvedValue(undefined);
+    rotatePasswordAndBumpSessionMock.mockResolvedValue(2);
 
     const res = await testApp.inject({
       method: 'PUT',
@@ -529,6 +536,24 @@ describe('PUT /api/settings/password', () => {
 
     expect(res.statusCode).toBe(200);
     expect(upsertAdminPasswordWarningMock).toHaveBeenCalledWith('u1');
+    expect(deleteAdminPasswordWarningMock).not.toHaveBeenCalled();
+  });
+
+  test('500 when rotatePasswordAndBumpSession throws — no admin-warning side effects', async () => {
+    getPasswordHashMock.mockResolvedValue('$2a$existing');
+    bcryptCompareMock.mockResolvedValue(true);
+    bcryptHashMock.mockResolvedValue('$2a$newhash');
+    rotatePasswordAndBumpSessionMock.mockRejectedValue(new Error('db down'));
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/settings/password',
+      headers: authHeader(),
+      payload: { currentPassword: 'old-pw1', newPassword: 'new-secure-pw' },
+    });
+
+    expect(res.statusCode).toBe(500);
+    expect(upsertAdminPasswordWarningMock).not.toHaveBeenCalled();
     expect(deleteAdminPasswordWarningMock).not.toHaveBeenCalled();
   });
 
@@ -589,7 +614,7 @@ describe('PUT /api/settings/password', () => {
     });
     expect(res.statusCode).toBe(400);
     expect(JSON.parse(res.body).error).toMatch(/Incorrect current password/);
-    expect(updatePasswordHashMock).not.toHaveBeenCalled();
+    expect(rotatePasswordAndBumpSessionMock).not.toHaveBeenCalled();
   });
 
   test('400 newPassword equals currentPassword', async () => {
@@ -604,7 +629,7 @@ describe('PUT /api/settings/password', () => {
     expect(getPasswordHashMock).not.toHaveBeenCalled();
     expect(bcryptCompareMock).not.toHaveBeenCalled();
     expect(bcryptHashMock).not.toHaveBeenCalled();
-    expect(updatePasswordHashMock).not.toHaveBeenCalled();
+    expect(rotatePasswordAndBumpSessionMock).not.toHaveBeenCalled();
   });
 
   test('401 missing token', async () => {
@@ -630,7 +655,7 @@ describe('PUT /api/settings/password', () => {
     expect(JSON.parse(res.body).error).toMatch(/identity provider/);
     expect(getPasswordHashMock).not.toHaveBeenCalled();
     expect(bcryptCompareMock).not.toHaveBeenCalled();
-    expect(updatePasswordHashMock).not.toHaveBeenCalled();
+    expect(rotatePasswordAndBumpSessionMock).not.toHaveBeenCalled();
   });
 });
 

--- a/server/test/routes/settings.test.ts
+++ b/server/test/routes/settings.test.ts
@@ -557,6 +557,30 @@ describe('PUT /api/settings/password', () => {
     expect(deleteAdminPasswordWarningMock).not.toHaveBeenCalled();
   });
 
+  // Regression: rotate succeeded, so the rotated x-auth-token must be on the
+  // response even when a downstream side effect fails — otherwise the admin's
+  // own password change forcibly logs them out via stale sliding-window token.
+  test('500 from admin warning still ships the rotated x-auth-token', async () => {
+    findAuthUserByIdMock.mockResolvedValue({ ...HAPPY_USER, username: 'admin' });
+    getPasswordHashMock.mockResolvedValue('$2a$existing');
+    bcryptCompareMock.mockResolvedValue(true);
+    bcryptHashMock.mockResolvedValue('$2a$newhash');
+    rotatePasswordAndBumpSessionMock.mockResolvedValue(2);
+    deleteAdminPasswordWarningMock.mockRejectedValue(new Error('notifications down'));
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/settings/password',
+      headers: authHeader(),
+      payload: { currentPassword: 'password', newPassword: 'new-secure-pw' },
+    });
+
+    expect(res.statusCode).toBe(500);
+    const rotated = res.headers['x-auth-token'];
+    expect(typeof rotated).toBe('string');
+    expect(decodeForAssertion(rotated as string).sessionVersion).toBe(2);
+  });
+
   test('400 missing currentPassword', async () => {
     const res = await testApp.inject({
       method: 'PUT',


### PR DESCRIPTION
## Summary

Fixes #400 — a session-invalidation bypass where `PUT /api/settings/password` updated the password hash but never bumped `session_version`. Stolen JWTs survived the password change for up to 8 hours (the configured max session window), so an attacker holding a token kept access even after the victim "secured" their account.

- Added `usersRepo.rotatePasswordAndBumpSession`: a single `UPDATE users SET password_hash = ?, session_version = session_version + 1 ... RETURNING session_version`. Atomic by definition (single statement), one DB round-trip instead of two, no transaction needed.
- The handler at `server/routes/settings.ts` re-signs `x-auth-token` with the bumped version so the caller's current device stays logged in. Every other live session — and the original stolen token — 401s with `Session revoked` on its next request (enforced by the existing `sessionVersion` check in `server/middleware/auth.ts`).
- PAT-authenticated callers have nothing to rotate; the version bump alone revokes any JWTs they hold elsewhere.
- Throws `NotFoundError` if the user row disappeared (uses the existing class from `server/utils/http-errors.ts`).
- Brief note added to the Italian and English `getting-started.md` so users know that changing the password signs out their other devices.

## Test plan

- [x] `bun test` in `server/` — 2316 pass / 0 fail (113 of those exercise auth-adjacent flows).
- [x] `bun test ./test` at root — 3328 frontend tests pass / 0 fail.
- [x] `bun run lint` at root — exit 0 (typecheck clean; 4 pre-existing biome warnings unrelated to this change).
- New unit tests in `server/test/routes/settings.test.ts`:
  - Happy path: asserts `rotatePasswordAndBumpSession` called with `(userId, newHash)` and that the response's `x-auth-token` decodes to a JWT with `sessionVersion === 2`.
  - 500 path: when the combined repo function rejects, the handler does not run the admin-warning side effects.
  - Negative paths (incorrect current password, identical new password, IdP-managed user) now assert the bump never runs.
- [ ] Manual: log in as the same user from two browsers, change the password from one, confirm the other 401s on its next request and that the original (pre-change) token no longer authenticates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)