### PR TITLE
auth(fix): close auth context TOCTOU race

### DIFF
--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -112,13 +112,14 @@ const loadAuthenticatedUserContext = async (
 
   const effectiveRole = activeRole ?? user.role;
 
-  // Run in parallel: this middleware fires on every authenticated request and the success path
-  // (user has the role) is the hot case. The wasted permissions lookup on a 403 is cheap
-  // compared to the latency saved on the 99%+ success path.
-  const [hasRole, permissions] = await Promise.all([
-    rolesRepo.userHasRole(user.id, effectiveRole),
-    getRolePermissions(effectiveRole),
-  ]);
+  const permissions = await getRolePermissions(effectiveRole);
+  // Final authorization check: re-read enabled/session state in the same statement that
+  // verifies role membership, so revocation between the initial user read and permission
+  // loading cannot bind a stale authenticated context.
+  const hasRole = await rolesRepo.userHasRole(user.id, effectiveRole, {
+    requireEnabledUser: true,
+    expectedSessionVersion,
+  });
   if (!hasRole) {
     reply.code(403).send({ error: 'Invalid or expired token' });
     return null;

--- a/server/middleware/mcpAuth.ts
+++ b/server/middleware/mcpAuth.ts
@@ -74,10 +74,8 @@ export const authenticateMcpToken = async (request: FastifyRequest, reply: Fasti
     return reply.code(403).send({ error: 'Invalid or revoked MCP token' });
   }
 
-  const [hasRole, rolePermissions] = await Promise.all([
-    rolesRepo.userHasRole(user.id, user.role),
-    getRolePermissions(user.role),
-  ]);
+  const rolePermissions = await getRolePermissions(user.role);
+  const hasRole = await rolesRepo.userHasRole(user.id, user.role, { requireEnabledUser: true });
   if (!hasRole) {
     return reply.code(403).send({ error: 'Invalid or revoked MCP token' });
   }

--- a/server/repositories/rolesRepo.ts
+++ b/server/repositories/rolesRepo.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, sql } from 'drizzle-orm';
+import { and, eq, inArray, type SQL, sql } from 'drizzle-orm';
 import { type DbExecutor, db } from '../db/drizzle.ts';
 import { rolePermissions, roles, userRoles } from '../db/schema/roles.ts';
 import { users } from '../db/schema/users.ts';
@@ -8,6 +8,12 @@ export type Role = {
   name: string;
   isSystem: boolean;
   isAdmin: boolean;
+};
+
+export type UserHasRoleOptions = {
+  exec?: DbExecutor;
+  requireEnabledUser?: boolean;
+  expectedSessionVersion?: number;
 };
 
 const ROLE_PROJECTION = {
@@ -41,8 +47,34 @@ export const findExistingIds = async (
 export const userHasRole = async (
   userId: string,
   roleId: string,
-  exec: DbExecutor = db,
+  optionsOrExec: DbExecutor | UserHasRoleOptions = db,
 ): Promise<boolean> => {
+  const options =
+    typeof optionsOrExec === 'object' && 'select' in optionsOrExec
+      ? { exec: optionsOrExec }
+      : optionsOrExec;
+  const exec = options.exec ?? db;
+  const needsUserStateCheck =
+    options.requireEnabledUser === true || options.expectedSessionVersion !== undefined;
+
+  if (needsUserStateCheck) {
+    const conditions: SQL[] = [eq(userRoles.userId, userId), eq(userRoles.roleId, roleId)];
+    if (options.requireEnabledUser === true) {
+      conditions.push(sql`COALESCE(${users.isDisabled}, false) = false`);
+    }
+    if (options.expectedSessionVersion !== undefined) {
+      conditions.push(eq(users.sessionVersion, options.expectedSessionVersion));
+    }
+
+    const rows = await exec
+      .select({ exists: sql`1` })
+      .from(userRoles)
+      .innerJoin(users, eq(users.id, userRoles.userId))
+      .where(and(...conditions))
+      .limit(1);
+    return rows.length > 0;
+  }
+
   const rows = await exec
     .select({ exists: sql`1` })
     .from(userRoles)

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -300,7 +300,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const session = requireSessionAuth(request, reply);
       if (!session) return;
 
-      const hasRole = await rolesRepo.userHasRole(session.userId, roleIdResult.value);
+      const permissions = await getRolePermissions(roleIdResult.value);
+      const hasRole = await rolesRepo.userHasRole(session.userId, roleIdResult.value, {
+        requireEnabledUser: true,
+        expectedSessionVersion: session.sessionVersion,
+      });
       if (!hasRole) {
         return replyError(request, reply, {
           statusCode: 403,
@@ -312,7 +316,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         });
       }
 
-      const permissions = await getRolePermissions(roleIdResult.value);
       const availableRoles = await rolesRepo.listAvailableRolesForUser(session.userId);
       const effectiveAvailableRoles =
         availableRoles.length > 0

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -300,7 +300,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const session = requireSessionAuth(request, reply);
       if (!session) return;
 
-      const permissions = await getRolePermissions(roleIdResult.value);
       const hasRole = await rolesRepo.userHasRole(session.userId, roleIdResult.value, {
         requireEnabledUser: true,
         expectedSessionVersion: session.sessionVersion,
@@ -316,6 +315,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         });
       }
 
+      const permissions = await getRolePermissions(roleIdResult.value);
       const availableRoles = await rolesRepo.listAvailableRolesForUser(session.userId);
       const effectiveAvailableRoles =
         availableRoles.length > 0

--- a/server/test/middleware/auth.test.ts
+++ b/server/test/middleware/auth.test.ts
@@ -251,13 +251,18 @@ describe('authenticateToken', () => {
     expect(reply.body).toEqual({ error: 'Account disabled', errorCode: 'account_disabled' });
   });
 
-  test('403 when rolesRepo.userHasRole returns false', async () => {
+  test('403 when final constrained role check returns false', async () => {
     userHasRoleMock.mockResolvedValue(false);
     const request = buildFakeRequest(signToken({ userId: 'u1' }));
     const reply = buildFakeReply();
     await authenticateToken(request as never, reply as never);
     expect(reply.statusCode).toBe(403);
     expect(reply.body).toEqual({ error: 'Invalid or expired token' });
+    expect(getRolePermissionsMock).toHaveBeenCalledWith('manager');
+    expect(userHasRoleMock).toHaveBeenCalledWith('u1', 'manager', {
+      requireEnabledUser: true,
+      expectedSessionVersion: 1,
+    });
   });
 
   test('200 happy path: populates request.user and rotates the x-auth-token header', async () => {
@@ -338,59 +343,38 @@ describe('authenticateToken', () => {
 
     expect(reply.statusCode).toBe(0);
     expect(request.user?.role).toBe('admin');
-    expect(userHasRoleMock).toHaveBeenCalledWith('u1', 'admin');
     expect(getRolePermissionsMock).toHaveBeenCalledWith('admin');
+    expect(userHasRoleMock).toHaveBeenCalledWith('u1', 'admin', {
+      requireEnabledUser: true,
+      expectedSessionVersion: 1,
+    });
   });
 
-  test('userHasRole and getRolePermissions are invoked concurrently (no serial await)', async () => {
-    let resolveRole!: () => void;
-    let resolvePerms!: () => void;
-    let signalRoleCalled!: () => void;
-    let signalPermsCalled!: () => void;
-
-    const rolePromise = new Promise<void>((resolve) => {
-      resolveRole = resolve;
-    });
-    const permsPromise = new Promise<void>((resolve) => {
-      resolvePerms = resolve;
-    });
-    const roleCalledPromise = new Promise<void>((resolve) => {
-      signalRoleCalled = resolve;
-    });
-    const permsCalledPromise = new Promise<void>((resolve) => {
-      signalPermsCalled = resolve;
-    });
-
-    userHasRoleMock.mockImplementation(async () => {
-      signalRoleCalled();
-      await rolePromise;
-      return true;
-    });
+  test('final role check runs after permission loading with current user constraints', async () => {
+    const calls: string[] = [];
     getRolePermissionsMock.mockImplementation(async () => {
-      signalPermsCalled();
-      await permsPromise;
+      calls.push('permissions');
       return HAPPY_PERMISSIONS;
+    });
+    userHasRoleMock.mockImplementation(async () => {
+      calls.push('role-check');
+      return true;
     });
 
     const request = buildFakeRequest(signToken({ userId: 'u1' }));
     const reply = buildFakeReply();
-    const inflight = authenticateToken(request as never, reply as never);
+    await authenticateToken(request as never, reply as never);
 
-    // Deterministic sync point: both mocks signal as soon as their bodies start. If either
-    // were awaiting the other, this Promise.all would hang past the test timeout instead
-    // of relying on a fixed sleep that's flaky under CI load.
-    await Promise.all([roleCalledPromise, permsCalledPromise]);
-    expect(userHasRoleMock).toHaveBeenCalledTimes(1);
-    expect(getRolePermissionsMock).toHaveBeenCalledTimes(1);
-
-    resolveRole();
-    resolvePerms();
-    await inflight;
     expect(reply.statusCode).toBe(0);
     expect(request.user).toBeDefined();
+    expect(calls).toEqual(['permissions', 'role-check']);
+    expect(userHasRoleMock).toHaveBeenCalledWith('u1', 'manager', {
+      requireEnabledUser: true,
+      expectedSessionVersion: 1,
+    });
   });
 
-  test('a rejection in the parallel lookup produces a single 403 response', async () => {
+  test('a rejection in the final role check produces a single 403 response', async () => {
     userHasRoleMock.mockRejectedValue(new Error('db down'));
     getRolePermissionsMock.mockResolvedValue(HAPPY_PERMISSIONS);
 
@@ -424,8 +408,11 @@ describe('authenticateToken', () => {
     const expectedHash = hashPersonalAccessToken(token);
     expect(findPersonalAccessTokenByHashMock).toHaveBeenCalledWith(expectedHash);
     expect(markPersonalAccessTokenUsedMock).toHaveBeenCalledWith(expectedHash);
-    expect(userHasRoleMock).toHaveBeenCalledWith('u1', 'manager');
     expect(getRolePermissionsMock).toHaveBeenCalledWith('manager');
+    expect(userHasRoleMock).toHaveBeenCalledWith('u1', 'manager', {
+      requireEnabledUser: true,
+      expectedSessionVersion: undefined,
+    });
   });
 
   test('PAT remains authenticated when last-used tracking fails', async () => {

--- a/server/test/middleware/mcpAuth.test.ts
+++ b/server/test/middleware/mcpAuth.test.ts
@@ -169,6 +169,23 @@ describe('authenticateMcpToken', () => {
       }),
     );
     expect(touchLastUsedMock).toHaveBeenCalledWith('mcp-token-1');
+    expect(getRolePermissionsMock).toHaveBeenCalledWith('manager');
+    expect(userHasRoleMock).toHaveBeenCalledWith('u1', 'manager', {
+      requireEnabledUser: true,
+    });
+  });
+
+  test('403 when final constrained role check fails', async () => {
+    userHasRoleMock.mockResolvedValue(false);
+    const request = makeRequest('praetor_mcp_token');
+    const reply = makeReply();
+
+    await authenticateMcpToken(request, reply);
+
+    expect(reply.statusCode).toBe(403);
+    expect(reply.body).toEqual({ error: 'Invalid or revoked MCP token' });
+    expect(getRolePermissionsMock).toHaveBeenCalledWith('manager');
+    expect(touchLastUsedMock).not.toHaveBeenCalled();
   });
 
   test('does not fail authentication when last-used timestamp update fails', async () => {

--- a/server/test/repositories/rolesRepo.test.ts
+++ b/server/test/repositories/rolesRepo.test.ts
@@ -57,6 +57,23 @@ describe('userHasRole', () => {
     const result = await rolesRepo.userHasRole('user-1', 'manager', testDb);
     expect(result).toBe(false);
   });
+
+  test('can re-read enabled user and session state in the role check query', async () => {
+    exec.enqueue({ rows: [[1]] });
+    const result = await rolesRepo.userHasRole('user-1', 'manager', {
+      exec: testDb,
+      requireEnabledUser: true,
+      expectedSessionVersion: 7,
+    });
+
+    expect(result).toBe(true);
+    expect(exec.calls[0].sql.toLowerCase()).toContain('inner join "users"');
+    expect(exec.calls[0].sql.toLowerCase()).toContain('coalesce("users"."is_disabled"');
+    expect(exec.calls[0].sql.toLowerCase()).toContain('"users"."session_version"');
+    expect(exec.calls[0].params).toContain('user-1');
+    expect(exec.calls[0].params).toContain('manager');
+    expect(exec.calls[0].params).toContain(7);
+  });
 });
 
 describe('listAvailableRolesForUser', () => {

--- a/server/test/routes/auth.test.ts
+++ b/server/test/routes/auth.test.ts
@@ -698,6 +698,9 @@ describe('POST /api/auth/switch-role', () => {
         entityId: 'admin',
       }),
     );
+    // Authentication loaded the current role once; the denied target role must not load
+    // permissions before authorization succeeds.
+    expect(getRolePermissionsMock).toHaveBeenCalledTimes(1);
   });
 
   test('403 rejects personal access tokens because role switching is session-only', async () => {

--- a/server/test/routes/auth.test.ts
+++ b/server/test/routes/auth.test.ts
@@ -655,8 +655,11 @@ describe('POST /api/auth/switch-role', () => {
     // sessionStart preserved
     expect(decoded.sessionStart).toBe(sessionStart);
 
-    // userHasRole called for the target role
-    expect(userHasRoleMock).toHaveBeenCalledWith('u1', 'admin');
+    // userHasRole called for the target role with a final enabled/session check
+    expect(userHasRoleMock).toHaveBeenCalledWith('u1', 'admin', {
+      requireEnabledUser: true,
+      expectedSessionVersion: 1,
+    });
 
     // Audit emission with from/to
     expect(logAuditMock).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary
- Closes the TOCTOU window in authenticated context loading by re-checking role membership together with current user enabled/session state.
- Applies the same constrained role verification to session/PAT auth, MCP token auth, and session role switching.

## Changes
- Extends `rolesRepo.userHasRole` with options for enabled-user and session-version constraints while preserving the existing executor call style.
- Sequences permission loading before a final constrained role check so revoked/disabled users cannot bind a stale authenticated context.
- Adds regression coverage for the constrained SQL shape and updated auth middleware behavior.

## Testing
- `bun test server/test/middleware/auth.test.ts`
- `bun test server/test/middleware/mcpAuth.test.ts`
- `bun test server/test/repositories/rolesRepo.test.ts`
- `bun test server/test/routes/auth.test.ts`
- `bun test server/test/middleware/auth-session-max.test.ts`
- `cd server && bun run build`
- `bun run test:server`
- `bun run lint` (passes; reports two existing unrelated frontend warnings)

## Risks / Rollout
- Auth-sensitive change. Risk is scoped to authenticated context loading and role switching.
- No migrations, config changes, API response shape changes, or user-facing docs changes.

## Issues
Fixes #509
