### PR TITLE
fix(sso): validate SAML provider updates

### DIFF
--- a/docs-site/src/content/docs/administration.md
+++ b/docs-site/src/content/docs/administration.md
@@ -17,6 +17,8 @@ Quando modifichi un ruolo, considera l'impatto su tutti gli utenti assegnati. Do
 
 Praetor supporta autenticazione locale e integrazioni aziendali come LDAP o SSO quando configurate. Mantieni aggiornati endpoint, mapping dei ruoli e impostazioni di sicurezza.
 
+Prima di abilitare un provider SAML, configura una sorgente metadata valida (URL o XML) oppure la configurazione manuale con **Entry Point** e **Certificato IdP**. Praetor rifiuta il salvataggio di provider SAML abilitati senza questi dati minimi.
+
 Nella lista utenti puoi usare il menu azioni e scegliere **Cambia metodo di autenticazione** per vincolare un utente applicativo a credenziali locali, LDAP, OIDC o SAML. Per OIDC e SAML seleziona anche il provider specifico: l'utente potrà accedere solo tramite quel provider. Dipendenti interni o esterni non sono account applicativi e non possono essere vincolati a LDAP/SSO.
 
 Quando vincoli un utente a LDAP, Praetor consulta la directory e applica subito i ruoli configurati nel mapping dei gruppi LDAP, sovrascrivendo il ruolo locale. Se la directory non è raggiungibile o l'utente non vi è presente, il ruolo esistente viene mantenuto e il prossimo accesso o sincronizzazione riapplicherà il mapping.

--- a/docs-site/src/content/docs/en/administration.md
+++ b/docs-site/src/content/docs/en/administration.md
@@ -17,6 +17,8 @@ When changing a role, consider the impact on every assigned user. After major ch
 
 Praetor supports local authentication and company integrations such as LDAP or SSO when configured. Keep endpoints, role mappings, and security settings updated.
 
+Before enabling a SAML provider, configure either a valid metadata source (URL or XML) or manual settings with **Entry Point** and **IdP Certificate**. Praetor rejects enabled SAML providers that are missing this minimum configuration.
+
 In the user list, open the row actions menu and choose **Change authentication method** to restrict an application user to local credentials, LDAP, OIDC, or SAML. For OIDC and SAML, also select the specific provider: the user will be able to sign in only through that provider. Internal and external employees are not application accounts and cannot be bound to LDAP/SSO.
 
 When you bind a user to LDAP, Praetor looks them up in the directory and immediately applies the roles configured in the LDAP group role mapping, overriding the local role. If the directory is unreachable or the user is not in it yet, the existing role is kept and the next login or sync will re-apply the mapping.

--- a/server/routes/sso.ts
+++ b/server/routes/sso.ts
@@ -4,7 +4,6 @@ import * as rolesRepo from '../repositories/rolesRepo.ts';
 import { standardRateLimitedErrorResponses } from '../schemas/common.ts';
 import * as ssoService from '../services/sso.ts';
 import { logAudit } from '../utils/audit.ts';
-import { MASKED_SECRET } from '../utils/crypto.ts';
 import { badRequest, parseBoolean, requireNonEmptyString } from '../utils/validation.ts';
 
 const roleMappingSchema = {
@@ -68,6 +67,14 @@ const idParamsSchema = {
 
 const slugPattern = /^[a-z0-9][a-z0-9-]{0,98}[a-z0-9]$/;
 
+const handleProviderValidationError = (error: unknown, reply: FastifyReply): boolean => {
+  if (error instanceof ssoService.SsoProviderValidationError) {
+    badRequest(reply, error.message);
+    return true;
+  }
+  return false;
+};
+
 const validateProviderBody = async (
   body: Record<string, unknown>,
   reply: FastifyReply,
@@ -128,19 +135,6 @@ const validateProviderBody = async (
         return null;
       }
       validated[field] = result.value;
-    }
-  }
-
-  if (validated.enabled && validated.protocol === 'saml' && options.isCreate) {
-    // A masked sentinel never counts as "present" — the service preserves the existing value
-    // on update, but it can't satisfy a fresh create where there is nothing to preserve.
-    const hasMetadataXml = !!source.metadataXml?.trim() && source.metadataXml !== MASKED_SECRET;
-    const hasMetadata = !!source.metadataUrl?.trim() || hasMetadataXml;
-    const hasIdpCert = !!source.idpCert?.trim() && source.idpCert !== MASKED_SECRET;
-    const hasManual = !!source.entryPoint?.trim() && hasIdpCert;
-    if (!hasMetadata && !hasManual) {
-      badRequest(reply, 'SAML requires metadata URL/XML or manual entryPoint and idpCert');
-      return null;
     }
   }
 
@@ -232,7 +226,13 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         isCreate: true,
       });
       if (!input) return reply;
-      const created = await ssoService.createProvider(input);
+      let created: ssoService.AdminSsoProvider;
+      try {
+        created = await ssoService.createProvider(input);
+      } catch (error) {
+        if (handleProviderValidationError(error, reply)) return reply;
+        throw error;
+      }
       await logAudit({
         request,
         action: 'sso_provider.created',
@@ -265,7 +265,13 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         isCreate: false,
       });
       if (!input) return reply;
-      const updated = await ssoService.updateProvider(id, input);
+      let updated: ssoService.AdminSsoProvider | null;
+      try {
+        updated = await ssoService.updateProvider(id, input);
+      } catch (error) {
+        if (handleProviderValidationError(error, reply)) return reply;
+        throw error;
+      }
       if (!updated) return reply.code(404).send({ error: 'SSO provider not found' });
       await logAudit({
         request,

--- a/server/routes/sso.ts
+++ b/server/routes/sso.ts
@@ -127,7 +127,7 @@ const validateProviderBody = async (
     validated.enabled = false;
   }
 
-  if (validated.enabled && validated.protocol === 'oidc') {
+  if (options.isCreate && validated.enabled && validated.protocol === 'oidc') {
     for (const field of ['issuerUrl', 'clientId', 'usernameAttribute'] as const) {
       const result = requireNonEmptyString(source[field], field);
       if (!result.ok) {

--- a/server/services/sso.ts
+++ b/server/services/sso.ts
@@ -35,6 +35,13 @@ export type SsoProviderInput = Partial<Omit<ssoProvidersRepo.SsoProvider, 'id'>>
   id?: string;
 };
 
+export class SsoProviderValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SsoProviderValidationError';
+  }
+}
+
 export type SsoLoginResponseUser = usersRepo.AuthUser & {
   permissions: string[];
   availableRoles: rolesRepo.Role[];
@@ -58,6 +65,43 @@ const getProviderSecrets = (provider: ssoProvidersRepo.SsoProvider) => ({
   clientSecret: provider.clientSecret ? decrypt(provider.clientSecret) : '',
   privateKey: provider.privateKey ? decrypt(provider.privateKey) : '',
 });
+
+const hasConfigValue = (value: unknown): boolean =>
+  typeof value === 'string' && value.trim().length > 0;
+
+const assertEnabledProviderConfig = (provider: ssoProvidersRepo.SsoProvider): void => {
+  if (!provider.enabled) return;
+
+  if (provider.protocol === 'oidc') {
+    for (const field of ['issuerUrl', 'clientId', 'usernameAttribute'] as const) {
+      if (!hasConfigValue(provider[field])) {
+        throw new SsoProviderValidationError(`${field} is required`);
+      }
+    }
+    return;
+  }
+
+  const hasMetadata = hasConfigValue(provider.metadataUrl) || hasConfigValue(provider.metadataXml);
+  const hasManual = hasConfigValue(provider.entryPoint) && hasConfigValue(provider.idpCert);
+  if (!hasMetadata && !hasManual) {
+    throw new SsoProviderValidationError(
+      'SAML requires metadata URL/XML or manual entryPoint and idpCert',
+    );
+  }
+};
+
+const applyDefinedProviderPatch = (
+  provider: ssoProvidersRepo.SsoProvider,
+  patch: ssoProvidersRepo.SsoProviderPatch,
+): ssoProvidersRepo.SsoProvider => {
+  const next = { ...provider };
+  for (const [key, value] of Object.entries(patch)) {
+    if (value !== undefined) {
+      (next as Record<string, unknown>)[key] = value;
+    }
+  }
+  return next;
+};
 
 const normalizeSlug = (slug: string) => slug.trim().toLowerCase();
 
@@ -554,7 +598,7 @@ export const createProvider = async (input: SsoProviderInput): Promise<AdminSsoP
   if (!input.slug) throw new Error('slug is required');
   if (!input.name) throw new Error('name is required');
   const patch = prepareProviderValues(input);
-  const created = await ssoProvidersRepo.insert({
+  const provider: ssoProvidersRepo.SsoProvider = {
     id: generatePrefixedId('sso'),
     protocol: input.protocol,
     slug: normalizeSlug(input.slug),
@@ -593,7 +637,9 @@ export const createProvider = async (input: SsoProviderInput): Promise<AdminSsoP
         ? ssoProvidersRepo.DEFAULT_SAML_FIELDS.groupsAttribute
         : ssoProvidersRepo.DEFAULT_OIDC_FIELDS.groupsAttribute),
     roleMappings: patch.roleMappings ?? [],
-  });
+  };
+  assertEnabledProviderConfig(provider);
+  const created = await ssoProvidersRepo.insert(provider);
   return maskProvider(created);
 };
 
@@ -604,6 +650,7 @@ export const updateProvider = async (
   const existing = await ssoProvidersRepo.findById(id);
   if (!existing) return null;
   const patch = prepareProviderValues(input, existing);
+  assertEnabledProviderConfig(applyDefinedProviderPatch(existing, patch));
   const updated = await ssoProvidersRepo.update(id, patch);
   return updated ? maskProvider(updated) : null;
 };

--- a/server/test/routes/sso.test.ts
+++ b/server/test/routes/sso.test.ts
@@ -111,6 +111,23 @@ const baseProvider: realSsoProvidersRepo.SsoProvider = {
   roleMappings: [],
 };
 
+const samlProvider = (
+  patch: Partial<realSsoProvidersRepo.SsoProvider> = {},
+): realSsoProvidersRepo.SsoProvider => ({
+  ...baseProvider,
+  protocol: 'saml',
+  issuerUrl: '',
+  clientId: '',
+  clientSecret: '',
+  metadataUrl: '',
+  metadataXml: '',
+  entryPoint: '',
+  idpIssuer: '',
+  idpCert: '',
+  spIssuer: '',
+  ...patch,
+});
+
 const authHeader = () => ({ authorization: `Bearer ${signToken({ userId: 'u1' })}` });
 
 // Snapshots are populated from preHandler/onResponse hooks. We rebuild the app each test so
@@ -260,10 +277,15 @@ describe('PUT /api/sso/providers/:id — masked sentinel preserves existing secr
   });
 
   test('metadataXml === MASKED_SECRET is dropped from patch', async () => {
-    findByIdMock.mockResolvedValue({ ...baseProvider, protocol: 'saml' });
+    const existing = samlProvider({
+      enabled: true,
+      metadataXml: '<EntityDescriptor />',
+      idpCert: 'MIIDstoredcert',
+    });
+    findByIdMock.mockResolvedValue(existing);
     updateMock.mockImplementation(
       async (_id: string, patch: realSsoProvidersRepo.SsoProviderPatch) => ({
-        ...baseProvider,
+        ...existing,
         ...patch,
       }),
     );
@@ -276,6 +298,56 @@ describe('PUT /api/sso/providers/:id — masked sentinel preserves existing secr
     expect(response.statusCode).toBe(200);
     const [, patch] = updateMock.mock.calls[0];
     expect(patch).not.toHaveProperty('metadataXml');
+    expect(patch).not.toHaveProperty('idpCert');
+  });
+});
+
+describe('PUT /api/sso/providers/:id — enabled SAML configuration validation', () => {
+  test('rejects enabling a SAML provider without metadata or manual IdP config', async () => {
+    findByIdMock.mockResolvedValue(samlProvider({ enabled: false }));
+
+    const response = await testApp.inject({
+      method: 'PUT',
+      url: '/api/sso/providers/sso-1',
+      headers: { ...authHeader(), 'content-type': 'application/json' },
+      payload: { enabled: true },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(JSON.parse(response.body)).toEqual({
+      error: 'SAML requires metadata URL/XML or manual entryPoint and idpCert',
+    });
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  test('allows enabling a manual SAML provider when masked idpCert preserves the stored cert', async () => {
+    const existing = samlProvider({
+      enabled: false,
+      entryPoint: 'https://idp.example.com/sso',
+      idpCert: 'MIIDstoredcert',
+    });
+    findByIdMock.mockResolvedValue(existing);
+    updateMock.mockImplementation(
+      async (_id: string, patch: realSsoProvidersRepo.SsoProviderPatch) => ({
+        ...existing,
+        ...patch,
+      }),
+    );
+
+    const response = await testApp.inject({
+      method: 'PUT',
+      url: '/api/sso/providers/sso-1',
+      headers: { ...authHeader(), 'content-type': 'application/json' },
+      payload: {
+        enabled: true,
+        entryPoint: 'https://idp.example.com/sso',
+        idpCert: MASKED_SECRET,
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const [, patch] = updateMock.mock.calls[0];
+    expect(patch.enabled).toBe(true);
     expect(patch).not.toHaveProperty('idpCert');
   });
 });

--- a/server/test/routes/sso.test.ts
+++ b/server/test/routes/sso.test.ts
@@ -320,6 +320,27 @@ describe('PUT /api/sso/providers/:id — enabled SAML configuration validation',
     expect(updateMock).not.toHaveBeenCalled();
   });
 
+  test('rejects clearing the only config source on an enabled SAML provider', async () => {
+    const existing = samlProvider({
+      enabled: true,
+      metadataUrl: 'https://idp.example.com/metadata',
+    });
+    findByIdMock.mockResolvedValue(existing);
+
+    const response = await testApp.inject({
+      method: 'PUT',
+      url: '/api/sso/providers/sso-1',
+      headers: { ...authHeader(), 'content-type': 'application/json' },
+      payload: { metadataUrl: '' },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(JSON.parse(response.body)).toEqual({
+      error: 'SAML requires metadata URL/XML or manual entryPoint and idpCert',
+    });
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
   test('allows enabling a manual SAML provider when masked idpCert preserves the stored cert', async () => {
     const existing = samlProvider({
       enabled: false,
@@ -349,6 +370,52 @@ describe('PUT /api/sso/providers/:id — enabled SAML configuration validation',
     const [, patch] = updateMock.mock.calls[0];
     expect(patch.enabled).toBe(true);
     expect(patch).not.toHaveProperty('idpCert');
+  });
+});
+
+describe('PUT /api/sso/providers/:id — enabled OIDC configuration validation', () => {
+  test('rejects enabling an OIDC provider without required stored config', async () => {
+    findByIdMock.mockResolvedValue({
+      ...baseProvider,
+      enabled: false,
+      issuerUrl: '',
+      clientId: '',
+      usernameAttribute: '',
+    });
+
+    const response = await testApp.inject({
+      method: 'PUT',
+      url: '/api/sso/providers/sso-1',
+      headers: { ...authHeader(), 'content-type': 'application/json' },
+      payload: { enabled: true },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(JSON.parse(response.body)).toEqual({ error: 'issuerUrl is required' });
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  test('allows a partial enable update when stored OIDC config is already complete', async () => {
+    const existing = { ...baseProvider, enabled: false };
+    findByIdMock.mockResolvedValue(existing);
+    updateMock.mockImplementation(
+      async (_id: string, patch: realSsoProvidersRepo.SsoProviderPatch) => ({
+        ...existing,
+        ...patch,
+      }),
+    );
+
+    const response = await testApp.inject({
+      method: 'PUT',
+      url: '/api/sso/providers/sso-1',
+      headers: { ...authHeader(), 'content-type': 'application/json' },
+      payload: { protocol: 'oidc', enabled: true },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const [, patch] = updateMock.mock.calls[0];
+    expect(patch.protocol).toBe('oidc');
+    expect(patch.enabled).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- validate enabled SAML provider configuration on both create and update
- preserve masked SAML secrets while checking the effective stored provider state
- add route regression tests and admin docs for SAML minimum configuration

## Root cause
`PUT /api/sso/providers/:id` validated request bodies with `isCreate: false`, so the SAML required-field guard was skipped during updates. A direct API request could enable an incomplete SAML provider that would later fail during login.

## Validation
- `bun test ./test/routes/sso.test.ts`
- `bun run build` from `server/`
- `bun run lint`

Fixes #392
