### PR TITLE
billing(fix): correct half-cent currency rounding

### DIFF
--- a/docs-site/src/content/docs/en/sales-accounting.md
+++ b/docs-site/src/content/docs/en/sales-accounting.md
@@ -35,6 +35,8 @@ After an invoice leaves draft status it becomes read-only: it cannot be moved ba
 
 The amount paid cannot exceed the invoice total. When an invoice is set to **paid**, the amount paid must cover at least the full total; otherwise Praetor rejects the save so aging, balances, and reports stay consistent.
 
+Praetor rounds taxable amounts, VAT, costs, and totals to two currency decimals using commercial half-cent rounding: values such as 1.005 become 1.01.
+
 ### Per-line VAT (IVA)
 
 Each customer-invoice line carries its own VAT rate (percent). New lines default to 22% (the standard Italian rate), but you can edit it to reflect reduced rates (10%, 5%, 4%) or exempt lines (0%). The summary panel shows the taxable subtotal, the total VAT, and the grand total (taxable + VAT). Invoices created before this feature was added load with 0% VAT, so their grand total remains unchanged.

--- a/docs-site/src/content/docs/sales-accounting.md
+++ b/docs-site/src/content/docs/sales-accounting.md
@@ -35,6 +35,8 @@ Quando una fattura esce dallo stato bozza diventa in sola lettura: non può esse
 
 L'importo pagato non può superare il totale della fattura. Quando una fattura viene impostata su **pagata**, l'importo pagato deve coprire almeno l'intero totale; in caso contrario Praetor respinge il salvataggio per mantenere coerenti scadenziari, saldi e report.
 
+Praetor arrotonda imponibili, IVA, costi e totali alla precisione monetaria di due decimali usando l'arrotondamento commerciale sui mezzi centesimi: valori come 1,005 diventano 1,01.
+
 ### IVA per riga
 
 Ogni riga della fattura cliente ha la propria aliquota IVA in percentuale. Il valore predefinito per le nuove righe è 22% (aliquota ordinaria italiana), ma puoi modificarla per riflettere aliquote ridotte (10%, 5%, 4%) o le righe esenti (0%). Il pannello di riepilogo mostra il subtotale (imponibile), l'IVA totale e il totale generale (imponibile + IVA). Le fatture precedenti alla migrazione vengono caricate con aliquota IVA pari a 0%, mantenendo invariato il loro totale.

--- a/server/test/utils/billing.test.ts
+++ b/server/test/utils/billing.test.ts
@@ -33,6 +33,11 @@ describe('computeEntryCost', () => {
     expect(computeEntryCost(1, 0.015)).toBe(0.02);
   });
 
+  test('rounds floating-point half-cent boundaries up', () => {
+    expect(computeEntryCost(1, 1.005)).toBe(1.01);
+    expect(computeEntryCost(1, 1.015)).toBe(1.02);
+  });
+
   test('handles negative duration as math allows (caller is responsible for validation)', () => {
     expect(computeEntryCost(-2, 50)).toBe(-100);
   });

--- a/server/test/utils/invoice-math.test.ts
+++ b/server/test/utils/invoice-math.test.ts
@@ -60,6 +60,19 @@ describe('computeInvoiceTotals', () => {
     });
   });
 
+  test('rounds floating-point half-cent boundaries up', () => {
+    expect(computeInvoiceTotals([{ quantity: 1, unitPrice: 1.005, discount: 0 }])).toEqual({
+      subtotal: 1.01,
+      taxTotal: 0,
+      total: 1.01,
+    });
+    expect(computeInvoiceTotals([{ quantity: 1, unitPrice: 1.015, discount: 0 }])).toEqual({
+      subtotal: 1.02,
+      taxTotal: 0,
+      total: 1.02,
+    });
+  });
+
   test('matches frontend formula: quantity * unitPrice * (1 - discount/100)', () => {
     // 7 * 13.50 * 0.85 = 80.325 → rounded to 80.33
     expect(computeInvoiceTotals([{ quantity: 7, unitPrice: 13.5, discount: 15 }])).toEqual({
@@ -124,5 +137,16 @@ describe('roundCurrency', () => {
 
   test('rounds halves up', () => {
     expect(roundCurrency(0.005)).toBe(0.01);
+  });
+
+  test('rounds floating-point half-cent boundaries up', () => {
+    expect(roundCurrency(1.005)).toBe(1.01);
+    expect(roundCurrency(1.015)).toBe(1.02);
+    expect(roundCurrency(10.075)).toBe(10.08);
+  });
+
+  test('does not return negative zero for sub-cent negative values', () => {
+    expect(Object.is(roundCurrency(-0.001), -0)).toBe(false);
+    expect(roundCurrency(-0.001)).toBe(0);
   });
 });

--- a/server/utils/invoice-math.ts
+++ b/server/utils/invoice-math.ts
@@ -6,10 +6,27 @@ type ItemMath = {
   taxRate?: number;
 };
 
+const CURRENCY_DECIMAL_PLACES = 2;
+
+const shiftDecimal = (value: number, decimalPlaces: number): number => {
+  const [coefficient, exponent = '0'] = value.toString().split('e');
+  return Number(`${coefficient}e${Number(exponent) + decimalPlaces}`);
+};
+
 // Match the NUMERIC(_, 2) precision used for invoice columns so totals computed here
 // align with what would be re-derived from the persisted rows. The frontend mirrors this
 // helper in `utils/numbers.ts` so both layers agree on rendered values.
-export const roundCurrency = (value: number) => Math.round(value * 100) / 100;
+export const roundCurrency = (value: number): number => {
+  if (!Number.isFinite(value)) return value;
+
+  const sign = Math.sign(value);
+  if (sign === 0) return 0;
+
+  const cents = Math.round(shiftDecimal(Math.abs(value), CURRENCY_DECIMAL_PLACES));
+  if (cents === 0) return 0;
+
+  return sign * shiftDecimal(cents, -CURRENCY_DECIMAL_PLACES);
+};
 
 export const computeInvoiceTotals = (
   items: ItemMath[],

--- a/test/utils/numbers.test.ts
+++ b/test/utils/numbers.test.ts
@@ -209,6 +209,12 @@ describe('calculatePricingTotals', () => {
     expect(t.total).toBe(0.3);
   });
 
+  test('rounds floating-point half-cent boundaries in returned totals', () => {
+    const t = calculatePricingTotals([{ unitPrice: 1.005, quantity: 1 }], 0);
+    expect(t.subtotal).toBe(1.01);
+    expect(t.total).toBe(1.01);
+  });
+
   test('rounds every returned field to 2 decimal places', () => {
     // Hand-picked to drift in every field: small unit prices + percentage discount.
     const items: PricingItem[] = [{ unitPrice: 0.1, quantity: 3, productCost: 0.05, discount: 10 }];
@@ -227,6 +233,17 @@ describe('roundCurrency', () => {
 
   test('rounds halves up', () => {
     expect(roundCurrency(0.005)).toBe(0.01);
+  });
+
+  test('rounds floating-point half-cent boundaries up', () => {
+    expect(roundCurrency(1.005)).toBe(1.01);
+    expect(roundCurrency(1.015)).toBe(1.02);
+    expect(roundCurrency(10.075)).toBe(10.08);
+  });
+
+  test('does not return negative zero for sub-cent negative values', () => {
+    expect(Object.is(roundCurrency(-0.001), -0)).toBe(false);
+    expect(roundCurrency(-0.001)).toBe(0);
   });
 
   test('passes through clean values', () => {

--- a/utils/numbers.ts
+++ b/utils/numbers.ts
@@ -1,8 +1,25 @@
 import type { DiscountType, SupplierUnitType } from '../types';
 
+const CURRENCY_DECIMAL_PLACES = 2;
+
+const shiftDecimal = (value: number, decimalPlaces: number): number => {
+  const [coefficient, exponent = '0'] = value.toString().split('e');
+  return Number(`${coefficient}e${Number(exponent) + decimalPlaces}`);
+};
+
 // Match the NUMERIC(_, 2) precision used by the backend so frontend and backend agree on
 // rendered totals. Mirrors `roundCurrency` in `server/utils/invoice-math.ts`.
-export const roundCurrency = (value: number) => Math.round(value * 100) / 100;
+export const roundCurrency = (value: number): number => {
+  if (!Number.isFinite(value)) return value;
+
+  const sign = Math.sign(value);
+  if (sign === 0) return 0;
+
+  const cents = Math.round(shiftDecimal(Math.abs(value), CURRENCY_DECIMAL_PLACES));
+  if (cents === 0) return 0;
+
+  return sign * shiftDecimal(cents, -CURRENCY_DECIMAL_PLACES);
+};
 
 export const parseNumberInputValue = (value: string, fallback: number | undefined = 0) => {
   if (value === '') return fallback;


### PR DESCRIPTION
## Summary
- Correct currency rounding for floating-point half-cent boundary values such as 1.005 and 1.015.
- Keep backend invoice math and frontend pricing totals aligned on the same rounding behavior.
- Document the two-decimal commercial rounding rule for invoice totals in Italian and English.

## Changes
- Replaces naive multiply-and-round currency rounding with decimal-shift rounding in backend and frontend helpers.
- Adds regression coverage for invoice totals, entry costs, and frontend pricing totals.
- Updates sales/accounting user docs to describe currency rounding behavior.

## Testing
- un run test`n- un run lint`n
## Risks / Rollout
- Low risk. Change is scoped to currency rounding helpers and their direct consumers. Existing persisted values are not migrated.

## Issues
Fixes #493