### PR TITLE
fix(assignments): wrap user-assignment writes in transactions

### DIFF
--- a/server/repositories/userAssignmentsRepo.ts
+++ b/server/repositories/userAssignmentsRepo.ts
@@ -1,6 +1,6 @@
 import { and, eq, type SQL, sql } from 'drizzle-orm';
 import type { AnyPgColumn } from 'drizzle-orm/pg-core';
-import { type DbExecutor, db, executeRows } from '../db/drizzle.ts';
+import { type DbExecutor, db, executeRows, runAtomically } from '../db/drizzle.ts';
 import {
   type AssignmentSource,
   MANUAL_ASSIGNMENT_SOURCE,
@@ -258,66 +258,72 @@ export const syncTopManagerAssignmentsForUser = async (
 ): Promise<void> => {
   const isTopManager = await userHasTopManagerRole(userId, exec);
 
-  if (!isTopManager) {
-    await Promise.all([
-      exec
-        .delete(userClients)
-        .where(
-          and(
-            eq(userClients.userId, userId),
-            eq(userClients.assignmentSource, TOP_MANAGER_AUTO_ASSIGNMENT_SOURCE),
+  // Each branch mutates multiple tables in parallel; the wrap rolls back the others when
+  // one Promise.all leg fails. (`runAtomically`'s default doc covers the simpler
+  // DELETE-then-INSERT case, not the multi-table parallel case.)
+  await runAtomically(exec, async (tx) => {
+    if (!isTopManager) {
+      await Promise.all([
+        tx
+          .delete(userClients)
+          .where(
+            and(
+              eq(userClients.userId, userId),
+              eq(userClients.assignmentSource, TOP_MANAGER_AUTO_ASSIGNMENT_SOURCE),
+            ),
           ),
-        ),
-      exec
-        .delete(userProjects)
-        .where(
-          and(
-            eq(userProjects.userId, userId),
-            eq(userProjects.assignmentSource, TOP_MANAGER_AUTO_ASSIGNMENT_SOURCE),
+        tx
+          .delete(userProjects)
+          .where(
+            and(
+              eq(userProjects.userId, userId),
+              eq(userProjects.assignmentSource, TOP_MANAGER_AUTO_ASSIGNMENT_SOURCE),
+            ),
           ),
-        ),
-      exec
-        .delete(userTasks)
-        .where(
-          and(
-            eq(userTasks.userId, userId),
-            eq(userTasks.assignmentSource, TOP_MANAGER_AUTO_ASSIGNMENT_SOURCE),
+        tx
+          .delete(userTasks)
+          .where(
+            and(
+              eq(userTasks.userId, userId),
+              eq(userTasks.assignmentSource, TOP_MANAGER_AUTO_ASSIGNMENT_SOURCE),
+            ),
           ),
-        ),
-    ]);
-    // Cascade rebuild reads from `user_projects`, which the parallel deletes above just
-    // modified - sequenced after the `await Promise.all(...)` so it sees the final state,
-    // never an interleaved view.
-    await applyProjectCascadeToClients(userId, exec);
-    return;
-  }
+      ]);
+      // Cascade rebuild reads from `user_projects`, which the parallel deletes above just
+      // modified - sequenced after the `await Promise.all(...)` so it sees the final state,
+      // never an interleaved view.
+      await applyProjectCascadeToClients(userId, tx);
+      return;
+    }
 
-  await Promise.all([
-    assignAllToUserAsTopManager(ASSIGNMENT_SPECS.clients, userId, exec),
-    assignAllToUserAsTopManager(ASSIGNMENT_SPECS.projects, userId, exec),
-    assignAllToUserAsTopManager(ASSIGNMENT_SPECS.tasks, userId, exec),
-  ]);
+    await Promise.all([
+      assignAllToUserAsTopManager(ASSIGNMENT_SPECS.clients, userId, tx),
+      assignAllToUserAsTopManager(ASSIGNMENT_SPECS.projects, userId, tx),
+      assignAllToUserAsTopManager(ASSIGNMENT_SPECS.tasks, userId, tx),
+    ]);
+  });
 };
 
-const replaceAssignments = async (
+const replaceAssignments = (
   spec: AssignmentSpec,
   userId: string,
   ids: string[],
   source: AssignmentSource,
   exec: DbExecutor,
-): Promise<void> => {
-  // sql.identifier safely injects the allowlisted table/column from ASSIGNMENT_SPECS.
-  await executeRows(exec, sql`DELETE FROM ${sql.identifier(spec.table)} WHERE user_id = ${userId}`);
-  if (ids.length === 0) return;
+): Promise<void> =>
+  runAtomically(exec, async (tx) => {
+    // sql.identifier safely injects the allowlisted table/column from ASSIGNMENT_SPECS.
+    await executeRows(tx, sql`DELETE FROM ${sql.identifier(spec.table)} WHERE user_id = ${userId}`);
+    if (ids.length === 0) return;
 
-  const valueRows = ids.map((id) => sql`(${userId}, ${id}, ${source})`);
-  await executeRows(
-    exec,
-    sql`INSERT INTO ${sql.identifier(spec.table)} (user_id, ${sql.identifier(spec.fkColumn)}, assignment_source)
-        VALUES ${sql.join(valueRows, sql`, `)}
-        ON CONFLICT DO NOTHING`,
-  );
-};
+    const valueRows = ids.map((id) => sql`(${userId}, ${id}, ${source})`);
+    await executeRows(
+      tx,
+      sql`INSERT INTO ${sql.identifier(spec.table)} (user_id, ${sql.identifier(spec.fkColumn)}, assignment_source)
+          VALUES ${sql.join(valueRows, sql`, `)}
+          ON CONFLICT DO NOTHING`,
+    );
+  });
 
 export const replaceUserClients = (
   userId: string,

--- a/server/test/repositories/userAssignmentsTransactional.test.ts
+++ b/server/test/repositories/userAssignmentsTransactional.test.ts
@@ -1,0 +1,254 @@
+// Asserts that `replaceAssignments` and `syncTopManagerAssignmentsForUser` run their
+// DELETE/INSERT pairs inside a single transaction, so a failing later statement rolls
+// back any earlier ones. Mocks `db/drizzle.ts` with an in-memory tx-aware fake.
+
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import * as realDrizzle from '../../db/drizzle.ts';
+import {
+  MANUAL_ASSIGNMENT_SOURCE,
+  TOP_MANAGER_AUTO_ASSIGNMENT_SOURCE,
+} from '../../db/schema/_userAssignmentTable.ts';
+import * as realRolesRepo from '../../repositories/rolesRepo.ts';
+
+type Row = { userId: string; refId: string; source: string };
+type TableKey = 'user_clients' | 'user_projects' | 'user_tasks';
+const TABLE_KEYS: readonly TableKey[] = ['user_clients', 'user_projects', 'user_tasks'];
+
+const tables: Record<TableKey, Row[]> = {
+  user_clients: [],
+  user_projects: [],
+  user_tasks: [],
+};
+
+let pending: Record<TableKey, Row[]> | null = null;
+const tableObjToKey = new WeakMap<object, TableKey>();
+const dialect = new PgDialect();
+
+let forcedFailure: { op: 'INSERT' | 'DELETE'; table: TableKey } | null = null;
+
+const live = (): Record<TableKey, Row[]> => pending ?? tables;
+
+const cloneTables = (): Record<TableKey, Row[]> => {
+  const snap = {} as Record<TableKey, Row[]>;
+  for (const k of TABLE_KEYS) snap[k] = tables[k].slice();
+  return snap;
+};
+
+// Match the leading INSERT/DELETE target so a `FROM user_projects up` in the body
+// of an `INSERT INTO user_clients ... SELECT ... FROM user_projects` doesn't shadow
+// the outer target. Both quoted (`"user_clients"`, from `sql.identifier(...)`) and
+// unquoted (`user_clients`, from raw SQL literals) forms appear in the repo.
+const detectTable = (sqlText: string): TableKey | null => {
+  const head = sqlText.trimStart().toUpperCase();
+  for (const t of TABLE_KEYS) {
+    const upper = t.toUpperCase();
+    if (head.startsWith(`INSERT INTO "${upper}"`)) return t;
+    if (head.startsWith(`INSERT INTO ${upper}`)) return t;
+    if (head.startsWith(`DELETE FROM "${upper}"`)) return t;
+    if (head.startsWith(`DELETE FROM ${upper}`)) return t;
+  }
+  return null;
+};
+
+const detectOp = (sqlText: string): 'INSERT' | 'DELETE' | 'OTHER' => {
+  const trimmed = sqlText.trimStart().toUpperCase();
+  if (trimmed.startsWith('INSERT')) return 'INSERT';
+  if (trimmed.startsWith('DELETE')) return 'DELETE';
+  return 'OTHER';
+};
+
+const fakeDb = {
+  delete(table: object) {
+    return {
+      where: async (_filter: unknown) => {
+        const key = tableObjToKey.get(table);
+        if (!key) throw new Error('userAssignments test: unknown delete target');
+        // The repo's actual deletes are scoped to (userId, assignment_source). Tests
+        // seed only matching rows for the test user, so a full clear is equivalent
+        // and avoids decoding Drizzle's filter expressions.
+        live()[key].length = 0;
+        return { rowCount: 0 };
+      },
+    };
+  },
+  async execute(sqlObj: unknown) {
+    const { sql: text } = dialect.sqlToQuery(sqlObj as never);
+    const op = detectOp(text);
+    const table = detectTable(text);
+    if (!table) throw new Error(`userAssignments test: unrecognized SQL (no known table): ${text}`);
+
+    if (forcedFailure?.op === op && forcedFailure.table === table) {
+      // Self-clear so a single forced failure doesn't keep firing inside the same tx.
+      forcedFailure = null;
+      throw new Error(`forced ${op} failure on ${table}`);
+    }
+
+    if (op === 'DELETE') {
+      live()[table].length = 0;
+    } else if (op === 'INSERT') {
+      // Sentinel row: the rollback property under test doesn't depend on what got inserted.
+      live()[table].push({ userId: 'inserted', refId: 'inserted', source: 'inserted' });
+    }
+    return { rows: [] };
+  },
+};
+
+// Re-entry as no-op so a `runAtomically(tx, ...)` passthrough doesn't double-snapshot.
+const fakeWithDbTransaction = async <T>(cb: (tx: unknown) => Promise<T>): Promise<T> => {
+  if (pending) return cb(fakeDb);
+  pending = cloneTables();
+  try {
+    const result = await cb(fakeDb);
+    for (const k of TABLE_KEYS) tables[k] = pending[k];
+    return result;
+  } finally {
+    pending = null;
+  }
+};
+
+const fakeRunAtomically = <T>(exec: unknown, cb: (tx: unknown) => Promise<T>): Promise<T> =>
+  exec === fakeDb ? fakeWithDbTransaction(cb) : cb(exec as unknown as never);
+
+// Snapshot real exports BEFORE mocking so the afterAll restore covers every key —
+// otherwise the mock leaks into later tests in the same Bun process.
+const drizzleSnap = { ...realDrizzle };
+const rolesRepoSnap = { ...realRolesRepo };
+
+mock.module('../../db/drizzle.ts', () => ({
+  ...drizzleSnap,
+  db: fakeDb,
+  withDbTransaction: fakeWithDbTransaction,
+  runAtomically: fakeRunAtomically,
+}));
+
+let userHasRoleResult = false;
+mock.module('../../repositories/rolesRepo.ts', () => ({
+  ...rolesRepoSnap,
+  userHasRole: async () => userHasRoleResult,
+}));
+
+let userAssignmentsRepo: typeof import('../../repositories/userAssignmentsRepo.ts');
+
+beforeAll(async () => {
+  const clientsSchema = await import('../../db/schema/clients.ts');
+  const projectsSchema = await import('../../db/schema/projects.ts');
+  const tasksSchema = await import('../../db/schema/tasks.ts');
+  tableObjToKey.set(clientsSchema.userClients as unknown as object, 'user_clients');
+  tableObjToKey.set(projectsSchema.userProjects as unknown as object, 'user_projects');
+  tableObjToKey.set(tasksSchema.userTasks as unknown as object, 'user_tasks');
+
+  userAssignmentsRepo = await import('../../repositories/userAssignmentsRepo.ts');
+});
+
+afterAll(() => {
+  mock.module('../../db/drizzle.ts', () => drizzleSnap);
+  mock.module('../../repositories/rolesRepo.ts', () => rolesRepoSnap);
+});
+
+beforeEach(() => {
+  for (const k of TABLE_KEYS) tables[k] = [];
+  pending = null;
+  forcedFailure = null;
+  userHasRoleResult = false;
+});
+
+type ReplaceFn = (
+  userId: string,
+  ids: string[],
+  source: typeof MANUAL_ASSIGNMENT_SOURCE,
+) => Promise<void>;
+
+describe.each<readonly [string, () => ReplaceFn, TableKey]>([
+  ['replaceUserClients', () => userAssignmentsRepo.replaceUserClients, 'user_clients'],
+  ['replaceUserProjects', () => userAssignmentsRepo.replaceUserProjects, 'user_projects'],
+  ['replaceUserTasks', () => userAssignmentsRepo.replaceUserTasks, 'user_tasks'],
+])('%s atomicity', (_label, getFn, tableKey) => {
+  // `getFn` is a thunk because `userAssignmentsRepo` is loaded in `beforeAll`, after the
+  // describe.each tuple is evaluated.
+  const callRepo = (ids: string[]) => getFn()('u-1', ids, MANUAL_ASSIGNMENT_SOURCE);
+
+  test('failed INSERT leaves prior assignments intact (DELETE rolled back)', async () => {
+    tables[tableKey] = [
+      { userId: 'u-1', refId: 'old-1', source: MANUAL_ASSIGNMENT_SOURCE },
+      { userId: 'u-1', refId: 'old-2', source: MANUAL_ASSIGNMENT_SOURCE },
+    ];
+    forcedFailure = { op: 'INSERT', table: tableKey };
+
+    await expect(callRepo(['ghost-id'])).rejects.toThrow(`forced INSERT failure on ${tableKey}`);
+
+    expect(tables[tableKey].map((r) => r.refId)).toEqual(['old-1', 'old-2']);
+  });
+
+  test('successful replace commits new ids and drops old ones', async () => {
+    tables[tableKey] = [{ userId: 'u-1', refId: 'old-1', source: MANUAL_ASSIGNMENT_SOURCE }];
+
+    await callRepo(['new-1']);
+
+    expect(tables[tableKey]).toHaveLength(1);
+    expect(tables[tableKey][0].refId).toBe('inserted');
+  });
+});
+
+describe('syncTopManagerAssignmentsForUser atomicity', () => {
+  const seedTopManagerAutoRows = () => {
+    tables.user_clients = [
+      { userId: 'u-1', refId: 'c-1', source: TOP_MANAGER_AUTO_ASSIGNMENT_SOURCE },
+    ];
+    tables.user_projects = [
+      { userId: 'u-1', refId: 'p-1', source: TOP_MANAGER_AUTO_ASSIGNMENT_SOURCE },
+    ];
+    tables.user_tasks = [
+      { userId: 'u-1', refId: 't-1', source: TOP_MANAGER_AUTO_ASSIGNMENT_SOURCE },
+    ];
+  };
+
+  test('non-TM branch: failed cascade INSERT leaves prior top_manager_auto rows intact', async () => {
+    userHasRoleResult = false;
+    seedTopManagerAutoRows();
+    // Cascade rebuild is the only INSERT in this branch and targets user_clients.
+    forcedFailure = { op: 'INSERT', table: 'user_clients' };
+
+    await expect(userAssignmentsRepo.syncTopManagerAssignmentsForUser('u-1')).rejects.toThrow(
+      'forced INSERT failure on user_clients',
+    );
+
+    expect(tables.user_clients.map((r) => r.refId)).toEqual(['c-1']);
+    expect(tables.user_projects.map((r) => r.refId)).toEqual(['p-1']);
+    expect(tables.user_tasks.map((r) => r.refId)).toEqual(['t-1']);
+  });
+
+  test('non-TM branch: successful sync clears top_manager_auto rows', async () => {
+    userHasRoleResult = false;
+    seedTopManagerAutoRows();
+
+    await userAssignmentsRepo.syncTopManagerAssignmentsForUser('u-1');
+
+    expect(tables.user_clients.map((r) => r.refId)).toEqual(['inserted']);
+    expect(tables.user_projects).toEqual([]);
+    expect(tables.user_tasks).toEqual([]);
+  });
+
+  test('TM branch: failed assign-all INSERT leaves all three tables empty', async () => {
+    userHasRoleResult = true;
+    forcedFailure = { op: 'INSERT', table: 'user_projects' };
+
+    await expect(userAssignmentsRepo.syncTopManagerAssignmentsForUser('u-1')).rejects.toThrow(
+      'forced INSERT failure on user_projects',
+    );
+
+    expect(tables.user_clients).toEqual([]);
+    expect(tables.user_projects).toEqual([]);
+    expect(tables.user_tasks).toEqual([]);
+  });
+
+  test('TM branch: successful sync runs all three INSERT...SELECT', async () => {
+    userHasRoleResult = true;
+
+    await userAssignmentsRepo.syncTopManagerAssignmentsForUser('u-1');
+
+    expect(tables.user_clients).toHaveLength(1);
+    expect(tables.user_projects).toHaveLength(1);
+    expect(tables.user_tasks).toHaveLength(1);
+  });
+});

--- a/server/test/repositories/userAssignmentsTransactional.test.ts
+++ b/server/test/repositories/userAssignmentsTransactional.test.ts
@@ -3,9 +3,11 @@
 // back any earlier ones. Mocks `db/drizzle.ts` with an in-memory tx-aware fake.
 
 import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { SQL } from 'drizzle-orm';
 import { PgDialect } from 'drizzle-orm/pg-core';
 import * as realDrizzle from '../../db/drizzle.ts';
 import {
+  type AssignmentSource,
   MANUAL_ASSIGNMENT_SOURCE,
   TOP_MANAGER_AUTO_ASSIGNMENT_SOURCE,
 } from '../../db/schema/_userAssignmentTable.ts';
@@ -73,7 +75,7 @@ const fakeDb = {
     };
   },
   async execute(sqlObj: unknown) {
-    const { sql: text } = dialect.sqlToQuery(sqlObj as never);
+    const { sql: text } = dialect.sqlToQuery(sqlObj as SQL);
     const op = detectOp(text);
     const table = detectTable(text);
     if (!table) throw new Error(`userAssignments test: unrecognized SQL (no known table): ${text}`);
@@ -108,7 +110,7 @@ const fakeWithDbTransaction = async <T>(cb: (tx: unknown) => Promise<T>): Promis
 };
 
 const fakeRunAtomically = <T>(exec: unknown, cb: (tx: unknown) => Promise<T>): Promise<T> =>
-  exec === fakeDb ? fakeWithDbTransaction(cb) : cb(exec as unknown as never);
+  exec === fakeDb ? fakeWithDbTransaction(cb) : cb(exec);
 
 // Snapshot real exports BEFORE mocking so the afterAll restore covers every key —
 // otherwise the mock leaks into later tests in the same Bun process.
@@ -153,11 +155,7 @@ beforeEach(() => {
   userHasRoleResult = false;
 });
 
-type ReplaceFn = (
-  userId: string,
-  ids: string[],
-  source: typeof MANUAL_ASSIGNMENT_SOURCE,
-) => Promise<void>;
+type ReplaceFn = (userId: string, ids: string[], source: AssignmentSource) => Promise<void>;
 
 describe.each<readonly [string, () => ReplaceFn, TableKey]>([
   ['replaceUserClients', () => userAssignmentsRepo.replaceUserClients, 'user_clients'],


### PR DESCRIPTION
Fixes #420.

## Summary

`replaceAssignments` and `syncTopManagerAssignmentsForUser` in `server/repositories/userAssignmentsRepo.ts` performed `DELETE` followed by `INSERT` (or multi-table parallel writes) without transaction wrapping. A failing later statement — FK violation, network blip, constraint error — would leave the prior `DELETE` permanently committed, silently wiping a user's client/project/task assignments.

## Fix

Wrap both functions in `runAtomically(exec, …)` (the existing helper in `server/db/drizzle.ts`):

- Opens a transaction only when the caller passed the default `db` (e.g. `server/db/demoSeed.ts:745`, which was the most exposed unsafe path today).
- Passthrough when the caller already supplied their own `tx` — so existing route callers that wrap in `withDbTransaction` (every `users.ts` and `external-auth.ts` call site) don't get nested transactions.

Same primitive and pattern as the prior fixes for `invoicesRepo.replaceItems`, `supplierInvoicesRepo.replaceItems`, etc.

## Test plan

- [x] New `server/test/repositories/userAssignmentsTransactional.test.ts` covers rollback for: `replaceUserClients/Projects/Tasks` failed `INSERT`, sync non-TM-branch failed cascade `INSERT`, sync TM-branch failed parallel `INSERT`, plus happy-path commits. Modeled on the existing `replaceItemsTransactional.test.ts` pattern.
- [x] Existing `server/test/repositories/userAssignmentsRepo.test.ts` continues to pass — passes `testDb` (which is `!== db`), so `runAtomically` becomes a passthrough and the SQL-shape assertions still observe the same `DELETE` then `INSERT` sequence.
- [x] Full backend suite: 2447 pass, 28 skip, 0 fail.
- [x] Full frontend suite: 1025 pass, 0 fail.
- [x] `bunx biome check` clean on both changed files; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)