### PR TITLE
fix(permissions): restrict recurring bulk delete scope

### DIFF
--- a/docs-site/src/content/docs/en/time-tracking.md
+++ b/docs-site/src/content/docs/en/time-tracking.md
@@ -48,3 +48,7 @@ The endpoint is idempotent: re-running it with the same window does not create d
 To prevent accidentally huge generations, the server caps the window at 366 days per call.
 
 The required permission is `timesheets.recurring.create`.
+
+### Cleaning up generated entries
+
+Bulk cleanup of recurring entries uses `DELETE /api/entries` with `projectId`, `task`, and, when needed, `futureOnly` or `placeholderOnly`. A role with only `timesheets.recurring.delete` can delete placeholder entries generated from recurrences only: the server always applies `placeholderOnly=true` in that case. Deleting real non-placeholder entries requires `timesheets.tracker.delete` in the assigned scope, or `timesheets.tracker_all.delete` for full scope.

--- a/docs-site/src/content/docs/time-tracking.md
+++ b/docs-site/src/content/docs/time-tracking.md
@@ -48,3 +48,7 @@ L'endpoint è idempotente: rieseguirlo con la stessa finestra non crea duplicati
 Per evitare generazioni accidentalmente troppo ampie, il server limita la finestra a 366 giorni per chiamata.
 
 Il permesso richiesto è `timesheets.recurring.create`.
+
+### Pulizia delle registrazioni generate
+
+La pulizia massiva delle registrazioni ricorrenti usa `DELETE /api/entries` con `projectId`, `task` e, quando necessario, `futureOnly` o `placeholderOnly`. Un ruolo con solo `timesheets.recurring.delete` può eliminare esclusivamente registrazioni segnaposto generate da ricorrenze: il server applica sempre `placeholderOnly=true` per quel caso. Per eliminare registrazioni effettive non segnaposto serve `timesheets.tracker.delete` nell'ambito assegnato, oppure `timesheets.tracker_all.delete` per l'ambito completo.

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -8792,6 +8792,7 @@
       },
       "delete": {
         "summary": "Bulk delete time entries",
+        "description": "Deletes entries matching `projectId` and `task`. Callers with only `timesheets.recurring.delete` are limited to placeholder entries, even if `placeholderOnly=false` is supplied; tracker delete permissions can delete all matching entries allowed by their scope.",
         "tags": [
           "entries"
         ],
@@ -8830,23 +8831,8 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "Default Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "message"
-                  ]
-                }
-              }
-            }
+          "204": {
+            "description": "Default Response"
           },
           "400": {
             "description": "Default Response",

--- a/server/routes/entries.ts
+++ b/server/routes/entries.ts
@@ -362,6 +362,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       schema: {
         tags: ['entries'],
         summary: 'Bulk delete time entries',
+        description:
+          'Deletes entries matching `projectId` and `task`. Callers with only ' +
+          '`timesheets.recurring.delete` are limited to placeholder entries, even if ' +
+          '`placeholderOnly=false` is supplied; tracker delete permissions can delete all ' +
+          'matching entries allowed by their scope.',
         querystring: entriesBulkDeleteQuerySchema,
         response: {
           204: { type: 'null' },

--- a/server/services/timeEntries.ts
+++ b/server/services/timeEntries.ts
@@ -489,10 +489,10 @@ export const bulkDeleteTimeEntries = async (
   actor: AuthenticatedActor,
   input: { projectId?: unknown; task?: unknown; futureOnly?: unknown; placeholderOnly?: unknown },
 ): Promise<{ message: string }> => {
-  if (
-    !hasTrackerPermission(actor, 'delete') &&
-    !hasPermission(actor, 'timesheets.recurring.delete')
-  ) {
+  const canDeleteTrackerEntries = hasTrackerPermission(actor, 'delete');
+  const canDeleteRecurringEntries = hasPermission(actor, 'timesheets.recurring.delete');
+
+  if (!canDeleteTrackerEntries && !canDeleteRecurringEntries) {
     fail(403, 'Insufficient permissions');
   }
 
@@ -500,7 +500,8 @@ export const bulkDeleteTimeEntries = async (
   const task = requireValid(requireNonEmptyString(input.task, 'task'));
 
   const futureOnlyValue = parseQueryBoolean(input.futureOnly) ?? false;
-  const placeholderOnlyValue = parseQueryBoolean(input.placeholderOnly) ?? false;
+  const requestedPlaceholderOnly = parseQueryBoolean(input.placeholderOnly) ?? false;
+  const placeholderOnlyValue = canDeleteTrackerEntries ? requestedPlaceholderOnly : true;
   const restrictToManagerScopeOf = hasPermission(actor, 'timesheets.tracker_all.delete')
     ? undefined
     : actor.id;

--- a/server/test/routes/entries.test.ts
+++ b/server/test/routes/entries.test.ts
@@ -1372,13 +1372,13 @@ describe('DELETE /api/entries (bulk)', () => {
     );
   });
 
-  test('204 with only timesheets.recurring.delete stays restricted to actor', async () => {
+  test('204 with only timesheets.recurring.delete is restricted to actor placeholders', async () => {
     getRolePermissionsMock.mockResolvedValue(['timesheets.recurring.delete']);
     entriesBulkDeleteMock.mockResolvedValue(2);
 
     const res = await testApp.inject({
       method: 'DELETE',
-      url: '/api/entries?projectId=p1&task=Dev',
+      url: '/api/entries?projectId=p1&task=Dev&placeholderOnly=false',
       headers: authHeader(),
     });
 
@@ -1389,6 +1389,7 @@ describe('DELETE /api/entries (bulk)', () => {
         projectId: 'p1',
         task: 'Dev',
         restrictToManagerScopeOf: 'u1',
+        placeholderOnly: true,
       }),
     );
   });


### PR DESCRIPTION
## Summary
- Fixes #397 by forcing recurring-only bulk deletes to target placeholder entries only.
- Adds a regression test for an explicit `placeholderOnly=false` bypass attempt.
- Documents the permission boundary in API metadata and user docs in Italian and English.

## Root cause
`bulkDeleteTimeEntries` accepted `timesheets.recurring.delete` as an alternative to tracker delete permission, but then defaulted `placeholderOnly` to `false` and forwarded the request value directly to `entriesRepo.bulkDelete`. A role with only recurring delete permission could therefore delete real, non-placeholder entries in its scope.

## Validation
- `bun test ./server/test/routes/entries.test.ts`
- `bun run test:server`
- `bun run typecheck`
- `bun run docs:user`
- `bun run lint` (passes with existing unrelated warnings)