### PR TITLE
invoice(fix): default missing item math fields

### DIFF
--- a/server/test/utils/invoice-math.test.ts
+++ b/server/test/utils/invoice-math.test.ts
@@ -109,6 +109,20 @@ describe('computeInvoiceTotals', () => {
     });
   });
 
+  test('missing quantity, unit price, or discount defaults to 0 instead of NaN', () => {
+    expect(
+      computeInvoiceTotals([
+        { quantity: 2, unitPrice: 50 },
+        { unitPrice: 50, discount: 0 },
+        { quantity: 2, discount: 0 },
+      ]),
+    ).toEqual({
+      subtotal: 100,
+      taxTotal: 0,
+      total: 100,
+    });
+  });
+
   test('total equals subtotal + taxTotal exactly (rounding consistency)', () => {
     const result = computeInvoiceTotals([
       { quantity: 3, unitPrice: 33.33, discount: 0, taxRate: 22 },

--- a/server/utils/invoice-math.ts
+++ b/server/utils/invoice-math.ts
@@ -1,7 +1,7 @@
 type ItemMath = {
-  quantity: number;
-  unitPrice: number;
-  discount: number;
+  quantity?: number;
+  unitPrice?: number;
+  discount?: number;
   // Per-item Italian VAT (IVA) rate in percent. Optional so pre-tax-feature data still computes.
   taxRate?: number;
 };
@@ -17,8 +17,11 @@ export const computeInvoiceTotals = (
   let subtotalRaw = 0;
   let taxTotalRaw = 0;
   for (const item of items) {
-    const discountFactor = 1 - item.discount / 100;
-    const taxableAmount = item.quantity * item.unitPrice * discountFactor;
+    const quantity = item.quantity ?? 0;
+    const unitPrice = item.unitPrice ?? 0;
+    const discount = item.discount ?? 0;
+    const discountFactor = 1 - discount / 100;
+    const taxableAmount = quantity * unitPrice * discountFactor;
     const taxRate = item.taxRate ?? 0;
     subtotalRaw += taxableAmount;
     taxTotalRaw += (taxableAmount * taxRate) / 100;


### PR DESCRIPTION
## Summary
- Prevent invoice total calculations from returning `NaN` when item quantity, unit price, or discount is omitted.
- Add regression coverage for missing invoice math fields.

## Changes
- Defaults missing `quantity`, `unitPrice`, and `discount` values to `0` inside `computeInvoiceTotals` before arithmetic.
- Extends the invoice math utility tests to cover omitted numeric item fields.

## Testing
- `bun test server/test/utils/invoice-math.test.ts`
- `bun test server/test/utils/invoice-math.test.ts test/utils/numbers.test.ts`
- `bun run typecheck`
- `bun run test:server`
- `bun run lint`

## Risks / Rollout
- Low risk. Change is scoped to server-side invoice math defaults and keeps validated invoice route inputs unchanged.

## Issues
Fixes #494