### PR TITLE
projects(fix): bind project id filters as arrays

### DIFF
--- a/server/repositories/projectsRepo.ts
+++ b/server/repositories/projectsRepo.ts
@@ -144,7 +144,7 @@ export const listByIds = async (ids: string[], exec: DbExecutor = db): Promise<P
     exec,
     sql`SELECT ${projectSelectSql}
           FROM projects p
-         WHERE p.id = ANY(${ids})
+         WHERE p.id = ANY(${sql.param(ids)}::text[])
          ORDER BY p.name`,
   );
   return rows.map(mapRawRow);
@@ -170,7 +170,7 @@ export const listNamesByIds = async (
     sql`SELECT p.id, p.name, p.client_id, c.name AS client_name
           FROM projects p
           INNER JOIN clients c ON c.id = p.client_id
-         WHERE p.id = ANY(${ids})`,
+         WHERE p.id = ANY(${sql.param(ids)}::text[])`,
   );
   return new Map(
     rows.map((row) => [

--- a/server/test/repositories/projectsRepo.test.ts
+++ b/server/test/repositories/projectsRepo.test.ts
@@ -106,18 +106,41 @@ describe('listForUser', () => {
 });
 
 describe('listByIds', () => {
-  test('returns mapped projects for the provided ids', async () => {
+  test('returns mapped projects and binds ids as one array parameter', async () => {
     exec.enqueue({ rows: [rawProjectRow] });
 
-    const result = await projectsRepo.listByIds(['p-1'], testDb);
+    const result = await projectsRepo.listByIds(['p-1', 'p-2'], testDb);
 
-    expect(exec.calls[0].sql).toContain('WHERE p.id = ANY');
-    expect(exec.calls[0].params).toContain('p-1');
+    expect(exec.calls[0].sql).toContain('WHERE p.id = ANY($1::text[])');
+    expect(exec.calls[0].params).toEqual([['p-1', 'p-2']]);
     expect(result[0]).toEqual(mappedRow);
   });
 
   test('returns empty array without querying for empty ids', async () => {
     expect(await projectsRepo.listByIds([], testDb)).toEqual([]);
+    expect(exec.calls).toHaveLength(0);
+  });
+});
+
+describe('listNamesByIds', () => {
+  test('returns project/client display names and binds ids as one array parameter', async () => {
+    exec.enqueue({
+      rows: [{ id: 'p-1', name: 'Alpha', client_id: 'c-1', client_name: 'Acme' }],
+    });
+
+    const result = await projectsRepo.listNamesByIds(['p-1', 'p-2'], testDb);
+
+    expect(exec.calls[0].sql).toContain('WHERE p.id = ANY($1::text[])');
+    expect(exec.calls[0].params).toEqual([['p-1', 'p-2']]);
+    expect(result.get('p-1')).toEqual({
+      projectName: 'Alpha',
+      clientId: 'c-1',
+      clientName: 'Acme',
+    });
+  });
+
+  test('returns empty map without querying for empty ids', async () => {
+    expect(await projectsRepo.listNamesByIds([], testDb)).toEqual(new Map());
     expect(exec.calls).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary
- Fixes project repository id filters so multi-id ANY() queries bind a PostgreSQL text array instead of expanded tuple parameters.
- Adds regression coverage for listByIds and listNamesByIds with multiple ids.

## Changes
- Replaces direct array interpolation with sql.param(ids)::text[] in the affected project lookup queries.
- Tightens repository tests to assert the emitted SQL and parameter shape.

## Testing
- un test server/test/repositories/projectsRepo.test.ts
- un run test:server
- un run lint

## Risks / Rollout
- Low risk. Change is scoped to project repository lookup SQL and unit coverage.
- No migrations, config changes, or user-facing documentation updates required.

## Issues
Fixes #498