### PR TITLE
fix(sales): update client quote table columns

### DIFF
--- a/components/sales/ClientQuotesView.tsx
+++ b/components/sales/ClientQuotesView.tsx
@@ -244,6 +244,22 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
     };
   }, [formData.items, formData.discount, formData.discountType]);
 
+  const formatDiscountPercentage = useCallback((quote: Quote) => {
+    if (quote.discountType !== 'currency') {
+      return `${quote.discount}%`;
+    }
+
+    const { discountAmount, subtotal } = calculatePricingTotals(
+      quote.items,
+      quote.discount,
+      'hours',
+      quote.discountType,
+    );
+    if (subtotal <= 0) return '0%';
+
+    return `${Number(((discountAmount / subtotal) * 100).toFixed(1))}%`;
+  }, []);
+
   const closeModal = useCallback(() => {
     setIsModalOpen(false);
     setPreviewVersion(null);
@@ -833,24 +849,6 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
       },
     },
     {
-      header: t('sales:clientQuotes.globalDiscount'),
-      id: 'globalDiscount',
-      className: 'whitespace-nowrap',
-      headerClassName: 'min-w-[9rem]',
-      disableSorting: true,
-      disableFiltering: true,
-      cell: ({ row }) => {
-        const history = isHistoryRow(row);
-        return (
-          <span
-            className={`text-sm font-semibold whitespace-nowrap ${history ? 'text-zinc-400' : 'text-zinc-600'}`}
-          >
-            {formatDiscountValue(row.discount, row.discountType, currency)}
-          </span>
-        );
-      },
-    },
-    {
       header: t('sales:clientQuotes.subtotal', { defaultValue: 'Subtotal' }),
       id: 'subtotal',
       accessorFn: (row) =>
@@ -871,6 +869,24 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
             className={`text-sm font-semibold whitespace-nowrap ${history ? 'text-zinc-400' : 'text-zinc-700'}`}
           >
             {subtotal.toFixed(2)} {currency}
+          </span>
+        );
+      },
+    },
+    {
+      header: t('sales:clientQuotes.discountPercentColumn'),
+      id: 'globalDiscount',
+      className: 'whitespace-nowrap',
+      headerClassName: 'min-w-[8rem]',
+      disableSorting: true,
+      disableFiltering: true,
+      cell: ({ row }) => {
+        const history = isHistoryRow(row);
+        return (
+          <span
+            className={`text-sm font-semibold whitespace-nowrap ${history ? 'text-zinc-400' : 'text-zinc-600'}`}
+          >
+            {formatDiscountPercentage(row)}
           </span>
         );
       },
@@ -910,6 +926,31 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
       },
     },
     {
+      header: t('sales:clientQuotes.discountedTotalColumn'),
+      id: 'total',
+      accessorFn: (row) =>
+        calculatePricingTotals(row.items, row.discount, 'hours', row.discountType).total,
+      className: 'whitespace-nowrap',
+      headerClassName: 'min-w-[9rem]',
+      disableFiltering: true,
+      cell: ({ row }) => {
+        const { total } = calculatePricingTotals(
+          row.items,
+          row.discount,
+          'hours',
+          row.discountType,
+        );
+        const history = isHistoryRow(row);
+        return (
+          <span
+            className={`text-sm font-bold whitespace-nowrap ${history ? 'text-zinc-400' : 'text-zinc-700'}`}
+          >
+            {total.toFixed(2)} {currency}
+          </span>
+        );
+      },
+    },
+    {
       header: t('sales:clientQuotes.marginLabel'),
       id: 'margin',
       accessorFn: (row) =>
@@ -935,15 +976,15 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
       },
     },
     {
-      header: t('sales:clientQuotes.totalColumn'),
-      id: 'total',
+      header: t('sales:clientQuotes.molLabel', { defaultValue: 'MOL' }),
+      id: 'mol',
       accessorFn: (row) =>
-        calculatePricingTotals(row.items, row.discount, 'hours', row.discountType).total,
+        calculatePricingTotals(row.items, row.discount, 'hours', row.discountType).marginPercentage,
       className: 'whitespace-nowrap',
-      headerClassName: 'min-w-[8rem]',
+      headerClassName: 'min-w-[6rem]',
       disableFiltering: true,
       cell: ({ row }) => {
-        const { total } = calculatePricingTotals(
+        const { marginPercentage } = calculatePricingTotals(
           row.items,
           row.discount,
           'hours',
@@ -952,9 +993,9 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
         const history = isHistoryRow(row);
         return (
           <span
-            className={`text-sm font-bold whitespace-nowrap ${history ? 'text-zinc-400' : 'text-zinc-700'}`}
+            className={`text-sm font-bold whitespace-nowrap ${history ? 'text-zinc-400' : 'text-emerald-600'}`}
           >
-            {total.toFixed(2)} {currency}
+            {marginPercentage.toFixed(1)}%
           </span>
         );
       },

--- a/docs-site/src/content/docs/en/sales-accounting.md
+++ b/docs-site/src/content/docs/en/sales-accounting.md
@@ -9,6 +9,8 @@ sidebar:
 
 Quotes and offers include products, quantities, prices, discounts, and terms. Use the catalog to start from consistent data and always check totals, margins, and validity before sending a document.
 
+The quote list shows code, insertion date, client, subtotal, discount percentage, absolute discount, discounted total, margin, MOL, payment terms, due date, and status so the main values can be checked without opening each record.
+
 When a document is accepted, continue by creating the linked order or next document instead of manually entering the same rows again.
 
 ## Supplier quotes

--- a/docs-site/src/content/docs/sales-accounting.md
+++ b/docs-site/src/content/docs/sales-accounting.md
@@ -9,6 +9,8 @@ sidebar:
 
 I preventivi e le offerte raccolgono prodotti, quantità, prezzi, sconti e condizioni. Usa il catalogo per partire da dati coerenti e controlla sempre totali, margini e validità prima di inviare il documento.
 
+La lista dei preventivi mostra codice, data di inserimento, cliente, subtotale, sconto percentuale, sconto assoluto, totale scontato, margine, MOL, termini di pagamento, scadenza e stato per controllare rapidamente i valori principali senza aprire ogni record.
+
 Quando un documento viene accettato, prosegui creando l'ordine o il documento collegato invece di reinserire manualmente le stesse righe.
 
 ## Preventivi fornitori

--- a/locales/en/sales.json
+++ b/locales/en/sales.json
@@ -129,6 +129,8 @@
     "quoteCodeColumn": "Code",
     "statusColumn": "Status",
     "totalColumn": "Total",
+    "discountPercentColumn": "Discount %",
+    "discountedTotalColumn": "Discounted Total",
     "paymentTermsColumn": "Payment Terms",
     "expirationColumn": "Expiration",
     "actionsColumn": "Actions",

--- a/locales/it/sales.json
+++ b/locales/it/sales.json
@@ -129,6 +129,8 @@
     "quoteCodeColumn": "Codice",
     "statusColumn": "Stato",
     "totalColumn": "Totale",
+    "discountPercentColumn": "Sconto %",
+    "discountedTotalColumn": "Totale Scontato",
     "paymentTermsColumn": "Termini di Pagamento",
     "expirationColumn": "Scadenza",
     "actionsColumn": "Azioni",

--- a/test/components/sales/ClientQuotesView.test.tsx
+++ b/test/components/sales/ClientQuotesView.test.tsx
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { screen } from '@testing-library/react';
+import type { Client, Quote } from '../../../types';
+import { installI18nMock } from '../../helpers/i18n';
+import { render } from '../../helpers/render';
+
+installI18nMock();
+
+mock.module('sonner', () => ({
+  toast: {
+    error: () => {},
+    success: () => {},
+    info: () => {},
+    warning: () => {},
+    message: () => {},
+  },
+  Toaster: () => null,
+}));
+
+const ClientQuotesView = (await import('../../../components/sales/ClientQuotesView')).default;
+
+const clients: Client[] = [{ id: 'client-1', name: 'Helios Energy Services' }];
+
+const quotes: Quote[] = [
+  {
+    id: 'Q-001',
+    clientId: 'client-1',
+    clientName: 'Helios Energy Services',
+    items: [
+      {
+        id: 'item-1',
+        quoteId: 'Q-001',
+        productId: 'product-1',
+        productName: 'Consulting',
+        quantity: 2,
+        unitPrice: 100,
+        productCost: 60,
+        productMolPercentage: 40,
+      },
+    ],
+    paymentTerms: '30gg',
+    discount: 10,
+    discountType: 'percentage',
+    status: 'draft',
+    expirationDate: '2026-06-30',
+    createdAt: Date.UTC(2026, 4, 14),
+    updatedAt: Date.UTC(2026, 4, 14),
+  },
+  {
+    id: 'Q-002',
+    clientId: 'client-1',
+    clientName: 'Helios Energy Services',
+    items: [
+      {
+        id: 'item-2',
+        quoteId: 'Q-002',
+        productId: 'product-1',
+        productName: 'Consulting',
+        quantity: 2,
+        unitPrice: 100,
+        productCost: 60,
+        productMolPercentage: 40,
+      },
+    ],
+    paymentTerms: '30gg',
+    discount: 25,
+    discountType: 'currency',
+    status: 'draft',
+    expirationDate: '2026-06-30',
+    createdAt: Date.UTC(2026, 4, 14),
+    updatedAt: Date.UTC(2026, 4, 14),
+  },
+];
+
+describe('<ClientQuotesView />', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('renders the quote list columns in the requested order with MOL next to margin', () => {
+    const { container } = render(
+      <ClientQuotesView
+        quotes={quotes}
+        clients={clients}
+        products={[]}
+        supplierQuotes={[]}
+        currency="EUR"
+        onAddQuote={mock(() => Promise.resolve())}
+        onUpdateQuote={mock(() => Promise.resolve())}
+        onDeleteQuote={mock(() => Promise.resolve())}
+      />,
+    );
+
+    const headerLabels = Array.from(container.querySelectorAll('[data-column-header-label]')).map(
+      (header) => header.textContent?.trim(),
+    );
+
+    expect(headerLabels).toEqual([
+      'sales:clientQuotes.quoteCodeColumn',
+      'crm:clients.tableHeaders.insertDate',
+      'sales:clientQuotes.clientColumn',
+      'sales:clientQuotes.subtotal',
+      'sales:clientQuotes.discountPercentColumn',
+      'common:labels.discount',
+      'sales:clientQuotes.discountedTotalColumn',
+      'sales:clientQuotes.marginLabel',
+      'sales:clientQuotes.molLabel',
+      'sales:clientQuotes.paymentTermsColumn',
+      'sales:clientQuotes.expirationColumn',
+      'sales:clientQuotes.statusColumn',
+      'sales:clientQuotes.actionsColumn',
+    ]);
+    expect(screen.getByText('33.3%')).toBeInTheDocument();
+    expect(screen.getByText('12.5%')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Reorders the Preventivi customer quote table into the requested identity, amounts, discount, totals, margin, terms, and status sequence.
- Renames the discount and discounted-total headers and adds the MOL percentage column next to margin.
- Updates Italian and English docs/locales and adds regression coverage for the rendered table headers.

## Changes
- Adds table-specific translation keys for `Sconto %` / `Discount %` and `Totale Scontato` / `Discounted Total`.
- Calculates MOL from the existing pricing totals margin percentage for each quote row.
- Documents the quote list columns in both Italian and English sales-accounting docs.

## Testing
- `bun test test/components/sales/ClientQuotesView.test.tsx`
- `bun run i18n:check`
- `bunx biome check components/sales/ClientQuotesView.tsx test/components/sales/ClientQuotesView.test.tsx locales/it/sales.json locales/en/sales.json docs-site/src/content/docs/sales-accounting.md docs-site/src/content/docs/en/sales-accounting.md`
- `bunx tsc -p tsconfig.json`

## Risks / Rollout
- Low risk. The change is scoped to the customer quote list table presentation and related translations/docs.
- Full `bun run typecheck` was attempted but this checkout is missing server dependencies such as Fastify and Drizzle, so it fails before frontend typechecking.

## Issues
Fixes #459
