### PR TITLE
fix(reports): coerce NULL session.title to empty string (#406)

### DIFF
--- a/server/repositories/reportsAiChatRepo.ts
+++ b/server/repositories/reportsAiChatRepo.ts
@@ -119,7 +119,8 @@ export const getActiveSessionForUser = async (
     .limit(1);
   const row = rows[0];
   if (!row) return null;
-  return { title: row.title };
+  // Defensive against legacy NULL rows even though the column is NOT NULL — callers .trim() this.
+  return { title: row.title ?? '' };
 };
 
 export const updateSessionTitleAndTouch = async (

--- a/server/test/repositories/reportsAiChatRepo.test.ts
+++ b/server/test/repositories/reportsAiChatRepo.test.ts
@@ -102,6 +102,12 @@ describe('getActiveSessionForUser', () => {
     expect(result).toEqual({ title: 'Hello' });
   });
 
+  test('coerces null title to empty string', async () => {
+    exec.enqueue({ rows: [[null]] });
+    const result = await repo.getActiveSessionForUser('s1', 'user-1', testDb);
+    expect(result).toEqual({ title: '' });
+  });
+
   test('filters on is_archived=false (bound as a param) and binds [id, userId]', async () => {
     exec.enqueue({ rows: [] });
     await repo.getActiveSessionForUser('s1', 'user-1', testDb);

--- a/server/test/routes/reports.test.ts
+++ b/server/test/routes/reports.test.ts
@@ -602,6 +602,32 @@ describe('POST /api/reports/ai-reporting/chat (non-streaming)', () => {
     expect(JSON.parse(res.body)).toEqual({ error: 'Session not found' });
   });
 
+  test('200 reuses session whose title is blank', async () => {
+    getActiveSessionForUserMock.mockResolvedValue({ id: 'rpt-chat-1', title: '' });
+    listRecentMessagesMock.mockResolvedValue([]);
+    insertUserMessageMock.mockResolvedValue(undefined);
+    insertAssistantMessageMock.mockResolvedValue(undefined);
+    updateSessionTitleAndTouchMock.mockResolvedValue(undefined);
+    getFirstUserMessageContentMock.mockResolvedValue('Tell me about revenue');
+
+    fetchMock.mockResolvedValue(
+      okFetchResponse({
+        candidates: [{ content: { parts: [{ text: 'Reply' }] } }],
+      }),
+    );
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/reports/ai-reporting/chat',
+      headers: authHeader(),
+      payload: { sessionId: 'rpt-chat-1', message: 'Hi' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(getFirstUserMessageContentMock).toHaveBeenCalledWith('rpt-chat-1');
+    expect(updateSessionTitleAndTouchMock).toHaveBeenCalled();
+  });
+
   test('400 when message is missing', async () => {
     const res = await testApp.inject({
       method: 'POST',


### PR DESCRIPTION
## Summary
- **Bug**: AI Reporting chat routes (`POST /api/reports/ai-reporting/chat` and `…/chat/stream`) call `session.title.trim()` without a guard. Although `report_chat_sessions.title` is `NOT NULL DEFAULT 'AI Reporting'`, a stray `NULL` row (legacy data, manual SQL) produces `TypeError: Cannot read properties of null (reading "trim")` → HTTP 500, leaving the session unrecoverable.
- **Fix**: One-line null coalesce at the repository boundary in `getActiveSessionForUser`, so the `{ title: string }` contract is honest at runtime and every current/future caller is safe — no route changes needed.
- **Tests**: Added a repo regression test (NULL row → `{ title: '' }`) and a route-level test exercising the chat flow when the title is blank (proves the auto-title branch runs and no 500 occurs).

Fixes #406.

## Why fix at the repo, not at each call site
The two known crash sites (`server/routes/reports.ts:1632` and `:2075`) both call `.trim()` immediately on the title. Coercing once at the repo:
- protects future call sites that might also assume a string;
- aligns with the established `?? ''` row-mapper convention used across other repos (`ssoProvidersRepo`, `usersRepo`, `notificationsRepo`, `clientQuotesRepo`, etc.);
- leaves the route handlers unchanged.

A blank/`''` title flows through the existing `shouldAutoTitle` check (`['AI Reporting', ''].includes(session.title.trim())`) and triggers a fresh auto-title on the next message — recovering the session organically.

## Test plan
- [x] `cd server && bun test test/repositories/reportsAiChatRepo.test.ts test/routes/reports.test.ts` — 88 pass / 0 fail
- [x] `bun run lint` — no new findings on the touched files
- [ ] Optional manual: `UPDATE report_chat_sessions SET title = NULL WHERE id = '<some-id>';` then send a message via the AI Reporting UI; request should succeed (200) and the title should be auto-generated from the new message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)