### PR TITLE
fix(entries): rate-limit POST / time-entry create (#515)

### DIFF
--- a/server/routes/entries.ts
+++ b/server/routes/entries.ts
@@ -237,7 +237,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.post(
     '/',
     {
-      onRequest: [authenticateToken, requireScopedPermission('timesheets.tracker', 'create')],
+      onRequest: [
+        fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
+        authenticateToken,
+        requireScopedPermission('timesheets.tracker', 'create'),
+      ],
       schema: {
         tags: ['entries'],
         summary: 'Create time entry',
@@ -247,7 +251,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         body: entryCreateBodySchema,
         response: {
           201: entrySchema,
-          ...standardErrorResponses,
+          ...standardRateLimitedErrorResponses,
         },
       },
     },

--- a/server/test/routes/entries.test.ts
+++ b/server/test/routes/entries.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
-import type { FastifyInstance, FastifyPluginAsync } from 'fastify';
+import Fastify, { type FastifyInstance, type FastifyPluginAsync } from 'fastify';
 import * as realDrizzle from '../../db/drizzle.ts';
 import * as realClientsRepo from '../../repositories/clientsRepo.ts';
 import * as realEntriesRepo from '../../repositories/entriesRepo.ts';
@@ -11,6 +11,7 @@ import * as realUserAssignmentsRepo from '../../repositories/userAssignmentsRepo
 import * as realUsersRepo from '../../repositories/usersRepo.ts';
 import * as realWorkUnitsRepo from '../../repositories/workUnitsRepo.ts';
 import * as realPermissions from '../../utils/permissions.ts';
+import { STANDARD_ROUTE_RATE_LIMIT } from '../../utils/rate-limit.ts';
 import {
   installAuthMiddlewareMock,
   restoreAuthMiddlewareMock,
@@ -1787,5 +1788,22 @@ describe('DELETE /api/entries (bulk)', () => {
         placeholderOnly: true,
       }),
     );
+  });
+});
+
+describe('rate-limit configuration on entries routes', () => {
+  test('every route opts in to fastify.rateLimit with STANDARD_ROUTE_RATE_LIMIT', async () => {
+    const rateLimitMock = mock((_options: unknown) => async () => {});
+    const app = Fastify({ logger: false });
+    app.decorate('rateLimit', rateLimitMock);
+    await app.register(entriesRoutePlugin, { prefix: '/api/entries' });
+    await app.ready();
+
+    expect(rateLimitMock).toHaveBeenCalledTimes(4);
+    for (const call of rateLimitMock.mock.calls) {
+      expect(call[0]).toBe(STANDARD_ROUTE_RATE_LIMIT);
+    }
+
+    await app.close();
   });
 });


### PR DESCRIPTION
## Summary
- Adds `fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT)` to `POST /api/entries` ([server/routes/entries.ts:237](https://github.com/xBounceIT/praetor/blob/claude/sweet-bhabha-9fb5f3/server/routes/entries.ts#L237)) so single-entry creation can't be flooded.
- Switches the route's 201 response schema to `standardRateLimitedErrorResponses` so 429 is part of the OpenAPI contract.
- Adds a regression test asserting every entries route opts into `fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT)`.

## Why
Fixes #515. The single-entry POST was the only entries route without a rate limit — `POST /recurring/generate`, `GET /`, and `DELETE /` all had one. Each create runs four DB queries (user cost lookup, task lookup, project check, assignment fetch), so unthrottled POSTs amplify DB load.

The fix mirrors the convention from PR #276 (invoice mutations) and PR #431 / #435 (settings/email/ai/mcp routes).

## Test plan
- [x] `bun test server/test/routes/entries.test.ts` — 77 pass.
- [x] Sanity-check the new test fails on the unfixed route: temporarily reverted the route change and confirmed the test reports `Received number of calls: 3` (expected 4); restoring the fix returns to green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)