### PR TITLE
auth(fix): lazily resolve JWT_SECRET (#529)

### DIFF
--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -32,7 +32,17 @@ const resolveJwtSecret = () => {
   return readRequiredNonDefaultEnv('JWT_SECRET', INSECURE_DEFAULT_JWT_SECRETS);
 };
 
-const JWT_SECRET = resolveJwtSecret();
+// Lazy + reset hook so tests can rotate JWT_SECRET between cases — see
+// getSessionMaxDurationMs below for the same pattern.
+let cachedJwtSecret: string | null = null;
+const getJwtSecret = (): string => {
+  if (cachedJwtSecret === null) cachedJwtSecret = resolveJwtSecret();
+  return cachedJwtSecret;
+};
+
+export const __resetJwtSecretCacheForTests = () => {
+  cachedJwtSecret = null;
+};
 
 // JWT signing algorithm. `jwt.sign` (see generateToken below) defaults to HS256, so we pin
 // verification to the same algorithm to prevent algorithm-confusion attacks (e.g. forged
@@ -171,7 +181,7 @@ export const authenticateToken = async (request: FastifyRequest, reply: FastifyR
   }
 
   try {
-    const decoded = jwt.verify(token, JWT_SECRET, {
+    const decoded = jwt.verify(token, getJwtSecret(), {
       algorithms: [JWT_ALGORITHM],
     }) as SessionJwtPayload;
     const sessionStart = decoded.sessionStart ?? Date.now();
@@ -361,7 +371,7 @@ export const generateToken = (
   activeRole: string | undefined,
   sessionVersion: number,
 ) =>
-  jwt.sign({ userId, sessionStart, activeRole, sessionVersion }, JWT_SECRET, {
+  jwt.sign({ userId, sessionStart, activeRole, sessionVersion }, getJwtSecret(), {
     expiresIn: '30m',
     algorithm: JWT_ALGORITHM,
   });

--- a/server/test/middleware/auth-jwt-secret.test.ts
+++ b/server/test/middleware/auth-jwt-secret.test.ts
@@ -1,0 +1,160 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { __resetJwtSecretCacheForTests, authenticateToken } from '../../middleware/auth.ts';
+import * as realRolesRepo from '../../repositories/rolesRepo.ts';
+import * as realUsersRepo from '../../repositories/usersRepo.ts';
+import * as realPermissions from '../../utils/permissions.ts';
+import { signToken } from '../helpers/jwt.ts';
+
+const usersRepoSnapshot = { ...realUsersRepo };
+const rolesRepoSnapshot = { ...realRolesRepo };
+const permissionsSnapshot = { ...realPermissions };
+
+const findAuthUserByIdMock = mock();
+const userHasRoleMock = mock();
+const getRolePermissionsMock = mock();
+
+const HAPPY_USER = {
+  id: 'u1',
+  name: 'Alice',
+  username: 'alice',
+  role: 'manager',
+  avatarInitials: 'AL',
+  isDisabled: false,
+  sessionVersion: 1,
+};
+
+const HAPPY_PERMISSIONS = ['timesheets.tracker.view'];
+
+const ORIGINAL_JWT_SECRET = process.env.JWT_SECRET;
+
+const SECRET_A = 'praetor-test-secret-A-aaaaaaaaaaaaaaaa';
+const SECRET_B = 'praetor-test-secret-B-bbbbbbbbbbbbbbbb';
+
+beforeAll(() => {
+  mock.module('../../repositories/usersRepo.ts', () => ({
+    ...usersRepoSnapshot,
+    findAuthUserById: findAuthUserByIdMock,
+  }));
+  mock.module('../../repositories/rolesRepo.ts', () => ({
+    ...rolesRepoSnapshot,
+    userHasRole: userHasRoleMock,
+  }));
+  mock.module('../../utils/permissions.ts', () => ({
+    ...permissionsSnapshot,
+    getRolePermissions: getRolePermissionsMock,
+  }));
+});
+
+afterAll(() => {
+  if (ORIGINAL_JWT_SECRET === undefined) {
+    delete process.env.JWT_SECRET;
+  } else {
+    process.env.JWT_SECRET = ORIGINAL_JWT_SECRET;
+  }
+  __resetJwtSecretCacheForTests();
+  mock.module('../../repositories/usersRepo.ts', () => usersRepoSnapshot);
+  mock.module('../../repositories/rolesRepo.ts', () => rolesRepoSnapshot);
+  mock.module('../../utils/permissions.ts', () => permissionsSnapshot);
+});
+
+type FakeReply = {
+  statusCode: number;
+  body: unknown;
+  headers: Record<string, string>;
+  code(c: number): FakeReply;
+  send(body: unknown): FakeReply;
+  header(name: string, value: string): FakeReply;
+};
+
+const buildFakeReply = (): FakeReply => {
+  const reply: FakeReply = {
+    statusCode: 0,
+    body: undefined,
+    headers: {},
+    code(c: number) {
+      reply.statusCode = c;
+      return reply;
+    },
+    send(body: unknown) {
+      reply.body = body;
+      return reply;
+    },
+    header(name: string, value: string) {
+      reply.headers[name.toLowerCase()] = value;
+      return reply;
+    },
+  };
+  return reply;
+};
+
+type FakeRequest = { headers: Record<string, string | undefined> };
+const buildFakeRequest = (token: string): FakeRequest => ({
+  headers: { authorization: `Bearer ${token}` },
+});
+
+beforeEach(() => {
+  findAuthUserByIdMock.mockReset();
+  userHasRoleMock.mockReset();
+  getRolePermissionsMock.mockReset();
+  findAuthUserByIdMock.mockResolvedValue(HAPPY_USER);
+  userHasRoleMock.mockResolvedValue(true);
+  getRolePermissionsMock.mockResolvedValue(HAPPY_PERMISSIONS);
+  __resetJwtSecretCacheForTests();
+});
+
+describe('JWT_SECRET lazy resolution', () => {
+  test('after reset, the next request honors the new process.env.JWT_SECRET', async () => {
+    process.env.JWT_SECRET = SECRET_A;
+    __resetJwtSecretCacheForTests();
+
+    const tokenA = signToken({ userId: 'u1', secret: SECRET_A });
+    const replyA = buildFakeReply();
+    await authenticateToken(buildFakeRequest(tokenA) as never, replyA as never);
+
+    expect(replyA.statusCode).toBe(0);
+    expect(typeof replyA.headers['x-auth-token']).toBe('string');
+
+    process.env.JWT_SECRET = SECRET_B;
+    __resetJwtSecretCacheForTests();
+
+    const replyStale = buildFakeReply();
+    await authenticateToken(buildFakeRequest(tokenA) as never, replyStale as never);
+
+    expect(replyStale.statusCode).toBe(403);
+    expect(replyStale.body).toEqual({ error: 'Invalid or expired token' });
+
+    const tokenB = signToken({ userId: 'u1', secret: SECRET_B });
+    const replyB = buildFakeReply();
+    await authenticateToken(buildFakeRequest(tokenB) as never, replyB as never);
+
+    expect(replyB.statusCode).toBe(0);
+  });
+
+  test('without calling the reset hook, the cached secret persists despite env mutation', async () => {
+    process.env.JWT_SECRET = SECRET_A;
+    __resetJwtSecretCacheForTests();
+    const warmup = buildFakeReply();
+    await authenticateToken(
+      buildFakeRequest(signToken({ userId: 'u1', secret: SECRET_A })) as never,
+      warmup as never,
+    );
+    expect(warmup.statusCode).toBe(0);
+
+    process.env.JWT_SECRET = SECRET_B;
+
+    const replyCached = buildFakeReply();
+    await authenticateToken(
+      buildFakeRequest(signToken({ userId: 'u1', secret: SECRET_A })) as never,
+      replyCached as never,
+    );
+    expect(replyCached.statusCode).toBe(0);
+
+    const replyNew = buildFakeReply();
+    await authenticateToken(
+      buildFakeRequest(signToken({ userId: 'u1', secret: SECRET_B })) as never,
+      replyNew as never,
+    );
+    expect(replyNew.statusCode).toBe(403);
+    expect(replyNew.body).toEqual({ error: 'Invalid or expired token' });
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #529. `JWT_SECRET` in `server/middleware/auth.ts` was resolved eagerly at module import time, so mutating `process.env.JWT_SECRET` between test suites had no effect and the only way to pick up a rotated secret was a process restart.
- Switched to the same lazy-cache + reset-hook pattern already used by `getSessionMaxDurationMs` and `getPatIdleTimeoutMs` in the same file: `getJwtSecret()` resolves on first use, caches for the lifetime of the process, and exposes `__resetJwtSecretCacheForTests` for test-only re-resolution.
- Added `server/test/middleware/auth-jwt-secret.test.ts` (modeled on the sibling `auth-session-max.test.ts`) with two cases that lock in the contract — both would fail on the old eager constant.

## Why
- Bug as reported in #529 (severity LOW): the eager constant blocked any test that needed to vary `JWT_SECRET` between suites and inconsistently diverged from the lazy pattern the rest of the file already uses for env-driven config.
- No production behavior change — auth flows still resolve to the same value via `resolveJwtSecret()` on first use.

## Notes for reviewer
- Production call sites updated: `jwt.verify` (auth.ts:184) and `jwt.sign` (auth.ts:374). No other module references `JWT_SECRET` directly.
- `__resetJwtSecretCacheForTests` is intentionally underscore-prefixed and not part of the public API surface, matching the existing `__reset*ForTests` helpers in the file.
- Full runtime rotation (multi-process broadcast, token revocation on rotate) is out of scope for this LOW-severity ticket.

## Test plan
- [x] `cd server && bun test test/middleware/` — 63 pass / 0 fail (2 new cases for JWT secret rotation + 50 existing auth tests + 11 sibling SESSION_MAX/PAT tests).
- [x] `biome check` on modified + new files — clean.
- [x] `tsc -p server/tsconfig.json --noEmit` — clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)