### PR TITLE
tasksRepo(docs): warn that omitting userId aggregates all entries

### DIFF
--- a/server/repositories/tasksRepo.ts
+++ b/server/repositories/tasksRepo.ts
@@ -329,6 +329,10 @@ export const findIdByProjectAndName = async (
   return rows[0]?.id ?? null;
 };
 
+// When `userId` is undefined this aggregates ALL time entries for the given projects with
+// no user filter — it is a deliberate "show everything" mode, not the absence of a filter.
+// Callers must authorize that broader scope before invoking. Do not pass `undefined` simply
+// because no user is at hand.
 export const sumHoursByProjects = async (
   projectIds: string[],
   userId: string | undefined,


### PR DESCRIPTION
## Summary

- Fixes [#533](https://github.com/xBounceIT/praetor/issues/533): `sumHoursByProjects` in [server/repositories/tasksRepo.ts](server/repositories/tasksRepo.ts) runs two structurally different queries depending on whether `userId` is provided, and callers were surprised that the `undefined` branch returns unfiltered data.
- The dual behavior is intentional — both call sites in [server/routes/tasks.ts](server/routes/tasks.ts) (the `/hours` and `/hours/batch` handlers) gate the choice on the `projects.tasks_all.view` permission. Existing tests in [server/test/repositories/tasksRepo.test.ts](server/test/repositories/tasksRepo.test.ts) cover both branches.
- Per the issue's primary suggested fix, this PR documents the dual mode at the function definition so future readers do not assume `undefined` means "unfiltered by accident." No logic change.

## What changed

A 4-line `//` comment immediately above `sumHoursByProjects`:

> When `userId` is undefined this aggregates ALL time entries for the given projects with no user filter — it is a deliberate "show everything" mode, not the absence of a filter. Callers must authorize that broader scope before invoking. Do not pass `undefined` simply because no user is at hand.

## Reviewer notes

- Validation: the `userId`-provided branch joins `time_entries → tasks` (via `timeEntriesTasksJoin`) `→ user_tasks` to restrict to the user's assigned tasks. The `userId === undefined` branch aggregates `time_entries` directly with no joins. Both return the same `{ projectId, task, total }` shape; only the **scope** differs.
- The comment deliberately avoids naming the specific route paths or permission constant — those references rot when routes/auth get refactored. The "surprise" worth flagging is the `undefined` branch, not the obvious `user_tasks`-join branch.
- No call site changes, no test changes, no SQL changes.

## Test plan

- [x] `bunx --bun biome check server/repositories/tasksRepo.ts` — clean
- [x] `bun test test/repositories/tasksRepo.test.ts` (from `server/`) — 26/26 pass
- [x] `bun test test/routes/tasks.test.ts` (from `server/`) — 52/52 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)