### PR TITLE
auth(fix): reject session tokens missing sessionStart (#525)

### DIFF
--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -106,8 +106,12 @@ const hasSessionAuthContext = (
   auth: FastifyRequest['auth'],
 ): auth is NonNullable<FastifyRequest['auth']> & {
   source: 'session';
+  sessionStart: number;
   sessionVersion: number;
-} => auth?.source === 'session' && typeof auth.sessionVersion === 'number';
+} =>
+  auth?.source === 'session' &&
+  typeof auth.sessionStart === 'number' &&
+  typeof auth.sessionVersion === 'number';
 
 const buildSessionAuthRequiredError = () => {
   const error = new Error('Session authentication required') as Error & { statusCode: number };
@@ -184,7 +188,16 @@ export const authenticateToken = async (request: FastifyRequest, reply: FastifyR
     const decoded = jwt.verify(token, getJwtSecret(), {
       algorithms: [JWT_ALGORITHM],
     }) as SessionJwtPayload;
-    const sessionStart = decoded.sessionStart ?? Date.now();
+
+    // Fail closed: tokens without sessionStart would compare `now - now ≈ 0` and trivially
+    // pass the max-duration check below. Reject them so the 8h cap cannot be bypassed.
+    if (typeof decoded.sessionStart !== 'number') {
+      return reply.code(401).send({
+        error: 'Session token outdated, please log in again',
+        errorCode: 'session_outdated',
+      });
+    }
+    const sessionStart = decoded.sessionStart;
 
     // Check for max session duration (configurable via SESSION_MAX_DURATION_MS env var,
     // default 8 hours). Resolved once per process — see getSessionMaxDurationMs above.
@@ -360,7 +373,7 @@ export const getSessionAuth = (request: FastifyRequest): SessionAuthContext => {
   }
   return {
     userId: request.auth.userId,
-    sessionStart: request.auth.sessionStart ?? Date.now(),
+    sessionStart: request.auth.sessionStart,
     sessionVersion: request.auth.sessionVersion,
   };
 };

--- a/server/test/helpers/jwt.ts
+++ b/server/test/helpers/jwt.ts
@@ -6,7 +6,8 @@ const SESSION_MAX_DURATION_MS = 8 * 60 * 60 * 1000;
 
 export type SignTokenInput = {
   userId: string;
-  sessionStart?: number;
+  // Pass null to omit the claim entirely (simulates pre-feature / forged tokens).
+  sessionStart?: number | null;
   activeRole?: string;
   // Pass null to omit the claim entirely (simulates pre-feature tokens).
   sessionVersion?: number | null;
@@ -22,7 +23,8 @@ export const signToken = ({
   expiresIn = '30m',
   secret = TEST_JWT_SECRET,
 }: SignTokenInput): string => {
-  const payload: Record<string, unknown> = { userId, sessionStart, activeRole };
+  const payload: Record<string, unknown> = { userId, activeRole };
+  if (sessionStart !== null) payload.sessionStart = sessionStart;
   if (sessionVersion !== null) payload.sessionVersion = sessionVersion;
   return jwt.sign(payload, secret, { expiresIn });
 };

--- a/server/test/middleware/auth.test.ts
+++ b/server/test/middleware/auth.test.ts
@@ -389,6 +389,18 @@ describe('authenticateToken', () => {
     expect(findAuthUserByIdMock).not.toHaveBeenCalled();
   });
 
+  test('401 when token has no sessionStart (cannot bypass max-duration check)', async () => {
+    const request = buildFakeRequest(signToken({ userId: 'u1', sessionStart: null }));
+    const reply = buildFakeReply();
+    await authenticateToken(request as never, reply as never);
+    expect(reply.statusCode).toBe(401);
+    expect(reply.body).toEqual({
+      error: 'Session token outdated, please log in again',
+      errorCode: 'session_outdated',
+    });
+    expect(findAuthUserByIdMock).not.toHaveBeenCalled();
+  });
+
   test('401 when token sessionVersion does not match the user (logout/revocation)', async () => {
     findAuthUserByIdMock.mockResolvedValue({ ...HAPPY_USER, sessionVersion: 5 });
     const request = buildFakeRequest(signToken({ userId: 'u1', sessionVersion: 2 }));


### PR DESCRIPTION
## Summary
- Closes #525. The JWT auth middleware defaulted a missing `sessionStart` claim to `Date.now()`, so the `SESSION_MAX_DURATION_MS` check became `now - now ≈ 0` and the 8h cap could be bypassed indefinitely with a hand-crafted token that omitted the claim.
- Fail closed instead: reject such tokens with the existing `session_outdated` 401, mirroring the adjacent missing-`sessionVersion` guard.
- Tightened `hasSessionAuthContext` to also assert `sessionStart: number`, which lets `getSessionAuth` drop its own `?? Date.now()` fallback (the same fail-open footgun, second instance).

## Test plan
- [x] `bun test test/middleware/auth.test.ts test/middleware/auth-session-max.test.ts test/utils/auth-assert.test.ts test/routes/auth.test.ts` → 84 pass.
- [x] New regression test in `server/test/middleware/auth.test.ts` signs a token without `sessionStart` and asserts 401 `session_outdated`; fails on the old code, passes on the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)