### PR TITLE
app(fix): avoid module load effect churn

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -703,6 +703,7 @@ const AppContent: React.FC = () => {
   const {
     loadedModules,
     moduleLoadErrors,
+    isModuleLoaded,
     isModuleLoading,
     loadDatasets,
     markModuleLoaded,
@@ -1174,7 +1175,7 @@ const AppContent: React.FC = () => {
     if (!isRouteAccessible) return;
     const module = getModuleFromView(activeView);
     if (!module) return;
-    if (loadedModules.has(module)) return;
+    if (isModuleLoaded(module)) return;
     const loadToken = ++moduleLoadTokenRef.current;
     const isCurrentModuleLoad = () =>
       moduleLoadTokenRef.current === loadToken && activeLoadModuleRef.current === module;
@@ -1835,7 +1836,7 @@ const AppContent: React.FC = () => {
     activeView,
     currentUser,
     isRouteAccessible,
-    loadedModules,
+    isModuleLoaded,
     loadDatasets,
     markModuleLoaded,
     invalidateModules,

--- a/hooks/useModuleLoader.ts
+++ b/hooks/useModuleLoader.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { getErrorMessage } from '../utils/errors';
 
 export type ModuleLoadErrors = Partial<Record<string, string[]>>;
@@ -25,6 +25,8 @@ export function useModuleLoader() {
   const [loadedModules, setLoadedModules] = useState<Set<string>>(new Set());
   const [moduleLoadErrors, setModuleLoadErrors] = useState<ModuleLoadErrors>({});
   const [loadingModules, setLoadingModules] = useState<Set<string>>(new Set());
+  const loadedModulesRef = useRef(loadedModules);
+  loadedModulesRef.current = loadedModules;
 
   const loadDatasets = useCallback(
     async (
@@ -77,6 +79,7 @@ export function useModuleLoader() {
 
   const markModuleLoaded = useCallback((moduleName: string) => {
     setLoadedModules((prev) => {
+      if (prev.has(moduleName)) return prev;
       const next = new Set(prev);
       next.add(moduleName);
       return next;
@@ -126,6 +129,10 @@ export function useModuleLoader() {
     setLoadingModules(new Set());
   }, []);
 
+  const isModuleLoaded = useCallback((moduleName: string) => {
+    return loadedModulesRef.current.has(moduleName);
+  }, []);
+
   const isModuleLoading = useCallback(
     (moduleName: string) => loadingModules.has(moduleName),
     [loadingModules],
@@ -135,6 +142,7 @@ export function useModuleLoader() {
     loadedModules,
     moduleLoadErrors,
     loadingModules,
+    isModuleLoaded,
     isModuleLoading,
     loadDatasets,
     markModuleLoaded,

--- a/test/App.moduleLoadCancellation.test.ts
+++ b/test/App.moduleLoadCancellation.test.ts
@@ -13,8 +13,11 @@ describe('App.tsx module-load cancellation', () => {
 
     expect(source).toContain('const moduleLoadTokenRef = useRef(0);');
     expect(source).toContain('const activeLoadModuleRef = useRef<string | null>(null);');
+    expect(source).toContain('isModuleLoaded,');
     expect(effectBody).toContain('const loadToken = ++moduleLoadTokenRef.current;');
     expect(effectBody).toContain('activeLoadModuleRef.current === module');
+    expect(effectBody).toContain('if (isModuleLoaded(module)) return;');
+    expect(effectBody).not.toContain('if (loadedModules.has(module)) return;');
     expect(effectBody).toContain('return cancelModuleLoad;');
     expect(effectBody).toContain('moduleLoadTokenRef.current += 1;');
     expect(effectBody).toContain('if (isCurrentModuleLoad()) {');
@@ -23,5 +26,13 @@ describe('App.tsx module-load cancellation', () => {
     const guardedDatasetCalls = effectBody.match(/shouldApply: isCurrentModuleLoad/g) ?? [];
     expect(loadDatasetCalls.length).toBeGreaterThan(0);
     expect(guardedDatasetCalls).toHaveLength(loadDatasetCalls.length);
+
+    const dependencyStart = source.indexOf('  }, [\n    activeView,', end);
+    expect(dependencyStart).toBeGreaterThanOrEqual(end);
+    const dependencyEnd = source.indexOf('  ]);', dependencyStart);
+    expect(dependencyEnd).toBeGreaterThan(dependencyStart);
+    const dependencies = source.slice(dependencyStart, dependencyEnd);
+    expect(dependencies).toContain('isModuleLoaded');
+    expect(dependencies).not.toContain('loadedModules');
   });
 });

--- a/test/hooks/useModuleLoader.test.ts
+++ b/test/hooks/useModuleLoader.test.ts
@@ -20,6 +20,7 @@ describe('useModuleLoader', () => {
     expect(result.current.loadedModules.size).toBe(0);
     expect(result.current.moduleLoadErrors).toEqual({});
     expect(result.current.loadingModules.size).toBe(0);
+    expect(result.current.isModuleLoaded('crm')).toBe(false);
     expect(result.current.isModuleLoading('crm')).toBe(false);
   });
 
@@ -195,12 +196,48 @@ describe('useModuleLoader', () => {
       result.current.markModuleLoaded('crm');
     });
     expect(result.current.loadedModules.has('crm')).toBe(true);
+    expect(result.current.isModuleLoaded('crm')).toBe(true);
 
     act(() => {
       result.current.markModuleLoaded('hr');
     });
     expect(result.current.loadedModules.has('hr')).toBe(true);
+    expect(result.current.isModuleLoaded('hr')).toBe(true);
     expect(result.current.loadedModules.size).toBe(2);
+  });
+
+  test('isModuleLoaded keeps a stable identity while reading current loaded modules', () => {
+    const { result } = renderHook(() => useModuleLoader());
+    const isModuleLoaded = result.current.isModuleLoaded;
+
+    act(() => {
+      result.current.markModuleLoaded('crm');
+    });
+
+    expect(result.current.isModuleLoaded).toBe(isModuleLoaded);
+    expect(isModuleLoaded('crm')).toBe(true);
+
+    act(() => {
+      result.current.invalidateModules(['crm']);
+    });
+
+    expect(result.current.isModuleLoaded).toBe(isModuleLoaded);
+    expect(isModuleLoaded('crm')).toBe(false);
+  });
+
+  test('markModuleLoaded is a no-op when the module is already loaded', () => {
+    const { result } = renderHook(() => useModuleLoader());
+
+    act(() => {
+      result.current.markModuleLoaded('crm');
+    });
+    const loadedModules = result.current.loadedModules;
+
+    act(() => {
+      result.current.markModuleLoaded('crm');
+    });
+
+    expect(result.current.loadedModules).toBe(loadedModules);
   });
 
   test('recordFailures sets errors for module', () => {
@@ -246,6 +283,8 @@ describe('useModuleLoader', () => {
     expect(result.current.loadedModules.has('crm')).toBe(false);
     expect(result.current.loadedModules.has('sales')).toBe(false);
     expect(result.current.loadedModules.has('projects')).toBe(true);
+    expect(result.current.isModuleLoaded('crm')).toBe(false);
+    expect(result.current.isModuleLoaded('projects')).toBe(true);
     expect(result.current.moduleLoadErrors.crm).toBeUndefined();
     expect(result.current.moduleLoadErrors.sales).toBeUndefined();
   });
@@ -277,6 +316,7 @@ describe('useModuleLoader', () => {
       result.current.reset();
     });
     expect(result.current.loadedModules.size).toBe(0);
+    expect(result.current.isModuleLoaded('crm')).toBe(false);
     expect(result.current.moduleLoadErrors).toEqual({});
     expect(result.current.loadingModules.size).toBe(0);
   });


### PR DESCRIPTION
## Summary
- Prevent the App module-loading effect from re-running solely because `loadedModules` receives a new `Set` reference.
- Keep loaded-module checks current through a stable `isModuleLoaded` callback and make duplicate `markModuleLoaded` calls no-op.

## Changes
- Adds `isModuleLoaded` to `useModuleLoader`, backed by the latest loaded-module ref.
- Updates `App.tsx` to depend on the stable callback instead of the raw `loadedModules` set in the loading effect.
- Adds regression coverage for the hook contract and App effect dependencies.

## Testing
- `bun test test/hooks/useModuleLoader.test.ts test/App.moduleLoadCancellation.test.ts`
- `bun run lint`
- `bun run test:frontend`

## Risks / Rollout
- Low risk. Change is scoped to module loader bookkeeping and preserves the existing `loadedModules` state for rendering.

## Issues
Fixes #531
