### PR TITLE
fix(ui): prevent stale audit log results

### DIFF
--- a/components/administration/LogsView.tsx
+++ b/components/administration/LogsView.tsx
@@ -3,7 +3,7 @@ import { ArrowRight, Loader2, RefreshCw } from 'lucide-react';
 import type React from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { logsApi } from '../../services/api';
+import { logsApi } from '../../services/api/logs';
 import type { AuditLogEntry } from '../../types';
 import DatePickerButton from '../shared/DatePickerButton';
 import SelectControl from '../shared/SelectControl';
@@ -195,6 +195,7 @@ const LogsView: React.FC<LogsViewProps> = ({
   const [error, setError] = useState('');
   const [isRefreshing, setIsRefreshing] = useState(false);
   const initialLoadRef = useRef(true);
+  const latestAuditRequestIdRef = useRef(0);
   const [selectedPreset, setSelectedPreset] = useState<TimeRange | null>('last7Days');
   const [startDate, setStartDate] = useState<Date>(() => getPresetRange('last7Days').start);
   const [endDate, setEndDate] = useState<Date>(() => getPresetRange('last7Days').end);
@@ -248,37 +249,56 @@ const LogsView: React.FC<LogsViewProps> = ({
     setSelectedPreset(null);
   }, []);
 
-  const loadAuditLogs = useCallback(async () => {
-    setError('');
-    try {
-      const data = await logsApi.listAudit({ startDate, endDate });
-      setRows(data);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : t('logs.errors.loadFailed');
-      setError(message || t('logs.errors.loadFailed'));
-    }
-  }, [t, startDate, endDate]);
+  const loadAuditLogs = useCallback(
+    async (requestId: number) => {
+      setError('');
+      try {
+        const data = await logsApi.listAudit({ startDate, endDate });
+        if (latestAuditRequestIdRef.current !== requestId) return false;
+        setRows(data);
+        return true;
+      } catch (err) {
+        if (latestAuditRequestIdRef.current !== requestId) return false;
+        const message = err instanceof Error ? err.message : t('logs.errors.loadFailed');
+        setError(message || t('logs.errors.loadFailed'));
+        return true;
+      }
+    },
+    [t, startDate, endDate],
+  );
 
   useEffect(() => {
+    const requestId = latestAuditRequestIdRef.current + 1;
+    latestAuditRequestIdRef.current = requestId;
+    const isInitialLoad = initialLoadRef.current;
+
     const load = async () => {
-      if (initialLoadRef.current) {
+      if (isInitialLoad) {
         setLoading(true);
-        await loadAuditLogs();
+        const isCurrent = await loadAuditLogs(requestId);
+        if (!isCurrent) return;
         setLoading(false);
         initialLoadRef.current = false;
       } else {
         setIsRefreshing(true);
-        await loadAuditLogs();
+        const isCurrent = await loadAuditLogs(requestId);
+        if (!isCurrent) return;
         setIsRefreshing(false);
       }
     };
 
     void load();
+    return () => {
+      latestAuditRequestIdRef.current += 1;
+    };
   }, [loadAuditLogs]);
 
   const handleRefreshLogs = async () => {
+    const requestId = latestAuditRequestIdRef.current + 1;
+    latestAuditRequestIdRef.current = requestId;
     setIsRefreshing(true);
-    await loadAuditLogs();
+    const isCurrent = await loadAuditLogs(requestId);
+    if (!isCurrent) return;
     setIsRefreshing(false);
   };
 

--- a/test/components/administration/LogsView.test.tsx
+++ b/test/components/administration/LogsView.test.tsx
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import type { AuditLogEntry } from '../../../types';
+import { clearSpyStateAfterAll } from '../../helpers/mockCleanup.ts';
+import { render } from '../../helpers/render';
+
+const t = (key: string) => key;
+
+mock.module('react-i18next', () => ({
+  useTranslation: () => ({
+    t,
+    i18n: { language: 'en', changeLanguage: () => {} },
+  }),
+  Trans: ({ children }: { children: ReactNode }) => children,
+  initReactI18next: { type: '3rdParty', init: () => {} },
+}));
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+};
+
+const createDeferred = <T,>(): Deferred<T> => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+};
+
+const auditRequests: Deferred<AuditLogEntry[]>[] = [];
+
+const logsApiMock = {
+  listAudit: mock(() => {
+    const request = createDeferred<AuditLogEntry[]>();
+    auditRequests.push(request);
+    return request.promise;
+  }),
+};
+
+mock.module('../../../services/api/logs', () => ({
+  logsApi: logsApiMock,
+}));
+
+clearSpyStateAfterAll();
+
+const LogsView = (await import('../../../components/administration/LogsView')).default;
+
+const makeAuditLog = (id: string, username: string): AuditLogEntry => ({
+  id,
+  userId: `user-${id}`,
+  userName: username,
+  username,
+  action: 'user.login',
+  entityType: 'user',
+  entityId: `user-${id}`,
+  ipAddress: '127.0.0.1',
+  createdAt: Date.UTC(2026, 0, 1, 12),
+  details: null,
+});
+
+const selectTimeRange = (currentLabel: string, nextLabel: string) => {
+  const trigger = screen.getByText(currentLabel).closest('button');
+  if (!trigger) throw new Error(`time range trigger "${currentLabel}" not found`);
+
+  fireEvent.click(trigger);
+  fireEvent.click(screen.getByRole('option', { name: nextLabel }));
+};
+
+describe('<LogsView />', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    auditRequests.length = 0;
+    logsApiMock.listAudit.mockClear();
+  });
+
+  test('ignores stale audit log responses after rapid date range changes', async () => {
+    render(<LogsView />);
+
+    await waitFor(() => expect(logsApiMock.listAudit).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      auditRequests[0].resolve([makeAuditLog('initial', 'Initial User')]);
+    });
+
+    expect(await screen.findByText('Initial User')).toBeInTheDocument();
+
+    selectTimeRange('logs.timeRanges.last7Days', 'logs.timeRanges.last30Days');
+    await waitFor(() => expect(logsApiMock.listAudit).toHaveBeenCalledTimes(2));
+
+    selectTimeRange('logs.timeRanges.last30Days', 'logs.timeRanges.last90Days');
+    await waitFor(() => expect(logsApiMock.listAudit).toHaveBeenCalledTimes(3));
+
+    await act(async () => {
+      auditRequests[2].resolve([makeAuditLog('latest', 'Latest User')]);
+    });
+
+    expect(await screen.findByText('Latest User')).toBeInTheDocument();
+
+    await act(async () => {
+      auditRequests[1].resolve([makeAuditLog('stale', 'Stale User')]);
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('Latest User')).toBeInTheDocument();
+    expect(screen.queryByText('Stale User')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Guard `LogsView` audit-log loading with a latest-request id so stale responses cannot overwrite newer date-range results.
- Keep loading and refreshing state tied to the current request only.
- Add a regression test that resolves an older audit request after a newer one and verifies the displayed rows stay current.

## Root Cause

`LogsView` reloaded audit logs whenever the date range changed, but each in-flight request called `setRows` unconditionally when it resolved. A slower older request could therefore replace the data from the latest filter selection.

Fixes #395.

## Validation

- `bun test test\components\administration\LogsView.test.tsx`
- `bunx biome check components\administration\LogsView.tsx test\components\administration\LogsView.test.tsx`
- `bun run test:frontend`

Note: full `bun run lint` is blocked in this checkout by missing backend dependencies such as `fastify`, `drizzle-orm`, and `@fastify/*`; the i18n check portion passed before dependency resolution failed.
