### PR TITLE
timeEntries(fix): serialize recurring generation

### DIFF
--- a/docs-site/src/content/docs/en/time-tracking.md
+++ b/docs-site/src/content/docs/en/time-tracking.md
@@ -45,7 +45,7 @@ Recurring entries are materialized on the server via `POST /api/entries/recurrin
 }
 ```
 
-The endpoint is idempotent: re-running it with the same window does not create duplicates, since existing `(date, project, task)` tuples are skipped. The response reports `generatedCount`, `skippedExistingCount`, and the list of created entries.
+The endpoint is idempotent and safe for overlapping generation requests: re-running it with the same window does not create duplicates, since existing `(date, project, task)` tuples are skipped. The response reports `generatedCount`, `skippedExistingCount`, and the list of created entries.
 
 To prevent accidentally huge generations, the server caps the window at 366 days per call.
 

--- a/docs-site/src/content/docs/time-tracking.md
+++ b/docs-site/src/content/docs/time-tracking.md
@@ -45,7 +45,7 @@ La materializzazione delle registrazioni ricorrenti avviene sul server tramite l
 }
 ```
 
-L'endpoint è idempotente: rieseguirlo con la stessa finestra non crea duplicati, perché le coppie già presenti `(data, progetto, attività)` vengono saltate. La risposta include `generatedCount`, `skippedExistingCount` e l'elenco delle registrazioni create.
+L'endpoint è idempotente e sicuro anche con richieste di generazione sovrapposte: rieseguirlo con la stessa finestra non crea duplicati, perché le coppie già presenti `(data, progetto, attività)` vengono saltate. La risposta include `generatedCount`, `skippedExistingCount` e l'elenco delle registrazioni create.
 
 Per evitare generazioni accidentalmente troppo ampie, il server limita la finestra a 366 giorni per chiamata.
 

--- a/server/db/drizzle.ts
+++ b/server/db/drizzle.ts
@@ -12,6 +12,12 @@ export type DbExecutor = PgDatabase<
   ExtractTablesWithRelations<typeof schema>
 >;
 
+export type DbTransactionConfig = {
+  isolationLevel?: 'read uncommitted' | 'read committed' | 'repeatable read' | 'serializable';
+  accessMode?: 'read only' | 'read write';
+  deferrable?: boolean;
+};
+
 // Wraps a Drizzle transaction so the callback receives a `tx` typed as `DbExecutor`. Routes
 // call this when they need to compose multiple repo calls atomically:
 //
@@ -25,8 +31,10 @@ export type DbExecutor = PgDatabase<
 // `delete`, `execute`, `transaction` for nesting) that `DbExecutor` exposes, but the two
 // classes don't share a nominal supertype that includes both, so TS rejects the direct cast.
 // The `unknown` step is a structural-equivalence assertion, not a load-bearing contract.
-export const withDbTransaction = <T>(callback: (tx: DbExecutor) => Promise<T>): Promise<T> =>
-  db.transaction((tx) => callback(tx as unknown as DbExecutor));
+export const withDbTransaction = <T>(
+  callback: (tx: DbExecutor) => Promise<T>,
+  config?: DbTransactionConfig,
+): Promise<T> => db.transaction((tx) => callback(tx as unknown as DbExecutor), config);
 
 // Run `cb` inside a transaction only when the caller has not already supplied one.
 // Repos call this in DELETE-then-INSERT paths so a failing INSERT rolls back the prior

--- a/server/services/timeEntries.ts
+++ b/server/services/timeEntries.ts
@@ -1,4 +1,4 @@
-import { withDbTransaction } from '../db/drizzle.ts';
+import { type DbExecutor, withDbTransaction } from '../db/drizzle.ts';
 import * as clientsRepo from '../repositories/clientsRepo.ts';
 import type { TimeEntry } from '../repositories/entriesRepo.ts';
 import * as entriesRepo from '../repositories/entriesRepo.ts';
@@ -395,6 +395,36 @@ export type GenerateRecurringResult = {
 };
 
 const MAX_RECURRING_DAYS = 366;
+const SERIALIZATION_FAILURE_SQLSTATE = '40001';
+const MAX_RECURRING_GENERATION_ATTEMPTS = 3;
+
+const getDbErrorCode = (err: unknown, depth = 0): string | undefined => {
+  if (depth > 3) return undefined;
+  if (typeof err !== 'object' || err === null) return undefined;
+  const code = (err as { code?: unknown }).code;
+  if (typeof code === 'string') return code;
+  return getDbErrorCode((err as { cause?: unknown }).cause, depth + 1);
+};
+
+const withRecurringGenerationTransaction = async <T>(
+  callback: (tx: DbExecutor) => Promise<T>,
+): Promise<T> => {
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      return await withDbTransaction(callback, {
+        isolationLevel: 'serializable',
+        accessMode: 'read write',
+      });
+    } catch (err) {
+      if (
+        getDbErrorCode(err) !== SERIALIZATION_FAILURE_SQLSTATE ||
+        attempt >= MAX_RECURRING_GENERATION_ATTEMPTS
+      ) {
+        throw err;
+      }
+    }
+  }
+};
 
 export const generateRecurringEntries = async (
   actor: AuthenticatedActor,
@@ -426,11 +456,10 @@ export const generateRecurringEntries = async (
     }
   }
 
-  const [recurringTasks, settings, hourlyCost, existingKeys] = await Promise.all([
+  const [recurringTasks, settings, hourlyCost] = await Promise.all([
     tasksRepo.listRecurringForUser(targetUserId),
     generalSettingsRepo.get(),
     usersRepo.findCostPerHour(targetUserId),
-    entriesRepo.findExistingRecurringKeys(targetUserId, fromDate, toDate),
   ]);
   if (recurringTasks.length === 0) {
     return {
@@ -507,10 +536,10 @@ export const generateRecurringEntries = async (
     location: settings?.defaultLocation ?? 'remote',
   });
 
-  const pending: PendingEntry[] = [];
-  let skippedExistingCount = 0;
+  type CandidateEntry = { key: string; entry: PendingEntry };
+  const candidates: CandidateEntry[] = [];
   // Track keys staged in this run so two recurring templates with the same (date, projectId,
-  // task) tuple don't insert duplicate rows in a single generation pass.
+  // task) tuple don't become duplicate insert candidates in a single generation pass.
   const stagedKeys = new Set<string>();
 
   for (const task of allowedTasks) {
@@ -540,26 +569,46 @@ export const generateRecurringEntries = async (
 
       const dateStr = formatLocalDateOnly(cursor);
       const key = `${dateStr}|${task.projectId}|${task.name}`;
-      if (existingKeys.has(key)) {
-        skippedExistingCount += 1;
-        continue;
-      }
       if (stagedKeys.has(key)) continue;
       stagedKeys.add(key);
-      pending.push(buildPendingEntry(task, project, dateStr));
+      candidates.push({ key, entry: buildPendingEntry(task, project, dateStr) });
     }
   }
 
-  if (pending.length === 0) {
+  if (candidates.length === 0) {
     return {
       generated: [],
       generatedCount: 0,
-      skippedExistingCount,
+      skippedExistingCount: 0,
       range: { fromDate, toDate },
     };
   }
 
-  const inserted = await withDbTransaction((tx) => entriesRepo.createMany(pending, tx));
+  const { inserted, skippedExistingCount } = await withRecurringGenerationTransaction(
+    async (tx) => {
+      const existingKeys = await entriesRepo.findExistingRecurringKeys(
+        targetUserId,
+        fromDate,
+        toDate,
+        tx,
+      );
+      const pending = candidates
+        .filter((candidate) => !existingKeys.has(candidate.key))
+        .map((candidate) => candidate.entry);
+
+      if (pending.length === 0) {
+        return {
+          inserted: [],
+          skippedExistingCount: candidates.length,
+        };
+      }
+
+      return {
+        inserted: await entriesRepo.createMany(pending, tx),
+        skippedExistingCount: candidates.length - pending.length,
+      };
+    },
+  );
   return {
     generated: inserted,
     generatedCount: inserted.length,

--- a/server/test/helpers/withDbTransactionMock.ts
+++ b/server/test/helpers/withDbTransactionMock.ts
@@ -19,7 +19,10 @@ import { TX_SENTINEL } from './txSentinel.ts';
 // the value channel (the cb receives whatever we hand it). Loosening the test-side type
 // lets per-test `mockImplementation` callers pass TX_SENTINEL or a real fake executor
 // without a redundant `as unknown as DbExecutor` cast at every site.
-type WithDbTransactionMockImpl = (cb: (tx: unknown) => unknown) => Promise<unknown>;
+type WithDbTransactionMockImpl = (
+  cb: (tx: unknown) => unknown,
+  config?: unknown,
+) => Promise<unknown>;
 
 export const makeWithDbTransactionMock = () => {
   const defaultImpl: WithDbTransactionMockImpl = async (cb) => cb(TX_SENTINEL);

--- a/server/test/routes/entries.test.ts
+++ b/server/test/routes/entries.test.ts
@@ -17,6 +17,7 @@ import {
 } from '../helpers/authMiddlewareMock.ts';
 import { buildRouteTestApp } from '../helpers/buildRouteTestApp.ts';
 import { signToken } from '../helpers/jwt.ts';
+import { TX_SENTINEL } from '../helpers/txSentinel.ts';
 import { makeWithDbTransactionMock } from '../helpers/withDbTransactionMock.ts';
 
 const usersRepoSnap = { ...realUsersRepo };
@@ -1121,8 +1122,19 @@ describe('POST /api/entries/recurring/generate', () => {
     expect(body.skippedExistingCount).toBe(0);
     expect(body.range).toEqual({ fromDate: '2025-06-09', toDate: '2025-06-13' });
     expect(entriesCreateManyMock).toHaveBeenCalledTimes(1);
+    expect(withDbTransactionMock.mock.calls[0][1]).toEqual({
+      isolationLevel: 'serializable',
+      accessMode: 'read write',
+    });
+    expect(entriesFindExistingRecurringKeysMock).toHaveBeenCalledWith(
+      'u1',
+      '2025-06-09',
+      '2025-06-13',
+      TX_SENTINEL,
+    );
 
     const inserted = entriesCreateManyMock.mock.calls[0][0] as Array<Record<string, unknown>>;
+    expect(entriesCreateManyMock.mock.calls[0][1]).toBe(TX_SENTINEL);
     expect(inserted.map((e) => e.date)).toEqual([
       '2025-06-09',
       '2025-06-10',
@@ -1399,6 +1411,43 @@ describe('POST /api/entries/recurring/generate', () => {
     expect(body.generatedCount).toBe(0);
     expect(body.skippedExistingCount).toBe(5);
     expect(entriesCreateManyMock).not.toHaveBeenCalled();
+  });
+
+  test('200: retries a serializable transaction conflict before reporting committed state', async () => {
+    setupHappyPath();
+    const generatedKeys = [
+      '2025-06-09|p1|Daily standup',
+      '2025-06-10|p1|Daily standup',
+      '2025-06-11|p1|Daily standup',
+      '2025-06-12|p1|Daily standup',
+      '2025-06-13|p1|Daily standup',
+    ];
+    entriesFindExistingRecurringKeysMock.mockReset();
+    entriesFindExistingRecurringKeysMock
+      .mockResolvedValueOnce(new Set<string>())
+      .mockResolvedValueOnce(new Set(generatedKeys));
+    withDbTransactionMock.mockImplementationOnce(async (cb: (tx: unknown) => unknown) => {
+      await cb(TX_SENTINEL);
+      throw Object.assign(new Error('could not serialize access'), { code: '40001' });
+    });
+    withDbTransactionMock.mockImplementationOnce(async (cb: (tx: unknown) => unknown) =>
+      cb(TX_SENTINEL),
+    );
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/entries/recurring/generate',
+      headers: authHeader(),
+      payload: { fromDate: '2025-06-09', toDate: '2025-06-13' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.generatedCount).toBe(0);
+    expect(body.skippedExistingCount).toBe(5);
+    expect(withDbTransactionMock).toHaveBeenCalledTimes(2);
+    expect(entriesFindExistingRecurringKeysMock).toHaveBeenCalledTimes(2);
+    expect(entriesCreateManyMock).toHaveBeenCalledTimes(1);
   });
 
   test('200: filters out a recurring task whose client assignment was revoked', async () => {


### PR DESCRIPTION
## Summary
- Fixes a race in recurring time-entry generation that could let overlapping requests insert duplicate placeholders.
- Keeps the existing manual duplicate-entry behavior intact while making server-side recurring generation idempotent under concurrency.

## Changes
- Runs the recurring-entry existing-key read and bulk insert inside a serializable transaction.
- Retries PostgreSQL serialization failures so a concurrent winner is observed before returning the final generated/skipped counts.
- Extends the shared transaction helper to accept Drizzle transaction options.
- Adds route-level regression coverage for transactional key reads and serialization retry behavior.
- Updates Italian and English time-tracking docs for the stronger idempotency guarantee.

## Testing
- `bun test server/test/routes/entries.test.ts`
- `bun run test:server`
- `bun run lint`

## Risks / Rollout
- Moderate database-concurrency risk, scoped to `POST /api/entries/recurring/generate`.
- No schema migration or data backfill is required.
- Serializable retries are capped at three attempts; persistent conflicts still surface as errors.

## Issues
Fixes #501
