### PR TITLE
auth(fix): clear pending retry-sleep timer on useAuth unmount (#521)

### DIFF
--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -11,11 +11,6 @@ const DEFAULT_SETTINGS: Settings = {
 
 export const AUTH_CHECK_RETRY_DELAYS_MS = [500, 1000, 2000];
 
-const sleep = (ms: number) =>
-  new Promise<void>((resolve) => {
-    setTimeout(resolve, ms);
-  });
-
 const isAuthRejection = (err: unknown): boolean =>
   err instanceof ApiError && (err.status === 401 || err.status === 403);
 
@@ -68,7 +63,15 @@ export function useAuth(opts: UseAuthOptions = {}) {
 
   useEffect(() => {
     let cancelled = false;
+    let pendingRetryTimer: ReturnType<typeof setTimeout> | null = null;
     const delays = retryDelaysRef.current;
+    const sleep = (ms: number) =>
+      new Promise<void>((resolve) => {
+        pendingRetryTimer = setTimeout(() => {
+          pendingRetryTimer = null;
+          resolve();
+        }, ms);
+      });
     const checkAuth = async () => {
       const token = getAuthToken();
       if (!token) {
@@ -109,6 +112,10 @@ export function useAuth(opts: UseAuthOptions = {}) {
     checkAuth();
     return () => {
       cancelled = true;
+      if (pendingRetryTimer !== null) {
+        clearTimeout(pendingRetryTimer);
+        pendingRetryTimer = null;
+      }
     };
   }, [loadUserSettings]);
 

--- a/test/hooks/useAuth.test.ts
+++ b/test/hooks/useAuth.test.ts
@@ -353,6 +353,50 @@ describe('useAuth', () => {
     expect(onLoginB).toHaveBeenLastCalledWith({ id: 'check-b' });
   });
 
+  test('pending retry-sleep timer is cleared on unmount (no leaked setTimeout)', async () => {
+    tokenStore.token = 'good-token';
+    apiMocks.authMe.mockImplementation(() => Promise.reject(new ApiErrorStub('offline', 0, true)));
+
+    // Pick a delay long enough that the timer cannot naturally fire before we
+    // unmount, so a `clearTimeout` call is the only way the timer goes away.
+    const SLEEP_MS = 5000;
+    const sleepTimerIds = new Set<unknown>();
+    const clearedIds: unknown[] = [];
+    const realSetTimeout = globalThis.setTimeout;
+    const realClearTimeout = globalThis.clearTimeout;
+    // Use plain assignment instead of spyOn so @testing-library doesn't treat
+    // setTimeout as a jest-fake-timer mock (which makes waitFor explode).
+    globalThis.setTimeout = ((
+      cb: (...args: unknown[]) => void,
+      ms?: number,
+      ...rest: unknown[]
+    ) => {
+      const id = (realSetTimeout as unknown as (...a: unknown[]) => unknown)(cb, ms, ...rest);
+      if (ms === SLEEP_MS) sleepTimerIds.add(id);
+      return id;
+    }) as unknown as typeof setTimeout;
+    globalThis.clearTimeout = ((id: unknown) => {
+      clearedIds.push(id);
+      return (realClearTimeout as unknown as (i: unknown) => void)(id);
+    }) as unknown as typeof clearTimeout;
+
+    try {
+      const { unmount } = renderHook(() => useAuth({ retryDelaysMs: [SLEEP_MS] }));
+
+      // Wait until the retry loop enters sleep() — observable via a setTimeout
+      // call with our distinctive delay.
+      await waitFor(() => expect(sleepTimerIds.size).toBeGreaterThan(0));
+
+      unmount();
+
+      const cleared = clearedIds.some((id) => sleepTimerIds.has(id));
+      expect(cleared).toBe(true);
+    } finally {
+      globalThis.setTimeout = realSetTimeout;
+      globalThis.clearTimeout = realClearTimeout;
+    }
+  });
+
   test('switchRole calls api and applies returned user/token via login', async () => {
     const onLogin = mock((_u: unknown) => {});
     apiMocks.authSwitchRole.mockImplementation((_roleId: string) =>


### PR DESCRIPTION
## Summary
- Fixes #521: `useAuth`'s auth-check retry loop called `await sleep(ms)` whose `setTimeout` was never tracked, so the effect cleanup set `cancelled = true` but the timer kept running until it naturally fired — a small leak across rapid mount/unmount cycles.
- Move `sleep` inside the effect so it can register its timer in a local `pendingRetryTimer`, and clear that timer in the cleanup alongside `cancelled`.
- Add a regression test that patches `globalThis.setTimeout`/`clearTimeout` (via direct assignment so `@testing-library`'s `waitFor` doesn't mistake it for jest fake timers), captures the long-delay retry timer id, unmounts mid-sleep, and asserts `clearTimeout` was called with that id. The test fails on the old code (`cleared` is `false`) and passes on the fix.

## Test plan
- [x] `bun test test/hooks/useAuth.test.ts` — 20/20 pass on the fix
- [x] Reverted `hooks/useAuth.ts`, re-ran new test — fails as expected (`Expected: true, Received: false`), confirming the test catches the original bug
- [x] `bunx --bun biome check hooks/useAuth.ts test/hooks/useAuth.test.ts` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)