### PR TITLE
auth(fix): reject empty permission guards

### DIFF
--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -82,6 +82,8 @@ type SessionJwtPayload = JwtPayload & {
   sessionVersion?: number;
 };
 
+type NonEmptyGuardArgs = [string, ...string[]];
+
 const loadAuthenticatedUserContext = async (
   request: FastifyRequest,
   reply: FastifyReply,
@@ -272,7 +274,11 @@ export const requireRole = (...roles: string[]) => {
   };
 };
 
-export const requirePermission = (...permissions: string[]) => {
+export const requirePermission = (...permissions: NonEmptyGuardArgs) => {
+  if (permissions.length === 0) {
+    throw new Error('requirePermission requires at least one permission');
+  }
+
   return async (request: FastifyRequest, reply: FastifyReply) => {
     if (!request.user) {
       return reply.code(401).send({ error: 'Authentication required' });

--- a/server/test/middleware/auth.test.ts
+++ b/server/test/middleware/auth.test.ts
@@ -693,14 +693,9 @@ describe('requirePermission (ALL semantics)', () => {
     expect(reply.body).toBeUndefined();
   });
 
-  test('vacuous: empty perms list passes (Array.every over zero elements)', async () => {
-    const reply = buildFakeReply();
-    await requirePermission()(
-      { user: { ...HAPPY_USER, permissions: [] } } as never,
-      reply as never,
-    );
-    expect(reply.statusCode).toBe(0);
-    expect(reply.body).toBeUndefined();
+  test('rejects empty permission guards before a route can be registered', () => {
+    // @ts-expect-error Regression coverage for runtime JavaScript callers.
+    expect(() => requirePermission()).toThrow('requirePermission requires at least one permission');
   });
 });
 


### PR DESCRIPTION
## Summary
- Rejects empty `requirePermission()` guard definitions before route registration to avoid vacuous `Array.every()` authorization passes.
- Adds regression coverage for runtime JavaScript callers that invoke the guard without required permissions.

## Changes
- Adds a non-empty tuple type for `requirePermission()` arguments.
- Throws `requirePermission requires at least one permission` when the guard is created with no permissions.
- Replaces the old test that documented the unsafe pass with a regression test for the closed failure mode.

## Testing
- `bun test test/middleware/auth.test.ts --test-name-pattern "rejects empty permission guards"` failed before the fix and passed after the fix.
- `bun test test/middleware/auth.test.ts` passed.
- `cd server && bun run build` passed.
- `bun run lint` passed with two unrelated pre-existing warnings.
- `bun run test:server` passed: 2556 pass, 28 expected integration skips.

## Risks / Rollout
- Low runtime risk for valid routes; the change only affects invalid empty `requirePermission()` guard declarations.
- Auth/permission code path, so route registration should be monitored after deploy for any hidden misconfigured guard.

## Issues
Fixes #492
