### PR TITLE
fix(projects): preserve project.revenue on edit (#404)

### DIFF
--- a/components/projects/ProjectsView.tsx
+++ b/components/projects/ProjectsView.tsx
@@ -876,7 +876,7 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
     manual: t('projects:projects.revenueManualHint'),
   };
   const displayedRevenue = revenueBySource[revenueSource];
-  const persistedRevenue = revenueSource === 'manual' && revenue ? parseFloat(revenue) : null;
+  const persistedRevenue = revenueSource === 'manual' && revenue ? parseFloat(revenue) : undefined;
 
   const managingProject = projects.find((p) => p.id === managingProjectId);
   const assignableUsers = users.filter(

--- a/test/components/projects/ProjectsView.test.ts
+++ b/test/components/projects/ProjectsView.test.ts
@@ -89,7 +89,7 @@ describe('ProjectsView lifecycle fields (issue #322)', () => {
     expect(source).toContain("readOnly={revenueSource !== 'manual'}");
     // Submit reuses the render-scope `persistedRevenue` (no duplicate computation)
     expect(source).toContain(
-      "const persistedRevenue = revenueSource === 'manual' && revenue ? parseFloat(revenue) : null;",
+      "const persistedRevenue = revenueSource === 'manual' && revenue ? parseFloat(revenue) : undefined;",
     );
   });
 


### PR DESCRIPTION
## Summary

Fixes [#404](https://github.com/xBounceIT/praetor/issues/404). Editing any field on a project whose revenue is derived from task activities or a linked order silently wiped `project.revenue` in the database.

## Root cause

[components/projects/ProjectsView.tsx:879](components/projects/ProjectsView.tsx) computed `persistedRevenue = null` whenever `revenueSource` was `'activities'` or `'order'`. That `null` rode along on the PUT payload. `JSON.stringify` preserves `null`, the server's `Object.hasOwn(body, 'revenue')` parser at [server/routes/projects.ts:482-486](server/routes/projects.ts) sees the field as provided, and [server/repositories/projectsRepo.ts:306-308](server/repositories/projectsRepo.ts) sets `revenue = NULL`.

The server side already distinguishes "field absent" from "field set to null" — the client just needed to honor that contract.

## Fix

One-character change: `: null` → `: undefined`. `JSON.stringify` drops `undefined` keys, so the server sees the field as absent and leaves the column untouched.

- Update path (the bug): existing `project.revenue` is preserved.
- Create path: unchanged — the route already coerces an absent `revenue` to `null` on insert, matching the prior `null` literal.
- Manual-mode revenue: unchanged on both paths.

## Test

Updated the source-string regression in [test/components/projects/ProjectsView.test.ts:92](test/components/projects/ProjectsView.test.ts) to assert the new expression. Verified by reverting the fix locally — the test fails on the old code and passes on the new code.

I also drafted a behavioral test that submits the edit modal and asserts `updates.revenue === undefined`, but a cross-file `mock.module` cache leak from [test/components/crm/ClientsView.test.tsx](test/components/crm/ClientsView.test.tsx) (which installs a partial `services/api` barrel mock that omits `projectsApi`) pre-loads the barrel before any later test's mock can apply. The behavioral test was infeasible without restructuring `services/api` imports across the suite, which is out of scope.

## Test plan

- [x] `bun run test:frontend` → 1025 pass / 0 fail
- [x] `bun run test:server` → 2437 pass / 28 skip / 0 fail
- [x] Manually reverted the fix and re-ran the updated test — confirms it fails on the old code and passes on the new code
- [ ] Reviewer: edit a project that has tasks with revenue, change a non-revenue field, save, and confirm `SELECT revenue FROM projects WHERE id = ...` is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)