### PR TITLE
crypto(fix): harden encrypted payload decoding

### DIFF
--- a/server/test/utils/crypto.test.ts
+++ b/server/test/utils/crypto.test.ts
@@ -43,6 +43,9 @@ const decryptPayloadWithAesGcmKey = (
   );
 };
 
+const base64Bytes = (length: number, fill = 0): string =>
+  Buffer.alloc(length, fill).toString('base64');
+
 beforeAll(() => {
   process.env.ENCRYPTION_KEY = 'test-encryption-key-for-unit-tests';
   __resetEncryptionKeyCacheForTests();
@@ -222,12 +225,48 @@ describe('decrypt', () => {
     expect(decrypt(ciphertext)).toBe('legacy secret');
   });
 
+  test('decrypts legacy empty plaintext ciphertext for backward compatibility', () => {
+    const legacyKey = deriveLegacyEncryptionKey(process.env.ENCRYPTION_KEY ?? '');
+    const ciphertext = encryptWithAesGcmKey('', legacyKey);
+    expect(decrypt(ciphertext)).toBe('');
+  });
+
   test('throws when input does not match the iv:authTag:encrypted format', () => {
     expect(() => decrypt('plaintext-no-colons')).toThrow(/Invalid encrypted value format/);
   });
 
+  test('throws a format error before Node crypto handles malformed decoded lengths', () => {
+    const malformedCiphertexts = [
+      `v2:${base64Bytes(SALT_LENGTH - 1)}:${base64Bytes(V2_IV_LENGTH)}:${base64Bytes(AUTH_TAG_LENGTH)}:`,
+      `v2:${base64Bytes(SALT_LENGTH)}:${base64Bytes(V2_IV_LENGTH - 1)}:${base64Bytes(AUTH_TAG_LENGTH)}:`,
+      `v2:${base64Bytes(SALT_LENGTH)}:${base64Bytes(V2_IV_LENGTH)}:${base64Bytes(AUTH_TAG_LENGTH - 1)}:`,
+      `${base64Bytes(LEGACY_IV_LENGTH - 1)}:${base64Bytes(AUTH_TAG_LENGTH)}:`,
+      `${base64Bytes(LEGACY_IV_LENGTH)}:${base64Bytes(AUTH_TAG_LENGTH - 1)}:`,
+    ];
+
+    for (const ciphertext of malformedCiphertexts) {
+      expect(() => decrypt(ciphertext)).toThrow(/Invalid encrypted value format/);
+    }
+  });
+
+  test('throws a format error for non-canonical base64 segments before decrypting', () => {
+    const malformedCiphertexts = [
+      `v2:${base64Bytes(SALT_LENGTH)}!:${base64Bytes(V2_IV_LENGTH)}:${base64Bytes(AUTH_TAG_LENGTH)}:`,
+      `v2:${base64Bytes(SALT_LENGTH)}:${base64Bytes(V2_IV_LENGTH)}!:${base64Bytes(AUTH_TAG_LENGTH)}:`,
+      `v2:${base64Bytes(SALT_LENGTH)}:${base64Bytes(V2_IV_LENGTH)}:${base64Bytes(AUTH_TAG_LENGTH)}!:`,
+      `v2:${base64Bytes(SALT_LENGTH)}:${base64Bytes(V2_IV_LENGTH)}:${base64Bytes(AUTH_TAG_LENGTH)}:!!!!`,
+      `${base64Bytes(LEGACY_IV_LENGTH)}!:${base64Bytes(AUTH_TAG_LENGTH)}:`,
+      `${base64Bytes(LEGACY_IV_LENGTH)}:${base64Bytes(AUTH_TAG_LENGTH)}!:`,
+      `${base64Bytes(LEGACY_IV_LENGTH)}:${base64Bytes(AUTH_TAG_LENGTH)}:!!!!`,
+    ];
+
+    for (const ciphertext of malformedCiphertexts) {
+      expect(() => decrypt(ciphertext)).toThrow(/Invalid encrypted value format/);
+    }
+  });
+
   test('throws when ciphertext parses but GCM auth tag verification fails', () => {
-    const fakeCiphertext = `${Buffer.from('iv').toString('base64')}:${Buffer.from('tag').toString('base64')}:${Buffer.from('data').toString('base64')}`;
+    const fakeCiphertext = `${base64Bytes(LEGACY_IV_LENGTH, 1)}:${base64Bytes(AUTH_TAG_LENGTH, 2)}:${Buffer.from('data').toString('base64')}`;
     expect(() => decrypt(fakeCiphertext)).toThrow();
   });
 

--- a/server/utils/crypto.ts
+++ b/server/utils/crypto.ts
@@ -140,6 +140,34 @@ type EncryptedPayload = {
   encrypted: Buffer;
 };
 
+const BASE64_PATTERN = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+
+const decodeBase64Segment = (value: string, allowEmpty = false): Buffer => {
+  if (value === '') {
+    if (allowEmpty) return Buffer.alloc(0);
+    throw new Error('Invalid encrypted value format');
+  }
+  if (!BASE64_PATTERN.test(value)) {
+    throw new Error('Invalid encrypted value format');
+  }
+  const decoded = Buffer.from(value, 'base64');
+  if (decoded.toString('base64') !== value) {
+    throw new Error('Invalid encrypted value format');
+  }
+  return decoded;
+};
+
+const assertEncryptedPayloadLengths = (payload: EncryptedPayload): void => {
+  const expectedIvLength = payload.salt === null ? LEGACY_IV_LENGTH : IV_LENGTH;
+  if (
+    (payload.salt !== null && payload.salt.length !== SALT_LENGTH) ||
+    payload.iv.length !== expectedIvLength ||
+    payload.authTag.length !== AUTH_TAG_LENGTH
+  ) {
+    throw new Error('Invalid encrypted value format');
+  }
+};
+
 const parseEncryptedPayload = (ciphertext: string): EncryptedPayload => {
   const parts = ciphertext.split(':');
   if (parts.length === 5 && parts[0] === ENCRYPTION_FORMAT_VERSION) {
@@ -147,12 +175,14 @@ const parseEncryptedPayload = (ciphertext: string): EncryptedPayload => {
     if (!saltB64 || !ivB64 || !authTagB64) {
       throw new Error('Invalid encrypted value format');
     }
-    return {
-      salt: Buffer.from(saltB64, 'base64'),
-      iv: Buffer.from(ivB64, 'base64'),
-      authTag: Buffer.from(authTagB64, 'base64'),
-      encrypted: Buffer.from(encryptedB64, 'base64'),
+    const payload = {
+      salt: decodeBase64Segment(saltB64),
+      iv: decodeBase64Segment(ivB64),
+      authTag: decodeBase64Segment(authTagB64),
+      encrypted: decodeBase64Segment(encryptedB64, true),
     };
+    assertEncryptedPayloadLengths(payload);
+    return payload;
   }
   if (parts.length !== 3) {
     throw new Error('Invalid encrypted value format');
@@ -161,12 +191,14 @@ const parseEncryptedPayload = (ciphertext: string): EncryptedPayload => {
   if (!ivB64 || !authTagB64) {
     throw new Error('Invalid encrypted value format');
   }
-  return {
+  const payload = {
     salt: null,
-    iv: Buffer.from(ivB64, 'base64'),
-    authTag: Buffer.from(authTagB64, 'base64'),
-    encrypted: Buffer.from(encryptedB64, 'base64'),
+    iv: decodeBase64Segment(ivB64),
+    authTag: decodeBase64Segment(authTagB64),
+    encrypted: decodeBase64Segment(encryptedB64, true),
   };
+  assertEncryptedPayloadLengths(payload);
+  return payload;
 };
 
 const decryptWithKey = (payload: EncryptedPayload, key: Buffer): string => {


### PR DESCRIPTION
## Summary
- Validates encrypted payload envelope segments before passing data to Node.js crypto.
- Returns the repository's standard `Invalid encrypted value format` error for corrupt IV, auth tag, salt, or malformed base64 data.

## Changes
- Adds strict canonical base64 decoding for decrypt payload segments while preserving empty ciphertext payloads for empty plaintext.
- Validates v2 salt, v2 IV, legacy IV, and auth tag byte lengths at the parse boundary.
- Adds regression tests for malformed decoded lengths, non-canonical base64, and legacy empty plaintext compatibility.

## Testing
- `bun test ./test/utils/crypto.test.ts`
- `bun x biome check server/utils/crypto.ts server/test/utils/crypto.test.ts`
- `bun run build` from `server/`

## Risks / Rollout
- Low risk. Change is scoped to decrypt-time validation of corrupt encrypted values.
- Backward compatibility for valid v2 and legacy ciphertexts is covered, including empty plaintext.

## Issues
Fixes #530