### PR TITLE
crypto(fix): encrypt empty plaintext values

### DIFF
--- a/server/repositories/ldapRepo.ts
+++ b/server/repositories/ldapRepo.ts
@@ -142,10 +142,15 @@ const buildUpdateSet = (patch: LdapConfigPatch) => {
       : patch.tlsCaCertificate === ''
         ? sql`NULL`
         : sql`${patch.tlsCaCertificate}`;
-  // bindPassword is encrypted at rest. `encrypt('')` returns '' so the explicit-clear
-  // semantic is preserved; `undefined` keeps the COALESCE preserve-existing branch.
+  // bindPassword is encrypted at rest. Empty string remains an explicit clear sentinel;
+  // `undefined` keeps the COALESCE preserve-existing branch.
   // Callers must pass plaintext — the route layer converts the masked sentinel to undefined.
-  const bindPasswordParam = patch.bindPassword === undefined ? null : encrypt(patch.bindPassword);
+  const bindPasswordParam =
+    patch.bindPassword === undefined
+      ? null
+      : patch.bindPassword === ''
+        ? ''
+        : encrypt(patch.bindPassword);
   return {
     enabled: sql`COALESCE(${patch.enabled ?? null}, ${ldapConfig.enabled})`,
     serverUrl: sql`COALESCE(${patch.serverUrl ?? null}, ${ldapConfig.serverUrl})`,

--- a/server/test/repositories/ldapRepo.test.ts
+++ b/server/test/repositories/ldapRepo.test.ts
@@ -223,10 +223,11 @@ describe('bindPassword encryption', () => {
       expect(hasEncryptedParam(params)).toBe(true);
     });
 
-    test('binds empty string for cleared bindPassword (encrypt("") === "")', async () => {
+    test('binds empty string for cleared bindPassword without encrypting the clear sentinel', async () => {
       exec.enqueue({ rows: [buildRow()] });
       await ldapRepo.update({ bindPassword: '' }, testDb);
       expect(exec.calls[0].params).toContain('');
+      expect(hasEncryptedParam(exec.calls[0].params)).toBe(false);
     });
 
     test('does not bind any encrypted value when bindPassword is omitted (COALESCE preserves)', async () => {

--- a/server/test/utils/crypto.test.ts
+++ b/server/test/utils/crypto.test.ts
@@ -6,6 +6,7 @@ import {
   encrypt,
   getEncryptionKey,
   getHmacKey,
+  isEncrypted,
   MASKED_SECRET,
 } from '../../utils/crypto.ts';
 
@@ -25,8 +26,11 @@ afterAll(() => {
 });
 
 describe('encrypt', () => {
-  test('returns empty string for empty input', () => {
-    expect(encrypt('')).toBe('');
+  test('encrypts empty plaintext as a real ciphertext envelope', () => {
+    const out = encrypt('');
+    expect(out).not.toBe('');
+    expect(isEncrypted(out)).toBe(true);
+    expect(decrypt(out)).toBe('');
   });
 
   test('produces a three-part base64 string (iv:authTag:ciphertext)', () => {
@@ -113,8 +117,8 @@ describe('getHmacKey', () => {
 });
 
 describe('decrypt', () => {
-  test('returns empty string for empty input', () => {
-    expect(decrypt('')).toBe('');
+  test('throws for empty ciphertext input', () => {
+    expect(() => decrypt('')).toThrow(/Invalid encrypted value format/);
   });
 
   test('round-trips ASCII plaintext', () => {

--- a/server/utils/crypto.ts
+++ b/server/utils/crypto.ts
@@ -63,8 +63,8 @@ const AUTH_TAG_LENGTH = 16;
 export function isEncrypted(value: string): boolean {
   const parts = value.split(':');
   if (parts.length !== 3) return false;
-  const [ivB64, authTagB64, encryptedB64] = parts;
-  if (!ivB64 || !authTagB64 || !encryptedB64) return false;
+  const [ivB64, authTagB64] = parts;
+  if (!ivB64 || !authTagB64) return false;
   return (
     Buffer.from(ivB64, 'base64').length === IV_LENGTH &&
     Buffer.from(authTagB64, 'base64').length === AUTH_TAG_LENGTH
@@ -72,7 +72,6 @@ export function isEncrypted(value: string): boolean {
 }
 
 export function encrypt(plaintext: string): string {
-  if (!plaintext) return '';
   const key = getEncryptionKey();
   const iv = crypto.randomBytes(IV_LENGTH);
   const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
@@ -83,9 +82,12 @@ export function encrypt(plaintext: string): string {
 }
 
 export function decrypt(ciphertext: string): string {
-  if (!ciphertext) return '';
-  const [ivB64, authTagB64, encryptedB64] = ciphertext.split(':');
-  if (!ivB64 || !authTagB64 || !encryptedB64) {
+  const parts = ciphertext.split(':');
+  if (parts.length !== 3) {
+    throw new Error('Invalid encrypted value format');
+  }
+  const [ivB64, authTagB64, encryptedB64] = parts;
+  if (!ivB64 || !authTagB64) {
     throw new Error('Invalid encrypted value format');
   }
   const key = getEncryptionKey();
@@ -94,5 +96,5 @@ export function decrypt(ciphertext: string): string {
   const encrypted = Buffer.from(encryptedB64, 'base64');
   const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
   decipher.setAuthTag(authTag);
-  return decipher.update(encrypted) + decipher.final('utf8');
+  return Buffer.concat([decipher.update(encrypted), decipher.final()]).toString('utf8');
 }


### PR DESCRIPTION
## Summary
- Fixes empty plaintext encryption so encrypted empty strings are stored as real AES-GCM ciphertext instead of an unset-looking empty value.
- Makes raw empty ciphertext invalid while preserving LDAP's explicit clear-password sentinel at the repository boundary.

## Changes
- Removes the early return in \\ncrypt('')\\ and allows empty payload ciphertext envelopes to round-trip.
- Tightens \\decrypt('')\\ handling to throw the same invalid-format error as malformed ciphertext.
- Keeps LDAP bind password clearing as an explicit \\''\\ storage sentinel without passing that sentinel through crypto.
- Updates crypto and LDAP repository regression tests.

## Testing
- \\un test server/test/utils/crypto.test.ts server/test/repositories/ldapRepo.test.ts\\
- \\cd server && bun run build\\

## Risks / Rollout
- Low risk. Change is scoped to crypto utility empty-string behavior and LDAP's existing clear-password path.
- Existing stored empty LDAP bind passwords remain readable as cleared values.

## Issues
Fixes #495