### PR TITLE
permissions(fix): match bare resource ids in isTopManagerOnlyPermission (#527)

### DIFF
--- a/server/test/utils/permissions.test.ts
+++ b/server/test/utils/permissions.test.ts
@@ -115,9 +115,19 @@ describe('isTopManagerOnlyPermission', () => {
     expect(isTopManagerOnlyPermission('hr.work_units_all.delete')).toBe(true);
   });
 
+  test('matches bare resource ids without an action suffix', () => {
+    expect(isTopManagerOnlyPermission('hr.work_units')).toBe(true);
+    expect(isTopManagerOnlyPermission('hr.work_units_all')).toBe(true);
+  });
+
   test('does not match unrelated hr permissions', () => {
     expect(isTopManagerOnlyPermission('hr.internal.view')).toBe(false);
     expect(isTopManagerOnlyPermission('hr.costs.update')).toBe(false);
+  });
+
+  test('does not match look-alike resource names', () => {
+    expect(isTopManagerOnlyPermission('hr.work_units_foo')).toBe(false);
+    expect(isTopManagerOnlyPermission('hr.work_units_foo.view')).toBe(false);
   });
 
   test('does not match permissions in other modules', () => {

--- a/server/utils/permissions.ts
+++ b/server/utils/permissions.ts
@@ -116,8 +116,11 @@ export const normalizePermission = (permission: string): Permission =>
       ? permission.replace('suppliers.quotes.', 'sales.supplier_quotes.')
       : permission) as Permission;
 
-export const isTopManagerOnlyPermission = (permission: string) =>
-  permission.startsWith('hr.work_units.') || permission.startsWith('hr.work_units_all.');
+export const isTopManagerOnlyPermission = (permission: string) => {
+  const matchesResource = (resource: string) =>
+    permission === resource || permission.startsWith(`${resource}.`);
+  return matchesResource('hr.work_units') || matchesResource('hr.work_units_all');
+};
 
 export const isPermissionKnown = (permission: string) =>
   ALL_PERMISSIONS.includes(normalizePermission(permission));

--- a/test/utils/permissions.test.ts
+++ b/test/utils/permissions.test.ts
@@ -85,9 +85,19 @@ describe('isTopManagerOnlyPermission', () => {
     expect(isTopManagerOnlyPermission('hr.work_units_all.delete')).toBe(true);
   });
 
+  test('matches bare resource ids without an action suffix', () => {
+    expect(isTopManagerOnlyPermission('hr.work_units')).toBe(true);
+    expect(isTopManagerOnlyPermission('hr.work_units_all')).toBe(true);
+  });
+
   test('does not match unrelated permissions', () => {
     expect(isTopManagerOnlyPermission('hr.internal.view')).toBe(false);
     expect(isTopManagerOnlyPermission('crm.clients.view')).toBe(false);
+  });
+
+  test('does not match look-alike resource names', () => {
+    expect(isTopManagerOnlyPermission('hr.work_units_foo')).toBe(false);
+    expect(isTopManagerOnlyPermission('hr.work_units_foo.view')).toBe(false);
   });
 });
 

--- a/utils/permissions.ts
+++ b/utils/permissions.ts
@@ -104,8 +104,11 @@ export const CONFIGURATION_PERMISSIONS: Permission[] = PERMISSION_DEFINITIONS.fi
   def.id.startsWith('administration.'),
 ).flatMap((def) => buildPermissions(def.id, def.actions));
 
-export const isTopManagerOnlyPermission = (permission: string) =>
-  permission.startsWith('hr.work_units.') || permission.startsWith('hr.work_units_all.');
+export const isTopManagerOnlyPermission = (permission: string) => {
+  const matchesResource = (resource: string) =>
+    permission === resource || permission.startsWith(`${resource}.`);
+  return matchesResource('hr.work_units') || matchesResource('hr.work_units_all');
+};
 
 export const formatPermissionLabel = (resource: string) => {
   const parts = resource.split('.');


### PR DESCRIPTION
## Summary
- `isTopManagerOnlyPermission` only matched action-suffixed forms (`hr.work_units.*`, `hr.work_units_all.*`) and would have misclassified the bare resource ids `hr.work_units` / `hr.work_units_all` as non-top-manager-only. No current caller passes the bare form (frontend always builds full `${id}.${action}` strings via `buildPermission`; backend gates on `isPermissionKnown` before reaching this function), but the function's contract is "is this permission top-manager-only?" and a bare resource id belongs to that family — closing a latent foot-gun for future callers.
- Fix applied to both copies (`server/utils/permissions.ts`, `utils/permissions.ts`). Uses a small local `matchesResource(resource)` helper so the "bare or with action suffix" intent reads directly instead of as four parallel clauses.
- Avoids the naive simplification `startsWith('hr.work_units')` alone, which would over-match a hypothetical `hr.work_units_foo`.

Closes #527.

## Test plan
- [x] `bun test test/utils/permissions.test.ts` — 78/78 pass (43 server + 35 frontend), including new bare-id positive case and `hr.work_units_foo` look-alike negative case
- [x] Biome lint clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)