### PR TITLE
accounting(fix): allow clearing nullable document fields

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -24677,7 +24677,10 @@
                     "type": "string"
                   },
                   "notes": {
-                    "type": "string"
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 }
               }
@@ -26602,7 +26605,10 @@
                     "type": "number"
                   },
                   "notes": {
-                    "type": "string"
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
                   "items": {
                     "type": "array",

--- a/server/repositories/clientsOrdersRepo.ts
+++ b/server/repositories/clientsOrdersRepo.ts
@@ -277,16 +277,32 @@ export const create = async (
 };
 
 export type ClientOrderUpdate = {
-  id?: string | null;
+  id?: string;
   linkedOfferId?: string | null;
   linkedQuoteId?: string | null;
-  clientId?: string | null;
-  clientName?: string | null;
-  paymentTerms?: string | null;
-  discount?: number | null;
-  discountType?: 'percentage' | 'currency' | null;
-  status?: string | null;
+  clientId?: string;
+  clientName?: string;
+  paymentTerms?: string;
+  discount?: number;
+  discountType?: 'percentage' | 'currency';
+  status?: string;
   notes?: string | null;
+};
+
+const orderUpdateValues = (patch: ClientOrderUpdate) => {
+  const set: Record<string, unknown> = {};
+  if (patch.id !== undefined) set.id = patch.id;
+  if (patch.linkedOfferId !== undefined) set.linkedOfferId = patch.linkedOfferId;
+  if (patch.linkedQuoteId !== undefined) set.linkedQuoteId = patch.linkedQuoteId;
+  if (patch.clientId !== undefined) set.clientId = patch.clientId;
+  if (patch.clientName !== undefined) set.clientName = patch.clientName;
+  if (patch.paymentTerms !== undefined) set.paymentTerms = patch.paymentTerms;
+  if (patch.discount !== undefined) set.discount = numericForDb(patch.discount);
+  if (patch.discountType !== undefined) set.discountType = patch.discountType;
+  if (patch.status !== undefined) set.status = patch.status;
+  if (patch.notes !== undefined) set.notes = patch.notes;
+  set.updatedAt = sql`CURRENT_TIMESTAMP`;
+  return set;
 };
 
 export const update = async (
@@ -296,19 +312,7 @@ export const update = async (
 ): Promise<ClientOrder | null> => {
   const rows = await exec
     .update(sales)
-    .set({
-      id: sql`COALESCE(${patch.id ?? null}, ${sales.id})`,
-      linkedOfferId: sql`COALESCE(${patch.linkedOfferId ?? null}, ${sales.linkedOfferId})`,
-      linkedQuoteId: sql`COALESCE(${patch.linkedQuoteId ?? null}, ${sales.linkedQuoteId})`,
-      clientId: sql`COALESCE(${patch.clientId ?? null}, ${sales.clientId})`,
-      clientName: sql`COALESCE(${patch.clientName ?? null}, ${sales.clientName})`,
-      paymentTerms: sql`COALESCE(${patch.paymentTerms ?? null}, ${sales.paymentTerms})`,
-      discount: sql`COALESCE(${numericForDb(patch.discount) ?? null}::numeric, ${sales.discount})`,
-      discountType: sql`COALESCE(${patch.discountType ?? null}, ${sales.discountType})`,
-      status: sql`COALESCE(${patch.status ?? null}, ${sales.status})`,
-      notes: sql`COALESCE(${patch.notes ?? null}, ${sales.notes})`,
-      updatedAt: sql`CURRENT_TIMESTAMP`,
-    })
+    .set(orderUpdateValues(patch))
     .where(eq(sales.id, id))
     .returning();
   return rows[0] ? mapOrder(rows[0]) : null;

--- a/server/repositories/invoicesRepo.ts
+++ b/server/repositories/invoicesRepo.ts
@@ -237,20 +237,22 @@ export type InvoiceUpdate = {
   notes?: string | null;
 };
 
-const invoiceUpdateValues = (patch: InvoiceUpdate) => ({
-  id: sql`COALESCE(${patch.id ?? null}, ${invoices.id})`,
-  clientId: sql`COALESCE(${patch.clientId ?? null}, ${invoices.clientId})`,
-  clientName: sql`COALESCE(${patch.clientName ?? null}, ${invoices.clientName})`,
-  issueDate: sql`COALESCE(${patch.issueDate ?? null}::date, ${invoices.issueDate})`,
-  dueDate: sql`COALESCE(${patch.dueDate ?? null}::date, ${invoices.dueDate})`,
-  status: sql`COALESCE(${patch.status ?? null}, ${invoices.status})`,
-  subtotal: sql`COALESCE(${numericForDb(patch.subtotal) ?? null}::numeric, ${invoices.subtotal})`,
-  taxTotal: sql`COALESCE(${numericForDb(patch.taxTotal) ?? null}::numeric, ${invoices.taxTotal})`,
-  total: sql`COALESCE(${numericForDb(patch.total) ?? null}::numeric, ${invoices.total})`,
-  amountPaid: sql`COALESCE(${numericForDb(patch.amountPaid) ?? null}::numeric, ${invoices.amountPaid})`,
-  notes: sql`COALESCE(${patch.notes ?? null}, ${invoices.notes})`,
-  updatedAt: sql`CURRENT_TIMESTAMP`,
-});
+const invoiceUpdateValues = (patch: InvoiceUpdate) => {
+  const set: Record<string, unknown> = {};
+  if (patch.id !== undefined) set.id = patch.id;
+  if (patch.clientId !== undefined) set.clientId = patch.clientId;
+  if (patch.clientName !== undefined) set.clientName = patch.clientName;
+  if (patch.issueDate !== undefined) set.issueDate = patch.issueDate;
+  if (patch.dueDate !== undefined) set.dueDate = patch.dueDate;
+  if (patch.status !== undefined) set.status = patch.status;
+  if (patch.subtotal !== undefined) set.subtotal = numericForDb(patch.subtotal);
+  if (patch.taxTotal !== undefined) set.taxTotal = numericForDb(patch.taxTotal);
+  if (patch.total !== undefined) set.total = numericForDb(patch.total);
+  if (patch.amountPaid !== undefined) set.amountPaid = numericForDb(patch.amountPaid);
+  if (patch.notes !== undefined) set.notes = patch.notes;
+  set.updatedAt = sql`CURRENT_TIMESTAMP`;
+  return set;
+};
 
 export const update = async (
   id: string,

--- a/server/routes/clients-orders.ts
+++ b/server/routes/clients-orders.ts
@@ -145,7 +145,7 @@ const clientOrderUpdateBodySchema = {
     discount: { type: 'number' },
     discountType: { type: 'string', enum: ['percentage', 'currency'] },
     status: { type: 'string' },
-    notes: { type: 'string' },
+    notes: { type: ['string', 'null'] },
   },
 } as const;
 
@@ -1102,22 +1102,27 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           if (shouldSnapshot) {
             await snapshotPreState(idResult.value, 'update', request, tx);
           }
-          const order = await clientsOrdersRepo.update(
-            idResult.value,
-            {
-              id: nextIdValue,
-              linkedOfferId: (linkedOfferIdValue as string | null | undefined) ?? null,
-              linkedQuoteId: linkedQuoteIdValue,
-              clientId: (clientIdValue as string | null | undefined) ?? null,
-              clientName: (clientNameValue as string | null | undefined) ?? null,
-              paymentTerms: (paymentTerms as string | null | undefined) ?? null,
-              discount: (discountValue as number | null | undefined) ?? null,
-              discountType: discountTypeValue ?? null,
-              status: (status as string | null | undefined) ?? null,
-              notes: (notes as string | null | undefined) ?? null,
-            },
-            tx,
-          );
+          const patch: clientsOrdersRepo.ClientOrderUpdate = {};
+          if (nextIdValue !== null) patch.id = nextIdValue;
+          if (linkedOfferId !== undefined && linkedOfferIdValue) {
+            patch.linkedOfferId = linkedOfferIdValue;
+            patch.linkedQuoteId = linkedQuoteIdValue;
+          }
+          if (clientIdValue !== undefined && clientIdValue !== null) {
+            patch.clientId = clientIdValue;
+          }
+          if (clientNameValue !== undefined && clientNameValue !== null) {
+            patch.clientName = clientNameValue;
+          }
+          if (typeof paymentTerms === 'string') patch.paymentTerms = paymentTerms;
+          if (discountValue !== undefined && discountValue !== null) {
+            patch.discount = discountValue;
+          }
+          if (discountTypeValue !== undefined) patch.discountType = discountTypeValue;
+          if (typeof status === 'string') patch.status = status;
+          if (notes !== undefined) patch.notes = notes as string | null;
+
+          const order = await clientsOrdersRepo.update(idResult.value, patch, tx);
           if (!order) return { order: null, items: [] };
 
           let nextItems: clientsOrdersRepo.ClientOrderItem[];

--- a/server/routes/invoices.ts
+++ b/server/routes/invoices.ts
@@ -143,7 +143,7 @@ const invoiceUpdateBodySchema = {
     dueDate: { type: 'string', format: 'date' },
     status: { type: 'string' },
     amountPaid: { type: 'number' },
-    notes: { type: 'string' },
+    notes: { type: ['string', 'null'] },
     items: { type: 'array', items: invoiceItemBodySchema },
   },
 } as const;

--- a/server/test/repositories/clientsOrdersRepo.test.ts
+++ b/server/test/repositories/clientsOrdersRepo.test.ts
@@ -120,14 +120,40 @@ describe('create / update', () => {
     expect(result.id).toBe('co-1');
   });
 
-  test('update uses COALESCE-per-column and includes id in WHERE', async () => {
+  test('update writes only provided columns and includes id in WHERE', async () => {
     exec.enqueue({ rows: [orderRow()] });
     await repo.update('co-1', { status: 'confirmed' }, testDb);
     const sql = exec.calls[0].sql.toLowerCase();
+    const setClause = sql.slice(sql.indexOf(' set ') + 5, sql.indexOf(' where '));
     expect(sql).toContain('update "sales"');
-    expect(sql).toContain('coalesce');
+    expect(setClause).not.toContain('coalesce');
+    expect(setClause).toContain('"status"');
+    expect(setClause).not.toContain('"notes"');
+    expect(setClause).not.toContain('"linked_offer_id"');
     expect(exec.calls[0].params).toContain('confirmed');
     expect(exec.calls[0].params).toContain('co-1');
+  });
+
+  test('explicit null notes and links clear nullable columns', async () => {
+    exec.enqueue({ rows: [orderRow()] });
+    await repo.update('co-1', { linkedOfferId: null, linkedQuoteId: null, notes: null }, testDb);
+    const sql = exec.calls[0].sql.toLowerCase();
+    const setClause = sql.slice(sql.indexOf(' set ') + 5, sql.indexOf(' where '));
+    expect(setClause).toContain('"linked_offer_id"');
+    expect(setClause).toContain('"linked_quote_id"');
+    expect(setClause).toContain('"notes"');
+    expect(setClause).not.toContain('coalesce');
+    expect(exec.calls[0].params.filter((param) => param === null)).toHaveLength(3);
+  });
+
+  test('empty patch only updates updated_at', async () => {
+    exec.enqueue({ rows: [orderRow()] });
+    await repo.update('co-1', {}, testDb);
+    const sql = exec.calls[0].sql.toLowerCase();
+    const setClause = sql.slice(sql.indexOf(' set ') + 5, sql.indexOf(' where '));
+    expect(setClause).toContain('"updated_at" = current_timestamp');
+    expect(setClause).not.toContain('"notes"');
+    expect(setClause).not.toContain('coalesce');
   });
 
   test('update returns null when no row matches', async () => {

--- a/server/test/repositories/invoicesRepo.test.ts
+++ b/server/test/repositories/invoicesRepo.test.ts
@@ -256,16 +256,30 @@ describe('create', () => {
 });
 
 describe('update', () => {
-  test('uses COALESCE-per-column, sets updated_at, and includes id in WHERE', async () => {
+  test('updates only provided columns, sets updated_at, and includes id in WHERE', async () => {
     exec.enqueue({ rows: [invoiceRow()] });
     await invoicesRepo.update('INV-2026-0001', { status: 'sent', total: 200 }, testDb);
     const sql = exec.calls[0].sql.toLowerCase();
+    const setClause = sql.slice(sql.indexOf(' set ') + 5, sql.indexOf(' where '));
     expect(sql).toContain('update "invoices"');
-    expect(sql).toContain('coalesce');
+    expect(setClause).not.toContain('coalesce');
+    expect(setClause).toContain('"status"');
+    expect(setClause).toContain('"total"');
+    expect(setClause).not.toContain('"notes"');
     expect(sql).toContain('current_timestamp');
     expect(exec.calls[0].params).toContain('sent');
     expect(exec.calls[0].params).toContain('200');
     expect(exec.calls[0].params).toContain('INV-2026-0001');
+  });
+
+  test('explicit null notes clears the nullable column', async () => {
+    exec.enqueue({ rows: [invoiceRow()] });
+    await invoicesRepo.update('INV-2026-0001', { notes: null }, testDb);
+    const sql = exec.calls[0].sql.toLowerCase();
+    const setClause = sql.slice(sql.indexOf(' set ') + 5, sql.indexOf(' where '));
+    expect(setClause).toContain('"notes"');
+    expect(setClause).not.toContain('coalesce');
+    expect(exec.calls[0].params).toContain(null);
   });
 
   test('returns null when no row updated', async () => {
@@ -273,10 +287,15 @@ describe('update', () => {
     expect(await invoicesRepo.update('INV-X', { status: 'sent' }, testDb)).toBeNull();
   });
 
-  test('empty patch still emits an UPDATE (every column COALESCEs to its own value)', async () => {
+  test('empty patch only updates updated_at', async () => {
     exec.enqueue({ rows: [invoiceRow()] });
     await invoicesRepo.update('INV-1', {}, testDb);
-    expect(exec.calls[0].sql.toLowerCase()).toContain('update');
+    const sql = exec.calls[0].sql.toLowerCase();
+    const setClause = sql.slice(sql.indexOf(' set ') + 5, sql.indexOf(' where '));
+    expect(sql).toContain('update');
+    expect(setClause).toContain('"updated_at" = current_timestamp');
+    expect(setClause).not.toContain('"notes"');
+    expect(setClause).not.toContain('coalesce');
     expect(exec.calls[0].params).toContain('INV-1');
   });
 });

--- a/server/test/routes/clients-orders-versions.test.ts
+++ b/server/test/routes/clients-orders-versions.test.ts
@@ -670,6 +670,38 @@ describe('PUT /api/clients-orders/:id snapshots pre-update state', () => {
     expect(res.statusCode).toBe(200);
     expect(ovInsertMock).not.toHaveBeenCalled();
     expect(coFindFullForSnapshotMock).not.toHaveBeenCalled();
+    expect(coUpdateMock).toHaveBeenCalledWith('o-1', { status: 'confirmed' }, TX_SENTINEL);
+  });
+
+  test('PUT with explicit null notes clears notes and snapshots the previous value', async () => {
+    coFindExistingMock.mockResolvedValue({
+      id: 'o-1',
+      linkedQuoteId: null,
+      linkedOfferId: null,
+      clientId: 'c1',
+      clientName: 'Client',
+      paymentTerms: 'immediate',
+      discount: 0,
+      discountType: 'percentage' as const,
+      status: 'draft',
+      notes: 'old note',
+    });
+    coFindFullForSnapshotMock.mockResolvedValue({
+      order: { ...SAMPLE_ORDER, notes: 'old note' },
+      items: [SAMPLE_ITEM],
+    });
+    coUpdateMock.mockResolvedValue({ ...SAMPLE_ORDER, notes: null });
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/clients-orders/o-1',
+      headers: authHeader(),
+      payload: { notes: null },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(ovInsertMock).toHaveBeenCalled();
+    expect(coUpdateMock).toHaveBeenCalledWith('o-1', { notes: null }, TX_SENTINEL);
   });
 
   test('PUT on source-linked order does NOT snapshot (status-only edit)', async () => {

--- a/server/test/routes/invoices.test.ts
+++ b/server/test/routes/invoices.test.ts
@@ -808,6 +808,22 @@ describe('PUT /api/invoices/:id', () => {
     expect(patch).not.toHaveProperty('total');
   });
 
+  test('200 explicit null notes clears invoice notes', async () => {
+    updateMock.mockResolvedValue({ ...SAMPLE_INVOICE, notes: null });
+    findItemsForInvoiceMock.mockResolvedValue([SAMPLE_ITEM]);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/invoices/inv-1',
+      headers: authHeader(),
+      payload: { notes: null },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const patch = updateMock.mock.calls[0][1] as Record<string, unknown>;
+    expect(patch).toHaveProperty('notes', null);
+  });
+
   test('400 amountPaid > computed total when items provided', async () => {
     const res = await testApp.inject({
       method: 'PUT',


### PR DESCRIPTION
## Summary
- Fixes nullable update handling for client invoices and client orders.
- Allows explicit `null` values to clear nullable fields while preserving omitted fields.
- Updates API docs and regression coverage for clear-to-null behavior.

## Changes
- Replaces COALESCE-based update patches in `invoicesRepo` and `clientsOrdersRepo` with explicit `undefined` checks.
- Keeps omitted client-order update fields out of the repository patch so partial updates remain non-destructive.
- Allows `notes: null` in invoice and client-order update schemas.
- Updates generated OpenAPI request bodies for nullable notes.
- Adds repository and route tests for explicit null clears and omitted-field preservation.

## Testing
- `bun run lint`
- `bun run test:server`

## Risks / Rollout
- Low risk. Change is scoped to update patch construction for invoices and client orders.
- No migrations or production configuration changes.

## Issues
Fixes #500