### PR TITLE
timeEntries(fix): clamp monthly recurrence to month end

### DIFF
--- a/docs-site/src/content/docs/en/time-tracking.md
+++ b/docs-site/src/content/docs/en/time-tracking.md
@@ -32,6 +32,8 @@ Each recurring template is defined on a project task and includes:
 - `recurrenceEnd` (optional): when set, generation stops on this date.
 - `recurrenceDuration`: the default duration (in hours) of each generated entry.
 
+For `monthly` recurrences, if the start-date day does not exist in a shorter month, the occurrence is generated on that month's final day.
+
 Sundays, Saturdays (when the _Treat Saturday as holiday_ setting is enabled), and Italian holidays are always skipped.
 
 ### Server-side generation

--- a/docs-site/src/content/docs/time-tracking.md
+++ b/docs-site/src/content/docs/time-tracking.md
@@ -32,6 +32,8 @@ Ogni template ricorrente è definito sull'attività di progetto e include:
 - `recurrenceEnd` (opzionale): se valorizzata, blocca la generazione oltre tale data.
 - `recurrenceDuration`: ore di default per ciascuna registrazione generata.
 
+Per le ricorrenze `monthly`, se il giorno della data di inizio non esiste in un mese più corto, l'occorrenza viene generata nell'ultimo giorno di quel mese.
+
 I giorni che cadono di domenica, di sabato (se l'impostazione _Tratta il sabato come festivo_ è attiva) e quelli che coincidono con festività italiane vengono sempre saltati.
 
 ### Generazione lato server

--- a/server/services/timeEntries.ts
+++ b/server/services/timeEntries.ts
@@ -341,7 +341,7 @@ export const deleteTimeEntry = async (
 // Recurring time-entry generation. Supported patterns:
 //   - 'daily'                : every weekday in the window
 //   - 'weekly'               : same weekday as `recurrence_start`
-//   - 'monthly'              : same day-of-month as `recurrence_start`
+//   - 'monthly'              : same day-of-month as `recurrence_start`, clamped to month end
 //   - 'monthly:<nth>:<dow>'  : Nth (first/second/third/fourth/last) weekday of the month;
 //                              `dow` is 0=Sun..6=Sat (matches JS `Date.getDay()`)
 //
@@ -352,7 +352,10 @@ export const deleteTimeEntry = async (
 const recurrenceMatches = (day: Date, pattern: string, start: Date): boolean => {
   if (pattern === 'daily') return true;
   if (pattern === 'weekly') return day.getDay() === start.getDay();
-  if (pattern === 'monthly') return day.getDate() === start.getDate();
+  if (pattern === 'monthly') {
+    const lastDayOfMonth = new Date(day.getFullYear(), day.getMonth() + 1, 0).getDate();
+    return day.getDate() === Math.min(start.getDate(), lastDayOfMonth);
+  }
   if (pattern.startsWith('monthly:')) {
     const parts = pattern.split(':');
     if (parts.length !== 3) return false;

--- a/server/test/routes/entries.test.ts
+++ b/server/test/routes/entries.test.ts
@@ -1076,6 +1076,14 @@ describe('POST /api/entries/recurring/generate', () => {
     recurrenceStart: '2025-06-01',
   };
 
+  const monthlyMonthEndTask = {
+    ...dailyTask,
+    id: 't5',
+    name: 'Month-end close',
+    recurrencePattern: 'monthly',
+    recurrenceStart: '2025-01-31',
+  };
+
   const endedTask = {
     ...dailyTask,
     id: 't4',
@@ -1225,6 +1233,27 @@ describe('POST /api/entries/recurring/generate', () => {
     const inserted = entriesCreateManyMock.mock.calls[0][0] as Array<Record<string, unknown>>;
     // First Mondays of Jun/Jul/Aug 2025: 06-02 (Repubblica holiday -> skipped), 07-07, 08-04.
     expect(inserted.map((e) => e.date)).toEqual(['2025-07-07', '2025-08-04']);
+  });
+
+  test('200: monthly pattern clamps start days beyond the end of shorter months', async () => {
+    setupHappyPath();
+    listRecurringForUserMock.mockResolvedValue([monthlyMonthEndTask]);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/entries/recurring/generate',
+      headers: authHeader(),
+      payload: { fromDate: '2025-01-01', toDate: '2025-04-30' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const inserted = entriesCreateManyMock.mock.calls[0][0] as Array<Record<string, unknown>>;
+    expect(inserted.map((e) => e.date)).toEqual([
+      '2025-01-31',
+      '2025-02-28',
+      '2025-03-31',
+      '2025-04-30',
+    ]);
   });
 
   test('200: respects recurrenceEnd', async () => {


### PR DESCRIPTION
## Summary
- Clamps plain monthly recurring-task generation to the last day of shorter months.
- Adds regression coverage for month-end templates so Jan 31 generates Feb 28 and Apr 30 instead of silently skipping those months.
- Documents the month-end behavior in the Italian and English time-tracking docs.

## Changes
- Updates `monthly` recurrence matching to compare against `min(startDay, lastDayOfMonth)`.
- Adds a focused `POST /api/entries/recurring/generate` route test for a Jan 31 template.
- Updates recurring-task documentation in both locale mirrors.

## Testing
- `bun test ./test/routes/entries.test.ts` in `server`
- `bun run build` in `server`
- `bun run lint`
- `git diff --check`

## Risks / Rollout
- Low risk. Change is scoped to recurring entry date matching for the plain `monthly` pattern.
- Existing idempotency behavior is unchanged because generated entries still use the same `(date, project, task)` duplicate key logic.

## Issues
Fixes #505
