### PR TITLE
chore(release): bump version to 0.6.3

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Praetor API",
     "description": "Praetor API documentation",
-    "version": "0.6.2"
+    "version": "0.6.3"
   },
   "components": {
     "securitySchemes": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praetor",
   "private": true,
-  "version": "0.6.2",
+  "version": "0.6.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server/app.ts
+++ b/server/app.ts
@@ -136,7 +136,7 @@ export const buildApp = async () => {
       info: {
         title: 'Praetor API',
         description: 'Praetor API documentation',
-        version: '0.6.2',
+        version: '0.6.3',
       },
       components: {
         securitySchemes: {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "praetor-server",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Praetor API Server",
   "main": "index.ts",
   "type": "module",

--- a/server/routes/mcp.ts
+++ b/server/routes/mcp.ts
@@ -236,7 +236,7 @@ const runBulkTimeEntryTool = async <T>(
 
 const buildServer = () => {
   const server = new McpServer(
-    { name: 'praetor', version: '0.6.2' },
+    { name: 'praetor', version: '0.6.3' },
     {
       instructions:
         'Use Praetor tools to inspect and update ERP data. Tool results are scoped to the authenticated MCP token user and their current Praetor role permissions.',

--- a/server/test/routes/mcp.test.ts
+++ b/server/test/routes/mcp.test.ts
@@ -357,7 +357,7 @@ describe('/api/mcp', () => {
 
     expect(res.statusCode).toBe(200);
     const body = parseMcpBody(res.body);
-    expect(body.result.serverInfo).toEqual({ name: 'praetor', version: '0.6.2' });
+    expect(body.result.serverInfo).toEqual({ name: 'praetor', version: '0.6.3' });
   });
 
   test('lists tools and calls permission-scoped list tools', async () => {


### PR DESCRIPTION
## Summary

Bumps the Praetor frontend and server package versions from `0.6.2` to `0.6.3`.

## Impact

This is a metadata-only patch version bump. Runtime behavior, API behavior, routing, and user documentation are unchanged.

## Validation

- `bun run lint`
- `bun run test`