### PR TITLE
sales(fix): wrap customer item replacements in transactions

### DIFF
--- a/server/repositories/clientOffersRepo.ts
+++ b/server/repositories/clientOffersRepo.ts
@@ -1,5 +1,5 @@
 import { and, asc, desc, eq, ne, sql } from 'drizzle-orm';
-import { type DbExecutor, db } from '../db/drizzle.ts';
+import { type DbExecutor, db, runAtomically } from '../db/drizzle.ts';
 import { customerOfferItems } from '../db/schema/customerOfferItems.ts';
 import { customerOffers } from '../db/schema/customerOffers.ts';
 import { sales } from '../db/schema/sales.ts';
@@ -388,10 +388,11 @@ export const replaceItems = async (
   offerId: string,
   items: NewClientOfferItem[],
   exec: DbExecutor = db,
-): Promise<ClientOfferItem[]> => {
-  await exec.delete(customerOfferItems).where(eq(customerOfferItems.offerId, offerId));
-  return insertItems(offerId, items, exec);
-};
+): Promise<ClientOfferItem[]> =>
+  runAtomically(exec, async (tx) => {
+    await tx.delete(customerOfferItems).where(eq(customerOfferItems.offerId, offerId));
+    return insertItems(offerId, items, tx);
+  });
 
 export const deleteById = async (id: string, exec: DbExecutor = db): Promise<boolean> => {
   const result = await exec.delete(customerOffers).where(eq(customerOffers.id, id));

--- a/server/repositories/clientQuotesRepo.ts
+++ b/server/repositories/clientQuotesRepo.ts
@@ -1,5 +1,5 @@
 import { and, asc, desc, eq, ne, sql } from 'drizzle-orm';
-import { type DbExecutor, db } from '../db/drizzle.ts';
+import { type DbExecutor, db, runAtomically } from '../db/drizzle.ts';
 import { customerOffers } from '../db/schema/customerOffers.ts';
 import { quoteItems, quotes } from '../db/schema/quotes.ts';
 import { sales } from '../db/schema/sales.ts';
@@ -510,10 +510,11 @@ export const replaceItems = async (
   quoteId: string,
   items: NewClientQuoteItem[],
   exec: DbExecutor = db,
-): Promise<ClientQuoteItem[]> => {
-  await exec.delete(quoteItems).where(eq(quoteItems.quoteId, quoteId));
-  return insertItems(quoteId, items, exec);
-};
+): Promise<ClientQuoteItem[]> =>
+  runAtomically(exec, async (tx) => {
+    await tx.delete(quoteItems).where(eq(quoteItems.quoteId, quoteId));
+    return insertItems(quoteId, items, tx);
+  });
 
 export const deleteById = async (id: string, exec: DbExecutor = db): Promise<boolean> => {
   const result = await exec.delete(quotes).where(eq(quotes.id, id));

--- a/server/repositories/clientsOrdersRepo.ts
+++ b/server/repositories/clientsOrdersRepo.ts
@@ -1,5 +1,5 @@
 import { and, asc, desc, eq, ne, sql } from 'drizzle-orm';
-import { type DbExecutor, db } from '../db/drizzle.ts';
+import { type DbExecutor, db, runAtomically } from '../db/drizzle.ts';
 import { customerOffers } from '../db/schema/customerOffers.ts';
 import { saleItems, sales } from '../db/schema/sales.ts';
 import { supplierSaleItems, supplierSales } from '../db/schema/supplierSales.ts';
@@ -418,10 +418,11 @@ export const replaceItems = async (
   orderId: string,
   items: NewClientOrderItem[],
   exec: DbExecutor = db,
-): Promise<ClientOrderItem[]> => {
-  await exec.delete(saleItems).where(eq(saleItems.saleId, orderId));
-  return insertItems(orderId, items, exec);
-};
+): Promise<ClientOrderItem[]> =>
+  runAtomically(exec, async (tx) => {
+    await tx.delete(saleItems).where(eq(saleItems.saleId, orderId));
+    return insertItems(orderId, items, tx);
+  });
 
 export const deleteById = async (id: string, exec: DbExecutor = db): Promise<boolean> => {
   const result = await exec.delete(sales).where(eq(sales.id, id));

--- a/server/test/repositories/replaceItemsTransactional.test.ts
+++ b/server/test/repositories/replaceItemsTransactional.test.ts
@@ -14,11 +14,13 @@ import * as realDrizzle from '../../db/drizzle.ts';
 
 type ItemRow = { id: string };
 type TableKey =
+  | 'saleItems'
   | 'invoiceItems'
   | 'supplierInvoiceItems'
   | 'supplierSaleItems'
   | 'supplierQuoteItems';
 const TABLE_KEYS: readonly TableKey[] = [
+  'saleItems',
   'invoiceItems',
   'supplierInvoiceItems',
   'supplierSaleItems',
@@ -28,6 +30,7 @@ const TABLE_KEYS: readonly TableKey[] = [
 // In-memory tables — one per repo. We don't decode Drizzle filter expressions; tests
 // instead seed/assert within a single parent-id and treat DELETE as "clear this table".
 const tables: Record<TableKey, ItemRow[]> = {
+  saleItems: [],
   invoiceItems: [],
   supplierInvoiceItems: [],
   supplierSaleItems: [],
@@ -111,16 +114,19 @@ mock.module('../../db/drizzle.ts', () => ({
 }));
 
 let invoicesRepo: typeof import('../../repositories/invoicesRepo.ts');
+let clientsOrdersRepo: typeof import('../../repositories/clientsOrdersRepo.ts');
 let supplierInvoicesRepo: typeof import('../../repositories/supplierInvoicesRepo.ts');
 let supplierOrdersRepo: typeof import('../../repositories/supplierOrdersRepo.ts');
 let supplierQuotesRepo: typeof import('../../repositories/supplierQuotesRepo.ts');
 
 beforeAll(async () => {
+  const salesSchema = await import('../../db/schema/sales.ts');
   const invoicesSchema = await import('../../db/schema/invoices.ts');
   const supplierInvoicesSchema = await import('../../db/schema/supplierInvoices.ts');
   const supplierSalesSchema = await import('../../db/schema/supplierSales.ts');
   const supplierQuotesSchema = await import('../../db/schema/supplierQuotes.ts');
 
+  tableToKey.set(salesSchema.saleItems as unknown as object, 'saleItems');
   tableToKey.set(invoicesSchema.invoiceItems as unknown as object, 'invoiceItems');
   tableToKey.set(
     supplierInvoicesSchema.supplierInvoiceItems as unknown as object,
@@ -133,6 +139,7 @@ beforeAll(async () => {
   );
 
   invoicesRepo = await import('../../repositories/invoicesRepo.ts');
+  clientsOrdersRepo = await import('../../repositories/clientsOrdersRepo.ts');
   supplierInvoicesRepo = await import('../../repositories/supplierInvoicesRepo.ts');
   supplierOrdersRepo = await import('../../repositories/supplierOrdersRepo.ts');
   supplierQuotesRepo = await import('../../repositories/supplierQuotesRepo.ts');
@@ -181,6 +188,47 @@ describe('invoicesRepo.replaceItems', () => {
     await invoicesRepo.replaceItems('INV-1', [newItem]);
 
     expect(tables.invoiceItems.map((i) => i.id)).toEqual(['item-new']);
+  });
+});
+
+describe('clientsOrdersRepo.replaceItems', () => {
+  const newItem = {
+    id: 'sale-new',
+    productId: 'prod-1',
+    productName: 'Product',
+    quantity: 1,
+    unitPrice: 5,
+    productCost: 2,
+    productMolPercentage: null,
+    discount: 0,
+    note: null,
+    supplierQuoteId: null,
+    supplierQuoteItemId: null,
+    supplierQuoteSupplierName: null,
+    supplierQuoteUnitPrice: null,
+    supplierSaleId: null,
+    supplierSaleItemId: null,
+    supplierSaleSupplierName: null,
+    unitType: 'unit' as const,
+  };
+
+  test('failed INSERT leaves prior items intact', async () => {
+    tables.saleItems = [{ id: 'sale-old' }];
+    failNextInsert = true;
+
+    await expect(clientsOrdersRepo.replaceItems('CO-1', [newItem])).rejects.toThrow(
+      'forced INSERT failure',
+    );
+
+    expect(tables.saleItems.map((i) => i.id)).toEqual(['sale-old']);
+  });
+
+  test('successful replace commits new items', async () => {
+    tables.saleItems = [{ id: 'sale-old' }];
+
+    await clientsOrdersRepo.replaceItems('CO-1', [newItem]);
+
+    expect(tables.saleItems.map((i) => i.id)).toEqual(['sale-new']);
   });
 });
 

--- a/server/test/repositories/replaceItemsTransactional.test.ts
+++ b/server/test/repositories/replaceItemsTransactional.test.ts
@@ -14,12 +14,16 @@ import * as realDrizzle from '../../db/drizzle.ts';
 
 type ItemRow = { id: string };
 type TableKey =
+  | 'customerOfferItems'
+  | 'quoteItems'
   | 'saleItems'
   | 'invoiceItems'
   | 'supplierInvoiceItems'
   | 'supplierSaleItems'
   | 'supplierQuoteItems';
 const TABLE_KEYS: readonly TableKey[] = [
+  'customerOfferItems',
+  'quoteItems',
   'saleItems',
   'invoiceItems',
   'supplierInvoiceItems',
@@ -30,6 +34,8 @@ const TABLE_KEYS: readonly TableKey[] = [
 // In-memory tables — one per repo. We don't decode Drizzle filter expressions; tests
 // instead seed/assert within a single parent-id and treat DELETE as "clear this table".
 const tables: Record<TableKey, ItemRow[]> = {
+  customerOfferItems: [],
+  quoteItems: [],
   saleItems: [],
   invoiceItems: [],
   supplierInvoiceItems: [],
@@ -114,18 +120,27 @@ mock.module('../../db/drizzle.ts', () => ({
 }));
 
 let invoicesRepo: typeof import('../../repositories/invoicesRepo.ts');
+let clientOffersRepo: typeof import('../../repositories/clientOffersRepo.ts');
+let clientQuotesRepo: typeof import('../../repositories/clientQuotesRepo.ts');
 let clientsOrdersRepo: typeof import('../../repositories/clientsOrdersRepo.ts');
 let supplierInvoicesRepo: typeof import('../../repositories/supplierInvoicesRepo.ts');
 let supplierOrdersRepo: typeof import('../../repositories/supplierOrdersRepo.ts');
 let supplierQuotesRepo: typeof import('../../repositories/supplierQuotesRepo.ts');
 
 beforeAll(async () => {
+  const customerOfferItemsSchema = await import('../../db/schema/customerOfferItems.ts');
+  const quotesSchema = await import('../../db/schema/quotes.ts');
   const salesSchema = await import('../../db/schema/sales.ts');
   const invoicesSchema = await import('../../db/schema/invoices.ts');
   const supplierInvoicesSchema = await import('../../db/schema/supplierInvoices.ts');
   const supplierSalesSchema = await import('../../db/schema/supplierSales.ts');
   const supplierQuotesSchema = await import('../../db/schema/supplierQuotes.ts');
 
+  tableToKey.set(
+    customerOfferItemsSchema.customerOfferItems as unknown as object,
+    'customerOfferItems',
+  );
+  tableToKey.set(quotesSchema.quoteItems as unknown as object, 'quoteItems');
   tableToKey.set(salesSchema.saleItems as unknown as object, 'saleItems');
   tableToKey.set(invoicesSchema.invoiceItems as unknown as object, 'invoiceItems');
   tableToKey.set(
@@ -139,6 +154,8 @@ beforeAll(async () => {
   );
 
   invoicesRepo = await import('../../repositories/invoicesRepo.ts');
+  clientOffersRepo = await import('../../repositories/clientOffersRepo.ts');
+  clientQuotesRepo = await import('../../repositories/clientQuotesRepo.ts');
   clientsOrdersRepo = await import('../../repositories/clientsOrdersRepo.ts');
   supplierInvoicesRepo = await import('../../repositories/supplierInvoicesRepo.ts');
   supplierOrdersRepo = await import('../../repositories/supplierOrdersRepo.ts');
@@ -188,6 +205,82 @@ describe('invoicesRepo.replaceItems', () => {
     await invoicesRepo.replaceItems('INV-1', [newItem]);
 
     expect(tables.invoiceItems.map((i) => i.id)).toEqual(['item-new']);
+  });
+});
+
+describe('clientOffersRepo.replaceItems', () => {
+  const newItem = {
+    id: 'offer-item-new',
+    productId: null,
+    productName: 'Product',
+    quantity: 1,
+    unitPrice: 5,
+    productCost: 2,
+    productMolPercentage: null,
+    discount: 0,
+    note: null,
+    supplierQuoteId: null,
+    supplierQuoteItemId: null,
+    supplierQuoteSupplierName: null,
+    supplierQuoteUnitPrice: null,
+    unitType: 'unit' as const,
+  };
+
+  test('failed INSERT leaves prior items intact', async () => {
+    tables.customerOfferItems = [{ id: 'offer-item-old' }];
+    failNextInsert = true;
+
+    await expect(clientOffersRepo.replaceItems('COFFER-1', [newItem])).rejects.toThrow(
+      'forced INSERT failure',
+    );
+
+    expect(tables.customerOfferItems.map((i) => i.id)).toEqual(['offer-item-old']);
+  });
+
+  test('successful replace commits new items', async () => {
+    tables.customerOfferItems = [{ id: 'offer-item-old' }];
+
+    await clientOffersRepo.replaceItems('COFFER-1', [newItem]);
+
+    expect(tables.customerOfferItems.map((i) => i.id)).toEqual(['offer-item-new']);
+  });
+});
+
+describe('clientQuotesRepo.replaceItems', () => {
+  const newItem = {
+    id: 'quote-item-new',
+    productId: null,
+    productName: 'Product',
+    quantity: 1,
+    unitPrice: 5,
+    productCost: 2,
+    productMolPercentage: null,
+    discount: 0,
+    note: null,
+    supplierQuoteId: null,
+    supplierQuoteItemId: null,
+    supplierQuoteSupplierName: null,
+    supplierQuoteUnitPrice: null,
+    unitType: 'unit' as const,
+  };
+
+  test('failed INSERT leaves prior items intact', async () => {
+    tables.quoteItems = [{ id: 'quote-item-old' }];
+    failNextInsert = true;
+
+    await expect(clientQuotesRepo.replaceItems('CQUOTE-1', [newItem])).rejects.toThrow(
+      'forced INSERT failure',
+    );
+
+    expect(tables.quoteItems.map((i) => i.id)).toEqual(['quote-item-old']);
+  });
+
+  test('successful replace commits new items', async () => {
+    tables.quoteItems = [{ id: 'quote-item-old' }];
+
+    await clientQuotesRepo.replaceItems('CQUOTE-1', [newItem]);
+
+    expect(tables.quoteItems.map((i) => i.id)).toEqual(['quote-item-new']);
   });
 });
 


### PR DESCRIPTION
## Summary
- Wraps customer-side item replacement in repository transactions so failed inserts roll back preceding deletes.
- Adds regression coverage for client quotes, client offers, and client orders alongside the existing invoice and supplier item replacement tests.

## Changes
- Uses `runAtomically` in `clientQuotesRepo.replaceItems`, `clientOffersRepo.replaceItems`, and `clientsOrdersRepo.replaceItems`.
- Passes the transaction executor through to each repository's `insertItems` call.
- Extends `replaceItemsTransactional.test.ts` with quote, offer, and order item rollback and success coverage.

## Testing
- `bun run build` from `server/`
- `bun test ./test/repositories/replaceItemsTransactional.test.ts` from `server/`
- `bun test ./test/repositories/clientOffersRepo.test.ts ./test/repositories/clientQuotesRepo.test.ts ./test/repositories/clientsOrdersRepo.test.ts` from `server/`

## Risks / Rollout
- Low risk. Changes are scoped to repository-level DELETE-then-INSERT replacement paths and reuse the transaction helper already used by invoice and supplier replacement repositories.

## Issues
Fixes #499