### PR TITLE
fix(calendar): make activity dots visible in dark mode

### DIFF
--- a/components/shared/Calendar.tsx
+++ b/components/shared/Calendar.tsx
@@ -226,7 +226,7 @@ const Calendar: React.FC<CalendarProps> = ({
 
               {hasActivity && selectionMode === 'single' && (
                 <span
-                  className={`absolute bottom-1 size-1 rounded-full ${isSelected ? 'bg-secondary-foreground' : isWeekendOrHoliday ? 'bg-red-300' : dailyTotals[dateStr] >= dailyGoal - 0.01 && dailyGoal > 0 ? 'bg-emerald-400' : 'bg-praetor'}`}
+                  className={`absolute bottom-1 size-1 rounded-full ${isSelected ? 'bg-secondary-foreground' : isWeekendOrHoliday ? 'bg-red-300' : dailyTotals[dateStr] >= dailyGoal - 0.01 && dailyGoal > 0 ? 'bg-emerald-400' : 'bg-foreground'}`}
                 ></span>
               )}
               {holidayName && selectionMode === 'single' && (


### PR DESCRIPTION
## Summary
- The `Calendar` activity dot (shown at the bottom of a day cell when the user has time entries) was nearly invisible in dark mode. The default branch used `bg-praetor`, which resolves to dark navy in both themes; inside `shadcn-theme-bridge` (applied by `Layout` and modal shells) it was further rewritten to `var(--secondary)` ≈ `oklch(0.274)`, almost identical to the dark background.
- Swapped that single branch to `bg-foreground`, which auto-flips between near-black on light and near-white on dark. Light-mode appearance is preserved (the brand `#20293f` and `--foreground` `oklch(0.141)` are visually indistinguishable); dark mode now shows a clearly visible dot.
- No legend update needed — the legend only documents the holiday/weekend and goal-reached dots, both of which already used mid-tone colors that read in either theme.

The other three branches of the dot color ladder (`bg-secondary-foreground` for selected, `bg-red-300` for weekend/holiday, `bg-emerald-400` for goal-reached) were already theme-safe and are untouched.

## Test plan
- [x] `bun test test/components/Calendar.test.tsx` — 11/11 pass
- [x] `bun test test/components/timesheet` — 12/12 pass
- [x] `bun test test/components/shared` — 4/4 pass
- [ ] Visual check, dark mode: in Timesheets / `WeeklyView` / `DatePickerButton`, days with entries show a clearly visible near-white dot. Spot-check normal/selected/weekend-or-holiday/goal-reached days.
- [ ] Visual check, light mode: dot still appears as the existing dark mark (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)