### PR TITLE
permissions(fix): warn when normalizePermission rewrites legacy names (#523)

### DIFF
--- a/server/test/utils/permissions-legacy-warning.test.ts
+++ b/server/test/utils/permissions-legacy-warning.test.ts
@@ -1,0 +1,65 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import {
+  __resetLegacyPermissionWarningsForTests,
+  __setLegacyPermissionWarnerForTests,
+  normalizePermission,
+} from '../../utils/permissions.ts';
+
+const warnMock = mock<(legacy: string, normalized: string) => void>(() => {});
+
+beforeEach(() => {
+  warnMock.mockClear();
+  __resetLegacyPermissionWarningsForTests();
+  __setLegacyPermissionWarnerForTests(warnMock);
+});
+
+afterAll(() => {
+  __setLegacyPermissionWarnerForTests(null);
+  __resetLegacyPermissionWarningsForTests();
+});
+
+describe('normalizePermission deprecation warning', () => {
+  test('warns when rewriting a legacy configuration.* permission', () => {
+    normalizePermission('configuration.general.view');
+
+    expect(warnMock).toHaveBeenCalledTimes(1);
+    expect(warnMock).toHaveBeenCalledWith(
+      'configuration.general.view',
+      'administration.general.view',
+    );
+  });
+
+  test('warns when rewriting a legacy suppliers.quotes.* permission', () => {
+    normalizePermission('suppliers.quotes.create');
+
+    expect(warnMock).toHaveBeenCalledTimes(1);
+    expect(warnMock).toHaveBeenCalledWith(
+      'suppliers.quotes.create',
+      'sales.supplier_quotes.create',
+    );
+  });
+
+  test('warns only once per unique legacy permission string', () => {
+    normalizePermission('configuration.general.view');
+    normalizePermission('configuration.general.view');
+    normalizePermission('configuration.general.view');
+
+    expect(warnMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('warns separately for each distinct legacy permission', () => {
+    normalizePermission('configuration.general.view');
+    normalizePermission('configuration.general.update');
+    normalizePermission('suppliers.quotes.create');
+
+    expect(warnMock).toHaveBeenCalledTimes(3);
+  });
+
+  test('does not warn for current-name permissions', () => {
+    normalizePermission('administration.general.view');
+    normalizePermission('crm.clients.view');
+    normalizePermission('sales.supplier_quotes.create');
+
+    expect(warnMock).not.toHaveBeenCalled();
+  });
+});

--- a/server/test/utils/permissions-legacy-warning.test.ts
+++ b/server/test/utils/permissions-legacy-warning.test.ts
@@ -62,4 +62,13 @@ describe('normalizePermission deprecation warning', () => {
 
     expect(warnMock).not.toHaveBeenCalled();
   });
+
+  test('does not warn (or record) when the rewrite produces an unknown permission', () => {
+    expect(normalizePermission('configuration.does.not_exist')).toBe(
+      'administration.does.not_exist',
+    );
+    expect(normalizePermission('suppliers.quotes.banana')).toBe('sales.supplier_quotes.banana');
+
+    expect(warnMock).not.toHaveBeenCalled();
+  });
 });

--- a/server/test/utils/permissions-legacy-warning.test.ts
+++ b/server/test/utils/permissions-legacy-warning.test.ts
@@ -64,10 +64,12 @@ describe('normalizePermission deprecation warning', () => {
   });
 
   test('does not warn (or record) when the rewrite produces an unknown permission', () => {
-    expect(normalizePermission('configuration.does.not_exist')).toBe(
-      'administration.does.not_exist',
+    expect(normalizePermission('configuration.does_not_exist.view')).toBe(
+      'administration.does_not_exist.view',
     );
-    expect(normalizePermission('suppliers.quotes.banana')).toBe('sales.supplier_quotes.banana');
+    expect(normalizePermission('suppliers.quotes.banana.view')).toBe(
+      'sales.supplier_quotes.banana.view',
+    );
 
     expect(warnMock).not.toHaveBeenCalled();
   });

--- a/server/utils/permissions.ts
+++ b/server/utils/permissions.ts
@@ -1,4 +1,7 @@
 import * as rolesRepo from '../repositories/rolesRepo.ts';
+import { createChildLogger } from './logger.ts';
+
+const logger = createChildLogger({ module: 'permissions' });
 
 export type PermissionAction = 'view' | 'create' | 'update' | 'delete';
 export type PermissionResource = string;
@@ -109,12 +112,50 @@ export const ALWAYS_GRANTED_NOTIFICATION_PERMISSIONS: Permission[] = buildPermis
   VIEW_UPDATE_DELETE,
 );
 
-export const normalizePermission = (permission: string): Permission =>
-  (permission.startsWith('configuration.')
-    ? permission.replace('configuration.', 'administration.')
-    : permission.startsWith('suppliers.quotes.')
-      ? permission.replace('suppliers.quotes.', 'sales.supplier_quotes.')
-      : permission) as Permission;
+const LEGACY_PERMISSION_REWRITES: ReadonlyArray<{ from: string; to: string }> = [
+  { from: 'configuration.', to: 'administration.' },
+  { from: 'suppliers.quotes.', to: 'sales.supplier_quotes.' },
+];
+
+const defaultLegacyPermissionWarner = (legacy: string, normalized: string) => {
+  logger.warn(
+    { legacyPermission: legacy, normalizedPermission: normalized },
+    'Encountered legacy permission name; rewrote on the fly. Update stored values and callers to use the new name — silent rewrites will be removed in a future release.',
+  );
+};
+
+let warnOnLegacyPermission = defaultLegacyPermissionWarner;
+
+// Dedupe legacy-permission warnings: `normalizePermission` is on the auth hot path
+// (every `hasPermission`/`getRolePermissions` call), so a single stale DB row or
+// hardcoded legacy name would otherwise log on every request.
+const warnedLegacyPermissions = new Set<string>();
+
+export const __resetLegacyPermissionWarningsForTests = () => {
+  warnedLegacyPermissions.clear();
+};
+
+// Bun shares the module cache across test files, so `mock.module('logger.ts')` cannot
+// reach the child logger captured at this module's load time. Injecting the warner is
+// the only way to assert the warning fires in the multi-file suite.
+export const __setLegacyPermissionWarnerForTests = (
+  warner: ((legacy: string, normalized: string) => void) | null,
+) => {
+  warnOnLegacyPermission = warner ?? defaultLegacyPermissionWarner;
+};
+
+export const normalizePermission = (permission: string): Permission => {
+  for (const { from, to } of LEGACY_PERMISSION_REWRITES) {
+    if (!permission.startsWith(from)) continue;
+    const normalized = (to + permission.slice(from.length)) as Permission;
+    if (!warnedLegacyPermissions.has(permission)) {
+      warnedLegacyPermissions.add(permission);
+      warnOnLegacyPermission(permission, normalized);
+    }
+    return normalized;
+  }
+  return permission as Permission;
+};
 
 export const isTopManagerOnlyPermission = (permission: string) =>
   permission.startsWith('hr.work_units.') || permission.startsWith('hr.work_units_all.');

--- a/server/utils/permissions.ts
+++ b/server/utils/permissions.ts
@@ -128,7 +128,11 @@ let warnOnLegacyPermission = defaultLegacyPermissionWarner;
 
 // Dedupe legacy-permission warnings: `normalizePermission` is on the auth hot path
 // (every `hasPermission`/`getRolePermissions` call), so a single stale DB row or
-// hardcoded legacy name would otherwise log on every request.
+// hardcoded legacy name would otherwise log on every request. Only known legacy
+// permissions get recorded — otherwise `roles.ts` validation flow would let a
+// privileged caller flood this set with `configuration.<random>.<random>` strings
+// before the unknown-permission check rejects them.
+const KNOWN_PERMISSIONS_SET = new Set<string>(ALL_PERMISSIONS);
 const warnedLegacyPermissions = new Set<string>();
 
 export const __resetLegacyPermissionWarningsForTests = () => {
@@ -148,7 +152,7 @@ export const normalizePermission = (permission: string): Permission => {
   for (const { from, to } of LEGACY_PERMISSION_REWRITES) {
     if (!permission.startsWith(from)) continue;
     const normalized = (to + permission.slice(from.length)) as Permission;
-    if (!warnedLegacyPermissions.has(permission)) {
+    if (KNOWN_PERMISSIONS_SET.has(normalized) && !warnedLegacyPermissions.has(permission)) {
       warnedLegacyPermissions.add(permission);
       warnOnLegacyPermission(permission, normalized);
     }


### PR DESCRIPTION
## Summary

- `normalizePermission` in [server/utils/permissions.ts](server/utils/permissions.ts) used to rewrite `configuration.*` → `administration.*` and `suppliers.quotes.*` → `sales.supplier_quotes.*` with no log. A stale DB row in `role_permissions`, or an admin POSTing a legacy name to `PUT /roles/:id/permissions`, was silently corrected — operators got no signal that the migration was still being relied on.
- Emit a structured pino `warn` (`{ legacyPermission, normalizedPermission }`) the first time each unique legacy string is seen. Subsequent calls are deduped via a `Set`, which matters because `normalizePermission` is on the auth hot path (`hasPermission`, `getRolePermissions`, `isPermissionKnown`) — a single stale row would otherwise log on every request.
- Replaces the prior ternary chain with a small `LEGACY_PERMISSION_REWRITES` table so adding/removing legacy mappings is a single-line edit.

## Why a test-only injection seam

The fix exposes `__resetLegacyPermissionWarningsForTests` (cache reset, matches the `__reset…CacheForTests` convention already used in [server/middleware/auth.ts](server/middleware/auth.ts)) and `__setLegacyPermissionWarnerForTests`. I tried first to mock the logger via `mock.module('../../utils/logger.ts', …)` (the pattern used in [server/test/services/ldap.test.ts](server/test/services/ldap.test.ts)) but Bun shares the module cache across test files: by the time my test ran, sibling test files had already imported `permissions.ts` with the real child logger captured, and `mock.module` does not re-evaluate cached dependents. Injecting the warner is the only way to assert the warning actually fires in the multi-file suite. The setter is annotated with a WHY-comment so future readers don't repeat that attempt.

## Test plan

- [x] New tests in [server/test/utils/permissions-legacy-warning.test.ts](server/test/utils/permissions-legacy-warning.test.ts) cover: warn fires with correct old/new pair for each legacy prefix; dedupes within a process; emits for distinct legacy strings; stays silent for current-name permissions.
- [x] Existing permission tests still pass: `bun test test/utils/permissions-legacy-warning.test.ts test/utils/permissions.test.ts test/utils/getRolePermissions.test.ts` → 50 pass, 0 fail.
- [x] Full server suite: `bun test` → 2629 pass, 28 skip, 0 fail (121 files).
- [x] `biome check` clean on both touched files.

Closes #523.

🤖 Generated with [Claude Code](https://claude.com/claude-code)