### PR TITLE
fix(sales): SupplierQuotesView row-status buttons surface failures

### DIFF
--- a/components/sales/SupplierQuotesView.tsx
+++ b/components/sales/SupplierQuotesView.tsx
@@ -305,6 +305,17 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
     setFormData((prev) => ({ ...prev, items: newItems }));
   };
 
+  const handleStatusUpdate = useCallback(
+    async (id: string, updates: Partial<SupplierQuote>) => {
+      try {
+        await onUpdateQuote(id, updates);
+      } catch (err) {
+        toastError((err as Error).message || t('sales:supplierQuotes.failedToUpdateStatus'));
+      }
+    },
+    [onUpdateQuote, t],
+  );
+
   const columns = useMemo<Column<SupplierQuote>[]>(
     () => [
       {
@@ -490,7 +501,7 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
                       <button
                         onClick={(event) => {
                           event.stopPropagation();
-                          onUpdateQuote(row.id, { status: 'sent' });
+                          handleStatusUpdate(row.id, { status: 'sent' });
                         }}
                         className="p-2 rounded-lg transition-all text-blue-700 hover:text-blue-600 hover:bg-blue-50"
                       >
@@ -511,7 +522,7 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
                         <button
                           onClick={(event) => {
                             event.stopPropagation();
-                            onUpdateQuote(row.id, { status: 'accepted' });
+                            handleStatusUpdate(row.id, { status: 'accepted' });
                           }}
                           className="p-2 rounded-lg transition-all text-emerald-700 hover:text-emerald-600 hover:bg-emerald-50"
                         >
@@ -531,7 +542,7 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
                         <button
                           onClick={(event) => {
                             event.stopPropagation();
-                            onUpdateQuote(row.id, { status: 'denied' });
+                            handleStatusUpdate(row.id, { status: 'denied' });
                           }}
                           className="p-2 rounded-lg transition-all text-red-600 hover:text-red-600 hover:bg-red-50"
                         >
@@ -596,7 +607,7 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
                         onClick={(event) => {
                           event.stopPropagation();
                           if (hasOrder) return;
-                          onUpdateQuote(row.id, { status: 'draft' });
+                          handleStatusUpdate(row.id, { status: 'draft' });
                         }}
                         disabled={hasOrder}
                         className={`p-2 rounded-lg transition-all ${hasOrder ? 'cursor-not-allowed opacity-50 text-emerald-700' : 'text-emerald-600 hover:text-emerald-700 hover:bg-emerald-50'}`}
@@ -623,7 +634,7 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
       currency,
       getStatusLabel,
       onCreateOrder,
-      onUpdateQuote,
+      handleStatusUpdate,
       onViewOrders,
       openEditModal,
       t,

--- a/locales/en/sales.json
+++ b/locales/en/sales.json
@@ -248,6 +248,7 @@
     "viewQuote": "View quote",
     "failedToSave": "Failed to save the supplier quote. Please retry.",
     "failedToDelete": "Failed to delete the supplier quote. Please retry.",
+    "failedToUpdateStatus": "Failed to update the supplier quote status. Please retry.",
     "readOnlyLinked": "This quote is read-only because an order was created from it.",
     "readOnlyStatus": "Read-only due to non-draft status",
     "linkedOrderTitle": "Linked Order",

--- a/locales/it/sales.json
+++ b/locales/it/sales.json
@@ -248,6 +248,7 @@
     "viewQuote": "Vedi preventivo",
     "failedToSave": "Impossibile salvare il preventivo fornitore. Riprova.",
     "failedToDelete": "Impossibile eliminare il preventivo fornitore. Riprova.",
+    "failedToUpdateStatus": "Impossibile aggiornare lo stato del preventivo fornitore. Riprova.",
     "readOnlyLinked": "Questo preventivo è in sola lettura perché è stato creato un ordine da esso.",
     "readOnlyStatus": "Sola lettura per stato non bozza",
     "linkedOrderTitle": "Ordine Collegato",


### PR DESCRIPTION
## Summary

#446 added try/catch + toast for SupplierQuotesView's `handleSubmit` and delete flow, but left the **four inline row-status buttons** (sent / accepted / denied / restore-to-draft) calling `onUpdateQuote(row.id, …)` directly. A rejection from the API was still silently logged with no user feedback and no row update — the same silent-failure bug #446 was meant to close.

This PR extends #446's pattern to those four call sites.

## Changes

- **`components/sales/SupplierQuotesView.tsx`**:
  - Extract `handleStatusUpdate` as a `useCallback(…, [onUpdateQuote, t])` placed above the `columns` `useMemo`, and add it to the memo's deps in place of the now-unused `onUpdateQuote` reference (so the memoized cell closures don't thrash).
  - Route all four row-button `onClick` handlers through `handleStatusUpdate`; on failure `toastError` fires with `sales:supplierQuotes.failedToUpdateStatus`.
- **`locales/{en,it}/sales.json`**: add the missing `supplierQuotes.failedToUpdateStatus` key. #446 added the equivalent key under `clientOffers` but not `supplierQuotes`.

## Why

The submit-flow fix in #446 wouldn't have caught a regression like "API rejects a status transition" — those updates go through different code paths (inline button onClicks, not the modal submit form), and the buttons swallowed the rejection. This PR is the same pattern, applied to the same view, for the remaining silent code paths.

## Test plan

- [ ] Sales → Supplier Quotes: trigger Mark-as-Sent / Mark-as-Accepted / Mark-as-Denied / Restore-to-Draft on a row, with the API rejecting (e.g. via a server-side validation rule on `PUT /supplier-quotes/:id`). Confirm a toast appears with the API error message instead of a silent no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)