### PR TITLE
sso(fix): require non-empty usernameAttribute for enabled providers (#605)

### DIFF
--- a/server/services/sso.ts
+++ b/server/services/sso.ts
@@ -72,12 +72,8 @@ const hasConfigValue = (value: unknown): boolean =>
 const assertEnabledProviderConfig = (provider: ssoProvidersRepo.SsoProvider): void => {
   if (!provider.enabled) return;
 
-  if (!hasConfigValue(provider.usernameAttribute)) {
-    throw new SsoProviderValidationError('usernameAttribute is required');
-  }
-
   if (provider.protocol === 'oidc') {
-    for (const field of ['issuerUrl', 'clientId'] as const) {
+    for (const field of ['issuerUrl', 'clientId', 'usernameAttribute'] as const) {
       if (!hasConfigValue(provider[field])) {
         throw new SsoProviderValidationError(`${field} is required`);
       }
@@ -91,6 +87,9 @@ const assertEnabledProviderConfig = (provider: ssoProvidersRepo.SsoProvider): vo
     throw new SsoProviderValidationError(
       'SAML requires metadata URL/XML or manual entryPoint and idpCert',
     );
+  }
+  if (!hasConfigValue(provider.usernameAttribute)) {
+    throw new SsoProviderValidationError('usernameAttribute is required');
   }
 };
 

--- a/server/services/sso.ts
+++ b/server/services/sso.ts
@@ -72,8 +72,12 @@ const hasConfigValue = (value: unknown): boolean =>
 const assertEnabledProviderConfig = (provider: ssoProvidersRepo.SsoProvider): void => {
   if (!provider.enabled) return;
 
+  if (!hasConfigValue(provider.usernameAttribute)) {
+    throw new SsoProviderValidationError('usernameAttribute is required');
+  }
+
   if (provider.protocol === 'oidc') {
-    for (const field of ['issuerUrl', 'clientId', 'usernameAttribute'] as const) {
+    for (const field of ['issuerUrl', 'clientId'] as const) {
       if (!hasConfigValue(provider[field])) {
         throw new SsoProviderValidationError(`${field} is required`);
       }

--- a/server/test/services/sso.test.ts
+++ b/server/test/services/sso.test.ts
@@ -378,3 +378,18 @@ describe('completeOidcLogin state-before-provider ordering', () => {
     expect(statesConsumeMock).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('updateProvider config validation', () => {
+  test('rejects enabling a SAML provider with empty usernameAttribute', async () => {
+    findByIdMock.mockResolvedValue({
+      ...SAML_PROVIDER,
+      metadataUrl: 'https://idp.example.com/metadata',
+    });
+    await expect(
+      sso.updateProvider('sso-1', { enabled: true, usernameAttribute: '' }),
+    ).rejects.toThrow(sso.SsoProviderValidationError);
+    await expect(
+      sso.updateProvider('sso-1', { enabled: true, usernameAttribute: '' }),
+    ).rejects.toThrow(/usernameAttribute/);
+  });
+});


### PR DESCRIPTION
## Summary
- `assertEnabledProviderConfig` previously only enforced non-empty `usernameAttribute` on the OIDC branch. A SAML provider whose `usernameAttribute` was cleared via `updateProvider` passed config validation and then failed at login time with a generic `External identity did not include a username` thrown from `resolveExternalIdentity`.
- Hoisted the `usernameAttribute` check above the protocol switch so it applies to both OIDC and SAML at config time. Dropped `usernameAttribute` from the OIDC required-field loop since it's now covered by the shared check.

## Why this surfaces only on update
`prepareProviderValues` defaults an empty `usernameAttribute` to the protocol's default (`nameID` for SAML, `preferred_username` for OIDC) on **create** but not on **update**. The cleared-via-update path was the only way to land an empty value in the DB.

## Test plan
- [x] Added `server/test/services/sso.test.ts` regression test that drives `updateProvider` with `usernameAttribute: ''` on an enabled SAML provider and asserts `SsoProviderValidationError` with a message mentioning `usernameAttribute`.
- [x] Verified the test fails on pre-fix code (reaches the DB update path) and passes on the fix.
- [x] `bun test test/services/sso.test.ts` — 28/28 pass.
- [x] `bun run lint` clean (2 pre-existing warnings in unrelated files).

Closes #605.

🤖 Generated with [Claude Code](https://claude.com/claude-code)