### PR TITLE
sso(fix): preserve admin-assigned roles when no SAML group matches (#596)

### DIFF
--- a/server/services/external-auth.ts
+++ b/server/services/external-auth.ts
@@ -1,4 +1,4 @@
-import { withDbTransaction } from '../db/drizzle.ts';
+import { type DbExecutor, withDbTransaction } from '../db/drizzle.ts';
 import type { SsoProtocol } from '../db/schema/sso.ts';
 import * as externalIdentitiesRepo from '../repositories/externalIdentitiesRepo.ts';
 import * as rolesRepo from '../repositories/rolesRepo.ts';
@@ -111,13 +111,18 @@ export const filterExistingRoleIds = async (roleIds: string[]): Promise<string[]
   return filtered.length > 0 ? filtered : [DEFAULT_ROLE_ID];
 };
 
-const writeExternalRoleIds = async (userId: string, roleIds: string[]): Promise<void> => {
-  await withDbTransaction(async (tx) => {
-    await usersRepo.replaceUserRoles(userId, roleIds, tx);
-    await usersRepo.setPrimaryRole(userId, roleIds[0], tx);
-    await userAssignmentsRepo.syncTopManagerAssignmentsForUser(userId, tx);
-  });
+const writeExternalRoleIdsTx = async (
+  userId: string,
+  roleIds: string[],
+  tx: DbExecutor,
+): Promise<void> => {
+  await usersRepo.replaceUserRoles(userId, roleIds, tx);
+  await usersRepo.setPrimaryRole(userId, roleIds[0], tx);
+  await userAssignmentsRepo.syncTopManagerAssignmentsForUser(userId, tx);
 };
+
+const writeExternalRoleIds = (userId: string, roleIds: string[]): Promise<void> =>
+  withDbTransaction((tx) => writeExternalRoleIdsTx(userId, roleIds, tx));
 
 const applyExternalRoleIdsForUser = async (
   userId: string,
@@ -167,10 +172,12 @@ export const resolveExternalIdentity = async (
     throw new Error('External identity did not include a subject');
   }
 
-  const mappedRoleIds = await filterExistingRoleIds(
-    mapExternalGroupsToRoleIds(input.groups, input.roleMappings),
+  // Match-only role IDs: empty when no SSO group mapped to an existing Praetor role.
+  // Preserve admin-assigned roles for existing users in that case (#596); new users
+  // still fall back to DEFAULT_ROLE_ID at provisioning so they get a baseline assignment.
+  const matchedRoleIds = await filterToExistingRoleIds(
+    mapExternalGroupsToMatchedRoleIds(input.groups, input.roleMappings),
   );
-  const primaryRole = mappedRoleIds[0];
 
   const resolveInTransaction = () =>
     withDbTransaction(async (tx) => {
@@ -198,13 +205,14 @@ export const resolveExternalIdentity = async (
           const name = input.name?.trim() || username;
           const avatarInitials = computeAvatarInitials(name);
           const id = generatePrefixedId('u');
+          const initialRole = matchedRoleIds[0] ?? DEFAULT_ROLE_ID;
           await usersRepo.insertUser(
             {
               id,
               name,
               username,
               passwordHash: usersRepo.EXTERNAL_PLACEHOLDER_PASSWORD_HASH,
-              role: primaryRole,
+              role: initialRole,
               avatarInitials,
               costPerHour: 0,
               isDisabled: false,
@@ -223,7 +231,7 @@ export const resolveExternalIdentity = async (
             id,
             name,
             username,
-            role: primaryRole,
+            role: initialRole,
             avatarInitials,
             isDisabled: false,
             sessionVersion: 1,
@@ -268,15 +276,22 @@ export const resolveExternalIdentity = async (
         throw new Error('User is disabled');
       }
 
-      await usersRepo.replaceUserRoles(user.id, mappedRoleIds, tx);
-      await usersRepo.setPrimaryRole(user.id, primaryRole, tx);
-      await userAssignmentsRepo.syncTopManagerAssignmentsForUser(user.id, tx);
+      // Write roles when SSO mapped to one, or when provisioning a brand-new user (whose
+      // user_roles row would otherwise be missing). Skip writes for an existing user with
+      // no match so admin-assigned roles are preserved (#596).
+      let effectivePrimaryRole = user.role;
+      const rolesToWrite =
+        matchedRoleIds.length > 0 ? matchedRoleIds : wasCreated ? [DEFAULT_ROLE_ID] : null;
+      if (rolesToWrite) {
+        await writeExternalRoleIdsTx(user.id, rolesToWrite, tx);
+        effectivePrimaryRole = rolesToWrite[0];
+      }
 
       return {
         id: user.id,
         name: user.name,
         username: user.username,
-        role: primaryRole,
+        role: effectivePrimaryRole,
         avatarInitials: user.avatarInitials,
         isDisabled: user.isDisabled,
         sessionVersion: user.sessionVersion,

--- a/server/test/services/external-auth.resolve.test.ts
+++ b/server/test/services/external-auth.resolve.test.ts
@@ -223,3 +223,114 @@ describe('resolveExternalIdentity auth method enforcement', () => {
     expect(insertIdentityMock).not.toHaveBeenCalled();
   });
 });
+
+describe('resolveExternalIdentity role mapping — regression #596', () => {
+  const adminUser = {
+    ...matchingSsoUser,
+    role: 'admin',
+  };
+
+  test('preserves admin role when no SAML group matches a mapping', async () => {
+    findByIdentityMock.mockResolvedValue({
+      id: 'eid-1',
+      providerId: 'sso-1',
+      protocol: 'oidc',
+      issuer: input.issuer,
+      subject: input.subject,
+      userId: 'u1',
+    });
+    findLoginUserByIdMock.mockResolvedValue(adminUser);
+
+    const result = await resolveExternalIdentity({
+      ...input,
+      groups: ['cn=guests,ou=groups,dc=example,dc=com'],
+      roleMappings: [{ externalGroup: 'admins', role: 'admin' }],
+    });
+
+    expect(result.role).toBe('admin');
+    expect(replaceUserRolesMock).not.toHaveBeenCalled();
+    expect(setPrimaryRoleMock).not.toHaveBeenCalled();
+    expect(syncTopManagerAssignmentsForUserMock).not.toHaveBeenCalled();
+  });
+
+  test('preserves admin role when matched mapping references a deleted role', async () => {
+    findByIdentityMock.mockResolvedValue({
+      id: 'eid-1',
+      providerId: 'sso-1',
+      protocol: 'oidc',
+      issuer: input.issuer,
+      subject: input.subject,
+      userId: 'u1',
+    });
+    findLoginUserByIdMock.mockResolvedValue(adminUser);
+    findExistingIdsMock.mockResolvedValue(new Set<string>());
+
+    const result = await resolveExternalIdentity({
+      ...input,
+      groups: ['cn=ghosts,ou=groups,dc=example,dc=com'],
+      roleMappings: [{ externalGroup: 'ghosts', role: 'deleted-role' }],
+    });
+
+    expect(result.role).toBe('admin');
+    expect(replaceUserRolesMock).not.toHaveBeenCalled();
+    expect(setPrimaryRoleMock).not.toHaveBeenCalled();
+  });
+
+  test('updates primary role when SAML group matches a mapping', async () => {
+    findByIdentityMock.mockResolvedValue({
+      id: 'eid-1',
+      providerId: 'sso-1',
+      protocol: 'oidc',
+      issuer: input.issuer,
+      subject: input.subject,
+      userId: 'u1',
+    });
+    findLoginUserByIdMock.mockResolvedValue({ ...adminUser, role: 'user' });
+    findExistingIdsMock.mockResolvedValue(new Set(['admin']));
+
+    const result = await resolveExternalIdentity({
+      ...input,
+      groups: ['cn=admins,ou=groups,dc=example,dc=com'],
+      roleMappings: [{ externalGroup: 'admins', role: 'admin' }],
+    });
+
+    expect(result.role).toBe('admin');
+    expect(replaceUserRolesMock).toHaveBeenCalledWith('u1', ['admin'], expect.anything());
+    expect(setPrimaryRoleMock).toHaveBeenCalledWith('u1', 'admin', expect.anything());
+    expect(syncTopManagerAssignmentsForUserMock).toHaveBeenCalledWith('u1', expect.anything());
+  });
+
+  test('new SSO user with no matching group still gets DEFAULT_ROLE_ID assignment', async () => {
+    let createdUserId: string | undefined;
+    insertUserMock.mockImplementation(async (row: { id: string }) => {
+      createdUserId = row.id;
+    });
+    // First findByIdentity: no prior binding. Second (post-insert): returns the row we just bound.
+    findByIdentityMock
+      .mockImplementationOnce(async () => null)
+      .mockImplementationOnce(async () => ({
+        id: 'eid-1',
+        providerId: 'sso-1',
+        protocol: 'oidc',
+        issuer: input.issuer,
+        subject: input.subject,
+        userId: createdUserId,
+      }));
+    findLoginUserByNormalizedUsernameMock.mockResolvedValue(null);
+
+    const result = await resolveExternalIdentity({
+      ...input,
+      groups: ['cn=guests,ou=groups,dc=example,dc=com'],
+      roleMappings: [{ externalGroup: 'admins', role: 'admin' }],
+    });
+
+    expect(result.wasCreated).toBe(true);
+    expect(result.role).toBe('user');
+    expect(insertUserMock).toHaveBeenCalledWith(
+      expect.objectContaining({ role: 'user' }),
+      expect.anything(),
+    );
+    expect(replaceUserRolesMock).toHaveBeenCalledWith(createdUserId, ['user'], expect.anything());
+    expect(setPrimaryRoleMock).toHaveBeenCalledWith(createdUserId, 'user', expect.anything());
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #596. `resolveExternalIdentity` was unconditionally calling `replaceUserRoles` / `setPrimaryRole` on every SSO login. When no SSO group mapped to an existing Praetor role, the upstream fallback in `mapExternalGroupsToRoleIds` + `filterExistingRoleIds` resolved to `[DEFAULT_ROLE_ID]` (`'user'`), silently demoting admins and managers on every login and wiping their `user_roles` rows.

## What changed

`server/services/external-auth.ts` — `resolveExternalIdentity`:
- Switched to the match-only path (`mapExternalGroupsToMatchedRoleIds` + `filterToExistingRoleIds`) so empty really means empty.
- Role writes (`replaceUserRoles`, `setPrimaryRole`, `syncTopManagerAssignmentsForUser`) now run only when SSO actually mapped to an existing role, **or** when provisioning a brand-new user (which still needs a baseline `DEFAULT_ROLE_ID` assignment row).
- For an existing user with no group match, all three writes are skipped and the user's current `role` is returned — mirroring the LDAP path's `applyExternalRolesForUserIfMatched` policy.

Reuse / simplification:
- Extracted `writeExternalRoleIdsTx(userId, roleIds, tx)` so the inline write block in the outer transaction reuses the same triple as the module-level `writeExternalRoleIds`. The existing helper is now a thin `withDbTransaction` wrapper around the new `Tx` variant.

## Why this is consistent

The LDAP login path at `server/services/ldap.ts:357` already uses `applyExternalRolesForUserIfMatched` "to preserve admin-assigned roles when no group matched." SSO now follows the same policy.

## Tests

Added four regression cases in `server/test/services/external-auth.resolve.test.ts`:
1. Existing admin SAML-logs-in with no matching group → role stays `admin`, no role writes.
2. Existing admin SAML-logs-in with matched mapping referencing a deleted role → role stays `admin`, no role writes.
3. Existing user SAML-logs-in with matching `admins` group → primary role updated to `admin`, writes called.
4. New SSO user with no matching group → still provisioned with `DEFAULT_ROLE_ID`.

Sanity-checked cases 1 and 2 fail on the buggy code (`Expected: "admin", Received: "user"`) and pass on the fix. Full local run: 110/110 across `external-auth.resolve`, `external-auth`, `sso`, `ldap` suites.

## Test plan
- [x] `bun test test/services/external-auth.resolve.test.ts test/services/external-auth.test.ts test/services/sso.test.ts test/services/ldap.test.ts` — 110 pass
- [ ] Manual SAML login as an admin with no group mapping configured → role remains `admin` after re-login
- [ ] Manual SAML login as a fresh user with no group mapping → provisioned as `user`
- [ ] Manual SAML login with a matching `admin` mapping → primary role updated to `admin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)