### PR TITLE
repositories(fix): lock billing_type during billingFrequency-only task update (#511)

### DIFF
--- a/server/repositories/tasksRepo.ts
+++ b/server/repositories/tasksRepo.ts
@@ -1,6 +1,6 @@
 import { and, eq, inArray, sql } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/pg-core';
-import { type DbExecutor, db, executeRows } from '../db/drizzle.ts';
+import { type DbExecutor, db, executeRows, runAtomically } from '../db/drizzle.ts';
 import { tasks, userTasks } from '../db/schema/tasks.ts';
 import { timeEntries } from '../db/schema/timeEntries.ts';
 import {
@@ -153,6 +153,18 @@ export const create = async (task: NewTask, exec: DbExecutor = db): Promise<Task
   }
 };
 
+const lockBillingTypeById = async (
+  id: string,
+  exec: DbExecutor,
+): Promise<StoredBillingType | null> => {
+  const rows = await exec
+    .select({ billingType: tasks.billingType })
+    .from(tasks)
+    .where(eq(tasks.id, id))
+    .for('update');
+  return rows[0]?.billingType ?? null;
+};
+
 export type TaskUpdate = {
   name?: string | null;
   description?: string | null;
@@ -196,14 +208,17 @@ export const update = async (
     set.billingType = nextBillingType;
     set.billingFrequency = normalizeBillingFrequency(nextBillingType, patch.billingFrequency);
   } else if (patch.billingFrequency !== undefined) {
-    const currentRows = await exec
-      .select({ billingType: tasks.billingType })
-      .from(tasks)
-      .where(eq(tasks.id, id));
-    set.billingFrequency = normalizeBillingFrequency(
-      currentRows[0]?.billingType ?? DEFAULT_BILLING_TYPE,
-      patch.billingFrequency,
-    );
+    // Lock billing_type while we normalize against it: a concurrent UPDATE of billing_type
+    // between the SELECT and our UPDATE would otherwise leave billing_frequency mismatched.
+    return runAtomically(exec, async (tx) => {
+      const billingType = await lockBillingTypeById(id, tx);
+      set.billingFrequency = normalizeBillingFrequency(
+        billingType ?? DEFAULT_BILLING_TYPE,
+        patch.billingFrequency,
+      );
+      const rows = await tx.update(tasks).set(set).where(eq(tasks.id, id)).returning();
+      return rows[0] ? mapRow(rows[0]) : null;
+    });
   }
 
   if (Object.keys(set).length === 0) {

--- a/server/test/repositories/tasksRepo.test.ts
+++ b/server/test/repositories/tasksRepo.test.ts
@@ -186,6 +186,21 @@ describe('update', () => {
     expect(exec.calls[1].params).not.toContain('one_time');
   });
 
+  // Without a row lock, a concurrent UPDATE that flips billingType between this SELECT and
+  // the following UPDATE would make our normalization stale and write a billingFrequency
+  // matched against the old billingType. The locking SELECT serializes the read against any
+  // concurrent writer of the same row.
+  test('billingFrequency-only update reads current billingType with FOR UPDATE', async () => {
+    exec.enqueue({ rows: [makeRow(['retainer'])] });
+    exec.enqueue({ rows: [taskRow({ 14: 'retainer', 15: 'one_time' })] });
+
+    await tasksRepo.update('t-1', { billingFrequency: 'one_time' }, testDb);
+
+    const selectSql = exec.calls[0].sql.toLowerCase();
+    expect(selectSql).toContain('select');
+    expect(selectSql).toContain('for update');
+  });
+
   test('returns null when UPDATE finds no row', async () => {
     exec.enqueue({ rows: [] });
     expect(await tasksRepo.update('t-x', { name: 'X' }, testDb)).toBeNull();


### PR DESCRIPTION
## Summary
- Closes #511. When only `billingFrequency` is patched, `tasksRepo.update` SELECTed `billing_type` unlocked, then issued a separate UPDATE — a concurrent change of `billing_type` between the two statements would write a `billing_frequency` normalized against stale data.
- The SELECT and UPDATE now run inside `runAtomically` with a `SELECT … FOR UPDATE` on the row, so the lock is held across normalization. The locking read is extracted into `lockBillingTypeById`, mirroring the `lock*ById` convention used in `projectsRepo`, `clientOffersRepo`, `supplierOrdersRepo`, etc.
- Routes that already pass an open tx reuse it (`runAtomically` short-circuits); the default-pool caller in `routes/tasks.ts` gets a fresh transaction.

## Test plan
- [x] `bun test` (server) — 2625 pass / 28 skip / 0 fail
- [x] New unit test asserts the emitted SELECT contains `FOR UPDATE`
- [x] Existing `normalizes billingFrequency-only update` test continues to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)