### PR TITLE
accounting(fix): validate invoice ID years

### DIFF
--- a/server/repositories/invoicesRepo.ts
+++ b/server/repositories/invoicesRepo.ts
@@ -67,6 +67,10 @@ const mapItem = (row: typeof invoiceItems.$inferSelect): InvoiceItem => ({
 });
 
 export const generateNextId = async (year: string, exec: DbExecutor = db): Promise<string> => {
+  if (!/^\d{4}$/.test(year)) {
+    throw new TypeError('invoice year must be a 4-digit year');
+  }
+
   // PostgreSQL regex `~` operator + server-side split_part avoids round-tripping every
   // matching id back to the app just to extract the sequence number.
   const rows = await executeRows<{ maxSequence: string | number | null }>(

--- a/server/repositories/supplierInvoicesRepo.ts
+++ b/server/repositories/supplierInvoicesRepo.ts
@@ -165,6 +165,10 @@ export const findIdConflict = async (
 // the route layer can compute the next ID. PG's POSIX `~` regex isn't expressible in Drizzle's
 // filter API, hence the raw SQL.
 export const maxSequenceForYear = async (year: string, exec: DbExecutor = db): Promise<bigint> => {
+  if (!/^\d{4}$/.test(year)) {
+    throw new TypeError('supplier invoice year must be a 4-digit year');
+  }
+
   const pattern = `^SINV-${year}-[0-9]+$`;
   const rows = await executeRows<{ maxSequence: string | number | bigint | null }>(
     exec,

--- a/server/test/repositories/invoicesRepo.test.ts
+++ b/server/test/repositories/invoicesRepo.test.ts
@@ -73,6 +73,13 @@ describe('generateNextId', () => {
     const id = await invoicesRepo.generateNextId('2026', testDb);
     expect(id).toBe('INV-2026-0001');
   });
+
+  test('rejects non-4-digit years before building the regex', async () => {
+    await expect(invoicesRepo.generateNextId('2026.*', testDb)).rejects.toThrow(
+      'invoice year must be a 4-digit year',
+    );
+    expect(exec.calls).toHaveLength(0);
+  });
 });
 
 describe('listAll', () => {

--- a/server/test/repositories/supplierInvoicesRepo.test.ts
+++ b/server/test/repositories/supplierInvoicesRepo.test.ts
@@ -152,6 +152,13 @@ describe('maxSequenceForYear', () => {
     exec.enqueue({ rows: [] });
     expect(await supplierInvoicesRepo.maxSequenceForYear('2026', testDb)).toBe(0n);
   });
+
+  test('rejects non-4-digit years before building the regex', async () => {
+    await expect(supplierInvoicesRepo.maxSequenceForYear('2026.*', testDb)).rejects.toThrow(
+      'supplier invoice year must be a 4-digit year',
+    );
+    expect(exec.calls).toHaveLength(0);
+  });
 });
 
 describe('create', () => {


### PR DESCRIPTION
## Summary
- Validates client and supplier invoice ID-generation years before composing PostgreSQL regex patterns.
- Adds regression coverage that malformed years are rejected before any DB query runs.

## Changes
- Rejects non-4-digit years in `invoicesRepo.generateNextId`.
- Rejects non-4-digit years in `supplierInvoicesRepo.maxSequenceForYear`.
- Adds focused repository tests for regex-metacharacter input in both paths.

## Testing
- `bun test ./test/repositories/invoicesRepo.test.ts ./test/repositories/supplierInvoicesRepo.test.ts`
- `bun run build`

## Risks / Rollout
- Low risk. The routes already derive these values from parsed dates; this hardens repository boundaries for direct callers.
- No migrations, config changes, or user-facing docs changes.

## Issues
Fixes #510