### PR TITLE
sso(fix): drop spIssuer fallback for SAML issuer (#598)

### DIFF
--- a/server/services/sso.ts
+++ b/server/services/sso.ts
@@ -744,8 +744,10 @@ export const completeSamlLogin = async (
   const claims = profile as Record<string, unknown>;
   const subject = coerceString(profile.nameID);
   if (!subject) throw new Error('SAML response did not include a subject');
+  const issuer = coerceString(profile.issuer) || provider.idpIssuer;
+  if (!issuer) throw new Error('SAML response did not include an issuer');
   return completeExternalLogin(provider, {
-    issuer: coerceString(profile.issuer) || provider.idpIssuer || provider.spIssuer,
+    issuer,
     subject,
     username: readClaim(claims, provider.usernameAttribute),
     name: readClaim(claims, provider.nameAttribute),

--- a/server/test/services/sso.test.ts
+++ b/server/test/services/sso.test.ts
@@ -1,9 +1,13 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
 import * as realDns from 'node:dns/promises';
+import * as realNodeSaml from '@node-saml/node-saml';
 import * as realSsoProvidersRepo from '../../repositories/ssoProvidersRepo.ts';
 import * as realSsoStatesRepo from '../../repositories/ssoStatesRepo.ts';
+import * as realExternalAuth from '../../services/external-auth.ts';
 
 const dnsSnap = { ...realDns };
+const nodeSamlSnap = { ...realNodeSaml };
+const externalAuthSnap = { ...realExternalAuth };
 const ssoProvidersRepoSnap = { ...realSsoProvidersRepo };
 const ssoStatesRepoSnap = { ...realSsoStatesRepo };
 
@@ -11,6 +15,14 @@ const dnsLookupMock = mock();
 const findBySlugMock = mock();
 const findByIdMock = mock();
 const statesConsumeMock = mock();
+const samlValidatePostMock = mock();
+const resolveExternalIdentityMock = mock();
+
+class StubSaml {
+  validatePostResponseAsync(formBody: Record<string, string>) {
+    return samlValidatePostMock(formBody);
+  }
+}
 
 let sso: typeof import('../../services/sso.ts');
 
@@ -19,6 +31,14 @@ beforeAll(async () => {
     ...dnsSnap,
     default: { ...dnsSnap, lookup: dnsLookupMock },
     lookup: dnsLookupMock,
+  }));
+  mock.module('@node-saml/node-saml', () => ({
+    ...nodeSamlSnap,
+    SAML: StubSaml,
+  }));
+  mock.module('../../services/external-auth.ts', () => ({
+    ...externalAuthSnap,
+    resolveExternalIdentity: resolveExternalIdentityMock,
   }));
   mock.module('../../repositories/ssoProvidersRepo.ts', () => ({
     ...ssoProvidersRepoSnap,
@@ -35,12 +55,22 @@ beforeAll(async () => {
 
 afterAll(() => {
   mock.module('node:dns/promises', () => dnsSnap);
+  mock.module('@node-saml/node-saml', () => nodeSamlSnap);
+  mock.module('../../services/external-auth.ts', () => externalAuthSnap);
   mock.module('../../repositories/ssoProvidersRepo.ts', () => ssoProvidersRepoSnap);
   mock.module('../../repositories/ssoStatesRepo.ts', () => ssoStatesRepoSnap);
 });
 
 beforeEach(() => {
-  for (const m of [dnsLookupMock, findBySlugMock, findByIdMock, statesConsumeMock]) m.mockReset();
+  for (const m of [
+    dnsLookupMock,
+    findBySlugMock,
+    findByIdMock,
+    statesConsumeMock,
+    samlValidatePostMock,
+    resolveExternalIdentityMock,
+  ])
+    m.mockReset();
 });
 
 describe('isPrivateIp', () => {
@@ -376,5 +406,55 @@ describe('completeOidcLogin state-before-provider ordering', () => {
       'Invalid or expired SSO state',
     );
     expect(statesConsumeMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('completeSamlLogin issuer resolution', () => {
+  const originalSsoBase = process.env.SSO_CALLBACK_BASE_URL;
+
+  const manualSamlProvider: realSsoProvidersRepo.SsoProvider = {
+    ...SAML_PROVIDER,
+    metadataUrl: '',
+    entryPoint: 'https://idp.example.com/sso',
+    idpCert: 'CERT',
+    idpIssuer: '',
+    spIssuer: 'https://app.example.com/sp/okta',
+  };
+
+  beforeEach(() => {
+    process.env.SSO_CALLBACK_BASE_URL = 'https://app.example.com';
+  });
+  afterAll(() => {
+    if (originalSsoBase === undefined) delete process.env.SSO_CALLBACK_BASE_URL;
+    else process.env.SSO_CALLBACK_BASE_URL = originalSsoBase;
+  });
+
+  test('throws when neither profile.issuer nor provider.idpIssuer is set (does NOT fall back to spIssuer)', async () => {
+    findBySlugMock.mockResolvedValue(manualSamlProvider);
+    samlValidatePostMock.mockResolvedValue({
+      profile: { nameID: 'user@example.com', issuer: '' },
+      loggedOut: false,
+    });
+    await expect(sso.completeSamlLogin('okta', { SAMLResponse: 'x' })).rejects.toThrow(
+      'SAML response did not include an issuer',
+    );
+    expect(resolveExternalIdentityMock).not.toHaveBeenCalled();
+  });
+
+  test('falls back to provider.idpIssuer when profile.issuer is missing', async () => {
+    findBySlugMock.mockResolvedValue({
+      ...manualSamlProvider,
+      idpIssuer: 'https://idp.example.com/realm',
+    });
+    samlValidatePostMock.mockResolvedValue({
+      profile: { nameID: 'user@example.com', issuer: '' },
+      loggedOut: false,
+    });
+    resolveExternalIdentityMock.mockRejectedValue(new Error('stop here'));
+    await expect(sso.completeSamlLogin('okta', { SAMLResponse: 'x' })).rejects.toThrow('stop here');
+    expect(resolveExternalIdentityMock).toHaveBeenCalledTimes(1);
+    expect(resolveExternalIdentityMock.mock.calls[0][0]).toMatchObject({
+      issuer: 'https://idp.example.com/realm',
+    });
   });
 });

--- a/server/test/services/sso.test.ts
+++ b/server/test/services/sso.test.ts
@@ -457,4 +457,20 @@ describe('completeSamlLogin issuer resolution', () => {
       issuer: 'https://idp.example.com/realm',
     });
   });
+
+  test('profile.issuer wins over provider.idpIssuer when both are set', async () => {
+    findBySlugMock.mockResolvedValue({
+      ...manualSamlProvider,
+      idpIssuer: 'https://idp.example.com/configured',
+    });
+    samlValidatePostMock.mockResolvedValue({
+      profile: { nameID: 'user@example.com', issuer: 'https://idp.example.com/from-response' },
+      loggedOut: false,
+    });
+    resolveExternalIdentityMock.mockRejectedValue(new Error('stop here'));
+    await expect(sso.completeSamlLogin('okta', { SAMLResponse: 'x' })).rejects.toThrow('stop here');
+    expect(resolveExternalIdentityMock.mock.calls[0][0]).toMatchObject({
+      issuer: 'https://idp.example.com/from-response',
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Fixes [#598](https://github.com/xBounceIT/praetor/issues/598): `completeSamlLogin` used `provider.spIssuer` (our SP entityID) as the third-tier fallback for the IdP issuer claim. That value would land in `external_identities.issuer`. Once the IdP later sent an issuer — or an admin populated `provider.idpIssuer` — `findByIdentity` would miss and insert a *second* identity row for the same user, orphaning the first.
- Drop the `spIssuer` fallback. When both `profile.issuer` and `provider.idpIssuer` are empty, throw `SAML response did not include an issuer` instead of silently persisting our own SP value.
- Adds two unit tests under `completeSamlLogin issuer resolution`:
  - Negative path: empty `profile.issuer` and empty `provider.idpIssuer` → throws, and `resolveExternalIdentity` is never called.
  - Positive path: empty `profile.issuer` with a configured `provider.idpIssuer` → `resolveExternalIdentity` receives that issuer.

The tests required mocking `@node-saml/node-saml.SAML` (stub `validatePostResponseAsync`) and `services/external-auth.resolveExternalIdentity`; both mocks are registered in `beforeAll` and restored in `afterAll` alongside the existing module mocks.

## Test plan

- [x] `cd server && bun test test/services/sso.test.ts` — 29 pass
- [x] `cd server && bun test test/services` — 133 pass
- [x] Verified the negative test fails on the unfixed code (received `undefined is not an object (evaluating 'user.id')` instead of the expected issuer-missing error), confirming it actually catches the regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)