### PR TITLE
repositories(fix): make listByIds surface missing ids (#535, #568)

### DIFF
--- a/server/repositories/clientsRepo.ts
+++ b/server/repositories/clientsRepo.ts
@@ -256,8 +256,11 @@ export const list = async (options: ListOptions, exec: DbExecutor = db): Promise
   return rows.map(mapClientRow);
 };
 
-export const listByIds = async (ids: string[], exec: DbExecutor = db): Promise<Client[]> => {
-  if (ids.length === 0) return [];
+export const listByIds = async (
+  ids: string[],
+  exec: DbExecutor = db,
+): Promise<Map<string, Client>> => {
+  if (ids.length === 0) return new Map();
 
   const rows = await executeRows<Record<string, unknown>>(
     exec,
@@ -268,7 +271,12 @@ export const listByIds = async (ids: string[], exec: DbExecutor = db): Promise<C
       WHERE c.id = ANY(${ids})
       ORDER BY c.name`,
   );
-  return rows.map(mapClientRow);
+  return new Map(
+    rows.map((row) => {
+      const client = mapClientRow(row);
+      return [client.id, client];
+    }),
+  );
 };
 
 export const findContactsForUpdate = async (

--- a/server/repositories/projectsRepo.ts
+++ b/server/repositories/projectsRepo.ts
@@ -137,8 +137,11 @@ export const findById = async (id: string, exec: DbExecutor = db): Promise<Proje
   return rows[0] ? mapRawRow(rows[0]) : null;
 };
 
-export const listByIds = async (ids: string[], exec: DbExecutor = db): Promise<Project[]> => {
-  if (ids.length === 0) return [];
+export const listByIds = async (
+  ids: string[],
+  exec: DbExecutor = db,
+): Promise<Map<string, Project>> => {
+  if (ids.length === 0) return new Map();
 
   const rows = await executeRows<ProjectRawRow>(
     exec,
@@ -147,7 +150,7 @@ export const listByIds = async (ids: string[], exec: DbExecutor = db): Promise<P
          WHERE p.id = ANY(${sql.param(ids)}::text[])
          ORDER BY p.name`,
   );
-  return rows.map(mapRawRow);
+  return new Map(rows.map((row) => [row.id, mapRawRow(row)]));
 };
 
 /**

--- a/server/routes/users.ts
+++ b/server/routes/users.ts
@@ -237,7 +237,7 @@ const canViewTargetUserAssignments = async (request: FastifyRequest, targetUserI
   return usersRepo.canManageUser(targetUserId, request.user?.id ?? '');
 };
 
-const mergeById = <T extends { id: string }>(items: T[], extraItems: T[]) => {
+const mergeById = <T extends { id: string }>(items: T[], extraItems: Iterable<T>) => {
   const seen = new Set(items.map((item) => item.id));
   const merged = [...items];
   for (const item of extraItems) {
@@ -1187,7 +1187,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         assignedProjectIds,
       );
       const taskParentProjects = await projectsRepo.listByIds(taskParentProjectIds);
-      const projects = mergeById(assignedProjects, taskParentProjects);
+      const projects = mergeById(assignedProjects, taskParentProjects.values());
 
       const assignedClientIds = new Set(assignedClients.map((client) => client.id));
       const parentClientIds = uniqueMissingIds(
@@ -1195,7 +1195,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         assignedClientIds,
       );
       const parentClients = await clientsRepo.listByIds(parentClientIds);
-      const clients = mergeById(assignedClients, parentClients);
+      const clients = mergeById(assignedClients, parentClients.values());
 
       return {
         clients: clients.map((client) => ({

--- a/server/test/repositories/clientsRepo.test.ts
+++ b/server/test/repositories/clientsRepo.test.ts
@@ -225,20 +225,33 @@ describe('list', () => {
 });
 
 describe('listByIds', () => {
-  test('returns mapped clients for the provided ids without aggregate totals', async () => {
+  test('returns a Map keyed by id for the provided ids without aggregate totals', async () => {
     exec.enqueue({ rows: [{ ...baseRow, total_sent_quotes: null, total_accepted_orders: null }] });
 
     const result = await clientsRepo.listByIds(['c-1'], testDb);
 
     expect(exec.calls[0].sql).toContain('WHERE c.id = ANY');
     expect(exec.calls[0].params).toContain('c-1');
-    expect(result[0].id).toBe('c-1');
-    expect(result[0].totalSentQuotes).toBeUndefined();
+    expect(result.get('c-1')?.id).toBe('c-1');
+    expect(result.get('c-1')?.totalSentQuotes).toBeUndefined();
   });
 
-  test('returns empty array without querying for empty ids', async () => {
-    expect(await clientsRepo.listByIds([], testDb)).toEqual([]);
+  test('returns an empty Map without querying for empty ids', async () => {
+    const result = await clientsRepo.listByIds([], testDb);
+    expect(result).toBeInstanceOf(Map);
+    expect(result.size).toBe(0);
     expect(exec.calls).toHaveLength(0);
+  });
+
+  // Regression test for issue #568: callers must be able to detect missing ids.
+  test('omits ids with no matching row from the returned Map', async () => {
+    exec.enqueue({ rows: [{ ...baseRow, total_sent_quotes: null, total_accepted_orders: null }] });
+
+    const result = await clientsRepo.listByIds(['c-1', 'c-missing'], testDb);
+
+    expect(result.size).toBe(1);
+    expect(result.has('c-1')).toBe(true);
+    expect(result.has('c-missing')).toBe(false);
   });
 });
 

--- a/server/test/repositories/projectsRepo.test.ts
+++ b/server/test/repositories/projectsRepo.test.ts
@@ -106,19 +106,32 @@ describe('listForUser', () => {
 });
 
 describe('listByIds', () => {
-  test('returns mapped projects and binds ids as one array parameter', async () => {
+  test('returns a Map keyed by id and binds ids as one array parameter', async () => {
     exec.enqueue({ rows: [rawProjectRow] });
 
     const result = await projectsRepo.listByIds(['p-1', 'p-2'], testDb);
 
     expect(exec.calls[0].sql).toContain('WHERE p.id = ANY($1::text[])');
     expect(exec.calls[0].params).toEqual([['p-1', 'p-2']]);
-    expect(result[0]).toEqual(mappedRow);
+    expect(result.get('p-1')).toEqual(mappedRow);
   });
 
-  test('returns empty array without querying for empty ids', async () => {
-    expect(await projectsRepo.listByIds([], testDb)).toEqual([]);
+  test('returns an empty Map without querying for empty ids', async () => {
+    const result = await projectsRepo.listByIds([], testDb);
+    expect(result).toBeInstanceOf(Map);
+    expect(result.size).toBe(0);
     expect(exec.calls).toHaveLength(0);
+  });
+
+  // Regression test for issue #535: callers must be able to detect missing ids.
+  test('omits ids with no matching row from the returned Map', async () => {
+    exec.enqueue({ rows: [rawProjectRow] });
+
+    const result = await projectsRepo.listByIds(['p-1', 'p-missing'], testDb);
+
+    expect(result.size).toBe(1);
+    expect(result.has('p-1')).toBe(true);
+    expect(result.has('p-missing')).toBe(false);
   });
 });
 

--- a/server/test/routes/users.test.ts
+++ b/server/test/routes/users.test.ts
@@ -343,9 +343,9 @@ beforeEach(async () => {
   filterAssignedProjectIdsMock.mockResolvedValue(new Set(['p1']));
   filterAssignedTaskIdsMock.mockResolvedValue(new Set(['t1']));
   listClientsMock.mockResolvedValue([]);
-  listClientsByIdsMock.mockResolvedValue([]);
+  listClientsByIdsMock.mockResolvedValue(new Map());
   listProjectsForUserMock.mockResolvedValue([]);
-  listProjectsByIdsMock.mockResolvedValue([]);
+  listProjectsByIdsMock.mockResolvedValue(new Map());
   listTasksForUserMock.mockResolvedValue([]);
 
   // Default: LDAP unreachable / disabled — route falls back to existing role.
@@ -1611,24 +1611,34 @@ describe('GET /api/users/:id/tracker-catalogs', () => {
         isDisabled: false,
       },
     ]);
-    listProjectsByIdsMock.mockResolvedValue([
-      {
-        id: 'p-parent',
-        name: 'Website Redesign',
-        clientId: 'c-parent',
-        color: '#123456',
-        isDisabled: false,
-        billingType: 'time_and_materials',
-        billingFrequency: 'monthly',
-      },
-    ]);
-    listClientsByIdsMock.mockResolvedValue([
-      {
-        id: 'c-parent',
-        name: 'Acme Corp',
-        isDisabled: false,
-      },
-    ]);
+    listProjectsByIdsMock.mockResolvedValue(
+      new Map([
+        [
+          'p-parent',
+          {
+            id: 'p-parent',
+            name: 'Website Redesign',
+            clientId: 'c-parent',
+            color: '#123456',
+            isDisabled: false,
+            billingType: 'time_and_materials',
+            billingFrequency: 'monthly',
+          },
+        ],
+      ]),
+    );
+    listClientsByIdsMock.mockResolvedValue(
+      new Map([
+        [
+          'c-parent',
+          {
+            id: 'c-parent',
+            name: 'Acme Corp',
+            isDisabled: false,
+          },
+        ],
+      ]),
+    );
 
     const res = await testApp.inject({
       method: 'GET',


### PR DESCRIPTION
## Summary
- `projectsRepo.listByIds` and `clientsRepo.listByIds` now return `Map<string, T>` instead of `T[]`, so callers can detect ids with no matching row. Both fixes match the existing `listNamesByIds` convention in `projectsRepo`. Closes #535 and #568.
- `mergeById` in `server/routes/users.ts` widened to accept `Iterable<T>` as its second arg, so the only caller of the changed repos passes `map.values()` directly without an extra array spread.
- Added a regression test for each repo asserting that ids with no matching row are absent from the returned Map; updated existing tests and the `users.ts` route mocks for the new return shape.

## Why
Callers could previously assume `result.length === input.length` and key by position; the array silently dropped missing ids. The `Map` contract makes the partial-result semantics explicit and matches the safer pattern already used by `listNamesByIds`.

## Reviewer notes
- The two new Map-builders look slightly different (`projectsRepo` uses a one-liner, `clientsRepo` uses a named intermediate). This is intentional: `ProjectRawRow` types `id: string` so `row.id` is safe, while `clientsRepo`'s rows are `Record<string, unknown>` and pulling `row.id` directly would require an `as string` cast — pulling it off the mapped `Client` keeps the path type-safe.
- The route at `users.ts:1187-1198` calls projects then clients sequentially; the clients call depends on the projects result (`parentClientIds` is derived from `projects.map(p => p.clientId)`), so they cannot be parallelized.

## Test plan
- [x] `cd server && bun test test/repositories/projectsRepo.test.ts test/repositories/clientsRepo.test.ts test/routes/users.test.ts` — 149/149 pass.
- [x] `cd server && bun run build` — clean.
- [x] `bunx --bun biome check` on all touched files — clean.
- [ ] Smoke `GET /api/users/:id/tracker-catalogs` for a user with task assignments pointing at projects/clients they aren't directly assigned to; confirm parent projects and clients still appear in the response (behavior unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)