### PR TITLE
fix(accounting): enforce invoice payment totals

### DIFF
--- a/docs-site/src/content/docs/en/sales-accounting.md
+++ b/docs-site/src/content/docs/en/sales-accounting.md
@@ -25,6 +25,8 @@ Customer and supplier invoices should match actual orders and deliveries. Check 
 
 After an invoice leaves draft status it becomes read-only: it cannot be moved back to draft or deleted. Delete only draft invoices that were created by mistake, before issuing them.
 
+The amount paid cannot exceed the invoice total. When an invoice is set to **paid**, the amount paid must cover at least the full total; otherwise Praetor rejects the save so aging, balances, and reports stay consistent.
+
 ### Per-line VAT (IVA)
 
 Each customer-invoice line carries its own VAT rate (percent). New lines default to 22% (the standard Italian rate), but you can edit it to reflect reduced rates (10%, 5%, 4%) or exempt lines (0%). The summary panel shows the taxable subtotal, the total VAT, and the grand total (taxable + VAT). Invoices created before this feature was added load with 0% VAT, so their grand total remains unchanged.

--- a/docs-site/src/content/docs/sales-accounting.md
+++ b/docs-site/src/content/docs/sales-accounting.md
@@ -25,6 +25,8 @@ Le fatture clienti e fornitori devono riflettere ordini e consegne effettive. Co
 
 Quando una fattura esce dallo stato bozza diventa in sola lettura: non può essere riportata in bozza o eliminata. Elimina solo le bozze create per errore, prima dell'emissione.
 
+L'importo pagato non può superare il totale della fattura. Quando una fattura viene impostata su **pagata**, l'importo pagato deve coprire almeno l'intero totale; in caso contrario Praetor respinge il salvataggio per mantenere coerenti scadenziari, saldi e report.
+
 ### IVA per riga
 
 Ogni riga della fattura cliente ha la propria aliquota IVA in percentuale. Il valore predefinito per le nuove righe è 22% (aliquota ordinaria italiana), ma puoi modificarla per riflettere aliquote ridotte (10%, 5%, 4%) o le righe esenti (0%). Il pannello di riepilogo mostra il subtotale (imponibile), l'IVA totale e il totale generale (imponibile + IVA). Le fatture precedenti alla migrazione vengono caricate con aliquota IVA pari a 0%, mantenendo invariato il loro totale.

--- a/server/repositories/supplierInvoicesRepo.ts
+++ b/server/repositories/supplierInvoicesRepo.ts
@@ -113,6 +113,8 @@ export const findExisting = async (
   status: string;
   issueDate: string;
   dueDate: string;
+  total: number;
+  amountPaid: number;
 } | null> => {
   const rows = await exec
     .select({
@@ -120,6 +122,8 @@ export const findExisting = async (
       status: supplierInvoices.status,
       issueDate: supplierInvoices.issueDate,
       dueDate: supplierInvoices.dueDate,
+      total: supplierInvoices.total,
+      amountPaid: supplierInvoices.amountPaid,
     })
     .from(supplierInvoices)
     .where(eq(supplierInvoices.id, id));
@@ -129,6 +133,8 @@ export const findExisting = async (
     status: rows[0].status,
     issueDate: requireDateOnly(rows[0].issueDate, 'supplierInvoice.issueDate'),
     dueDate: requireDateOnly(rows[0].dueDate, 'supplierInvoice.dueDate'),
+    total: parseDbNumber(rows[0].total, 0),
+    amountPaid: parseDbNumber(rows[0].amountPaid, 0),
   };
 };
 

--- a/server/routes/invoices.ts
+++ b/server/routes/invoices.ts
@@ -21,6 +21,8 @@ import {
 } from '../utils/validation.ts';
 
 const UNIT_OF_MEASURE_VALUES = ['unit', 'hours'] as const;
+const AMOUNT_PAID_EXCEEDS_TOTAL_ERROR = 'amountPaid cannot exceed total';
+const PAID_INVOICE_UNDERPAID_ERROR = 'amountPaid must be at least total when status is paid';
 
 const idParamSchema = {
   type: 'object',
@@ -347,7 +349,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       if (!amountPaidResult.ok) return badRequest(reply, amountPaidResult.message);
       const amountPaidValue = amountPaidResult.value || 0;
       if (amountPaidValue > computedTotal) {
-        return badRequest(reply, 'amountPaid cannot exceed total');
+        return badRequest(reply, AMOUNT_PAID_EXCEEDS_TOTAL_ERROR);
+      }
+      const statusValue = typeof status === 'string' && status.length > 0 ? status : 'draft';
+      if (statusValue === 'paid' && amountPaidValue < computedTotal) {
+        return badRequest(reply, PAID_INVOICE_UNDERPAID_ERROR);
       }
 
       const nextIdResult = optionalNonEmptyString(nextId, 'id');
@@ -366,7 +372,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
               clientName: clientNameResult.value,
               issueDate: issueDateResult.value,
               dueDate: dueDateResult.value,
-              status: (status as string) || 'draft',
+              status: statusValue,
               subtotal: computedSubtotal,
               taxTotal: computedTaxTotal,
               total: computedTotal,
@@ -545,25 +551,58 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         patch.total = computed.total;
       }
 
+      let persistedTotal: number | null | undefined;
+      let persistedAmountPaid: number | null | undefined;
+      const getTotalForPaymentCheck = async () => {
+        if (patch.total !== undefined) return patch.total;
+        if (persistedTotal === undefined) {
+          persistedTotal = await invoicesRepo.findTotal(idResult.value);
+        }
+        return persistedTotal;
+      };
+      const getAmountPaidForPaymentCheck = async () => {
+        if (amountPaidValue !== undefined) return amountPaidValue;
+        if (persistedAmountPaid === undefined) {
+          persistedAmountPaid = await invoicesRepo.findAmountPaid(idResult.value);
+        }
+        return persistedAmountPaid;
+      };
+
       if (amountPaidValue !== undefined) {
-        const totalForCheck = patch.total ?? (await invoicesRepo.findTotal(idResult.value));
+        const totalForCheck = await getTotalForPaymentCheck();
         if (totalForCheck === null) {
           return reply.code(404).send({ error: 'Invoice not found' });
         }
         if (amountPaidValue > totalForCheck) {
-          return badRequest(reply, 'amountPaid cannot exceed total');
+          return badRequest(reply, AMOUNT_PAID_EXCEEDS_TOTAL_ERROR);
         }
         patch.amountPaid = amountPaidValue;
       } else if (patch.total !== undefined) {
         // Items replaced (so total may be lower) but amountPaid not in this patch - verify the
         // persisted amountPaid still fits under the new total. Without this, paying-down to a
         // partial total would leave amountPaid > total and skew SUM(GREATEST(total - paid, 0)).
-        const persistedAmountPaid = await invoicesRepo.findAmountPaid(idResult.value);
-        if (persistedAmountPaid === null) {
+        const amountPaidForCheck = await getAmountPaidForPaymentCheck();
+        if (amountPaidForCheck === null) {
           return reply.code(404).send({ error: 'Invoice not found' });
         }
-        if (persistedAmountPaid > patch.total) {
-          return badRequest(reply, 'amountPaid cannot exceed total');
+        if (amountPaidForCheck > patch.total) {
+          return badRequest(reply, AMOUNT_PAID_EXCEEDS_TOTAL_ERROR);
+        }
+      }
+
+      if (patch.status === 'paid') {
+        const [totalForCheck, amountPaidForCheck] = await Promise.all([
+          getTotalForPaymentCheck(),
+          getAmountPaidForPaymentCheck(),
+        ]);
+        if (totalForCheck === null || amountPaidForCheck === null) {
+          return reply.code(404).send({ error: 'Invoice not found' });
+        }
+        if (amountPaidForCheck > totalForCheck) {
+          return badRequest(reply, AMOUNT_PAID_EXCEEDS_TOTAL_ERROR);
+        }
+        if (amountPaidForCheck < totalForCheck) {
+          return badRequest(reply, PAID_INVOICE_UNDERPAID_ERROR);
         }
       }
 

--- a/server/routes/supplier-invoices.ts
+++ b/server/routes/supplier-invoices.ts
@@ -22,6 +22,9 @@ import {
 const isSupplierInvoiceIdConflict = (databaseError: DatabaseError) =>
   databaseError.constraint === 'supplier_invoices_pkey' || databaseError.detail?.includes('(id)');
 
+const AMOUNT_PAID_EXCEEDS_TOTAL_ERROR = 'amountPaid cannot exceed total';
+const PAID_INVOICE_UNDERPAID_ERROR = 'amountPaid must be at least total when status is paid';
+
 const duplicateInvoiceError = (databaseError: DatabaseError) => {
   if (databaseError.constraint === 'idx_supplier_invoices_linked_sale_id_unique') {
     return 'An invoice already exists for this order';
@@ -315,6 +318,16 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       if (!totalResult.ok) return badRequest(reply, totalResult.message);
       const amountPaidResult = optionalLocalizedNonNegativeNumber(amountPaid, 'amountPaid');
       if (!amountPaidResult.ok) return badRequest(reply, amountPaidResult.message);
+      const totalValue = totalResult.value ?? 0;
+      const amountPaidValue = amountPaidResult.value ?? 0;
+      const statusValue = typeof status === 'string' && status.length > 0 ? status : 'draft';
+
+      if (amountPaidValue > totalValue) {
+        return badRequest(reply, AMOUNT_PAID_EXCEEDS_TOTAL_ERROR);
+      }
+      if (statusValue === 'paid' && amountPaidValue < totalValue) {
+        return badRequest(reply, PAID_INVOICE_UNDERPAID_ERROR);
+      }
 
       if (linkedSaleIdResult.value) {
         const [sourceOrder, existingInvoiceId] = await Promise.all([
@@ -394,10 +407,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
                   supplierName: supplierNameResult.value,
                   issueDate: issueDateResult.value,
                   dueDate: dueDateResult.value,
-                  status: typeof status === 'string' && status.length > 0 ? status : 'draft',
-                  subtotal: subtotalResult.value || 0,
-                  total: totalResult.value || 0,
-                  amountPaid: amountPaidResult.value || 0,
+                  status: statusValue,
+                  subtotal: subtotalResult.value ?? 0,
+                  total: totalValue,
+                  amountPaid: amountPaidValue,
                   notes: typeof notes === 'string' ? notes : null,
                 },
                 tx,
@@ -593,6 +606,18 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
 
       if (typeof status === 'string') patch.status = status;
       if (typeof notes === 'string') patch.notes = notes;
+
+      const effectiveTotal = patch.total ?? existingInvoice.total;
+      const effectiveAmountPaid = patch.amountPaid ?? existingInvoice.amountPaid;
+      if (
+        (patch.total !== undefined || patch.amountPaid !== undefined || patch.status === 'paid') &&
+        effectiveAmountPaid > effectiveTotal
+      ) {
+        return badRequest(reply, AMOUNT_PAID_EXCEEDS_TOTAL_ERROR);
+      }
+      if (patch.status === 'paid' && effectiveAmountPaid < effectiveTotal) {
+        return badRequest(reply, PAID_INVOICE_UNDERPAID_ERROR);
+      }
 
       let normalizedItems: supplierInvoicesRepo.NewSupplierInvoiceItem[] | null = null;
       if (items !== undefined) {

--- a/server/test/repositories/supplierInvoicesRepo.test.ts
+++ b/server/test/repositories/supplierInvoicesRepo.test.ts
@@ -111,13 +111,17 @@ describe('findInvoiceForLinkedSale', () => {
 });
 
 describe('findExisting', () => {
-  test('returns id, status, issueDate, dueDate', async () => {
-    exec.enqueue({ rows: [['SINV-2026-0001', 'draft', '2026-04-01', '2026-04-30']] });
+  test('returns update-gating fields', async () => {
+    exec.enqueue({
+      rows: [['SINV-2026-0001', 'draft', '2026-04-01', '2026-04-30', '120.60', '20.10']],
+    });
     expect(await supplierInvoicesRepo.findExisting('SINV-2026-0001', testDb)).toEqual({
       id: 'SINV-2026-0001',
       status: 'draft',
       issueDate: '2026-04-01',
       dueDate: '2026-04-30',
+      total: 120.6,
+      amountPaid: 20.1,
     });
   });
 });

--- a/server/test/routes/invoices.test.ts
+++ b/server/test/routes/invoices.test.ts
@@ -378,6 +378,21 @@ describe('POST /api/invoices', () => {
     );
   });
 
+  test('400 paid status requires amountPaid to cover computed total', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/invoices',
+      headers: authHeader(),
+      payload: { ...validBody, status: 'paid', amountPaid: 50 },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'amountPaid must be at least total when status is paid',
+    });
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
   test('400 dueDate before issueDate', async () => {
     const res = await testApp.inject({
       method: 'POST',
@@ -802,6 +817,44 @@ describe('PUT /api/invoices/:id', () => {
     expect(findTotalMock).toHaveBeenCalledWith('inv-1');
     const patch = updateMock.mock.calls[0][1] as Record<string, unknown>;
     expect(patch.amountPaid).toBe(50);
+  });
+
+  test('400 paid status requires persisted amountPaid to cover persisted total', async () => {
+    findTotalMock.mockResolvedValue(100);
+    findAmountPaidMock.mockResolvedValue(0);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/invoices/inv-1',
+      headers: authHeader(),
+      payload: { status: 'paid' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'amountPaid must be at least total when status is paid',
+    });
+    expect(findTotalMock).toHaveBeenCalledWith('inv-1');
+    expect(findAmountPaidMock).toHaveBeenCalledWith('inv-1');
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  test('400 paid status rejects persisted amountPaid above persisted total', async () => {
+    findTotalMock.mockResolvedValue(100);
+    findAmountPaidMock.mockResolvedValue(101);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/invoices/inv-1',
+      headers: authHeader(),
+      payload: { status: 'paid' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({ error: 'amountPaid cannot exceed total' });
+    expect(findTotalMock).toHaveBeenCalledWith('inv-1');
+    expect(findAmountPaidMock).toHaveBeenCalledWith('inv-1');
+    expect(updateMock).not.toHaveBeenCalled();
   });
 
   test('200 status-only update skips findTotal entirely', async () => {

--- a/server/test/routes/supplier-invoices.test.ts
+++ b/server/test/routes/supplier-invoices.test.ts
@@ -150,6 +150,25 @@ const SAMPLE_ITEM = {
   discount: 0,
 };
 
+const existingInvoiceForUpdate = (
+  overrides: Partial<{
+    id: string;
+    status: string;
+    issueDate: string;
+    dueDate: string;
+    total: number;
+    amountPaid: number;
+  }> = {},
+) => ({
+  id: 'SINV-2025-0001',
+  status: 'draft',
+  issueDate: '2025-06-01',
+  dueDate: '2025-07-01',
+  total: 100,
+  amountPaid: 0,
+  ...overrides,
+});
+
 const allMocks = [
   findAuthUserByIdMock,
   userHasRoleMock,
@@ -337,6 +356,34 @@ describe('POST /api/supplier-invoices', () => {
     expect(res.statusCode).toBe(400);
   });
 
+  test('400 amountPaid cannot exceed total', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/supplier-invoices',
+      headers: authHeader(),
+      payload: { ...validBody, total: 100, amountPaid: 101 },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({ error: 'amountPaid cannot exceed total' });
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  test('400 paid status requires amountPaid to cover total', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/supplier-invoices',
+      headers: authHeader(),
+      payload: { ...validBody, status: 'paid', total: 100, amountPaid: 50 },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'amountPaid must be at least total when status is paid',
+    });
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
   test('404 linkedSaleId points to missing source order', async () => {
     findOrderByIdMock.mockResolvedValue(null);
     findInvoiceForLinkedSaleMock.mockResolvedValue(null);
@@ -425,12 +472,7 @@ describe('POST /api/supplier-invoices', () => {
 
 describe('PUT /api/supplier-invoices/:id', () => {
   test('200 partial update on draft invoice', async () => {
-    findExistingMock.mockResolvedValue({
-      id: 'SINV-2025-0001',
-      status: 'draft',
-      issueDate: '2025-06-01',
-      dueDate: '2025-07-01',
-    });
+    findExistingMock.mockResolvedValue(existingInvoiceForUpdate());
     updateMock.mockResolvedValue({ ...SAMPLE_INVOICE, status: 'sent' });
     findItemsForInvoiceMock.mockResolvedValue([SAMPLE_ITEM]);
 
@@ -450,12 +492,7 @@ describe('PUT /api/supplier-invoices/:id', () => {
   });
 
   test('200 update with new items uses replaceItems', async () => {
-    findExistingMock.mockResolvedValue({
-      id: 'SINV-2025-0001',
-      status: 'draft',
-      issueDate: '2025-06-01',
-      dueDate: '2025-07-01',
-    });
+    findExistingMock.mockResolvedValue(existingInvoiceForUpdate());
     updateMock.mockResolvedValue(SAMPLE_INVOICE);
     replaceItemsMock.mockResolvedValue([SAMPLE_ITEM]);
 
@@ -487,12 +524,7 @@ describe('PUT /api/supplier-invoices/:id', () => {
   });
 
   test('409 non-draft invoice with locked field updates is read-only', async () => {
-    findExistingMock.mockResolvedValue({
-      id: 'SINV-2025-0001',
-      status: 'sent',
-      issueDate: '2025-06-01',
-      dueDate: '2025-07-01',
-    });
+    findExistingMock.mockResolvedValue(existingInvoiceForUpdate({ status: 'sent' }));
 
     const res = await testApp.inject({
       method: 'PUT',
@@ -507,12 +539,7 @@ describe('PUT /api/supplier-invoices/:id', () => {
   });
 
   test('409 id conflict on rename', async () => {
-    findExistingMock.mockResolvedValue({
-      id: 'SINV-2025-0001',
-      status: 'draft',
-      issueDate: '2025-06-01',
-      dueDate: '2025-07-01',
-    });
+    findExistingMock.mockResolvedValue(existingInvoiceForUpdate());
     findIdConflictMock.mockResolvedValue(true);
 
     const res = await testApp.inject({
@@ -527,12 +554,7 @@ describe('PUT /api/supplier-invoices/:id', () => {
   });
 
   test('400 dueDate before issueDate using effective dates', async () => {
-    findExistingMock.mockResolvedValue({
-      id: 'SINV-2025-0001',
-      status: 'draft',
-      issueDate: '2025-06-01',
-      dueDate: '2025-07-01',
-    });
+    findExistingMock.mockResolvedValue(existingInvoiceForUpdate());
 
     const res = await testApp.inject({
       method: 'PUT',
@@ -547,13 +569,70 @@ describe('PUT /api/supplier-invoices/:id', () => {
     });
   });
 
-  test('400 empty items array on update', async () => {
-    findExistingMock.mockResolvedValue({
-      id: 'SINV-2025-0001',
-      status: 'draft',
-      issueDate: '2025-06-01',
-      dueDate: '2025-07-01',
+  test('400 amountPaid cannot exceed existing total', async () => {
+    findExistingMock.mockResolvedValue(existingInvoiceForUpdate());
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/supplier-invoices/SINV-2025-0001',
+      headers: authHeader(),
+      payload: { amountPaid: 101 },
     });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({ error: 'amountPaid cannot exceed total' });
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  test('400 total cannot be lowered below existing amountPaid', async () => {
+    findExistingMock.mockResolvedValue(existingInvoiceForUpdate({ amountPaid: 80 }));
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/supplier-invoices/SINV-2025-0001',
+      headers: authHeader(),
+      payload: { total: 50 },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({ error: 'amountPaid cannot exceed total' });
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  test('400 paid status requires amountPaid to cover total', async () => {
+    findExistingMock.mockResolvedValue(existingInvoiceForUpdate({ amountPaid: 50 }));
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/supplier-invoices/SINV-2025-0001',
+      headers: authHeader(),
+      payload: { status: 'paid' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'amountPaid must be at least total when status is paid',
+    });
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  test('400 paid status rejects existing amountPaid above total', async () => {
+    findExistingMock.mockResolvedValue(existingInvoiceForUpdate({ amountPaid: 101 }));
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/supplier-invoices/SINV-2025-0001',
+      headers: authHeader(),
+      payload: { status: 'paid' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({ error: 'amountPaid cannot exceed total' });
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  test('400 empty items array on update', async () => {
+    findExistingMock.mockResolvedValue(existingInvoiceForUpdate());
 
     const res = await testApp.inject({
       method: 'PUT',
@@ -567,12 +646,7 @@ describe('PUT /api/supplier-invoices/:id', () => {
   });
 
   test('404 update returns null after transaction', async () => {
-    findExistingMock.mockResolvedValue({
-      id: 'SINV-2025-0001',
-      status: 'draft',
-      issueDate: '2025-06-01',
-      dueDate: '2025-07-01',
-    });
+    findExistingMock.mockResolvedValue(existingInvoiceForUpdate());
     updateMock.mockResolvedValue(null);
 
     const res = await testApp.inject({


### PR DESCRIPTION
## Summary

Fixes #399 by enforcing invoice payment invariants on the server for both client and supplier invoices.

## Root cause

Client invoice routes prevented overpayment but did not verify that a `paid` invoice had `amountPaid >= total`. Supplier invoice routes only validated that `amountPaid` was non-negative, so overpayments were accepted on create and update.

## Changes

- Reject client invoices marked `paid` unless the effective amount paid covers the effective total.
- Reject supplier invoice create/update requests when `amountPaid > total`.
- Reject supplier invoices marked `paid` unless the effective amount paid covers the effective total.
- Extend supplier invoice update lookup to include total and amount paid for validation.
- Document the invoice payment rule in Italian and English user docs.

## Validation

- `bun test ./test/routes/invoices.test.ts ./test/routes/supplier-invoices.test.ts ./test/repositories/supplierInvoicesRepo.test.ts`
- `bun run typecheck`
- `bunx biome check server/routes/invoices.ts server/routes/supplier-invoices.ts server/repositories/supplierInvoicesRepo.ts server/test/routes/invoices.test.ts server/test/routes/supplier-invoices.test.ts server/test/repositories/supplierInvoicesRepo.test.ts docs-site/src/content/docs/sales-accounting.md docs-site/src/content/docs/en/sales-accounting.md`
- `bun run test:server`