### PR TITLE
fix(sso): surface provider save errors

### DIFF
--- a/components/administration/AuthSettings.tsx
+++ b/components/administration/AuthSettings.tsx
@@ -1,3 +1,4 @@
+import { CircleAlert } from 'lucide-react';
 import type React from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -14,6 +15,7 @@ import type {
 } from '../../types';
 import SelectControl from '../shared/SelectControl';
 import Toggle from '../shared/Toggle';
+import { Alert, AlertDescription, AlertTitle } from '../ui/alert';
 import { Button } from '../ui/button';
 import { Switch } from '../ui/switch';
 
@@ -106,6 +108,9 @@ const AuthSettings: React.FC<AuthSettingsProps> = ({
   const [isTestingLdap, setIsTestingLdap] = useState(false);
   const [isSaved, setIsSaved] = useState(false);
   const [savingProvider, setSavingProvider] = useState<SsoProtocol | null>(null);
+  const [providerSaveErrors, setProviderSaveErrors] = useState<
+    Partial<Record<SsoProtocol, string>>
+  >({});
   const tlsCaFileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -267,7 +272,22 @@ const AuthSettings: React.FC<AuthSettingsProps> = ({
     }
   };
 
+  const clearProviderSaveError = (protocol: SsoProtocol) => {
+    setProviderSaveErrors((current) => {
+      if (!current[protocol]) return current;
+      const next = { ...current };
+      delete next[protocol];
+      return next;
+    });
+  };
+
+  const getProviderSaveErrorMessage = (err: unknown) =>
+    err instanceof Error && err.message.trim()
+      ? err.message
+      : t('admin.sso.errors.saveFailed', 'Could not save provider');
+
   const updateProviderDraft = (protocol: SsoProtocol, patch: Partial<SsoProvider>) => {
+    clearProviderSaveError(protocol);
     setProviderDrafts((current) => ({
       ...current,
       [protocol]: { ...current[protocol], ...patch, protocol },
@@ -340,6 +360,7 @@ const AuthSettings: React.FC<AuthSettingsProps> = ({
 
   const handleSaveProvider = async (protocol: SsoProtocol, event: React.FormEvent) => {
     event.preventDefault();
+    clearProviderSaveError(protocol);
     const draft = providerDrafts[protocol];
     if (!validateProvider(draft)) return;
     setSavingProvider(protocol);
@@ -352,6 +373,11 @@ const AuthSettings: React.FC<AuthSettingsProps> = ({
       });
       setProviderDrafts((current) => ({ ...current, [protocol]: saved }));
       showSaved();
+    } catch (err) {
+      setProviderSaveErrors((current) => ({
+        ...current,
+        [protocol]: getProviderSaveErrorMessage(err),
+      }));
     } finally {
       setSavingProvider(null);
     }
@@ -470,6 +496,16 @@ const AuthSettings: React.FC<AuthSettingsProps> = ({
         </div>
 
         <div className="p-6 space-y-6">
+          {providerSaveErrors[protocol] && (
+            <Alert variant="destructive" className="border-destructive/30">
+              <CircleAlert />
+              <AlertTitle>
+                {t('admin.sso.errors.saveFailedTitle', 'Provider could not be saved')}
+              </AlertTitle>
+              <AlertDescription>{providerSaveErrors[protocol]}</AlertDescription>
+            </Alert>
+          )}
+
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <Field
               label={t('admin.sso.name', 'Name')}

--- a/components/ui/alert.tsx
+++ b/components/ui/alert.tsx
@@ -1,0 +1,60 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+import type * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+const alertVariants = cva(
+  'relative grid w-full grid-cols-[0_1fr] items-start gap-y-0.5 rounded-lg border px-4 py-3 text-sm has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] has-[>svg]:gap-x-3 [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current',
+  {
+    variants: {
+      variant: {
+        default: 'bg-card text-card-foreground',
+        destructive:
+          'bg-card text-destructive *:data-[slot=alert-description]:text-destructive/90 [&>svg]:text-current',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+);
+
+function Alert({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<'div'> & VariantProps<typeof alertVariants>) {
+  return (
+    <div
+      data-slot="alert"
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn('col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight', className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDescription({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        'col-start-2 grid justify-items-start gap-1 text-sm text-muted-foreground [&_p]:leading-relaxed',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Alert, AlertDescription, AlertTitle };

--- a/docs-site/src/content/docs/administration.md
+++ b/docs-site/src/content/docs/administration.md
@@ -19,6 +19,8 @@ Praetor supporta autenticazione locale e integrazioni aziendali come LDAP o SSO 
 
 Prima di abilitare un provider SAML, configura una sorgente metadata valida (URL o XML) oppure la configurazione manuale con **Entry Point** e **Certificato IdP**. Praetor rifiuta il salvataggio di provider SAML abilitati senza questi dati minimi.
 
+Se il salvataggio di un provider OIDC o SAML non riesce, la scheda del provider mostra un messaggio di errore con il dettaglio restituito dal server. Correggi i campi indicati o riprova quando il servizio torna disponibile prima di considerare la configurazione aggiornata.
+
 Nella lista utenti puoi usare il menu azioni e scegliere **Cambia metodo di autenticazione** per vincolare un utente applicativo a credenziali locali, LDAP, OIDC o SAML. Per OIDC e SAML seleziona anche il provider specifico: l'utente potrà accedere solo tramite quel provider. Dipendenti interni o esterni non sono account applicativi e non possono essere vincolati a LDAP/SSO.
 
 Quando vincoli un utente a LDAP, Praetor consulta la directory e applica subito i ruoli configurati nel mapping dei gruppi LDAP, sovrascrivendo il ruolo locale. Se la directory non è raggiungibile o l'utente non vi è presente, il ruolo esistente viene mantenuto e il prossimo accesso o sincronizzazione riapplicherà il mapping.

--- a/docs-site/src/content/docs/en/administration.md
+++ b/docs-site/src/content/docs/en/administration.md
@@ -19,6 +19,8 @@ Praetor supports local authentication and company integrations such as LDAP or S
 
 Before enabling a SAML provider, configure either a valid metadata source (URL or XML) or manual settings with **Entry Point** and **IdP Certificate**. Praetor rejects enabled SAML providers that are missing this minimum configuration.
 
+If saving an OIDC or SAML provider fails, the provider tab shows an error message with the detail returned by the server. Correct the reported fields or retry when the service is available before treating the configuration as updated.
+
 In the user list, open the row actions menu and choose **Change authentication method** to restrict an application user to local credentials, LDAP, OIDC, or SAML. For OIDC and SAML, also select the specific provider: the user will be able to sign in only through that provider. Internal and external employees are not application accounts and cannot be bound to LDAP/SSO.
 
 When you bind a user to LDAP, Praetor looks them up in the directory and immediately applies the roles configured in the LDAP group role mapping, overriding the local role. If the directory is unreachable or the user is not in it yet, the existing role is kept and the next login or sync will re-apply the mapping.

--- a/locales/en/auth.json
+++ b/locales/en/auth.json
@@ -165,7 +165,9 @@
         "clientIdRequired": "Client ID is required",
         "usernameAttributeRequired": "Username claim is required",
         "samlConfigRequired": "Metadata or manual IdP fields are required",
-        "externalGroupRequired": "External group is required"
+        "externalGroupRequired": "External group is required",
+        "saveFailedTitle": "Provider could not be saved",
+        "saveFailed": "Could not save provider"
       }
     }
   },

--- a/locales/it/auth.json
+++ b/locales/it/auth.json
@@ -165,7 +165,9 @@
         "clientIdRequired": "Il Client ID è obbligatorio",
         "usernameAttributeRequired": "Il claim nome utente è obbligatorio",
         "samlConfigRequired": "Metadata o campi IdP manuali sono obbligatori",
-        "externalGroupRequired": "Il gruppo esterno è obbligatorio"
+        "externalGroupRequired": "Il gruppo esterno è obbligatorio",
+        "saveFailedTitle": "Impossibile salvare il provider",
+        "saveFailed": "Impossibile salvare il provider"
       }
     }
   },

--- a/test/components/administration/AuthSettings.test.tsx
+++ b/test/components/administration/AuthSettings.test.tsx
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import type { ComponentProps } from 'react';
-import type { LdapConfig } from '../../../types';
+import type { LdapConfig, Role, SsoProtocol, SsoProvider } from '../../../types';
 import { installI18nMock } from '../../helpers/i18n';
 import { clearSpyStateAfterAll } from '../../helpers/mockCleanup.ts';
 import { render } from '../../helpers/render';
@@ -41,15 +41,52 @@ const ldapConfig: LdapConfig = {
   autoProvisionAll: false,
 };
 
+const roles: Role[] = [
+  {
+    id: 'user',
+    name: 'User',
+    permissions: [],
+    isAdmin: false,
+    isSystem: true,
+  },
+];
+
+const buildProvider = (protocol: SsoProtocol, patch: Partial<SsoProvider> = {}): SsoProvider => ({
+  id: `${protocol}-provider`,
+  protocol,
+  enabled: false,
+  slug: `${protocol}-provider`,
+  name: `${protocol.toUpperCase()} Provider`,
+  issuerUrl: '',
+  clientId: '',
+  clientSecret: '',
+  scopes: 'openid profile email',
+  metadataUrl: '',
+  metadataXml: '',
+  entryPoint: '',
+  idpIssuer: '',
+  idpCert: '',
+  spIssuer: '',
+  privateKey: '',
+  publicCert: '',
+  usernameAttribute: protocol === 'saml' ? 'nameID' : 'preferred_username',
+  nameAttribute: 'name',
+  emailAttribute: 'email',
+  groupsAttribute: 'groups',
+  roleMappings: [],
+  ...patch,
+});
+
 const renderAuthSettings = (overrides: Partial<ComponentProps<typeof AuthSettings>> = {}) => {
+  const defaultOnSaveSsoProvider = mock(async (provider: Partial<SsoProvider>) =>
+    buildProvider(provider.protocol ?? 'oidc', provider),
+  );
   const props: ComponentProps<typeof AuthSettings> = {
     config: ldapConfig,
     onSave: mock(async () => {}),
-    roles: [],
+    roles,
     ssoProviders: [],
-    onSaveSsoProvider: mock(async () => {
-      throw new Error('not used');
-    }),
+    onSaveSsoProvider: defaultOnSaveSsoProvider,
     onDeleteSsoProvider: mock(async () => {}),
     ...overrides,
   };
@@ -62,6 +99,28 @@ const inputForLabel = (label: string): HTMLInputElement => {
   const input = screen.getByText(label).parentElement?.querySelector('input');
   if (!input) throw new Error(`Input not found for label ${label}`);
   return input;
+};
+
+const fillMinimalOidcProvider = () => {
+  fireEvent.click(screen.getByRole('button', { name: 'admin.tabs.oidc' }));
+
+  const heading = screen.getByText('admin.sso.newProvider');
+  const form = heading.closest('form') as HTMLFormElement | null;
+  if (!form) throw new Error('OIDC provider form not found');
+
+  const getInputByLabel = (labelText: string) => {
+    const label = [...form.querySelectorAll('label')].find(
+      (element) => element.textContent === labelText,
+    );
+    const input = label?.parentElement?.querySelector('input');
+    if (!input) throw new Error(`Input for "${labelText}" not found`);
+    return input;
+  };
+
+  fireEvent.change(getInputByLabel('admin.sso.name'), { target: { value: 'Broken OIDC' } });
+  fireEvent.change(getInputByLabel('admin.sso.slug'), { target: { value: 'broken-oidc' } });
+
+  return form;
 };
 
 describe('<AuthSettings />', () => {
@@ -82,5 +141,24 @@ describe('<AuthSettings />', () => {
     await waitFor(() => {
       expect(ldapApiMock.testAuthentication).toHaveBeenCalledWith('alice', 'secret');
     });
+  });
+
+  test('surfaces SSO provider save failures inline and restores the save button', async () => {
+    const onSaveSsoProvider = mock(async () => {
+      throw new Error('OIDC save failed');
+    });
+    renderAuthSettings({ onSaveSsoProvider });
+
+    const form = fillMinimalOidcProvider();
+    fireEvent.submit(form);
+
+    await waitFor(() => expect(onSaveSsoProvider).toHaveBeenCalledTimes(1));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('admin.sso.errors.saveFailedTitle');
+    expect(alert).toHaveTextContent('OIDC save failed');
+    expect(screen.queryByText('admin.ldap.changesSaved')).not.toBeInTheDocument();
+
+    expect(within(form).getByRole('button', { name: 'admin.sso.saveProvider' })).toBeEnabled();
   });
 });


### PR DESCRIPTION
## Summary
- catch failed OIDC/SAML provider saves and show the server error inline in the provider form
- add the shadcn alert primitive used by the failure state
- add a regression test plus English and Italian documentation/translation updates

## Root cause
`handleSaveProvider` only reset the loading state in `finally`; rejected saves from `onSaveSsoProvider` bubbled out without any user-visible error.

## Validation
- `bun test ./test/components/administration/AuthSettings.test.tsx`
- `bun run test:frontend`
- `bun run typecheck`
- `bun run i18n:check`
- `bun run lint`