### PR TITLE
cache easter computations and return fresh dates

### DIFF
--- a/server/test/utils/holidays.test.ts
+++ b/server/test/utils/holidays.test.ts
@@ -29,4 +29,17 @@ describe('server isItalianHoliday', () => {
     expect(isItalianHoliday(new Date(2025, 3, 20))).toBe('Pasqua');
     expect(isItalianHoliday(new Date(2025, 3, 21))).toBe("Lunedì dell'Angelo");
   });
+
+  test('getEaster returns a fresh Date each call so callers can mutate safely', () => {
+    const a = getEaster(2025);
+    const b = getEaster(2025);
+    expect(a).not.toBe(b);
+    expect(a.getTime()).toBe(b.getTime());
+
+    // Mutating the returned Date must not poison subsequent calls.
+    a.setDate(a.getDate() + 10);
+    const c = getEaster(2025);
+    expect(c.getMonth()).toBe(3);
+    expect(c.getDate()).toBe(20);
+  });
 });

--- a/server/utils/holidays.ts
+++ b/server/utils/holidays.ts
@@ -6,17 +6,24 @@
  * UI does, so the two implementations must stay in sync.
  */
 
+const easterCache = new Map<number, { month: number; day: number }>();
+
 export const getEaster = (year: number): Date => {
-  const floor = Math.floor;
-  const G = year % 19;
-  const C = floor(year / 100);
-  const H = (C - floor(C / 4) - floor((8 * C + 13) / 25) + 19 * G + 15) % 30;
-  const I = H - floor(H / 28) * (1 - floor(29 / (H + 1)) * floor((21 - G) / 11));
-  const J = (year + floor(year / 4) + I + 2 - C + floor(C / 4)) % 7;
-  const L = I - J;
-  const month = 3 + floor((L + 40) / 44);
-  const day = L + 28 - 31 * floor(month / 4);
-  return new Date(year, month - 1, day);
+  let cached = easterCache.get(year);
+  if (!cached) {
+    const floor = Math.floor;
+    const G = year % 19;
+    const C = floor(year / 100);
+    const H = (C - floor(C / 4) - floor((8 * C + 13) / 25) + 19 * G + 15) % 30;
+    const I = H - floor(H / 28) * (1 - floor(29 / (H + 1)) * floor((21 - G) / 11));
+    const J = (year + floor(year / 4) + I + 2 - C + floor(C / 4)) % 7;
+    const L = I - J;
+    const month = 3 + floor((L + 40) / 44);
+    const day = L + 28 - 31 * floor(month / 4);
+    cached = { month, day };
+    easterCache.set(year, cached);
+  }
+  return new Date(year, cached.month - 1, cached.day);
 };
 
 const FIXED_HOLIDAYS: Record<string, string> = {


### PR DESCRIPTION
## Summary
- Introduced a year-based cache in `server/utils/holidays.ts` to store Easter as `{ month, day }` and avoid recalculating on every call.
- Updated `getEaster(year)` to always return a new `Date` object from cached month/day values so each caller gets an independent instance.
- Added unit coverage in `server/test/utils/holidays.test.ts` to verify:
  - repeated calls return distinct `Date` objects with equal timestamps,
  - mutating one returned `Date` does not affect subsequent `getEaster` results.

## Testing
- Not run (not executed in this environment).