### PR TITLE
refactor(state): centralize auth reset and parallelize async workflows

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -89,6 +89,7 @@ import type {
   View,
   WorkUnit,
 } from './types';
+import { clearAuthScopedState } from './utils/authScopedState';
 import { formatDateOnlyForLocale, getLocalDateString } from './utils/date';
 import { getTechnicalDocsViewFromPathname } from './utils/docsRoutes';
 import { getErrorMessage } from './utils/errors';
@@ -875,40 +876,47 @@ const AppContent: React.FC = () => {
   notificationsRef.current = notifications;
 
   const clearAuthScopedAppState = useCallback(() => {
+    // Bump cancellation tokens before any setter call so in-flight async
+    // commits (module loads, entries pagination) gate out before their
+    // continuations can fire — the setters are queued, but these ref
+    // writes take effect synchronously.
     moduleLoadTokenRef.current++;
-    resetModuleLoader();
-    setHasLoadedGeneralSettings(false);
-    setGeneralSettings(INITIAL_GENERAL_SETTINGS);
-    setHasLoadedLdapConfig(false);
-    setLdapConfig(INITIAL_LDAP_CONFIG);
-    setHasLoadedEmailConfig(false);
-    setEmailConfig(INITIAL_EMAIL_CONFIG);
-    setHasLoadedSsoProviders(false);
-    setSsoProviders([]);
-    setHasLoadedRoles(false);
-    setRoles([]);
-    setUsers([]);
-    setClients([]);
-    setProjects([]);
-    setProjectTasks([]);
-    setProducts([]);
-    setQuotes([]);
-    setClientOffers([]);
-    setClientsOrders([]);
-    setInvoices([]);
-    setSuppliers([]);
-    setSupplierQuotes([]);
-    setSupplierOrders([]);
-    setSupplierInvoices([]);
-    setEntries([]);
     entriesStreamTokenRef.current++;
-    setEntriesLoaded(false);
-    setWorkUnits([]);
-    setViewingUserAssignmentState({
-      userId: '',
-      assignments: null,
-      catalogs: null,
-      isLoading: false,
+    resetModuleLoader();
+    clearAuthScopedState({
+      hasLoadedGeneralSettings: () => setHasLoadedGeneralSettings(false),
+      generalSettings: () => setGeneralSettings(INITIAL_GENERAL_SETTINGS),
+      hasLoadedLdapConfig: () => setHasLoadedLdapConfig(false),
+      ldapConfig: () => setLdapConfig(INITIAL_LDAP_CONFIG),
+      hasLoadedEmailConfig: () => setHasLoadedEmailConfig(false),
+      emailConfig: () => setEmailConfig(INITIAL_EMAIL_CONFIG),
+      hasLoadedSsoProviders: () => setHasLoadedSsoProviders(false),
+      ssoProviders: () => setSsoProviders([]),
+      hasLoadedRoles: () => setHasLoadedRoles(false),
+      roles: () => setRoles([]),
+      users: () => setUsers([]),
+      clients: () => setClients([]),
+      projects: () => setProjects([]),
+      projectTasks: () => setProjectTasks([]),
+      products: () => setProducts([]),
+      quotes: () => setQuotes([]),
+      clientOffers: () => setClientOffers([]),
+      clientsOrders: () => setClientsOrders([]),
+      invoices: () => setInvoices([]),
+      suppliers: () => setSuppliers([]),
+      supplierQuotes: () => setSupplierQuotes([]),
+      supplierOrders: () => setSupplierOrders([]),
+      supplierInvoices: () => setSupplierInvoices([]),
+      entries: () => setEntries([]),
+      entriesLoaded: () => setEntriesLoaded(false),
+      workUnits: () => setWorkUnits([]),
+      viewingUserAssignmentState: () =>
+        setViewingUserAssignmentState({
+          userId: '',
+          assignments: null,
+          catalogs: null,
+          isLoading: false,
+        }),
     });
   }, [resetModuleLoader]);
 

--- a/test/utils/authScopedState.test.ts
+++ b/test/utils/authScopedState.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, mock, test } from 'bun:test';
+import {
+  ALL_AUTH_SCOPED_KEYS,
+  type AuthScopedStateKey,
+  type AuthScopedStateResetters,
+  clearAuthScopedState,
+} from '../../utils/authScopedState';
+
+const EXPECTED_KEYS: readonly AuthScopedStateKey[] = [
+  'hasLoadedGeneralSettings',
+  'generalSettings',
+  'hasLoadedLdapConfig',
+  'ldapConfig',
+  'hasLoadedEmailConfig',
+  'emailConfig',
+  'hasLoadedSsoProviders',
+  'ssoProviders',
+  'hasLoadedRoles',
+  'roles',
+  'users',
+  'clients',
+  'projects',
+  'projectTasks',
+  'products',
+  'quotes',
+  'clientOffers',
+  'clientsOrders',
+  'invoices',
+  'suppliers',
+  'supplierQuotes',
+  'supplierOrders',
+  'supplierInvoices',
+  'entries',
+  'entriesLoaded',
+  'workUnits',
+  'viewingUserAssignmentState',
+];
+
+const buildResetters = (recorder: (key: AuthScopedStateKey) => void): AuthScopedStateResetters => {
+  const entries = EXPECTED_KEYS.map((key) => [key, () => recorder(key)] as const);
+  return Object.fromEntries(entries) as AuthScopedStateResetters;
+};
+
+describe('authScopedState', () => {
+  describe('ALL_AUTH_SCOPED_KEYS', () => {
+    test('contains exactly the keys in the AuthScopedStateKey union', () => {
+      // If the union grows but the array doesn't (or vice versa), this fails.
+      // The Record<...> type elsewhere already catches a missing setter at
+      // compile time; this runtime check guards the array/union themselves.
+      expect([...ALL_AUTH_SCOPED_KEYS].sort()).toEqual([...EXPECTED_KEYS].sort());
+    });
+
+    test('has no duplicate keys', () => {
+      expect(new Set(ALL_AUTH_SCOPED_KEYS).size).toBe(ALL_AUTH_SCOPED_KEYS.length);
+    });
+  });
+
+  describe('clearAuthScopedState', () => {
+    test('invokes every registered setter exactly once', () => {
+      const calls: AuthScopedStateKey[] = [];
+      clearAuthScopedState(buildResetters((key) => calls.push(key)));
+
+      expect(calls.length).toBe(ALL_AUTH_SCOPED_KEYS.length);
+      for (const key of ALL_AUTH_SCOPED_KEYS) {
+        expect(calls.filter((k) => k === key).length).toBe(1);
+      }
+    });
+
+    test('fires setters in the registry-declared order', () => {
+      const calls: AuthScopedStateKey[] = [];
+      clearAuthScopedState(buildResetters((key) => calls.push(key)));
+      expect(calls).toEqual([...ALL_AUTH_SCOPED_KEYS]);
+    });
+
+    test('individual mocked setters each fire once', () => {
+      // Sanity: a handful of representative setters wired with mock() each
+      // see exactly one invocation.
+      const setUsers = mock(() => {});
+      const setClients = mock(() => {});
+      const setEntries = mock(() => {});
+      const setEntriesLoaded = mock(() => {});
+
+      const noop = () => {};
+      // Build a full resetters map where most are no-ops and a few are mocks.
+      const resetters = Object.fromEntries(
+        EXPECTED_KEYS.map((key) => {
+          if (key === 'users') return [key, setUsers];
+          if (key === 'clients') return [key, setClients];
+          if (key === 'entries') return [key, setEntries];
+          if (key === 'entriesLoaded') return [key, setEntriesLoaded];
+          return [key, noop];
+        }),
+      ) as AuthScopedStateResetters;
+
+      clearAuthScopedState(resetters);
+
+      expect(setUsers).toHaveBeenCalledTimes(1);
+      expect(setClients).toHaveBeenCalledTimes(1);
+      expect(setEntries).toHaveBeenCalledTimes(1);
+      expect(setEntriesLoaded).toHaveBeenCalledTimes(1);
+    });
+
+    test('compile-time guarantee: omitting a key fails to typecheck', () => {
+      // This block documents that the `Record<...>` (not `Partial<...>`)
+      // signature forces every key to be registered. Uncomment the
+      // assignment to verify locally: `bun run build` will fail with
+      // "Property 'users' is missing in type ...".
+      //
+      // // @ts-expect-error — `users` missing from setters map
+      // const _incomplete: AuthScopedStateResetters = {
+      //   hasLoadedGeneralSettings: () => {},
+      // };
+      expect(true).toBe(true);
+    });
+  });
+});

--- a/utils/authScopedState.ts
+++ b/utils/authScopedState.ts
@@ -1,0 +1,78 @@
+// Auth-scoped state lives on App.tsx and must be reset on login/logout so
+// stale data from a previous session never bleeds into the next one. The
+// helper below iterates a typed setter map so adding a new piece of
+// auth-scoped state forces a compile error (via the `Record` below) until
+// the App.tsx setters map registers it — instead of silently leaking on
+// the next login/logout.
+//
+// Mirrors `utils/moduleScopedState.ts`, which solves the equivalent
+// problem for module-navigation transitions.
+
+export type AuthScopedStateKey =
+  | 'hasLoadedGeneralSettings'
+  | 'generalSettings'
+  | 'hasLoadedLdapConfig'
+  | 'ldapConfig'
+  | 'hasLoadedEmailConfig'
+  | 'emailConfig'
+  | 'hasLoadedSsoProviders'
+  | 'ssoProviders'
+  | 'hasLoadedRoles'
+  | 'roles'
+  | 'users'
+  | 'clients'
+  | 'projects'
+  | 'projectTasks'
+  | 'products'
+  | 'quotes'
+  | 'clientOffers'
+  | 'clientsOrders'
+  | 'invoices'
+  | 'suppliers'
+  | 'supplierQuotes'
+  | 'supplierOrders'
+  | 'supplierInvoices'
+  | 'entries'
+  | 'entriesLoaded'
+  | 'workUnits'
+  | 'viewingUserAssignmentState';
+
+export const ALL_AUTH_SCOPED_KEYS: readonly AuthScopedStateKey[] = [
+  'hasLoadedGeneralSettings',
+  'generalSettings',
+  'hasLoadedLdapConfig',
+  'ldapConfig',
+  'hasLoadedEmailConfig',
+  'emailConfig',
+  'hasLoadedSsoProviders',
+  'ssoProviders',
+  'hasLoadedRoles',
+  'roles',
+  'users',
+  'clients',
+  'projects',
+  'projectTasks',
+  'products',
+  'quotes',
+  'clientOffers',
+  'clientsOrders',
+  'invoices',
+  'suppliers',
+  'supplierQuotes',
+  'supplierOrders',
+  'supplierInvoices',
+  'entries',
+  'entriesLoaded',
+  'workUnits',
+  'viewingUserAssignmentState',
+];
+
+// `Record` (not `Partial`) so a new union member that lacks a registered
+// setter is a compile error — the entire point of the refactor.
+export type AuthScopedStateResetters = Record<AuthScopedStateKey, () => void>;
+
+export function clearAuthScopedState(resetters: AuthScopedStateResetters): void {
+  for (const key of ALL_AUTH_SCOPED_KEYS) {
+    resetters[key]();
+  }
+}


### PR DESCRIPTION
## Summary
- Centralized auth/session-scoped state cleanup into `clearAuthScopedState` and wired it into `App.tsx` so logout/login transitions reset module/entries/user data through one utility path while bumping cancellation tokens first.
- Simplified `useModuleLoader` by removing the stale `loadedModulesRef` cache and using the `Set` state directly in load checks.
- Parallelized multiple independent DB reads/writes with `Promise.all` across repositories and routes, including:
  - Snapshot fetches for client/supplier quotes, offers, and orders.
  - Restore/version checks and linked-record prechecks.
  - Project/task assignment fan-out and role-assign workflows.
  - Validation logic in project/task/quote/order routes.
- Updated `userAssignmentsRepo.syncTopManagerAssignmentsForUser` to run related delete/assign steps in parallel inside one transaction.
- Removed time-entry duplicate precheck flow (`existsForEntryKey`) from create service path and dropped its tests; create now directly inserts via `entriesRepo.create`.
- Kept serializable retry semantics for recurring entries generation only, with a dedicated retry wrapper and clearer short-circuit when nothing is pending.
- Updated docs for duplicate-entry behavior wording and removed outdated OpenAPI description text; added auth-scoped state utility + tests and adjusted repository tests for Promise.all query order.

## Testing
- Not run: `bun run test`.
- Not run: `bun run lint` / `bun run build`.
- Not run: backend/frontend manual regression checks.
- Existing test updates included:
  - Added `test/utils/authScopedState.test.ts`.
  - Updated repository tests for `findFullForSnapshot` ordering expectations after Promise.all.
  - Removed `existsForEntryKey` tests from `server/test/repositories/entriesRepo.test.ts`.
- Open question to validate before merge: run the full suite to confirm no race/perf regressions from newly parallelized DB calls in assignment routes/repositories.