### PR TITLE
auth(fix): tolerate MCP token touch failures

### DIFF
--- a/server/middleware/mcpAuth.ts
+++ b/server/middleware/mcpAuth.ts
@@ -95,7 +95,11 @@ export const authenticateMcpToken = async (request: FastifyRequest, reply: Fasti
 
   request.user = mcpUser;
   request.auth = { userId: user.id, sessionStart: Date.now() };
-  await mcpTokensRepo.touchLastUsed(token.id);
+  try {
+    await mcpTokensRepo.touchLastUsed(token.id);
+  } catch (err) {
+    request.log?.warn({ err }, 'Failed to update MCP token last-used timestamp');
+  }
 
   const authInfo: AuthInfo = {
     token: rawToken,

--- a/server/test/middleware/mcpAuth.test.ts
+++ b/server/test/middleware/mcpAuth.test.ts
@@ -70,8 +70,11 @@ const makeReply = () => {
 const makeRequest = (token?: string) =>
   ({
     headers: token ? { authorization: `Bearer ${token}` } : {},
+    log: {
+      warn: mock(),
+    },
     raw: {},
-  }) as FastifyRequest & { raw: { auth?: unknown } };
+  }) as FastifyRequest & { log: { warn: ReturnType<typeof mock> }; raw: { auth?: unknown } };
 
 beforeEach(() => {
   for (const m of [
@@ -166,6 +169,33 @@ describe('authenticateMcpToken', () => {
       }),
     );
     expect(touchLastUsedMock).toHaveBeenCalledWith('mcp-token-1');
+  });
+
+  test('does not fail authentication when last-used timestamp update fails', async () => {
+    const updateError = new Error('database unavailable');
+    touchLastUsedMock.mockRejectedValue(updateError);
+    const request = makeRequest('praetor_mcp_token');
+    const reply = makeReply();
+
+    await authenticateMcpToken(request, reply);
+
+    expect(reply.statusCode).toBe(200);
+    expect(request.user).toEqual(
+      expect.objectContaining({
+        id: 'u1',
+        permissions: ['timesheets.tracker.view'],
+      }),
+    );
+    expect(request.raw.auth).toEqual(
+      expect.objectContaining({
+        token: 'praetor_mcp_token',
+        clientId: 'u1',
+      }),
+    );
+    expect(request.log.warn).toHaveBeenCalledWith(
+      { err: updateError },
+      'Failed to update MCP token last-used timestamp',
+    );
   });
 
   test('403 when token has been idle beyond the timeout', async () => {


### PR DESCRIPTION
## Summary
- Prevent MCP authentication from returning a 500 when updating the token last-used timestamp fails after validation.
- Add regression coverage for transient 	ouchLastUsed failures.

## Changes
- Wrap mcpTokensRepo.touchLastUsed in a best-effort try/catch and log a warning on failure.
- Extend the MCP auth middleware test helper with a mock logger and assert successful authentication when timestamp tracking fails.

## Testing
- un test test/middleware/mcpAuth.test.ts

## Risks / Rollout
- Low risk. Change is scoped to MCP token usage tracking; validation and authorization behavior are unchanged.

## Issues
Fixes #497