### PR TITLE
validation(fix): reject invalid boolean inputs

### DIFF
--- a/server/routes/general-settings.ts
+++ b/server/routes/general-settings.ts
@@ -12,7 +12,7 @@ import {
   optionalEnum,
   optionalLocalizedNonNegativeNumber,
   optionalNonEmptyString,
-  parseBoolean,
+  parseBooleanField,
 } from '../utils/validation.ts';
 
 const generalSettingsSchema = {
@@ -140,20 +140,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       },
     },
     async (request: FastifyRequest, reply: FastifyReply) => {
-      const {
-        currency,
-        dailyLimit,
-        startOfWeek,
-        treatSaturdayAsHoliday,
-        enableAiReporting,
-        geminiApiKey,
-        aiProvider,
-        openrouterApiKey,
-        geminiModelId,
-        openrouterModelId,
-        allowWeekendSelection,
-        defaultLocation,
-      } = request.body as {
+      const body = (request.body ?? {}) as {
         currency?: string;
         dailyLimit?: number;
         startOfWeek?: string;
@@ -167,6 +154,17 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         allowWeekendSelection?: boolean;
         defaultLocation?: string;
       };
+      const {
+        currency,
+        dailyLimit,
+        startOfWeek,
+        geminiApiKey,
+        aiProvider,
+        openrouterApiKey,
+        geminiModelId,
+        openrouterModelId,
+        defaultLocation,
+      } = body;
       const currencyResult = optionalNonEmptyString(currency, 'currency');
       if (!currencyResult.ok) return badRequest(reply, currencyResult.message);
 
@@ -207,22 +205,29 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       if (geminiApiKey !== undefined && geminiApiKey !== null && typeof geminiApiKey !== 'string')
         return badRequest(reply, 'geminiApiKey must be a string');
 
-      const treatSaturdayAsHolidayValue = parseBoolean(treatSaturdayAsHoliday);
-      const enableAiReportingValue = parseBoolean(enableAiReporting);
-      const allowWeekendSelectionValue = parseBoolean(allowWeekendSelection);
+      const treatSaturdayAsHolidayResult = parseBooleanField(body, 'treatSaturdayAsHoliday');
+      if (!treatSaturdayAsHolidayResult.ok) {
+        return badRequest(reply, treatSaturdayAsHolidayResult.message);
+      }
+      const enableAiReportingResult = parseBooleanField(body, 'enableAiReporting');
+      if (!enableAiReportingResult.ok) return badRequest(reply, enableAiReportingResult.message);
+      const allowWeekendSelectionResult = parseBooleanField(body, 'allowWeekendSelection');
+      if (!allowWeekendSelectionResult.ok) {
+        return badRequest(reply, allowWeekendSelectionResult.message);
+      }
 
       const settings = await generalSettingsRepo.update({
         currency: currencyResult.value,
         dailyLimit: dailyLimitResult.value,
         startOfWeek: startOfWeekResult.value,
-        treatSaturdayAsHoliday: treatSaturdayAsHolidayValue,
-        enableAiReporting: enableAiReportingValue,
+        treatSaturdayAsHoliday: treatSaturdayAsHolidayResult.value,
+        enableAiReporting: enableAiReportingResult.value,
         geminiApiKey,
         aiProvider: aiProviderResult.value,
         openrouterApiKey,
         geminiModelId,
         openrouterModelId,
-        allowWeekendSelection: allowWeekendSelectionValue,
+        allowWeekendSelection: allowWeekendSelectionResult.value,
         defaultLocation: defaultLocationResult.value,
       });
 

--- a/server/routes/ldap.ts
+++ b/server/routes/ldap.ts
@@ -8,7 +8,7 @@ import { DEFAULT_ROLE_ID } from '../services/external-auth.ts';
 import { getAuditCounts, logAudit } from '../utils/audit.ts';
 import { MASKED_SECRET } from '../utils/crypto.ts';
 import { validateGroupFilterTemplate, validateUserFilterTemplate } from '../utils/ldap-filter.ts';
-import { badRequest, parseBoolean, requireNonEmptyString } from '../utils/validation.ts';
+import { badRequest, parseBooleanField, requireNonEmptyString } from '../utils/validation.ts';
 
 // 64 KB matches the UI's file-import size cap (AuthSettings.tsx); keeping these in
 // sync prevents a save flow where a 32-64 KB chain passes the picker but fails the API.
@@ -196,7 +196,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       },
     },
     async (request: FastifyRequest, reply: FastifyReply) => {
-      const body = request.body as {
+      const body = (request.body ?? {}) as {
         enabled?: boolean;
         serverUrl?: string;
         baseDn?: string;
@@ -209,16 +209,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         tlsCaCertificate?: string | null;
         autoProvisionAll?: boolean;
       };
-      const {
-        enabled,
-        serverUrl,
-        baseDn,
-        userFilter,
-        groupBaseDn,
-        groupFilter,
-        roleMappings,
-        autoProvisionAll,
-      } = body;
+      const { serverUrl, baseDn, userFilter, groupBaseDn, groupFilter, roleMappings } = body;
       // bindPassword === MASKED_SECRET means "preserve the stored secret" (the UI round-trips
       // the masked value when the operator did not edit the field). To satisfy the paired
       // validation below, bindDn is also dropped from the patch, but only when the client's
@@ -243,7 +234,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         bindDn = body.bindDn;
         bindPassword = body.bindPassword;
       }
-      const enabledValue = parseBoolean(enabled);
+      const enabledResult = parseBooleanField(body, 'enabled');
+      if (!enabledResult.ok) return badRequest(reply, enabledResult.message);
+      const enabledValue = enabledResult.value;
       const tlsCaResult = parseTlsCaForPatch(body.tlsCaCertificate);
       if (!tlsCaResult.ok) {
         return badRequest(reply, tlsCaResult.message);
@@ -251,7 +244,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       let normalizedUserFilter = userFilter;
       let normalizedGroupFilter = groupFilter;
 
-      if (enabledValue) {
+      if (enabledValue === true) {
         const serverUrlResult = requireNonEmptyString(serverUrl, 'serverUrl');
         if (!serverUrlResult.ok) return badRequest(reply, serverUrlResult.message);
 
@@ -320,6 +313,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         }
       }
 
+      const autoProvisionAllResult = parseBooleanField(body, 'autoProvisionAll');
+      if (!autoProvisionAllResult.ok) {
+        return badRequest(reply, autoProvisionAllResult.message);
+      }
+
       const updated = await ldapRepo.update({
         enabled: enabledValue,
         serverUrl,
@@ -330,8 +328,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         groupBaseDn,
         groupFilter: normalizedGroupFilter,
         roleMappings: validatedMappings,
-        autoProvisionAll:
-          autoProvisionAll === undefined ? undefined : parseBoolean(autoProvisionAll),
+        autoProvisionAll: autoProvisionAllResult.value,
         ...tlsCaResult.patch,
       });
 

--- a/server/routes/products.ts
+++ b/server/routes/products.ts
@@ -10,7 +10,7 @@ import { generatePrefixedId } from '../utils/order-ids.ts';
 import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import {
   badRequest,
-  parseBoolean,
+  parseBooleanField,
   parseLocalizedNonNegativeNumber,
   requireNonEmptyString,
   validateEnum,
@@ -267,7 +267,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
     },
     async (request: FastifyRequest, reply: FastifyReply) => {
       const { id } = request.params as { id: string };
-      const body = request.body as {
+      const body = (request.body ?? {}) as {
         name?: unknown;
         productCode?: unknown;
         description?: unknown;
@@ -399,8 +399,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         fields.costUnit = costUnitResult.value;
       }
 
-      if (body.isDisabled !== undefined) {
-        fields.isDisabled = parseBoolean(body.isDisabled);
+      const isDisabledResult = parseBooleanField(body, 'isDisabled');
+      if (!isDisabledResult.ok) return badRequest(reply, isDisabledResult.message);
+      if (isDisabledResult.value !== undefined) {
+        fields.isDisabled = isDisabledResult.value;
       }
 
       const product =
@@ -426,13 +428,13 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         body.subcategory !== undefined ? 'subcategory' : null,
         body.type !== undefined ? 'type' : null,
         body.costUnit !== undefined ? 'costUnit' : null,
-        body.isDisabled !== undefined ? 'isDisabled' : null,
+        isDisabledResult.value !== undefined ? 'isDisabled' : null,
         body.supplierId !== undefined ? 'supplierId' : null,
       ].filter((field): field is string => field !== null);
 
       let action = 'product.updated';
       if (changedFields.length === 1 && changedFields[0] === 'isDisabled') {
-        action = body.isDisabled ? 'product.disabled' : 'product.enabled';
+        action = isDisabledResult.value ? 'product.disabled' : 'product.enabled';
       }
 
       await logAudit({

--- a/server/routes/sso.ts
+++ b/server/routes/sso.ts
@@ -4,7 +4,7 @@ import * as rolesRepo from '../repositories/rolesRepo.ts';
 import { standardRateLimitedErrorResponses } from '../schemas/common.ts';
 import * as ssoService from '../services/sso.ts';
 import { logAudit } from '../utils/audit.ts';
-import { badRequest, parseBoolean, requireNonEmptyString } from '../utils/validation.ts';
+import { badRequest, parseBooleanField, requireNonEmptyString } from '../utils/validation.ts';
 
 const roleMappingSchema = {
   type: 'object',
@@ -121,8 +121,13 @@ const validateProviderBody = async (
     validated.name = name.value;
   }
 
-  if (source.enabled !== undefined) {
-    validated.enabled = parseBoolean(source.enabled);
+  const enabledResult = parseBooleanField(source, 'enabled');
+  if (!enabledResult.ok) {
+    badRequest(reply, enabledResult.message);
+    return null;
+  }
+  if (enabledResult.value !== undefined) {
+    validated.enabled = enabledResult.value;
   } else if (options.isCreate) {
     validated.enabled = false;
   }

--- a/server/routes/suppliers.ts
+++ b/server/routes/suppliers.ts
@@ -14,7 +14,7 @@ import {
   badRequest,
   optionalEmail,
   optionalNonEmptyString,
-  parseBoolean,
+  parseBooleanField,
   requireNonEmptyString,
 } from '../utils/validation.ts';
 
@@ -225,7 +225,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
     },
     async (request: FastifyRequest, reply: FastifyReply) => {
       const { id } = request.params as { id: string };
-      const body = request.body as {
+      const body = (request.body ?? {}) as {
         name?: string;
         isDisabled?: boolean;
         supplierCode?: string;
@@ -240,7 +240,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       };
       const {
         name,
-        isDisabled,
         supplierCode,
         contactName,
         email,
@@ -293,7 +292,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const notesResult = optionalNonEmptyString(notes, 'notes');
       if (!notesResult.ok) return badRequest(reply, notesResult.message);
 
-      const isDisabledValue = isDisabled !== undefined ? parseBoolean(isDisabled) : undefined;
+      const isDisabledResult = parseBooleanField(body, 'isDisabled');
+      if (!isDisabledResult.ok) return badRequest(reply, isDisabledResult.message);
+      const isDisabledValue = isDisabledResult.value;
 
       const patch: suppliersRepo.SupplierUpdate = {};
       // `name` is NOT NULL in the DB - an empty payload here means "don't change",
@@ -332,7 +333,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
 
       let action = 'supplier.updated';
       if (changedFields.length === 1 && changedFields[0] === 'isDisabled') {
-        action = body.isDisabled ? 'supplier.disabled' : 'supplier.enabled';
+        action = isDisabledValue ? 'supplier.disabled' : 'supplier.enabled';
       }
 
       await logAudit({

--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -33,7 +33,7 @@ import {
   optionalDateString,
   optionalEnum,
   optionalLocalizedNonNegativeNumber,
-  parseBoolean,
+  parseBooleanField,
   parseDateString,
   requireNonEmptyArrayOfStrings,
   requireNonEmptyString,
@@ -180,21 +180,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
     },
     async (request: FastifyRequest, reply: FastifyReply) => {
       if (!assertAuthenticated(request, reply)) return;
-      const {
-        name,
-        projectId,
-        description,
-        isRecurring,
-        recurrencePattern,
-        recurrenceStart,
-        recurrenceDuration,
-        expectedEffort,
-        monthlyEffort,
-        revenue,
-        notes,
-        billingType,
-        billingFrequency,
-      } = request.body as {
+      const body = (request.body ?? {}) as {
         name: string;
         projectId: string;
         description?: string;
@@ -209,6 +195,20 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         billingType?: string;
         billingFrequency?: string;
       };
+      const {
+        name,
+        projectId,
+        description,
+        recurrencePattern,
+        recurrenceStart,
+        recurrenceDuration,
+        expectedEffort,
+        monthlyEffort,
+        revenue,
+        notes,
+        billingType,
+        billingFrequency,
+      } = body;
       const nameResult = requireNonEmptyString(name, 'name');
       if (!nameResult.ok) return badRequest(reply, nameResult.message);
 
@@ -261,7 +261,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           DEFAULT_BILLING_FREQUENCY,
       );
 
-      const isRecurringValue = parseBoolean(isRecurring);
+      const isRecurringResult = parseBooleanField(body, 'isRecurring');
+      if (!isRecurringResult.ok) return badRequest(reply, isRecurringResult.message);
+      const isRecurringValue = isRecurringResult.value ?? false;
       let start: string | null = null;
       if (isRecurringValue) {
         const patternResult = requireNonEmptyString(recurrencePattern, 'recurrencePattern');
@@ -481,7 +483,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
     },
     async (request: FastifyRequest, reply: FastifyReply) => {
       const { id } = request.params as { id: string };
-      const body = request.body as {
+      const body = (request.body ?? {}) as {
         name?: string;
         description?: string;
         isRecurring?: boolean;
@@ -500,7 +502,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const {
         name,
         description,
-        isRecurring,
         recurrencePattern,
         recurrenceStart,
         recurrenceEnd,
@@ -558,8 +559,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         return badRequest(reply, 'recurrenceStart must be on or before recurrenceEnd');
       }
 
-      const isRecurringValue =
-        isRecurring === undefined || isRecurring === null ? undefined : parseBoolean(isRecurring);
+      const isRecurringResult = parseBooleanField(body, 'isRecurring');
+      if (!isRecurringResult.ok) return badRequest(reply, isRecurringResult.message);
+      const isRecurringValue = isRecurringResult.value;
 
       const updated = await tasksRepo.update(idResult.value, {
         name: name || undefined,
@@ -589,7 +591,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         getAuditChangedFields({
           name,
           description,
-          isRecurring,
+          isRecurring: isRecurringValue,
           recurrencePattern,
           recurrenceStart,
           recurrenceEnd,

--- a/server/services/timeEntries.ts
+++ b/server/services/timeEntries.ts
@@ -15,7 +15,7 @@ import {
   isWeekendDate,
   optionalLocalizedNonNegativeNumber,
   optionalNonEmptyString,
-  parseBoolean,
+  parseBooleanField,
   parseDateString,
   parseLocalizedNonNegativeNumber,
   parseQueryBoolean,
@@ -173,6 +173,7 @@ export const createTimeEntry = async (
   }
 
   const location = parseOptionalLocation(input.location, fail) ?? 'remote';
+  const parsedIsPlaceholder = requireValid(parseBooleanField(input, 'isPlaceholder'));
 
   return entriesRepo.create({
     id: generatePrefixedId('te'),
@@ -187,7 +188,7 @@ export const createTimeEntry = async (
     notes: typeof input.notes === 'string' ? input.notes : null,
     duration: duration ?? 0,
     hourlyCost,
-    isPlaceholder: parseBoolean(input.isPlaceholder),
+    isPlaceholder: parsedIsPlaceholder ?? false,
     location,
   });
 };
@@ -224,11 +225,12 @@ export const updateTimeEntry = async (
       (await tasksRepo.findIdByProjectAndName(context.projectId, context.task)) ?? undefined;
   }
 
+  const parsedIsPlaceholder = requireValid(parseBooleanField(input, 'isPlaceholder'));
+
   const updated = await entriesRepo.update(entryId, {
     duration: parsedDuration,
     notes: validatedNotes,
-    isPlaceholder:
-      input.isPlaceholder === undefined ? undefined : parseBoolean(input.isPlaceholder),
+    isPlaceholder: parsedIsPlaceholder,
     location: parseOptionalLocation(input.location, fail),
     taskId: backfilledTaskId,
   });

--- a/server/test/routes/entries.test.ts
+++ b/server/test/routes/entries.test.ts
@@ -429,8 +429,20 @@ describe('POST /api/entries', () => {
 
     expect(res.statusCode).toBe(201);
     expect(entriesCreateMock).toHaveBeenCalledWith(
-      expect.objectContaining({ duration: 0, taskId: null }),
+      expect.objectContaining({ duration: 0, taskId: null, isPlaceholder: false }),
     );
+  });
+
+  test('400 invalid isPlaceholder value does not create entry', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/entries',
+      headers: authHeader(),
+      payload: { ...validBody, isPlaceholder: 'ture' } as unknown as Record<string, unknown>,
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(entriesCreateMock).not.toHaveBeenCalled();
   });
 
   test('400 weekend date when allowWeekendSelection=false', async () => {
@@ -702,6 +714,18 @@ describe('PUT /api/entries/:id', () => {
 
     expect(res.statusCode).toBe(400);
     expect(JSON.parse(res.body).error).toMatch(/duration must be zero or positive/);
+  });
+
+  test('400 invalid isPlaceholder value does not update entry', async () => {
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/entries/te-1',
+      headers: authHeader(),
+      payload: { isPlaceholder: 'ture' } as unknown as Record<string, unknown>,
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(entriesUpdateMock).not.toHaveBeenCalled();
   });
 
   test('200 empty-string location does not pass through to repo (would violate CHECK)', async () => {

--- a/server/test/routes/general-settings.test.ts
+++ b/server/test/routes/general-settings.test.ts
@@ -204,7 +204,7 @@ describe('PUT /api/general-settings', () => {
     expect(body.geminiApiKey).toBe('plaintext-gemini-key');
   });
 
-  test('200 boolean strings parsed via parseBoolean', async () => {
+  test('200 boolean strings parsed via strict boolean field validation', async () => {
     settingsUpdateMock.mockResolvedValue(SETTINGS_WITH_KEYS);
 
     const res = await testApp.inject({
@@ -226,6 +226,36 @@ describe('PUT /api/general-settings', () => {
         allowWeekendSelection: true,
       }),
     );
+  });
+
+  test('200 omitted boolean fields are preserved instead of coerced to false', async () => {
+    settingsUpdateMock.mockResolvedValue(SETTINGS_WITH_KEYS);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/general-settings',
+      headers: authHeader(),
+      payload: { currency: 'USD' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const patch = settingsUpdateMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(patch.currency).toBe('USD');
+    expect(patch.treatSaturdayAsHoliday).toBeUndefined();
+    expect(patch.enableAiReporting).toBeUndefined();
+    expect(patch.allowWeekendSelection).toBeUndefined();
+  });
+
+  test('400 invalid boolean value does not update settings', async () => {
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/general-settings',
+      headers: authHeader(),
+      payload: { enableAiReporting: 'ture' } as unknown as Record<string, unknown>,
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(settingsUpdateMock).not.toHaveBeenCalled();
   });
 
   test('400 invalid aiProvider enum', async () => {

--- a/server/test/routes/ldap.test.ts
+++ b/server/test/routes/ldap.test.ts
@@ -339,6 +339,23 @@ describe('PUT /api/ldap/config - autoProvisionAll', () => {
     const patch = ldapUpdateMock.mock.calls[0][0] as Partial<realLdapRepo.LdapConfig>;
     expect(patch.autoProvisionAll).toBe(false);
   });
+
+  test('invalid enabled value does not update LDAP config', async () => {
+    const response = await putConfig({ enabled: 'ture' } as unknown as object);
+
+    expect(response.statusCode).toBe(400);
+    expect(ldapUpdateMock).not.toHaveBeenCalled();
+  });
+
+  test('invalid autoProvisionAll value does not update LDAP config', async () => {
+    const response = await putConfig({
+      enabled: false,
+      autoProvisionAll: 'ture',
+    } as unknown as object);
+
+    expect(response.statusCode).toBe(400);
+    expect(ldapUpdateMock).not.toHaveBeenCalled();
+  });
 });
 
 describe('PUT /api/ldap/config - tlsCaCertificate', () => {

--- a/server/test/routes/products.test.ts
+++ b/server/test/routes/products.test.ts
@@ -555,6 +555,18 @@ describe('PUT /api/products/:id', () => {
     );
   });
 
+  test('400 invalid isDisabled value does not update product', async () => {
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/products/p-1',
+      headers: authHeader(),
+      payload: { isDisabled: 'ture' } as unknown as Record<string, unknown>,
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(updateProductDynamicMock).not.toHaveBeenCalled();
+  });
+
   test('200 type change loads currentProduct + recomputes costUnit', async () => {
     findProductCoreByIdMock.mockResolvedValue({
       type: 'goods',

--- a/server/test/routes/sso.test.ts
+++ b/server/test/routes/sso.test.ts
@@ -417,6 +417,20 @@ describe('PUT /api/sso/providers/:id — enabled OIDC configuration validation',
     expect(patch.protocol).toBe('oidc');
     expect(patch.enabled).toBe(true);
   });
+
+  test('rejects invalid enabled value without updating provider', async () => {
+    findByIdMock.mockResolvedValue({ ...baseProvider, enabled: false });
+
+    const response = await testApp.inject({
+      method: 'PUT',
+      url: '/api/sso/providers/sso-1',
+      headers: { ...authHeader(), 'content-type': 'application/json' },
+      payload: { enabled: 'ture' } as unknown as Record<string, unknown>,
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(updateMock).not.toHaveBeenCalled();
+  });
 });
 
 describe('POST /api/sso/providers — validateProviderBody', () => {
@@ -478,5 +492,22 @@ describe('POST /api/sso/providers — validateProviderBody', () => {
     expect(insertMock).not.toHaveBeenCalled();
     expect(bodySnapshots.before).toEqual(payload);
     expect(bodySnapshots.after).toEqual(payload);
+  });
+
+  test('rejects invalid enabled value without creating provider', async () => {
+    const response = await testApp.inject({
+      method: 'POST',
+      url: '/api/sso/providers',
+      headers: { ...authHeader(), 'content-type': 'application/json' },
+      payload: {
+        protocol: 'oidc',
+        slug: 'bad-enabled',
+        name: 'Bad Enabled',
+        enabled: 'ture',
+      } as unknown as Record<string, unknown>,
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(insertMock).not.toHaveBeenCalled();
   });
 });

--- a/server/test/routes/suppliers.test.ts
+++ b/server/test/routes/suppliers.test.ts
@@ -364,6 +364,18 @@ describe('PUT /api/suppliers/:id', () => {
     );
   });
 
+  test('400 invalid isDisabled value does not update supplier', async () => {
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/suppliers/s-1',
+      headers: authHeader(),
+      payload: { isDisabled: 'ture' } as unknown as Record<string, unknown>,
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
   test('200 accepts crm.suppliers_all.update without base update', async () => {
     getRolePermissionsMock.mockResolvedValue(['crm.suppliers_all.update']);
     updateMock.mockResolvedValue({ ...SAMPLE_SUPPLIER, name: 'ACME 2' });

--- a/server/test/routes/tasks.test.ts
+++ b/server/test/routes/tasks.test.ts
@@ -430,6 +430,21 @@ describe('POST /api/tasks', () => {
     expect(JSON.parse(res.body)).toEqual({ error: 'recurrencePattern is required' });
   });
 
+  test('400: invalid isRecurring value does not create task', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/tasks',
+      headers: authHeader(),
+      payload: { name: 'X', projectId: 'p-1', isRecurring: 'ture' } as unknown as Record<
+        string,
+        unknown
+      >,
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
   test('400: recurring task with invalid recurrenceStart format', async () => {
     const res = await testApp.inject({
       method: 'POST',
@@ -800,6 +815,18 @@ describe('PUT /api/tasks/:id', () => {
     });
 
     expect(res.statusCode).toBe(400);
+  });
+
+  test('400: invalid isRecurring value does not update task', async () => {
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/tasks/t-1',
+      headers: authHeader(),
+      payload: { isRecurring: 'ture' } as unknown as Record<string, unknown>,
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(updateMock).not.toHaveBeenCalled();
   });
 
   test('404: task not found', async () => {

--- a/server/test/utils/validation.test.ts
+++ b/server/test/utils/validation.test.ts
@@ -20,6 +20,8 @@ import {
   optionalNumber,
   optionalPositiveNumber,
   parseBoolean,
+  parseBooleanField,
+  parseBooleanStrict,
   parseDateString,
   parseLocalizedNonNegativeNumber,
   parseLocalizedNumber,
@@ -468,6 +470,48 @@ describe('parseBoolean', () => {
   });
 });
 
+describe('parseBooleanStrict', () => {
+  test('accepts booleans and recognized strings', () => {
+    expect(parseBooleanStrict(true, 'enabled')).toEqual({ ok: true, value: true });
+    expect(parseBooleanStrict(false, 'enabled')).toEqual({ ok: true, value: false });
+    expect(parseBooleanStrict(' YES ', 'enabled')).toEqual({ ok: true, value: true });
+    expect(parseBooleanStrict('0', 'enabled')).toEqual({ ok: true, value: false });
+  });
+
+  test('rejects invalid, null, undefined, and non-string inputs', () => {
+    for (const value of ['ture', '', 'off', null, undefined, 1, {}, []]) {
+      const result = parseBooleanStrict(value, 'enabled');
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.message).toContain('enabled');
+        expect(result.message).toContain('true, false, 1, 0, yes, no');
+      }
+    }
+  });
+});
+
+describe('parseBooleanField', () => {
+  test('returns undefined for missing fields and parses present values', () => {
+    expect(parseBooleanField({}, 'enabled')).toEqual({ ok: true, value: undefined });
+    expect(parseBooleanField({ enabled: 'true' }, 'enabled')).toEqual({
+      ok: true,
+      value: true,
+    });
+    expect(parseBooleanField({ enabled: false }, 'enabled')).toEqual({
+      ok: true,
+      value: false,
+    });
+  });
+
+  test('rejects present null, undefined, and invalid strings', () => {
+    for (const source of [{ enabled: null }, { enabled: undefined }, { enabled: 'ture' }]) {
+      const result = parseBooleanField(source, 'enabled');
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.message).toContain('enabled');
+    }
+  });
+});
+
 describe('optionalBoolean', () => {
   test('returns null for undefined/null/empty', () => {
     expect(optionalBoolean(undefined)).toBeNull();
@@ -482,7 +526,7 @@ describe('optionalBoolean', () => {
     expect(optionalBoolean('no')).toBe(false);
   });
 
-  test('returns false for unrecognized non-empty input (strict parseBoolean)', () => {
+  test('returns false for unrecognized non-empty input (lenient parseBoolean)', () => {
     expect(optionalBoolean(1)).toBe(false);
     expect(optionalBoolean('maybe')).toBe(false);
   });

--- a/server/utils/validation.ts
+++ b/server/utils/validation.ts
@@ -276,25 +276,53 @@ export function optionalLocalizedPositiveNumber(
   return result;
 }
 
-/**
- * Parse a boolean strictly. Accepts native booleans and a fixed allow-list of strings
- * ('true'/'false'/'1'/'0'/'yes'/'no', case-insensitive, trimmed). Anything else — numbers,
- * objects, unrecognized strings — returns `false` rather than relying on JS truthiness,
- * which previously coerced truthy strings like `'off'` or stray numbers into `true`.
- */
 const TRUE_STRINGS = new Set(['true', '1', 'yes']);
 const FALSE_STRINGS = new Set(['false', '0', 'no']);
+const BOOLEAN_VALUES_DESCRIPTION = 'true, false, 1, 0, yes, no';
 
+/**
+ * Lenient boolean coercion for legacy callers. Use parseBooleanStrict or parseBooleanField
+ * when an invalid value should be rejected instead of treated as false.
+ */
 export function parseBoolean(value: unknown): boolean {
+  const result = parseBooleanStrict(value);
+  return result.ok ? result.value : false;
+}
+
+/**
+ * Parse a boolean strictly. Accepts native booleans and a fixed allow-list of strings
+ * ('true'/'false'/'1'/'0'/'yes'/'no', case-insensitive, trimmed). Anything else is invalid.
+ */
+export function parseBooleanStrict(
+  value: unknown,
+  fieldName: string = 'value',
+): { ok: true; value: boolean } | { ok: false; message: string } {
   if (typeof value === 'boolean') {
-    return value;
+    return { ok: true, value };
   }
   if (typeof value === 'string') {
     const normalized = value.trim().toLowerCase();
-    if (TRUE_STRINGS.has(normalized)) return true;
-    if (FALSE_STRINGS.has(normalized)) return false;
+    if (TRUE_STRINGS.has(normalized)) return { ok: true, value: true };
+    if (FALSE_STRINGS.has(normalized)) return { ok: true, value: false };
   }
-  return false;
+  return {
+    ok: false,
+    message: `${fieldName} must be a boolean or one of: ${BOOLEAN_VALUES_DESCRIPTION}`,
+  };
+}
+
+/**
+ * Parse an optional PATCH-style boolean field. A missing property means "not provided";
+ * if the property is present, even as null or undefined, it must be a valid boolean value.
+ */
+export function parseBooleanField(
+  source: object,
+  fieldName: string,
+): { ok: true; value: boolean | undefined } | { ok: false; message: string } {
+  if (!Object.hasOwn(source, fieldName)) {
+    return { ok: true, value: undefined };
+  }
+  return parseBooleanStrict((source as Record<string, unknown>)[fieldName], fieldName);
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #388 by adding strict boolean validation for API update paths that previously treated invalid or missing boolean inputs as `false`.

## What changed

- Added `parseBooleanStrict` and `parseBooleanField` validation helpers while keeping the legacy lenient `parseBoolean` behavior for callers that still need it.
- Updated boolean fields in general settings, LDAP config, products, suppliers, time entries, tasks, and SSO provider updates to reject invalid present values instead of silently toggling features off.
- Preserved PATCH semantics for omitted boolean fields so omitted values do not overwrite existing state.
- Added regression tests for invalid boolean values and omitted boolean settings.

## Validation

- `bun test ./test/utils/validation.test.ts ./test/routes/general-settings.test.ts ./test/routes/products.test.ts ./test/routes/suppliers.test.ts ./test/routes/ldap.test.ts ./test/routes/entries.test.ts ./test/routes/tasks.test.ts ./test/routes/sso.test.ts`
- `bun run typecheck`
- `bunx biome check` on touched files
- `git diff --check`

Note: full `bun run lint` still reports unrelated pre-existing lint issues in `hooks/handlers/userHandlers.ts`, `server/services/ldap.ts`, and `test/hooks/handlers/quoteHandlers.test.ts`.