### PR TITLE
http-errors(fix): expose statusCode on NotFoundError and ForeignKeyError (#514)

### DIFF
--- a/server/test/utils/http-errors.test.ts
+++ b/server/test/utils/http-errors.test.ts
@@ -17,6 +17,10 @@ describe('NotFoundError', () => {
     expect(new NotFoundError('Anything').name).toBe('NotFoundError');
   });
 
+  test('exposes statusCode 404', () => {
+    expect(new NotFoundError('User').statusCode).toBe(404);
+  });
+
   test('stack trace is captured', () => {
     const err = new NotFoundError('User');
     expect(typeof err.stack).toBe('string');
@@ -42,6 +46,10 @@ describe('ForeignKeyError', () => {
 
   test('name is "ForeignKeyError"', () => {
     expect(new ForeignKeyError('any').name).toBe('ForeignKeyError');
+  });
+
+  test('exposes statusCode 400 to match how routes handle FK violations', () => {
+    expect(new ForeignKeyError('Project').statusCode).toBe(400);
   });
 
   test('is distinguishable from NotFoundError despite identical message format', () => {

--- a/server/utils/http-errors.ts
+++ b/server/utils/http-errors.ts
@@ -1,4 +1,5 @@
 export class NotFoundError extends Error {
+  readonly statusCode = 404;
   constructor(entity: string) {
     super(`${entity} not found`);
     this.name = 'NotFoundError';
@@ -6,6 +7,7 @@ export class NotFoundError extends Error {
 }
 
 export class ForeignKeyError extends Error {
+  readonly statusCode = 400;
   constructor(public readonly target: string) {
     super(`${target} not found`);
     this.name = 'ForeignKeyError';


### PR DESCRIPTION
## Summary

Closes #514. Both `NotFoundError` and `ForeignKeyError` previously extended `Error` with no machine-readable status code, so any instance that bubbled to the global Fastify error handler in `server/app.ts` (which reads `error.statusCode || 500`) was reported as a 500 — even though the routes that catch them explicitly knew better.

This adds a `readonly statusCode` field to each class:

- `NotFoundError` → **404**
- `ForeignKeyError` → **400**

### Note on `ForeignKeyError` = 400 (not 409)

The original issue suggested `409 Conflict`, but every existing route handler (`routes/projects.ts:364`, `routes/projects.ts:732`, `routes/tasks.ts:348`) maps `ForeignKeyError` to **400 Bad Request**, and the route tests assert 400. The error is semantically "you passed an ID that does not exist" — bad input, not a resource-state conflict. Setting the default to 400 keeps handled and unhandled paths consistent. The existing `instanceof` catches still work; the new default only matters for paths that forget to catch it.

## Test plan

- [x] `bun test server/test/utils/http-errors.test.ts` — 11 pass (added two assertions for the new `statusCode` values)
- [ ] CI runs full backend + frontend suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)