### PR TITLE
fix(security): guard role deletion for secondary assignments

### DIFF
--- a/docs-site/src/content/docs/administration.md
+++ b/docs-site/src/content/docs/administration.md
@@ -11,7 +11,7 @@ Gli amministratori gestiscono utenti, ruoli e permessi. Ogni ruolo dovrebbe conc
 
 Le righe di permesso con ambito **All** concedono accesso trasversale a tutti i record della stessa area, ad esempio tutti i clienti, fornitori, progetti, task, consuntivi o work unit. L'azione **View** abilita la vista e la consultazione su tutti i record; quando selezionate, anche **Create**, **Update** e **Delete** sono permessi reali e consentono scritture su record non assegnati. I permessi senza **All** mantengono l'ambito assegnato all'utente.
 
-Quando modifichi un ruolo, considera l'impatto su tutti gli utenti assegnati. Dopo modifiche importanti, verifica l'accesso con un profilo di prova o con un utente rappresentativo.
+Quando modifichi un ruolo, considera l'impatto su tutti gli utenti assegnati. Praetor impedisce l'eliminazione di un ruolo ancora assegnato a un utente, sia come ruolo principale sia come ruolo aggiuntivo. Dopo modifiche importanti, verifica l'accesso con un profilo di prova o con un utente rappresentativo.
 
 ## Autenticazione
 

--- a/docs-site/src/content/docs/en/administration.md
+++ b/docs-site/src/content/docs/en/administration.md
@@ -11,7 +11,7 @@ Administrators manage users, roles, and permissions. Each role should grant only
 
 Permission rows marked **All** grant cross-record access for the same area, such as all clients, suppliers, projects, tasks, time entries, or work units. **View** opens the matching view and allows reading every matching record; when selected, **Create**, **Update**, and **Delete** are real write permissions and can operate on records that are not assigned to the user. Non-**All** permissions keep the user's assigned-record scope.
 
-When changing a role, consider the impact on every assigned user. After major changes, verify access with a test profile or representative user.
+When changing a role, consider the impact on every assigned user. Praetor blocks deletion of any role still assigned to a user, either as the primary role or as an additional role. After major changes, verify access with a test profile or representative user.
 
 ## Authentication
 

--- a/server/repositories/rolesRepo.ts
+++ b/server/repositories/rolesRepo.ts
@@ -134,10 +134,17 @@ export const clearPermissions = async (roleId: string, exec: DbExecutor = db): P
 };
 
 export const isRoleInUse = async (roleId: string, exec: DbExecutor = db): Promise<boolean> => {
-  const rows = await exec
+  const primaryRows = await exec
     .select({ exists: sql`1` })
     .from(users)
     .where(eq(users.role, roleId))
     .limit(1);
-  return rows.length > 0;
+  if (primaryRows.length > 0) return true;
+
+  const secondaryRows = await exec
+    .select({ exists: sql`1` })
+    .from(userRoles)
+    .where(eq(userRoles.roleId, roleId))
+    .limit(1);
+  return secondaryRows.length > 0;
 };

--- a/server/test/repositories/rolesRepo.test.ts
+++ b/server/test/repositories/rolesRepo.test.ts
@@ -231,9 +231,21 @@ describe('isRoleInUse', () => {
     expect(exec.calls[0].params).toContain('manager');
   });
 
+  test('returns true when the role is assigned through user_roles', async () => {
+    exec.enqueue({ rows: [] });
+    exec.enqueue({ rows: [[1]] });
+    const result = await rolesRepo.isRoleInUse('manager', testDb);
+    expect(result).toBe(true);
+    expect(exec.calls).toHaveLength(2);
+    expect(exec.calls[1].sql.toLowerCase()).toContain('from "user_roles"');
+    expect(exec.calls[1].params).toContain('manager');
+  });
+
   test('returns false when no user has the role', async () => {
+    exec.enqueue({ rows: [] });
     exec.enqueue({ rows: [] });
     const result = await rolesRepo.isRoleInUse('manager', testDb);
     expect(result).toBe(false);
+    expect(exec.calls).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Summary
- fix role deletion guard to consider secondary assignments in user_roles
- add regression coverage proving secondary-only assignments block deletion
- document role deletion behavior in Italian and English admin docs

## Root cause
Issue #401 was valid: isRoleInUse only checked users.role, so deleting a role assigned only through user_roles could silently cascade and remove those assignments.

## Validation
- bun test ./test/repositories/rolesRepo.test.ts ./test/routes/roles.test.ts
- bun run typecheck
- bun run docs:user
- bun run lint

Closes #401