### PR TITLE
auth(fix): normalize legacy permission checks

### DIFF
--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -7,6 +7,8 @@ import { logAudit } from '../utils/audit.ts';
 import {
   equivalentPermissionsFor,
   getRolePermissions,
+  hasAnyPermission,
+  hasPermission,
   type PermissionAction,
   type PermissionResource,
 } from '../utils/permissions.ts';
@@ -285,7 +287,7 @@ export const requirePermission = (...permissions: NonEmptyGuardArgs) => {
     }
 
     const userPermissions = request.user.permissions || [];
-    const hasAll = permissions.every((permission) => userPermissions.includes(permission));
+    const hasAll = permissions.every((permission) => hasPermission(userPermissions, permission));
     if (!hasAll) {
       return denyForbidden(request, reply, 'permission', permissions);
     }
@@ -299,7 +301,7 @@ export const requireAnyPermission = (...permissions: string[]) => {
     }
 
     const userPermissions = request.user.permissions || [];
-    const hasAny = permissions.some((permission) => userPermissions.includes(permission));
+    const hasAny = hasAnyPermission(userPermissions, permissions);
     if (!hasAny) {
       return denyForbidden(request, reply, 'permission', permissions);
     }

--- a/server/test/middleware/auth.test.ts
+++ b/server/test/middleware/auth.test.ts
@@ -693,6 +693,21 @@ describe('requirePermission (ALL semantics)', () => {
     expect(reply.body).toBeUndefined();
   });
 
+  test('normalizes legacy permission aliases before checking all required perms', async () => {
+    const reply = buildFakeReply();
+    await requirePermission('configuration.general.view', 'suppliers.quotes.create')(
+      {
+        user: {
+          ...HAPPY_USER,
+          permissions: ['administration.general.view', 'sales.supplier_quotes.create'],
+        },
+      } as never,
+      reply as never,
+    );
+    expect(reply.statusCode).toBe(0);
+    expect(reply.body).toBeUndefined();
+  });
+
   test('rejects empty permission guards before a route can be registered', () => {
     // @ts-expect-error Regression coverage for runtime JavaScript callers.
     expect(() => requirePermission()).toThrow('requirePermission requires at least one permission');
@@ -732,6 +747,16 @@ describe('requireAnyPermission (ANY semantics)', () => {
     const reply = buildFakeReply();
     await requireAnyPermission('a.view', 'b.view')(
       { user: { ...HAPPY_USER, permissions: ['b.view'] } } as never,
+      reply as never,
+    );
+    expect(reply.statusCode).toBe(0);
+    expect(reply.body).toBeUndefined();
+  });
+
+  test('normalizes legacy permission aliases before checking any required perm', async () => {
+    const reply = buildFakeReply();
+    await requireAnyPermission('crm.clients.view', 'configuration.general.update')(
+      { user: { ...HAPPY_USER, permissions: ['administration.general.update'] } } as never,
       reply as never,
     );
     expect(reply.statusCode).toBe(0);

--- a/server/test/utils/permissions.test.ts
+++ b/server/test/utils/permissions.test.ts
@@ -8,6 +8,7 @@ import {
   buildPermissions,
   DEFAULT_ROLE_PERMISSIONS,
   equivalentPermissionsFor,
+  hasAnyPermission,
   hasPermission,
   hasScopedActionPermission,
   isPermissionKnown,
@@ -210,11 +211,24 @@ describe('equivalentPermissionsFor / hasScopedActionPermission', () => {
   });
 });
 
+describe('hasAnyPermission', () => {
+  test('normalizes legacy required permission aliases before checking', () => {
+    expect(hasAnyPermission(['administration.general.view'], ['configuration.general.view'])).toBe(
+      true,
+    );
+  });
+});
+
 describe('hasPermission', () => {
   test('returns true when the array contains the permission', () => {
     expect(hasPermission(['crm.clients.view', 'crm.clients.update'], 'crm.clients.view')).toBe(
       true,
     );
+  });
+
+  test('normalizes legacy permission aliases before checking', () => {
+    expect(hasPermission(['administration.general.view'], 'configuration.general.view')).toBe(true);
+    expect(hasPermission(['sales.supplier_quotes.create'], 'suppliers.quotes.create')).toBe(true);
   });
 
   test('returns false when the permission is missing', () => {
@@ -304,6 +318,11 @@ describe('requestHasPermission', () => {
   test('returns true when request.user.permissions contains the permission', () => {
     const request = { user: { permissions: ['crm.clients.view'] } };
     expect(requestHasPermission(request, 'crm.clients.view')).toBe(true);
+  });
+
+  test('normalizes legacy permission aliases before checking request permissions', () => {
+    const request = { user: { permissions: ['administration.general.update'] } };
+    expect(requestHasPermission(request, 'configuration.general.update')).toBe(true);
   });
 
   test('returns false when request has no user', () => {

--- a/server/utils/permissions.ts
+++ b/server/utils/permissions.ts
@@ -235,8 +235,8 @@ export const getRolePermissions = async (roleId: string): Promise<Permission[]> 
   return withNotifications;
 };
 
-export const hasPermission = (permissions: string[] | undefined, permission: Permission) =>
-  !!permissions?.includes(permission);
+export const hasPermission = (permissions: string[] | undefined, permission: Permission | string) =>
+  !!permissions?.includes(normalizePermission(permission));
 
 export const scopeResourceFor = (resource: PermissionResource): PermissionResource | undefined => {
   const scoped = `${resource}_all`;
@@ -254,7 +254,7 @@ export const equivalentPermissionsFor = (
 };
 
 export const hasAnyPermission = (permissions: string[] | undefined, required: string[]) =>
-  required.some((permission) => permissions?.includes(permission));
+  required.some((permission) => hasPermission(permissions, permission));
 
 export const hasScopedActionPermission = (
   permissions: string[] | undefined,
@@ -265,7 +265,7 @@ export const hasScopedActionPermission = (
 export const requestHasPermission = (
   request: { user?: { permissions?: string[] } },
   permission: Permission | string,
-) => !!request.user?.permissions?.includes(permission);
+) => hasPermission(request.user?.permissions, permission);
 
 // Duck-typed locally so this module doesn't pull in `fastify` and create an import cycle.
 type RequestWithUser = { user?: { id?: string; permissions?: string[] } };


### PR DESCRIPTION
## Summary
- Normalizes legacy permission aliases before checking authorization helper inputs.
- Keeps direct request checks, multi-permission checks, and route middleware guards consistent with role permission normalization.

## Changes
- Updates `hasPermission` to normalize the requested permission before comparing it with the user's normalized permissions.
- Routes `hasAnyPermission`, `requestHasPermission`, `requirePermission`, and `requireAnyPermission` through normalized helper paths.
- Adds regression coverage for `configuration.*` and `suppliers.quotes.*` legacy aliases across utility and middleware checks.

## Testing
- `bun test server/test/utils/permissions.test.ts server/test/middleware/auth.test.ts`
- `bun run build` from `server/`
- `bunx biome check server/utils/permissions.ts server/test/utils/permissions.test.ts server/middleware/auth.ts server/test/middleware/auth.test.ts`

## Risks / Rollout
- Low risk. Change is scoped to authorization permission comparisons and preserves existing normalized permission strings.

## Issues
Fixes #504