### PR TITLE
entries(fix): harden bulk delete boolean query handling

### DIFF
--- a/server/routes/entries.ts
+++ b/server/routes/entries.ts
@@ -390,8 +390,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const { projectId, task, futureOnly, placeholderOnly } = request.query as {
         projectId: string;
         task: string;
-        futureOnly?: string;
-        placeholderOnly?: string;
+        futureOnly?: unknown;
+        placeholderOnly?: unknown;
       };
       try {
         await bulkDeleteTimeEntries(actorFromRequest(request), {

--- a/server/test/routes/entries.test.ts
+++ b/server/test/routes/entries.test.ts
@@ -1629,6 +1629,58 @@ describe('DELETE /api/entries (bulk)', () => {
     expect(callArgs.fromDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
   });
 
+  test('204 futureOnly=false leaves fromDate unset', async () => {
+    entriesBulkDeleteMock.mockResolvedValue(1);
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/entries?projectId=p1&task=Dev&futureOnly=false',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(204);
+    expect(entriesBulkDeleteMock).toHaveBeenCalledTimes(1);
+    const callArgs = entriesBulkDeleteMock.mock.calls[0][0];
+    expect(callArgs.fromDate).toBeUndefined();
+  });
+
+  test('204 placeholderOnly=true restricts tracker deletes to placeholders', async () => {
+    entriesBulkDeleteMock.mockResolvedValue(1);
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/entries?projectId=p1&task=Dev&placeholderOnly=true',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(204);
+    expect(entriesBulkDeleteMock).toHaveBeenCalledWith(
+      expect.objectContaining({ placeholderOnly: true }),
+    );
+  });
+
+  test('400 invalid boolean query value does not delete', async () => {
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/entries?projectId=p1&task=Dev&futureOnly=1',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(entriesBulkDeleteMock).not.toHaveBeenCalled();
+  });
+
+  test('400 repeated boolean query value does not delete', async () => {
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/entries?projectId=p1&task=Dev&placeholderOnly=true&placeholderOnly=false',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(entriesBulkDeleteMock).not.toHaveBeenCalled();
+  });
+
   test('400 missing projectId (Fastify schema)', async () => {
     const res = await testApp.inject({
       method: 'DELETE',


### PR DESCRIPTION
## Summary
- Aligns bulk entry delete query typing with the boolean schema and service parser boundary.
- Adds regression coverage for accepted and rejected boolean query edge cases.

## Changes
- Treats \utureOnly\ and \placeholderOnly\ as unknown in the route before service normalization.
- Covers explicit \utureOnly=false\, \placeholderOnly=true\, invalid boolean values, and repeated boolean params.

## Testing
- \cd server && bun test ./test/routes/entries.test.ts\`n- \un run typecheck\`n- \un x biome check server/routes/entries.ts server/test/routes/entries.test.ts\`n
## Risks / Rollout
- Low risk. The API schema and runtime behavior stay unchanged; this narrows route typing and adds regression tests.

## Issues
Fixes #537