### PR TITLE
auth(fix): await auth error replies

### DIFF
--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -94,19 +94,19 @@ const loadAuthenticatedUserContext = async (
   const user = await usersRepo.findAuthUserById(userId);
 
   if (!user) {
-    reply.code(401).send({ error: 'User not found' });
+    await reply.code(401).send({ error: 'User not found' });
     return null;
   }
 
   if (user.isDisabled) {
-    reply.code(403).send({ error: 'Account disabled', errorCode: 'account_disabled' });
+    await reply.code(403).send({ error: 'Account disabled', errorCode: 'account_disabled' });
     return null;
   }
 
   // Session version mismatch means the token was issued before a logout (or other
   // forced revocation) bumped the user's session version. Reject without rotating.
   if (expectedSessionVersion !== undefined && user.sessionVersion !== expectedSessionVersion) {
-    reply.code(401).send({ error: 'Session revoked', errorCode: 'session_revoked' });
+    await reply.code(401).send({ error: 'Session revoked', errorCode: 'session_revoked' });
     return null;
   }
 
@@ -120,7 +120,7 @@ const loadAuthenticatedUserContext = async (
     getRolePermissions(effectiveRole),
   ]);
   if (!hasRole) {
-    reply.code(403).send({ error: 'Invalid or expired token' });
+    await reply.code(403).send({ error: 'Invalid or expired token' });
     return null;
   }
 

--- a/server/test/middleware/auth.test.ts
+++ b/server/test/middleware/auth.test.ts
@@ -94,7 +94,7 @@ type FakeReply = {
   headers: Record<string, string>;
   sentCount: number;
   code(c: number): FakeReply;
-  send(body: unknown): FakeReply;
+  send(body: unknown): FakeReply | Promise<FakeReply>;
   header(name: string, value: string): FakeReply;
 };
 
@@ -119,6 +119,22 @@ const buildFakeReply = (): FakeReply => {
     },
   };
   return reply;
+};
+
+const buildDeferredSendReply = () => {
+  const reply = buildFakeReply();
+  const sendNow = reply.send.bind(reply);
+  let resolveSend!: () => void;
+  const sendCompleted = new Promise<void>((resolve) => {
+    resolveSend = resolve;
+  });
+
+  reply.send = (body: unknown) => {
+    sendNow(body);
+    return sendCompleted.then(() => reply);
+  };
+
+  return { reply, resolveSend };
 };
 
 type FakeRequest = {
@@ -259,6 +275,63 @@ describe('authenticateToken', () => {
     expect(reply.statusCode).toBe(403);
     expect(reply.body).toEqual({ error: 'Invalid or expired token' });
   });
+
+  const authContextErrorScenarios = [
+    {
+      name: 'missing user',
+      setup: () => findAuthUserByIdMock.mockResolvedValue(null),
+      token: () => signToken({ userId: 'u1' }),
+      expectedStatus: 401,
+      expectedBody: { error: 'User not found' },
+    },
+    {
+      name: 'disabled user',
+      setup: () => findAuthUserByIdMock.mockResolvedValue({ ...HAPPY_USER, isDisabled: true }),
+      token: () => signToken({ userId: 'u1' }),
+      expectedStatus: 403,
+      expectedBody: { error: 'Account disabled', errorCode: 'account_disabled' },
+    },
+    {
+      name: 'revoked session',
+      setup: () => findAuthUserByIdMock.mockResolvedValue({ ...HAPPY_USER, sessionVersion: 5 }),
+      token: () => signToken({ userId: 'u1', sessionVersion: 2 }),
+      expectedStatus: 401,
+      expectedBody: { error: 'Session revoked', errorCode: 'session_revoked' },
+    },
+    {
+      name: 'unassigned role',
+      setup: () => userHasRoleMock.mockResolvedValue(false),
+      token: () => signToken({ userId: 'u1' }),
+      expectedStatus: 403,
+      expectedBody: { error: 'Invalid or expired token' },
+    },
+  ];
+
+  for (const scenario of authContextErrorScenarios) {
+    test(`waits for async ${scenario.name} response before resolving`, async () => {
+      scenario.setup();
+      const request = buildFakeRequest(scenario.token());
+      const { reply, resolveSend } = buildDeferredSendReply();
+      let completed = false;
+
+      const inflight = authenticateToken(request as never, reply as never).then(() => {
+        completed = true;
+      });
+
+      for (let i = 0; i < 5 && reply.body === undefined; i += 1) {
+        await Promise.resolve();
+      }
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(reply.statusCode).toBe(scenario.expectedStatus);
+      expect(reply.body).toEqual(scenario.expectedBody);
+      expect(completed).toBe(false);
+
+      resolveSend();
+      await inflight;
+      expect(completed).toBe(true);
+    });
+  }
 
   test('200 happy path: populates request.user and rotates the x-auth-token header', async () => {
     const sessionStart = Date.now() - 60_000;


### PR DESCRIPTION
## Summary
- Awaits Fastify auth error replies in `loadAuthenticatedUserContext` so early responses finish before the middleware resolves.
- Adds regression coverage for the missing user, disabled account, revoked session, and unassigned role paths.

## Changes
- Updates the four auth-context error branches to await `reply.code(...).send(...)` before returning `null`.
- Extends auth middleware tests with a deferred async reply fake that catches premature middleware resolution.

## Testing
- `bun test test/middleware/auth.test.ts`
- `bun run build`
- `bun x biome check server/middleware/auth.ts server/test/middleware/auth.test.ts`
- Earlier full server suite: `bun test ./test` (2579 passed, 28 skipped, 0 failed)

## Risks / Rollout
- Low risk and scoped to auth error paths. No migrations, config changes, or API contract changes.

## Issues
Fixes #507