### PR TITLE
app(fix): retry and surface paginated entry stream failures (#512)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1497,9 +1497,9 @@ const AppContent: React.FC = () => {
                 !isCurrentModuleLoad() || entriesStreamTokenRef.current !== token;
               while (cursor) {
                 const pageCursor = cursor;
-                let page: Awaited<ReturnType<typeof api.entries.listPage>> | null;
+                let result: Awaited<ReturnType<typeof api.entries.listPage>> | null;
                 try {
-                  page = await retryTransient(
+                  result = await retryTransient(
                     () => api.entries.listPage({ cursor: pageCursor, limit: 500 }),
                     { isCancelled },
                   );
@@ -1512,7 +1512,9 @@ const AppContent: React.FC = () => {
                   );
                   return;
                 }
-                if (page === null) return;
+                if (result === null) return;
+                // Bind to a const so TS narrowing survives into the setState closure.
+                const page = result;
                 setEntries((prev) => mergeById(prev, page.entries));
                 cursor = page.nextCursor;
               }

--- a/App.tsx
+++ b/App.tsx
@@ -111,7 +111,9 @@ import {
   TOP_MANAGER_ROLE_ID,
   VIEW_PERMISSION_MAP,
 } from './utils/permissions';
+import { retryTransient } from './utils/retry';
 import { applyTheme, getTheme } from './utils/theme';
+import { toastError } from './utils/toast';
 import {
   filterTrackerCatalogs,
   type TrackerAssignmentState,
@@ -703,6 +705,7 @@ const AppContent: React.FC = () => {
     markModuleLoaded,
     invalidateModules,
     recordFailures,
+    appendFailure,
     reset: resetModuleLoader,
   } = useModuleLoader();
   const [hasLoadedGeneralSettings, setHasLoadedGeneralSettings] = useState(false);
@@ -1490,18 +1493,28 @@ const AppContent: React.FC = () => {
               return merged;
             };
             const streamRemainingEntries = async (cursor: string | null, token: number) => {
+              const isCancelled = () =>
+                !isCurrentModuleLoad() || entriesStreamTokenRef.current !== token;
               while (cursor) {
-                if (!isCurrentModuleLoad() || entriesStreamTokenRef.current !== token) return;
+                const pageCursor = cursor;
+                let page: Awaited<ReturnType<typeof api.entries.listPage>> | null;
                 try {
-                  const page = await api.entries.listPage({ cursor, limit: 500 });
-                  if (!isCurrentModuleLoad() || entriesStreamTokenRef.current !== token) return;
-                  setEntries((prev) => mergeById(prev, page.entries));
-                  cursor = page.nextCursor;
+                  page = await retryTransient(
+                    () => api.entries.listPage({ cursor: pageCursor, limit: 500 }),
+                    { isCancelled },
+                  );
                 } catch (err) {
-                  if (!isCurrentModuleLoad() || entriesStreamTokenRef.current !== token) return;
+                  if (isCancelled()) return;
                   console.error('Failed to stream remaining entries:', err);
+                  appendFailure(module, 'additional entries');
+                  toastError(
+                    'Some time entries could not be loaded. Displayed data may be incomplete.',
+                  );
                   return;
                 }
+                if (page === null) return;
+                setEntries((prev) => mergeById(prev, page.entries));
+                cursor = page.nextCursor;
               }
             };
             failedDatasets = await loadDatasets(
@@ -1847,6 +1860,7 @@ const AppContent: React.FC = () => {
     markModuleLoaded,
     invalidateModules,
     recordFailures,
+    appendFailure,
     hasLoadedGeneralSettings,
     hasLoadedLdapConfig,
     hasLoadedSsoProviders,

--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import api, { ApiError, getAuthToken, type Settings, setAuthToken } from '../services/api';
 import type { User } from '../types';
 import { applyLanguagePreference } from '../utils/language';
+import { isTransientError, RETRY_DELAYS_MS, sleep } from '../utils/retry';
 
 const DEFAULT_SETTINGS: Settings = {
   fullName: '',
@@ -9,24 +10,10 @@ const DEFAULT_SETTINGS: Settings = {
   language: 'auto',
 };
 
-export const AUTH_CHECK_RETRY_DELAYS_MS = [500, 1000, 2000];
-
-const sleep = (ms: number) =>
-  new Promise<void>((resolve) => {
-    setTimeout(resolve, ms);
-  });
+export const AUTH_CHECK_RETRY_DELAYS_MS = RETRY_DELAYS_MS;
 
 const isAuthRejection = (err: unknown): boolean =>
   err instanceof ApiError && (err.status === 401 || err.status === 403);
-
-// Anything that looks like flaky infrastructure rather than a definite client
-// or auth failure - retry these instead of logging the user out.
-const isTransientError = (err: unknown): boolean => {
-  if (err instanceof ApiError) {
-    return err.isNetworkError || err.status === 0 || err.status >= 500;
-  }
-  return true;
-};
 
 export type UseAuthOptions = {
   onLogin?: (user: User) => void;

--- a/hooks/useModuleLoader.ts
+++ b/hooks/useModuleLoader.ts
@@ -123,6 +123,16 @@ export function useModuleLoader() {
     });
   }, []);
 
+  // Additive counterpart to recordFailures, for async tail-work that completes
+  // after the initial failure list has been written.
+  const appendFailure = useCallback((moduleName: string, failure: string) => {
+    setModuleLoadErrors((prev) => {
+      const existing = prev[moduleName] ?? [];
+      if (existing.includes(failure)) return prev;
+      return { ...prev, [moduleName]: [...existing, failure] };
+    });
+  }, []);
+
   const reset = useCallback(() => {
     setLoadedModules(new Set());
     setModuleLoadErrors({});
@@ -148,6 +158,7 @@ export function useModuleLoader() {
     markModuleLoaded,
     invalidateModules,
     recordFailures,
+    appendFailure,
     reset,
   };
 }

--- a/test/App.streamRemainingEntries.test.ts
+++ b/test/App.streamRemainingEntries.test.ts
@@ -36,6 +36,6 @@ describe('App.tsx streamRemainingEntries', () => {
   });
 
   test('bails out silently on cancellation (retryTransient returns null)', () => {
-    expect(body).toContain('if (page === null) return;');
+    expect(body).toContain('if (result === null) return;');
   });
 });

--- a/test/App.streamRemainingEntries.test.ts
+++ b/test/App.streamRemainingEntries.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Pin the streamRemainingEntries contract introduced for issue #512:
+//   - listPage calls go through the shared retryTransient helper
+//     (which handles backoff + 4xx short-circuit + cancellation)
+//   - persistent failures surface via appendFailure + toastError
+//   - cancellation (stale token / stale module load) bails silently
+//
+// The function is locally scoped inside the timesheets case block, so this is
+// a source-text contract test rather than a behavioral one.
+describe('App.tsx streamRemainingEntries', () => {
+  const source = readFileSync(join(import.meta.dir, '..', 'App.tsx'), 'utf8');
+  const start = source.indexOf('const streamRemainingEntries = async');
+  const end = source.indexOf('failedDatasets = await loadDatasets(', start);
+  const body = source.slice(start, end);
+
+  test('locates the streamRemainingEntries function', () => {
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+  });
+
+  test('delegates retry/backoff to the shared retryTransient helper', () => {
+    expect(body).toContain('retryTransient(');
+    expect(body).toContain('isCancelled');
+  });
+
+  test('appends a module failure and toasts on persistent failure', () => {
+    expect(body).toContain("appendFailure(module, 'additional entries');");
+    expect(body).toMatch(/toastError\(\s*['"]Some time entries could not be loaded/);
+  });
+
+  test('still logs to console on persistent failure for diagnostics', () => {
+    expect(body).toContain("console.error('Failed to stream remaining entries:'");
+  });
+
+  test('bails out silently on cancellation (retryTransient returns null)', () => {
+    expect(body).toContain('if (page === null) return;');
+  });
+});

--- a/test/hooks/useModuleLoader.test.ts
+++ b/test/hooks/useModuleLoader.test.ts
@@ -250,6 +250,39 @@ describe('useModuleLoader', () => {
     expect(result.current.moduleLoadErrors.crm).toEqual(['clients', 'suppliers']);
   });
 
+  test('appendFailure adds a dataset to an existing failure list without clobbering', () => {
+    const { result } = renderHook(() => useModuleLoader());
+
+    act(() => {
+      result.current.recordFailures('timesheets', ['clients']);
+    });
+    expect(result.current.moduleLoadErrors.timesheets).toEqual(['clients']);
+
+    act(() => {
+      result.current.appendFailure('timesheets', 'additional entries');
+    });
+    expect(result.current.moduleLoadErrors.timesheets).toEqual(['clients', 'additional entries']);
+  });
+
+  test('appendFailure creates the module entry if none exists', () => {
+    const { result } = renderHook(() => useModuleLoader());
+
+    act(() => {
+      result.current.appendFailure('timesheets', 'additional entries');
+    });
+    expect(result.current.moduleLoadErrors.timesheets).toEqual(['additional entries']);
+  });
+
+  test('appendFailure is idempotent for the same dataset', () => {
+    const { result } = renderHook(() => useModuleLoader());
+
+    act(() => {
+      result.current.appendFailure('timesheets', 'additional entries');
+      result.current.appendFailure('timesheets', 'additional entries');
+    });
+    expect(result.current.moduleLoadErrors.timesheets).toEqual(['additional entries']);
+  });
+
   test('recordFailures with empty array clears the module entry', () => {
     const { result } = renderHook(() => useModuleLoader());
 

--- a/test/utils/retry.test.ts
+++ b/test/utils/retry.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { ApiError } from '../../services/api';
+import { isTransientError, retryTransient, sleep } from '../../utils/retry';
+
+describe('utils/retry', () => {
+  describe('isTransientError', () => {
+    test('network errors are transient', () => {
+      expect(isTransientError(new ApiError('offline', 0, true))).toBe(true);
+    });
+
+    test('5xx are transient', () => {
+      expect(isTransientError(new ApiError('boom', 500))).toBe(true);
+      expect(isTransientError(new ApiError('boom', 503))).toBe(true);
+    });
+
+    test('4xx are NOT transient (retrying just wastes time on a definite no)', () => {
+      expect(isTransientError(new ApiError('nope', 400))).toBe(false);
+      expect(isTransientError(new ApiError('auth', 401))).toBe(false);
+      expect(isTransientError(new ApiError('forbidden', 403))).toBe(false);
+      expect(isTransientError(new ApiError('not found', 404))).toBe(false);
+    });
+
+    test('non-ApiError errors are treated as transient', () => {
+      expect(isTransientError(new Error('???'))).toBe(true);
+      expect(isTransientError('weird')).toBe(true);
+    });
+  });
+
+  describe('retryTransient', () => {
+    test('returns immediately on success without sleeping', async () => {
+      const fn = mock(() => Promise.resolve('ok'));
+      const result = await retryTransient(fn, { delaysMs: [10, 20, 30] });
+      expect(result).toBe('ok');
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    test('retries transient errors until success', async () => {
+      let calls = 0;
+      const fn = mock(() => {
+        calls += 1;
+        if (calls < 3) return Promise.reject(new ApiError('flaky', 503));
+        return Promise.resolve('ok');
+      });
+      const result = await retryTransient(fn, { delaysMs: [0, 0, 0] });
+      expect(result).toBe('ok');
+      expect(fn).toHaveBeenCalledTimes(3);
+    });
+
+    test('throws after exhausting all retries on transient errors', async () => {
+      const fn = mock(() => Promise.reject(new ApiError('boom', 500)));
+      await expect(retryTransient(fn, { delaysMs: [0, 0] })).rejects.toThrow('boom');
+      // delays.length + 1 attempts = 3
+      expect(fn).toHaveBeenCalledTimes(3);
+    });
+
+    test('throws immediately on non-transient (4xx) errors — no retries', async () => {
+      const fn = mock(() => Promise.reject(new ApiError('nope', 400)));
+      await expect(retryTransient(fn, { delaysMs: [0, 0, 0] })).rejects.toThrow('nope');
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    test('returns null when cancelled before the first attempt', async () => {
+      const fn = mock(() => Promise.resolve('ok'));
+      const result = await retryTransient(fn, { isCancelled: () => true });
+      expect(result).toBeNull();
+      expect(fn).not.toHaveBeenCalled();
+    });
+
+    test('returns null when cancelled mid-retry', async () => {
+      let cancelled = false;
+      const fn = mock(() => {
+        cancelled = true;
+        return Promise.reject(new ApiError('flaky', 503));
+      });
+      const result = await retryTransient(fn, {
+        delaysMs: [0, 0, 0],
+        isCancelled: () => cancelled,
+      });
+      expect(result).toBeNull();
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('sleep', () => {
+    test('resolves after the given delay', async () => {
+      const start = performance.now();
+      await sleep(10);
+      expect(performance.now() - start).toBeGreaterThanOrEqual(8);
+    });
+  });
+});

--- a/utils/retry.ts
+++ b/utils/retry.ts
@@ -1,0 +1,46 @@
+import { ApiError } from '../services/api';
+
+export const RETRY_DELAYS_MS: readonly number[] = [500, 1000, 2000];
+
+export const sleep = (ms: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+// Retry on flaky infrastructure (network, 0, 5xx). 4xx/auth are definite
+// failures — retrying just wastes the user's time on an answer the server
+// already gave.
+export const isTransientError = (err: unknown): boolean => {
+  if (err instanceof ApiError) {
+    return err.isNetworkError || err.status === 0 || err.status >= 500;
+  }
+  return true;
+};
+
+export type RetryOptions = {
+  delaysMs?: readonly number[];
+  isCancelled?: () => boolean;
+};
+
+// Returns the function's result, or `null` if the caller cancelled mid-flight.
+// Throws on persistent failure (non-transient error or all retries exhausted)
+// so callers can attach context with try/catch.
+export const retryTransient = async <T>(
+  fn: () => Promise<T>,
+  options: RetryOptions = {},
+): Promise<T | null> => {
+  const delays = options.delaysMs ?? RETRY_DELAYS_MS;
+  const isCancelled = options.isCancelled ?? (() => false);
+  let attempt = 0;
+  while (true) {
+    if (isCancelled()) return null;
+    try {
+      return await fn();
+    } catch (err) {
+      if (isCancelled()) return null;
+      if (!isTransientError(err) || attempt >= delays.length) throw err;
+      await sleep(delays[attempt]);
+      attempt += 1;
+    }
+  }
+};


### PR DESCRIPTION
## Summary

Fixes [#512](https://github.com/xBounceIT/praetor/issues/512). Pages 2+ of the paginated time-entry stream silently swallowed failures, leaving users with partial data and no signal that anything was wrong.

- Each continuation page now goes through `retryTransient` — 3 retries with 500ms/1s/2s backoff for network blips / 5xx, immediate short-circuit on 4xx.
- Persistent failure surfaces via the existing module-load banner (`appendFailure(module, 'additional entries')`) plus a toast ("Some time entries could not be loaded. Displayed data may be incomplete.").
- Extracted the shared retry primitives (`sleep`, `isTransientError`, `RETRY_DELAYS_MS`, `retryTransient`) into `utils/retry.ts` and replaced the duplicates previously private to `useAuth.ts`.

## Notable design choices

- `useModuleLoader` gains an `appendFailure(moduleName, failure)` helper alongside the existing `recordFailures`. The async streaming tail completes after `loadDatasets` has already written its failure list, so an additive op is needed; merging it into `recordFailures` would muddy the overwrite semantics.
- `useAuth.AUTH_CHECK_RETRY_DELAYS_MS` is preserved as a re-export so existing call sites and tests keep working.
- `streamRemainingEntries` is locally scoped inside the timesheets switch case, so its contract test uses source-text inspection (matches the existing pattern in `App.moduleLoadCancellation.test.ts`).

## Test plan

- [x] `bun test ./test` — 1101 pass / 0 fail
- [x] `bunx tsc -p tsconfig.json --noEmit` — clean
- [x] `bunx biome check` on changed files — clean
- New tests added: `test/utils/retry.test.ts` (11 cases covering retry/transient/cancellation), `test/App.streamRemainingEntries.test.ts` (5 contract pins), 3 new `useModuleLoader` cases for `appendFailure`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)