### PR TITLE
fix(db): resume skipped drizzle migrations

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -71,6 +71,12 @@ docker compose --env-file .env -f deploy/docker-compose.customer.yml pull
 docker compose --env-file .env -f deploy/docker-compose.customer.yml up -d
 ```
 
+The backend applies pending database migrations before serving requests. The migration runner
+uses the hashes recorded in `drizzle.__drizzle_migrations` to find missing journal entries, so
+re-running the same `up -d` command is safe when a deployment is interrupted after only part of
+the migration journal was applied. If startup still fails, inspect the backend logs before
+rolling back; the service exits rather than serving against a partially upgraded schema.
+
 ## Rollback
 
 Set `PRAETOR_VERSION` back to the previous tag and run the same pull/up commands.

--- a/docs-site/src/content/docs/en/faq.md
+++ b/docs-site/src/content/docs/en/faq.md
@@ -21,6 +21,10 @@ Review discounts, discount type, units, quantities, and unit price. If the docum
 
 Sign in again. Sessions expire to protect data when the application is left idle.
 
+## An upgrade stops during migrations
+
+The backend applies database migrations before accepting traffic. If a deployment is interrupted halfway through, run the same upgrade command again: recorded migrations are skipped and missing entries are detected by hash. If startup still fails, inspect backend logs before rolling back.
+
 ## Is technical documentation still available?
 
 Yes. API documentation remains available at `/docs/api` and frontend documentation remains available at `/docs/frontend`.

--- a/docs-site/src/content/docs/faq.md
+++ b/docs-site/src/content/docs/faq.md
@@ -21,6 +21,10 @@ Rivedi sconti, tipo di sconto, unità di misura, quantità e prezzo unitario. Se
 
 Effettua di nuovo l'accesso. Le sessioni scadono per proteggere i dati quando l'applicazione resta inattiva.
 
+## Un aggiornamento si ferma durante le migrazioni
+
+Il backend applica le migrazioni del database prima di accettare traffico. Se un deploy viene interrotto a metà, rilancia lo stesso comando di upgrade: le migrazioni già registrate vengono saltate e quelle mancanti vengono riconosciute tramite hash. Se l'avvio continua a fallire, controlla i log del backend prima di fare rollback.
+
 ## La documentazione tecnica è ancora disponibile?
 
 Sì. La documentazione API resta su `/docs/api` e la documentazione frontend resta su `/docs/frontend`.

--- a/server/db/README.md
+++ b/server/db/README.md
@@ -68,6 +68,13 @@ Once Drizzle's migration ledger exists, startup skips `schema.sql` entirely and
 only applies pending Drizzle migrations. Migration failures are fatal: the
 backend exits instead of starting against a partially upgraded schema.
 
+The runtime runner reads Drizzle's `meta/_journal.json` and SQL files, then
+compares each migration's SQL hash against the hashes already recorded in
+`drizzle.__drizzle_migrations`. This is deliberately stricter than relying on
+the latest `created_at` value alone: if journal timestamps are ever out of
+order, incremental upgrades still apply every missing migration instead of
+skipping lower-timestamp entries.
+
 For a non-Compose local DB, apply migrations manually:
 
 ```bash
@@ -75,7 +82,9 @@ cd server
 bun run db:migrate
 ```
 
-Idempotent: re-running is a no-op if everything's applied. The runner is `db/migrationsRunner.ts` (calling `drizzle-orm/node-postgres/migrator` directly), not `drizzle-kit migrate` — see "Why not `drizzle-kit migrate`" below.
+Idempotent: re-running is a no-op if everything's applied. The runner is
+`db/migrationsRunner.ts`, not `drizzle-kit migrate` — see "Why not
+`drizzle-kit migrate`" below.
 
 ## Local DB setup
 
@@ -111,7 +120,11 @@ From `server/`:
 
 drizzle-kit 0.31's `migrate` CLI wraps the migrator in a hanji `renderWithTask` spinner that swallows error output in non-TTY environments (CI, deploy hooks, anything where stdout isn't a real terminal). When migrations fail, the CLI exits 1 with no error message — the actual exception never reaches stderr because the spinner consumes the rejected promise.
 
-We invoke `drizzle-orm/node-postgres/migrator` directly via `db/migrationsRunner.ts` instead. The migration files, journal, snapshot, and `__drizzle_migrations` tracking table all behave identically — only the framing differs. Errors propagate as normal Node exceptions.
+We invoke the same Drizzle migration file reader through `db/migrationsRunner.ts`
+instead. The migration files, journal, snapshot, and `__drizzle_migrations`
+tracking table stay compatible with Drizzle, while pending detection is based on
+recorded SQL hashes so timestamp-skipped upgrades can self-heal. Errors
+propagate as normal Node exceptions.
 
 `drizzle-kit generate`, `db:check`, and `db:studio` continue to use the drizzle-kit CLI because their failure modes are observable from interactive use.
 

--- a/server/db/migrationsRunner.ts
+++ b/server/db/migrationsRunner.ts
@@ -1,7 +1,6 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { drizzle } from 'drizzle-orm/node-postgres';
-import { migrate } from 'drizzle-orm/node-postgres/migrator';
+import { type MigrationMeta, readMigrationFiles } from 'drizzle-orm/migrator';
 import pg, { type PoolClient } from 'pg';
 import { createChildLogger, serializeError } from '../utils/logger.ts';
 import { createDbPoolConfig, getDbConnectionLabel } from './config.ts';
@@ -15,8 +14,94 @@ const MIGRATION_LOCK_SQL = 'SELECT pg_try_advisory_lock(hashtextextended($1, 0::
 const MIGRATION_UNLOCK_SQL = 'SELECT pg_advisory_unlock(hashtextextended($1, 0::bigint))';
 const MIGRATION_LOCK_RETRY_MS = 1_000;
 const MIGRATION_LOCK_MAX_ATTEMPTS = 60;
+const DRIZZLE_MIGRATIONS_SCHEMA = 'drizzle';
+const DRIZZLE_MIGRATIONS_TABLE = '__drizzle_migrations';
+const CREATE_MIGRATIONS_SCHEMA_SQL = `CREATE SCHEMA IF NOT EXISTS "${DRIZZLE_MIGRATIONS_SCHEMA}"`;
+const CREATE_MIGRATIONS_TABLE_SQL = `
+  CREATE TABLE IF NOT EXISTS "${DRIZZLE_MIGRATIONS_SCHEMA}"."${DRIZZLE_MIGRATIONS_TABLE}" (
+    id SERIAL PRIMARY KEY,
+    hash text NOT NULL,
+    created_at bigint
+  )
+`;
+const SELECT_APPLIED_MIGRATION_HASHES_SQL = `
+  SELECT hash
+  FROM "${DRIZZLE_MIGRATIONS_SCHEMA}"."${DRIZZLE_MIGRATIONS_TABLE}"
+  ORDER BY id ASC
+`;
+const INSERT_APPLIED_MIGRATION_SQL = `
+  INSERT INTO "${DRIZZLE_MIGRATIONS_SCHEMA}"."${DRIZZLE_MIGRATIONS_TABLE}" ("hash", "created_at")
+  VALUES ($1, $2)
+`;
 
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+type AppliedMigrationHashRow = {
+  hash: string;
+};
+
+type RunDrizzleMigrationsOptions = {
+  migrationsDir?: string;
+};
+
+const countHashes = (hashes: Iterable<string>): Map<string, number> => {
+  const counts = new Map<string, number>();
+
+  for (const hash of hashes) {
+    counts.set(hash, (counts.get(hash) ?? 0) + 1);
+  }
+
+  return counts;
+};
+
+const validateAppliedMigrationHashes = (
+  migrations: readonly MigrationMeta[],
+  appliedHashCounts: ReadonlyMap<string, number>,
+) => {
+  const expectedHashCounts = countHashes(migrations.map((migration) => migration.hash));
+
+  for (const [hash, appliedCount] of appliedHashCounts) {
+    const expectedCount = expectedHashCounts.get(hash) ?? 0;
+    if (appliedCount <= expectedCount) continue;
+
+    throw new Error(
+      [
+        'Drizzle migration ledger contains applied migration hashes that do not match the current migration files.',
+        `Hash ${hash.slice(0, 12)} is present ${appliedCount} time(s) in the database ledger but ${expectedCount} time(s) in the migration journal.`,
+        'This usually means an already-applied migration file was edited; refusing to infer pending migrations automatically.',
+      ].join(' '),
+    );
+  }
+};
+
+const getPendingMigrations = (
+  migrations: readonly MigrationMeta[],
+  appliedHashCounts: ReadonlyMap<string, number>,
+): MigrationMeta[] => {
+  const remainingAppliedHashCounts = new Map(appliedHashCounts);
+  const pendingMigrations: MigrationMeta[] = [];
+
+  for (const migration of migrations) {
+    const remainingAppliedCount = remainingAppliedHashCounts.get(migration.hash) ?? 0;
+
+    if (remainingAppliedCount > 0) {
+      remainingAppliedHashCounts.set(migration.hash, remainingAppliedCount - 1);
+      continue;
+    }
+
+    pendingMigrations.push(migration);
+  }
+
+  return pendingMigrations;
+};
+
+const hasOutOfOrderMigrationTimestamps = (migrations: readonly MigrationMeta[]): boolean =>
+  migrations.some((migration, index) => {
+    const previousMigration = migrations[index - 1];
+    return (
+      previousMigration !== undefined && migration.folderMillis <= previousMigration.folderMillis
+    );
+  });
 
 const acquireMigrationLock = async (client: PoolClient): Promise<void> => {
   for (let attempt = 1; attempt <= MIGRATION_LOCK_MAX_ATTEMPTS; attempt += 1) {
@@ -47,9 +132,65 @@ const acquireMigrationLock = async (client: PoolClient): Promise<void> => {
   }
 };
 
-export const runDrizzleMigrationsWithClient = async (client: PoolClient): Promise<void> => {
-  const db = drizzle(client);
-  await migrate(db, { migrationsFolder });
+export const runDrizzleMigrationsWithClient = async (
+  client: PoolClient,
+  options: RunDrizzleMigrationsOptions = {},
+): Promise<void> => {
+  const migrationsDir = options.migrationsDir ?? migrationsFolder;
+  const migrations = readMigrationFiles({ migrationsFolder: migrationsDir });
+
+  await client.query(CREATE_MIGRATIONS_SCHEMA_SQL);
+  await client.query(CREATE_MIGRATIONS_TABLE_SQL);
+
+  const appliedMigrationRows = await client.query<AppliedMigrationHashRow>(
+    SELECT_APPLIED_MIGRATION_HASHES_SQL,
+  );
+  const appliedHashCounts = countHashes(appliedMigrationRows.rows.map((row) => row.hash));
+
+  validateAppliedMigrationHashes(migrations, appliedHashCounts);
+
+  const pendingMigrations = getPendingMigrations(migrations, appliedHashCounts);
+  if (pendingMigrations.length === 0) {
+    return;
+  }
+
+  if (hasOutOfOrderMigrationTimestamps(migrations)) {
+    logger.warn(
+      {
+        migrationsDir,
+        pendingMigrationCount: pendingMigrations.length,
+      },
+      'Drizzle migration journal timestamps are not monotonic; applying pending migrations by hash',
+    );
+  }
+
+  await client.query('BEGIN');
+  try {
+    for (const migration of pendingMigrations) {
+      for (const statement of migration.sql) {
+        if (statement.trim().length === 0) continue;
+        await client.query(statement);
+      }
+
+      await client.query(INSERT_APPLIED_MIGRATION_SQL, [
+        migration.hash,
+        String(migration.folderMillis),
+      ]);
+    }
+
+    await client.query('COMMIT');
+  } catch (err) {
+    try {
+      await client.query('ROLLBACK');
+    } catch (rollbackErr) {
+      logger.warn(
+        { err: serializeError(rollbackErr) },
+        'Failed to roll back Drizzle migration transaction',
+      );
+    }
+
+    throw err;
+  }
 };
 
 export const withMigrationLock = async <T>(

--- a/server/scripts/run-migrations.ts
+++ b/server/scripts/run-migrations.ts
@@ -8,10 +8,11 @@
 // stderr is left empty when migrations fail. This blocks CI diagnosis and
 // breaks any deploy script that relies on stderr to surface failures.
 //
-// drizzle-orm's `migrate` function reads the same `db/migrations/` directory
-// and `meta/_journal.json` as drizzle-kit, applies migrations in the same
+// The runtime runner reads the same `db/migrations/` directory and
+// `meta/_journal.json` as drizzle-kit, applies missing migrations in journal
 // order, and records them in the same `__drizzle_migrations` tracking table.
-// The behaviour is identical; only the framing differs.
+// Pending detection is hash-based so out-of-order journal timestamps do not
+// skip lower-timestamp migrations during incremental upgrades.
 
 import 'dotenv/config';
 import { runDrizzleMigrations } from '../db/migrationsRunner.ts';

--- a/server/test/db/migrationsRunner.test.ts
+++ b/server/test/db/migrationsRunner.test.ts
@@ -64,7 +64,10 @@ const removeMigrationsDir = (dir: string) => {
   rmSync(dir, { recursive: true, force: true });
 };
 
-const makeClient = (appliedHashes: readonly string[] = []): FakeClient => {
+const makeClient = (
+  appliedHashes: readonly string[] = [],
+  options: { failOnSql?: string } = {},
+): FakeClient => {
   const calls: QueryCall[] = [];
 
   return {
@@ -74,6 +77,10 @@ const makeClient = (appliedHashes: readonly string[] = []): FakeClient => {
       params: unknown[] = [],
     ): Promise<QueryResult<T>> {
       calls.push({ text, params });
+
+      if (options.failOnSql !== undefined && text === options.failOnSql) {
+        throw new Error(`query failed: ${text}`);
+      }
 
       if (text.includes('SELECT hash') && text.includes('__drizzle_migrations')) {
         return makeQueryResult(appliedHashes.map((hash) => ({ hash }) as unknown as T));
@@ -133,6 +140,30 @@ describe('runDrizzleMigrationsWithClient', () => {
       expect(client.calls.some((call) => call.text === 'BEGIN')).toBe(false);
       expect(client.calls.some((call) => call.text === firstSql)).toBe(false);
       expect(client.calls.some((call) => call.text === secondSql)).toBe(false);
+    } finally {
+      removeMigrationsDir(dir);
+    }
+  });
+
+  test('rolls back when a pending migration statement fails', async () => {
+    const failingSql = 'SELECT fail;';
+    const dir = makeMigrationsDir([{ tag: '0000_failing', when: 1_000, sql: failingSql }]);
+    const client = makeClient([], { failOnSql: failingSql });
+
+    try {
+      await expect(
+        runDrizzleMigrationsWithClient(client as unknown as PoolClient, {
+          migrationsDir: dir,
+        }),
+      ).rejects.toThrow(`query failed: ${failingSql}`);
+
+      expect(client.calls.some((call) => call.text === 'BEGIN')).toBe(true);
+      expect(client.calls.some((call) => call.text === 'ROLLBACK')).toBe(true);
+      expect(
+        client.calls.some((call) =>
+          call.text.includes('INSERT INTO "drizzle"."__drizzle_migrations"'),
+        ),
+      ).toBe(false);
     } finally {
       removeMigrationsDir(dir);
     }

--- a/server/test/db/migrationsRunner.test.ts
+++ b/server/test/db/migrationsRunner.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, test } from 'bun:test';
+import { createHash } from 'node:crypto';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { PoolClient, QueryResult, QueryResultRow } from 'pg';
+import { runDrizzleMigrationsWithClient } from '../../db/migrationsRunner.ts';
+
+type TestMigration = {
+  tag: string;
+  when: number;
+  sql: string;
+};
+
+type QueryCall = {
+  text: string;
+  params: unknown[];
+};
+
+type FakeClient = {
+  calls: QueryCall[];
+  query: <T extends QueryResultRow = QueryResultRow>(
+    text: string,
+    params?: unknown[],
+  ) => Promise<QueryResult<T>>;
+};
+
+const makeQueryResult = <T extends QueryResultRow>(rows: T[]): QueryResult<T> => ({
+  rows,
+  rowCount: rows.length,
+  command: '',
+  oid: 0,
+  fields: [],
+});
+
+const hashSql = (sql: string): string => createHash('sha256').update(sql).digest('hex');
+
+const makeMigrationsDir = (migrations: readonly TestMigration[]): string => {
+  const dir = mkdtempSync(join(tmpdir(), 'praetor-migrations-'));
+  mkdirSync(join(dir, 'meta'));
+
+  const journal = {
+    version: '7',
+    dialect: 'postgresql',
+    entries: migrations.map((migration, idx) => ({
+      idx,
+      version: '7',
+      when: migration.when,
+      tag: migration.tag,
+      breakpoints: true,
+    })),
+  };
+
+  writeFileSync(join(dir, 'meta', '_journal.json'), JSON.stringify(journal, null, 2));
+
+  for (const migration of migrations) {
+    writeFileSync(join(dir, `${migration.tag}.sql`), migration.sql);
+  }
+
+  return dir;
+};
+
+const removeMigrationsDir = (dir: string) => {
+  rmSync(dir, { recursive: true, force: true });
+};
+
+const makeClient = (appliedHashes: readonly string[] = []): FakeClient => {
+  const calls: QueryCall[] = [];
+
+  return {
+    calls,
+    async query<T extends QueryResultRow = QueryResultRow>(
+      text: string,
+      params: unknown[] = [],
+    ): Promise<QueryResult<T>> {
+      calls.push({ text, params });
+
+      if (text.includes('SELECT hash') && text.includes('__drizzle_migrations')) {
+        return makeQueryResult(appliedHashes.map((hash) => ({ hash }) as unknown as T));
+      }
+
+      return makeQueryResult<T>([]);
+    },
+  };
+};
+
+describe('runDrizzleMigrationsWithClient', () => {
+  test('applies a missing migration even when its journal timestamp is older than the latest ledger row', async () => {
+    const firstSql = 'SELECT 1 AS first;';
+    const secondSql = 'SELECT 2 AS second;';
+    const secondWhen = 1_000;
+    const dir = makeMigrationsDir([
+      { tag: '0000_first', when: 2_000, sql: firstSql },
+      { tag: '0001_second', when: secondWhen, sql: secondSql },
+    ]);
+    const firstHash = hashSql(firstSql);
+    const secondHash = hashSql(secondSql);
+    const client = makeClient([firstHash]);
+
+    try {
+      await runDrizzleMigrationsWithClient(client as unknown as PoolClient, {
+        migrationsDir: dir,
+      });
+
+      expect(client.calls.some((call) => call.text === firstSql)).toBe(false);
+      expect(client.calls.some((call) => call.text === secondSql)).toBe(true);
+      expect(client.calls.some((call) => call.text === 'BEGIN')).toBe(true);
+      expect(client.calls.some((call) => call.text === 'COMMIT')).toBe(true);
+
+      const insertCall = client.calls.find((call) =>
+        call.text.includes('INSERT INTO "drizzle"."__drizzle_migrations"'),
+      );
+      expect(insertCall?.params).toEqual([secondHash, String(secondWhen)]);
+    } finally {
+      removeMigrationsDir(dir);
+    }
+  });
+
+  test('does not open a transaction when every migration hash is already recorded', async () => {
+    const firstSql = 'SELECT 1 AS first;';
+    const secondSql = 'SELECT 2 AS second;';
+    const dir = makeMigrationsDir([
+      { tag: '0000_first', when: 1_000, sql: firstSql },
+      { tag: '0001_second', when: 2_000, sql: secondSql },
+    ]);
+    const client = makeClient([hashSql(firstSql), hashSql(secondSql)]);
+
+    try {
+      await runDrizzleMigrationsWithClient(client as unknown as PoolClient, {
+        migrationsDir: dir,
+      });
+
+      expect(client.calls.some((call) => call.text === 'BEGIN')).toBe(false);
+      expect(client.calls.some((call) => call.text === firstSql)).toBe(false);
+      expect(client.calls.some((call) => call.text === secondSql)).toBe(false);
+    } finally {
+      removeMigrationsDir(dir);
+    }
+  });
+
+  test('refuses to run when the ledger contains a hash that is not in the current journal', async () => {
+    const dir = makeMigrationsDir([{ tag: '0000_first', when: 1_000, sql: 'SELECT 1;' }]);
+    const client = makeClient(['not-a-current-migration-hash']);
+
+    try {
+      await expect(
+        runDrizzleMigrationsWithClient(client as unknown as PoolClient, {
+          migrationsDir: dir,
+        }),
+      ).rejects.toThrow('applied migration hashes that do not match the current migration files');
+
+      expect(client.calls.some((call) => call.text === 'BEGIN')).toBe(false);
+    } finally {
+      removeMigrationsDir(dir);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes backend startup migration handling so interrupted or timestamp-skewed Drizzle upgrades can resume missing migrations instead of leaving the service in a crash loop.
- Documents the safer retry behavior for customer deploys and troubleshooting docs.

## Changes
- Switches runtime pending-migration detection from latest `created_at` to SQL hashes recorded in `drizzle.__drizzle_migrations`.
- Applies missing migrations in journal order inside a transaction and fails loudly if the ledger contains unknown hashes.
- Adds regression coverage for a missing migration with an older journal timestamp than the latest applied row.
- Updates deployment, DB migration, and FAQ docs in Italian and English.

## Testing
- `cd server && bun test ./test`
- `cd server && bun run build`
- `bunx --bun biome check server/db/migrationsRunner.ts server/test/db/migrationsRunner.test.ts server/scripts/run-migrations.ts`
- `git diff --check`

## Risks / Rollout
- Migration startup path change; rollback should be handled carefully if a newer app version has already applied schema migrations.
- The runner remains compatible with Drizzle's migration table and journal files, but now refuses ledgers containing hashes not present in the current migration journal.

## Issues
Issue: Not linked