### PR TITLE
feat(timesheet): edit entries from the daily activity table

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -43,6 +43,7 @@ import SelectControl from './components/shared/SelectControl';
 import StandardTable, { type Column } from './components/shared/StandardTable';
 import StatusBadge from './components/shared/StatusBadge';
 import DailyView from './components/timesheet/DailyView';
+import EntryEditDialog from './components/timesheet/EntryEditDialog';
 import RecurringManager from './components/timesheet/RecurringManager';
 import WeeklyView from './components/timesheet/WeeklyView';
 import UserSettings from './components/UserSettings';
@@ -234,6 +235,7 @@ const TrackerView: React.FC<{
   }, [filteredEntries]);
 
   const [pendingDeleteEntry, setPendingDeleteEntry] = useState<TimeEntry | null>(null);
+  const [editingEntry, setEditingEntry] = useState<TimeEntry | null>(null);
 
   const handleDeleteClick = useCallback(
     (entry: TimeEntry) => {
@@ -355,31 +357,52 @@ const TrackerView: React.FC<{
         ),
       },
       {
-        id: 'delete',
+        id: 'actions',
         header: t('common:labels.actions', { defaultValue: 'Actions' }),
         disableSorting: true,
         disableFiltering: true,
         sticky: 'right',
         cell: ({ row }) => (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span className="inline-flex">
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-xs"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    handleDeleteClick(row);
-                  }}
-                  className="text-muted-foreground hover:text-destructive"
-                >
-                  <i className="fa-solid fa-trash-can text-xs"></i>
-                </Button>
-              </span>
-            </TooltipTrigger>
-            <TooltipContent>{t('common:buttons.delete')}</TooltipContent>
-          </Tooltip>
+          <div className="inline-flex items-center gap-1">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="inline-flex">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-xs"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setEditingEntry(row);
+                    }}
+                    className="text-muted-foreground hover:text-praetor"
+                  >
+                    <i className="fa-solid fa-pen text-xs"></i>
+                  </Button>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>{t('common:buttons.edit')}</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="inline-flex">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-xs"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleDeleteClick(row);
+                    }}
+                    className="text-muted-foreground hover:text-destructive"
+                  >
+                    <i className="fa-solid fa-trash-can text-xs"></i>
+                  </Button>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>{t('common:buttons.delete')}</TooltipContent>
+            </Tooltip>
+          </div>
         ),
       },
     ],
@@ -548,6 +571,18 @@ const TrackerView: React.FC<{
           </div>
         </div>
       )}
+
+      <EntryEditDialog
+        entry={editingEntry}
+        onClose={() => setEditingEntry(null)}
+        onSave={onUpdateEntry}
+        clients={clients}
+        projects={projects}
+        projectTasks={projectTasks}
+        permissions={permissions}
+        currency={currency}
+        onAddCustomTask={onAddCustomTask}
+      />
 
       {/* Recurring Delete Modal */}
       {pendingDeleteEntry && (

--- a/components/timesheet/EntryEditDialog.tsx
+++ b/components/timesheet/EntryEditDialog.tsx
@@ -140,15 +140,12 @@ const EntryEditDialogContent: React.FC<ContentProps> = ({
     }
 
     // (clientId, projectId, task) is a tuple on the server — send all three together when
-    // any one changes so the backend never validates against a stale field.
+    // any one changes so the backend never validates against a stale field. Display names
+    // (clientName, projectName) are derived server-side from the IDs.
     const patch: Partial<TimeEntry> = {};
     if (catalogChanged) {
-      const project = projects.find((p) => p.id === selection.projectId);
-      const client = clients.find((c) => c.id === selection.clientId);
       patch.clientId = selection.clientId;
-      patch.clientName = client?.name || entry.clientName;
       patch.projectId = selection.projectId;
-      patch.projectName = project?.name || entry.projectName;
       patch.task = selection.taskName;
     }
     if (parsedDuration !== entry.duration) patch.duration = parsedDuration;

--- a/components/timesheet/EntryEditDialog.tsx
+++ b/components/timesheet/EntryEditDialog.tsx
@@ -217,7 +217,18 @@ const EntryEditDialogContent: React.FC<ContentProps> = ({
               className="grid-cols-1 sm:grid-cols-2 md:grid-cols-2 xl:grid-cols-2"
             />
 
-            <div className="grid grid-cols-1 sm:grid-cols-[180px_minmax(0,1fr)] gap-4 items-start">
+            <div className="grid grid-cols-1 sm:grid-cols-[minmax(0,1fr)_110px] gap-4 items-start">
+              <Field className="min-w-0">
+                <FieldLabel htmlFor="entry-edit-notes">{t('entry.notesDescription')}</FieldLabel>
+                <Input
+                  id="entry-edit-notes"
+                  type="text"
+                  value={notes}
+                  onChange={(e) => setNotes(e.target.value)}
+                  placeholder={t('entry.notesPlaceholder')}
+                  className="h-10 rounded-lg"
+                />
+              </Field>
               <Field className="min-w-0">
                 <FieldLabel htmlFor="entry-edit-hours">
                   {t('entry.hours')} <span className="text-destructive">*</span>
@@ -232,20 +243,9 @@ const EntryEditDialogContent: React.FC<ContentProps> = ({
                   placeholder="0.0"
                   aria-invalid={durationInvalid}
                   className={cn(
-                    'h-10 rounded-lg',
+                    'h-10 rounded-lg text-right tabular-nums',
                     durationInvalid && 'border-destructive focus-visible:ring-destructive',
                   )}
-                />
-              </Field>
-              <Field className="min-w-0">
-                <FieldLabel htmlFor="entry-edit-notes">{t('entry.notesDescription')}</FieldLabel>
-                <Input
-                  id="entry-edit-notes"
-                  type="text"
-                  value={notes}
-                  onChange={(e) => setNotes(e.target.value)}
-                  placeholder={t('entry.notesPlaceholder')}
-                  className="h-10 rounded-lg"
                 />
               </Field>
             </div>

--- a/components/timesheet/EntryEditDialog.tsx
+++ b/components/timesheet/EntryEditDialog.tsx
@@ -201,36 +201,39 @@ const EntryEditDialogContent: React.FC<ContentProps> = ({
               onLocationChange={selection.setLocation}
               allowCustomTask={allowCustomTask}
               errors={errors}
-              extraTrailing={
-                <Field className="min-w-0">
-                  <FieldLabel htmlFor="entry-edit-hours">
-                    {t('entry.hours')} <span className="text-destructive">*</span>
-                  </FieldLabel>
-                  <Input
-                    id="entry-edit-hours"
-                    type="text"
-                    inputMode="decimal"
-                    pattern="^[0-9]*([.,][0-9]*)?$"
-                    value={duration}
-                    onChange={handleDurationInputChange}
-                    placeholder="0.0"
-                    className="h-9 min-h-9 max-h-9 rounded-lg py-2"
-                  />
-                </Field>
-              }
+              // Override the default 5-column layout — the dialog is much narrower than
+              // DailyView, so a 2-column grid keeps the dropdown values fully readable.
+              className="grid-cols-1 sm:grid-cols-2 md:grid-cols-2 xl:grid-cols-2"
             />
 
-            <Field className="min-w-0">
-              <FieldLabel htmlFor="entry-edit-notes">{t('entry.notesDescription')}</FieldLabel>
-              <Input
-                id="entry-edit-notes"
-                type="text"
-                value={notes}
-                onChange={(e) => setNotes(e.target.value)}
-                placeholder={t('entry.notesPlaceholder')}
-                className="h-10 rounded-lg"
-              />
-            </Field>
+            <div className="grid grid-cols-1 sm:grid-cols-[180px_minmax(0,1fr)] gap-4 items-start">
+              <Field className="min-w-0">
+                <FieldLabel htmlFor="entry-edit-hours">
+                  {t('entry.hours')} <span className="text-destructive">*</span>
+                </FieldLabel>
+                <Input
+                  id="entry-edit-hours"
+                  type="text"
+                  inputMode="decimal"
+                  pattern="^[0-9]*([.,][0-9]*)?$"
+                  value={duration}
+                  onChange={handleDurationInputChange}
+                  placeholder="0.0"
+                  className="h-10 rounded-lg"
+                />
+              </Field>
+              <Field className="min-w-0">
+                <FieldLabel htmlFor="entry-edit-notes">{t('entry.notesDescription')}</FieldLabel>
+                <Input
+                  id="entry-edit-notes"
+                  type="text"
+                  value={notes}
+                  onChange={(e) => setNotes(e.target.value)}
+                  placeholder={t('entry.notesPlaceholder')}
+                  className="h-10 rounded-lg"
+                />
+              </Field>
+            </div>
           </ModalBody>
           <ModalFooter>
             <Button type="button" variant="outline" onClick={onClose} disabled={isSubmitting}>

--- a/components/timesheet/EntryEditDialog.tsx
+++ b/components/timesheet/EntryEditDialog.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { Field, FieldLabel } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
 import type { Client, Project, ProjectTask, TimeEntry } from '../../types';
 import { hasScopedActionPermission } from '../../utils/permissions';
 import { toastError } from '../../utils/toast';
@@ -65,6 +66,13 @@ const EntryEditDialogContent: React.FC<ContentProps> = ({
   const { t } = useTranslation(['timesheets', 'common']);
   const canCreateCustomTask = hasScopedActionPermission(permissions, 'projects.tasks', 'create');
 
+  // Resolve a missing taskId via name lookup so legacy/orphan entries (FK never set)
+  // still seed a real catalog id rather than '', which would render an empty dropdown.
+  const seededTaskId =
+    entry.taskId ??
+    projectTasks.find((t) => t.projectId === entry.projectId && t.name === entry.task)?.id ??
+    '';
+
   const selection = useCatalogSelection({
     clients,
     projects,
@@ -73,7 +81,7 @@ const EntryEditDialogContent: React.FC<ContentProps> = ({
     initialSelection: {
       clientId: entry.clientId,
       projectId: entry.projectId,
-      taskId: entry.taskId ?? '',
+      taskId: seededTaskId,
       taskName: entry.task,
     },
   });
@@ -114,8 +122,11 @@ const EntryEditDialogContent: React.FC<ContentProps> = ({
   };
 
   const parsedDuration = parseFloat(duration);
-  // Backend accepts duration >= 0 (placeholders carry 0); only block on blank/NaN.
+  // Backend accepts duration >= 0 (placeholders carry 0); blank means "untouched".
+  const isDurationBlank = duration.trim() === '';
   const hasValidDuration = Number.isFinite(parsedDuration) && parsedDuration >= 0;
+  const durationChanged = !isDurationBlank && hasValidDuration && parsedDuration !== entry.duration;
+  const durationInvalid = !isDurationBlank && !hasValidDuration;
 
   const catalogChanged =
     selection.clientId !== entry.clientId ||
@@ -124,7 +135,7 @@ const EntryEditDialogContent: React.FC<ContentProps> = ({
   const isDirty =
     catalogChanged ||
     selection.location !== entry.location ||
-    (hasValidDuration && parsedDuration !== entry.duration) ||
+    durationChanged ||
     (notes || '') !== (entry.notes ?? '');
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -134,7 +145,7 @@ const EntryEditDialogContent: React.FC<ContentProps> = ({
     if (!selection.projectId) newErrors.projectId = t('entry.projectRequired');
     if (!selection.taskName) newErrors.task = t('entry.taskRequired');
 
-    if (Object.keys(newErrors).length > 0 || !hasValidDuration) {
+    if (Object.keys(newErrors).length > 0 || durationInvalid) {
       setErrors(newErrors);
       return;
     }
@@ -148,7 +159,7 @@ const EntryEditDialogContent: React.FC<ContentProps> = ({
       patch.projectId = selection.projectId;
       patch.task = selection.taskName;
     }
-    if (parsedDuration !== entry.duration) patch.duration = parsedDuration;
+    if (durationChanged) patch.duration = parsedDuration;
     if ((notes || '') !== (entry.notes ?? '')) patch.notes = notes;
     if (selection.location !== entry.location) patch.location = selection.location;
 
@@ -219,7 +230,11 @@ const EntryEditDialogContent: React.FC<ContentProps> = ({
                   value={duration}
                   onChange={handleDurationInputChange}
                   placeholder="0.0"
-                  className="h-10 rounded-lg"
+                  aria-invalid={durationInvalid}
+                  className={cn(
+                    'h-10 rounded-lg',
+                    durationInvalid && 'border-destructive focus-visible:ring-destructive',
+                  )}
                 />
               </Field>
               <Field className="min-w-0">
@@ -239,7 +254,7 @@ const EntryEditDialogContent: React.FC<ContentProps> = ({
             <Button type="button" variant="outline" onClick={onClose} disabled={isSubmitting}>
               {t('common:buttons.cancel')}
             </Button>
-            <Button type="submit" disabled={isSubmitting || !isDirty || !hasValidDuration}>
+            <Button type="submit" disabled={isSubmitting || !isDirty || durationInvalid}>
               <Save className="size-4" aria-hidden="true" />
               {t('common:buttons.save')}
             </Button>

--- a/components/timesheet/EntryEditDialog.tsx
+++ b/components/timesheet/EntryEditDialog.tsx
@@ -1,0 +1,264 @@
+import { Save } from 'lucide-react';
+import type React from 'react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/button';
+import { Field, FieldLabel } from '@/components/ui/field';
+import { Input } from '@/components/ui/input';
+import type { Client, Project, ProjectTask, TimeEntry } from '../../types';
+import { hasScopedActionPermission } from '../../utils/permissions';
+import TaskFormModal, {
+  type RecurringConfig,
+  type TaskFormDetails,
+} from '../projects/TaskFormModal';
+import Modal from '../shared/Modal';
+import {
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle,
+} from '../shared/ModalLayout';
+import EntryCatalogSelector from './EntryCatalogSelector';
+import { CUSTOM_TASK_SENTINEL, useCatalogSelection } from './useCatalogSelection';
+
+export interface EntryEditDialogProps {
+  entry: TimeEntry | null;
+  onClose: () => void;
+  onSave: (id: string, updates: Partial<TimeEntry>) => Promise<void> | void;
+  clients: Client[];
+  projects: Project[];
+  projectTasks: ProjectTask[];
+  permissions: string[];
+  currency: string;
+  onAddCustomTask: (
+    name: string,
+    projectId: string,
+    recurringConfig?: RecurringConfig,
+    description?: string,
+    details?: TaskFormDetails,
+  ) => Promise<ProjectTask>;
+}
+
+// `key={entry.id}` forces a fresh hook state per entry — without it, useCatalogSelection
+// would carry stale selection across opens.
+const EntryEditDialog: React.FC<EntryEditDialogProps> = ({ entry, ...rest }) =>
+  entry ? <EntryEditDialogContent key={entry.id} entry={entry} {...rest} /> : null;
+
+interface ContentProps extends Omit<EntryEditDialogProps, 'entry'> {
+  entry: TimeEntry;
+}
+
+const EntryEditDialogContent: React.FC<ContentProps> = ({
+  entry,
+  onClose,
+  onSave,
+  clients,
+  projects,
+  projectTasks,
+  permissions,
+  currency,
+  onAddCustomTask,
+}) => {
+  const { t } = useTranslation(['timesheets', 'common']);
+  const canCreateCustomTask = hasScopedActionPermission(permissions, 'projects.tasks', 'create');
+
+  const selection = useCatalogSelection({
+    clients,
+    projects,
+    projectTasks,
+    defaultLocation: entry.location || 'remote',
+    initialSelection: {
+      clientId: entry.clientId,
+      projectId: entry.projectId,
+      taskId: entry.taskId ?? '',
+      taskName: entry.task,
+    },
+  });
+
+  const [duration, setDuration] = useState(String(entry.duration));
+  const [notes, setNotes] = useState(entry.notes ?? '');
+  const [errors, setErrors] = useState<{
+    clientId?: string;
+    projectId?: string;
+    task?: string;
+  }>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isAddTaskModalOpen, setIsAddTaskModalOpen] = useState(false);
+
+  const allowCustomTask = canCreateCustomTask && selection.projectId !== '';
+
+  const handleDurationInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const rawValue = event.target.value;
+    if (rawValue !== '' && !/^[0-9]*([.,][0-9]*)?$/.test(rawValue)) return;
+    setDuration(rawValue.replace(',', '.'));
+  };
+
+  const clearTaskError = () => {
+    if (errors.task) setErrors((prev) => ({ ...prev, task: '' }));
+  };
+
+  const handleAddCustomTaskSubmit = async (
+    taskName: string,
+    taskProjectId: string,
+    _recurringConfig: RecurringConfig | undefined,
+    description: string,
+    details: TaskFormDetails,
+  ): Promise<ProjectTask> => {
+    const created = await onAddCustomTask(taskName, taskProjectId, undefined, description, details);
+    selection.setTask(created.id, created.name);
+    clearTaskError();
+    return created;
+  };
+
+  const parsedDuration = parseFloat(duration);
+  const hasValidDuration = Number.isFinite(parsedDuration) && parsedDuration > 0;
+
+  const catalogChanged =
+    selection.clientId !== entry.clientId ||
+    selection.projectId !== entry.projectId ||
+    selection.taskName !== entry.task;
+  const isDirty =
+    catalogChanged ||
+    selection.location !== entry.location ||
+    (hasValidDuration && parsedDuration !== entry.duration) ||
+    (notes || '') !== (entry.notes ?? '');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const newErrors: typeof errors = {};
+    if (!selection.clientId) newErrors.clientId = t('entry.clientRequired');
+    if (!selection.projectId) newErrors.projectId = t('entry.projectRequired');
+    if (!selection.taskName) newErrors.task = t('entry.taskRequired');
+
+    if (Object.keys(newErrors).length > 0 || !hasValidDuration) {
+      setErrors(newErrors);
+      return;
+    }
+
+    // (clientId, projectId, task) is a tuple on the server — send all three together when
+    // any one changes so the backend never validates against a stale field.
+    const patch: Partial<TimeEntry> = {};
+    if (catalogChanged) {
+      const project = projects.find((p) => p.id === selection.projectId);
+      const client = clients.find((c) => c.id === selection.clientId);
+      patch.clientId = selection.clientId;
+      patch.clientName = client?.name || entry.clientName;
+      patch.projectId = selection.projectId;
+      patch.projectName = project?.name || entry.projectName;
+      patch.task = selection.taskName;
+    }
+    if (parsedDuration !== entry.duration) patch.duration = parsedDuration;
+    if ((notes || '') !== (entry.notes ?? '')) patch.notes = notes;
+    if (selection.location !== entry.location) patch.location = selection.location;
+
+    setIsSubmitting(true);
+    try {
+      if (Object.keys(patch).length > 0) {
+        await onSave(entry.id, patch);
+      }
+      onClose();
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal isOpen={true} onClose={onClose} ariaLabel={t('entry.editEntry')}>
+      <ModalContent size="xl">
+        <ModalHeader>
+          <ModalTitle>{t('entry.editEntry')}</ModalTitle>
+          <ModalCloseButton onClick={onClose} disabled={isSubmitting} />
+        </ModalHeader>
+        <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col">
+          <ModalBody className="space-y-4">
+            <EntryCatalogSelector
+              clients={clients}
+              filteredProjects={selection.filteredProjects}
+              filteredTasks={selection.filteredTasks}
+              selectedClientId={selection.clientId}
+              selectedProjectId={selection.projectId}
+              selectedTaskId={selection.taskId}
+              location={selection.location}
+              onClientChange={(id) => {
+                selection.setClient(id);
+                if (errors.clientId) setErrors((prev) => ({ ...prev, clientId: '' }));
+              }}
+              onProjectChange={(id) => {
+                selection.setProject(id);
+                if (errors.projectId) setErrors((prev) => ({ ...prev, projectId: '' }));
+              }}
+              onTaskChange={(taskId) => {
+                if (taskId === CUSTOM_TASK_SENTINEL) {
+                  setIsAddTaskModalOpen(true);
+                  return;
+                }
+                selection.setTask(taskId);
+                clearTaskError();
+              }}
+              onLocationChange={selection.setLocation}
+              allowCustomTask={allowCustomTask}
+              errors={errors}
+              extraTrailing={
+                <Field className="min-w-0">
+                  <FieldLabel htmlFor="entry-edit-hours">
+                    {t('entry.hours')} <span className="text-destructive">*</span>
+                  </FieldLabel>
+                  <Input
+                    id="entry-edit-hours"
+                    type="text"
+                    inputMode="decimal"
+                    pattern="^[0-9]*([.,][0-9]*)?$"
+                    value={duration}
+                    onChange={handleDurationInputChange}
+                    placeholder="0.0"
+                    className="h-9 min-h-9 max-h-9 rounded-lg py-2"
+                  />
+                </Field>
+              }
+            />
+
+            <Field className="min-w-0">
+              <FieldLabel htmlFor="entry-edit-notes">{t('entry.notesDescription')}</FieldLabel>
+              <Input
+                id="entry-edit-notes"
+                type="text"
+                value={notes}
+                onChange={(e) => setNotes(e.target.value)}
+                placeholder={t('entry.notesPlaceholder')}
+                className="h-10 rounded-lg"
+              />
+            </Field>
+          </ModalBody>
+          <ModalFooter>
+            <Button type="button" variant="outline" onClick={onClose} disabled={isSubmitting}>
+              {t('common:buttons.cancel')}
+            </Button>
+            <Button type="submit" disabled={isSubmitting || !isDirty || !hasValidDuration}>
+              <Save className="size-4" aria-hidden="true" />
+              {t('common:buttons.save')}
+            </Button>
+          </ModalFooter>
+        </form>
+      </ModalContent>
+      <TaskFormModal
+        isOpen={isAddTaskModalOpen}
+        onClose={() => setIsAddTaskModalOpen(false)}
+        mode="add"
+        projects={projects}
+        clients={clients}
+        currency={currency}
+        canCreate={canCreateCustomTask}
+        canUpdate={false}
+        canDelete={false}
+        onAdd={handleAddCustomTaskSubmit}
+        onUpdate={() => {}}
+        initialProjectId={selection.projectId}
+        projectLocked={true}
+      />
+    </Modal>
+  );
+};
+
+export default EntryEditDialog;

--- a/components/timesheet/EntryEditDialog.tsx
+++ b/components/timesheet/EntryEditDialog.tsx
@@ -7,6 +7,7 @@ import { Field, FieldLabel } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
 import type { Client, Project, ProjectTask, TimeEntry } from '../../types';
 import { hasScopedActionPermission } from '../../utils/permissions';
+import { toastError } from '../../utils/toast';
 import TaskFormModal, {
   type RecurringConfig,
   type TaskFormDetails,
@@ -113,7 +114,8 @@ const EntryEditDialogContent: React.FC<ContentProps> = ({
   };
 
   const parsedDuration = parseFloat(duration);
-  const hasValidDuration = Number.isFinite(parsedDuration) && parsedDuration > 0;
+  // Backend accepts duration >= 0 (placeholders carry 0); only block on blank/NaN.
+  const hasValidDuration = Number.isFinite(parsedDuration) && parsedDuration >= 0;
 
   const catalogChanged =
     selection.clientId !== entry.clientId ||
@@ -159,6 +161,8 @@ const EntryEditDialogContent: React.FC<ContentProps> = ({
         await onSave(entry.id, patch);
       }
       onClose();
+    } catch (err) {
+      toastError(err instanceof Error ? err.message : t('entry.entryUpdateFailed'));
     } finally {
       setIsSubmitting(false);
     }

--- a/components/timesheet/WeeklyView.tsx
+++ b/components/timesheet/WeeklyView.tsx
@@ -19,6 +19,7 @@ import type { Client, Project, ProjectTask, TimeEntry, TimeEntryLocation } from 
 import { downloadCsv } from '../../utils/csv';
 import { dateOnlyStringToLocalDate, getLocalDateString } from '../../utils/date';
 import { isItalianHoliday } from '../../utils/holidays';
+import { toastError } from '../../utils/toast';
 import Calendar from '../shared/Calendar';
 import { TABLE_CONTROL_BUTTON_CLASSNAME } from '../shared/tableControlStyles';
 import ValidatedNumberInput from '../shared/ValidatedNumberInput';
@@ -492,10 +493,14 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
       for (const id of entriesToDelete) {
         pending.push(Promise.resolve(onDeleteEntry(id)));
       }
-      await Promise.all(pending);
-      setPendingEdits({});
-      setWeekNote('');
-      setShowSuccess(true);
+      try {
+        await Promise.all(pending);
+        setPendingEdits({});
+        setWeekNote('');
+        setShowSuccess(true);
+      } catch (err) {
+        toastError(err instanceof Error ? err.message : t('entry.entryUpdateFailed'));
+      }
     } finally {
       setIsLoading(false);
     }

--- a/components/timesheet/WeeklyView.tsx
+++ b/components/timesheet/WeeklyView.tsx
@@ -493,13 +493,20 @@ const WeeklyView: React.FC<WeeklyViewProps> = ({
       for (const id of entriesToDelete) {
         pending.push(Promise.resolve(onDeleteEntry(id)));
       }
-      try {
-        await Promise.all(pending);
+      // allSettled (not all): a single failure shouldn't abort the rest. Successful
+      // writes already update local entry state via their handlers; we only gate the
+      // "clear pendingEdits / show success" path on every write succeeding.
+      const results = await Promise.allSettled(pending);
+      const rejected = results.filter((r): r is PromiseRejectedResult => r.status === 'rejected');
+      if (rejected.length === 0) {
         setPendingEdits({});
         setWeekNote('');
         setShowSuccess(true);
-      } catch (err) {
-        toastError(err instanceof Error ? err.message : t('entry.entryUpdateFailed'));
+      } else {
+        const firstReason = rejected[0].reason;
+        toastError(
+          firstReason instanceof Error ? firstReason.message : t('entry.entryUpdateFailed'),
+        );
       }
     } finally {
       setIsLoading(false);

--- a/components/timesheet/useCatalogSelection.ts
+++ b/components/timesheet/useCatalogSelection.ts
@@ -8,6 +8,16 @@ export interface UseCatalogSelectionOptions {
   projects: Project[];
   projectTasks: ProjectTask[];
   defaultLocation?: TimeEntryLocation;
+  /**
+   * Seed the initial selection (used by the edit dialog so the form opens on the entry's
+   * existing client/project/task instead of the catalog's first row). Only read on mount.
+   */
+  initialSelection?: {
+    clientId?: string;
+    projectId?: string;
+    taskId?: string;
+    taskName?: string;
+  };
 }
 
 export interface UseCatalogSelectionResult {
@@ -30,11 +40,12 @@ export function useCatalogSelection({
   projects,
   projectTasks,
   defaultLocation = 'remote',
+  initialSelection,
 }: UseCatalogSelectionOptions): UseCatalogSelectionResult {
-  const [clientId, setClientId] = useState(clients[0]?.id ?? '');
-  const [projectId, setProjectId] = useState('');
-  const [taskId, setTaskId] = useState('');
-  const [taskName, setTaskName] = useState('');
+  const [clientId, setClientId] = useState(initialSelection?.clientId ?? clients[0]?.id ?? '');
+  const [projectId, setProjectId] = useState(initialSelection?.projectId ?? '');
+  const [taskId, setTaskId] = useState(initialSelection?.taskId ?? '');
+  const [taskName, setTaskName] = useState(initialSelection?.taskName ?? '');
   const [location, setLocation] = useState<TimeEntryLocation>(defaultLocation);
 
   useEffect(() => {

--- a/components/timesheet/useCatalogSelection.ts
+++ b/components/timesheet/useCatalogSelection.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { Client, Project, ProjectTask, TimeEntryLocation } from '../../types';
 
 export const CUSTOM_TASK_SENTINEL = 'custom';
@@ -48,6 +48,13 @@ export function useCatalogSelection({
   const [taskName, setTaskName] = useState(initialSelection?.taskName ?? '');
   const [location, setLocation] = useState<TimeEntryLocation>(defaultLocation);
 
+  // When seeded (edit dialog), the seed must survive the first snap-to-first pass —
+  // otherwise an entry whose task/project is no longer in the scoped catalog (orphan,
+  // archived) would silently jump to the catalog's first row. One ref per field so
+  // they consume independently.
+  const skipProjectSnapRef = useRef(initialSelection?.projectId !== undefined);
+  const skipTaskSnapRef = useRef(initialSelection?.taskId !== undefined);
+
   useEffect(() => {
     if (clients.length === 0) {
       if (clientId !== '') setClientId('');
@@ -72,16 +79,21 @@ export function useCatalogSelection({
   const firstFilteredTaskName = filteredTasks[0]?.name ?? '';
 
   useEffect(() => {
+    const skipOnce = skipProjectSnapRef.current;
+    skipProjectSnapRef.current = false;
     if (filteredProjects.length === 0) {
       if (projectId !== '') setProjectId('');
       return;
     }
     if (!filteredProjects.some((project) => project.id === projectId)) {
+      if (skipOnce) return;
       setProjectId(firstFilteredProjectId);
     }
   }, [filteredProjects, firstFilteredProjectId, projectId]);
 
   useEffect(() => {
+    const skipOnce = skipTaskSnapRef.current;
+    skipTaskSnapRef.current = false;
     if (filteredTasks.length === 0) {
       setTaskId('');
       setTaskName('');
@@ -89,6 +101,7 @@ export function useCatalogSelection({
     }
 
     if (!filteredTasks.some((task) => task.id === taskId)) {
+      if (skipOnce) return;
       setTaskName(firstFilteredTaskName);
       setTaskId(firstFilteredTaskId);
     }

--- a/components/timesheet/useCatalogSelection.ts
+++ b/components/timesheet/useCatalogSelection.ts
@@ -82,6 +82,7 @@ export function useCatalogSelection({
     const skipOnce = skipProjectSnapRef.current;
     skipProjectSnapRef.current = false;
     if (filteredProjects.length === 0) {
+      if (skipOnce) return;
       if (projectId !== '') setProjectId('');
       return;
     }
@@ -95,6 +96,7 @@ export function useCatalogSelection({
     const skipOnce = skipTaskSnapRef.current;
     skipTaskSnapRef.current = false;
     if (filteredTasks.length === 0) {
+      if (skipOnce) return;
       setTaskId('');
       setTaskName('');
       return;

--- a/hooks/handlers/entryHandlers.ts
+++ b/hooks/handlers/entryHandlers.ts
@@ -79,6 +79,7 @@ export const makeEntryHandlers = (deps: EntryHandlersDeps) => {
       setEntries((prev) => prev.map((e) => (e.id === id ? updated : e)));
     } catch (err) {
       console.error('Failed to update entry:', err);
+      throw err;
     }
   };
 

--- a/locales/en/timesheets.json
+++ b/locales/en/timesheets.json
@@ -32,6 +32,7 @@
     "addToTimesheet": "Add to Timesheet",
     "entryAdded": "Time entry added successfully",
     "entryUpdated": "Time entry updated successfully",
+    "entryUpdateFailed": "Failed to update time entry",
     "entryDeleted": "Time entry deleted",
     "deleteConfirm": "Are you sure you want to delete this time entry?",
     "recurring": "This is a recurring task",

--- a/locales/it/timesheets.json
+++ b/locales/it/timesheets.json
@@ -32,6 +32,7 @@
     "addToTimesheet": "Aggiungi al Timesheet",
     "entryAdded": "Voce timesheet aggiunta con successo",
     "entryUpdated": "Voce timesheet aggiornata con successo",
+    "entryUpdateFailed": "Impossibile aggiornare la voce timesheet",
     "entryDeleted": "Voce timesheet eliminata",
     "deleteConfirm": "Sei sicuro di voler eliminare questa voce timesheet?",
     "recurring": "Questa è un'attività ricorrente",

--- a/server/repositories/clientsRepo.ts
+++ b/server/repositories/clientsRepo.ts
@@ -288,6 +288,11 @@ export const existsById = async (id: string, exec: DbExecutor = db): Promise<boo
   return rows.length > 0;
 };
 
+export const findName = async (id: string, exec: DbExecutor = db): Promise<string | null> => {
+  const rows = await exec.select({ name: clients.name }).from(clients).where(eq(clients.id, id));
+  return rows[0]?.name ?? null;
+};
+
 export const findByFiscalCode = async (
   fiscalCode: string,
   excludeId: string | null,

--- a/server/repositories/entriesRepo.ts
+++ b/server/repositories/entriesRepo.ts
@@ -259,7 +259,11 @@ export const findOwner = async (id: string, exec: DbExecutor = db): Promise<stri
 
 export type EntryContext = {
   userId: string;
+  date: string;
+  clientId: string;
+  clientName: string;
   projectId: string;
+  projectName: string;
   task: string;
   taskId: string | null;
 };
@@ -271,13 +275,21 @@ export const findContext = async (
   const rows = await exec
     .select({
       userId: timeEntries.userId,
+      date: timeEntries.date,
+      clientId: timeEntries.clientId,
+      clientName: timeEntries.clientName,
       projectId: timeEntries.projectId,
+      projectName: timeEntries.projectName,
       task: timeEntries.task,
       taskId: timeEntries.taskId,
     })
     .from(timeEntries)
     .where(eq(timeEntries.id, id));
-  return rows[0] ?? null;
+  const row = rows[0];
+  if (!row) return null;
+  const date = normalizeNullableDateOnly(row.date, 'entry.date');
+  if (!date) throw new TypeError('Invalid date value for entry.date');
+  return { ...row, date };
 };
 
 export type NewEntry = {
@@ -364,13 +376,22 @@ export const createMany = async (
 };
 
 export type EntryUpdate = {
+  date?: string;
+  clientId?: string;
+  clientName?: string;
+  projectId?: string;
+  projectName?: string;
+  task?: string;
   duration?: number;
   /** `null` clears the column (the schema allows NULL); `undefined` leaves it untouched. */
   notes?: string | null;
   isPlaceholder?: boolean;
   location?: string;
-  /** Backfill-only: pass the resolved task FK on legacy rows. `undefined` leaves it untouched. */
-  taskId?: string;
+  /**
+   * `null` clears the column (orphan a legacy entry), `string` writes the resolved task FK,
+   * `undefined` leaves it untouched.
+   */
+  taskId?: string | null;
 };
 
 export const update = async (
@@ -379,6 +400,12 @@ export const update = async (
   exec: DbExecutor = db,
 ): Promise<TimeEntry | null> => {
   const setValues: Partial<typeof timeEntries.$inferInsert> = {};
+  if (patch.date !== undefined) setValues.date = patch.date;
+  if (patch.clientId !== undefined) setValues.clientId = patch.clientId;
+  if (patch.clientName !== undefined) setValues.clientName = patch.clientName;
+  if (patch.projectId !== undefined) setValues.projectId = patch.projectId;
+  if (patch.projectName !== undefined) setValues.projectName = patch.projectName;
+  if (patch.task !== undefined) setValues.task = patch.task;
   if (patch.duration !== undefined) setValues.duration = numericForDb(patch.duration);
   if (patch.notes !== undefined) setValues.notes = patch.notes;
   if (patch.isPlaceholder !== undefined) setValues.isPlaceholder = patch.isPlaceholder;

--- a/server/repositories/projectsRepo.ts
+++ b/server/repositories/projectsRepo.ts
@@ -188,6 +188,17 @@ export const findClientId = async (id: string, exec: DbExecutor = db): Promise<s
   return rows[0]?.clientId ?? null;
 };
 
+export const findClientIdAndName = async (
+  id: string,
+  exec: DbExecutor = db,
+): Promise<{ clientId: string; name: string } | null> => {
+  const rows = await exec
+    .select({ clientId: projects.clientId, name: projects.name })
+    .from(projects)
+    .where(eq(projects.id, id));
+  return rows[0] ?? null;
+};
+
 export const lockClientIdById = async (
   id: string,
   exec: DbExecutor = db,

--- a/server/routes/entries.ts
+++ b/server/routes/entries.ts
@@ -86,12 +86,12 @@ const entryCreateBodySchema = {
 
 const entryUpdateBodySchema = {
   type: 'object',
+  // Display names (clientName, projectName) are derived server-side from the IDs and
+  // intentionally not part of the update wire format — see `updateTimeEntry`.
   properties: {
     date: { type: 'string', format: 'date' },
     clientId: { type: 'string' },
-    clientName: { type: 'string' },
     projectId: { type: 'string' },
-    projectName: { type: 'string' },
     task: { type: 'string' },
     duration: { type: 'number' },
     notes: { type: ['string', 'null'] },

--- a/server/routes/entries.ts
+++ b/server/routes/entries.ts
@@ -87,8 +87,14 @@ const entryCreateBodySchema = {
 const entryUpdateBodySchema = {
   type: 'object',
   properties: {
+    date: { type: 'string', format: 'date' },
+    clientId: { type: 'string' },
+    clientName: { type: 'string' },
+    projectId: { type: 'string' },
+    projectName: { type: 'string' },
+    task: { type: 'string' },
     duration: { type: 'number' },
-    notes: { type: 'string' },
+    notes: { type: ['string', 'null'] },
     isPlaceholder: { type: 'boolean' },
     location: { type: 'string' },
   },

--- a/server/services/timeEntries.ts
+++ b/server/services/timeEntries.ts
@@ -196,7 +196,18 @@ export const createTimeEntry = async (
 export const updateTimeEntry = async (
   actor: AuthenticatedActor,
   id: unknown,
-  input: { duration?: unknown; notes?: unknown; isPlaceholder?: unknown; location?: unknown },
+  input: {
+    date?: unknown;
+    clientId?: unknown;
+    clientName?: unknown;
+    projectId?: unknown;
+    projectName?: unknown;
+    task?: unknown;
+    duration?: unknown;
+    notes?: unknown;
+    isPlaceholder?: unknown;
+    location?: unknown;
+  },
 ): Promise<TimeEntry> => {
   if (!hasTrackerPermission(actor, 'update')) fail(403, 'Insufficient permissions');
   const entryId = requireValid(requireNonEmptyString(id, 'id'));
@@ -219,20 +230,91 @@ export const updateTimeEntry = async (
     if (!allowed) fail(403, 'Not authorized to update this entry');
   }
 
-  let backfilledTaskId: string | undefined;
-  if (context.taskId === null) {
-    backfilledTaskId =
-      (await tasksRepo.findIdByProjectAndName(context.projectId, context.task)) ?? undefined;
+  const date =
+    input.date !== undefined ? requireValid(parseDateString(input.date, 'date')) : undefined;
+  const clientId =
+    input.clientId !== undefined
+      ? requireValid(requireNonEmptyString(input.clientId, 'clientId'))
+      : undefined;
+  const clientName =
+    input.clientName !== undefined
+      ? requireValid(requireNonEmptyString(input.clientName, 'clientName'))
+      : undefined;
+  const projectId =
+    input.projectId !== undefined
+      ? requireValid(requireNonEmptyString(input.projectId, 'projectId'))
+      : undefined;
+  const projectName =
+    input.projectName !== undefined
+      ? requireValid(requireNonEmptyString(input.projectName, 'projectName'))
+      : undefined;
+  const task =
+    input.task !== undefined ? requireValid(requireNonEmptyString(input.task, 'task')) : undefined;
+
+  // (clientId, projectId, task) is a tuple — partial patches risk silently orphaning taskId
+  // or 403-ing on assignment checks against a stale field. Require all three together.
+  const catalogFieldsSet = [clientId, projectId, task].filter((v) => v !== undefined).length;
+  if (catalogFieldsSet !== 0 && catalogFieldsSet !== 3) {
+    badRequest('clientId, projectId, and task must be updated together');
+  }
+  const catalogChanging = catalogFieldsSet === 3;
+
+  if (date !== undefined && isWeekendDate(date)) {
+    const settings = await generalSettingsRepo.get();
+    if (!(settings?.allowWeekendSelection ?? true)) {
+      badRequest('Time entries on weekends are not allowed');
+    }
+  }
+
+  let resolvedTaskId: string | null | undefined;
+  if (catalogChanging) {
+    // Non-null because catalogFieldsSet === 3 above.
+    const effectiveClientId = clientId as string;
+    const effectiveProjectId = projectId as string;
+    const effectiveTask = task as string;
+
+    const [projectClientId, taskFkLookup] = await Promise.all([
+      projectsRepo.findClientId(effectiveProjectId),
+      tasksRepo.findIdByProjectAndName(effectiveProjectId, effectiveTask),
+    ]);
+    if (projectClientId === null) badRequest('Project not found');
+    if (projectClientId !== effectiveClientId) {
+      badRequest('Project does not belong to the selected client');
+    }
+
+    resolvedTaskId = taskFkLookup ?? null;
+
+    if (!hasPermission(actor, 'timesheets.tracker_all.update')) {
+      const [clientAllowed, projectAllowed, taskAllowed] = await Promise.all([
+        userAssignmentsRepo.isClientAssignedToUser(context.userId, effectiveClientId),
+        userAssignmentsRepo.isProjectAssignedToUser(context.userId, effectiveProjectId),
+        resolvedTaskId
+          ? userAssignmentsRepo.isTaskAssignedToUser(context.userId, resolvedTaskId)
+          : Promise.resolve(true),
+      ]);
+      if (!clientAllowed || !projectAllowed || !taskAllowed) {
+        fail(403, 'Not authorized to assign this entry to that client, project, or task');
+      }
+    }
+  } else if (context.taskId === null) {
+    const backfill = await tasksRepo.findIdByProjectAndName(context.projectId, context.task);
+    if (backfill) resolvedTaskId = backfill;
   }
 
   const parsedIsPlaceholder = requireValid(parseBooleanField(input, 'isPlaceholder'));
 
   const updated = await entriesRepo.update(entryId, {
+    date,
+    clientId,
+    clientName,
+    projectId,
+    projectName,
+    task,
     duration: parsedDuration,
     notes: validatedNotes,
     isPlaceholder: parsedIsPlaceholder,
     location: parseOptionalLocation(input.location, fail),
-    taskId: backfilledTaskId,
+    taskId: resolvedTaskId,
   });
 
   if (updated === null) return fail(404, 'Entry not found');

--- a/server/services/timeEntries.ts
+++ b/server/services/timeEntries.ts
@@ -1,4 +1,5 @@
 import { withDbTransaction } from '../db/drizzle.ts';
+import * as clientsRepo from '../repositories/clientsRepo.ts';
 import type { TimeEntry } from '../repositories/entriesRepo.ts';
 import * as entriesRepo from '../repositories/entriesRepo.ts';
 import * as generalSettingsRepo from '../repositories/generalSettingsRepo.ts';
@@ -199,9 +200,7 @@ export const updateTimeEntry = async (
   input: {
     date?: unknown;
     clientId?: unknown;
-    clientName?: unknown;
     projectId?: unknown;
-    projectName?: unknown;
     task?: unknown;
     duration?: unknown;
     notes?: unknown;
@@ -236,17 +235,9 @@ export const updateTimeEntry = async (
     input.clientId !== undefined
       ? requireValid(requireNonEmptyString(input.clientId, 'clientId'))
       : undefined;
-  const clientName =
-    input.clientName !== undefined
-      ? requireValid(requireNonEmptyString(input.clientName, 'clientName'))
-      : undefined;
   const projectId =
     input.projectId !== undefined
       ? requireValid(requireNonEmptyString(input.projectId, 'projectId'))
-      : undefined;
-  const projectName =
-    input.projectName !== undefined
-      ? requireValid(requireNonEmptyString(input.projectName, 'projectName'))
       : undefined;
   const task =
     input.task !== undefined ? requireValid(requireNonEmptyString(input.task, 'task')) : undefined;
@@ -267,22 +258,30 @@ export const updateTimeEntry = async (
   }
 
   let resolvedTaskId: string | null | undefined;
+  // Names are derived server-side from the IDs to keep the denormalized display fields
+  // consistent with the FK targets — any clientName/projectName the caller sent is ignored.
+  let resolvedClientName: string | undefined;
+  let resolvedProjectName: string | undefined;
   if (catalogChanging) {
     // Non-null because catalogFieldsSet === 3 above.
     const effectiveClientId = clientId as string;
     const effectiveProjectId = projectId as string;
     const effectiveTask = task as string;
 
-    const [projectClientId, taskFkLookup] = await Promise.all([
-      projectsRepo.findClientId(effectiveProjectId),
+    const [projectHeader, taskFkLookup, clientNameLookup] = await Promise.all([
+      projectsRepo.findClientIdAndName(effectiveProjectId),
       tasksRepo.findIdByProjectAndName(effectiveProjectId, effectiveTask),
+      clientsRepo.findName(effectiveClientId),
     ]);
-    if (projectClientId === null) badRequest('Project not found');
-    if (projectClientId !== effectiveClientId) {
+    if (projectHeader === null) return fail(400, 'Project not found');
+    if (clientNameLookup === null) return fail(400, 'Client not found');
+    if (projectHeader.clientId !== effectiveClientId) {
       badRequest('Project does not belong to the selected client');
     }
 
     resolvedTaskId = taskFkLookup ?? null;
+    resolvedProjectName = projectHeader.name;
+    resolvedClientName = clientNameLookup;
 
     if (!hasPermission(actor, 'timesheets.tracker_all.update')) {
       const [clientAllowed, projectAllowed, taskAllowed] = await Promise.all([
@@ -306,9 +305,9 @@ export const updateTimeEntry = async (
   const updated = await entriesRepo.update(entryId, {
     date,
     clientId,
-    clientName,
+    clientName: resolvedClientName,
     projectId,
-    projectName,
+    projectName: resolvedProjectName,
     task,
     duration: parsedDuration,
     notes: validatedNotes,

--- a/server/test/repositories/entriesRepo.test.ts
+++ b/server/test/repositories/entriesRepo.test.ts
@@ -238,17 +238,25 @@ describe('findOwner', () => {
 
 describe('findContext', () => {
   test('returns full context including taskId when present', async () => {
-    exec.enqueue({ rows: [['u-1', 'p-1', 'Dev', 't-1']] });
+    exec.enqueue({
+      rows: [['u-1', '2026-04-30', 'c-1', 'Acme', 'p-1', 'Alpha', 'Dev', 't-1']],
+    });
     expect(await entriesRepo.findContext('e-1', testDb)).toEqual({
       userId: 'u-1',
+      date: '2026-04-30',
+      clientId: 'c-1',
+      clientName: 'Acme',
       projectId: 'p-1',
+      projectName: 'Alpha',
       task: 'Dev',
       taskId: 't-1',
     });
   });
 
   test('returns context with null taskId for orphaned entries', async () => {
-    exec.enqueue({ rows: [['u-1', 'p-1', 'Dev', null]] });
+    exec.enqueue({
+      rows: [['u-1', '2026-04-30', 'c-1', 'Acme', 'p-1', 'Alpha', 'Dev', null]],
+    });
     expect((await entriesRepo.findContext('e-1', testDb))?.taskId).toBeNull();
   });
 

--- a/server/test/routes/entries.test.ts
+++ b/server/test/routes/entries.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
 import type { FastifyInstance, FastifyPluginAsync } from 'fastify';
 import * as realDrizzle from '../../db/drizzle.ts';
+import * as realClientsRepo from '../../repositories/clientsRepo.ts';
 import * as realEntriesRepo from '../../repositories/entriesRepo.ts';
 import * as realGeneralSettingsRepo from '../../repositories/generalSettingsRepo.ts';
 import * as realProjectsRepo from '../../repositories/projectsRepo.ts';
@@ -25,6 +26,7 @@ const entriesRepoSnap = { ...realEntriesRepo };
 const generalSettingsRepoSnap = { ...realGeneralSettingsRepo };
 const tasksRepoSnap = { ...realTasksRepo };
 const projectsRepoSnap = { ...realProjectsRepo };
+const clientsRepoSnap = { ...realClientsRepo };
 const userAssignmentsRepoSnap = { ...realUserAssignmentsRepo };
 const workUnitsRepoSnap = { ...realWorkUnitsRepo };
 const drizzleSnap = { ...realDrizzle };
@@ -54,7 +56,9 @@ const entriesFindExistingRecurringKeysMock = mock();
 const entriesDecodeCursorMock = mock();
 const entriesEncodeCursorMock = mock((c: unknown) => `enc:${JSON.stringify(c)}`);
 const projectsFindClientIdMock = mock();
+const projectsFindClientIdAndNameMock = mock();
 const projectsListNamesByIdsMock = mock();
+const clientsFindNameMock = mock();
 const isClientAssignedToUserMock = mock();
 const isProjectAssignedToUserMock = mock();
 const isTaskAssignedToUserMock = mock();
@@ -108,7 +112,12 @@ beforeAll(async () => {
   mock.module('../../repositories/projectsRepo.ts', () => ({
     ...projectsRepoSnap,
     findClientId: projectsFindClientIdMock,
+    findClientIdAndName: projectsFindClientIdAndNameMock,
     listNamesByIds: projectsListNamesByIdsMock,
+  }));
+  mock.module('../../repositories/clientsRepo.ts', () => ({
+    ...clientsRepoSnap,
+    findName: clientsFindNameMock,
   }));
   mock.module('../../db/drizzle.ts', () => ({
     ...drizzleSnap,
@@ -140,6 +149,7 @@ afterAll(() => {
   mock.module('../../repositories/generalSettingsRepo.ts', () => generalSettingsRepoSnap);
   mock.module('../../repositories/tasksRepo.ts', () => tasksRepoSnap);
   mock.module('../../repositories/projectsRepo.ts', () => projectsRepoSnap);
+  mock.module('../../repositories/clientsRepo.ts', () => clientsRepoSnap);
   mock.module('../../repositories/userAssignmentsRepo.ts', () => userAssignmentsRepoSnap);
   mock.module('../../repositories/workUnitsRepo.ts', () => workUnitsRepoSnap);
   mock.module('../../db/drizzle.ts', () => drizzleSnap);
@@ -228,7 +238,9 @@ const allMocks = [
   entriesFindExistingRecurringKeysMock,
   entriesDecodeCursorMock,
   projectsFindClientIdMock,
+  projectsFindClientIdAndNameMock,
   projectsListNamesByIdsMock,
+  clientsFindNameMock,
   isClientAssignedToUserMock,
   isProjectAssignedToUserMock,
   isTaskAssignedToUserMock,
@@ -254,6 +266,8 @@ beforeEach(async () => {
   userHasRoleMock.mockResolvedValue(true);
   getRolePermissionsMock.mockResolvedValue(TRACKER_PERMS);
   projectsFindClientIdMock.mockResolvedValue('c1');
+  projectsFindClientIdAndNameMock.mockResolvedValue({ clientId: 'c1', name: 'Project' });
+  clientsFindNameMock.mockResolvedValue('Client');
   isClientAssignedToUserMock.mockResolvedValue(true);
   isProjectAssignedToUserMock.mockResolvedValue(true);
   isTaskAssignedToUserMock.mockResolvedValue(true);
@@ -797,16 +811,17 @@ describe('PUT /api/entries/:id', () => {
     expect(entriesUpdateMock).not.toHaveBeenCalled();
   });
 
-  test('200 reassigns client/project/task and resolves new taskId', async () => {
+  test('200 reassigns client/project/task and derives names server-side, resolves new taskId', async () => {
     entriesFindContextMock.mockResolvedValue(sampleContext());
-    projectsFindClientIdMock.mockResolvedValue('c2');
+    projectsFindClientIdAndNameMock.mockResolvedValue({ clientId: 'c2', name: 'Beta (resolved)' });
+    clientsFindNameMock.mockResolvedValue('Other (resolved)');
     findIdByProjectAndNameMock.mockResolvedValue('t2');
     entriesUpdateMock.mockResolvedValue({
       ...SAMPLE_ENTRY,
       clientId: 'c2',
-      clientName: 'Other',
+      clientName: 'Other (resolved)',
       projectId: 'p2',
-      projectName: 'Beta',
+      projectName: 'Beta (resolved)',
       task: 'QA',
       taskId: 't2',
     });
@@ -815,24 +830,26 @@ describe('PUT /api/entries/:id', () => {
       method: 'PUT',
       url: '/api/entries/te-1',
       headers: authHeader(),
+      // Send caller-supplied names that the service must IGNORE and replace with repo lookups.
       payload: {
         clientId: 'c2',
-        clientName: 'Other',
+        clientName: 'stale-from-client',
         projectId: 'p2',
-        projectName: 'Beta',
+        projectName: 'stale-from-client',
         task: 'QA',
       },
     });
 
     expect(res.statusCode).toBe(200);
-    expect(projectsFindClientIdMock).toHaveBeenCalledWith('p2');
+    expect(projectsFindClientIdAndNameMock).toHaveBeenCalledWith('p2');
+    expect(clientsFindNameMock).toHaveBeenCalledWith('c2');
     expect(findIdByProjectAndNameMock).toHaveBeenCalledWith('p2', 'QA');
     const patch = entriesUpdateMock.mock.calls[0][1] as Record<string, unknown>;
     expect(patch).toMatchObject({
       clientId: 'c2',
-      clientName: 'Other',
+      clientName: 'Other (resolved)',
       projectId: 'p2',
-      projectName: 'Beta',
+      projectName: 'Beta (resolved)',
       task: 'QA',
       taskId: 't2',
     });
@@ -840,7 +857,7 @@ describe('PUT /api/entries/:id', () => {
 
   test('400 when new project does not belong to the new client', async () => {
     entriesFindContextMock.mockResolvedValue(sampleContext());
-    projectsFindClientIdMock.mockResolvedValue('c-other');
+    projectsFindClientIdAndNameMock.mockResolvedValue({ clientId: 'c-other', name: 'Beta' });
 
     const res = await testApp.inject({
       method: 'PUT',
@@ -848,9 +865,7 @@ describe('PUT /api/entries/:id', () => {
       headers: authHeader(),
       payload: {
         clientId: 'c2',
-        clientName: 'Other',
         projectId: 'p2',
-        projectName: 'Beta',
         task: 'QA',
       },
     });
@@ -862,7 +877,8 @@ describe('PUT /api/entries/:id', () => {
 
   test('403 reassigning to project the owner is not assigned to', async () => {
     entriesFindContextMock.mockResolvedValue(sampleContext());
-    projectsFindClientIdMock.mockResolvedValue('c2');
+    projectsFindClientIdAndNameMock.mockResolvedValue({ clientId: 'c2', name: 'Beta' });
+    clientsFindNameMock.mockResolvedValue('Other');
     findIdByProjectAndNameMock.mockResolvedValue('t2');
     isProjectAssignedToUserMock.mockResolvedValue(false);
 
@@ -872,9 +888,7 @@ describe('PUT /api/entries/:id', () => {
       headers: authHeader(),
       payload: {
         clientId: 'c2',
-        clientName: 'Other',
         projectId: 'p2',
-        projectName: 'Beta',
         task: 'QA',
       },
     });
@@ -911,7 +925,8 @@ describe('PUT /api/entries/:id', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(projectsFindClientIdMock).not.toHaveBeenCalled();
+    expect(projectsFindClientIdAndNameMock).not.toHaveBeenCalled();
+    expect(clientsFindNameMock).not.toHaveBeenCalled();
     const patch = entriesUpdateMock.mock.calls[0][1] as Record<string, unknown>;
     expect(patch.clientId).toBeUndefined();
     expect(patch.projectId).toBeUndefined();
@@ -950,7 +965,7 @@ describe('PUT /api/entries/:id', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(projectsFindClientIdMock).not.toHaveBeenCalled();
+    expect(projectsFindClientIdAndNameMock).not.toHaveBeenCalled();
     const patch = entriesUpdateMock.mock.calls[0][1] as Record<string, unknown>;
     expect(patch.date).toBe('2025-06-03');
   });

--- a/server/test/routes/entries.test.ts
+++ b/server/test/routes/entries.test.ts
@@ -918,6 +918,59 @@ describe('PUT /api/entries/:id', () => {
     expect(patch.task).toBeUndefined();
     expect(patch.duration).toBe(7);
   });
+
+  test.each([
+    ['task without projectId/clientId', { task: 'QA' }],
+    ['clientId without projectId/task', { clientId: 'c2', clientName: 'Other' }],
+    ['clientId + task without projectId', { clientId: 'c2', clientName: 'Other', task: 'QA' }],
+  ])('400 partial catalog patch (%s) is rejected', async (_label, payload) => {
+    entriesFindContextMock.mockResolvedValue(sampleContext());
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/entries/te-1',
+      headers: authHeader(),
+      payload,
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/must be updated together/);
+    expect(entriesUpdateMock).not.toHaveBeenCalled();
+  });
+
+  test('200 updating date alone forwards the new value to the repo', async () => {
+    entriesFindContextMock.mockResolvedValue(sampleContext());
+    entriesUpdateMock.mockResolvedValue({ ...SAMPLE_ENTRY, date: '2025-06-03' });
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/entries/te-1',
+      headers: authHeader(),
+      payload: { date: '2025-06-03' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(projectsFindClientIdMock).not.toHaveBeenCalled();
+    const patch = entriesUpdateMock.mock.calls[0][1] as Record<string, unknown>;
+    expect(patch.date).toBe('2025-06-03');
+  });
+
+  test('400 updating date to a weekend when allowWeekendSelection is false', async () => {
+    entriesFindContextMock.mockResolvedValue(sampleContext());
+    generalSettingsGetMock.mockResolvedValue({ allowWeekendSelection: false } as never);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/entries/te-1',
+      headers: authHeader(),
+      // 2025-06-07 is a Saturday.
+      payload: { date: '2025-06-07' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/weekend/i);
+    expect(entriesUpdateMock).not.toHaveBeenCalled();
+  });
 });
 
 describe('DELETE /api/entries/:id', () => {

--- a/server/test/routes/entries.test.ts
+++ b/server/test/routes/entries.test.ts
@@ -183,6 +183,29 @@ const SAMPLE_ENTRY = {
   createdAt: 1_700_000_000_000,
 };
 
+type SampleContextOverrides = Partial<{
+  userId: string;
+  date: string;
+  clientId: string;
+  clientName: string;
+  projectId: string;
+  projectName: string;
+  task: string;
+  taskId: string | null;
+}>;
+
+const sampleContext = (overrides: SampleContextOverrides = {}) => ({
+  userId: SAMPLE_ENTRY.userId,
+  date: SAMPLE_ENTRY.date,
+  clientId: SAMPLE_ENTRY.clientId,
+  clientName: SAMPLE_ENTRY.clientName,
+  projectId: SAMPLE_ENTRY.projectId,
+  projectName: SAMPLE_ENTRY.projectName,
+  task: SAMPLE_ENTRY.task,
+  taskId: SAMPLE_ENTRY.taskId as string | null,
+  ...overrides,
+});
+
 const allMocks = [
   findAuthUserByIdMock,
   userHasRoleMock,
@@ -599,12 +622,7 @@ describe('POST /api/entries', () => {
 
 describe('PUT /api/entries/:id', () => {
   test('200 update own entry', async () => {
-    entriesFindContextMock.mockResolvedValue({
-      userId: 'u1',
-      projectId: 'p1',
-      task: 'Dev',
-      taskId: 't1',
-    });
+    entriesFindContextMock.mockResolvedValue(sampleContext());
     entriesUpdateMock.mockResolvedValue({ ...SAMPLE_ENTRY, duration: 6 });
 
     const res = await testApp.inject({
@@ -622,12 +640,7 @@ describe('PUT /api/entries/:id', () => {
   });
 
   test('200 backfills taskId when context.taskId is null', async () => {
-    entriesFindContextMock.mockResolvedValue({
-      userId: 'u1',
-      projectId: 'p1',
-      task: 'Dev',
-      taskId: null,
-    });
+    entriesFindContextMock.mockResolvedValue(sampleContext({ taskId: null }));
     findIdByProjectAndNameMock.mockResolvedValue('t-resolved');
     entriesUpdateMock.mockResolvedValue(SAMPLE_ENTRY);
 
@@ -661,12 +674,7 @@ describe('PUT /api/entries/:id', () => {
   });
 
   test('404 when update returns null', async () => {
-    entriesFindContextMock.mockResolvedValue({
-      userId: 'u1',
-      projectId: 'p1',
-      task: 'Dev',
-      taskId: 't1',
-    });
+    entriesFindContextMock.mockResolvedValue(sampleContext());
     entriesUpdateMock.mockResolvedValue(null);
 
     const res = await testApp.inject({
@@ -680,12 +688,7 @@ describe('PUT /api/entries/:id', () => {
   });
 
   test('403 cross-user update without manager link', async () => {
-    entriesFindContextMock.mockResolvedValue({
-      userId: 'u2',
-      projectId: 'p1',
-      task: 'Dev',
-      taskId: 't1',
-    });
+    entriesFindContextMock.mockResolvedValue(sampleContext({ userId: 'u2' }));
     isUserManagedByMock.mockResolvedValue(false);
 
     const res = await testApp.inject({
@@ -700,12 +703,7 @@ describe('PUT /api/entries/:id', () => {
   });
 
   test('400 invalid duration', async () => {
-    entriesFindContextMock.mockResolvedValue({
-      userId: 'u1',
-      projectId: 'p1',
-      task: 'Dev',
-      taskId: 't1',
-    });
+    entriesFindContextMock.mockResolvedValue(sampleContext());
 
     const res = await testApp.inject({
       method: 'PUT',
@@ -731,12 +729,7 @@ describe('PUT /api/entries/:id', () => {
   });
 
   test('200 empty-string location does not pass through to repo (would violate CHECK)', async () => {
-    entriesFindContextMock.mockResolvedValue({
-      userId: 'u1',
-      projectId: 'p1',
-      task: 'Dev',
-      taskId: 't1',
-    });
+    entriesFindContextMock.mockResolvedValue(sampleContext());
     entriesUpdateMock.mockResolvedValue(SAMPLE_ENTRY);
 
     const res = await testApp.inject({
@@ -753,12 +746,7 @@ describe('PUT /api/entries/:id', () => {
   });
 
   test('200 whitespace-only location is treated as untouched', async () => {
-    entriesFindContextMock.mockResolvedValue({
-      userId: 'u1',
-      projectId: 'p1',
-      task: 'Dev',
-      taskId: 't1',
-    });
+    entriesFindContextMock.mockResolvedValue(sampleContext());
     entriesUpdateMock.mockResolvedValue(SAMPLE_ENTRY);
 
     const res = await testApp.inject({
@@ -775,12 +763,7 @@ describe('PUT /api/entries/:id', () => {
   });
 
   test('200 valid location string is forwarded to repo', async () => {
-    entriesFindContextMock.mockResolvedValue({
-      userId: 'u1',
-      projectId: 'p1',
-      task: 'Dev',
-      taskId: 't1',
-    });
+    entriesFindContextMock.mockResolvedValue(sampleContext());
     entriesUpdateMock.mockResolvedValue(SAMPLE_ENTRY);
 
     const res = await testApp.inject({
@@ -800,12 +783,7 @@ describe('PUT /api/entries/:id', () => {
     // Previously a non-empty invalid value passed through to the repo and
     // bubbled up as a 500 from the DB CHECK constraint. Now caught at the
     // service layer.
-    entriesFindContextMock.mockResolvedValue({
-      userId: 'u1',
-      projectId: 'p1',
-      task: 'Dev',
-      taskId: 't1',
-    });
+    entriesFindContextMock.mockResolvedValue(sampleContext());
 
     const res = await testApp.inject({
       method: 'PUT',
@@ -817,6 +795,128 @@ describe('PUT /api/entries/:id', () => {
     expect(res.statusCode).toBe(400);
     expect(JSON.parse(res.body).error).toContain('Invalid location');
     expect(entriesUpdateMock).not.toHaveBeenCalled();
+  });
+
+  test('200 reassigns client/project/task and resolves new taskId', async () => {
+    entriesFindContextMock.mockResolvedValue(sampleContext());
+    projectsFindClientIdMock.mockResolvedValue('c2');
+    findIdByProjectAndNameMock.mockResolvedValue('t2');
+    entriesUpdateMock.mockResolvedValue({
+      ...SAMPLE_ENTRY,
+      clientId: 'c2',
+      clientName: 'Other',
+      projectId: 'p2',
+      projectName: 'Beta',
+      task: 'QA',
+      taskId: 't2',
+    });
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/entries/te-1',
+      headers: authHeader(),
+      payload: {
+        clientId: 'c2',
+        clientName: 'Other',
+        projectId: 'p2',
+        projectName: 'Beta',
+        task: 'QA',
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(projectsFindClientIdMock).toHaveBeenCalledWith('p2');
+    expect(findIdByProjectAndNameMock).toHaveBeenCalledWith('p2', 'QA');
+    const patch = entriesUpdateMock.mock.calls[0][1] as Record<string, unknown>;
+    expect(patch).toMatchObject({
+      clientId: 'c2',
+      clientName: 'Other',
+      projectId: 'p2',
+      projectName: 'Beta',
+      task: 'QA',
+      taskId: 't2',
+    });
+  });
+
+  test('400 when new project does not belong to the new client', async () => {
+    entriesFindContextMock.mockResolvedValue(sampleContext());
+    projectsFindClientIdMock.mockResolvedValue('c-other');
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/entries/te-1',
+      headers: authHeader(),
+      payload: {
+        clientId: 'c2',
+        clientName: 'Other',
+        projectId: 'p2',
+        projectName: 'Beta',
+        task: 'QA',
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/Project does not belong/);
+    expect(entriesUpdateMock).not.toHaveBeenCalled();
+  });
+
+  test('403 reassigning to project the owner is not assigned to', async () => {
+    entriesFindContextMock.mockResolvedValue(sampleContext());
+    projectsFindClientIdMock.mockResolvedValue('c2');
+    findIdByProjectAndNameMock.mockResolvedValue('t2');
+    isProjectAssignedToUserMock.mockResolvedValue(false);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/entries/te-1',
+      headers: authHeader(),
+      payload: {
+        clientId: 'c2',
+        clientName: 'Other',
+        projectId: 'p2',
+        projectName: 'Beta',
+        task: 'QA',
+      },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body).error).toMatch(/Not authorized to assign/);
+    expect(entriesUpdateMock).not.toHaveBeenCalled();
+  });
+
+  test('400 partial catalog patch (projectId without task) is rejected', async () => {
+    entriesFindContextMock.mockResolvedValue(sampleContext());
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/entries/te-1',
+      headers: authHeader(),
+      payload: { projectId: 'p2', projectName: 'Beta' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toMatch(/must be updated together/);
+    expect(entriesUpdateMock).not.toHaveBeenCalled();
+  });
+
+  test('200 updating only duration leaves catalog fields untouched (no client/project/task lookup)', async () => {
+    entriesFindContextMock.mockResolvedValue(sampleContext());
+    entriesUpdateMock.mockResolvedValue({ ...SAMPLE_ENTRY, duration: 7 });
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/entries/te-1',
+      headers: authHeader(),
+      payload: { duration: 7 },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(projectsFindClientIdMock).not.toHaveBeenCalled();
+    const patch = entriesUpdateMock.mock.calls[0][1] as Record<string, unknown>;
+    expect(patch.clientId).toBeUndefined();
+    expect(patch.projectId).toBeUndefined();
+    expect(patch.task).toBeUndefined();
+    expect(patch.duration).toBe(7);
   });
 });
 

--- a/test/components/timesheet/EntryEditDialog.test.tsx
+++ b/test/components/timesheet/EntryEditDialog.test.tsx
@@ -6,6 +6,13 @@ import { render } from '../../helpers/render';
 
 installI18nMock();
 
+const toastErrorMock = mock(() => {});
+mock.module('../../../utils/toast', () => ({
+  toastError: toastErrorMock,
+  toastSuccess: () => {},
+  toast: { error: () => {}, success: () => {}, info: () => {} },
+}));
+
 const EntryEditDialog = (await import('../../../components/timesheet/EntryEditDialog')).default;
 
 const clients: Client[] = [
@@ -123,6 +130,60 @@ describe('<EntryEditDialog />', () => {
       expect(onClose).toHaveBeenCalled();
     });
     expect(onSave).not.toHaveBeenCalled();
+  });
+
+  test('keeps the dialog open and surfaces a toast when onSave rejects', async () => {
+    toastErrorMock.mockClear();
+    const onSave = mock(() => Promise.reject(new Error('Server said no')));
+    const onClose = mock(() => {});
+
+    render(
+      <EntryEditDialog
+        {...baseProps}
+        entry={sampleEntry}
+        onClose={onClose}
+        onSave={onSave as never}
+      />,
+    );
+
+    const hoursInput = document.getElementById('entry-edit-hours') as HTMLInputElement;
+    fireEvent.change(hoursInput, { target: { value: '4' } });
+    fireEvent.submit(hoursInput.closest('form') as HTMLFormElement);
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith('Server said no');
+    });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  test('allows editing other fields on a duration=0 placeholder entry', async () => {
+    const onSave = mock(() => Promise.resolve());
+    const onClose = mock(() => {});
+
+    render(
+      <EntryEditDialog
+        {...baseProps}
+        entry={{ ...sampleEntry, duration: 0, isPlaceholder: true }}
+        onClose={onClose}
+        onSave={onSave as never}
+      />,
+    );
+
+    const hoursInput = document.getElementById('entry-edit-hours') as HTMLInputElement;
+    const notesInput = document.getElementById('entry-edit-notes') as HTMLInputElement;
+    expect(hoursInput.value).toBe('0');
+
+    fireEvent.change(notesInput, { target: { value: 'placeholder note' } });
+    fireEvent.submit(hoursInput.closest('form') as HTMLFormElement);
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledTimes(1);
+    });
+    const [, patch] = (onSave as unknown as { mock: { calls: unknown[][] } }).mock.calls[0] as [
+      string,
+      Partial<TimeEntry>,
+    ];
+    expect(patch).toEqual({ notes: 'placeholder note' });
   });
 
   test('cancel closes without saving', () => {

--- a/test/components/timesheet/EntryEditDialog.test.tsx
+++ b/test/components/timesheet/EntryEditDialog.test.tsx
@@ -1,0 +1,153 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { fireEvent, waitFor } from '@testing-library/react';
+import type { Client, Project, ProjectTask, TimeEntry } from '../../../types';
+import { installI18nMock } from '../../helpers/i18n';
+import { render } from '../../helpers/render';
+
+installI18nMock();
+
+const EntryEditDialog = (await import('../../../components/timesheet/EntryEditDialog')).default;
+
+const clients: Client[] = [
+  { id: 'client-alpha', name: 'Alpha Client' },
+  { id: 'client-beta', name: 'Beta Client' },
+];
+
+const projects: Project[] = [
+  { id: 'project-alpha', name: 'Alpha Project', clientId: 'client-alpha', color: '#111111' },
+  { id: 'project-beta', name: 'Beta Project', clientId: 'client-beta', color: '#222222' },
+];
+
+const projectTasks: ProjectTask[] = [
+  { id: 'task-alpha', name: 'Alpha Task', projectId: 'project-alpha' },
+  { id: 'task-alpha-2', name: 'Alpha QA', projectId: 'project-alpha' },
+  { id: 'task-beta', name: 'Beta Task', projectId: 'project-beta' },
+];
+
+const sampleEntry: TimeEntry = {
+  id: 'te-1',
+  userId: 'u-1',
+  date: '2026-05-11',
+  clientId: 'client-alpha',
+  clientName: 'Alpha Client',
+  projectId: 'project-alpha',
+  projectName: 'Alpha Project',
+  task: 'Alpha Task',
+  taskId: 'task-alpha',
+  notes: 'initial notes',
+  duration: 2.5,
+  hourlyCost: 50,
+  cost: 125,
+  isPlaceholder: false,
+  location: 'remote',
+  createdAt: 1_700_000_000_000,
+};
+
+const baseProps = {
+  clients,
+  projects,
+  projectTasks,
+  permissions: [],
+  currency: '$',
+  onAddCustomTask: mock(() => Promise.resolve(undefined)) as never,
+};
+
+describe('<EntryEditDialog />', () => {
+  test('renders nothing when entry is null', () => {
+    const { container } = render(
+      <EntryEditDialog
+        {...baseProps}
+        entry={null}
+        onClose={mock(() => {})}
+        onSave={mock(() => {})}
+      />,
+    );
+    expect(container).not.toHaveTextContent('entry.editEntry');
+  });
+
+  test('pre-populates fields from the entry and saves the edited duration + notes', async () => {
+    const onSave = mock(() => Promise.resolve());
+    const onClose = mock(() => {});
+
+    render(
+      <EntryEditDialog
+        {...baseProps}
+        entry={sampleEntry}
+        onClose={onClose}
+        onSave={onSave as never}
+      />,
+    );
+
+    // Hours input shows the original duration; notes input shows the original notes.
+    const hoursInput = document.getElementById('entry-edit-hours') as HTMLInputElement;
+    const notesInput = document.getElementById('entry-edit-notes') as HTMLInputElement;
+    expect(hoursInput.value).toBe('2.5');
+    expect(notesInput.value).toBe('initial notes');
+
+    fireEvent.change(hoursInput, { target: { value: '3.25' } });
+    fireEvent.change(notesInput, { target: { value: 'updated notes' } });
+
+    fireEvent.submit(hoursInput.closest('form') as HTMLFormElement);
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledTimes(1);
+    });
+    const [id, patch] = (onSave as unknown as { mock: { calls: unknown[][] } }).mock.calls[0] as [
+      string,
+      Partial<TimeEntry>,
+    ];
+    expect(id).toBe('te-1');
+    expect(patch).toEqual({ duration: 3.25, notes: 'updated notes' });
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  test('does not call onSave when no field changed; still closes', async () => {
+    const onSave = mock(() => Promise.resolve());
+    const onClose = mock(() => {});
+
+    render(
+      <EntryEditDialog
+        {...baseProps}
+        entry={sampleEntry}
+        onClose={onClose}
+        onSave={onSave as never}
+      />,
+    );
+
+    const hoursInput = document.getElementById('entry-edit-hours') as HTMLInputElement;
+    fireEvent.submit(hoursInput.closest('form') as HTMLFormElement);
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalled();
+    });
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  test('cancel closes without saving', () => {
+    const onSave = mock(() => Promise.resolve());
+    const onClose = mock(() => {});
+
+    render(
+      <EntryEditDialog
+        {...baseProps}
+        entry={sampleEntry}
+        onClose={onClose}
+        onSave={onSave as never}
+      />,
+    );
+
+    const hoursInput = document.getElementById('entry-edit-hours') as HTMLInputElement;
+    fireEvent.change(hoursInput, { target: { value: '9' } });
+
+    const cancelButtons = Array.from(document.querySelectorAll('button')).filter((b) =>
+      b.textContent?.includes('common:buttons.cancel'),
+    );
+    expect(cancelButtons.length).toBeGreaterThan(0);
+    fireEvent.click(cancelButtons[0]);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onSave).not.toHaveBeenCalled();
+  });
+});

--- a/test/components/timesheet/EntryEditDialog.test.tsx
+++ b/test/components/timesheet/EntryEditDialog.test.tsx
@@ -186,6 +186,53 @@ describe('<EntryEditDialog />', () => {
     expect(patch).toEqual({ notes: 'placeholder note' });
   });
 
+  test('clearing the hours field still allows saving notes-only changes', async () => {
+    const onSave = mock(() => Promise.resolve());
+    const onClose = mock(() => {});
+
+    render(
+      <EntryEditDialog
+        {...baseProps}
+        entry={sampleEntry}
+        onClose={onClose}
+        onSave={onSave as never}
+      />,
+    );
+
+    const hoursInput = document.getElementById('entry-edit-hours') as HTMLInputElement;
+    const notesInput = document.getElementById('entry-edit-notes') as HTMLInputElement;
+
+    fireEvent.change(hoursInput, { target: { value: '' } });
+    fireEvent.change(notesInput, { target: { value: 'just the note' } });
+    fireEvent.submit(hoursInput.closest('form') as HTMLFormElement);
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledTimes(1);
+    });
+    const [, patch] = (onSave as unknown as { mock: { calls: unknown[][] } }).mock.calls[0] as [
+      string,
+      Partial<TimeEntry>,
+    ];
+    // Blank duration is treated as "untouched" — no `duration` field in the patch.
+    expect(patch).toEqual({ notes: 'just the note' });
+  });
+
+  test('resolves seeded taskId via name lookup when the entry has no taskId FK', () => {
+    render(
+      <EntryEditDialog
+        {...baseProps}
+        // Legacy/orphan entry: taskId is null but the task name matches a catalog row.
+        entry={{ ...sampleEntry, taskId: null }}
+        onClose={mock(() => {})}
+        onSave={mock(() => {})}
+      />,
+    );
+
+    // The Task SelectControl trigger surfaces the resolved task name, not the placeholder,
+    // proving the seed found a real catalog id rather than rendering an empty dropdown.
+    expect(document.body).toHaveTextContent('Alpha Task');
+  });
+
   test('cancel closes without saving', () => {
     const onSave = mock(() => Promise.resolve());
     const onClose = mock(() => {});

--- a/test/handlers/entryHandlers.test.ts
+++ b/test/handlers/entryHandlers.test.ts
@@ -281,7 +281,7 @@ describe('makeEntryHandlers', () => {
     expect(entries.get()[1]).toEqual({ id: 'e2', createdAt: 2, task: 'B' });
   });
 
-  test('update swallows errors', async () => {
+  test('update rethrows errors after logging so callers can react', async () => {
     apiMocks.entriesUpdate.mockImplementation(() => Promise.reject(new Error('boom')));
     const entries = makeStubSetter<EntryLike>([{ id: 'e1', createdAt: 1, task: 'A' }]);
     const handlers = makeEntryHandlers({
@@ -292,7 +292,7 @@ describe('makeEntryHandlers', () => {
 
     const restore = silenceConsole();
     try {
-      await handlers.update('e1', { task: 'A2' } as never);
+      await expect(handlers.update('e1', { task: 'A2' } as never)).rejects.toThrow('boom');
       expect(entries.get()).toEqual([{ id: 'e1', createdAt: 1, task: 'A' }]);
     } finally {
       restore();


### PR DESCRIPTION
## Summary

Adds right-click editing for time entries in the Daily mode activity table. Right-clicking a row (or clicking the new pen icon in the actions column) opens a dialog with the same fields as the creation form — client, project, task, location, hours, notes — and saves via `PUT /api/entries/:id`.

## What changed

**Backend (`server/`)**
- Broadened `entryUpdateBodySchema` in `routes/entries.ts` to accept `date / clientId / clientName / projectId / projectName / task`.
- Extended `services/timeEntries.ts:updateTimeEntry` to validate the catalog change: project-belongs-to-client, user-assignment scope, and re-resolution of `taskId`. The two DB lookups (`projectsRepo.findClientId` + `tasksRepo.findIdByProjectAndName`) run in parallel.
- `(clientId, projectId, task)` is treated as a **tuple** on the wire: if any of the three is in the patch, all three must be — otherwise a partial patch could silently orphan `taskId` or 403 against an unrelated assignment. The service returns 400 on partial catalog patches.
- `repositories/entriesRepo.ts`: extended `EntryContext` and `EntryUpdate` to cover all editable columns; `findContext` now also returns date/clientId/clientName/projectName.

**Frontend**
- New `components/timesheet/EntryEditDialog.tsx`: reuses `EntryCatalogSelector` + a new `initialSelection` seed on `useCatalogSelection` so the form opens on the entry's existing client/project/task. The patch sent to the backend only includes fields that actually changed (and always sends the catalog trio together when any one changes).
- `App.tsx`: the daily activity table's actions column gets an Edit button next to Delete. `StandardTable` already auto-derives the row context menu from action-column buttons, so right-click → "Edit" / "Delete" works without extra wiring. Dialog mounted once at the tracker view, controlled by `editingEntry` state.

## Why partial-catalog rejection

`updateTimeEntry` builds an "effective" `(clientId, projectId, task)` tuple from current+patch values to validate. But the patch persisted to the repo only contains the *changed* fields. A patch like `{ projectId: 'p2' }` would silently null `taskId` (no task named X under p2) or 403 against an assignment for a task the user didn't try to change. Forcing the trio to travel together at the wire level removes the drift surface.

## Tests

- **Backend**: full-tuple reassignment (200), partial-catalog rejection (400), project/client mismatch (400), missing assignment (403), duration-only update doesn't trigger catalog lookups, regression coverage for existing duration/notes/location paths.
- **Frontend**: `EntryEditDialog` opens with pre-populated fields, saves only changed fields, no-op submit doesn't call onSave, Cancel closes without saving.
- Total suite: 2,502 frontend + 1,029 backend tests, all green; lint clean.

## Test plan

- [ ] In Daily mode, right-click an entry row → context menu shows **Edit** + **Delete**.
- [ ] Click **Edit** → dialog opens with all fields pre-populated from the row.
- [ ] Change only hours → Save → table updates, day total recalculates, no network error.
- [ ] Change client → project + task auto-reset to first valid options → pick a new project + task → Save → row reflects new client/project/task.
- [ ] Try to save with empty task → inline validation error, dialog stays open.
- [ ] Cancel → dialog closes, table unchanged.

## Not done in this PR

- Docs under `docs-site/src/content/docs/` (it + en) describing the new edit affordance. Worth a fast-follow per the CLAUDE.md docs-maintenance rule.
- Broader refactor extracting shared form pieces (`duration-input handler`, `errors hook`, `catalog-tuple validator`) between `DailyView` / `EntryEditDialog` and `createTimeEntry` / `updateTimeEntry`. Real reuse opportunity, but a bigger change than this feature warrants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)