### PR TITLE
Fix hash canonicalization loop and parallelize time-entry/domain DB flows

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -92,6 +92,7 @@ import type {
 import { formatDateOnlyForLocale, getLocalDateString } from './utils/date';
 import { getTechnicalDocsViewFromPathname } from './utils/docsRoutes';
 import { getErrorMessage } from './utils/errors';
+import { canonicalizeLegacyHash } from './utils/hashCanonicalization';
 import {
   clearStaleModuleScopedState,
   getStaleModulesAfterNavigation,
@@ -143,14 +144,6 @@ const getModuleFromView = (view: View | '404'): string | null => {
   if (view.startsWith('administration/')) return 'administration';
   if (view === 'settings') return 'settings';
   return null;
-};
-
-const canonicalizeLegacyHash = (hash: string) => {
-  if (hash === 'suppliers/manage') return 'crm/suppliers';
-  if (hash === 'suppliers/quotes') return 'sales/supplier-quotes';
-  if (hash === 'sales/supplier-offers') return 'sales/supplier-quotes';
-  if (hash === 'administration/work-units') return 'hr/work-units';
-  return hash;
 };
 
 type TimeEntryDraft = Omit<
@@ -832,6 +825,11 @@ const AppContent: React.FC = () => {
   // refs so in-flight awaits still observe the latest value.
   const activeViewRef = useRef<View | '404'>(activeView);
   activeViewRef.current = activeView;
+  // Tracks the full `#/...` value we last wrote to window.location.hash so
+  // the hashchange listener can short-circuit on events fired by our own
+  // writes. Prevents an infinite rewrite loop if canonicalizeLegacyHash ever
+  // becomes non-idempotent (see issue #540).
+  const programmaticHashRef = useRef<string | null>(null);
   const setActiveView = useCallback<React.Dispatch<React.SetStateAction<View | '404'>>>((next) => {
     const resolved =
       typeof next === 'function'
@@ -1122,11 +1120,11 @@ const AppContent: React.FC = () => {
       }
       return;
     }
-    if (!currentUser) {
-      if (window.location.hash !== '#/login') window.location.hash = '/login';
-      return;
+    const nextHash = currentUser ? `#/${activeView}` : '#/login';
+    if (window.location.hash !== nextHash) {
+      programmaticHashRef.current = nextHash;
+      window.location.hash = nextHash.slice(1);
     }
-    window.location.hash = '/' + activeView;
   }, [activeView, currentUser, isLoading]);
 
   // Filter-id cleanup now happens inside `setActiveView` itself - any caller
@@ -1136,6 +1134,11 @@ const AppContent: React.FC = () => {
   // Sync state with hash (for back/forward buttons)
   useEffect(() => {
     const handleHashChange = () => {
+      if (programmaticHashRef.current === window.location.hash) {
+        programmaticHashRef.current = null;
+        return;
+      }
+      programmaticHashRef.current = null;
       const rawHash = window.location.hash.replace('#/', '').replace('#', '');
       if (rawHash === 'login') {
         if (currentUser) {
@@ -1145,6 +1148,7 @@ const AppContent: React.FC = () => {
       }
       const canonicalHash = canonicalizeLegacyHash(rawHash);
       if (canonicalHash !== rawHash) {
+        programmaticHashRef.current = `#/${canonicalHash}`;
         window.location.hash = `/${canonicalHash}`;
         return;
       }

--- a/App.tsx
+++ b/App.tsx
@@ -92,7 +92,7 @@ import type {
 import { formatDateOnlyForLocale, getLocalDateString } from './utils/date';
 import { getTechnicalDocsViewFromPathname } from './utils/docsRoutes';
 import { getErrorMessage } from './utils/errors';
-import { canonicalizeLegacyHash } from './utils/hashCanonicalization';
+import { canonicalizeLegacyHash, resolveHashChange } from './utils/hashCanonicalization';
 import {
   clearStaleModuleScopedState,
   getStaleModulesAfterNavigation,
@@ -1140,27 +1140,21 @@ const AppContent: React.FC = () => {
       }
       programmaticHashRef.current = null;
       const rawHash = window.location.hash.replace('#/', '').replace('#', '');
-      if (rawHash === 'login') {
-        if (currentUser) {
-          setActiveView('timesheets/tracker');
-        }
-        return;
+      const outcome = resolveHashChange({
+        rawHash,
+        activeView,
+        validViews: VALID_VIEWS,
+        hasUser: !!currentUser,
+      });
+      if (outcome.kind === 'noop') return;
+      if (outcome.kind === 'rewrite-hash') {
+        // Apply the resolved view in this same call: the follow-up hashchange
+        // fired by the rewrite below will be short-circuited by the guard
+        // above, so we cannot rely on it to set the view.
+        programmaticHashRef.current = outcome.newHash;
+        window.location.hash = outcome.newHash.slice(1);
       }
-      const canonicalHash = canonicalizeLegacyHash(rawHash);
-      if (canonicalHash !== rawHash) {
-        programmaticHashRef.current = `#/${canonicalHash}`;
-        window.location.hash = `/${canonicalHash}`;
-        return;
-      }
-      const hash = canonicalHash as View;
-      const nextView = VALID_VIEWS.includes(hash)
-        ? hash
-        : canonicalHash === ''
-          ? 'timesheets/tracker'
-          : '404';
-      if (nextView !== activeView) {
-        setActiveView(nextView);
-      }
+      setActiveView(outcome.view);
     };
     window.addEventListener('hashchange', handleHashChange);
     return () => window.removeEventListener('hashchange', handleHashChange);

--- a/test/utils/hashCanonicalization.test.ts
+++ b/test/utils/hashCanonicalization.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
-import { canonicalizeLegacyHash } from '../../utils/hashCanonicalization';
+import type { View } from '../../types';
+import { canonicalizeLegacyHash, resolveHashChange } from '../../utils/hashCanonicalization';
 
 describe('canonicalizeLegacyHash', () => {
   test('maps each legacy alias to its current view', () => {
@@ -44,5 +45,128 @@ describe('canonicalizeLegacyHash', () => {
       const twice = canonicalizeLegacyHash(once);
       expect(twice).toBe(once);
     }
+  });
+});
+
+describe('resolveHashChange', () => {
+  const validViews: View[] = [
+    'timesheets/tracker',
+    'crm/clients',
+    'crm/suppliers',
+    'sales/supplier-quotes',
+    'hr/work-units',
+  ];
+
+  test('returns noop when hash already matches activeView', () => {
+    expect(
+      resolveHashChange({
+        rawHash: 'crm/clients',
+        activeView: 'crm/clients',
+        validViews,
+        hasUser: true,
+      }),
+    ).toEqual({ kind: 'noop' });
+  });
+
+  test('returns set-view when valid hash differs from activeView', () => {
+    expect(
+      resolveHashChange({
+        rawHash: 'crm/clients',
+        activeView: 'crm/suppliers',
+        validViews,
+        hasUser: true,
+      }),
+    ).toEqual({ kind: 'set-view', view: 'crm/clients' });
+  });
+
+  test('rewrite-hash carries the resolved view so it can be applied in one call', () => {
+    // Regression test for PR #567 / issue #540 follow-up: previously the
+    // handler rewrote the hash and returned, relying on a follow-up
+    // hashchange to call setActiveView. The new programmatic-hash guard
+    // short-circuits that follow-up, so the resolver must return the view
+    // alongside the rewrite so the caller can set it synchronously.
+    expect(
+      resolveHashChange({
+        rawHash: 'suppliers/manage',
+        activeView: 'timesheets/tracker',
+        validViews,
+        hasUser: true,
+      }),
+    ).toEqual({
+      kind: 'rewrite-hash',
+      newHash: '#/crm/suppliers',
+      view: 'crm/suppliers',
+    });
+  });
+
+  test('rewrite-hash resolves all legacy aliases to their canonical view', () => {
+    expect(
+      resolveHashChange({
+        rawHash: 'suppliers/quotes',
+        activeView: 'timesheets/tracker',
+        validViews,
+        hasUser: true,
+      }),
+    ).toEqual({
+      kind: 'rewrite-hash',
+      newHash: '#/sales/supplier-quotes',
+      view: 'sales/supplier-quotes',
+    });
+    expect(
+      resolveHashChange({
+        rawHash: 'administration/work-units',
+        activeView: 'timesheets/tracker',
+        validViews,
+        hasUser: true,
+      }),
+    ).toEqual({
+      kind: 'rewrite-hash',
+      newHash: '#/hr/work-units',
+      view: 'hr/work-units',
+    });
+  });
+
+  test('resolves empty hash to tracker', () => {
+    expect(
+      resolveHashChange({
+        rawHash: '',
+        activeView: 'crm/clients',
+        validViews,
+        hasUser: true,
+      }),
+    ).toEqual({ kind: 'set-view', view: 'timesheets/tracker' });
+  });
+
+  test('resolves login to tracker when user is authenticated', () => {
+    expect(
+      resolveHashChange({
+        rawHash: 'login',
+        activeView: 'crm/clients',
+        validViews,
+        hasUser: true,
+      }),
+    ).toEqual({ kind: 'set-view', view: 'timesheets/tracker' });
+  });
+
+  test('returns noop for login when user is not authenticated', () => {
+    expect(
+      resolveHashChange({
+        rawHash: 'login',
+        activeView: 'timesheets/tracker',
+        validViews,
+        hasUser: false,
+      }),
+    ).toEqual({ kind: 'noop' });
+  });
+
+  test('resolves unknown hash to 404', () => {
+    expect(
+      resolveHashChange({
+        rawHash: 'unknown/route',
+        activeView: 'timesheets/tracker',
+        validViews,
+        hasUser: true,
+      }),
+    ).toEqual({ kind: 'set-view', view: '404' });
   });
 });

--- a/test/utils/hashCanonicalization.test.ts
+++ b/test/utils/hashCanonicalization.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'bun:test';
+import { canonicalizeLegacyHash } from '../../utils/hashCanonicalization';
+
+describe('canonicalizeLegacyHash', () => {
+  test('maps each legacy alias to its current view', () => {
+    expect(canonicalizeLegacyHash('suppliers/manage')).toBe('crm/suppliers');
+    expect(canonicalizeLegacyHash('suppliers/quotes')).toBe('sales/supplier-quotes');
+    expect(canonicalizeLegacyHash('sales/supplier-offers')).toBe('sales/supplier-quotes');
+    expect(canonicalizeLegacyHash('administration/work-units')).toBe('hr/work-units');
+  });
+
+  test('returns non-legacy hashes unchanged', () => {
+    for (const hash of [
+      '',
+      'timesheets/tracker',
+      'crm/clients',
+      'hr/work-units',
+      'sales/supplier-quotes',
+    ]) {
+      expect(canonicalizeLegacyHash(hash)).toBe(hash);
+    }
+  });
+
+  test('is idempotent — canonicalize(canonicalize(x)) === canonicalize(x)', () => {
+    // Idempotency is required so the hash-sync effect in App.tsx cannot loop.
+    // If a future edit adds an alias whose target is itself an alias, this
+    // test catches it before the latent infinite loop can ship.
+    const samples = [
+      '',
+      'login',
+      'timesheets/tracker',
+      'suppliers/manage',
+      'suppliers/quotes',
+      'sales/supplier-offers',
+      'administration/work-units',
+      'crm/suppliers',
+      'sales/supplier-quotes',
+      'hr/work-units',
+      'unknown/route',
+      '404',
+    ];
+    for (const hash of samples) {
+      const once = canonicalizeLegacyHash(hash);
+      const twice = canonicalizeLegacyHash(once);
+      expect(twice).toBe(once);
+    }
+  });
+});

--- a/utils/hashCanonicalization.ts
+++ b/utils/hashCanonicalization.ts
@@ -1,0 +1,11 @@
+// Maps legacy hash aliases to their current canonical form. Must remain
+// idempotent: canonicalize(canonicalize(x)) === canonicalize(x) for all x.
+// Non-idempotent additions would, in concert with the bidirectional
+// hash<->activeView sync in App.tsx, risk an infinite hashchange loop.
+export const canonicalizeLegacyHash = (hash: string): string => {
+  if (hash === 'suppliers/manage') return 'crm/suppliers';
+  if (hash === 'suppliers/quotes') return 'sales/supplier-quotes';
+  if (hash === 'sales/supplier-offers') return 'sales/supplier-quotes';
+  if (hash === 'administration/work-units') return 'hr/work-units';
+  return hash;
+};

--- a/utils/hashCanonicalization.ts
+++ b/utils/hashCanonicalization.ts
@@ -1,3 +1,5 @@
+import type { View } from '../types';
+
 // Maps legacy hash aliases to their current canonical form. Must remain
 // idempotent: canonicalize(canonicalize(x)) === canonicalize(x) for all x.
 // Non-idempotent additions would, in concert with the bidirectional
@@ -8,4 +10,37 @@ export const canonicalizeLegacyHash = (hash: string): string => {
   if (hash === 'sales/supplier-offers') return 'sales/supplier-quotes';
   if (hash === 'administration/work-units') return 'hr/work-units';
   return hash;
+};
+
+export type HashChangeOutcome =
+  | { kind: 'noop' }
+  | { kind: 'set-view'; view: View | '404' }
+  | { kind: 'rewrite-hash'; newHash: string; view: View | '404' };
+
+// Decides what a hashchange event should do given the current state. The
+// `rewrite-hash` outcome includes the resolved view so the caller can apply
+// it synchronously in the same handler call — App.tsx's programmatic-hash
+// guard short-circuits the follow-up hashchange fired by the rewrite, so the
+// view must be applied here rather than relying on a second pass.
+export const resolveHashChange = (params: {
+  rawHash: string;
+  activeView: View | '404';
+  validViews: readonly View[];
+  hasUser: boolean;
+}): HashChangeOutcome => {
+  const { rawHash, activeView, validViews, hasUser } = params;
+  if (rawHash === 'login') {
+    return hasUser ? { kind: 'set-view', view: 'timesheets/tracker' } : { kind: 'noop' };
+  }
+  const canonicalHash = canonicalizeLegacyHash(rawHash);
+  const hash = canonicalHash as View;
+  const view: View | '404' = validViews.includes(hash)
+    ? hash
+    : canonicalHash === ''
+      ? 'timesheets/tracker'
+      : '404';
+  if (canonicalHash !== rawHash) {
+    return { kind: 'rewrite-hash', newHash: `#/${canonicalHash}`, view };
+  }
+  return view !== activeView ? { kind: 'set-view', view } : { kind: 'noop' };
 };


### PR DESCRIPTION
## Summary
- Centralized legacy hash normalization into `utils/hashCanonicalization.ts`, moved hash canonicalization usage into `App.tsx`, and added a programmatic-hash guard to avoid rewrite loops when canonicalizing route fragments.
- Reworked module-load state handling in `App.tsx` and `hooks/useModuleLoader.ts` to use `loadedModules` directly (removing stale refs) and keep module loading idempotent.
- Parallelized several repository and route data fetches (`Promise.all`) to reduce sequential DB round-trips, including snapshot hydration and restore/restore-guard checks in multiple routes.
- Simplified time-entry creation/recurrence behavior in `server/services/timeEntries.ts`: removed separate duplicate-existence precheck for `createTimeEntry`, introduced a targeted serializable retry helper for recurring-generation path, and preserved conflict-aware generation via existing key checks.
- Removed duplicate-entry constraint assumptions from docs and OpenAPI (`time-tracking` docs + `docs/api/openapi.json`) and updated tests to match new async execution order and removed obsolete assertions.
- Added hash canonicalization tests in `test/utils/hashCanonicalization.test.ts` and updated repo tests to account for `Promise.all` execution order.

## Testing
- Not run: `bun test` (not executed in this environment).
- Not run: `bun run lint`.
- Not run: `bun run build`.
- Not run: focused route/repository test run for files touched (`server/test/repositories/*`, `server/test/routes/*`, `test/hooks/*`).
- Manual checks recommended: navigate hash routes (`#/suppliers/manage`, `#/sales/supplier-offers`, `#/administration/work-units`) to confirm canonicalization redirects without loop; verify login/hash sync behavior for logged-in/out transitions.