### PR TITLE
fix(ui): keep StandardTable height stable across empty/sparse/full states (#464)

### DIFF
--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -47,6 +47,7 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from '../ui/dropdown-menu';
+import { Empty, EmptyHeader, EmptyTitle } from '../ui/empty';
 import { Field, FieldError, FieldLabel } from '../ui/field';
 import { Input } from '../ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
@@ -88,6 +89,10 @@ const STORAGE_SUFFIX = {
   activeView: 'activeview',
 } as const;
 type StorageSuffix = (typeof STORAGE_SUFFIX)[keyof typeof STORAGE_SUFFIX];
+
+// Keep in sync with the `h-11` Tailwind class on padding rows (1rem*2.75 = 44px).
+// Reserved height of empty-state cell = minBodyRows × this constant.
+const BODY_ROW_HEIGHT_PX = 44;
 
 const slugify = (s: string) => s.replace(/[^a-zA-Z0-9]/g, '_').toLowerCase();
 
@@ -172,6 +177,12 @@ export type StandardTableProps<T extends object = object> = {
   data?: T[];
   columns?: Column<T>[];
   defaultRowsPerPage?: number;
+  /**
+   * Minimum visible body rows. When the current page has fewer rows than this,
+   * the body is padded with inert placeholder rows so the table footprint stays
+   * stable across empty / sparse / full states. Defaults to 4.
+   */
+  minBodyRows?: number;
   rowClassName?: (row: T) => string;
   disabledRow?: (row: T) => boolean;
   onRowClick?: (row: T) => void;
@@ -195,6 +206,7 @@ const StandardTable = <T extends object>({
   data,
   columns,
   defaultRowsPerPage = 10,
+  minBodyRows = 4,
   rowClassName,
   disabledRow,
   onRowClick,
@@ -701,6 +713,15 @@ const StandardTable = <T extends object>({
   const hasTrailingSpacer =
     shouldRenderTable && !shouldAnchorTrailingActionColumn && visibleColumns.length > 0;
   const tableStretches = shouldAnchorTrailingActionColumn || hasTrailingSpacer;
+  const bodyColSpan = Math.max(
+    visibleColumns.length +
+      (shouldAnchorTrailingActionColumn ? 1 : 0) +
+      (hasTrailingSpacer ? 1 : 0),
+    1,
+  );
+  const normalizedMinBodyRows = Math.max(0, minBodyRows);
+  const paddingRowCount = Math.max(0, normalizedMinBodyRows - paginatedRows.length);
+  const emptyStateMinHeightPx = normalizedMinBodyRows * BODY_ROW_HEIGHT_PX;
 
   useEffect(() => {
     if (totalPages === 0) {
@@ -1814,185 +1835,208 @@ const StandardTable = <T extends object>({
             </TableHeader>
             <TableBody>
               {paginatedRows.length > 0 ? (
-                paginatedRows.map((tableRow) => {
-                  const row = tableRow.original;
-                  const visibleCells = tableRow.getVisibleCells();
-                  const rowActionCell = visibleCells.find((cell) => {
-                    const col = colsById.get(cell.column.id);
-                    return col ? isRowActionColumn(col) : false;
-                  });
-                  const rowActionColumn = rowActionCell
-                    ? colsById.get(rowActionCell.column.id)
-                    : undefined;
-                  const rowActionValue = rowActionCell?.getValue() as
-                    | T[keyof T]
-                    | string
-                    | number
-                    | boolean
-                    | null
-                    | undefined;
-                  const rowActionContent = rowActionCell
-                    ? rowActionColumn?.cell
-                      ? rowActionColumn.cell({
-                          getValue: () => rowActionValue,
-                          row,
-                          value: rowActionValue,
-                        })
-                      : flexRender(rowActionCell.column.columnDef.cell, rowActionCell.getContext())
-                    : null;
-                  const rowActionMenuItems = hasActionMenuItems(rowActionContent)
-                    ? renderActionMenuItems(rowActionContent)
-                    : null;
-                  const isActionMenuOpen = openActionMenuRowId === tableRow.id;
-                  const isContextMenuOpen = openContextMenuRowId === tableRow.id;
-                  const rowElement = (
-                    <TableRow
-                      key={tableRow.id}
-                      onClick={() => !disabledRow?.(row) && onRowClick?.(row)}
-                      className={`group border-border transition-colors ${fontSizeClass} ${disabledRow?.(row) ? 'bg-muted text-muted-foreground opacity-70' : `${onRowClick ? 'cursor-pointer' : ''} ${rowClassName ? rowClassName(row) : 'hover:bg-muted/50'}`}`}
-                    >
-                      {visibleCells.map((cell, colIdx) => {
-                        const colId = cell.column.id;
-                        const col = colsById.get(colId);
-                        if (!col) return null;
-                        const isActionColumn = isRowActionColumn(col);
-                        const isStickyRightColumn = col.sticky === 'right' || isActionColumn;
-                        const isFirstColumn = colIdx === 0;
-                        const isLastColumn = colIdx === visibleCells.length - 1;
-                        const shouldStickRightColumn = isStickyRightColumn;
-                        // Force alignment: first column left, last column right, otherwise use col.align
-                        const effectiveAlign = isFirstColumn
-                          ? 'left'
-                          : isLastColumn
-                            ? 'right'
-                            : col.align;
-                        const minColumnWidth = getColumnMinWidth(col);
-                        const colWidth = Math.max(cell.column.getSize(), minColumnWidth);
-                        const stickyBorderClass =
-                          shouldStickRightColumn && !isActionColumn ? 'border-l border-border' : '';
-                        const stickyHoverClass =
-                          shouldStickRightColumn && !isActionColumn
-                            ? 'group-hover:bg-muted/50'
-                            : '';
-                        const rawValue = cell.getValue() as
-                          | T[keyof T]
-                          | string
-                          | number
-                          | boolean
-                          | null
-                          | undefined;
-                        const cellContent =
-                          isActionColumn && cell.id === rowActionCell?.id
-                            ? rowActionContent
-                            : col.cell
-                              ? col.cell({ getValue: () => rawValue, row, value: rawValue })
-                              : flexRender(cell.column.columnDef.cell, cell.getContext());
-                        const actionMenuItems = isActionColumn ? rowActionMenuItems : null;
-                        return (
-                          <Fragment key={cell.id}>
-                            {shouldAnchorTrailingActionColumn && isActionColumn && (
-                              <TableCell
-                                aria-hidden="true"
-                                style={{ width: 'auto', minWidth: 0 }}
-                                className="border-border p-0"
-                              />
-                            )}
-                            <TableCell
-                              onDoubleClick={(e) => {
-                                e.stopPropagation();
-                                col.onCellDoubleClick?.(row);
-                              }}
-                              style={{ width: colWidth, minWidth: minColumnWidth }}
-                              className={`${isLastColumn ? 'pl-3 pr-2' : 'px-3'} py-2 whitespace-nowrap ${!isActionColumn ? 'standard-table-value-cell max-w-0 overflow-hidden text-ellipsis font-normal' : ''} ${shouldStickRightColumn ? 'w-auto text-right' : `align-middle ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''}`} ${shouldStickRightColumn ? `sticky right-0 z-20 bg-background transition-colors ${stickyBorderClass} ${stickyHoverClass}` : ''} ${col.className || ''}`}
-                            >
-                              {isActionColumn ? (
-                                actionMenuItems ? (
-                                  <DropdownMenu
-                                    open={isActionMenuOpen}
-                                    onOpenChange={(open) =>
-                                      setOpenActionMenuRowId(open ? tableRow.id : null)
-                                    }
-                                  >
-                                    <DropdownMenuTrigger asChild>
-                                      <Button
-                                        type="button"
-                                        variant="ghost"
-                                        size="icon-xs"
-                                        aria-label={t('table.rowActions')}
-                                        onClick={(event) => event.stopPropagation()}
-                                        className="rounded-lg"
-                                      >
-                                        <i
-                                          className="fa-solid fa-ellipsis text-[10px]"
-                                          aria-hidden="true"
-                                        ></i>
-                                      </Button>
-                                    </DropdownMenuTrigger>
-                                    {isActionMenuOpen && (
-                                      <DropdownMenuContent
-                                        align="end"
-                                        data-standard-table-action-menu="true"
-                                        className={ACTION_MENU_CONTENT_CLASSNAME}
-                                        onClick={(event) => event.stopPropagation()}
-                                        onDoubleClick={(event) => event.stopPropagation()}
-                                      >
-                                        <div className={ACTION_MENU_ITEMS_CLASSNAME}>
-                                          {actionMenuItems}
-                                        </div>
-                                      </DropdownMenuContent>
-                                    )}
-                                  </DropdownMenu>
-                                ) : null
-                              ) : (
-                                cellContent
+                <>
+                  {paginatedRows.map((tableRow) => {
+                    const row = tableRow.original;
+                    const visibleCells = tableRow.getVisibleCells();
+                    const rowActionCell = visibleCells.find((cell) => {
+                      const col = colsById.get(cell.column.id);
+                      return col ? isRowActionColumn(col) : false;
+                    });
+                    const rowActionColumn = rowActionCell
+                      ? colsById.get(rowActionCell.column.id)
+                      : undefined;
+                    const rowActionValue = rowActionCell?.getValue() as
+                      | T[keyof T]
+                      | string
+                      | number
+                      | boolean
+                      | null
+                      | undefined;
+                    const rowActionContent = rowActionCell
+                      ? rowActionColumn?.cell
+                        ? rowActionColumn.cell({
+                            getValue: () => rowActionValue,
+                            row,
+                            value: rowActionValue,
+                          })
+                        : flexRender(
+                            rowActionCell.column.columnDef.cell,
+                            rowActionCell.getContext(),
+                          )
+                      : null;
+                    const rowActionMenuItems = hasActionMenuItems(rowActionContent)
+                      ? renderActionMenuItems(rowActionContent)
+                      : null;
+                    const isActionMenuOpen = openActionMenuRowId === tableRow.id;
+                    const isContextMenuOpen = openContextMenuRowId === tableRow.id;
+                    const rowElement = (
+                      <TableRow
+                        key={tableRow.id}
+                        onClick={() => !disabledRow?.(row) && onRowClick?.(row)}
+                        className={`group border-border transition-colors ${fontSizeClass} ${disabledRow?.(row) ? 'bg-muted text-muted-foreground opacity-70' : `${onRowClick ? 'cursor-pointer' : ''} ${rowClassName ? rowClassName(row) : 'hover:bg-muted/50'}`}`}
+                      >
+                        {visibleCells.map((cell, colIdx) => {
+                          const colId = cell.column.id;
+                          const col = colsById.get(colId);
+                          if (!col) return null;
+                          const isActionColumn = isRowActionColumn(col);
+                          const isStickyRightColumn = col.sticky === 'right' || isActionColumn;
+                          const isFirstColumn = colIdx === 0;
+                          const isLastColumn = colIdx === visibleCells.length - 1;
+                          const shouldStickRightColumn = isStickyRightColumn;
+                          // Force alignment: first column left, last column right, otherwise use col.align
+                          const effectiveAlign = isFirstColumn
+                            ? 'left'
+                            : isLastColumn
+                              ? 'right'
+                              : col.align;
+                          const minColumnWidth = getColumnMinWidth(col);
+                          const colWidth = Math.max(cell.column.getSize(), minColumnWidth);
+                          const stickyBorderClass =
+                            shouldStickRightColumn && !isActionColumn
+                              ? 'border-l border-border'
+                              : '';
+                          const stickyHoverClass =
+                            shouldStickRightColumn && !isActionColumn
+                              ? 'group-hover:bg-muted/50'
+                              : '';
+                          const rawValue = cell.getValue() as
+                            | T[keyof T]
+                            | string
+                            | number
+                            | boolean
+                            | null
+                            | undefined;
+                          const cellContent =
+                            isActionColumn && cell.id === rowActionCell?.id
+                              ? rowActionContent
+                              : col.cell
+                                ? col.cell({ getValue: () => rawValue, row, value: rawValue })
+                                : flexRender(cell.column.columnDef.cell, cell.getContext());
+                          const actionMenuItems = isActionColumn ? rowActionMenuItems : null;
+                          return (
+                            <Fragment key={cell.id}>
+                              {shouldAnchorTrailingActionColumn && isActionColumn && (
+                                <TableCell
+                                  aria-hidden="true"
+                                  style={{ width: 'auto', minWidth: 0 }}
+                                  className="border-border p-0"
+                                />
                               )}
-                            </TableCell>
-                          </Fragment>
-                        );
-                      })}
-                      {hasTrailingSpacer && (
-                        <TableCell
-                          aria-hidden="true"
-                          style={{ width: 'auto', minWidth: 0 }}
-                          className="border-border p-0"
-                        />
-                      )}
-                    </TableRow>
-                  );
+                              <TableCell
+                                onDoubleClick={(e) => {
+                                  e.stopPropagation();
+                                  col.onCellDoubleClick?.(row);
+                                }}
+                                style={{ width: colWidth, minWidth: minColumnWidth }}
+                                className={`${isLastColumn ? 'pl-3 pr-2' : 'px-3'} py-2 whitespace-nowrap ${!isActionColumn ? 'standard-table-value-cell max-w-0 overflow-hidden text-ellipsis font-normal' : ''} ${shouldStickRightColumn ? 'w-auto text-right' : `align-middle ${effectiveAlign === 'right' ? 'text-right' : effectiveAlign === 'center' ? 'text-center' : ''}`} ${shouldStickRightColumn ? `sticky right-0 z-20 bg-background transition-colors ${stickyBorderClass} ${stickyHoverClass}` : ''} ${col.className || ''}`}
+                              >
+                                {isActionColumn ? (
+                                  actionMenuItems ? (
+                                    <DropdownMenu
+                                      open={isActionMenuOpen}
+                                      onOpenChange={(open) =>
+                                        setOpenActionMenuRowId(open ? tableRow.id : null)
+                                      }
+                                    >
+                                      <DropdownMenuTrigger asChild>
+                                        <Button
+                                          type="button"
+                                          variant="ghost"
+                                          size="icon-xs"
+                                          aria-label={t('table.rowActions')}
+                                          onClick={(event) => event.stopPropagation()}
+                                          className="rounded-lg"
+                                        >
+                                          <i
+                                            className="fa-solid fa-ellipsis text-[10px]"
+                                            aria-hidden="true"
+                                          ></i>
+                                        </Button>
+                                      </DropdownMenuTrigger>
+                                      {isActionMenuOpen && (
+                                        <DropdownMenuContent
+                                          align="end"
+                                          data-standard-table-action-menu="true"
+                                          className={ACTION_MENU_CONTENT_CLASSNAME}
+                                          onClick={(event) => event.stopPropagation()}
+                                          onDoubleClick={(event) => event.stopPropagation()}
+                                        >
+                                          <div className={ACTION_MENU_ITEMS_CLASSNAME}>
+                                            {actionMenuItems}
+                                          </div>
+                                        </DropdownMenuContent>
+                                      )}
+                                    </DropdownMenu>
+                                  ) : null
+                                ) : (
+                                  cellContent
+                                )}
+                              </TableCell>
+                            </Fragment>
+                          );
+                        })}
+                        {hasTrailingSpacer && (
+                          <TableCell
+                            aria-hidden="true"
+                            style={{ width: 'auto', minWidth: 0 }}
+                            className="border-border p-0"
+                          />
+                        )}
+                      </TableRow>
+                    );
 
-                  return rowActionMenuItems ? (
-                    <ContextMenu
-                      key={tableRow.id}
-                      onOpenChange={(open) => setOpenContextMenuRowId(open ? tableRow.id : null)}
+                    return rowActionMenuItems ? (
+                      <ContextMenu
+                        key={tableRow.id}
+                        onOpenChange={(open) => setOpenContextMenuRowId(open ? tableRow.id : null)}
+                      >
+                        <ContextMenuTrigger asChild>{rowElement}</ContextMenuTrigger>
+                        {isContextMenuOpen && (
+                          <ContextMenuContent
+                            data-standard-table-action-menu="true"
+                            className={ACTION_MENU_CONTENT_CLASSNAME}
+                            onClick={(event) => event.stopPropagation()}
+                            onDoubleClick={(event) => event.stopPropagation()}
+                          >
+                            <div className={ACTION_MENU_ITEMS_CLASSNAME}>{rowActionMenuItems}</div>
+                          </ContextMenuContent>
+                        )}
+                      </ContextMenu>
+                    ) : (
+                      rowElement
+                    );
+                  })}
+                  {Array.from({ length: paddingRowCount }).map((_, idx) => (
+                    <TableRow
+                      key={`__padding-${idx}`}
+                      aria-hidden="true"
+                      className="pointer-events-none hover:bg-transparent"
                     >
-                      <ContextMenuTrigger asChild>{rowElement}</ContextMenuTrigger>
-                      {isContextMenuOpen && (
-                        <ContextMenuContent
-                          data-standard-table-action-menu="true"
-                          className={ACTION_MENU_CONTENT_CLASSNAME}
-                          onClick={(event) => event.stopPropagation()}
-                          onDoubleClick={(event) => event.stopPropagation()}
-                        >
-                          <div className={ACTION_MENU_ITEMS_CLASSNAME}>{rowActionMenuItems}</div>
-                        </ContextMenuContent>
-                      )}
-                    </ContextMenu>
-                  ) : (
-                    rowElement
-                  );
-                })
+                      <TableCell colSpan={bodyColSpan} className="h-11 p-0" />
+                    </TableRow>
+                  ))}
+                </>
               ) : (
-                <TableRow className="border-border">
-                  <TableCell
-                    colSpan={Math.max(
-                      visibleColumns.length +
-                        (shouldAnchorTrailingActionColumn ? 1 : 0) +
-                        (hasTrailingSpacer ? 1 : 0),
-                      1,
+                <TableRow className="hover:bg-transparent">
+                  <TableCell colSpan={bodyColSpan} className="p-0">
+                    {emptyState ? (
+                      <div
+                        className="flex w-full items-center justify-center"
+                        style={{ minHeight: emptyStateMinHeightPx }}
+                      >
+                        {emptyState}
+                      </div>
+                    ) : (
+                      <Empty style={{ minHeight: emptyStateMinHeightPx }}>
+                        <EmptyHeader>
+                          <EmptyTitle className="text-sm font-medium text-muted-foreground">
+                            {t('table.noResults')}
+                          </EmptyTitle>
+                        </EmptyHeader>
+                      </Empty>
                     )}
-                    className="p-12 text-center text-sm font-medium text-muted-foreground"
-                  >
-                    {emptyState ?? t('table.noResults')}
                   </TableCell>
                 </TableRow>
               )}

--- a/components/ui/empty.tsx
+++ b/components/ui/empty.tsx
@@ -1,0 +1,94 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/lib/utils';
+
+function Empty({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="empty"
+      className={cn(
+        'flex min-w-0 flex-1 flex-col items-center justify-center gap-6 rounded-lg border-dashed p-6 text-center text-balance md:p-12',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function EmptyHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="empty-header"
+      className={cn('flex max-w-sm flex-col items-center gap-2 text-center', className)}
+      {...props}
+    />
+  );
+}
+
+const emptyMediaVariants = cva(
+  'mb-2 flex shrink-0 items-center justify-center [&_svg]:pointer-events-none [&_svg]:shrink-0',
+  {
+    variants: {
+      variant: {
+        default: 'bg-transparent',
+        icon: "flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground [&_svg:not([class*='size-'])]:size-6",
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+);
+
+function EmptyMedia({
+  className,
+  variant = 'default',
+  ...props
+}: React.ComponentProps<'div'> & VariantProps<typeof emptyMediaVariants>) {
+  return (
+    <div
+      data-slot="empty-icon"
+      data-variant={variant}
+      className={cn(emptyMediaVariants({ variant, className }))}
+      {...props}
+    />
+  );
+}
+
+function EmptyTitle({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="empty-title"
+      className={cn('text-lg font-medium tracking-tight', className)}
+      {...props}
+    />
+  );
+}
+
+function EmptyDescription({ className, ...props }: React.ComponentProps<'p'>) {
+  return (
+    <div
+      data-slot="empty-description"
+      className={cn(
+        'text-sm/relaxed text-muted-foreground [&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function EmptyContent({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="empty-content"
+      className={cn(
+        'flex w-full max-w-sm min-w-0 flex-col items-center gap-4 text-sm text-balance',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Empty, EmptyContent, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle };

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -1,17 +1,9 @@
 import { afterAll, afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
-import type { RenderOptions, RenderResult } from '@testing-library/react';
-import {
-  act,
-  fireEvent,
-  render as rtlRender,
-  screen,
-  waitFor,
-  within,
-} from '@testing-library/react';
+import { act, fireEvent, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import type { ReactNode } from 'react';
 import { THEME_STORAGE_KEY } from '../../utils/theme';
 import { installI18nMock } from '../helpers/i18n';
+import { render } from '../helpers/render';
 
 installI18nMock();
 
@@ -25,20 +17,14 @@ const readClipboardSpy = spyOn(clipboardModule, 'readTextFromClipboard').mockRes
   reason: 'unavailable',
 });
 
-const { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } = await import(
-  '../../components/ui/tooltip'
-);
+const { Tooltip, TooltipContent, TooltipTrigger } = await import('../../components/ui/tooltip');
 const { useState } = await import('react');
 const StandardTable = (await import('../../components/shared/StandardTable')).default;
 const Modal = (await import('../../components/shared/Modal')).default;
 const StatusBadge = (await import('../../components/shared/StatusBadge')).default;
 
-const render = (ui: ReactNode, options?: RenderOptions): RenderResult => {
-  const result = rtlRender(<TooltipProvider>{ui}</TooltipProvider>, options);
-  const rerender = (nextUi: ReactNode) =>
-    result.rerender(<TooltipProvider>{nextUi}</TooltipProvider>);
-  return { ...result, rerender };
-};
+const countPaddingRows = (container: HTMLElement) =>
+  container.querySelectorAll('tbody tr[aria-hidden="true"]').length;
 
 type Row = { id: string; name: string; age: number };
 
@@ -133,6 +119,17 @@ describe('<StandardTable />', () => {
     expect(screen.getByText('table.noResults')).toBeInTheDocument();
   });
 
+  test('empty state renders the shadcn Empty primitive at minimum height', () => {
+    const { container } = render(
+      <StandardTable<Row> title="People" data={[]} columns={sampleColumns} />,
+    );
+    const emptyEl = container.querySelector('[data-slot="empty"]') as HTMLElement | null;
+    expect(emptyEl).not.toBeNull();
+    expect(emptyEl?.textContent).toContain('table.noResults');
+    // Default minBodyRows = 4, body row height = 44px → at least 176px reserved.
+    expect(Number.parseInt(emptyEl?.style.minHeight ?? '0', 10)).toBeGreaterThanOrEqual(176);
+  });
+
   test('custom emptyState overrides default text', () => {
     render(
       <StandardTable<Row>
@@ -144,6 +141,61 @@ describe('<StandardTable />', () => {
     );
     expect(screen.getByText('Nothing here')).toBeInTheDocument();
     expect(screen.queryByText('table.noResults')).not.toBeInTheDocument();
+  });
+
+  test('short pages are padded with aria-hidden placeholder rows up to minBodyRows', () => {
+    const { container } = render(
+      <StandardTable<Row>
+        title="ShortPage"
+        data={sampleRows.slice(0, 1)}
+        columns={sampleColumns}
+      />,
+    );
+    const paddingRows = container.querySelectorAll('tbody tr[aria-hidden="true"]');
+    expect(paddingRows.length).toBe(3);
+    // Padding rows must be inert and excluded from the a11y tree so existing
+    // role-based queries (and screen readers) ignore them.
+    for (const padding of paddingRows) {
+      expect(padding.className).toContain('pointer-events-none');
+      expect(padding.querySelector('button')).toBeNull();
+    }
+    expect(screen.getAllByRole('row').slice(1)).toHaveLength(1);
+  });
+
+  test('full pages skip padding rows entirely', () => {
+    const many: Row[] = Array.from({ length: 5 }, (_, i) => ({
+      id: String(i + 1),
+      name: `User${i + 1}`,
+      age: 20 + i,
+    }));
+    const { container } = render(
+      <StandardTable<Row> title="FullPage" data={many} columns={sampleColumns} />,
+    );
+    expect(countPaddingRows(container)).toBe(0);
+  });
+
+  test('minBodyRows prop overrides the default padding target', () => {
+    const { container } = render(
+      <StandardTable<Row>
+        title="CustomMin"
+        data={sampleRows.slice(0, 1)}
+        columns={sampleColumns}
+        minBodyRows={2}
+      />,
+    );
+    expect(countPaddingRows(container)).toBe(1);
+  });
+
+  test('minBodyRows={0} disables padding so the body collapses to its rows', () => {
+    const { container } = render(
+      <StandardTable<Row>
+        title="NoPadding"
+        data={sampleRows.slice(0, 1)}
+        columns={sampleColumns}
+        minBodyRows={0}
+      />,
+    );
+    expect(countPaddingRows(container)).toBe(0);
   });
 
   test('renders rows in source order by default', () => {


### PR DESCRIPTION
## Summary

Fixes [#464](https://github.com/xBounceIT/praetor/issues/464). The Offerte Clienti list (and every other `StandardTable` consumer) collapsed to the height of however many rows fit on the current page, so the surrounding layout jumped between empty / 1-row / many-row states.

- Added a `minBodyRows` prop (default `4`) on `StandardTable`. Short pages are padded with inert, `aria-hidden` placeholder rows of `h-11` so the body always reserves at least N row-heights.
- Replaced the bespoke no-results cell with the shadcn `Empty` / `EmptyHeader` / `EmptyTitle` primitives (`bunx --bun shadcn@latest add empty`). The empty cell reserves the same `minBodyRows × 44px` min-height as the padded short-row state.
- Added 5 unit tests covering the new behavior (empty state with min-height, padding behavior at 1 row, no padding at 4+ rows, `minBodyRows` override, `minBodyRows={0}` disabling).

Custom `emptyState` callers keep their visuals; the wrapper just enforces the min-height. Existing role-based test queries are unaffected because padding rows are `aria-hidden` and excluded from the accessibility tree.

## Why

Per the issue: an empty table renders comfortably (it had `p-12` padding around "Nessun risultato"), but a 1-row table collapses to ~one row's height. That makes filters and pagination feel jumpy. The fix gives every `StandardTable` a stable ~4-row minimum footprint.

## Test plan
- [x] `bun run test:frontend` — 1036 / 1036 pass (5 new + 65 existing `StandardTable` tests stay green because `aria-hidden` padding rows are excluded from `getAllByRole('row')`).
- [x] `tsc -p tsconfig.json --noEmit` — clean.
- [x] `biome check .` — clean on touched files.
- [ ] Manual: visit **Vendite → Offerte Clienti**, filter to 0 / 1 / 5+ rows and verify the table footprint stays stable. Repeat in **Preventivi Clienti** and **Preventivi Fornitori**.

## Notes for reviewers

- `BODY_ROW_HEIGHT_PX = 44` is coupled to the `h-11` Tailwind class on padding rows — comment in the source flags this. The empty-state min-height is computed dynamically (`minBodyRows × 44`) since the prop is configurable.
- The fix is global (applies to every `StandardTable` consumer) per agreed scope; no per-view edits were needed for ClientOffersView.
- Other consumers that pass a custom `emptyState` (e.g. `ProjectsView` with a bare `<span>`) keep working — they're wrapped in a `min-h` flex container so they center properly in the reserved space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)