### PR TITLE
fix(sso): recover concurrent first-time login

### DIFF
--- a/server/services/external-auth.ts
+++ b/server/services/external-auth.ts
@@ -5,6 +5,7 @@ import * as rolesRepo from '../repositories/rolesRepo.ts';
 import * as settingsRepo from '../repositories/settingsRepo.ts';
 import * as userAssignmentsRepo from '../repositories/userAssignmentsRepo.ts';
 import * as usersRepo from '../repositories/usersRepo.ts';
+import { getUniqueViolation } from '../utils/db-errors.ts';
 import { computeAvatarInitials } from '../utils/initials.ts';
 import { generatePrefixedId } from '../utils/order-ids.ts';
 
@@ -43,6 +44,15 @@ const assertUserAllowsExternalProvider = (
   ) {
     throw new Error('External identity is not allowed for this Praetor user');
   }
+};
+
+const isUsernameUniqueViolation = (err: unknown): boolean => {
+  const dup = getUniqueViolation(err);
+  return (
+    dup?.constraint === 'users_username_unique' ||
+    dup?.constraint === 'users_username_key' ||
+    !!dup?.detail?.includes('(username)')
+  );
 };
 
 export const normalizeExternalUsername = (username: string): string =>
@@ -162,114 +172,123 @@ export const resolveExternalIdentity = async (
   );
   const primaryRole = mappedRoleIds[0];
 
-  return withDbTransaction(async (tx) => {
-    const existingIdentity = await externalIdentitiesRepo.findByIdentity(
-      {
-        providerId: input.providerId,
-        protocol: input.protocol,
-        issuer: input.issuer,
-        subject: input.subject,
-      },
-      tx,
-    );
+  const resolveInTransaction = () =>
+    withDbTransaction(async (tx) => {
+      const existingIdentity = await externalIdentitiesRepo.findByIdentity(
+        {
+          providerId: input.providerId,
+          protocol: input.protocol,
+          issuer: input.issuer,
+          subject: input.subject,
+        },
+        tx,
+      );
 
-    let user: usersRepo.LoginUserWithAuth | null = null;
-    let wasCreated = false;
-    let wasBound = false;
+      let user: usersRepo.LoginUserWithAuth | null = null;
+      let wasCreated = false;
+      let wasBound = false;
 
-    if (existingIdentity) {
-      user = await usersRepo.findLoginUserById(existingIdentity.userId, tx);
-      if (!user) throw new Error('Bound Praetor user no longer exists');
-      assertUserAllowsExternalProvider(user, input);
-    } else {
-      user = await usersRepo.findLoginUserByNormalizedUsername(normalizedUsername, tx);
-      if (!user) {
-        const name = input.name?.trim() || username;
-        const avatarInitials = computeAvatarInitials(name);
-        const id = generatePrefixedId('u');
-        await usersRepo.insertUser(
-          {
+      if (existingIdentity) {
+        user = await usersRepo.findLoginUserById(existingIdentity.userId, tx);
+        if (!user) throw new Error('Bound Praetor user no longer exists');
+        assertUserAllowsExternalProvider(user, input);
+      } else {
+        user = await usersRepo.findLoginUserByNormalizedUsername(normalizedUsername, tx);
+        if (!user) {
+          const name = input.name?.trim() || username;
+          const avatarInitials = computeAvatarInitials(name);
+          const id = generatePrefixedId('u');
+          await usersRepo.insertUser(
+            {
+              id,
+              name,
+              username,
+              passwordHash: usersRepo.EXTERNAL_PLACEHOLDER_PASSWORD_HASH,
+              role: primaryRole,
+              avatarInitials,
+              costPerHour: 0,
+              isDisabled: false,
+              employeeType: 'app_user',
+              authMethod: input.protocol,
+              authProviderId: input.providerId,
+            },
+            tx,
+          );
+          await settingsRepo.upsertForUser(
+            id,
+            { fullName: name, email: input.email?.trim() || '', language: null },
+            tx,
+          );
+          user = {
             id,
             name,
             username,
-            passwordHash: usersRepo.EXTERNAL_PLACEHOLDER_PASSWORD_HASH,
             role: primaryRole,
             avatarInitials,
-            costPerHour: 0,
             isDisabled: false,
+            sessionVersion: 1,
+            passwordHash: usersRepo.EXTERNAL_PLACEHOLDER_PASSWORD_HASH,
             employeeType: 'app_user',
             authMethod: input.protocol,
             authProviderId: input.providerId,
+          };
+          wasCreated = true;
+        } else {
+          assertUserAllowsExternalProvider(user, input);
+        }
+
+        await externalIdentitiesRepo.insert(
+          {
+            id: generatePrefixedId('eid'),
+            providerId: input.providerId,
+            protocol: input.protocol,
+            issuer: input.issuer,
+            subject: input.subject,
+            userId: user.id,
           },
           tx,
         );
-        await settingsRepo.upsertForUser(
-          id,
-          { fullName: name, email: input.email?.trim() || '', language: null },
+        const persistedIdentity = await externalIdentitiesRepo.findByIdentity(
+          {
+            providerId: input.providerId,
+            protocol: input.protocol,
+            issuer: input.issuer,
+            subject: input.subject,
+          },
           tx,
         );
-        user = {
-          id,
-          name,
-          username,
-          role: primaryRole,
-          avatarInitials,
-          isDisabled: false,
-          sessionVersion: 1,
-          passwordHash: usersRepo.EXTERNAL_PLACEHOLDER_PASSWORD_HASH,
-          employeeType: 'app_user',
-          authMethod: input.protocol,
-          authProviderId: input.providerId,
-        };
-        wasCreated = true;
-      } else {
-        assertUserAllowsExternalProvider(user, input);
+        if (!persistedIdentity || persistedIdentity.userId !== user.id) {
+          throw new Error('External identity is already bound to another user');
+        }
+        wasBound = true;
       }
 
-      await externalIdentitiesRepo.insert(
-        {
-          id: generatePrefixedId('eid'),
-          providerId: input.providerId,
-          protocol: input.protocol,
-          issuer: input.issuer,
-          subject: input.subject,
-          userId: user.id,
-        },
-        tx,
-      );
-      const persistedIdentity = await externalIdentitiesRepo.findByIdentity(
-        {
-          providerId: input.providerId,
-          protocol: input.protocol,
-          issuer: input.issuer,
-          subject: input.subject,
-        },
-        tx,
-      );
-      if (!persistedIdentity || persistedIdentity.userId !== user.id) {
-        throw new Error('External identity is already bound to another user');
+      if (user.isDisabled) {
+        throw new Error('User is disabled');
       }
-      wasBound = true;
-    }
 
-    if (user.isDisabled) {
-      throw new Error('User is disabled');
-    }
+      await usersRepo.replaceUserRoles(user.id, mappedRoleIds, tx);
+      await usersRepo.setPrimaryRole(user.id, primaryRole, tx);
+      await userAssignmentsRepo.syncTopManagerAssignmentsForUser(user.id, tx);
 
-    await usersRepo.replaceUserRoles(user.id, mappedRoleIds, tx);
-    await usersRepo.setPrimaryRole(user.id, primaryRole, tx);
-    await userAssignmentsRepo.syncTopManagerAssignmentsForUser(user.id, tx);
+      return {
+        id: user.id,
+        name: user.name,
+        username: user.username,
+        role: primaryRole,
+        avatarInitials: user.avatarInitials,
+        isDisabled: user.isDisabled,
+        sessionVersion: user.sessionVersion,
+        wasCreated,
+        wasBound,
+      };
+    });
 
-    return {
-      id: user.id,
-      name: user.name,
-      username: user.username,
-      role: primaryRole,
-      avatarInitials: user.avatarInitials,
-      isDisabled: user.isDisabled,
-      sessionVersion: user.sessionVersion,
-      wasCreated,
-      wasBound,
-    };
-  });
+  try {
+    return await resolveInTransaction();
+  } catch (err) {
+    if (!isUsernameUniqueViolation(err)) throw err;
+    // A Postgres unique violation aborts the active transaction, so retry outside it.
+    return resolveInTransaction();
+  }
 };

--- a/server/test/services/external-auth.resolve.test.ts
+++ b/server/test/services/external-auth.resolve.test.ts
@@ -5,6 +5,7 @@ import * as realRolesRepo from '../../repositories/rolesRepo.ts';
 import * as realSettingsRepo from '../../repositories/settingsRepo.ts';
 import * as realUserAssignmentsRepo from '../../repositories/userAssignmentsRepo.ts';
 import * as realUsersRepo from '../../repositories/usersRepo.ts';
+import { makeDbError } from '../helpers/dbErrors.ts';
 import { makeWithDbTransactionMock } from '../helpers/withDbTransactionMock.ts';
 
 const drizzleSnap = { ...realDrizzle };
@@ -135,6 +136,45 @@ describe('resolveExternalIdentity auth method enforcement', () => {
 
     expect(result.wasBound).toBe(true);
     expect(insertIdentityMock).toHaveBeenCalled();
+  });
+
+  test('retries after a concurrent first-time SSO username insert conflict', async () => {
+    findByIdentityMock
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        id: 'eid-1',
+        providerId: 'sso-1',
+        protocol: 'oidc',
+        issuer: input.issuer,
+        subject: input.subject,
+        userId: 'u1',
+      });
+    findLoginUserByNormalizedUsernameMock
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(matchingSsoUser);
+    insertUserMock.mockRejectedValueOnce(makeDbError('23505', 'users_username_unique'));
+
+    const result = await resolveExternalIdentity(input);
+
+    expect(withDbTransactionMock).toHaveBeenCalledTimes(2);
+    expect(result.id).toBe('u1');
+    expect(result.wasCreated).toBe(false);
+    expect(result.wasBound).toBe(true);
+    expect(insertUserMock).toHaveBeenCalledTimes(1);
+    expect(upsertForUserMock).not.toHaveBeenCalled();
+    expect(insertIdentityMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not retry unrelated unique violations', async () => {
+    findByIdentityMock.mockResolvedValueOnce(null);
+    findLoginUserByNormalizedUsernameMock.mockResolvedValueOnce(null);
+    insertUserMock.mockRejectedValueOnce(makeDbError('23505', 'users_pkey'));
+
+    await expect(resolveExternalIdentity(input)).rejects.toThrow('boom');
+
+    expect(withDbTransactionMock).toHaveBeenCalledTimes(1);
+    expect(insertIdentityMock).not.toHaveBeenCalled();
   });
 
   test('rejects existing username when provider does not match', async () => {


### PR DESCRIPTION
## Summary

Fixes #396.

Concurrent first-time SSO callbacks for the same user could both miss the existing Praetor user and attempt to insert `users.username`. The losing request hit PostgreSQL `23505` and surfaced a transient 500.

This changes SSO identity resolution to catch unique violations after the transaction rolls back and retry the whole resolution flow once. On retry, the request re-reads the user created by the winning transaction and binds the external identity normally.

## Validation

- `bun test ./test/services/external-auth.resolve.test.ts`
- `bun test ./test/services/external-auth.test.ts ./test/utils/db-errors.test.ts`
- `bun run build` in `server`
- `bun x biome check server/services/external-auth.ts server/test/services/external-auth.resolve.test.ts`
- `git diff --check`