### PR TITLE
sso(fix): scope SAML cache lookups by providerId (#599)

### DIFF
--- a/server/repositories/ssoStatesRepo.ts
+++ b/server/repositories/ssoStatesRepo.ts
@@ -58,11 +58,15 @@ export const consume = async (
   return rows[0] ? mapRow(rows[0]) : null;
 };
 
-export const get = async (state: string, exec: DbExecutor = db): Promise<SsoState | null> => {
+export const getForProvider = async (
+  state: string,
+  providerId: string,
+  exec: DbExecutor = db,
+): Promise<SsoState | null> => {
   const rows = await exec
     .select(STATE_PROJECTION)
     .from(ssoStates)
-    .where(eq(ssoStates.state, state));
+    .where(and(eq(ssoStates.state, state), eq(ssoStates.providerId, providerId)));
   return rows[0] ? mapRow(rows[0]) : null;
 };
 

--- a/server/services/sso.ts
+++ b/server/services/sso.ts
@@ -220,7 +220,7 @@ const prepareProviderValues = (
   return patch;
 };
 
-class DbSamlCacheProvider implements CacheProvider {
+export class DbSamlCacheProvider implements CacheProvider {
   constructor(private readonly providerId: string) {}
 
   async saveAsync(key: string, value: string): Promise<CacheItem | null> {
@@ -236,7 +236,7 @@ class DbSamlCacheProvider implements CacheProvider {
   }
 
   async getAsync(key: string): Promise<string | null> {
-    const state = await ssoStatesRepo.get(key);
+    const state = await ssoStatesRepo.getForProvider(key, this.providerId);
     if (!state || state.protocol !== 'saml' || state.expiresAt <= new Date()) return null;
     return state.relayState;
   }

--- a/server/test/services/sso.test.ts
+++ b/server/test/services/sso.test.ts
@@ -11,6 +11,9 @@ const dnsLookupMock = mock();
 const findBySlugMock = mock();
 const findByIdMock = mock();
 const statesConsumeMock = mock();
+const statesGetForProviderMock = mock();
+const statesInsertMock = mock();
+const statesRemoveMock = mock();
 
 let sso: typeof import('../../services/sso.ts');
 
@@ -28,6 +31,9 @@ beforeAll(async () => {
   mock.module('../../repositories/ssoStatesRepo.ts', () => ({
     ...ssoStatesRepoSnap,
     consume: statesConsumeMock,
+    getForProvider: statesGetForProviderMock,
+    insert: statesInsertMock,
+    remove: statesRemoveMock,
   }));
 
   sso = await import('../../services/sso.ts');
@@ -40,7 +46,16 @@ afterAll(() => {
 });
 
 beforeEach(() => {
-  for (const m of [dnsLookupMock, findBySlugMock, findByIdMock, statesConsumeMock]) m.mockReset();
+  for (const m of [
+    dnsLookupMock,
+    findBySlugMock,
+    findByIdMock,
+    statesConsumeMock,
+    statesGetForProviderMock,
+    statesInsertMock,
+    statesRemoveMock,
+  ])
+    m.mockReset();
 });
 
 describe('isPrivateIp', () => {
@@ -376,5 +391,45 @@ describe('completeOidcLogin state-before-provider ordering', () => {
       'Invalid or expired SSO state',
     );
     expect(statesConsumeMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('DbSamlCacheProvider provider scoping', () => {
+  const fakeRow = {
+    state: 'in-response-to-1',
+    providerId: 'sso-A',
+    protocol: 'saml' as const,
+    codeVerifier: '',
+    relayState: 'relay-A',
+    expiresAt: new Date(Date.now() + 60_000),
+  };
+
+  beforeEach(() => {
+    statesGetForProviderMock.mockImplementation(async (state: string, providerId: string) =>
+      state === fakeRow.state && providerId === fakeRow.providerId ? fakeRow : null,
+    );
+  });
+
+  test("returns the value when queried by the same provider's cache", async () => {
+    const cache = new sso.DbSamlCacheProvider('sso-A');
+    expect(await cache.getAsync('in-response-to-1')).toBe('relay-A');
+    expect(statesGetForProviderMock).toHaveBeenCalledWith('in-response-to-1', 'sso-A');
+  });
+
+  test("returns null when a different provider's cache instance queries the same key", async () => {
+    const cache = new sso.DbSamlCacheProvider('sso-B');
+    expect(await cache.getAsync('in-response-to-1')).toBeNull();
+    expect(statesGetForProviderMock).toHaveBeenCalledWith('in-response-to-1', 'sso-B');
+  });
+
+  test('saveAsync records the cache provider providerId', async () => {
+    statesInsertMock.mockResolvedValue(undefined);
+    const cache = new sso.DbSamlCacheProvider('sso-A');
+    await cache.saveAsync('k', 'v');
+    const inserted = statesInsertMock.mock.calls[0][0];
+    expect(inserted.state).toBe('k');
+    expect(inserted.providerId).toBe('sso-A');
+    expect(inserted.protocol).toBe('saml');
+    expect(inserted.relayState).toBe('v');
   });
 });

--- a/server/test/services/sso.test.ts
+++ b/server/test/services/sso.test.ts
@@ -13,7 +13,6 @@ const findByIdMock = mock();
 const statesConsumeMock = mock();
 const statesGetForProviderMock = mock();
 const statesInsertMock = mock();
-const statesRemoveMock = mock();
 
 let sso: typeof import('../../services/sso.ts');
 
@@ -33,7 +32,6 @@ beforeAll(async () => {
     consume: statesConsumeMock,
     getForProvider: statesGetForProviderMock,
     insert: statesInsertMock,
-    remove: statesRemoveMock,
   }));
 
   sso = await import('../../services/sso.ts');
@@ -53,7 +51,6 @@ beforeEach(() => {
     statesConsumeMock,
     statesGetForProviderMock,
     statesInsertMock,
-    statesRemoveMock,
   ])
     m.mockReset();
 });


### PR DESCRIPTION
## Summary
- Fixes [#599](https://github.com/xBounceIT/praetor/issues/599). `DbSamlCacheProvider.saveAsync` records `providerId`, but `getAsync` only filtered the `sso_states` row by `state` — so an `InResponseTo` from provider A could match a SAML callback for provider B if request IDs ever collided.
- Replaces `ssoStatesRepo.get(state)` (only had one caller, the broken cache provider) with `getForProvider(state, providerId)` that filters on both columns. `DbSamlCacheProvider.getAsync` now passes `this.providerId`.
- AuthnRequest IDs are random base64 and cert/signature checks still protect against impersonation in practice — but the cache shouldn't be cross-provider in the first place.

## Why
Defense-in-depth. The save side already stamped `providerId`; the read side just wasn't honoring it.

## Test plan
- [x] `bun test test/services/sso.test.ts` — 30/30 pass (3 new scoping tests + existing).
- [x] `bun test test/repositories` — 929/929 pass (no other callers of the removed `get`).
- New tests cover: same-provider cache returns the value, cross-provider cache instance returns `null` for the same key (the bug repro), and `saveAsync` stamps the correct `providerId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)