### PR TITLE
auth(fix): allow saved LDAP bind DN updates

### DIFF
--- a/docs-site/src/content/docs/administration.md
+++ b/docs-site/src/content/docs/administration.md
@@ -19,6 +19,8 @@ Praetor supporta autenticazione locale e integrazioni aziendali come LDAP o SSO 
 
 Quando salvi la configurazione LDAP, Praetor conferma il salvataggio solo dopo la persistenza riuscita. Se il server rifiuta le impostazioni, la schermata mostra il messaggio di errore e mantiene visibili i valori da correggere.
 
+Quando modifichi una configurazione LDAP già salvata, la password di bind resta mascherata. Puoi aggiornare il Bind DN senza reinserire la password se il segreto esistente resta valido; reinserisci la password solo quando vuoi cambiarla o cancellala insieme al Bind DN per rimuovere le credenziali di bind.
+
 Prima di abilitare un provider SAML, configura una sorgente metadata valida (URL o XML) oppure la configurazione manuale con **Entry Point** e **Certificato IdP**. Praetor rifiuta il salvataggio di provider SAML abilitati senza questi dati minimi.
 
 Se il salvataggio di un provider OIDC o SAML non riesce, la scheda del provider mostra un messaggio di errore con il dettaglio restituito dal server. Correggi i campi indicati o riprova quando il servizio torna disponibile prima di considerare la configurazione aggiornata.

--- a/docs-site/src/content/docs/en/administration.md
+++ b/docs-site/src/content/docs/en/administration.md
@@ -19,6 +19,8 @@ Praetor supports local authentication and company integrations such as LDAP or S
 
 When saving LDAP configuration, Praetor confirms the save only after the settings are persisted successfully. If the server rejects the settings, the page shows the error message and keeps the values visible for correction.
 
+When editing an already saved LDAP configuration, the bind password remains masked. You can update the Bind DN without re-entering the password when the existing secret is still valid; re-enter the password only when changing it, or clear it together with the Bind DN to remove bind credentials.
+
 Before enabling a SAML provider, configure either a valid metadata source (URL or XML) or manual settings with **Entry Point** and **IdP Certificate**. Praetor rejects enabled SAML providers that are missing this minimum configuration.
 
 If saving an OIDC or SAML provider fails, the provider tab shows an error message with the detail returned by the server. Correct the reported fields or retry when the service is available before treating the configuration as updated.

--- a/server/repositories/ldapRepo.ts
+++ b/server/repositories/ldapRepo.ts
@@ -1,4 +1,4 @@
-import { eq, sql } from 'drizzle-orm';
+import { eq, type SQL, sql } from 'drizzle-orm';
 import { type DbExecutor, db } from '../db/drizzle.ts';
 import { ldapConfig } from '../db/schema/ldapConfig.ts';
 import { decrypt, encrypt, isEncrypted } from '../utils/crypto.ts';
@@ -126,10 +126,7 @@ export const get = async (exec: DbExecutor = db): Promise<LdapConfig | null> => 
   return mapRow(rows[0]);
 };
 
-export const update = async (
-  patch: LdapConfigPatch,
-  exec: DbExecutor = db,
-): Promise<LdapConfig> => {
+const buildUpdateSet = (patch: LdapConfigPatch) => {
   // COALESCE preserves the existing column when the patch value is undefined (legacy
   // "undefined leaves column unchanged" semantic). Same pattern as settingsRepo.upsertForUser.
   // `role_mappings` needs the explicit `::jsonb` cast on the bound text param so COALESCE's
@@ -149,26 +146,54 @@ export const update = async (
   // semantic is preserved; `undefined` keeps the COALESCE preserve-existing branch.
   // Callers must pass plaintext — the route layer converts the masked sentinel to undefined.
   const bindPasswordParam = patch.bindPassword === undefined ? null : encrypt(patch.bindPassword);
+  return {
+    enabled: sql`COALESCE(${patch.enabled ?? null}, ${ldapConfig.enabled})`,
+    serverUrl: sql`COALESCE(${patch.serverUrl ?? null}, ${ldapConfig.serverUrl})`,
+    baseDn: sql`COALESCE(${patch.baseDn ?? null}, ${ldapConfig.baseDn})`,
+    bindDn: sql`COALESCE(${patch.bindDn ?? null}, ${ldapConfig.bindDn})`,
+    bindPassword: sql`COALESCE(${bindPasswordParam}, ${ldapConfig.bindPassword})`,
+    userFilter: sql`COALESCE(${patch.userFilter ?? null}, ${ldapConfig.userFilter})`,
+    groupBaseDn: sql`COALESCE(${patch.groupBaseDn ?? null}, ${ldapConfig.groupBaseDn})`,
+    groupFilter: sql`COALESCE(${patch.groupFilter ?? null}, ${ldapConfig.groupFilter})`,
+    roleMappings: sql`COALESCE(${roleMappingsParam}::jsonb, ${ldapConfig.roleMappings})`,
+    tlsCaCertificate: tlsCaParam,
+    autoProvisionAll: sql`COALESCE(${patch.autoProvisionAll ?? null}, ${ldapConfig.autoProvisionAll})`,
+    updatedAt: sql`CURRENT_TIMESTAMP`,
+  };
+};
+
+const updateWhere = async (
+  patch: LdapConfigPatch,
+  whereClause: SQL,
+  exec: DbExecutor,
+): Promise<LdapConfig | null> => {
   const result = await exec
     .update(ldapConfig)
-    .set({
-      enabled: sql`COALESCE(${patch.enabled ?? null}, ${ldapConfig.enabled})`,
-      serverUrl: sql`COALESCE(${patch.serverUrl ?? null}, ${ldapConfig.serverUrl})`,
-      baseDn: sql`COALESCE(${patch.baseDn ?? null}, ${ldapConfig.baseDn})`,
-      bindDn: sql`COALESCE(${patch.bindDn ?? null}, ${ldapConfig.bindDn})`,
-      bindPassword: sql`COALESCE(${bindPasswordParam}, ${ldapConfig.bindPassword})`,
-      userFilter: sql`COALESCE(${patch.userFilter ?? null}, ${ldapConfig.userFilter})`,
-      groupBaseDn: sql`COALESCE(${patch.groupBaseDn ?? null}, ${ldapConfig.groupBaseDn})`,
-      groupFilter: sql`COALESCE(${patch.groupFilter ?? null}, ${ldapConfig.groupFilter})`,
-      roleMappings: sql`COALESCE(${roleMappingsParam}::jsonb, ${ldapConfig.roleMappings})`,
-      tlsCaCertificate: tlsCaParam,
-      autoProvisionAll: sql`COALESCE(${patch.autoProvisionAll ?? null}, ${ldapConfig.autoProvisionAll})`,
-      updatedAt: sql`CURRENT_TIMESTAMP`,
-    })
-    .where(eq(ldapConfig.id, 1))
+    .set(buildUpdateSet(patch))
+    .where(whereClause)
     .returning(LDAP_PROJECTION);
-  if (result.length === 0) {
+  return result[0] ? mapRow(result[0]) : null;
+};
+
+export const update = async (
+  patch: LdapConfigPatch,
+  exec: DbExecutor = db,
+): Promise<LdapConfig> => {
+  const updated = await updateWhere(patch, eq(ldapConfig.id, 1), exec);
+  if (!updated) {
     throw new Error('ldap_config row (id=1) not found; seed missing');
   }
-  return mapRow(result[0]);
+  return updated;
+};
+
+export const updatePreservingStoredBindPassword = async (
+  patch: LdapConfigPatch,
+  exec: DbExecutor = db,
+): Promise<LdapConfig | null> => {
+  const result = await updateWhere(
+    { ...patch, bindPassword: undefined },
+    sql`${ldapConfig.id} = ${1} AND ${ldapConfig.bindPassword} IS NOT NULL AND ${ldapConfig.bindPassword} <> ''`,
+    exec,
+  );
+  return result;
 };

--- a/server/routes/ldap.ts
+++ b/server/routes/ldap.ts
@@ -212,24 +212,20 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       };
       const { serverUrl, baseDn, userFilter, groupBaseDn, groupFilter, roleMappings } = body;
       // bindPassword === MASKED_SECRET means "preserve the stored secret" (the UI round-trips
-      // the masked value when the operator did not edit the field). To satisfy the paired
-      // validation below, bindDn is also dropped from the patch, but only when the client's
-      // bindDn matches what is currently stored - otherwise a request that changes bindDn
-      // while keeping the masked password would silently swallow the DN edit and return 200.
-      // To actually rotate bindDn, the operator must re-enter bindPassword (supply a non-mask
-      // value) so the credentials are updated together.
+      // the masked value when the operator did not edit the password field). Bind DN remains
+      // editable in that flow: a DN rename often keeps the same service-account password.
+      // The paired validation below checks the effective post-save credential pair so a
+      // masked password cannot invent a missing stored secret or leave only one side set.
       const isBindPasswordMasked = body.bindPassword === MASKED_SECRET;
+      let storedConfigForMaskedPassword: ldapRepo.LdapConfig | undefined;
       let bindDn: string | undefined;
       let bindPassword: string | undefined;
       if (isBindPasswordMasked) {
-        const storedConfig = (await ldapRepo.get()) ?? ldapRepo.DEFAULT_CONFIG;
-        if (body.bindDn !== undefined && body.bindDn !== storedConfig.bindDn) {
-          return badRequest(
-            reply,
-            'bindDn cannot be changed while bindPassword is masked; re-enter bindPassword to rotate credentials',
-          );
-        }
-        bindDn = undefined;
+        storedConfigForMaskedPassword = (await ldapRepo.get()) ?? ldapRepo.DEFAULT_CONFIG;
+        bindDn =
+          body.bindDn !== undefined && body.bindDn !== storedConfigForMaskedPassword.bindDn
+            ? body.bindDn
+            : undefined;
         bindPassword = undefined;
       } else {
         bindDn = body.bindDn;
@@ -272,9 +268,14 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         normalizedGroupFilter = groupFilterTemplateResult.value;
       }
 
-      const hasBindDn = bindDn !== undefined && bindDn !== null && bindDn !== '';
-      const hasBindPassword =
-        bindPassword !== undefined && bindPassword !== null && bindPassword !== '';
+      const hasCredentialValue = (value: string | undefined | null): boolean =>
+        value !== undefined && value !== null && value !== '';
+      const hasBindDn = isBindPasswordMasked
+        ? hasCredentialValue(bindDn ?? storedConfigForMaskedPassword?.bindDn)
+        : hasCredentialValue(bindDn);
+      const hasBindPassword = isBindPasswordMasked
+        ? hasCredentialValue(storedConfigForMaskedPassword?.bindPassword)
+        : hasCredentialValue(bindPassword);
       if (hasBindDn !== hasBindPassword) {
         return badRequest(reply, 'bindDn and bindPassword must be provided together or not at all');
       }

--- a/server/routes/ldap.ts
+++ b/server/routes/ldap.ts
@@ -320,7 +320,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         return badRequest(reply, autoProvisionAllResult.message);
       }
 
-      const updated = await ldapRepo.update({
+      const updatePatch: ldapRepo.LdapConfigPatch = {
         enabled: enabledValue,
         serverUrl,
         baseDn,
@@ -332,7 +332,19 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         roleMappings: validatedMappings,
         autoProvisionAll: autoProvisionAllResult.value,
         ...tlsCaResult.patch,
-      });
+      };
+
+      const updated = isBindPasswordMasked
+        ? await ldapRepo.updatePreservingStoredBindPassword(updatePatch)
+        : await ldapRepo.update(updatePatch);
+
+      if (!updated) {
+        return reply.code(409).send({
+          error:
+            'LDAP bind credentials changed while saving; reload the configuration and try again',
+          errorCode: 'ldap_bind_credentials_changed',
+        });
+      }
 
       // Drop the cached config in the singleton LDAPService so the next
       // authenticate()/syncUsers() call re-reads from the DB. Without this,

--- a/server/test/repositories/ldapRepo.test.ts
+++ b/server/test/repositories/ldapRepo.test.ts
@@ -161,6 +161,37 @@ describe('update', () => {
   });
 });
 
+describe('updatePreservingStoredBindPassword', () => {
+  test('guards masked-password saves with a non-empty bindPassword predicate', async () => {
+    const ciphertext = encrypt('stored-secret');
+    exec.enqueue({ rows: [buildRow({ bindDn: 'cn=rotated', bindPassword: ciphertext })] });
+
+    const result = await ldapRepo.updatePreservingStoredBindPassword(
+      { bindDn: 'cn=rotated', bindPassword: 'must-not-be-written' },
+      testDb,
+    );
+
+    expect(result?.bindDn).toBe('cn=rotated');
+    expect(result?.bindPassword).toBe('stored-secret');
+    expect(exec.calls[0].sql).toMatch(/"id"\s*=\s*\$\d+/);
+    expect(exec.calls[0].sql).toMatch(/"bind_password"\s+is\s+not\s+null/i);
+    expect(exec.calls[0].sql).toMatch(/"bind_password"\s*<>\s*''/i);
+    expect(exec.calls[0].params).not.toContain('must-not-be-written');
+    expect(exec.calls[0].params.some((p) => typeof p === 'string' && isEncrypted(p))).toBe(false);
+  });
+
+  test('returns null when the conditional masked-password update matches no row', async () => {
+    exec.enqueue({ rows: [] });
+
+    const result = await ldapRepo.updatePreservingStoredBindPassword(
+      { bindDn: 'cn=rotated' },
+      testDb,
+    );
+
+    expect(result).toBeNull();
+  });
+});
+
 describe('DEFAULT_CONFIG', () => {
   test('matches the schema-default shape used as a fallback when seed is absent', () => {
     expect(ldapRepo.DEFAULT_CONFIG).toEqual({

--- a/server/test/routes/ldap.test.ts
+++ b/server/test/routes/ldap.test.ts
@@ -256,9 +256,13 @@ describe('GET /api/ldap/config', () => {
 
 describe('PUT /api/ldap/config - bindPassword masking', () => {
   test('bindPassword=MASKED_SECRET is dropped from the patch so the stored secret is preserved', async () => {
-    // The client must round-trip the SAME bindDn it received from GET when keeping the
-    // mask sentinel - otherwise the request is rejected to prevent a silent DN edit.
-    ldapGetMock.mockResolvedValue({ ...BASE_CONFIG, bindDn: 'cn=admin,dc=example,dc=com' });
+    // The client can round-trip the same bindDn it received from GET while keeping the
+    // mask sentinel; only the stored password is preserved.
+    ldapGetMock.mockResolvedValue({
+      ...BASE_CONFIG,
+      bindDn: 'cn=admin,dc=example,dc=com',
+      bindPassword: 'stored-secret',
+    });
     const response = await putConfig({
       enabled: false,
       bindDn: 'cn=admin,dc=example,dc=com',
@@ -267,20 +271,42 @@ describe('PUT /api/ldap/config - bindPassword masking', () => {
     expect(response.statusCode).toBe(200);
     const patch = ldapUpdateMock.mock.calls[0][0] as Partial<realLdapRepo.LdapConfig>;
     expect(patch.bindPassword).toBeUndefined();
-    // bindDn must also be dropped (paired with bindPassword) so the stored credential survives
-    // unchanged; otherwise the COALESCE-on-undefined trick can't preserve the pair atomically.
+    // Unchanged bindDn is omitted from the patch, avoiding a no-op write to that column.
     expect(patch.bindDn).toBeUndefined();
   });
 
-  test('rejects a bindDn change when bindPassword is masked (no silent DN swap)', async () => {
-    ldapGetMock.mockResolvedValue({ ...BASE_CONFIG, bindDn: 'cn=admin,dc=example,dc=com' });
+  test('allows a bindDn change when bindPassword is masked by preserving the stored secret', async () => {
+    ldapGetMock.mockResolvedValue({
+      ...BASE_CONFIG,
+      bindDn: 'cn=admin,dc=example,dc=com',
+      bindPassword: 'stored-secret',
+    });
+    const response = await putConfig({
+      enabled: false,
+      bindDn: 'cn=rotated,dc=example,dc=com',
+      bindPassword: MASKED_SECRET,
+    });
+    expect(response.statusCode).toBe(200);
+    const patch = ldapUpdateMock.mock.calls[0][0] as Partial<realLdapRepo.LdapConfig>;
+    expect(patch.bindDn).toBe('cn=rotated,dc=example,dc=com');
+    expect(patch.bindPassword).toBeUndefined();
+  });
+
+  test('rejects a masked bindPassword when there is no stored secret to preserve', async () => {
+    ldapGetMock.mockResolvedValue({
+      ...BASE_CONFIG,
+      bindDn: 'cn=admin,dc=example,dc=com',
+      bindPassword: '',
+    });
     const response = await putConfig({
       enabled: false,
       bindDn: 'cn=rotated,dc=example,dc=com',
       bindPassword: MASKED_SECRET,
     });
     expect(response.statusCode).toBe(400);
-    expect(JSON.parse(response.body).error).toContain('bindDn cannot be changed');
+    expect(JSON.parse(response.body).error).toContain(
+      'bindDn and bindPassword must be provided together',
+    );
     expect(ldapUpdateMock).not.toHaveBeenCalled();
   });
 

--- a/server/test/routes/ldap.test.ts
+++ b/server/test/routes/ldap.test.ts
@@ -29,6 +29,7 @@ const userHasRoleMock = mock();
 const getRolePermissionsMock = mock();
 const ldapGetMock = mock();
 const ldapUpdateMock = mock();
+const ldapUpdatePreservingStoredBindPasswordMock = mock();
 const findExistingIdsMock = mock();
 const logAuditMock = mock(async () => undefined);
 const invalidateConfigMock = mock();
@@ -57,6 +58,7 @@ beforeAll(async () => {
     ...ldapRepoSnap,
     get: ldapGetMock,
     update: ldapUpdateMock,
+    updatePreservingStoredBindPassword: ldapUpdatePreservingStoredBindPasswordMock,
   }));
   mock.module('../../utils/audit.ts', () => ({
     ...auditSnap,
@@ -101,6 +103,7 @@ const allMocks = [
   getRolePermissionsMock,
   ldapGetMock,
   ldapUpdateMock,
+  ldapUpdatePreservingStoredBindPasswordMock,
   findExistingIdsMock,
   logAuditMock,
   invalidateConfigMock,
@@ -143,6 +146,18 @@ beforeEach(async () => {
     }
     return merged;
   });
+  ldapUpdatePreservingStoredBindPasswordMock.mockImplementation(
+    async (patch: Partial<realLdapRepo.LdapConfig>) => {
+      const stored = (await ldapGetMock()) ?? BASE_CONFIG;
+      if (!stored.bindPassword) return null;
+      const merged = { ...stored };
+      for (const [k, v] of Object.entries(patch)) {
+        if (k === 'bindPassword') continue;
+        if (v !== undefined) (merged as Record<string, unknown>)[k] = v;
+      }
+      return merged;
+    },
+  );
   logAuditMock.mockImplementation(async () => undefined);
   invalidateConfigMock.mockImplementation(() => {});
   authenticateWithProfileMock.mockResolvedValue({
@@ -269,7 +284,9 @@ describe('PUT /api/ldap/config - bindPassword masking', () => {
       bindPassword: MASKED_SECRET,
     });
     expect(response.statusCode).toBe(200);
-    const patch = ldapUpdateMock.mock.calls[0][0] as Partial<realLdapRepo.LdapConfig>;
+    expect(ldapUpdateMock).not.toHaveBeenCalled();
+    const patch = ldapUpdatePreservingStoredBindPasswordMock.mock
+      .calls[0][0] as Partial<realLdapRepo.LdapConfig>;
     expect(patch.bindPassword).toBeUndefined();
     // Unchanged bindDn is omitted from the patch, avoiding a no-op write to that column.
     expect(patch.bindDn).toBeUndefined();
@@ -287,9 +304,33 @@ describe('PUT /api/ldap/config - bindPassword masking', () => {
       bindPassword: MASKED_SECRET,
     });
     expect(response.statusCode).toBe(200);
-    const patch = ldapUpdateMock.mock.calls[0][0] as Partial<realLdapRepo.LdapConfig>;
+    expect(ldapUpdateMock).not.toHaveBeenCalled();
+    const patch = ldapUpdatePreservingStoredBindPasswordMock.mock
+      .calls[0][0] as Partial<realLdapRepo.LdapConfig>;
     expect(patch.bindDn).toBe('cn=rotated,dc=example,dc=com');
     expect(patch.bindPassword).toBeUndefined();
+  });
+
+  test('returns 409 if the stored bindPassword is cleared before the masked update writes', async () => {
+    ldapGetMock.mockResolvedValue({
+      ...BASE_CONFIG,
+      bindDn: 'cn=admin,dc=example,dc=com',
+      bindPassword: 'stored-secret',
+    });
+    ldapUpdatePreservingStoredBindPasswordMock.mockResolvedValue(null);
+    const response = await putConfig({
+      enabled: false,
+      bindDn: 'cn=rotated,dc=example,dc=com',
+      bindPassword: MASKED_SECRET,
+    });
+    expect(response.statusCode).toBe(409);
+    expect(JSON.parse(response.body)).toEqual({
+      error: 'LDAP bind credentials changed while saving; reload the configuration and try again',
+      errorCode: 'ldap_bind_credentials_changed',
+    });
+    expect(ldapUpdateMock).not.toHaveBeenCalled();
+    expect(invalidateConfigMock).not.toHaveBeenCalled();
+    expect(logAuditMock).not.toHaveBeenCalled();
   });
 
   test('rejects a masked bindPassword when there is no stored secret to preserve', async () => {
@@ -308,6 +349,7 @@ describe('PUT /api/ldap/config - bindPassword masking', () => {
       'bindDn and bindPassword must be provided together',
     );
     expect(ldapUpdateMock).not.toHaveBeenCalled();
+    expect(ldapUpdatePreservingStoredBindPasswordMock).not.toHaveBeenCalled();
   });
 
   test('a real new bindPassword (non-mask) is forwarded to ldapRepo.update', async () => {


### PR DESCRIPTION
## Summary
- Allows admins to update the LDAP Bind DN on an already saved configuration while preserving the masked stored bind password.
- Keeps credential-pair validation so a masked password is rejected when no saved secret exists.
- Documents the saved LDAP credential edit behavior in Italian and English admin docs.

## Changes
- Adjusts `/api/ldap/config` masked bind-password handling to compare against the stored config and patch only changed Bind DN values.
- Adds regression coverage for unchanged Bind DN, changed Bind DN with a stored masked password, and masked-password rejection without a stored secret.
- Updates user documentation for LDAP bind credential edits.

## Testing
- `cd server && bun test test/routes/ldap.test.ts`
- `bun test test/docs/user-docs.test.ts`
- `cd server && bun run build`
- `bun run lint` (passes with 3 existing warnings in unchanged files)

## Risks / Rollout
- Low-to-medium risk because this touches authentication configuration persistence, scoped to LDAP admin settings.
- No migrations or production configuration changes.

## Issues
Issue: Not linked
