### PR TITLE
fix(accounting): guard finalized client invoices

### DIFF
--- a/docs-site/src/content/docs/en/sales-accounting.md
+++ b/docs-site/src/content/docs/en/sales-accounting.md
@@ -23,6 +23,8 @@ Customer and supplier orders consolidate operational information. Before confirm
 
 Customer and supplier invoices should match actual orders and deliveries. Check taxable amounts, VAT, totals, and references to the linked document.
 
+After an invoice leaves draft status it becomes read-only: it cannot be moved back to draft or deleted. Delete only draft invoices that were created by mistake, before issuing them.
+
 ### Per-line VAT (IVA)
 
 Each customer-invoice line carries its own VAT rate (percent). New lines default to 22% (the standard Italian rate), but you can edit it to reflect reduced rates (10%, 5%, 4%) or exempt lines (0%). The summary panel shows the taxable subtotal, the total VAT, and the grand total (taxable + VAT). Invoices created before this feature was added load with 0% VAT, so their grand total remains unchanged.

--- a/docs-site/src/content/docs/sales-accounting.md
+++ b/docs-site/src/content/docs/sales-accounting.md
@@ -23,6 +23,8 @@ Gli ordini clienti e fornitori consolidano le informazioni operative. Prima di c
 
 Le fatture clienti e fornitori devono riflettere ordini e consegne effettive. Controlla imponibili, IVA, totale e riferimenti al documento collegato.
 
+Quando una fattura esce dallo stato bozza diventa in sola lettura: non puo' essere riportata in bozza o eliminata. Elimina solo le bozze create per errore, prima dell'emissione.
+
 ### IVA per riga
 
 Ogni riga della fattura cliente ha la propria aliquota IVA in percentuale. Il valore predefinito per le nuove righe è 22% (aliquota ordinaria italiana), ma puoi modificarla per riflettere aliquote ridotte (10%, 5%, 4%) o le righe esenti (0%). Il pannello di riepilogo mostra il subtotale (imponibile), l'IVA totale e il totale generale (imponibile + IVA). Le fatture precedenti alla migrazione vengono caricate con aliquota IVA pari a 0%, mantenendo invariato il loro totale.

--- a/docs-site/src/content/docs/sales-accounting.md
+++ b/docs-site/src/content/docs/sales-accounting.md
@@ -23,7 +23,7 @@ Gli ordini clienti e fornitori consolidano le informazioni operative. Prima di c
 
 Le fatture clienti e fornitori devono riflettere ordini e consegne effettive. Controlla imponibili, IVA, totale e riferimenti al documento collegato.
 
-Quando una fattura esce dallo stato bozza diventa in sola lettura: non puo' essere riportata in bozza o eliminata. Elimina solo le bozze create per errore, prima dell'emissione.
+Quando una fattura esce dallo stato bozza diventa in sola lettura: non può essere riportata in bozza o eliminata. Elimina solo le bozze create per errore, prima dell'emissione.
 
 ### IVA per riga
 

--- a/server/repositories/invoicesRepo.ts
+++ b/server/repositories/invoicesRepo.ts
@@ -237,6 +237,21 @@ export type InvoiceUpdate = {
   notes?: string | null;
 };
 
+const invoiceUpdateValues = (patch: InvoiceUpdate) => ({
+  id: sql`COALESCE(${patch.id ?? null}, ${invoices.id})`,
+  clientId: sql`COALESCE(${patch.clientId ?? null}, ${invoices.clientId})`,
+  clientName: sql`COALESCE(${patch.clientName ?? null}, ${invoices.clientName})`,
+  issueDate: sql`COALESCE(${patch.issueDate ?? null}::date, ${invoices.issueDate})`,
+  dueDate: sql`COALESCE(${patch.dueDate ?? null}::date, ${invoices.dueDate})`,
+  status: sql`COALESCE(${patch.status ?? null}, ${invoices.status})`,
+  subtotal: sql`COALESCE(${numericForDb(patch.subtotal) ?? null}::numeric, ${invoices.subtotal})`,
+  taxTotal: sql`COALESCE(${numericForDb(patch.taxTotal) ?? null}::numeric, ${invoices.taxTotal})`,
+  total: sql`COALESCE(${numericForDb(patch.total) ?? null}::numeric, ${invoices.total})`,
+  amountPaid: sql`COALESCE(${numericForDb(patch.amountPaid) ?? null}::numeric, ${invoices.amountPaid})`,
+  notes: sql`COALESCE(${patch.notes ?? null}, ${invoices.notes})`,
+  updatedAt: sql`CURRENT_TIMESTAMP`,
+});
+
 export const update = async (
   id: string,
   patch: InvoiceUpdate,
@@ -244,21 +259,21 @@ export const update = async (
 ): Promise<Invoice | null> => {
   const rows = await exec
     .update(invoices)
-    .set({
-      id: sql`COALESCE(${patch.id ?? null}, ${invoices.id})`,
-      clientId: sql`COALESCE(${patch.clientId ?? null}, ${invoices.clientId})`,
-      clientName: sql`COALESCE(${patch.clientName ?? null}, ${invoices.clientName})`,
-      issueDate: sql`COALESCE(${patch.issueDate ?? null}::date, ${invoices.issueDate})`,
-      dueDate: sql`COALESCE(${patch.dueDate ?? null}::date, ${invoices.dueDate})`,
-      status: sql`COALESCE(${patch.status ?? null}, ${invoices.status})`,
-      subtotal: sql`COALESCE(${numericForDb(patch.subtotal) ?? null}::numeric, ${invoices.subtotal})`,
-      taxTotal: sql`COALESCE(${numericForDb(patch.taxTotal) ?? null}::numeric, ${invoices.taxTotal})`,
-      total: sql`COALESCE(${numericForDb(patch.total) ?? null}::numeric, ${invoices.total})`,
-      amountPaid: sql`COALESCE(${numericForDb(patch.amountPaid) ?? null}::numeric, ${invoices.amountPaid})`,
-      notes: sql`COALESCE(${patch.notes ?? null}, ${invoices.notes})`,
-      updatedAt: sql`CURRENT_TIMESTAMP`,
-    })
+    .set(invoiceUpdateValues(patch))
     .where(eq(invoices.id, id))
+    .returning();
+  return rows[0] ? mapInvoice(rows[0]) : null;
+};
+
+export const updateDraft = async (
+  id: string,
+  patch: InvoiceUpdate,
+  exec: DbExecutor = db,
+): Promise<Invoice | null> => {
+  const rows = await exec
+    .update(invoices)
+    .set(invoiceUpdateValues(patch))
+    .where(and(eq(invoices.id, id), eq(invoices.status, 'draft')))
     .returning();
   return rows[0] ? mapInvoice(rows[0]) : null;
 };
@@ -316,6 +331,17 @@ export const deleteById = async (
   const rows = await exec
     .delete(invoices)
     .where(eq(invoices.id, id))
+    .returning({ id: invoices.id, clientName: invoices.clientName });
+  return rows[0] ?? null;
+};
+
+export const deleteDraftById = async (
+  id: string,
+  exec: DbExecutor = db,
+): Promise<{ id: string; clientName: string } | null> => {
+  const rows = await exec
+    .delete(invoices)
+    .where(and(eq(invoices.id, id), eq(invoices.status, 'draft')))
     .returning({ id: invoices.id, clientName: invoices.clientName });
   return rows[0] ?? null;
 };

--- a/server/repositories/invoicesRepo.ts
+++ b/server/repositories/invoicesRepo.ts
@@ -141,6 +141,28 @@ export const findAmountPaid = async (
   return parseDbNumber(rows[0].amountPaid, 0);
 };
 
+export const findStatus = async (
+  invoiceId: string,
+  exec: DbExecutor = db,
+): Promise<string | null> => {
+  const rows = await exec
+    .select({ status: invoices.status })
+    .from(invoices)
+    .where(eq(invoices.id, invoiceId));
+  return rows[0]?.status ?? null;
+};
+
+export const findStatusAndClientName = async (
+  invoiceId: string,
+  exec: DbExecutor = db,
+): Promise<{ status: string; clientName: string } | null> => {
+  const rows = await exec
+    .select({ status: invoices.status, clientName: invoices.clientName })
+    .from(invoices)
+    .where(eq(invoices.id, invoiceId));
+  return rows[0] ?? null;
+};
+
 export const findIdConflict = async (
   newId: string,
   currentId: string,

--- a/server/routes/invoices.ts
+++ b/server/routes/invoices.ts
@@ -454,17 +454,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         return reply.code(404).send({ error: 'Invoice not found' });
       }
 
-      const hasLockedFieldUpdates =
-        nextId !== undefined ||
-        clientId !== undefined ||
-        clientName !== undefined ||
-        issueDate !== undefined ||
-        dueDate !== undefined ||
-        amountPaid !== undefined ||
-        notes !== undefined ||
-        items !== undefined;
-      const hasStatusChange = typeof status === 'string' && status !== existingStatus;
-      if (existingStatus !== 'draft' && (hasLockedFieldUpdates || hasStatusChange)) {
+      if (existingStatus !== 'draft') {
         return reply.code(409).send({
           error: 'Non-draft invoices are read-only',
           currentStatus: existingStatus,
@@ -583,7 +573,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       };
       try {
         result = await withDbTransaction(async (tx) => {
-          const updated = await invoicesRepo.update(idResult.value, patch, tx);
+          const updated = await invoicesRepo.updateDraft(idResult.value, patch, tx);
           if (!updated) return { invoice: null, items: [] };
           const itemsOut = normalizedItemsForUpdate
             ? await invoicesRepo.replaceItems(
@@ -605,6 +595,13 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const invoice = result.invoice;
       const updatedItems = result.items;
       if (!invoice) {
+        const currentStatus = await invoicesRepo.findStatus(idResult.value);
+        if (currentStatus && currentStatus !== 'draft') {
+          return reply.code(409).send({
+            error: 'Non-draft invoices are read-only',
+            currentStatus,
+          });
+        }
         return reply.code(404).send({ error: 'Invoice not found' });
       }
 
@@ -652,9 +649,13 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
 
       // Invoice items will be deleted automatically via CASCADE
       try {
-        const result = await invoicesRepo.deleteById(idResult.value);
+        const result = await invoicesRepo.deleteDraftById(idResult.value);
 
         if (!result) {
+          const currentStatus = await invoicesRepo.findStatus(idResult.value);
+          if (currentStatus && currentStatus !== 'draft') {
+            return reply.code(409).send({ error: 'Only draft invoices can be deleted' });
+          }
           return reply.code(404).send({ error: 'Invoice not found' });
         }
 

--- a/server/routes/invoices.ts
+++ b/server/routes/invoices.ts
@@ -449,6 +449,28 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
 
+      const existingStatus = await invoicesRepo.findStatus(idResult.value);
+      if (existingStatus === null) {
+        return reply.code(404).send({ error: 'Invoice not found' });
+      }
+
+      const hasLockedFieldUpdates =
+        nextId !== undefined ||
+        clientId !== undefined ||
+        clientName !== undefined ||
+        issueDate !== undefined ||
+        dueDate !== undefined ||
+        amountPaid !== undefined ||
+        notes !== undefined ||
+        items !== undefined;
+      const hasStatusChange = typeof status === 'string' && status !== existingStatus;
+      if (existingStatus !== 'draft' && (hasLockedFieldUpdates || hasStatusChange)) {
+        return reply.code(409).send({
+          error: 'Non-draft invoices are read-only',
+          currentStatus: existingStatus,
+        });
+      }
+
       const patch: invoicesRepo.InvoiceUpdate = {};
 
       if (clientId !== undefined) {
@@ -620,6 +642,14 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
 
+      const existing = await invoicesRepo.findStatusAndClientName(idResult.value);
+      if (!existing) {
+        return reply.code(404).send({ error: 'Invoice not found' });
+      }
+      if (existing.status !== 'draft') {
+        return reply.code(409).send({ error: 'Only draft invoices can be deleted' });
+      }
+
       // Invoice items will be deleted automatically via CASCADE
       try {
         const result = await invoicesRepo.deleteById(idResult.value);
@@ -635,7 +665,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           entityId: idResult.value,
           details: {
             targetLabel: idResult.value,
-            secondaryLabel: result.clientName ?? '',
+            secondaryLabel: existing.clientName,
           },
         });
         return reply.code(204).send();

--- a/server/test/repositories/invoicesRepo.test.ts
+++ b/server/test/repositories/invoicesRepo.test.ts
@@ -181,6 +181,36 @@ describe('findAmountPaid', () => {
   });
 });
 
+describe('findStatus', () => {
+  test('returns status when row exists', async () => {
+    exec.enqueue({ rows: [['paid']] });
+    const result = await invoicesRepo.findStatus('INV-1', testDb);
+    expect(result).toBe('paid');
+    expect(exec.calls[0].sql.toLowerCase()).toContain('select "status" from "invoices"');
+    expect(exec.calls[0].params).toContain('INV-1');
+  });
+
+  test('returns null when invoice not found', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await invoicesRepo.findStatus('INV-X', testDb)).toBeNull();
+  });
+});
+
+describe('findStatusAndClientName', () => {
+  test('returns status and clientName when row exists', async () => {
+    exec.enqueue({ rows: [['sent', 'Acme']] });
+    const result = await invoicesRepo.findStatusAndClientName('INV-1', testDb);
+    expect(result).toEqual({ status: 'sent', clientName: 'Acme' });
+    expect(exec.calls[0].sql.toLowerCase()).toContain('select "status", "client_name"');
+    expect(exec.calls[0].params).toContain('INV-1');
+  });
+
+  test('returns null when invoice not found', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await invoicesRepo.findStatusAndClientName('INV-X', testDb)).toBeNull();
+  });
+});
+
 describe('findIdConflict', () => {
   test('excludes self with both id-equality and id-inequality predicates', async () => {
     exec.enqueue({ rows: [] });

--- a/server/test/repositories/invoicesRepo.test.ts
+++ b/server/test/repositories/invoicesRepo.test.ts
@@ -281,6 +281,23 @@ describe('update', () => {
   });
 });
 
+describe('updateDraft', () => {
+  test('scopes update to the draft row', async () => {
+    exec.enqueue({ rows: [invoiceRow({ 6: 'sent' })] });
+    await invoicesRepo.updateDraft('INV-2026-0001', { status: 'sent' }, testDb);
+    const sql = exec.calls[0].sql.toLowerCase();
+    expect(sql).toContain('update "invoices"');
+    expect(sql).toContain('"status" =');
+    expect(exec.calls[0].params).toContain('INV-2026-0001');
+    expect(exec.calls[0].params).toContain('draft');
+  });
+
+  test('returns null when no draft row updated', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await invoicesRepo.updateDraft('INV-X', { status: 'sent' }, testDb)).toBeNull();
+  });
+});
+
 describe('replaceItems', () => {
   test('issues DELETE then a single multi-row INSERT and preserves order', async () => {
     exec.enqueue({ rows: [] });
@@ -341,6 +358,24 @@ describe('deleteById', () => {
   test('returns null when no row deleted', async () => {
     exec.enqueue({ rows: [] });
     expect(await invoicesRepo.deleteById('INV-X', testDb)).toBeNull();
+  });
+});
+
+describe('deleteDraftById', () => {
+  test('returns id and clientName when a draft row is deleted', async () => {
+    exec.enqueue({ rows: [['INV-1', 'Acme']] });
+    expect(await invoicesRepo.deleteDraftById('INV-1', testDb)).toEqual({
+      id: 'INV-1',
+      clientName: 'Acme',
+    });
+    expect(exec.calls[0].sql.toLowerCase()).toContain('delete from "invoices"');
+    expect(exec.calls[0].params).toContain('INV-1');
+    expect(exec.calls[0].params).toContain('draft');
+  });
+
+  test('returns null when no draft row is deleted', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await invoicesRepo.deleteDraftById('INV-X', testDb)).toBeNull();
   });
 });
 

--- a/server/test/routes/invoices.test.ts
+++ b/server/test/routes/invoices.test.ts
@@ -37,6 +37,8 @@ const findItemsForInvoiceMock = mock();
 const findDatesMock = mock();
 const findTotalMock = mock();
 const findAmountPaidMock = mock();
+const findStatusMock = mock();
+const findStatusAndClientNameMock = mock();
 const findIdConflictMock = mock();
 const deleteByIdMock = mock();
 const logAuditMock = mock(async () => undefined);
@@ -71,6 +73,8 @@ beforeAll(async () => {
     findDates: findDatesMock,
     findTotal: findTotalMock,
     findAmountPaid: findAmountPaidMock,
+    findStatus: findStatusMock,
+    findStatusAndClientName: findStatusAndClientNameMock,
     findIdConflict: findIdConflictMock,
     deleteById: deleteByIdMock,
   }));
@@ -156,6 +160,8 @@ const allMocks = [
   findDatesMock,
   findTotalMock,
   findAmountPaidMock,
+  findStatusMock,
+  findStatusAndClientNameMock,
   findIdConflictMock,
   deleteByIdMock,
   logAuditMock,
@@ -169,6 +175,8 @@ beforeEach(async () => {
   findAuthUserByIdMock.mockResolvedValue(HAPPY_USER);
   userHasRoleMock.mockResolvedValue(true);
   getRolePermissionsMock.mockResolvedValue(FULL_PERMS);
+  findStatusMock.mockResolvedValue('draft');
+  findStatusAndClientNameMock.mockResolvedValue({ status: 'draft', clientName: 'Client' });
   resetWithDbTransactionMock();
   logAuditMock.mockImplementation(async () => undefined);
 
@@ -812,6 +820,36 @@ describe('PUT /api/invoices/:id', () => {
     expect(patch).not.toHaveProperty('total');
   });
 
+  test('409 non-draft invoice with locked field updates is read-only', async () => {
+    findStatusMock.mockResolvedValue('paid');
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/invoices/inv-1',
+      headers: authHeader(),
+      payload: { clientName: 'Renamed Client' },
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Non-draft invoices are read-only' });
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  test('409 non-draft invoice status cannot be changed', async () => {
+    findStatusMock.mockResolvedValue('paid');
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/invoices/inv-1',
+      headers: authHeader(),
+      payload: { status: 'draft' },
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Non-draft invoices are read-only' });
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
   test('400 dueDate < issueDate using stored findDates for missing side', async () => {
     findDatesMock.mockResolvedValue({ issueDate: '2025-07-01', dueDate: '2025-08-01' });
 
@@ -841,6 +879,21 @@ describe('PUT /api/invoices/:id', () => {
 
     expect(res.statusCode).toBe(404);
     expect(JSON.parse(res.body)).toEqual({ error: 'Invoice not found' });
+  });
+
+  test('404 when status lookup does not find invoice', async () => {
+    findStatusMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/invoices/missing',
+      headers: authHeader(),
+      payload: { status: 'sent' },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Invoice not found' });
+    expect(updateMock).not.toHaveBeenCalled();
   });
 
   test('409 unique violation on rename', async () => {
@@ -879,6 +932,20 @@ describe('DELETE /api/invoices/:id', () => {
   });
 
   test('404 not found', async () => {
+    findStatusAndClientNameMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/invoices/missing',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Invoice not found' });
+    expect(deleteByIdMock).not.toHaveBeenCalled();
+  });
+
+  test('404 when invoice disappears before delete', async () => {
     deleteByIdMock.mockResolvedValue(null);
 
     const res = await testApp.inject({
@@ -889,6 +956,25 @@ describe('DELETE /api/invoices/:id', () => {
 
     expect(res.statusCode).toBe(404);
     expect(JSON.parse(res.body)).toEqual({ error: 'Invoice not found' });
+  });
+
+  test('409 non-draft invoice cannot be deleted', async () => {
+    findStatusAndClientNameMock.mockResolvedValue({
+      status: 'paid',
+      clientName: 'Client',
+    });
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/invoices/inv-1',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'Only draft invoices can be deleted',
+    });
+    expect(deleteByIdMock).not.toHaveBeenCalled();
   });
 
   test('409 FK violation maps to referenced-by message', async () => {

--- a/server/test/routes/invoices.test.ts
+++ b/server/test/routes/invoices.test.ts
@@ -68,6 +68,7 @@ beforeAll(async () => {
     create: createMock,
     insertItems: insertItemsMock,
     update: updateMock,
+    updateDraft: updateMock,
     replaceItems: replaceItemsMock,
     findItemsForInvoice: findItemsForInvoiceMock,
     findDates: findDatesMock,
@@ -77,6 +78,7 @@ beforeAll(async () => {
     findStatusAndClientName: findStatusAndClientNameMock,
     findIdConflict: findIdConflictMock,
     deleteById: deleteByIdMock,
+    deleteDraftById: deleteByIdMock,
   }));
   mock.module('../../utils/audit.ts', () => ({
     ...auditSnap,
@@ -850,6 +852,21 @@ describe('PUT /api/invoices/:id', () => {
     expect(updateMock).not.toHaveBeenCalled();
   });
 
+  test('409 non-draft invoice status cannot be re-saved', async () => {
+    findStatusMock.mockResolvedValue('paid');
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/invoices/inv-1',
+      headers: authHeader(),
+      payload: { status: 'paid' },
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Non-draft invoices are read-only' });
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
   test('400 dueDate < issueDate using stored findDates for missing side', async () => {
     findDatesMock.mockResolvedValue({ issueDate: '2025-07-01', dueDate: '2025-08-01' });
 
@@ -879,6 +896,21 @@ describe('PUT /api/invoices/:id', () => {
 
     expect(res.statusCode).toBe(404);
     expect(JSON.parse(res.body)).toEqual({ error: 'Invoice not found' });
+  });
+
+  test('409 when invoice leaves draft before update write', async () => {
+    findStatusMock.mockResolvedValueOnce('draft').mockResolvedValueOnce('sent');
+    updateMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/invoices/inv-1',
+      headers: authHeader(),
+      payload: { status: 'sent' },
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Non-draft invoices are read-only' });
   });
 
   test('404 when status lookup does not find invoice', async () => {
@@ -975,6 +1007,22 @@ describe('DELETE /api/invoices/:id', () => {
       error: 'Only draft invoices can be deleted',
     });
     expect(deleteByIdMock).not.toHaveBeenCalled();
+  });
+
+  test('409 when invoice leaves draft before delete write', async () => {
+    deleteByIdMock.mockResolvedValue(null);
+    findStatusMock.mockResolvedValue('sent');
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/invoices/inv-1',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'Only draft invoices can be deleted',
+    });
   });
 
   test('409 FK violation maps to referenced-by message', async () => {


### PR DESCRIPTION
## Summary
- Add server-side guards so client invoices are read-only after leaving draft status.
- Restrict client-invoice deletion to draft invoices only.
- Add repository/route tests for status lookups and finalized-invoice update/delete rejections.
- Update Italian and English sales/accounting docs with the finalized-invoice behavior.

## Root Cause
Client invoice routes did not check the current invoice status before updates or deletes, unlike the other financial document routes. That allowed paid or otherwise finalized invoices to be modified, reverted to draft, or deleted.

## Validation
- `bun test test/routes/invoices.test.ts test/repositories/invoicesRepo.test.ts` from `server/`
- `bun run build` from `server/`
- `bun run i18n:check`
- `bun run lint`

Fixes #398