### PR TITLE
timesheets(bug): prevent duplicate time entries

### DIFF
--- a/docs-site/src/content/docs/en/time-tracking.md
+++ b/docs-site/src/content/docs/en/time-tracking.md
@@ -11,13 +11,15 @@ Use the tracker to record time spent on projects and tasks. Each entry should in
 
 Before saving, verify that dates are correct and that the task belongs to the selected project. This keeps reports, totals, and costs consistent.
 
+Praetor does not allow a second entry for the same user, date, project, and task: `POST /api/entries` returns `409` when that combination already exists. Update the existing entry instead of creating a duplicate.
+
 When an entry is edited, Praetor uses the API-returned `version` field to prevent concurrent overwrites. If the same entry was saved elsewhere meanwhile, `PUT /api/entries/:id` returns `409` and the entry must be reloaded before retrying.
 
 ## Weekly view
 
 The weekly view helps you quickly review hours across days. Use it to find missing days, duplicates, or entries assigned to the wrong project.
 
-Each existing entry occupies its own row, so duplicates on the same client/project/task pair stay visible and can be edited independently. The "New entry" row at the top is for creating new entries only.
+Each existing entry occupies its own row, so any historical duplicate data stays visible and can be edited independently. The "New entry" row at the top is for creating new entries only and follows the duplicate-entry guard.
 
 ## Recurring tasks
 

--- a/docs-site/src/content/docs/time-tracking.md
+++ b/docs-site/src/content/docs/time-tracking.md
@@ -11,13 +11,15 @@ Usa il tracker per registrare il tempo lavorato su progetto e attività. Ogni re
 
 Prima di salvare, verifica che le date siano corrette e che l'attività appartenga al progetto selezionato. Questo mantiene coerenti report, consuntivi e costi.
 
+Praetor non consente di creare una seconda registrazione per lo stesso utente, data, progetto e attività: `POST /api/entries` risponde con `409` se la combinazione esiste già. Aggiorna la registrazione esistente invece di crearne una duplicata.
+
 Quando una registrazione viene modificata, Praetor usa il campo `version` restituito dall'API per impedire sovrascritture concorrenti. Se la stessa registrazione è stata salvata altrove nel frattempo, `PUT /api/entries/:id` risponde con `409` e occorre ricaricare la registrazione prima di riprovare.
 
 ## Vista settimanale
 
 La vista settimanale aiuta a controllare rapidamente le ore distribuite sui giorni. È utile per individuare giornate mancanti, duplicazioni o attività attribuite al progetto sbagliato.
 
-Ogni registrazione esistente occupa una propria riga, così eventuali duplicazioni sulla stessa coppia cliente/progetto/attività restano visibili e modificabili in modo indipendente. La riga "Nuova voce" in alto serve esclusivamente a creare nuove registrazioni.
+Ogni registrazione esistente occupa una propria riga, così eventuali dati storici duplicati restano visibili e modificabili in modo indipendente. La riga "Nuova voce" in alto serve esclusivamente a creare nuove registrazioni e rispetta il controllo anti-duplicato.
 
 ## Attività ricorrenti
 

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -9462,6 +9462,7 @@
         "tags": [
           "entries"
         ],
+        "description": "Creates one time entry. Returns 409 when the target user already has an entry for the same date, project, and task.",
         "requestBody": {
           "required": true,
           "content": {

--- a/server/repositories/entriesRepo.ts
+++ b/server/repositories/entriesRepo.ts
@@ -253,6 +253,32 @@ export const findExistingRecurringKeys = async (
   return new Set(rows.map((row) => `${row.date}|${row.projectId}|${row.task}`));
 };
 
+export type EntryUniquenessKey = {
+  userId: string;
+  date: string;
+  projectId: string;
+  task: string;
+};
+
+export const existsForEntryKey = async (
+  key: EntryUniquenessKey,
+  exec: DbExecutor = db,
+): Promise<boolean> => {
+  const rows = await exec
+    .select({ id: timeEntries.id })
+    .from(timeEntries)
+    .where(
+      and(
+        eq(timeEntries.userId, key.userId),
+        eq(timeEntries.date, key.date),
+        eq(timeEntries.projectId, key.projectId),
+        eq(timeEntries.task, key.task),
+      ),
+    )
+    .limit(1);
+  return rows.length > 0;
+};
+
 export const findOwner = async (id: string, exec: DbExecutor = db): Promise<string | null> => {
   const rows = await exec
     .select({ userId: timeEntries.userId })

--- a/server/routes/entries.ts
+++ b/server/routes/entries.ts
@@ -241,6 +241,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       schema: {
         tags: ['entries'],
         summary: 'Create time entry',
+        description:
+          'Creates one time entry. Returns 409 when the target user already has an entry ' +
+          'for the same date, project, and task.',
         body: entryCreateBodySchema,
         response: {
           201: entrySchema,

--- a/server/services/timeEntries.ts
+++ b/server/services/timeEntries.ts
@@ -80,6 +80,37 @@ const parseExpectedVersion = (value: unknown): number => {
   return value as number;
 };
 
+const SERIALIZATION_FAILURE_SQLSTATE = '40001';
+const MAX_SERIALIZABLE_WRITE_ATTEMPTS = 3;
+
+const getDbErrorCode = (err: unknown, depth = 0): string | undefined => {
+  if (depth > 3) return undefined;
+  if (typeof err !== 'object' || err === null) return undefined;
+  const code = (err as { code?: unknown }).code;
+  if (typeof code === 'string') return code;
+  return getDbErrorCode((err as { cause?: unknown }).cause, depth + 1);
+};
+
+const withSerializableWriteTransaction = async <T>(
+  callback: (tx: DbExecutor) => Promise<T>,
+): Promise<T> => {
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      return await withDbTransaction(callback, {
+        isolationLevel: 'serializable',
+        accessMode: 'read write',
+      });
+    } catch (err) {
+      if (
+        getDbErrorCode(err) !== SERIALIZATION_FAILURE_SQLSTATE ||
+        attempt >= MAX_SERIALIZABLE_WRITE_ATTEMPTS
+      ) {
+        throw err;
+      }
+    }
+  }
+};
+
 export const listTimeEntries = async (
   actor: AuthenticatedActor,
   input: { userId?: unknown; limit?: unknown; cursor?: unknown },
@@ -183,21 +214,34 @@ export const createTimeEntry = async (
   const location = parseOptionalLocation(input.location, fail) ?? 'remote';
   const parsedIsPlaceholder = requireValid(parseBooleanField(input, 'isPlaceholder'));
 
-  return entriesRepo.create({
-    id: generatePrefixedId('te'),
-    userId: targetUserId,
-    date,
-    clientId,
-    clientName,
-    projectId,
-    projectName,
-    task,
-    taskId: resolvedTaskId,
-    notes: typeof input.notes === 'string' ? input.notes : null,
-    duration: duration ?? 0,
-    hourlyCost,
-    isPlaceholder: parsedIsPlaceholder ?? false,
-    location,
+  return withSerializableWriteTransaction(async (tx) => {
+    const duplicateExists = await entriesRepo.existsForEntryKey(
+      { userId: targetUserId, date, projectId, task },
+      tx,
+    );
+    if (duplicateExists) {
+      fail(409, 'A time entry already exists for this date, project, and task');
+    }
+
+    return entriesRepo.create(
+      {
+        id: generatePrefixedId('te'),
+        userId: targetUserId,
+        date,
+        clientId,
+        clientName,
+        projectId,
+        projectName,
+        task,
+        taskId: resolvedTaskId,
+        notes: typeof input.notes === 'string' ? input.notes : null,
+        duration: duration ?? 0,
+        hourlyCost,
+        isPlaceholder: parsedIsPlaceholder ?? false,
+        location,
+      },
+      tx,
+    );
   });
 };
 
@@ -410,36 +454,6 @@ export type GenerateRecurringResult = {
 };
 
 const MAX_RECURRING_DAYS = 366;
-const SERIALIZATION_FAILURE_SQLSTATE = '40001';
-const MAX_RECURRING_GENERATION_ATTEMPTS = 3;
-
-const getDbErrorCode = (err: unknown, depth = 0): string | undefined => {
-  if (depth > 3) return undefined;
-  if (typeof err !== 'object' || err === null) return undefined;
-  const code = (err as { code?: unknown }).code;
-  if (typeof code === 'string') return code;
-  return getDbErrorCode((err as { cause?: unknown }).cause, depth + 1);
-};
-
-const withRecurringGenerationTransaction = async <T>(
-  callback: (tx: DbExecutor) => Promise<T>,
-): Promise<T> => {
-  for (let attempt = 1; ; attempt += 1) {
-    try {
-      return await withDbTransaction(callback, {
-        isolationLevel: 'serializable',
-        accessMode: 'read write',
-      });
-    } catch (err) {
-      if (
-        getDbErrorCode(err) !== SERIALIZATION_FAILURE_SQLSTATE ||
-        attempt >= MAX_RECURRING_GENERATION_ATTEMPTS
-      ) {
-        throw err;
-      }
-    }
-  }
-};
 
 export const generateRecurringEntries = async (
   actor: AuthenticatedActor,
@@ -599,31 +613,29 @@ export const generateRecurringEntries = async (
     };
   }
 
-  const { inserted, skippedExistingCount } = await withRecurringGenerationTransaction(
-    async (tx) => {
-      const existingKeys = await entriesRepo.findExistingRecurringKeys(
-        targetUserId,
-        fromDate,
-        toDate,
-        tx,
-      );
-      const pending = candidates
-        .filter((candidate) => !existingKeys.has(candidate.key))
-        .map((candidate) => candidate.entry);
+  const { inserted, skippedExistingCount } = await withSerializableWriteTransaction(async (tx) => {
+    const existingKeys = await entriesRepo.findExistingRecurringKeys(
+      targetUserId,
+      fromDate,
+      toDate,
+      tx,
+    );
+    const pending = candidates
+      .filter((candidate) => !existingKeys.has(candidate.key))
+      .map((candidate) => candidate.entry);
 
-      if (pending.length === 0) {
-        return {
-          inserted: [],
-          skippedExistingCount: candidates.length,
-        };
-      }
-
+    if (pending.length === 0) {
       return {
-        inserted: await entriesRepo.createMany(pending, tx),
-        skippedExistingCount: candidates.length - pending.length,
+        inserted: [],
+        skippedExistingCount: candidates.length,
       };
-    },
-  );
+    }
+
+    return {
+      inserted: await entriesRepo.createMany(pending, tx),
+      skippedExistingCount: candidates.length - pending.length,
+    };
+  });
   return {
     generated: inserted,
     generatedCount: inserted.length,

--- a/server/test/repositories/entriesRepo.test.ts
+++ b/server/test/repositories/entriesRepo.test.ts
@@ -467,6 +467,36 @@ describe('findExistingRecurringKeys', () => {
   });
 });
 
+describe('existsForEntryKey', () => {
+  test('checks the full user/date/project/task tuple and returns true when found', async () => {
+    exec.enqueue({ rows: [['e-1']] });
+
+    const result = await entriesRepo.existsForEntryKey(
+      { userId: 'u-1', date: '2026-04-30', projectId: 'p-1', task: 'Dev' },
+      testDb,
+    );
+
+    expect(result).toBe(true);
+    expect(exec.calls[0].params).toEqual(['u-1', '2026-04-30', 'p-1', 'Dev', 1]);
+    const sql = exec.calls[0].sql;
+    expect(sql).toContain('user_id');
+    expect(sql).toContain('project_id');
+    expect(sql).toContain('task');
+    expect(sql).toContain('limit $5');
+  });
+
+  test('returns false when no matching tuple exists', async () => {
+    exec.enqueue({ rows: [] });
+
+    const result = await entriesRepo.existsForEntryKey(
+      { userId: 'u-1', date: '2026-04-30', projectId: 'p-1', task: 'Dev' },
+      testDb,
+    );
+
+    expect(result).toBe(false);
+  });
+});
+
 const newEntry = {
   id: 'e-1',
   userId: 'u-1',

--- a/server/test/routes/entries.test.ts
+++ b/server/test/routes/entries.test.ts
@@ -54,6 +54,7 @@ const entriesBulkDeleteMock = mock();
 const entriesFindContextMock = mock();
 const entriesFindOwnerMock = mock();
 const entriesFindExistingRecurringKeysMock = mock();
+const entriesExistsForEntryKeyMock = mock();
 const entriesDecodeCursorMock = mock();
 const entriesEncodeCursorMock = mock((c: unknown) => `enc:${JSON.stringify(c)}`);
 const projectsFindClientIdMock = mock();
@@ -98,6 +99,7 @@ beforeAll(async () => {
     findContext: entriesFindContextMock,
     findOwner: entriesFindOwnerMock,
     findExistingRecurringKeys: entriesFindExistingRecurringKeysMock,
+    existsForEntryKey: entriesExistsForEntryKeyMock,
     decodeCursor: entriesDecodeCursorMock,
     encodeCursor: entriesEncodeCursorMock,
   }));
@@ -243,6 +245,7 @@ const allMocks = [
   entriesFindContextMock,
   entriesFindOwnerMock,
   entriesFindExistingRecurringKeysMock,
+  entriesExistsForEntryKeyMock,
   entriesDecodeCursorMock,
   projectsFindClientIdMock,
   projectsFindClientIdAndNameMock,
@@ -275,6 +278,7 @@ beforeEach(async () => {
   projectsFindClientIdMock.mockResolvedValue('c1');
   projectsFindClientIdAndNameMock.mockResolvedValue({ clientId: 'c1', name: 'Project' });
   clientsFindNameMock.mockResolvedValue('Client');
+  entriesExistsForEntryKeyMock.mockResolvedValue(false);
   isClientAssignedToUserMock.mockResolvedValue(true);
   isProjectAssignedToUserMock.mockResolvedValue(true);
   isTaskAssignedToUserMock.mockResolvedValue(true);
@@ -454,6 +458,15 @@ describe('POST /api/entries', () => {
         notes: 'hello',
         isPlaceholder: false,
       }),
+      TX_SENTINEL,
+    );
+    expect(withDbTransactionMock.mock.calls[0][1]).toEqual({
+      isolationLevel: 'serializable',
+      accessMode: 'read write',
+    });
+    expect(entriesExistsForEntryKeyMock).toHaveBeenCalledWith(
+      { userId: 'u1', date: '2025-06-02', projectId: 'p1', task: 'Dev' },
+      TX_SENTINEL,
     );
   });
 
@@ -476,7 +489,31 @@ describe('POST /api/entries', () => {
     expect(res.statusCode).toBe(201);
     expect(entriesCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({ duration: 0, taskId: null, isPlaceholder: false }),
+      TX_SENTINEL,
     );
+  });
+
+  test('409 duplicate date/project/task for the target user does not create entry', async () => {
+    entriesExistsForEntryKeyMock.mockResolvedValue(true);
+    findCostPerHourMock.mockResolvedValue(50);
+    findIdByProjectAndNameMock.mockResolvedValue('t1');
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/entries',
+      headers: authHeader(),
+      payload: validBody,
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'A time entry already exists for this date, project, and task',
+    });
+    expect(entriesExistsForEntryKeyMock).toHaveBeenCalledWith(
+      { userId: 'u1', date: '2025-06-02', projectId: 'p1', task: 'Dev' },
+      TX_SENTINEL,
+    );
+    expect(entriesCreateMock).not.toHaveBeenCalled();
   });
 
   test('400 invalid isPlaceholder value does not create entry', async () => {
@@ -592,6 +629,11 @@ describe('POST /api/entries', () => {
     expect(findCostPerHourMock).toHaveBeenCalledWith('u2');
     expect(entriesCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({ userId: 'u2', hourlyCost: 60 }),
+      TX_SENTINEL,
+    );
+    expect(entriesExistsForEntryKeyMock).toHaveBeenCalledWith(
+      { userId: 'u2', date: '2025-06-02', projectId: 'p1', task: 'Dev' },
+      TX_SENTINEL,
     );
   });
 


### PR DESCRIPTION
## Summary
- Adds a duplicate-entry guard for manual time-entry creation.
- Returns `409` when the target user already has an entry for the same date, project, and task.

## Changes
- Adds a repository tuple-existence check for `(userId, date, projectId, task)`.
- Runs the manual create check and insert inside a serializable write transaction with retry handling shared with recurring generation.
- Updates route/OpenAPI docs and Italian/English user docs.
- Adds route and repository regression coverage.

## Testing
- `bun test ./test/routes/entries.test.ts`
- `bun test ./test/repositories/entriesRepo.test.ts`
- `bun run build` in `server`
- `JWT_SECRET=docs-generation-local-secret bun run docs:api`
- `bun run docs:user`
- `bun run lint`
- `bun run test:server`

## Risks / Rollout
- Low risk. Change is scoped to time-entry creation and keeps historical duplicate rows editable.
- No migrations or configuration changes.

## Issues
Fixes #517