### PR TITLE
auth(fix): test saved disabled LDAP config

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -14011,6 +14011,7 @@
         "tags": [
           "ldap"
         ],
+        "description": "Tests credentials against the latest saved LDAP configuration, even when LDAP login is disabled.",
         "requestBody": {
           "required": true,
           "content": {

--- a/server/routes/ldap.ts
+++ b/server/routes/ldap.ts
@@ -373,6 +373,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       schema: {
         tags: ['ldap'],
         summary: 'Test LDAP authentication',
+        description:
+          'Tests credentials against the latest saved LDAP configuration, even when LDAP login is disabled.',
         body: ldapTestBodySchema,
         response: {
           200: ldapTestResponseSchema,
@@ -395,6 +397,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         result = await ldapService.authenticateWithProfile(
           usernameResult.value,
           passwordResult.value,
+          { allowDisabledConfig: true, reloadConfig: true },
         );
       } catch (err) {
         // Admin diagnostic — surface the outage in the response body instead of a 500

--- a/server/services/ldap.ts
+++ b/server/services/ldap.ts
@@ -13,7 +13,6 @@ import { generatePrefixedId } from '../utils/order-ids.ts';
 import {
   applyExternalRolesForUser,
   applyExternalRolesForUserIfMatched,
-  DEFAULT_ROLE_ID,
   type ExternalRoleMapping,
   filterExistingRoleIds,
   mapExternalGroupsToMatchedRoleIds,
@@ -85,6 +84,11 @@ export type LdapUserEntry = {
   attributes: Record<string, unknown>;
 };
 
+type LdapClientOptions = {
+  allowDisabledConfig?: boolean;
+  reloadConfig?: boolean;
+};
+
 const warnRoleMappingNoMatch = (
   phase: string,
   user: { id: string; username: string; role: string },
@@ -142,12 +146,12 @@ class LDAPService {
     this.config = null;
   }
 
-  async getClient(): Promise<LdapClient | null> {
-    if (!this.config) {
+  async getClient(options: LdapClientOptions = {}): Promise<LdapClient | null> {
+    if (!this.config || options.reloadConfig) {
       await this.loadConfig();
     }
 
-    if (!this.config?.enabled) {
+    if (!this.config || (!options.allowDisabledConfig && !this.config.enabled)) {
       return null;
     }
 
@@ -190,10 +194,14 @@ class LDAPService {
     }));
   }
 
-  async authenticateWithProfile(username: string, password: string): Promise<LdapAuthResult> {
+  async authenticateWithProfile(
+    username: string,
+    password: string,
+    options: LdapClientOptions = {},
+  ): Promise<LdapAuthResult> {
     let client: LdapClient | null = null;
     try {
-      client = await this.getClient();
+      client = await this.getClient(options);
       if (!client) {
         return { authenticated: false, groups: [], matchedRoleIds: [] };
       }

--- a/server/test/routes/ldap.test.ts
+++ b/server/test/routes/ldap.test.ts
@@ -519,7 +519,10 @@ describe('POST /api/ldap/test', () => {
     const response = await testLdapAuth({ username: ' alice ', password: 'secret' });
 
     expect(response.statusCode).toBe(200);
-    expect(authenticateWithProfileMock).toHaveBeenCalledWith('alice', 'secret');
+    expect(authenticateWithProfileMock).toHaveBeenCalledWith('alice', 'secret', {
+      allowDisabledConfig: true,
+      reloadConfig: true,
+    });
     expect(JSON.parse(response.body)).toEqual({
       success: true,
       authenticated: true,

--- a/server/test/services/ldap.test.ts
+++ b/server/test/services/ldap.test.ts
@@ -243,6 +243,13 @@ describe('getClient', () => {
     expect(createClientMock).not.toHaveBeenCalled();
   });
 
+  test('can create a diagnostic client when config.enabled is false', async () => {
+    ldapRepoGetMock.mockResolvedValue({ ...ENABLED_LDAP_CONFIG, enabled: false });
+    const client = await ldapService.getClient({ allowDisabledConfig: true });
+    expect(client).not.toBeNull();
+    expect(createClientMock).toHaveBeenCalledTimes(1);
+  });
+
   test('calls loadConfig when cache is empty', async () => {
     await ldapService.getClient();
     expect(ldapRepoGetMock).toHaveBeenCalledTimes(1);
@@ -335,6 +342,20 @@ describe('invalidateConfig', () => {
     await ldapService.getClient();
     expect(ldapRepoGetMock).toHaveBeenCalledTimes(2);
   });
+
+  test('reloadConfig re-reads the saved config even when the cache is populated', async () => {
+    await ldapService.getClient();
+    ldapRepoGetMock.mockResolvedValue({
+      ...ENABLED_LDAP_CONFIG,
+      serverUrl: 'ldap://new-ldap.test:389',
+    });
+
+    await ldapService.getClient({ reloadConfig: true });
+
+    expect(ldapRepoGetMock).toHaveBeenCalledTimes(2);
+    const opts = createClientMock.mock.calls[1]?.[0] as { url: string };
+    expect(opts.url).toBe('ldap://new-ldap.test:389');
+  });
 });
 
 describe('authenticate', () => {
@@ -388,6 +409,32 @@ describe('authenticate', () => {
     const ok = await ldapService.authenticate('alice', 'pw');
     expect(ok).toBe(true);
     expect(lastClientStats?.unbindCalls).toBe(1);
+    expect(lastClientStats?.bindCalls).toEqual([
+      { dn: 'cn=admin,dc=test,dc=com', password: 'admin-pw' },
+      { dn: 'uid=alice,dc=test,dc=com', password: 'pw' },
+    ]);
+  });
+
+  test('authenticateWithProfile can use a disabled saved config for diagnostics', async () => {
+    ldapRepoGetMock.mockResolvedValue({ ...ENABLED_LDAP_CONFIG, enabled: false });
+    nextFixture = {
+      bindResponses: [null, null],
+      searchResponses: [
+        {
+          entries: [{ objectName: 'uid=alice,dc=test,dc=com', object: { uid: 'alice' } }],
+          status: 0,
+        },
+        { entries: [], status: 0 },
+        { entries: [], status: 0 },
+      ],
+    };
+
+    const result = await ldapService.authenticateWithProfile('alice', 'pw', {
+      allowDisabledConfig: true,
+    });
+
+    expect(result.authenticated).toBe(true);
+    expect(createClientMock).toHaveBeenCalledTimes(1);
     expect(lastClientStats?.bindCalls).toEqual([
       { dn: 'cn=admin,dc=test,dc=com', password: 'admin-pw' },
       { dn: 'uid=alice,dc=test,dc=com', password: 'pw' },


### PR DESCRIPTION
## Summary
- Fixes the LDAP connection tester so it uses the latest saved LDAP settings even when LDAP login is disabled.
- Keeps normal LDAP login, user lookup, and sync behavior gated by enabled LDAP configuration.

## Changes
- Adds opt-in LDAP client options for diagnostic calls to bypass the enabled-state gate and reload saved config from the database.
- Updates `/api/ldap/test` to use the diagnostic path and documents the endpoint behavior in OpenAPI.
- Adds regression coverage for disabled saved configs and forced config reloads.

## Testing
- `bun test ./test/routes/ldap.test.ts ./test/services/ldap.test.ts`
- `bun run typecheck`
- `bunx biome check server/services/ldap.ts server/routes/ldap.ts server/test/routes/ldap.test.ts server/test/services/ldap.test.ts docs/api/openapi.json`
- `git diff --check`

## Risks / Rollout
- Low risk. The bypass is only used by the admin LDAP tester; login and sync still require LDAP to be enabled.

## Issues
Issue: Not linked
