### PR TITLE
sales(fix): make client offer discount sortable

### DIFF
--- a/components/sales/ClientOffersView.tsx
+++ b/components/sales/ClientOffersView.tsx
@@ -101,22 +101,32 @@ const formatPercentageLabelValue = (value: number): string => {
   return rounded.toFixed(2).replace(/0+$/, '').replace(/\.$/, '');
 };
 
+const getDiscountPercentageValue = (
+  discount: number,
+  discountType: DiscountType,
+  subtotal: number,
+  discountAmount: number,
+): number => {
+  if (discountType === 'percentage') {
+    return Number.isFinite(discount) ? discount : 0;
+  }
+
+  if (!Number.isFinite(subtotal) || subtotal <= 0 || !Number.isFinite(discountAmount)) {
+    return 0;
+  }
+
+  return (discountAmount / subtotal) * 100;
+};
+
 const getDiscountPercentageLabelValue = (
   discount: number,
   discountType: DiscountType,
   subtotal: number,
   discountAmount: number,
-): string => {
-  if (discountType === 'percentage') {
-    return `${formatPercentageLabelValue(Number.isFinite(discount) ? discount : 0)}%`;
-  }
-
-  if (!Number.isFinite(subtotal) || subtotal <= 0 || !Number.isFinite(discountAmount)) {
-    return '0%';
-  }
-
-  return `${formatPercentageLabelValue((discountAmount / subtotal) * 100)}%`;
-};
+): string =>
+  `${formatPercentageLabelValue(
+    getDiscountPercentageValue(discount, discountType, subtotal, discountAmount),
+  )}%`;
 
 const ClientOffersView: React.FC<ClientOffersViewProps> = ({
   offers,
@@ -456,9 +466,17 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
     {
       header: t('sales:clientOffers.discountPercentColumn', { defaultValue: 'Discount %' }),
       id: 'globalDiscount',
+      accessorFn: (row) => {
+        const { subtotal, discountAmount } = calculatePricingTotals(
+          row.items,
+          row.discount,
+          'hours',
+          row.discountType,
+        );
+        return getDiscountPercentageValue(row.discount, row.discountType, subtotal, discountAmount);
+      },
       className: 'whitespace-nowrap',
       headerClassName: 'min-w-[8rem]',
-      disableSorting: true,
       disableFiltering: true,
       cell: ({ row }) => {
         const { subtotal, discountAmount } = calculatePricingTotals(

--- a/test/components/sales/ClientOffersView.test.tsx
+++ b/test/components/sales/ClientOffersView.test.tsx
@@ -151,6 +151,61 @@ describe('<ClientOffersView /> list', () => {
     expect(screen.getByText('-15.00 EUR')).toBeInTheDocument();
   });
 
+  test('sorts the global discount column by equivalent percentage', async () => {
+    const user = userEvent.setup();
+    const percentageDiscountOffer = buildOffer({
+      id: 'O-PERCENT-10',
+      discount: 10,
+      discountType: 'percentage',
+    });
+    const fixedDiscountOffer = buildOffer({
+      id: 'O-FIXED-5',
+      discount: 10,
+      discountType: 'currency',
+      items: [
+        {
+          id: 'item-fixed',
+          offerId: 'O-FIXED-5',
+          productId: 'p-fixed',
+          productName: 'Fixed discount service',
+          quantity: 2,
+          unitPrice: 100,
+          productCost: 60,
+          productMolPercentage: 40,
+          unitType: 'unit',
+        },
+      ],
+    });
+    const zeroDiscountOffer = buildOffer({
+      id: 'O-ZERO',
+      discount: 0,
+      discountType: 'percentage',
+    });
+
+    render(
+      <ClientOffersView
+        {...baseProps}
+        offers={[zeroDiscountOffer, fixedDiscountOffer, percentageDiscountOffer]}
+      />,
+    );
+
+    const sortButton = screen.getByRole('button', {
+      name: 'sales:clientOffers.discountPercentColumn',
+    });
+    expect(sortButton).toBeEnabled();
+    await user.click(sortButton);
+
+    await waitFor(() => {
+      const rows = screen
+        .getAllByRole('row')
+        .slice(1)
+        .map((row) => row.textContent ?? '');
+      expect(rows[0]).toContain('O-PERCENT-10');
+      expect(rows[1]).toContain('O-FIXED-5');
+      expect(rows[2]).toContain('O-ZERO');
+    });
+  });
+
   test('renders every offer passed in (no external search/status filter)', () => {
     render(<ClientOffersView {...baseProps} />);
     expect(screen.getByText('O-ACME-DRAFT')).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- Makes the client offers global discount column header clickable by giving it a sortable numeric equivalent-percentage accessor.
- Keeps the displayed discount percentage behavior unchanged for both percentage and fixed-amount discounts.

## Changes
- Extracts equivalent discount percentage calculation for reuse by the column accessor and display label.
- Enables sorting for the client offers `Discount %` column.
- Adds regression coverage that clicks the header and verifies offers sort by equivalent discount percentage.

## Testing
- `bun test test\components\sales\ClientOffersView.test.tsx`
- `bunx biome check components\sales\ClientOffersView.tsx test\components\sales\ClientOffersView.test.tsx`
- `bun run lint` partially ran: i18n passed, then server typecheck failed because local server dependencies such as `fastify` and `drizzle-orm` are not installed in this worktree.

## Risks / Rollout
- Low risk. Change is scoped to client offer table sorting and test coverage; no API, migration, or documentation behavior changes.

## Issues
Issue: Not linked
