### PR TITLE
fix(projects): require start/end dates at creation (#474)

### DIFF
--- a/components/projects/ProjectsView.tsx
+++ b/components/projects/ProjectsView.tsx
@@ -423,8 +423,10 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
 
     if (!offerId) newErrors.offerId = t('projects:projects.offerRequired');
 
-    if (!startDate) newErrors.startDate = t('projects:projects.startDateRequired');
-    if (!endDate) newErrors.endDate = t('projects:projects.endDateRequired');
+    if (!editingProject) {
+      if (!startDate) newErrors.startDate = t('projects:projects.startDateRequired');
+      if (!endDate) newErrors.endDate = t('projects:projects.endDateRequired');
+    }
     if (startDate && endDate && startDate > endDate) {
       newErrors.dateRange = t('projects:projects.dateRangeInvalid');
     }
@@ -1221,12 +1223,12 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
                   <div className="grid gap-4 md:grid-cols-2">
                     <Field data-invalid={Boolean(errors.startDate || errors.dateRange)}>
                       <FieldLabel htmlFor="project-start-date">
-                        {t('projects:projects.startDate')} <RequiredMark />
+                        {t('projects:projects.startDate')} {!editingProject && <RequiredMark />}
                       </FieldLabel>
                       <Input
                         id="project-start-date"
                         type="date"
-                        required
+                        required={!editingProject}
                         value={startDate}
                         aria-invalid={Boolean(errors.startDate || errors.dateRange)}
                         onChange={(e) => {
@@ -1240,12 +1242,12 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
                     </Field>
                     <Field data-invalid={Boolean(errors.endDate || errors.dateRange)}>
                       <FieldLabel htmlFor="project-end-date">
-                        {t('projects:projects.endDate')} <RequiredMark />
+                        {t('projects:projects.endDate')} {!editingProject && <RequiredMark />}
                       </FieldLabel>
                       <Input
                         id="project-end-date"
                         type="date"
-                        required
+                        required={!editingProject}
                         value={endDate}
                         aria-invalid={Boolean(errors.endDate || errors.dateRange)}
                         onChange={(e) => {

--- a/components/projects/ProjectsView.tsx
+++ b/components/projects/ProjectsView.tsx
@@ -423,6 +423,8 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
 
     if (!offerId) newErrors.offerId = t('projects:projects.offerRequired');
 
+    if (!startDate) newErrors.startDate = t('projects:projects.startDateRequired');
+    if (!endDate) newErrors.endDate = t('projects:projects.endDateRequired');
     if (startDate && endDate && startDate > endDate) {
       newErrors.dateRange = t('projects:projects.dateRangeInvalid');
     }
@@ -1217,35 +1219,43 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
                   </Field>
 
                   <div className="grid gap-4 md:grid-cols-2">
-                    <Field data-invalid={Boolean(errors.dateRange)}>
+                    <Field data-invalid={Boolean(errors.startDate || errors.dateRange)}>
                       <FieldLabel htmlFor="project-start-date">
-                        {t('projects:projects.startDate')}
+                        {t('projects:projects.startDate')} <RequiredMark />
                       </FieldLabel>
                       <Input
                         id="project-start-date"
                         type="date"
+                        required
                         value={startDate}
-                        aria-invalid={Boolean(errors.dateRange)}
+                        aria-invalid={Boolean(errors.startDate || errors.dateRange)}
                         onChange={(e) => {
                           setStartDate(e.target.value);
-                          if (errors.dateRange) setErrors((prev) => ({ ...prev, dateRange: '' }));
+                          if (errors.startDate || errors.dateRange) {
+                            setErrors((prev) => ({ ...prev, startDate: '', dateRange: '' }));
+                          }
                         }}
                       />
+                      <FieldError className="text-xs">{errors.startDate}</FieldError>
                     </Field>
-                    <Field data-invalid={Boolean(errors.dateRange)}>
+                    <Field data-invalid={Boolean(errors.endDate || errors.dateRange)}>
                       <FieldLabel htmlFor="project-end-date">
-                        {t('projects:projects.endDate')}
+                        {t('projects:projects.endDate')} <RequiredMark />
                       </FieldLabel>
                       <Input
                         id="project-end-date"
                         type="date"
+                        required
                         value={endDate}
-                        aria-invalid={Boolean(errors.dateRange)}
+                        aria-invalid={Boolean(errors.endDate || errors.dateRange)}
                         onChange={(e) => {
                           setEndDate(e.target.value);
-                          if (errors.dateRange) setErrors((prev) => ({ ...prev, dateRange: '' }));
+                          if (errors.endDate || errors.dateRange) {
+                            setErrors((prev) => ({ ...prev, endDate: '', dateRange: '' }));
+                          }
                         }}
                       />
+                      <FieldError className="text-xs">{errors.endDate}</FieldError>
                     </Field>
                   </div>
                   {errors.dateRange && (

--- a/docs-site/src/content/docs/crm-projects.md
+++ b/docs-site/src/content/docs/crm-projects.md
@@ -31,7 +31,7 @@ Usa la stima di impegno mensile per pianificare il carico ricorrente e l'impegno
 
 Quando crei o modifichi un progetto puoi compilare anche:
 
-- **Data inizio progetto** e **Data fine progetto** — definiscono la finestra temporale prevista; la data di fine non può precedere la data di inizio.
+- **Data inizio progetto** e **Data fine progetto** — definiscono la finestra temporale prevista. Entrambe sono obbligatorie alla creazione e restano modificabili sui progetti esistenti per riflettere eventuali variazioni di pianificazione; la data di fine non può precedere la data di inizio.
 - **Riferimento offerta** — collega il progetto a un'offerta accettata. Il campo è obbligatorio.
 - **Ricavo progetto** — segue questa precedenza: (1) se le attività hanno un valore di ricavo, il ricavo del progetto è la somma di quei valori in sola lettura; (2) altrimenti, se è collegato un ordine, il ricavo è ereditato in sola lettura dal totale dell'ordine; (3) altrimenti puoi inserirlo manualmente.
 

--- a/docs-site/src/content/docs/en/crm-projects.md
+++ b/docs-site/src/content/docs/en/crm-projects.md
@@ -31,7 +31,7 @@ Use estimated monthly effort to plan recurring load and total effort to track pr
 
 When creating or editing a project you can also fill in:
 
-- **Project start date** and **Project end date** — define the planned window; the end date must not precede the start date.
+- **Project start date** and **Project end date** — define the planned window. Both are required at creation and remain editable on existing projects so you can adjust them when the schedule shifts; the end date must not precede the start date.
 - **Offer reference** — links the project to an accepted offer. This field is required.
 - **Project revenue** — resolved with this precedence: (1) if the activities have a per-row revenue, the project revenue is the sum of those values shown read-only; (2) otherwise, if an order is linked, the revenue is inherited read-only from the order total; (3) otherwise you can enter it manually.
 

--- a/locales/en/projects.json
+++ b/locales/en/projects.json
@@ -54,6 +54,8 @@
     "inheritedClientLabel": "Client (inherited from order)",
     "startDate": "Project start date",
     "endDate": "Project end date",
+    "startDateRequired": "Project start date is required",
+    "endDateRequired": "Project end date is required",
     "dateRangeInvalid": "End date must be on or after start date",
     "offerReference": "Offer reference",
     "selectOffer": "Select Offer...",

--- a/locales/it/projects.json
+++ b/locales/it/projects.json
@@ -54,6 +54,8 @@
     "inheritedClientLabel": "Cliente (ereditato dall'ordine)",
     "startDate": "Data inizio progetto",
     "endDate": "Data fine progetto",
+    "startDateRequired": "La data di inizio progetto è obbligatoria",
+    "endDateRequired": "La data di fine progetto è obbligatoria",
     "dateRangeInvalid": "La data di fine deve essere uguale o successiva alla data di inizio",
     "offerReference": "Riferimento offerta",
     "selectOffer": "Seleziona Offerta...",

--- a/server/routes/projects.ts
+++ b/server/routes/projects.ts
@@ -38,6 +38,7 @@ import {
   optionalEnum,
   optionalNonEmptyString,
   optionalNonNegativeNumber,
+  parseDateString,
   requireNonEmptyString,
   validateHexColor,
 } from '../utils/validation.ts';
@@ -92,13 +93,13 @@ const projectCreateBodySchema = {
     },
     orderId: { type: 'string' },
     offerId: { type: 'string' },
-    startDate: { type: ['string', 'null'] },
-    endDate: { type: ['string', 'null'] },
+    startDate: { type: 'string' },
+    endDate: { type: 'string' },
     revenue: { type: ['number', 'null'] },
     billingType: { type: 'string', enum: STORED_BILLING_TYPES },
     billingFrequency: { type: 'string', enum: BILLING_FREQUENCIES },
   },
-  required: ['name', 'clientId', 'offerId'],
+  required: ['name', 'clientId', 'offerId', 'startDate', 'endDate'],
 } as const;
 
 const projectUpdateBodySchema = {
@@ -206,8 +207,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         billingType?: string;
         billingFrequency?: string;
         offerId?: string;
-        startDate?: string | null;
-        endDate?: string | null;
+        startDate?: string;
+        endDate?: string;
         revenue?: number | string | null;
       };
 
@@ -233,15 +234,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const offerIdResult = requireNonEmptyString(body.offerId, 'offerId');
       if (!offerIdResult.ok) return badRequest(reply, offerIdResult.message);
 
-      const startDateResult = optionalDateString(body.startDate, 'startDate');
+      const startDateResult = parseDateString(body.startDate, 'startDate');
       if (!startDateResult.ok) return badRequest(reply, startDateResult.message);
-      const endDateResult = optionalDateString(body.endDate, 'endDate');
+      const endDateResult = parseDateString(body.endDate, 'endDate');
       if (!endDateResult.ok) return badRequest(reply, endDateResult.message);
-      if (
-        startDateResult.value &&
-        endDateResult.value &&
-        startDateResult.value > endDateResult.value
-      ) {
+      if (startDateResult.value > endDateResult.value) {
         return badRequest(reply, 'startDate must be on or before endDate');
       }
 

--- a/server/test/routes/projects.test.ts
+++ b/server/test/routes/projects.test.ts
@@ -193,6 +193,14 @@ const SAMPLE_PROJECT = {
   billingFrequency: 'monthly',
 };
 
+const VALID_CREATE_PAYLOAD = {
+  name: 'Site',
+  clientId: 'c-1',
+  offerId: 'of-1',
+  startDate: '2026-01-01',
+  endDate: '2026-12-31',
+};
+
 const allMocks = [
   findAuthUserByIdMock,
   userHasRoleMock,
@@ -315,12 +323,11 @@ describe('POST /api/projects', () => {
       url: '/api/projects',
       headers: authHeader(),
       payload: {
+        ...VALID_CREATE_PAYLOAD,
         name: 'Website',
-        clientId: 'c-1',
         description: 'A new site',
         color: '#abcdef',
         orderId: 'o-1',
-        offerId: 'of-1',
       },
     });
 
@@ -397,7 +404,7 @@ describe('POST /api/projects', () => {
       method: 'POST',
       url: '/api/projects',
       headers: authHeader(),
-      payload: { name: 'Site', clientId: 'c-1', offerId: 'of-1' },
+      payload: { ...VALID_CREATE_PAYLOAD },
     });
 
     expect(res.statusCode).toBe(201);
@@ -421,7 +428,7 @@ describe('POST /api/projects', () => {
       method: 'POST',
       url: '/api/projects',
       headers: authHeader(),
-      payload: { name: 'Site', clientId: 'c-1', offerId: 'of-1' },
+      payload: { ...VALID_CREATE_PAYLOAD },
     });
 
     const color = JSON.parse(res.body).color;
@@ -438,7 +445,7 @@ describe('POST /api/projects', () => {
       method: 'POST',
       url: '/api/projects',
       headers: authHeader(),
-      payload: { name: 'Site', clientId: 'c-1', offerId: 'of-1', color: '#ABC' },
+      payload: { ...VALID_CREATE_PAYLOAD, color: '#ABC' },
     });
 
     expect(res.statusCode).toBe(409);
@@ -459,7 +466,7 @@ describe('POST /api/projects', () => {
       method: 'POST',
       url: '/api/projects',
       headers: authHeader(),
-      payload: { name: 'Site', clientId: 'c-1', offerId: 'of-1' },
+      payload: { ...VALID_CREATE_PAYLOAD },
     });
 
     expect(res.statusCode).toBe(201);
@@ -474,7 +481,7 @@ describe('POST /api/projects', () => {
       method: 'POST',
       url: '/api/projects',
       headers: authHeader(),
-      payload: { name: 'X', clientId: 'c-1', offerId: 'of-1', orderId: 'co-foreign' },
+      payload: { ...VALID_CREATE_PAYLOAD, orderId: 'co-foreign' },
     });
 
     expect(res.statusCode).toBe(400);
@@ -492,7 +499,7 @@ describe('POST /api/projects', () => {
       method: 'POST',
       url: '/api/projects',
       headers: authHeader(),
-      payload: { name: 'X', clientId: 'c-1', offerId: 'of-1', orderId: 'co-same' },
+      payload: { ...VALID_CREATE_PAYLOAD, orderId: 'co-same' },
     });
 
     expect(res.statusCode).toBe(201);
@@ -509,7 +516,7 @@ describe('POST /api/projects', () => {
       method: 'POST',
       url: '/api/projects',
       headers: authHeader(),
-      payload: { name: 'X', clientId: 'c-1', offerId: 'of-1', orderId: '' },
+      payload: { ...VALID_CREATE_PAYLOAD, orderId: '' },
     });
 
     expect(res.statusCode).toBe(201);
@@ -527,7 +534,7 @@ describe('POST /api/projects', () => {
       method: 'POST',
       url: '/api/projects',
       headers: authHeader(),
-      payload: { name: 'Orderless', clientId: 'c-1', offerId: 'of-1' },
+      payload: { ...VALID_CREATE_PAYLOAD, name: 'Orderless' },
     });
 
     expect(res.statusCode).toBe(201);
@@ -544,7 +551,7 @@ describe('POST /api/projects', () => {
       method: 'POST',
       url: '/api/projects',
       headers: authHeader(),
-      payload: { name: 'X', clientId: 'c-1', offerId: 'of-foreign' },
+      payload: { ...VALID_CREATE_PAYLOAD, offerId: 'of-foreign' },
     });
 
     expect(res.statusCode).toBe(400);
@@ -562,7 +569,7 @@ describe('POST /api/projects', () => {
       method: 'POST',
       url: '/api/projects',
       headers: authHeader(),
-      payload: { name: 'X', clientId: 'c-1', offerId: 'of-same' },
+      payload: { ...VALID_CREATE_PAYLOAD, offerId: 'of-same' },
     });
 
     expect(res.statusCode).toBe(201);
@@ -577,7 +584,7 @@ describe('POST /api/projects', () => {
       method: 'POST',
       url: '/api/projects',
       headers: authHeader(),
-      payload: { name: '   ', clientId: 'c-1', offerId: 'of-1' },
+      payload: { ...VALID_CREATE_PAYLOAD, name: '   ' },
     });
 
     expect(res.statusCode).toBe(400);
@@ -589,7 +596,7 @@ describe('POST /api/projects', () => {
       method: 'POST',
       url: '/api/projects',
       headers: authHeader(),
-      payload: { name: 'Website', clientId: '   ', offerId: 'of-1' },
+      payload: { ...VALID_CREATE_PAYLOAD, clientId: '   ' },
     });
 
     expect(res.statusCode).toBe(400);
@@ -601,11 +608,37 @@ describe('POST /api/projects', () => {
       method: 'POST',
       url: '/api/projects',
       headers: authHeader(),
-      payload: { name: 'Website', clientId: 'c-1' },
+      payload: { ...VALID_CREATE_PAYLOAD, offerId: undefined },
     });
 
     expect(res.statusCode).toBe(400);
     expect(JSON.parse(res.body).error).toBe('Bad Request');
+  });
+
+  test('400: missing startDate', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/projects',
+      headers: authHeader(),
+      payload: { ...VALID_CREATE_PAYLOAD, startDate: undefined },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toBe('Bad Request');
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  test('400: missing endDate', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/projects',
+      headers: authHeader(),
+      payload: { ...VALID_CREATE_PAYLOAD, endDate: undefined },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toBe('Bad Request');
+    expect(createMock).not.toHaveBeenCalled();
   });
 
   test('400: startDate after endDate', async () => {
@@ -613,13 +646,7 @@ describe('POST /api/projects', () => {
       method: 'POST',
       url: '/api/projects',
       headers: authHeader(),
-      payload: {
-        name: 'Website',
-        clientId: 'c-1',
-        offerId: 'of-1',
-        startDate: '2026-12-31',
-        endDate: '2026-01-01',
-      },
+      payload: { ...VALID_CREATE_PAYLOAD, startDate: '2026-12-31', endDate: '2026-01-01' },
     });
 
     expect(res.statusCode).toBe(400);
@@ -633,12 +660,7 @@ describe('POST /api/projects', () => {
       method: 'POST',
       url: '/api/projects',
       headers: authHeader(),
-      payload: {
-        name: 'Website',
-        clientId: 'c-1',
-        offerId: 'of-1',
-        startDate: '01/01/2026',
-      },
+      payload: { ...VALID_CREATE_PAYLOAD, startDate: '01/01/2026' },
     });
 
     expect(res.statusCode).toBe(400);
@@ -650,12 +672,7 @@ describe('POST /api/projects', () => {
       method: 'POST',
       url: '/api/projects',
       headers: authHeader(),
-      payload: {
-        name: 'Website',
-        clientId: 'c-1',
-        offerId: 'of-1',
-        revenue: -10,
-      },
+      payload: { ...VALID_CREATE_PAYLOAD, revenue: -10 },
     });
 
     expect(res.statusCode).toBe(400);
@@ -667,7 +684,7 @@ describe('POST /api/projects', () => {
       method: 'POST',
       url: '/api/projects',
       headers: authHeader(),
-      payload: { name: 'X', clientId: 'c-1', offerId: 'of-1', color: 'not-a-hex' },
+      payload: { ...VALID_CREATE_PAYLOAD, color: 'not-a-hex' },
     });
 
     expect(res.statusCode).toBe(400);
@@ -679,7 +696,7 @@ describe('POST /api/projects', () => {
       method: 'POST',
       url: '/api/projects',
       headers: authHeader(),
-      payload: { name: 'X', clientId: 'c-1', offerId: 'of-1', billingType: 'mixed' },
+      payload: { ...VALID_CREATE_PAYLOAD, billingType: 'mixed' },
     });
 
     expect(res.statusCode).toBe(400);
@@ -695,7 +712,7 @@ describe('POST /api/projects', () => {
       method: 'POST',
       url: '/api/projects',
       headers: authHeader(),
-      payload: { name: 'Site', clientId: 'c-missing', offerId: 'of-1' },
+      payload: { ...VALID_CREATE_PAYLOAD, clientId: 'c-missing' },
     });
 
     expect(res.statusCode).toBe(400);
@@ -711,7 +728,7 @@ describe('POST /api/projects', () => {
       method: 'POST',
       url: '/api/projects',
       headers: authHeader(),
-      payload: { name: 'Site', clientId: 'c-1', offerId: 'of-missing' },
+      payload: { ...VALID_CREATE_PAYLOAD, offerId: 'of-missing' },
     });
 
     expect(res.statusCode).toBe(400);
@@ -722,7 +739,7 @@ describe('POST /api/projects', () => {
     const res = await testApp.inject({
       method: 'POST',
       url: '/api/projects',
-      payload: { name: 'X', clientId: 'c-1', offerId: 'of-1' },
+      payload: { ...VALID_CREATE_PAYLOAD },
     });
     expect(res.statusCode).toBe(401);
   });
@@ -734,7 +751,7 @@ describe('POST /api/projects', () => {
       method: 'POST',
       url: '/api/projects',
       headers: authHeader(),
-      payload: { name: 'X', clientId: 'c-1', offerId: 'of-1' },
+      payload: { ...VALID_CREATE_PAYLOAD },
     });
 
     expect(res.statusCode).toBe(403);
@@ -748,7 +765,7 @@ describe('POST /api/projects', () => {
       method: 'POST',
       url: '/api/projects',
       headers: authHeader(),
-      payload: { name: 'X', clientId: 'c-1', offerId: 'of-1' },
+      payload: { ...VALID_CREATE_PAYLOAD },
     });
 
     expect(res.statusCode).toBe(403);
@@ -773,7 +790,7 @@ describe('POST /api/projects', () => {
       method: 'POST',
       url: '/api/projects',
       headers: authHeader(),
-      payload: { name: 'Website', clientId: 'c-1', offerId: 'of-1' },
+      payload: { ...VALID_CREATE_PAYLOAD },
     });
 
     // The handler propagates the error → Fastify returns 500.

--- a/test/components/projects/ProjectsView.test.ts
+++ b/test/components/projects/ProjectsView.test.ts
@@ -141,7 +141,10 @@ describe('ProjectsView lifecycle fields (issue #322)', () => {
     expect(source).toMatch(/setOfferId\(nextOfferId\)[\s\S]{0,600}['"]offer['"]/);
   });
 
-  test('start and end dates are required on submit (issue #474)', async () => {
+  test('start and end dates are required at creation only (issue #474)', async () => {
+    // Gated on !editingProject so legacy projects (created before this change with null
+    // dates) can still be saved on edit — matches the backend PATCH which still accepts
+    // null. The dateRange check stays unconditional in both modes.
     const source = await Bun.file(
       new URL('../../../components/projects/ProjectsView.tsx', import.meta.url),
     ).text();
@@ -152,8 +155,12 @@ describe('ProjectsView lifecycle fields (issue #322)', () => {
     expect(source).toContain(
       "if (!endDate) newErrors.endDate = t('projects:projects.endDateRequired');",
     );
-    expect(source).toMatch(/projects\.startDate'\)\}\s*<RequiredMark\s*\/>/);
-    expect(source).toMatch(/projects\.endDate'\)\}\s*<RequiredMark\s*\/>/);
+    expect(source).toMatch(
+      /if \(!editingProject\) \{\s*if \(!startDate\) newErrors\.startDate[\s\S]*?if \(!endDate\) newErrors\.endDate/,
+    );
+    expect(source).toMatch(/projects\.startDate'\)\}\s*\{!editingProject && <RequiredMark\s*\/>\}/);
+    expect(source).toMatch(/projects\.endDate'\)\}\s*\{!editingProject && <RequiredMark\s*\/>\}/);
+    expect(source).toContain('required={!editingProject}');
   });
 
   test('edit-mode revenue resolves the effective order from editingProject.orderId', async () => {

--- a/test/components/projects/ProjectsView.test.ts
+++ b/test/components/projects/ProjectsView.test.ts
@@ -141,6 +141,21 @@ describe('ProjectsView lifecycle fields (issue #322)', () => {
     expect(source).toMatch(/setOfferId\(nextOfferId\)[\s\S]{0,600}['"]offer['"]/);
   });
 
+  test('start and end dates are required on submit (issue #474)', async () => {
+    const source = await Bun.file(
+      new URL('../../../components/projects/ProjectsView.tsx', import.meta.url),
+    ).text();
+
+    expect(source).toContain(
+      "if (!startDate) newErrors.startDate = t('projects:projects.startDateRequired');",
+    );
+    expect(source).toContain(
+      "if (!endDate) newErrors.endDate = t('projects:projects.endDateRequired');",
+    );
+    expect(source).toMatch(/projects\.startDate'\)\}\s*<RequiredMark\s*\/>/);
+    expect(source).toMatch(/projects\.endDate'\)\}\s*<RequiredMark\s*\/>/);
+  });
+
   test('edit-mode revenue resolves the effective order from editingProject.orderId', async () => {
     // Regression for the order-derived branch silently falling back to "manual" on edit:
     // the form's `orderId` state is empty in openEditModal (no order selector is shown there —


### PR DESCRIPTION
## Summary
Closes #474.

- **Frontend** ([components/projects/ProjectsView.tsx](components/projects/ProjectsView.tsx)): mark `Data inizio progetto` and `Data fine progetto` as required with the `*` indicator used by the other mandatory fields (Cliente, Nome Progetto, Riferimento offerta). Block submission when either is empty; keep the existing end ≥ start check. Both inputs remain editable on existing projects.
- **Backend** ([server/routes/projects.ts](server/routes/projects.ts)): tighten the POST `/api/projects` JSON schema so `startDate` and `endDate` are required strings, and switch to `parseDateString` so empty values are rejected. PATCH stays unchanged so older projects without dates can still be edited.
- **Locales** ([locales/en/projects.json](locales/en/projects.json), [locales/it/projects.json](locales/it/projects.json)): new `startDateRequired` / `endDateRequired` strings.
- **Docs** ([docs-site/src/content/docs/crm-projects.md](docs-site/src/content/docs/crm-projects.md) + EN mirror): note that both dates are mandatory at creation and editable afterwards.
- **Tests**: backend test file gets a shared `VALID_CREATE_PAYLOAD` fixture and new coverage for `400: missing startDate` / `400: missing endDate`; frontend test asserts the validation + `RequiredMark` on both date inputs.

## Test plan
- [ ] `cd server && bun test test/routes/projects.test.ts` — 75/75 pass locally
- [ ] `bun test ./test/components/projects/ProjectsView.test.ts` — 13/13 pass locally
- [ ] `bun run lint` — clean for modified files
- [ ] Manual: open "Crea Nuovo Progetto", confirm both date fields show the `*`, submit with one or both empty and verify the form blocks with field-level errors, then verify the date-range error still appears when end < start
- [ ] Manual: open an existing project and confirm both dates are still editable

🤖 Generated with [Claude Code](https://claude.com/claude-code)