### PR TITLE
database(fix): serialize transaction queries

### DIFF
--- a/server/repositories/clientOffersRepo.ts
+++ b/server/repositories/clientOffersRepo.ts
@@ -220,11 +220,13 @@ export const findFullForSnapshot = async (
   id: string,
   exec: DbExecutor = db,
 ): Promise<{ offer: ClientOffer; items: ClientOfferItem[] } | null> => {
-  const [offerRows, items] = await Promise.all([
-    exec.select().from(customerOffers).where(eq(customerOffers.id, id)).limit(1),
-    findItemsForOffer(id, exec),
-  ]);
+  const offerRows = await exec
+    .select()
+    .from(customerOffers)
+    .where(eq(customerOffers.id, id))
+    .limit(1);
   if (offerRows.length === 0) return null;
+  const items = await findItemsForOffer(id, exec);
   return { offer: mapOffer(offerRows[0]), items };
 };
 

--- a/server/repositories/clientQuotesRepo.ts
+++ b/server/repositories/clientQuotesRepo.ts
@@ -350,11 +350,13 @@ export const findFullForSnapshot = async (
   id: string,
   exec: DbExecutor = db,
 ): Promise<{ quote: ClientQuote; items: ClientQuoteItem[] } | null> => {
-  const [quoteRows, items] = await Promise.all([
-    exec.select(QUOTE_BASE_PROJECTION).from(quotes).where(eq(quotes.id, id)).limit(1),
-    findItemsForQuote(id, exec),
-  ]);
+  const quoteRows = await exec
+    .select(QUOTE_BASE_PROJECTION)
+    .from(quotes)
+    .where(eq(quotes.id, id))
+    .limit(1);
   if (quoteRows.length === 0) return null;
+  const items = await findItemsForQuote(id, exec);
   return { quote: mapQuote(quoteRows[0]), items };
 };
 

--- a/server/repositories/clientsOrdersRepo.ts
+++ b/server/repositories/clientsOrdersRepo.ts
@@ -233,11 +233,9 @@ export const findFullForSnapshot = async (
   orderId: string,
   exec: DbExecutor = db,
 ): Promise<{ order: ClientOrder; items: ClientOrderItem[] } | null> => {
-  const [orderRows, items] = await Promise.all([
-    exec.select().from(sales).where(eq(sales.id, orderId)).limit(1),
-    findItemsForOrder(orderId, exec),
-  ]);
+  const orderRows = await exec.select().from(sales).where(eq(sales.id, orderId)).limit(1);
   if (orderRows.length === 0) return null;
+  const items = await findItemsForOrder(orderId, exec);
   return { order: mapOrder(orderRows[0]), items };
 };
 

--- a/server/repositories/supplierOrdersRepo.ts
+++ b/server/repositories/supplierOrdersRepo.ts
@@ -88,11 +88,13 @@ export const findFullForSnapshot = async (
   id: string,
   exec: DbExecutor = db,
 ): Promise<{ order: SupplierOrder; items: SupplierOrderItem[] } | null> => {
-  const [orderRows, items] = await Promise.all([
-    exec.select().from(supplierSales).where(eq(supplierSales.id, id)).limit(1),
-    findItemsForOrder(id, exec),
-  ]);
+  const orderRows = await exec
+    .select()
+    .from(supplierSales)
+    .where(eq(supplierSales.id, id))
+    .limit(1);
   if (orderRows.length === 0) return null;
+  const items = await findItemsForOrder(id, exec);
   return { order: mapOrder(orderRows[0]), items };
 };
 

--- a/server/repositories/supplierQuotesRepo.ts
+++ b/server/repositories/supplierQuotesRepo.ts
@@ -127,11 +127,13 @@ export const findFullForSnapshot = async (
   id: string,
   exec: DbExecutor = db,
 ): Promise<{ quote: SupplierQuote; items: SupplierQuoteItem[] } | null> => {
-  const [quoteRows, items] = await Promise.all([
-    exec.select().from(supplierQuotes).where(eq(supplierQuotes.id, id)).limit(1),
-    findItemsForQuote(id, exec),
-  ]);
+  const quoteRows = await exec
+    .select()
+    .from(supplierQuotes)
+    .where(eq(supplierQuotes.id, id))
+    .limit(1);
   if (quoteRows.length === 0) return null;
+  const items = await findItemsForQuote(id, exec);
   return { quote: mapQuote(quoteRows[0]), items };
 };
 

--- a/server/repositories/userAssignmentsRepo.ts
+++ b/server/repositories/userAssignmentsRepo.ts
@@ -256,51 +256,46 @@ export const syncTopManagerAssignmentsForUser = async (
   userId: string,
   exec: DbExecutor = db,
 ): Promise<void> => {
-  const isTopManager = await userHasTopManagerRole(userId, exec);
-
-  // Each branch mutates multiple tables in parallel; the wrap rolls back the others when
-  // one Promise.all leg fails. (`runAtomically`'s default doc covers the simpler
-  // DELETE-then-INSERT case, not the multi-table parallel case.)
+  // Keep the role read and assignment fan-out in one atomic scope for standalone callers;
+  // callers that already supplied a transaction reuse it via runAtomically.
   await runAtomically(exec, async (tx) => {
+    const isTopManager = await userHasTopManagerRole(userId, tx);
+
+    // These branches often run inside an existing transaction. Keep the statements
+    // serialized because Drizzle's transaction executor is backed by a single pg client.
     if (!isTopManager) {
-      await Promise.all([
-        tx
-          .delete(userClients)
-          .where(
-            and(
-              eq(userClients.userId, userId),
-              eq(userClients.assignmentSource, TOP_MANAGER_AUTO_ASSIGNMENT_SOURCE),
-            ),
+      await tx
+        .delete(userClients)
+        .where(
+          and(
+            eq(userClients.userId, userId),
+            eq(userClients.assignmentSource, TOP_MANAGER_AUTO_ASSIGNMENT_SOURCE),
           ),
-        tx
-          .delete(userProjects)
-          .where(
-            and(
-              eq(userProjects.userId, userId),
-              eq(userProjects.assignmentSource, TOP_MANAGER_AUTO_ASSIGNMENT_SOURCE),
-            ),
+        );
+      await tx
+        .delete(userProjects)
+        .where(
+          and(
+            eq(userProjects.userId, userId),
+            eq(userProjects.assignmentSource, TOP_MANAGER_AUTO_ASSIGNMENT_SOURCE),
           ),
-        tx
-          .delete(userTasks)
-          .where(
-            and(
-              eq(userTasks.userId, userId),
-              eq(userTasks.assignmentSource, TOP_MANAGER_AUTO_ASSIGNMENT_SOURCE),
-            ),
+        );
+      await tx
+        .delete(userTasks)
+        .where(
+          and(
+            eq(userTasks.userId, userId),
+            eq(userTasks.assignmentSource, TOP_MANAGER_AUTO_ASSIGNMENT_SOURCE),
           ),
-      ]);
-      // Cascade rebuild reads from `user_projects`, which the parallel deletes above just
-      // modified - sequenced after the `await Promise.all(...)` so it sees the final state,
-      // never an interleaved view.
+        );
+      // Cascade rebuild reads from `user_projects`, which the deletes above just modified.
       await applyProjectCascadeToClients(userId, tx);
       return;
     }
 
-    await Promise.all([
-      assignAllToUserAsTopManager(ASSIGNMENT_SPECS.clients, userId, tx),
-      assignAllToUserAsTopManager(ASSIGNMENT_SPECS.projects, userId, tx),
-      assignAllToUserAsTopManager(ASSIGNMENT_SPECS.tasks, userId, tx),
-    ]);
+    await assignAllToUserAsTopManager(ASSIGNMENT_SPECS.clients, userId, tx);
+    await assignAllToUserAsTopManager(ASSIGNMENT_SPECS.projects, userId, tx);
+    await assignAllToUserAsTopManager(ASSIGNMENT_SPECS.tasks, userId, tx);
   });
 };
 

--- a/server/routes/client-offers.ts
+++ b/server/routes/client-offers.ts
@@ -1210,11 +1210,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       // and the restore write.
       const result: RestoreOutcome = await withDbTransaction(async (tx) => {
         const current = await clientOffersRepo.lockExistingById(idResult.value, tx);
-        const [linkedSaleId, version] = await Promise.all([
-          clientOffersRepo.findLinkedSaleId(idResult.value, tx),
-          offerVersionsRepo.findById(idResult.value, versionIdResult.value, tx),
-        ]);
-
         if (!current) {
           return {
             ok: false,
@@ -1233,6 +1228,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
             extraBody: { currentStatus: current.status },
           };
         }
+
+        const linkedSaleId = await clientOffersRepo.findLinkedSaleId(idResult.value, tx);
         if (linkedSaleId) {
           return {
             ok: false,
@@ -1242,6 +1239,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
             secondaryLabel: 'sale_order_exists',
           };
         }
+
+        const version = await offerVersionsRepo.findById(idResult.value, versionIdResult.value, tx);
         if (!version) {
           return {
             ok: false,

--- a/server/routes/client-quotes.ts
+++ b/server/routes/client-quotes.ts
@@ -1142,11 +1142,12 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           };
         }
 
-        const [linkedOfferId, nonDraftLinkedSale, version] = await Promise.all([
-          clientQuotesRepo.findLinkedOfferId(idResult.value, tx),
-          clientQuotesRepo.findNonDraftLinkedSale(idResult.value, tx),
-          quoteVersionsRepo.findById(idResult.value, versionIdResult.value, tx),
-        ]);
+        const linkedOfferId = await clientQuotesRepo.findLinkedOfferId(idResult.value, tx);
+        const nonDraftLinkedSale = await clientQuotesRepo.findNonDraftLinkedSale(
+          idResult.value,
+          tx,
+        );
+        const version = await quoteVersionsRepo.findById(idResult.value, versionIdResult.value, tx);
 
         if (linkedOfferId) {
           return {

--- a/server/routes/clients-orders.ts
+++ b/server/routes/clients-orders.ts
@@ -681,13 +681,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
             // terms on the auto-created order.
             const lockedStatus = await supplierQuotesRepo.lockStatusById(sqId, tx);
             if (!lockedStatus || lockedStatus.status !== 'accepted') return false;
-            const [linkedUnderLock, supplierQuote, supplierItems] = await Promise.all([
-              supplierQuotesRepo.findLinkedOrderId(sqId, tx),
-              supplierQuotesRepo.findById(sqId, tx),
-              supplierQuotesRepo.findItemsForQuote(sqId, tx),
-            ]);
+            const linkedUnderLock = await supplierQuotesRepo.findLinkedOrderId(sqId, tx);
             if (linkedUnderLock) return false;
+            const supplierQuote = await supplierQuotesRepo.findById(sqId, tx);
             if (!supplierQuote) return false;
+            const supplierItems = await supplierQuotesRepo.findItemsForQuote(sqId, tx);
 
             const supplierOrderId = await generateSupplierOrderId(tx);
             await clientsOrdersRepo.createSupplierOrder(

--- a/server/routes/projects.ts
+++ b/server/routes/projects.ts
@@ -316,17 +316,15 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
                 tx,
               );
 
-              await Promise.all([
-                userAssignmentsRepo.assignClientToUser(
-                  request.user.id,
-                  clientIdResult.value,
-                  undefined,
-                  tx,
-                ),
-                userAssignmentsRepo.assignProjectToUser(request.user.id, id, undefined, tx),
-                userAssignmentsRepo.assignClientToTopManagers(clientIdResult.value, tx),
-                userAssignmentsRepo.assignProjectToTopManagers(id, tx),
-              ]);
+              await userAssignmentsRepo.assignClientToUser(
+                request.user.id,
+                clientIdResult.value,
+                undefined,
+                tx,
+              );
+              await userAssignmentsRepo.assignProjectToUser(request.user.id, id, undefined, tx);
+              await userAssignmentsRepo.assignClientToTopManagers(clientIdResult.value, tx);
+              await userAssignmentsRepo.assignProjectToTopManagers(id, tx);
 
               return project;
             });
@@ -605,7 +603,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           // otherwise the existing column value. We only need the existing values when the
           // client is also changing (an unchanged client means the existing link was already
           // valid). Cross-checking both is otherwise the same lookup that previously ran
-          // only against patch values — running both in parallel pipelines on one connection.
+          // only against patch values; keep the reads serialized on this transaction
+          // connection.
           const orderIdPatch = orderId === undefined ? undefined : orderId || null;
           const orderPatchPresent = orderIdPatch !== undefined;
           const existingLinks =
@@ -617,10 +616,12 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
             ? offerIdPatch.value
             : (existingLinks?.offerId ?? null);
 
-          const [orderClientId, offerClientId] = await Promise.all([
-            finalOrderId ? clientsOrdersRepo.findClientIdById(finalOrderId, tx) : null,
-            finalOfferId ? clientOffersRepo.findClientIdById(finalOfferId, tx) : null,
-          ]);
+          const orderClientId = finalOrderId
+            ? await clientsOrdersRepo.findClientIdById(finalOrderId, tx)
+            : null;
+          const offerClientId = finalOfferId
+            ? await clientOffersRepo.findClientIdById(finalOfferId, tx)
+            : null;
           if (finalOrderId && orderClientId !== null && orderClientId !== requestedClientId) {
             throw new OrderClientMismatchError('orderId does not belong to the specified clientId');
           }

--- a/server/routes/supplier-orders.ts
+++ b/server/routes/supplier-orders.ts
@@ -872,10 +872,12 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           };
         }
 
-        const [linkedInvoiceId, version] = await Promise.all([
-          supplierOrdersRepo.findLinkedInvoiceId(idResult.value, tx),
-          supplierOrderVersionsRepo.findById(idResult.value, versionIdResult.value, tx),
-        ]);
+        const linkedInvoiceId = await supplierOrdersRepo.findLinkedInvoiceId(idResult.value, tx);
+        const version = await supplierOrderVersionsRepo.findById(
+          idResult.value,
+          versionIdResult.value,
+          tx,
+        );
 
         if (linkedInvoiceId) {
           return {

--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -314,24 +314,19 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
             tx,
           );
 
-          const assignments: Promise<void>[] = [
-            userAssignmentsRepo.assignProjectToUser(
-              request.user.id,
-              projectIdResult.value,
-              undefined,
-              tx,
-            ),
-            userAssignmentsRepo.assignTaskToUser(request.user.id, id, undefined, tx),
-            userAssignmentsRepo.assignProjectToTopManagers(projectIdResult.value, tx),
-            userAssignmentsRepo.assignTaskToTopManagers(id, tx),
-          ];
+          await userAssignmentsRepo.assignProjectToUser(
+            request.user.id,
+            projectIdResult.value,
+            undefined,
+            tx,
+          );
+          await userAssignmentsRepo.assignTaskToUser(request.user.id, id, undefined, tx);
+          await userAssignmentsRepo.assignProjectToTopManagers(projectIdResult.value, tx);
+          await userAssignmentsRepo.assignTaskToTopManagers(id, tx);
           if (clientId) {
-            assignments.push(
-              userAssignmentsRepo.assignClientToUser(request.user.id, clientId, undefined, tx),
-              userAssignmentsRepo.assignClientToTopManagers(clientId, tx),
-            );
+            await userAssignmentsRepo.assignClientToUser(request.user.id, clientId, undefined, tx);
+            await userAssignmentsRepo.assignClientToTopManagers(clientId, tx);
           }
-          await Promise.all(assignments);
 
           return task;
         });

--- a/server/test/repositories/clientOffersRepo.test.ts
+++ b/server/test/repositories/clientOffersRepo.test.ts
@@ -351,11 +351,9 @@ describe('replaceItems', () => {
 });
 
 describe('findFullForSnapshot', () => {
-  // The items helper hits its query during synchronous async-fn evaluation, so it lands
-  // ahead of the offer thenable in the enqueue queue.
   test('returns offer + items when offer exists', async () => {
-    exec.enqueue({ rows: [itemRow()] });
     exec.enqueue({ rows: [offerRow()] });
+    exec.enqueue({ rows: [itemRow()] });
     const result = await clientOffersRepo.findFullForSnapshot('co-1', testDb);
     expect(result).not.toBeNull();
     expect(result?.offer.id).toBe('co-1');

--- a/server/test/repositories/clientQuotesRepo.test.ts
+++ b/server/test/repositories/clientQuotesRepo.test.ts
@@ -389,11 +389,8 @@ describe('findItemsForQuote', () => {
 
 describe('findFullForSnapshot', () => {
   test('returns quote and items when quote exists', async () => {
-    // Promise.all dispatches `findItemsForQuote(id)` first (its async body runs to its first
-    // await before the sibling thenable is consumed), so the items query is what dequeues the
-    // first response.
-    exec.enqueue({ rows: [itemRow()] });
     exec.enqueue({ rows: [quoteRow()] });
+    exec.enqueue({ rows: [itemRow()] });
     const result = await clientQuotesRepo.findFullForSnapshot('cq-1', testDb);
     expect(result).not.toBeNull();
     expect(result?.quote.id).toBe('cq-1');

--- a/server/test/repositories/clientsOrdersRepo.test.ts
+++ b/server/test/repositories/clientsOrdersRepo.test.ts
@@ -439,10 +439,8 @@ describe('findItemsForOrder', () => {
 
 describe('findFullForSnapshot', () => {
   test('returns order and items when order exists', async () => {
-    // Promise.all dispatches `findItemsForOrder(id)` first (its async body runs to its first
-    // await before the sibling thenable is consumed), so the items query dequeues first.
-    exec.enqueue({ rows: [itemRow()] });
     exec.enqueue({ rows: [orderRow()] });
+    exec.enqueue({ rows: [itemRow()] });
     const result = await repo.findFullForSnapshot('co-1', testDb);
     expect(result).not.toBeNull();
     expect(result?.order.id).toBe('co-1');

--- a/server/test/repositories/supplierOrdersRepo.test.ts
+++ b/server/test/repositories/supplierOrdersRepo.test.ts
@@ -263,10 +263,8 @@ describe('findItemsForOrder', () => {
 
 describe('findFullForSnapshot', () => {
   test('returns order and items when order exists', async () => {
-    // Promise.all dispatches `findItemsForOrder(id)` first (its async body runs to its first
-    // await before the sibling thenable is consumed), so the items query dequeues first.
-    exec.enqueue({ rows: [itemRow()] });
     exec.enqueue({ rows: [orderRow()] });
+    exec.enqueue({ rows: [itemRow()] });
     const result = await supplierOrdersRepo.findFullForSnapshot('so-1', testDb);
     expect(result).not.toBeNull();
     expect(result?.order.id).toBe('so-1');

--- a/server/test/repositories/supplierQuotesRepo.test.ts
+++ b/server/test/repositories/supplierQuotesRepo.test.ts
@@ -280,10 +280,8 @@ describe('findItemsForQuote', () => {
 
 describe('findFullForSnapshot', () => {
   test('returns quote and items when quote exists', async () => {
-    // Promise.all dispatches `findItemsForQuote(id)` first (its async body runs to its first
-    // await before the sibling thenable is consumed), so the items query dequeues first.
-    exec.enqueue({ rows: [itemRow()] });
     exec.enqueue({ rows: [quoteRow()] });
+    exec.enqueue({ rows: [itemRow()] });
     const result = await supplierQuotesRepo.findFullForSnapshot('q-1', testDb);
     expect(result).not.toBeNull();
     expect(result?.quote.id).toBe('q-1');

--- a/server/test/repositories/userAssignmentsRepo.test.ts
+++ b/server/test/repositories/userAssignmentsRepo.test.ts
@@ -149,7 +149,7 @@ describe('syncTopManagerAssignmentsForUser', () => {
     // Role check returns no row → not a top manager → 3 deletes + cascade rebuild.
     const enqueueNonTopManager = () => {
       exec.enqueue({ rows: [] }); // userHasTopManagerRole → false
-      exec.enqueueEmptyN(4); // 3 parallel deletes + 1 cascade rebuild
+      exec.enqueueEmptyN(4); // 3 deletes + 1 cascade rebuild
     };
 
     test('runs the role check first', async () => {
@@ -161,7 +161,6 @@ describe('syncTopManagerAssignmentsForUser', () => {
     test('deletes top_manager_auto rows from user_clients/user_projects/user_tasks', async () => {
       enqueueNonTopManager();
       await syncTopManagerAssignmentsForUser('u-1', testDb);
-      // Promise.all order isn't deterministic; assert each delete by table name.
       for (const table of ['user_clients', 'user_projects', 'user_tasks']) {
         const call = findCall((s) => s.toLowerCase().includes(`delete from "${table}"`));
         expect(call).toBeDefined();
@@ -198,7 +197,7 @@ describe('syncTopManagerAssignmentsForUser', () => {
     // Role check returns a row → top manager → 3 INSERTs (no deletes).
     const enqueueTopManager = () => {
       exec.enqueue({ rows: [[1]] }); // userHasTopManagerRole → true
-      exec.enqueueEmptyN(3); // 3 parallel INSERTs
+      exec.enqueueEmptyN(3); // 3 INSERTs
     };
 
     test('runs the role check first', async () => {

--- a/server/test/routes/client-offers-versions.test.ts
+++ b/server/test/routes/client-offers-versions.test.ts
@@ -405,6 +405,8 @@ describe('POST /api/sales/client-offers/:id/versions/:versionId/restore', () => 
     expect(res.statusCode).toBe(404);
     expect(coRestoreSnapshotOfferMock).not.toHaveBeenCalled();
     expect(ovInsertMock).not.toHaveBeenCalled();
+    expect(coFindLinkedSaleIdMock).not.toHaveBeenCalled();
+    expect(ovFindByIdMock).not.toHaveBeenCalled();
   });
 
   test('409 when offer is not draft', async () => {
@@ -424,6 +426,8 @@ describe('POST /api/sales/client-offers/:id/versions/:versionId/restore', () => 
 
     expect(res.statusCode).toBe(409);
     expect(coRestoreSnapshotOfferMock).not.toHaveBeenCalled();
+    expect(coFindLinkedSaleIdMock).not.toHaveBeenCalled();
+    expect(ovFindByIdMock).not.toHaveBeenCalled();
   });
 
   test('409 when any linked sale exists (draft or otherwise)', async () => {
@@ -445,6 +449,7 @@ describe('POST /api/sales/client-offers/:id/versions/:versionId/restore', () => 
     expect(res.statusCode).toBe(409);
     expect(coRestoreSnapshotOfferMock).not.toHaveBeenCalled();
     expect(ovInsertMock).not.toHaveBeenCalled();
+    expect(ovFindByIdMock).not.toHaveBeenCalled();
   });
 
   test('409 when snapshot client no longer exists', async () => {
@@ -623,6 +628,7 @@ describe('POST /api/sales/client-offers/:id/revert-to-draft', () => {
     expect(res.statusCode).toBe(409);
     expect(coUpdateMock).not.toHaveBeenCalled();
     expect(ovInsertMock).not.toHaveBeenCalled();
+    expect(coFindLinkedSaleIdMock).not.toHaveBeenCalled();
   });
 
   test('409 when accepted offer already has a linked sale order', async () => {

--- a/server/test/routes/client-quotes-versions.test.ts
+++ b/server/test/routes/client-quotes-versions.test.ts
@@ -427,6 +427,9 @@ describe('POST /api/sales/client-quotes/:id/versions/:versionId/restore', () => 
 
     expect(res.statusCode).toBe(404);
     expect(cqRestoreSnapshotQuoteMock).not.toHaveBeenCalled();
+    expect(cqFindLinkedOfferIdMock).not.toHaveBeenCalled();
+    expect(cqFindNonDraftLinkedSaleMock).not.toHaveBeenCalled();
+    expect(qvFindByIdMock).not.toHaveBeenCalled();
   });
 
   test('409 when quote is confirmed', async () => {
@@ -445,6 +448,9 @@ describe('POST /api/sales/client-quotes/:id/versions/:versionId/restore', () => 
 
     expect(res.statusCode).toBe(409);
     expect(cqRestoreSnapshotQuoteMock).not.toHaveBeenCalled();
+    expect(cqFindLinkedOfferIdMock).not.toHaveBeenCalled();
+    expect(cqFindNonDraftLinkedSaleMock).not.toHaveBeenCalled();
+    expect(qvFindByIdMock).not.toHaveBeenCalled();
   });
 
   test('409 when non-draft linked sale exists', async () => {

--- a/server/test/routes/supplier-orders-versions.test.ts
+++ b/server/test/routes/supplier-orders-versions.test.ts
@@ -415,6 +415,8 @@ describe('POST /api/accounting/supplier-orders/:id/versions/:versionId/restore',
 
     expect(res.statusCode).toBe(404);
     expect(soRestoreSnapshotOrderMock).not.toHaveBeenCalled();
+    expect(soFindLinkedInvoiceIdMock).not.toHaveBeenCalled();
+    expect(sovFindByIdMock).not.toHaveBeenCalled();
   });
 
   test('409 when order is non-draft', async () => {
@@ -435,6 +437,8 @@ describe('POST /api/accounting/supplier-orders/:id/versions/:versionId/restore',
 
     expect(res.statusCode).toBe(409);
     expect(soRestoreSnapshotOrderMock).not.toHaveBeenCalled();
+    expect(soFindLinkedInvoiceIdMock).not.toHaveBeenCalled();
+    expect(sovFindByIdMock).not.toHaveBeenCalled();
   });
 
   test('409 when snapshot supplier no longer exists', async () => {


### PR DESCRIPTION
## Summary
- Serializes Drizzle queries that share a transaction executor to avoid pg client re-entry deprecation warnings.
- Keeps snapshot reads and restore gate checks ordered inside transactions, with early exits for missing or invalid locked rows.
- Keeps top-manager assignment role checks inside the same atomic scope as assignment synchronization.

## Changes
- Replaces transaction-scoped `Promise.all` usage in restore flows, project/task assignment fan-out, supplier-order auto-creation, and top-manager sync.
- Updates snapshot helpers to read the parent row before item rows when using a shared executor.
- Adds/updates regression coverage for serialized snapshot reads and skipped restore checks.

## Testing
- `cd server && bun run build`
- `cd server && bun test ./test`
- `bun run lint`

Note: `bun run lint` passes with two pre-existing warnings in `components/HR/EmployeeAssignmentsModal.tsx` and `hooks/handlers/userHandlers.ts`.

## Risks / Rollout
- Low risk. The change is scoped to query orchestration inside existing transaction flows.
- No migrations, dependency changes, or user-facing API changes.
- Potential runtime tradeoff is slightly less intra-request parallelism for these transaction-bound paths, which is intentional because they share one pg client.

## Issues
Issue: Not linked