### PR TITLE
ai-reporting(fix): gate route on hasLoadedGeneralSettings to prevent 404 flash (#520)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2275,15 +2275,20 @@ const AppContent: React.FC = () => {
 
   const activeModule = activeView === '404' ? null : getModuleFromView(activeView);
   const activeModuleLoadFailures = activeModule ? (moduleLoadErrors[activeModule] ?? []) : [];
-  const isActiveModulePending = Boolean(
-    activeModule &&
-      activeModule !== 'settings' &&
-      (!loadedModules.has(activeModule) || isModuleLoading(activeModule)),
-  );
   const reportsSettingsFailed =
     activeView === 'reports/ai-reporting' &&
     !hasLoadedGeneralSettings &&
     activeModuleLoadFailures.includes('general settings');
+  // Until generalSettings is loaded we don't yet know whether enableAiReporting
+  // is true; keep the route in the generic pending state so ai-reporting chrome
+  // doesn't flash before the 404 redirect fires.
+  const isActiveModulePending =
+    Boolean(
+      activeModule &&
+        activeModule !== 'settings' &&
+        (!loadedModules.has(activeModule) || isModuleLoading(activeModule)),
+    ) ||
+    (activeView === 'reports/ai-reporting' && !hasLoadedGeneralSettings && !reportsSettingsFailed);
 
   if (isLoading) {
     return (
@@ -2822,24 +2827,15 @@ const AppContent: React.FC = () => {
               />
             )}
             {activeView === 'reports/ai-reporting' &&
-              (!hasLoadedGeneralSettings ? (
-                reportsSettingsFailed ? (
-                  <div className="flex h-[calc(100vh-180px)] min-h-[560px] items-center justify-center">
-                    <div className="text-center">
-                      <i className="fa-solid fa-triangle-exclamation text-3xl text-amber-500 mb-3" />
-                      <p className="text-zinc-700 font-medium">
-                        {tApp('reports:aiReporting.settingsFailedToLoad')}
-                      </p>
-                    </div>
+              (reportsSettingsFailed ? (
+                <div className="flex h-[calc(100vh-180px)] min-h-[560px] items-center justify-center">
+                  <div className="text-center">
+                    <i className="fa-solid fa-triangle-exclamation text-3xl text-amber-500 mb-3" />
+                    <p className="text-zinc-700 font-medium">
+                      {tApp('reports:aiReporting.settingsFailedToLoad')}
+                    </p>
                   </div>
-                ) : (
-                  <div className="flex h-[calc(100vh-180px)] min-h-[560px] items-center justify-center">
-                    <div className="text-center">
-                      <i className="fa-solid fa-circle-notch fa-spin text-3xl text-praetor mb-3" />
-                      <p className="text-zinc-600 font-medium">{tApp('common:states.loading')}</p>
-                    </div>
-                  </div>
-                )
+                </div>
               ) : (
                 <AiReportingView
                   currentUserId={currentUser.id}

--- a/test/App.aiReportingPendingRender.test.ts
+++ b/test/App.aiReportingPendingRender.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const source = readFileSync(join(import.meta.dir, '..', 'App.tsx'), 'utf8');
+
+describe('reports/ai-reporting pending render (issue #520)', () => {
+  test('isActiveModulePending stays true while waiting for generalSettings', () => {
+    const start = source.indexOf('const isActiveModulePending');
+    expect(start).toBeGreaterThan(-1);
+    const semicolon = source.indexOf(';', start);
+    const declaration = source.slice(start, semicolon);
+
+    // Must extend the pending gate with the ai-reporting-specific wait so the
+    // generic loading state covers the gap before generalSettings loads.
+    expect(declaration).toMatch(
+      /activeView === 'reports\/ai-reporting'[\s\S]*?!hasLoadedGeneralSettings[\s\S]*?!reportsSettingsFailed/,
+    );
+  });
+
+  test('reportsSettingsFailed is defined before isActiveModulePending so it can be referenced', () => {
+    const failedIdx = source.indexOf('const reportsSettingsFailed');
+    const pendingIdx = source.indexOf('const isActiveModulePending');
+    expect(failedIdx).toBeGreaterThan(-1);
+    expect(pendingIdx).toBeGreaterThan(-1);
+    expect(failedIdx).toBeLessThan(pendingIdx);
+  });
+
+  test('ai-reporting render block no longer renders its own pending spinner', () => {
+    // Anchor on the JSX-level render of the AI reporting block; earlier
+    // occurrences of `reports/ai-reporting` belong to the routing/access logic.
+    const blockStart = source.indexOf("{activeView === 'reports/ai-reporting' &&");
+    expect(blockStart).toBeGreaterThan(-1);
+    const blockEnd = source.indexOf('))}', blockStart);
+    expect(blockEnd).toBeGreaterThan(blockStart);
+    const block = source.slice(blockStart, blockEnd);
+
+    expect(block).toContain('reportsSettingsFailed');
+    expect(block).toContain('<AiReportingView');
+    // The inline ai-reporting spinner used to use this translation key and
+    // `fa-circle-notch fa-spin` icon. Both must be gone — pending state now
+    // flows through the generic isActiveModulePending spinner instead.
+    expect(block).not.toContain("tApp('common:states.loading')");
+    expect(block).not.toContain('fa-circle-notch fa-spin');
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes #520: navigating to `reports/ai-reporting` before `generalSettings` had loaded briefly rendered the AI reporting page's inline loading chrome and then redirected to 404 once the settings resolved with `enableAiReporting=false`.
- Rolls the "awaiting general settings" wait into the generic `isActiveModulePending` gate so the shared module-pending spinner covers the gap before the flag is known.
- Drops the AI reporting block's own inline spinner; the block now only renders the failure UI (`reportsSettingsFailed`) or `<AiReportingView />`. When the flag is off, `isRouteAccessible` flips and `<NotFound />` renders directly — no ai-reporting chrome paints first.

## Test plan

- [x] `bun test test/App.aiReportingPendingRender.test.ts` — 3 new source-string assertions verify the pending gate, declaration order, and absence of the inline spinner.
- [x] `bun test test/App.*.{ts,tsx}` — 19/19 App-level tests pass.
- [x] Biome clean on `App.tsx` and the new test file.
- [ ] Manual: navigate to `#/reports/ai-reporting` with `enableAiReporting=false` from a cold page load and confirm only the generic loading spinner appears, then NotFound — no AI-reporting-branded spinner flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)