### PR TITLE
fix(sales): show offer discount percentage

### DIFF
--- a/components/sales/ClientOffersView.tsx
+++ b/components/sales/ClientOffersView.tsx
@@ -93,6 +93,20 @@ const getDefaultFormData = (): Partial<ClientOffer> => ({
   notes: '',
 });
 
+const formatPercentageLabelValue = (value: number): string => {
+  const rounded = Math.round(value * 100) / 100;
+  if (Number.isInteger(rounded)) return String(rounded);
+  return rounded.toFixed(2).replace(/0+$/, '').replace(/\.$/, '');
+};
+
+const getDiscountPercentageLabelValue = (subtotal: number, discountAmount: number): string => {
+  if (!Number.isFinite(subtotal) || subtotal <= 0 || !Number.isFinite(discountAmount)) {
+    return '0%';
+  }
+
+  return `${formatPercentageLabelValue((discountAmount / subtotal) * 100)}%`;
+};
+
 const ClientOffersView: React.FC<ClientOffersViewProps> = ({
   offers,
   clients,
@@ -1498,10 +1512,9 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                             discountAmount > 0
                               ? {
                                   label: t('sales:clientOffers.discountAmount', {
-                                    value: formatDiscountValue(
-                                      formData.discount ?? 0,
-                                      formData.discountType ?? 'percentage',
-                                      currency,
+                                    value: getDiscountPercentageLabelValue(
+                                      subtotal,
+                                      discountAmount,
                                     ),
                                   }),
                                   amount: discountAmount,

--- a/components/sales/ClientOffersView.tsx
+++ b/components/sales/ClientOffersView.tsx
@@ -11,6 +11,7 @@ import type {
   Client,
   ClientOffer,
   ClientOfferItem,
+  DiscountType,
   OfferVersion,
   Product,
   SupplierQuote,
@@ -99,7 +100,16 @@ const formatPercentageLabelValue = (value: number): string => {
   return rounded.toFixed(2).replace(/0+$/, '').replace(/\.$/, '');
 };
 
-const getDiscountPercentageLabelValue = (subtotal: number, discountAmount: number): string => {
+const getDiscountPercentageLabelValue = (
+  discount: number,
+  discountType: DiscountType,
+  subtotal: number,
+  discountAmount: number,
+): string => {
+  if (discountType === 'percentage') {
+    return `${formatPercentageLabelValue(Number.isFinite(discount) ? discount : 0)}%`;
+  }
+
   if (!Number.isFinite(subtotal) || subtotal <= 0 || !Number.isFinite(discountAmount)) {
     return '0%';
   }
@@ -1513,6 +1523,8 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                               ? {
                                   label: t('sales:clientOffers.discountAmount', {
                                     value: getDiscountPercentageLabelValue(
+                                      discountValue,
+                                      formData.discountType ?? 'percentage',
                                       subtotal,
                                       discountAmount,
                                     ),

--- a/docs-site/src/content/docs/en/sales-accounting.md
+++ b/docs-site/src/content/docs/en/sales-accounting.md
@@ -11,6 +11,8 @@ Quotes and offers include products, quantities, prices, discounts, and terms. Us
 
 The quote list shows code, insertion date, client, subtotal, discount percentage, absolute discount, discounted total, margin, MOL, payment terms, due date, and status so the main values can be checked without opening each record.
 
+In offer summaries, the **Discount** row always shows the equivalent percentage in parentheses, even when the global discount is entered as a fixed amount. The discount amount remains visible in currency on the right.
+
 When a document is accepted, continue by creating the linked order or next document instead of manually entering the same rows again.
 
 ## Supplier quotes

--- a/docs-site/src/content/docs/sales-accounting.md
+++ b/docs-site/src/content/docs/sales-accounting.md
@@ -11,6 +11,8 @@ I preventivi e le offerte raccolgono prodotti, quantità, prezzi, sconti e condi
 
 La lista dei preventivi mostra codice, data di inserimento, cliente, subtotale, sconto percentuale, sconto assoluto, totale scontato, margine, MOL, termini di pagamento, scadenza e stato per controllare rapidamente i valori principali senza aprire ogni record.
 
+Nel riepilogo delle offerte, la riga **Sconto** mostra sempre la percentuale equivalente tra parentesi, anche quando lo sconto globale è inserito come importo fisso. L'importo dello sconto resta visibile in valuta sulla destra.
+
 Quando un documento viene accettato, prosegui creando l'ordine o il documento collegato invece di reinserire manualmente le stesse righe.
 
 ## Preventivi fornitori

--- a/test/components/ClientOffersView.test.tsx
+++ b/test/components/ClientOffersView.test.tsx
@@ -1,10 +1,14 @@
-import { afterEach, describe, expect, test } from 'bun:test';
+import { afterEach, describe, expect, mock, test } from 'bun:test';
 import { fireEvent, screen } from '@testing-library/react';
 import type { Client, ClientOffer, Product, SupplierQuote } from '../../types';
 import { installI18nMock } from '../helpers/i18n';
 import { render } from '../helpers/render';
 
-installI18nMock();
+installI18nMock({ includeInterpolatedValues: true });
+
+mock.module('../../components/sales/OfferVersionsPanel', () => ({
+  default: () => null,
+}));
 
 const ClientOffersView = (await import('../../components/sales/ClientOffersView')).default;
 
@@ -119,5 +123,25 @@ describe('<ClientOffersView /> filter controls', () => {
     pickStatusOption('sales:clientOffers.allStatuses');
     expect(screen.getByText('O-ACME-DRAFT')).toBeInTheDocument();
     expect(screen.getByText('O-GLOBEX-SENT')).toBeInTheDocument();
+  });
+});
+
+describe('<ClientOffersView /> discount summary', () => {
+  test('labels a fixed global discount with the equivalent percentage', () => {
+    const fixedDiscountOffer = buildOffer({
+      id: 'O-FIXED-DISCOUNT',
+      discount: 15,
+      discountType: 'currency',
+    });
+
+    render(<ClientOffersView {...baseProps} offers={[fixedDiscountOffer]} />);
+
+    fireEvent.click(screen.getByText('O-FIXED-DISCOUNT'));
+
+    expect(screen.getByText('sales:clientOffers.editOffer')).toBeInTheDocument();
+    expect(screen.getByText('sales:clientOffers.discountAmount (15%)')).toBeInTheDocument();
+    expect(
+      screen.queryByText('sales:clientOffers.discountAmount (15 EUR)'),
+    ).not.toBeInTheDocument();
   });
 });

--- a/test/components/ClientOffersView.test.tsx
+++ b/test/components/ClientOffersView.test.tsx
@@ -69,6 +69,18 @@ const baseProps = {
   currency: 'EUR',
 };
 
+const tinySubtotalItem: ClientOffer['items'][number] = {
+  id: 'tiny-item',
+  offerId: 'O-base',
+  productId: 'p-1',
+  productName: 'Tiny Widget',
+  quantity: 1,
+  unitPrice: 0.03,
+  productCost: 0,
+  productMolPercentage: 0,
+  unitType: 'unit',
+};
+
 afterEach(() => {
   document.body.style.overflow = '';
 });
@@ -140,8 +152,27 @@ describe('<ClientOffersView /> discount summary', () => {
 
     expect(screen.getByText('sales:clientOffers.editOffer')).toBeInTheDocument();
     expect(screen.getByText('sales:clientOffers.discountAmount (15%)')).toBeInTheDocument();
+    expect(screen.getAllByText('-15.00 EUR').length).toBeGreaterThan(0);
     expect(
       screen.queryByText('sales:clientOffers.discountAmount (15 EUR)'),
+    ).not.toBeInTheDocument();
+  });
+
+  test('keeps the entered percentage label when the rounded discount amount differs', () => {
+    const percentageDiscountOffer = buildOffer({
+      id: 'O-PERCENT-DISCOUNT',
+      discount: 50,
+      discountType: 'percentage',
+      items: [tinySubtotalItem],
+    });
+
+    render(<ClientOffersView {...baseProps} offers={[percentageDiscountOffer]} />);
+
+    fireEvent.click(screen.getByText('O-PERCENT-DISCOUNT'));
+
+    expect(screen.getByText('sales:clientOffers.discountAmount (50%)')).toBeInTheDocument();
+    expect(
+      screen.queryByText('sales:clientOffers.discountAmount (66.67%)'),
     ).not.toBeInTheDocument();
   });
 });

--- a/test/helpers/i18n.tsx
+++ b/test/helpers/i18n.tsx
@@ -6,10 +6,15 @@ import type { ReactNode } from 'react';
  * Test assertions check translation keys, not translations.
  * Call once at the top of a test file before importing components.
  */
-export const installI18nMock = () => {
+export const installI18nMock = (options?: { includeInterpolatedValues?: boolean }) => {
   mock.module('react-i18next', () => ({
     useTranslation: () => ({
-      t: (key: string) => key,
+      t: (key: string, values?: Record<string, unknown>) => {
+        if (options?.includeInterpolatedValues && values && 'value' in values) {
+          return `${key} (${String(values.value)})`;
+        }
+        return key;
+      },
       i18n: { language: 'en', changeLanguage: () => {} },
     }),
     Trans: ({ children }: { children: ReactNode }) => children,


### PR DESCRIPTION
## Summary
- Updates the client offer edit summary so fixed-amount global discounts display their equivalent percentage in the discount label.
- Keeps the absolute discount amount visible in currency on the right side of the summary row.
- Documents the summary behavior in Italian and English user docs.

## Changes
- Derives the summary discount label from the calculated discount amount divided by subtotal.
- Adds regression coverage for a fixed EUR offer discount rendering as a percentage label.
- Extends the shared i18n test helper so tests can assert interpolated label values when needed.

## Testing
- `bun test test\components\ClientOffersView.test.tsx`
- `bun test test\utils\numbers.test.ts`
- `bunx --bun biome check components\sales\ClientOffersView.tsx test\components\ClientOffersView.test.tsx test\helpers\i18n.tsx docs-site\src\content\docs\sales-accounting.md docs-site\src\content\docs\en\sales-accounting.md`
- `bunx --bun tsc -p tsconfig.json --noEmit`
- `bun run docs:user`

## Risks / Rollout
- Low risk. Change is scoped to the client offer summary label and documentation.
- Full `bun run typecheck` is currently blocked in this workspace by missing server dependencies such as `fastify`, `drizzle-orm`, and `@fastify/cors`.

## Issues
Fixes #463
