### PR TITLE
date(fix): handle space-separated datetime in date-only normalizers (#522)

### DIFF
--- a/server/test/utils/date.test.ts
+++ b/server/test/utils/date.test.ts
@@ -42,6 +42,10 @@ describe('normalizeNullableDateOnly', () => {
     expect(normalizeNullableDateOnly('2026-05-15T10:30:00Z', 'startDate')).toBe('2026-05-15');
   });
 
+  test('strips a time component from a space-separated datetime string', () => {
+    expect(normalizeNullableDateOnly('2026-05-15 10:30:00', 'startDate')).toBe('2026-05-15');
+  });
+
   test('passes a plain YYYY-MM-DD string through unchanged', () => {
     expect(normalizeNullableDateOnly('2026-05-15', 'startDate')).toBe('2026-05-15');
   });
@@ -100,5 +104,9 @@ describe('isPastLocalDate', () => {
 
   test('strips a time component from the input before comparing', () => {
     expect(isPastLocalDate('2026-05-14T23:59:59Z', reference)).toBe(true);
+  });
+
+  test('strips a space-separated time component before comparing', () => {
+    expect(isPastLocalDate('2026-05-14 23:59:59', reference)).toBe(true);
   });
 });

--- a/server/utils/date.ts
+++ b/server/utils/date.ts
@@ -1,7 +1,9 @@
 const padDatePart = (value: number) => String(value).padStart(2, '0');
 
+const DATE_TIME_SEPARATOR = /[T ]/;
+
 const extractDateOnlyString = (value: string) => {
-  const separatorIndex = value.indexOf('T');
+  const separatorIndex = value.search(DATE_TIME_SEPARATOR);
   return separatorIndex >= 0 ? value.slice(0, separatorIndex) : value;
 };
 

--- a/test/utils/date.test.ts
+++ b/test/utils/date.test.ts
@@ -30,6 +30,10 @@ describe('normalizeDateOnlyString', () => {
     expect(normalizeDateOnlyString('2026-05-15T10:30:00Z')).toBe('2026-05-15');
   });
 
+  test('strips a time component from a space-separated datetime string', () => {
+    expect(normalizeDateOnlyString('2026-05-15 10:30:00')).toBe('2026-05-15');
+  });
+
   test('passes a plain YYYY-MM-DD string through unchanged', () => {
     expect(normalizeDateOnlyString('2026-05-15')).toBe('2026-05-15');
   });

--- a/utils/date.ts
+++ b/utils/date.ts
@@ -9,8 +9,10 @@ export const getLocalDateString = (date: Date = new Date()): string => {
   return `${year}-${month}-${day}`;
 };
 
+const DATE_TIME_SEPARATOR = /[T ]/;
+
 export const normalizeDateOnlyString = (value: string): string => {
-  const separatorIndex = value.indexOf('T');
+  const separatorIndex = value.search(DATE_TIME_SEPARATOR);
   return separatorIndex >= 0 ? value.slice(0, separatorIndex) : value;
 };
 


### PR DESCRIPTION
## Summary
- Fixes [#522](https://github.com/xBounceIT/praetor/issues/522): `extractDateOnlyString` (and its frontend twin `normalizeDateOnlyString`) only checked for the ISO `T` separator. A datetime string using a space separator (e.g. `"2024-01-15 12:00:00"` — the canonical Postgres `TIMESTAMP` text form) was returned with the time portion intact, which would silently leak through `normalizeNullableDateOnly`, `isPastLocalDate`, and the frontend `isDateOnlyBeforeToday` / `isDateOnlyAfterToday`.
- Both helpers now use a `/[T ]/` regex to find either separator. The regex is hoisted to module scope (`DATE_TIME_SEPARATOR`) because these helpers run in per-row `mapRow` paths (`entriesRepo`, `tasksRepo`, invoice/quote repos), so we want to remove any per-call regex-construction overhead.
- Added regression tests for the space-separated case in both `server/test/utils/date.test.ts` and `test/utils/date.test.ts`.

## Why the issue's suggested fix wasn't used
The issue suggested `Math.min(value.indexOf("T"), value.indexOf(" "))`. That's broken when only one separator is present — the missing one returns `-1`, which `Math.min` then picks, causing the function to slice at position `-1` (i.e. drop the last character) instead of leaving the string alone. The regex search avoids this by only returning a non-negative index when at least one separator is actually found.

## Notes for the reviewer
- Character class is deliberately `[T ]` (literal `T` plus ASCII space), not `\s`. ISO-8601 and Postgres only use those two; broader whitespace would over-match and a stray tab in input is almost certainly worth surfacing as a bug rather than silently truncating.
- No callers were changed — the helper's contract is unchanged, just more correct for inputs that were previously slipping through.

## Test plan
- [x] `bun test test/utils/date.test.ts` (frontend) — 22/22 pass
- [x] `cd server && bun test test/utils/date.test.ts` (backend) — 22/22 pass
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)