### PR TITLE
auth(fix): make session auth a route guard

### DIFF
--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -82,7 +82,26 @@ type SessionJwtPayload = JwtPayload & {
   sessionVersion?: number;
 };
 
+type SessionAuthContext = {
+  userId: string;
+  sessionStart: number;
+  sessionVersion: number;
+};
+
 type NonEmptyGuardArgs = [string, ...string[]];
+
+const hasSessionAuthContext = (
+  auth: FastifyRequest['auth'],
+): auth is NonNullable<FastifyRequest['auth']> & {
+  source: 'session';
+  sessionVersion: number;
+} => auth?.source === 'session' && typeof auth.sessionVersion === 'number';
+
+const buildSessionAuthRequiredError = () => {
+  const error = new Error('Session authentication required') as Error & { statusCode: number };
+  error.statusCode = 403;
+  return error;
+};
 
 const loadAuthenticatedUserContext = async (
   request: FastifyRequest,
@@ -309,21 +328,27 @@ export const requireAnyPermission = (...permissions: string[]) => {
 export const requireScopedPermission = (resource: PermissionResource, action: PermissionAction) =>
   requireAnyPermission(...equivalentPermissionsFor(resource, action));
 
-// Narrow `request.auth` to a session-sourced context for endpoints that must not be
-// callable with a personal access token (logout, role switch). Returns null after sending
-// a response if the caller doesn't have a valid session.
-export const requireSessionAuth = (
+// Fastify guard for endpoints that must not be callable with a personal access token
+// (logout, role switch). Keep this hook response-only; handlers should call
+// `getSessionAuth` after the guard has run to read a non-null session context.
+export const requireSessionAuth = async (
   request: FastifyRequest,
   reply: FastifyReply,
-): { userId: string; sessionStart: number; sessionVersion: number } | null => {
-  if (request.auth?.source !== 'session') {
+): Promise<void> => {
+  if (!hasSessionAuthContext(request.auth)) {
     reply.code(403).send({ error: 'Session authentication required' });
-    return null;
+    return;
+  }
+};
+
+export const getSessionAuth = (request: FastifyRequest): SessionAuthContext => {
+  if (!hasSessionAuthContext(request.auth)) {
+    throw buildSessionAuthRequiredError();
   }
   return {
     userId: request.auth.userId,
     sessionStart: request.auth.sessionStart ?? Date.now(),
-    sessionVersion: request.auth.sessionVersion as number,
+    sessionVersion: request.auth.sessionVersion,
   };
 };
 
@@ -344,5 +369,7 @@ export default {
   requirePermission,
   requireAnyPermission,
   requireScopedPermission,
+  requireSessionAuth,
+  getSessionAuth,
   generateToken,
 };

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -1,6 +1,11 @@
 import bcrypt from 'bcryptjs';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
-import { authenticateToken, generateToken, requireSessionAuth } from '../middleware/auth.ts';
+import {
+  authenticateToken,
+  generateToken,
+  getSessionAuth,
+  requireSessionAuth,
+} from '../middleware/auth.ts';
 import * as rolesRepo from '../repositories/rolesRepo.ts';
 import * as usersRepo from '../repositories/usersRepo.ts';
 import { standardRateLimitedErrorResponses } from '../schemas/common.ts';
@@ -281,7 +286,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.post(
     '/switch-role',
     {
-      onRequest: [authenticateToken],
+      onRequest: [authenticateToken, requireSessionAuth],
       schema: {
         tags: ['auth'],
         summary: 'Switch active role (session-only)',
@@ -297,8 +302,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const roleIdResult = requireNonEmptyString(roleId, 'roleId');
       if (!roleIdResult.ok) return badRequest(reply, roleIdResult.message);
 
-      const session = requireSessionAuth(request, reply);
-      if (!session) return;
+      const session = getSessionAuth(request);
 
       const hasRole = await rolesRepo.userHasRole(session.userId, roleIdResult.value);
       if (!hasRole) {
@@ -366,7 +370,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.post(
     '/logout',
     {
-      onRequest: [authenticateToken],
+      onRequest: [authenticateToken, requireSessionAuth],
       schema: {
         tags: ['auth'],
         summary: 'Logout (revoke all sessions for this user)',
@@ -377,8 +381,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       },
     },
     async (request: FastifyRequest, reply: FastifyReply) => {
-      const session = requireSessionAuth(request, reply);
-      if (!session) return;
+      const session = getSessionAuth(request);
 
       await Promise.all([
         usersRepo.bumpSessionVersion(session.userId),

--- a/server/test/helpers/authMiddlewareMock.ts
+++ b/server/test/helpers/authMiddlewareMock.ts
@@ -30,6 +30,7 @@ export const installAuthMiddlewareMock = () => {
       wrapHook(middlewareSnap.requirePermission(...args)),
     requireAnyPermission: (...args: Parameters<typeof middlewareSnap.requireAnyPermission>) =>
       wrapHook(middlewareSnap.requireAnyPermission(...args)),
+    requireSessionAuth: wrapHook(middlewareSnap.requireSessionAuth),
   }));
 };
 

--- a/server/test/middleware/auth.test.ts
+++ b/server/test/middleware/auth.test.ts
@@ -4,9 +4,11 @@ import {
   __resetPatIdleTimeoutCacheForTests,
   authenticateToken,
   generateToken,
+  getSessionAuth,
   requireAnyPermission,
   requirePermission,
   requireRole,
+  requireSessionAuth,
 } from '../../middleware/auth.ts';
 import * as realAuditLogsRepo from '../../repositories/auditLogsRepo.ts';
 import * as realPersonalAccessTokensRepo from '../../repositories/personalAccessTokensRepo.ts';
@@ -644,6 +646,55 @@ describe('requireRole', () => {
     expect(reply.statusCode).toBe(0);
     expect(reply.body).toBeUndefined();
     expect(auditLogsCreateMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('requireSessionAuth', () => {
+  test('403s as a hook when request auth is not session-backed', async () => {
+    const request = {
+      auth: { userId: 'u1', source: 'personalAccessToken' },
+    };
+    const reply = buildFakeReply();
+
+    await requireSessionAuth(request as never, reply as never);
+
+    expect(reply.statusCode).toBe(403);
+    expect(reply.body).toEqual({ error: 'Session authentication required' });
+  });
+
+  test('does not return nullable session data from the hook', async () => {
+    const request = {
+      auth: {
+        userId: 'u1',
+        source: 'session',
+        sessionStart: 123,
+        sessionVersion: 2,
+      },
+    };
+    const reply = buildFakeReply();
+
+    const result = await requireSessionAuth(request as never, reply as never);
+
+    expect(result).toBeUndefined();
+    expect(reply.statusCode).toBe(0);
+    expect(getSessionAuth(request as never)).toEqual({
+      userId: 'u1',
+      sessionStart: 123,
+      sessionVersion: 2,
+    });
+  });
+
+  test('getSessionAuth throws a 403 error if the session guard was not satisfied', () => {
+    const request = {
+      auth: { userId: 'u1', source: 'personalAccessToken' },
+    };
+
+    expect(() => getSessionAuth(request as never)).toThrow('Session authentication required');
+    try {
+      getSessionAuth(request as never);
+    } catch (error) {
+      expect((error as { statusCode?: number }).statusCode).toBe(403);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- Converts session-only auth checks into a Fastify onRequest guard for role switching and logout.
- Adds a non-null session context reader for handlers after the guard has passed.
- Adds regression coverage for the guard and reader contract.

## Changes
- Splits requireSessionAuth into a response-only route guard and getSessionAuth for session context access.
- Applies the session guard to /api/auth/switch-role and /api/auth/logout.
- Updates auth route test middleware wrapping so the new guard short-circuits under Fastify inject.

## Testing
- bun x biome check server/middleware/auth.ts server/routes/auth.ts server/test/helpers/authMiddlewareMock.ts server/test/middleware/auth.test.ts
- bun run typecheck
- bun test test/middleware/auth.test.ts (from server/)
- bun test test/routes/auth.test.ts (from server/)
- bun run test:server

## Risks / Rollout
- Low risk. Behavior is scoped to session-only auth endpoints and preserves the existing 403 response for personal access tokens.

## Issues
Fixes #508