### PR TITLE
fix(api): prevent supplier and product id collisions

### DIFF
--- a/server/routes/products.ts
+++ b/server/routes/products.ts
@@ -216,7 +216,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         if (costUnitResult.ok) expectedCostUnit = costUnitResult.value;
       }
 
-      const id = `p-${Date.now()}`;
+      const id = generatePrefixedId('p');
       const created = await productsRepo.insertProduct({
         id,
         name: nameResult.value,

--- a/server/routes/suppliers.ts
+++ b/server/routes/suppliers.ts
@@ -8,6 +8,7 @@ import * as suppliersRepo from '../repositories/suppliersRepo.ts';
 import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
 import { logAudit } from '../utils/audit.ts';
 import { getForeignKeyViolation } from '../utils/db-errors.ts';
+import { generatePrefixedId } from '../utils/order-ids.ts';
 import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
@@ -177,7 +178,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       if (!notesResult.ok) return badRequest(reply, notesResult.message);
 
       const now = Date.now();
-      const id = 's-' + now;
+      const id = generatePrefixedId('s');
       const created = await suppliersRepo.create({
         id,
         name: nameResult.value,

--- a/server/test/routes/products.test.ts
+++ b/server/test/routes/products.test.ts
@@ -1,4 +1,14 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from 'bun:test';
 import type { FastifyInstance, FastifyPluginAsync } from 'fastify';
 import * as realDrizzle from '../../db/drizzle.ts';
 import * as realProductsRepo from '../../repositories/productsRepo.ts';
@@ -349,6 +359,57 @@ describe('POST /api/products', () => {
     expect(logAuditMock).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'product.created' }),
     );
+  });
+
+  test('201 generates unique ids for same-millisecond product creates', async () => {
+    const fixedNow = 1_700_000_000_000;
+    const dateNowSpy = spyOn(Date, 'now').mockReturnValue(fixedNow);
+    insertProductMock.mockImplementation(async (input: Record<string, unknown>) => ({
+      ...SAMPLE_PRODUCT,
+      ...input,
+    }));
+
+    try {
+      const [firstRes, secondRes] = await Promise.all([
+        testApp.inject({
+          method: 'POST',
+          url: '/api/products',
+          headers: authHeader(),
+          payload: {
+            name: 'Widget 1',
+            productCode: 'WGT-1',
+            costo: 10,
+            molPercentage: 30,
+            type: 'goods',
+          },
+        }),
+        testApp.inject({
+          method: 'POST',
+          url: '/api/products',
+          headers: authHeader(),
+          payload: {
+            name: 'Widget 2',
+            productCode: 'WGT-2',
+            costo: 10,
+            molPercentage: 30,
+            type: 'goods',
+          },
+        }),
+      ]);
+
+      expect(firstRes.statusCode).toBe(201);
+      expect(secondRes.statusCode).toBe(201);
+      expect(insertProductMock).toHaveBeenCalledTimes(2);
+
+      const firstInput = insertProductMock.mock.calls[0]?.[0] as { id: string };
+      const secondInput = insertProductMock.mock.calls[1]?.[0] as { id: string };
+
+      expect(firstInput.id).toMatch(/^p-/);
+      expect(secondInput.id).toMatch(/^p-/);
+      expect(firstInput.id).not.toBe(secondInput.id);
+    } finally {
+      dateNowSpy.mockRestore();
+    }
   });
 
   test('400 invalid productCode characters', async () => {

--- a/server/test/routes/suppliers.test.ts
+++ b/server/test/routes/suppliers.test.ts
@@ -1,4 +1,14 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from 'bun:test';
 import type { FastifyInstance, FastifyPluginAsync } from 'fastify';
 import * as realRolesRepo from '../../repositories/rolesRepo.ts';
 import * as realSuppliersRepo from '../../repositories/suppliersRepo.ts';
@@ -191,6 +201,47 @@ describe('POST /api/suppliers', () => {
         entityType: 'supplier',
       }),
     );
+  });
+
+  test('201 generates unique ids for same-millisecond supplier creates', async () => {
+    const fixedNow = 1_700_000_000_000;
+    const dateNowSpy = spyOn(Date, 'now').mockReturnValue(fixedNow);
+    createMock.mockImplementation(async (input: Record<string, unknown>) => ({
+      ...SAMPLE_SUPPLIER,
+      ...input,
+    }));
+
+    try {
+      const [firstRes, secondRes] = await Promise.all([
+        testApp.inject({
+          method: 'POST',
+          url: '/api/suppliers',
+          headers: authHeader(),
+          payload: { name: 'ACME 1', vatNumber: 'IT123' },
+        }),
+        testApp.inject({
+          method: 'POST',
+          url: '/api/suppliers',
+          headers: authHeader(),
+          payload: { name: 'ACME 2', vatNumber: 'IT456' },
+        }),
+      ]);
+
+      expect(firstRes.statusCode).toBe(201);
+      expect(secondRes.statusCode).toBe(201);
+      expect(createMock).toHaveBeenCalledTimes(2);
+
+      const firstInput = createMock.mock.calls[0]?.[0] as { id: string; createdAt: number };
+      const secondInput = createMock.mock.calls[1]?.[0] as { id: string; createdAt: number };
+
+      expect(firstInput.id).toMatch(/^s-/);
+      expect(secondInput.id).toMatch(/^s-/);
+      expect(firstInput.id).not.toBe(secondInput.id);
+      expect(firstInput.createdAt).toBe(fixedNow);
+      expect(secondInput.createdAt).toBe(fixedNow);
+    } finally {
+      dateNowSpy.mockRestore();
+    }
   });
 
   test('201 accepts crm.suppliers_all.create without base create', async () => {


### PR DESCRIPTION
## Summary
- Replace timestamp-only supplier and product IDs with `generatePrefixedId()`.
- Keep existing `s-` and `p-` public ID prefixes while adding UUID entropy.
- Add route regression tests that freeze `Date.now()` and verify same-millisecond creates get distinct IDs.

## Root cause
Supplier and product creation used `Date.now()` as the only source of ID entropy. Concurrent requests in the same millisecond could produce duplicate primary keys and return HTTP 500.

## Validation
- `cd server && bun test ./test/routes/suppliers.test.ts`
- `cd server && bun test ./test/routes/products.test.ts`
- `bun run test:server`
- `bun run lint` (passes with existing unrelated warnings)

Fixes #389