### PR TITLE
order-ids(fix): handle sequence suffix overflow

### DIFF
--- a/server/repositories/invoicesRepo.ts
+++ b/server/repositories/invoicesRepo.ts
@@ -2,6 +2,7 @@ import { and, asc, desc, eq, ne, sql } from 'drizzle-orm';
 import { type DbExecutor, db, executeRows, runAtomically } from '../db/drizzle.ts';
 import { invoiceItems, invoices } from '../db/schema/invoices.ts';
 import { requireDateOnly } from '../utils/date.ts';
+import { formatSequenceSuffix } from '../utils/order-ids.ts';
 import { numericForDb, parseDbNumber } from '../utils/parse.ts';
 
 export type Invoice = {
@@ -70,12 +71,12 @@ export const generateNextId = async (year: string, exec: DbExecutor = db): Promi
   // matching id back to the app just to extract the sequence number.
   const rows = await executeRows<{ maxSequence: string | number | null }>(
     exec,
-    sql`SELECT COALESCE(MAX(CAST(split_part(id, '-', 3) AS INTEGER)), 0) AS "maxSequence"
+    sql`SELECT COALESCE(MAX(CAST(split_part(id, '-', 3) AS BIGINT)), 0) AS "maxSequence"
           FROM invoices
          WHERE id ~ ${`^INV-${year}-[0-9]+$`}`,
   );
-  const nextSequence = Number(rows[0]?.maxSequence ?? 0) + 1;
-  return `INV-${year}-${String(nextSequence).padStart(4, '0')}`;
+  const nextSequence = BigInt(rows[0]?.maxSequence ?? 0) + 1n;
+  return `INV-${year}-${formatSequenceSuffix(nextSequence)}`;
 };
 
 export const listAll = async (exec: DbExecutor = db): Promise<Invoice[]> => {

--- a/server/repositories/supplierInvoicesRepo.ts
+++ b/server/repositories/supplierInvoicesRepo.ts
@@ -168,7 +168,7 @@ export const maxSequenceForYear = async (year: string, exec: DbExecutor = db): P
   const pattern = `^SINV-${year}-[0-9]+$`;
   const rows = await executeRows<{ maxSequence: string | number | null }>(
     exec,
-    sql`SELECT COALESCE(MAX(CAST(split_part(id, '-', 3) AS INTEGER)), 0) AS "maxSequence"
+    sql`SELECT COALESCE(MAX(CAST(split_part(id, '-', 3) AS BIGINT)), 0) AS "maxSequence"
         FROM ${supplierInvoices} WHERE id ~ ${pattern}`,
   );
   return parseDbNumber(rows[0]?.maxSequence, 0);

--- a/server/repositories/supplierInvoicesRepo.ts
+++ b/server/repositories/supplierInvoicesRepo.ts
@@ -164,14 +164,14 @@ export const findIdConflict = async (
 // Matches `SINV-<year>-<sequence>` IDs and returns the largest sequence for the given year so
 // the route layer can compute the next ID. PG's POSIX `~` regex isn't expressible in Drizzle's
 // filter API, hence the raw SQL.
-export const maxSequenceForYear = async (year: string, exec: DbExecutor = db): Promise<number> => {
+export const maxSequenceForYear = async (year: string, exec: DbExecutor = db): Promise<bigint> => {
   const pattern = `^SINV-${year}-[0-9]+$`;
-  const rows = await executeRows<{ maxSequence: string | number | null }>(
+  const rows = await executeRows<{ maxSequence: string | number | bigint | null }>(
     exec,
     sql`SELECT COALESCE(MAX(CAST(split_part(id, '-', 3) AS BIGINT)), 0) AS "maxSequence"
         FROM ${supplierInvoices} WHERE id ~ ${pattern}`,
   );
-  return parseDbNumber(rows[0]?.maxSequence, 0);
+  return BigInt(rows[0]?.maxSequence ?? 0);
 };
 
 export type NewSupplierInvoice = {

--- a/server/routes/supplier-invoices.ts
+++ b/server/routes/supplier-invoices.ts
@@ -202,7 +202,7 @@ const normalizeItems = (
 const generateSupplierInvoiceId = async (issueDate: string) => {
   const year = issueDate.split('-')[0];
   const maxSequence = await supplierInvoicesRepo.maxSequenceForYear(year);
-  const nextSequence = maxSequence + 1;
+  const nextSequence = maxSequence + 1n;
   return `SINV-${year}-${formatSequenceSuffix(nextSequence)}`;
 };
 

--- a/server/routes/supplier-invoices.ts
+++ b/server/routes/supplier-invoices.ts
@@ -6,7 +6,7 @@ import * as supplierOrdersRepo from '../repositories/supplierOrdersRepo.ts';
 import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
 import { logAudit } from '../utils/audit.ts';
 import { type DatabaseError, getUniqueViolation } from '../utils/db-errors.ts';
-import { generateItemId } from '../utils/order-ids.ts';
+import { formatSequenceSuffix, generateItemId } from '../utils/order-ids.ts';
 import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import { replyError } from '../utils/replyError.ts';
 import {
@@ -203,7 +203,7 @@ const generateSupplierInvoiceId = async (issueDate: string) => {
   const year = issueDate.split('-')[0];
   const maxSequence = await supplierInvoicesRepo.maxSequenceForYear(year);
   const nextSequence = maxSequence + 1;
-  return `SINV-${year}-${String(nextSequence).padStart(4, '0')}`;
+  return `SINV-${year}-${formatSequenceSuffix(nextSequence)}`;
 };
 
 export default async function (fastify: FastifyInstance, _opts: unknown) {

--- a/server/test/repositories/invoicesRepo.test.ts
+++ b/server/test/repositories/invoicesRepo.test.ts
@@ -62,6 +62,12 @@ describe('generateNextId', () => {
     expect(id).toBe('INV-2026-0008');
   });
 
+  test('keeps the suffix untruncated after 9999', async () => {
+    exec.enqueue({ rows: [{ maxSequence: '9999' }] });
+    const id = await invoicesRepo.generateNextId('2026', testDb);
+    expect(id).toBe('INV-2026-10000');
+  });
+
   test('handles missing maxSequence row', async () => {
     exec.enqueue({ rows: [] });
     const id = await invoicesRepo.generateNextId('2026', testDb);

--- a/server/test/repositories/supplierInvoicesRepo.test.ts
+++ b/server/test/repositories/supplierInvoicesRepo.test.ts
@@ -127,14 +127,19 @@ describe('findExisting', () => {
 });
 
 describe('maxSequenceForYear', () => {
-  test('parses string maxSequence to Number', async () => {
+  test('parses string maxSequence to BigInt', async () => {
     exec.enqueue({ rows: [{ maxSequence: '42' }] });
-    expect(await supplierInvoicesRepo.maxSequenceForYear('2026', testDb)).toBe(42);
+    expect(await supplierInvoicesRepo.maxSequenceForYear('2026', testDb)).toBe(42n);
   });
 
-  test('parses numeric maxSequence as-is', async () => {
+  test('parses numeric maxSequence as BigInt', async () => {
     exec.enqueue({ rows: [{ maxSequence: 7 }] });
-    expect(await supplierInvoicesRepo.maxSequenceForYear('2026', testDb)).toBe(7);
+    expect(await supplierInvoicesRepo.maxSequenceForYear('2026', testDb)).toBe(7n);
+  });
+
+  test('preserves sequence values beyond Number safe integer precision', async () => {
+    exec.enqueue({ rows: [{ maxSequence: '9007199254740993' }] });
+    expect(await supplierInvoicesRepo.maxSequenceForYear('2026', testDb)).toBe(9007199254740993n);
   });
 
   test('uses regex parameter for the year', async () => {
@@ -145,7 +150,7 @@ describe('maxSequenceForYear', () => {
 
   test('returns 0 when no rows or null maxSequence', async () => {
     exec.enqueue({ rows: [] });
-    expect(await supplierInvoicesRepo.maxSequenceForYear('2026', testDb)).toBe(0);
+    expect(await supplierInvoicesRepo.maxSequenceForYear('2026', testDb)).toBe(0n);
   });
 });
 

--- a/server/test/routes/supplier-invoices.test.ts
+++ b/server/test/routes/supplier-invoices.test.ts
@@ -269,7 +269,7 @@ describe('POST /api/supplier-invoices', () => {
   };
 
   test('201 creates invoice with auto-generated id', async () => {
-    maxSequenceForYearMock.mockResolvedValue(0);
+    maxSequenceForYearMock.mockResolvedValue(0n);
     createMock.mockResolvedValue(SAMPLE_INVOICE);
     insertItemsMock.mockResolvedValue([SAMPLE_ITEM]);
 
@@ -293,7 +293,7 @@ describe('POST /api/supplier-invoices', () => {
   });
 
   test('201 keeps auto-generated id suffix untruncated after 9999', async () => {
-    maxSequenceForYearMock.mockResolvedValue(9999);
+    maxSequenceForYearMock.mockResolvedValue(9999n);
     createMock.mockImplementation(async (input: Record<string, unknown>) => ({
       ...SAMPLE_INVOICE,
       id: input.id as string,

--- a/server/test/routes/supplier-invoices.test.ts
+++ b/server/test/routes/supplier-invoices.test.ts
@@ -292,6 +292,29 @@ describe('POST /api/supplier-invoices', () => {
     );
   });
 
+  test('201 keeps auto-generated id suffix untruncated after 9999', async () => {
+    maxSequenceForYearMock.mockResolvedValue(9999);
+    createMock.mockImplementation(async (input: Record<string, unknown>) => ({
+      ...SAMPLE_INVOICE,
+      id: input.id as string,
+    }));
+    insertItemsMock.mockResolvedValue([SAMPLE_ITEM]);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/supplier-invoices',
+      headers: authHeader(),
+      payload: validBody,
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'SINV-2025-10000' }),
+      expect.anything(),
+    );
+    expect(JSON.parse(res.body).id).toBe('SINV-2025-10000');
+  });
+
   test('201 uses caller-supplied id when provided', async () => {
     createMock.mockResolvedValue({ ...SAMPLE_INVOICE, id: 'CUSTOM-1' });
     insertItemsMock.mockResolvedValue([{ ...SAMPLE_ITEM, invoiceId: 'CUSTOM-1' }]);

--- a/server/test/utils/order-ids.test.ts
+++ b/server/test/utils/order-ids.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 import {
+  formatSequenceSuffix,
   generateClientOrderId,
   generatePrefixedId,
   generateSupplierOrderId,
@@ -18,6 +19,17 @@ describe('generatePrefixedId', () => {
   test('preserves multi-segment prefixes verbatim', () => {
     const id = generatePrefixedId('rpt-chat');
     expect(id.startsWith('rpt-chat-')).toBe(true);
+  });
+});
+
+describe('formatSequenceSuffix', () => {
+  test('uses 4 digits as the minimum display width', () => {
+    expect(formatSequenceSuffix(1)).toBe('0001');
+    expect(formatSequenceSuffix(9999)).toBe('9999');
+  });
+
+  test('keeps sequence suffixes untruncated after 9999', () => {
+    expect(formatSequenceSuffix(10000)).toBe('10000');
   });
 });
 
@@ -59,7 +71,7 @@ describe('generateSequentialId (sequence-backed)', () => {
     expect(new Set(ids).size).toBe(ids.length);
     const year = new Date().getFullYear();
     for (const id of ids) {
-      expect(id).toMatch(new RegExp(`^ORD-${year}-\\d{4}$`));
+      expect(id).toMatch(new RegExp(`^ORD-${year}-\\d{4,}$`));
     }
   });
 
@@ -70,7 +82,7 @@ describe('generateSequentialId (sequence-backed)', () => {
     expect(new Set(ids).size).toBe(ids.length);
     const year = new Date().getFullYear();
     for (const id of ids) {
-      expect(id).toMatch(new RegExp(`^SORD-${year}-\\d{4}$`));
+      expect(id).toMatch(new RegExp(`^SORD-${year}-\\d{4,}$`));
     }
   });
 
@@ -78,5 +90,12 @@ describe('generateSequentialId (sequence-backed)', () => {
     const id = await generateClientOrderId(mockExec as never);
     const year = new Date().getFullYear();
     expect(id).toBe(`ORD-${year}-0001`);
+  });
+
+  test('does not truncate generated ids after the 4-digit range', async () => {
+    counter = 9999;
+    const id = await generateClientOrderId(mockExec as never);
+    const year = new Date().getFullYear();
+    expect(id).toBe(`ORD-${year}-10000`);
   });
 });

--- a/server/utils/order-ids.ts
+++ b/server/utils/order-ids.ts
@@ -19,6 +19,19 @@ const SEQUENCE_NAMES = {
 
 type SequentialPrefix = keyof typeof SEQUENCE_NAMES;
 
+export const ORDER_ID_SEQUENCE_MIN_DIGITS = 4;
+
+export const formatSequenceSuffix = (
+  sequence: string | number | bigint,
+  minDigits = ORDER_ID_SEQUENCE_MIN_DIGITS,
+): string => {
+  const value = String(sequence);
+  if (!/^\d+$/.test(value)) {
+    throw new Error(`Invalid sequence value: ${value}`);
+  }
+  return value.padStart(minDigits, '0');
+};
+
 const generateSequentialId = async (
   prefix: SequentialPrefix,
   exec: DbExecutor = db,
@@ -33,8 +46,7 @@ const generateSequentialId = async (
   if (rows.length === 0 || rows[0]?.nextValue == null) {
     throw new Error(`Sequence ${sequenceName} returned no value — schema migration likely missing`);
   }
-  const nextSequence = Number(rows[0].nextValue);
-  return `${prefix}-${year}-${String(nextSequence).padStart(4, '0')}`;
+  return `${prefix}-${year}-${formatSequenceSuffix(rows[0].nextValue)}`;
 };
 
 export const generateClientOrderId = (exec?: DbExecutor) => generateSequentialId('ORD', exec);


### PR DESCRIPTION
## Summary
- Treat financial document sequence suffixes as 4 digits minimum instead of fixed-width.
- Prevent order, client invoice, and supplier invoice IDs from truncating or losing precision once sequences grow beyond the old 4-digit range.

## Changes
- Adds a shared sequence suffix formatter for `ORD` and `SORD` IDs.
- Reuses the formatter for client invoice and supplier invoice ID generation.
- Casts invoice sequence scans to `BIGINT` and preserves supplier invoice max sequence values as `bigint`.
- Adds regression tests for suffix value `10000` and large supplier invoice sequence precision.

## Testing
- `bun test test/utils/order-ids.test.ts test/repositories/invoicesRepo.test.ts test/repositories/supplierInvoicesRepo.test.ts test/routes/supplier-invoices.test.ts` from `server/`
- `bun run build` from `server/`
- `bunx biome check server/utils/order-ids.ts server/repositories/invoicesRepo.ts server/repositories/supplierInvoicesRepo.ts server/routes/supplier-invoices.ts server/test/utils/order-ids.test.ts server/test/repositories/invoicesRepo.test.ts server/test/repositories/supplierInvoicesRepo.test.ts server/test/routes/supplier-invoices.test.ts`

## Risks / Rollout
- Low risk. Existing 1-9999 IDs keep the same display format; larger suffixes expand as already implied by parser regexes.
- No migration required.

## Issues
Fixes #506