### PR TITLE
fix(timesheet): left-align hours column in daily activity table

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -352,7 +352,6 @@ const TrackerView: React.FC<{
         id: 'duration',
         header: t('entry.hours'),
         accessorKey: 'duration',
-        align: 'right',
         cell: ({ row }) => (
           <span className="font-black text-zinc-900">
             {row.isPlaceholder && row.duration === 0 ? '--' : row.duration.toFixed(2)}


### PR DESCRIPTION
## Summary
- Drop `align: 'right'` from the `duration` column in the daily activity table so the "Ore" header sits flush against the column separator instead of leaving a visible gap.
- The values render left-aligned as well, matching the header.

## Test plan
- [ ] Open the Tracker → Daily view and confirm the "Ore" header no longer has a gap between the column separator and the label.
- [ ] Verify hour values render under the header without overflowing into adjacent columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)