### PR TITLE
fix(timesheet): render duplicate TimeEntries in separate weekly rows

### DIFF
--- a/components/timesheet/WeeklyView.tsx
+++ b/components/timesheet/WeeklyView.tsx
@@ -83,6 +83,7 @@ type EntryRow = {
 };
 
 const FORM_ROW_KEY = '__form_row__';
+const EMPTY_DAY_MAP: DayMap = {};
 
 const parseDuration = (raw: string): number => {
   if (!raw) return 0;
@@ -196,91 +197,89 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
     setPendingEdits({});
   }, [currentWeekStart]);
 
-  // Entries matching the form selection in the current week — used to pre-fill
-  // the "Nuova voce" row so an existing combo isn't double-rendered.
-  const formRowBaseDays = useMemo<DayMap>(() => {
-    if (!selection.clientId || !selection.projectId || !selection.taskName) return {};
-    const days: DayMap = {};
-    for (const entry of userEntries) {
-      if (entry.clientId !== selection.clientId) continue;
-      if (entry.projectId !== selection.projectId) continue;
-      if (entry.task !== selection.taskName) continue;
-      if (!weekDates.includes(entry.date)) continue;
-      days[entry.date] = {
-        duration: String(entry.duration),
-        note: entry.notes ?? '',
-        entryId: entry.id,
-      };
-    }
-    return days;
-  }, [userEntries, weekDates, selection.clientId, selection.projectId, selection.taskName]);
-
-  // Rows for previously-logged combos. Includes every distinct (client,
-  // project, task) the viewing user has used and is still in scope. Combos
-  // with entries in the current week sort first; the rest fall back to most-
-  // recent `createdAt`. The combo matching the form selection is dropped so
-  // the "Nuova voce" row at the top isn't duplicated.
+  // One row per TimeEntry in the current week (keyed by entry.id) so duplicates
+  // sharing (client, project, task, date) stay visible and independently
+  // editable. Combos with no in-week entries get an empty quick-log row keyed
+  // by `combo:…`, capped at 5; the active form-selection combo is filtered out
+  // so the "Nuova voce" row at the top isn't shadowed by an empty duplicate.
   const entryRows: EntryRow[] = useMemo(() => {
-    const groups = new Map<
-      string,
-      { row: EntryRow; maxCreatedAt: number; hasWeekEntry: boolean }
-    >();
     const clientById = new Map(clients.map((c) => [c.id, c]));
     const projectById = new Map(projects.map((p) => [p.id, p]));
     const taskKey = (projectId: string, name: string) => `${projectId}|${name}`;
     const taskSet = new Set(projectTasks.map((task) => taskKey(task.projectId, task.name)));
+    const comboKey = (cid: string, pid: string, task: string) => `${cid}|${pid}|${task}`;
 
-    for (const entry of userEntries) {
-      if (!clientById.has(entry.clientId)) continue;
-      if (!projectById.has(entry.projectId)) continue;
-      if (!taskSet.has(taskKey(entry.projectId, entry.task))) continue;
+    const scopedEntries = userEntries.filter(
+      (entry) =>
+        clientById.has(entry.clientId) &&
+        projectById.has(entry.projectId) &&
+        taskSet.has(taskKey(entry.projectId, entry.task)),
+    );
 
-      const key = `${entry.clientId}|${entry.projectId}|${entry.task}`;
-      let group = groups.get(key);
+    const scopedInWeek = scopedEntries
+      .filter((entry) => weekDates.includes(entry.date))
+      .sort((a, b) => {
+        if (a.date !== b.date) return a.date < b.date ? -1 : 1;
+        if (a.createdAt !== b.createdAt) return a.createdAt - b.createdAt;
+        return a.id < b.id ? -1 : 1;
+      });
+
+    const phase1: EntryRow[] = scopedInWeek.map((entry) => ({
+      key: entry.id,
+      clientId: entry.clientId,
+      clientName: clientById.get(entry.clientId)?.name ?? '',
+      projectId: entry.projectId,
+      projectName: projectById.get(entry.projectId)?.name ?? '',
+      taskName: entry.task,
+      location: entry.location ?? defaultLocation,
+      baseDays: {
+        [entry.date]: {
+          duration: String(entry.duration),
+          note: entry.notes ?? '',
+          entryId: entry.id,
+        },
+      },
+    }));
+
+    const inWeekCombos = new Set(
+      scopedInWeek.map((e) => comboKey(e.clientId, e.projectId, e.task)),
+    );
+
+    const comboGroups = new Map<string, { row: EntryRow; maxCreatedAt: number }>();
+    for (const entry of scopedEntries) {
+      const key = comboKey(entry.clientId, entry.projectId, entry.task);
+      if (inWeekCombos.has(key)) continue;
+      const group = comboGroups.get(key);
       if (!group) {
-        const client = clientById.get(entry.clientId);
-        const project = projectById.get(entry.projectId);
-        group = {
+        comboGroups.set(key, {
           row: {
-            key,
+            key: `combo:${key}`,
             clientId: entry.clientId,
-            clientName: client?.name ?? '',
+            clientName: clientById.get(entry.clientId)?.name ?? '',
             projectId: entry.projectId,
-            projectName: project?.name ?? '',
+            projectName: projectById.get(entry.projectId)?.name ?? '',
             taskName: entry.task,
             location: entry.location ?? defaultLocation,
             baseDays: {},
           },
           maxCreatedAt: entry.createdAt,
-          hasWeekEntry: false,
-        };
-        groups.set(key, group);
-      }
-      if (entry.createdAt > group.maxCreatedAt) group.maxCreatedAt = entry.createdAt;
-      if (weekDates.includes(entry.date)) {
-        group.hasWeekEntry = true;
-        group.row.baseDays[entry.date] = {
-          duration: String(entry.duration),
-          note: entry.notes ?? '',
-          entryId: entry.id,
-        };
-        if (entry.location) group.row.location = entry.location;
+        });
+      } else if (entry.createdAt > group.maxCreatedAt) {
+        group.maxCreatedAt = entry.createdAt;
+        group.row.location = entry.location ?? group.row.location;
       }
     }
 
-    const formKey =
-      selection.clientId && selection.projectId && selection.taskName
-        ? `${selection.clientId}|${selection.projectId}|${selection.taskName}`
-        : '';
-    if (formKey) groups.delete(formKey);
+    if (selection.clientId && selection.projectId && selection.taskName) {
+      comboGroups.delete(comboKey(selection.clientId, selection.projectId, selection.taskName));
+    }
 
-    return Array.from(groups.values())
-      .sort((a, b) => {
-        if (a.hasWeekEntry !== b.hasWeekEntry) return a.hasWeekEntry ? -1 : 1;
-        return b.maxCreatedAt - a.maxCreatedAt;
-      })
+    const phase2 = Array.from(comboGroups.values())
+      .sort((a, b) => b.maxCreatedAt - a.maxCreatedAt)
       .slice(0, 5)
       .map((g) => g.row);
+
+    return [...phase1, ...phase2];
   }, [
     userEntries,
     weekDates,
@@ -383,9 +382,6 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
     const newErrors: WeeklyEntryFormErrors = {};
     const formEdits = pendingEdits[FORM_ROW_KEY] ?? {};
     const hasFormHours = Object.values(formEdits).some((cell) => parseDuration(cell.duration) > 0);
-    const hasFormChanges = Object.entries(formEdits).some(
-      ([dateStr, cell]) => classifyEdit(formRowBaseDays[dateStr], cell) !== 'noop',
-    );
 
     if (hasFormHours) {
       if (!selection.clientId) newErrors.clientId = t('common:validation.clientRequired');
@@ -463,13 +459,13 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
       }
     };
 
-    if (hasFormChanges) {
+    if (hasFormHours) {
       submitRow(FORM_ROW_KEY, {
         clientId: selection.clientId,
         projectId: selection.projectId,
         taskName: selection.taskName,
         location: selection.location,
-        baseDays: formRowBaseDays,
+        baseDays: EMPTY_DAY_MAP,
       });
     }
 
@@ -512,12 +508,7 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
     for (const day of weekDays) {
       let sum = 0;
       const formEdit = pendingEdits[FORM_ROW_KEY]?.[day.dateStr];
-      if (formEdit) {
-        sum += parseDuration(formEdit.duration);
-      } else {
-        const formBase = formRowBaseDays[day.dateStr];
-        if (formBase) sum += parseDuration(formBase.duration);
-      }
+      if (formEdit) sum += parseDuration(formEdit.duration);
       for (const row of entryRows) {
         const edit = pendingEdits[row.key]?.[day.dateStr];
         if (edit) {
@@ -530,7 +521,7 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
       totals[day.dateStr] = sum;
     }
     return totals;
-  }, [weekDays, entryRows, pendingEdits, formRowBaseDays]);
+  }, [weekDays, entryRows, pendingEdits]);
 
   const weekTotal = useMemo(() => Object.values(dayTotals).reduce((a, b) => a + b, 0), [dayTotals]);
 
@@ -584,9 +575,9 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
         ([dateStr, edit]) => classifyEdit(baseDays[dateStr], edit) !== 'noop',
       );
     };
-    if (rowHasChange(FORM_ROW_KEY, formRowBaseDays)) return true;
+    if (rowHasChange(FORM_ROW_KEY, EMPTY_DAY_MAP)) return true;
     return entryRows.some((row) => rowHasChange(row.key, row.baseDays));
-  }, [pendingEdits, formRowBaseDays, entryRows]);
+  }, [pendingEdits, entryRows]);
   const weeklyGoal = dailyGoal * 5;
 
   const handleExportToCsv = () => {
@@ -605,7 +596,7 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
       [clientName, projectName, taskName].filter(Boolean).join(' · ');
 
     const formRowValues = visibleWeekDays.map((day) => {
-      const cell = getCellValue(FORM_ROW_KEY, day.dateStr, formRowBaseDays);
+      const cell = getCellValue(FORM_ROW_KEY, day.dateStr);
       return formatHours(parseDuration(cell.duration));
     });
     const formRowTotal = sumDayValues(formRowValues);
@@ -820,7 +811,7 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
                       day.isWeekendOrHoliday && 'bg-destructive/5',
                     )}
                   >
-                    {renderDayCellInputs(FORM_ROW_KEY, day, formRowBaseDays)}
+                    {renderDayCellInputs(FORM_ROW_KEY, day, EMPTY_DAY_MAP)}
                   </TableCell>
                 ))}
               </TableRow>

--- a/docs-site/src/content/docs/en/time-tracking.md
+++ b/docs-site/src/content/docs/en/time-tracking.md
@@ -15,6 +15,8 @@ Before saving, verify that dates are correct and that the task belongs to the se
 
 The weekly view helps you quickly review hours across days. Use it to find missing days, duplicates, or entries assigned to the wrong project.
 
+Each existing entry occupies its own row, so duplicates on the same client/project/task pair stay visible and can be edited independently. The "New entry" row at the top is for creating new entries only.
+
 ## Recurring tasks
 
 Recurring tasks generate repeated entries, such as weekly meetings or periodic administrative work.

--- a/docs-site/src/content/docs/time-tracking.md
+++ b/docs-site/src/content/docs/time-tracking.md
@@ -15,6 +15,8 @@ Prima di salvare, verifica che le date siano corrette e che l'attività apparten
 
 La vista settimanale aiuta a controllare rapidamente le ore distribuite sui giorni. È utile per individuare giornate mancanti, duplicazioni o attività attribuite al progetto sbagliato.
 
+Ogni registrazione esistente occupa una propria riga, così eventuali duplicazioni sulla stessa coppia cliente/progetto/attività restano visibili e modificabili in modo indipendente. La riga "Nuova voce" in alto serve esclusivamente a creare nuove registrazioni.
+
 ## Attività ricorrenti
 
 Le attività ricorrenti permettono di generare registrazioni ripetitive, per esempio riunioni settimanali o attività amministrative periodiche.

--- a/test/components/timesheet/WeeklyView.test.tsx
+++ b/test/components/timesheet/WeeklyView.test.tsx
@@ -354,6 +354,75 @@ describe('<WeeklyView /> submit mutations', () => {
     expect(updateCalls).toEqual([]);
   });
 
+  test('typing hours on an empty day of a Phase 1 row creates a new entry with that row combo', async () => {
+    // A Phase 1 row is keyed by an existing entry's id, but the user can fill
+    // any of its empty day cells to add a new entry against the same
+    // (client, project, task) — the row's location carries forward.
+    const today = todayDateOnly();
+    const addCalls: Array<Record<string, unknown>[]> = [];
+
+    render(
+      <WeeklyView
+        entries={[entryBOn(today)]}
+        {...twoComboCatalog}
+        {...sharedProps}
+        onAddBulkEntries={async (entries) => {
+          addCalls.push(entries as unknown as Record<string, unknown>[]);
+        }}
+      />,
+    );
+
+    const filledInput = await waitFor(() => {
+      const input = findDurationInputWithValue('3.5');
+      if (!input) throw new Error('pre-filled 3.5 input not found');
+      return input;
+    });
+
+    const row = filledInput.closest('tr');
+    if (!row) throw new Error('phase 1 row not found');
+    const emptyInRow = Array.from(
+      row.querySelectorAll<HTMLInputElement>('input[inputmode="decimal"]'),
+    ).find((i) => i !== filledInput && i.value === '' && !i.disabled);
+    if (!emptyInRow) throw new Error('no empty day cell in the phase 1 row');
+
+    setDurationInput(emptyInRow, '1.5');
+    clickSubmit();
+
+    await waitFor(() => {
+      expect(addCalls).toHaveLength(1);
+      expect(addCalls[0]).toHaveLength(1);
+      const added = addCalls[0][0];
+      expect(added.task).toBe('Task B');
+      expect(added.clientId).toBe('client-b');
+      expect(added.projectId).toBe('project-b');
+      expect(added.duration).toBe(1.5);
+      expect(added.location).toBe('remote');
+      expect(added.date).not.toBe(today);
+    });
+  });
+
+  test('renders an out-of-week combo as an empty quick-log row', async () => {
+    // Phase 2: a combo with no current-week entries surfaces as an empty
+    // quick-log row keyed by `combo:…`. The historical entry itself is not
+    // pre-filled anywhere, but the user can type into the row to log against
+    // the same combo on any day of the visible week.
+    const lastMonth = (() => {
+      const d = new Date();
+      d.setDate(d.getDate() - 40);
+      return d.toISOString().slice(0, 10);
+    })();
+
+    render(<WeeklyView entries={[entryBOn(lastMonth)]} {...twoComboCatalog} {...sharedProps} />);
+
+    await waitFor(() => {
+      expect(document.body).toHaveTextContent('Task B');
+    });
+
+    const inputs = document.body.querySelectorAll<HTMLInputElement>('input[inputmode="decimal"]');
+    const prefilled = Array.from(inputs).some((i) => i.value === '3.5');
+    expect(prefilled).toBe(false);
+  });
+
   test('handleSubmit awaits onUpdateEntry before flashing success', async () => {
     const today = todayDateOnly();
     let resolveUpdate: () => void = () => {

--- a/test/components/timesheet/WeeklyView.test.tsx
+++ b/test/components/timesheet/WeeklyView.test.tsx
@@ -84,7 +84,7 @@ describe('<WeeklyView /> RBAC catalog scoping', () => {
     });
   });
 
-  test('pre-fills the form row when the catalog selection matches an existing entry', async () => {
+  test('renders an existing entry as its own row with pre-filled hours', async () => {
     const entries: TimeEntry[] = [
       {
         id: 'entry-1',
@@ -104,9 +104,6 @@ describe('<WeeklyView /> RBAC catalog scoping', () => {
 
     render(<WeeklyView entries={entries} {...alphaCatalog} {...sharedProps} />);
 
-    // The form auto-selects Alpha Task, so the entry collapses into the
-    // editable "Nuova voce" row. The pre-filled 3.5h must surface in a
-    // day-cell decimal input.
     await waitFor(() => {
       const inputs = document.body.querySelectorAll<HTMLInputElement>('input[inputmode="decimal"]');
       const prefilled = Array.from(inputs).some((input) => input.value === '3.5');
@@ -211,10 +208,10 @@ describe('<WeeklyView /> submit mutations', () => {
     expect(updateCalls).toEqual([]);
   });
 
-  test('clearing a form-row cell that maps to an existing entry calls onDeleteEntry', async () => {
-    // The single-combo catalog auto-selects, collapsing the matching entry
-    // into the form row. Clearing it must still flow through submitRow so
-    // hasFormChanges triggers the delete instead of dropping the edit.
+  test('clearing an entry-row cell triggers onDeleteEntry even when the catalog has a single combo', async () => {
+    // With a single-combo catalog the form auto-selects that combo, but the
+    // existing entry still renders as its own Phase 1 row (keyed by entry.id).
+    // Clearing it must flow through submitRow and delete the entry.
     const today = todayDateOnly();
     const deleteCalls: string[] = [];
 
@@ -314,6 +311,47 @@ describe('<WeeklyView /> submit mutations', () => {
       expect(addCalls[0]).toHaveLength(1);
       expect(addCalls[0][0] as Record<string, unknown>).not.toHaveProperty('hourlyCost');
     });
+  });
+
+  test('renders two TimeEntries sharing (client, project, task, date) as independent rows', async () => {
+    // Regression: the old per-combo grouping wrote `baseDays[entry.date]` in
+    // a loop and the second entry overwrote the first, so duplicates were
+    // invisible in the UI. With one row per entry both must render and be
+    // independently deletable.
+    const today = todayDateOnly();
+    const deleteCalls: string[] = [];
+    const updateCalls: Array<{ id: string; updates: unknown }> = [];
+
+    render(
+      <WeeklyView
+        entries={[
+          { ...entryBOn(today), id: 'entry-b-1', duration: 2, createdAt: 1 },
+          { ...entryBOn(today), id: 'entry-b-2', duration: 5, createdAt: 2 },
+        ]}
+        {...twoComboCatalog}
+        {...sharedProps}
+        onUpdateEntry={(id, updates) => {
+          updateCalls.push({ id, updates });
+        }}
+        onDeleteEntry={(id) => {
+          deleteCalls.push(id);
+        }}
+      />,
+    );
+
+    const inputs = await waitForDurationInputs(
+      (xs) => xs.some((i) => i.value === '2') && xs.some((i) => i.value === '5'),
+    );
+    const twoInput = inputs.find((i) => i.value === '2');
+    if (!twoInput) throw new Error('expected 2h input to render');
+
+    setDurationInput(twoInput, '');
+    clickSubmit();
+
+    await waitFor(() => {
+      expect(deleteCalls).toEqual(['entry-b-1']);
+    });
+    expect(updateCalls).toEqual([]);
   });
 
   test('handleSubmit awaits onUpdateEntry before flashing success', async () => {


### PR DESCRIPTION
## Summary

- The weekly view grouped entries by `(clientId, projectId, task)` and wrote `baseDays[entry.date]`, so two entries that share the same `(client, project, task, date)` silently collapsed — the second overwrote the first, leaving it invisible and undeletable in the UI. The DB does not enforce uniqueness on that tuple, so duplicates are valid data that we were hiding.
- Rebuild `entryRows` in two phases: **one row per in-week TimeEntry** keyed by `entry.id` (duplicates kept), plus **empty quick-log rows** for recently-used combos that have no in-week entries (capped at 5, keyed by `combo:…`).
- Drop the "Nuova voce" form-row prefill — matching existing entries now appear as their own editable rows, so the form row is purely for new entries. Collapses `hasFormChanges` into `hasFormHours` and removes the dead `formBase` branch in `dayTotals`.

## Test plan

- [x] `bunx tsc -p tsconfig.json --noEmit`
- [x] `bunx biome check` on touched files
- [x] `bun test test/components/timesheet/WeeklyView.test.tsx` — 7/7 pass, including a new regression test that places two TimeEntries with identical `(client, project, task, date)`, asserts both render with their durations, and verifies clearing one only deletes that one.
- [ ] Manual: open the weekly view with two entries sharing `(client, project, task, date)`; confirm both rows render and are independently editable.
- [ ] Manual: type hours in an empty day of a per-entry row → submits as a new entry; on next render it appears as its own row.

## Notes for reviewers

- `submitRow`, `getCellValue`, `pendingEdits` cleanup, CSV export, and JSX rendering are all key-agnostic and unchanged — the only structural change is what `entryRows` produces.
- Two existing tests were renamed (the descriptions referenced the old "collapse into form row" behavior); their assertions are unchanged and still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)