### PR TITLE
sso(fix): SAML metadata 404s for disabled providers (#600)

### DIFF
--- a/server/services/sso.ts
+++ b/server/services/sso.ts
@@ -16,6 +16,7 @@ import * as ssoStatesRepo from '../repositories/ssoStatesRepo.ts';
 import * as usersRepo from '../repositories/usersRepo.ts';
 import { decrypt, encrypt, MASKED_SECRET } from '../utils/crypto.ts';
 import { buildFrontendUrl } from '../utils/frontend-url.ts';
+import { NotFoundError } from '../utils/http-errors.ts';
 import { generatePrefixedId } from '../utils/order-ids.ts';
 import { getRolePermissions } from '../utils/permissions.ts';
 import { resolveExternalIdentity } from './external-auth.ts';
@@ -517,7 +518,7 @@ const getEnabledProviderBySlug = async (
 ): Promise<ssoProvidersRepo.SsoProvider> => {
   const provider = await ssoProvidersRepo.findBySlug(slug);
   if (!provider || provider.protocol !== protocol || !provider.enabled) {
-    throw new Error('SSO provider is not enabled');
+    throw new NotFoundError('SSO provider');
   }
   return provider;
 };
@@ -528,18 +529,7 @@ const getEnabledProviderById = async (
 ): Promise<ssoProvidersRepo.SsoProvider> => {
   const provider = await ssoProvidersRepo.findById(id);
   if (!provider || provider.protocol !== protocol || !provider.enabled) {
-    throw new Error('SSO provider is not enabled');
-  }
-  return provider;
-};
-
-const getProviderBySlug = async (
-  protocol: 'oidc' | 'saml',
-  slug: string,
-): Promise<ssoProvidersRepo.SsoProvider> => {
-  const provider = await ssoProvidersRepo.findBySlug(slug);
-  if (!provider || provider.protocol !== protocol) {
-    throw new Error('SSO provider not found');
+    throw new NotFoundError('SSO provider');
   }
   return provider;
 };
@@ -756,7 +746,7 @@ export const completeSamlLogin = async (
 
 export const getSamlMetadata = async (slug: string): Promise<string> => {
   const baseUrl = resolvePublicBaseUrl();
-  const provider = await getProviderBySlug('saml', slug);
+  const provider = await getEnabledProviderBySlug('saml', slug);
   const { privateKey } = getProviderSecrets(provider);
   const issuer = provider.spIssuer || buildSamlMetadataUrl(provider.slug, baseUrl);
   return generateServiceProviderMetadata({

--- a/server/test/routes/sso-auth.test.ts
+++ b/server/test/routes/sso-auth.test.ts
@@ -47,25 +47,34 @@ const samlProvider: realSsoProvidersRepo.SsoProvider = {
   roleMappings: [],
 };
 
+const oidcProvider: realSsoProvidersRepo.SsoProvider = {
+  ...samlProvider,
+  protocol: 'oidc',
+  slug: 'google',
+  issuerUrl: 'https://accounts.google.com',
+  clientId: 'client-123',
+  entryPoint: '',
+};
+
+const originalSsoBase = process.env.SSO_CALLBACK_BASE_URL;
+let testApp: FastifyInstance;
+
+beforeEach(async () => {
+  process.env.SSO_CALLBACK_BASE_URL = 'https://app.example.com';
+  findBySlugMock.mockReset();
+  testApp = await buildRouteTestApp(routePlugin, '/api/auth/sso');
+});
+
+afterEach(async () => {
+  await testApp.close();
+});
+
+afterAll(() => {
+  if (originalSsoBase === undefined) delete process.env.SSO_CALLBACK_BASE_URL;
+  else process.env.SSO_CALLBACK_BASE_URL = originalSsoBase;
+});
+
 describe('GET /api/auth/sso/saml/:slug/metadata', () => {
-  const originalSsoBase = process.env.SSO_CALLBACK_BASE_URL;
-  let testApp: FastifyInstance;
-
-  beforeEach(async () => {
-    process.env.SSO_CALLBACK_BASE_URL = 'https://app.example.com';
-    findBySlugMock.mockReset();
-    testApp = await buildRouteTestApp(routePlugin, '/api/auth/sso');
-  });
-
-  afterEach(async () => {
-    await testApp.close();
-  });
-
-  afterAll(() => {
-    if (originalSsoBase === undefined) delete process.env.SSO_CALLBACK_BASE_URL;
-    else process.env.SSO_CALLBACK_BASE_URL = originalSsoBase;
-  });
-
   test.each([
     ['disabled provider', { ...samlProvider, enabled: false }],
     ['missing provider', null],
@@ -88,5 +97,37 @@ describe('GET /api/auth/sso/saml/:slug/metadata', () => {
     expect(response.statusCode).toBe(200);
     expect(response.headers['content-type']).toContain('application/samlmetadata+xml');
     expect(response.body).toContain('EntityDescriptor');
+  });
+});
+
+// Locks in the /start-route behaviour change introduced alongside #600: missing or disabled
+// providers now surface as 404 via NotFoundError instead of the previous bare 500.
+describe('GET /api/auth/sso/saml/:slug/start', () => {
+  test.each([
+    ['disabled provider', { ...samlProvider, enabled: false }],
+    ['missing provider', null],
+    ['wrong-protocol provider', { ...samlProvider, protocol: 'oidc' as const }],
+  ])('returns 404 for %s', async (_label, mocked) => {
+    findBySlugMock.mockResolvedValue(mocked);
+    const response = await testApp.inject({
+      method: 'GET',
+      url: '/api/auth/sso/saml/okta/start',
+    });
+    expect(response.statusCode).toBe(404);
+  });
+});
+
+describe('GET /api/auth/sso/oidc/:slug/start', () => {
+  test.each([
+    ['disabled provider', { ...oidcProvider, enabled: false }],
+    ['missing provider', null],
+    ['wrong-protocol provider', { ...oidcProvider, protocol: 'saml' as const }],
+  ])('returns 404 for %s', async (_label, mocked) => {
+    findBySlugMock.mockResolvedValue(mocked);
+    const response = await testApp.inject({
+      method: 'GET',
+      url: '/api/auth/sso/oidc/google/start',
+    });
+    expect(response.statusCode).toBe(404);
   });
 });

--- a/server/test/routes/sso-auth.test.ts
+++ b/server/test/routes/sso-auth.test.ts
@@ -1,0 +1,92 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { FastifyInstance, FastifyPluginAsync } from 'fastify';
+import * as realSsoProvidersRepo from '../../repositories/ssoProvidersRepo.ts';
+import { buildRouteTestApp } from '../helpers/buildRouteTestApp.ts';
+
+const ssoProvidersRepoSnap = { ...realSsoProvidersRepo };
+
+const findBySlugMock = mock();
+
+let routePlugin: FastifyPluginAsync;
+
+beforeAll(async () => {
+  mock.module('../../repositories/ssoProvidersRepo.ts', () => ({
+    ...ssoProvidersRepoSnap,
+    findBySlug: findBySlugMock,
+  }));
+
+  routePlugin = (await import('../../routes/sso-auth.ts')).default as FastifyPluginAsync;
+});
+
+afterAll(() => {
+  mock.module('../../repositories/ssoProvidersRepo.ts', () => ssoProvidersRepoSnap);
+});
+
+const samlProvider: realSsoProvidersRepo.SsoProvider = {
+  id: 'sso-1',
+  protocol: 'saml',
+  slug: 'okta',
+  name: 'Okta',
+  enabled: true,
+  issuerUrl: '',
+  clientId: '',
+  clientSecret: '',
+  scopes: '',
+  metadataUrl: '',
+  metadataXml: '',
+  entryPoint: 'https://idp.example.com/sso',
+  idpIssuer: '',
+  idpCert: '',
+  spIssuer: '',
+  privateKey: '',
+  publicCert: '',
+  usernameAttribute: 'nameID',
+  nameAttribute: 'name',
+  emailAttribute: 'email',
+  groupsAttribute: 'groups',
+  roleMappings: [],
+};
+
+describe('GET /api/auth/sso/saml/:slug/metadata', () => {
+  const originalSsoBase = process.env.SSO_CALLBACK_BASE_URL;
+  let testApp: FastifyInstance;
+
+  beforeEach(async () => {
+    process.env.SSO_CALLBACK_BASE_URL = 'https://app.example.com';
+    findBySlugMock.mockReset();
+    testApp = await buildRouteTestApp(routePlugin, '/api/auth/sso');
+  });
+
+  afterEach(async () => {
+    await testApp.close();
+  });
+
+  afterAll(() => {
+    if (originalSsoBase === undefined) delete process.env.SSO_CALLBACK_BASE_URL;
+    else process.env.SSO_CALLBACK_BASE_URL = originalSsoBase;
+  });
+
+  test.each([
+    ['disabled provider', { ...samlProvider, enabled: false }],
+    ['missing provider', null],
+    ['wrong-protocol provider', { ...samlProvider, protocol: 'oidc' as const }],
+  ])('returns 404 for %s', async (_label, mocked) => {
+    findBySlugMock.mockResolvedValue(mocked);
+    const response = await testApp.inject({
+      method: 'GET',
+      url: '/api/auth/sso/saml/okta/metadata',
+    });
+    expect(response.statusCode).toBe(404);
+  });
+
+  test('returns 200 with SAML metadata XML for an enabled provider', async () => {
+    findBySlugMock.mockResolvedValue(samlProvider);
+    const response = await testApp.inject({
+      method: 'GET',
+      url: '/api/auth/sso/saml/okta/metadata',
+    });
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['content-type']).toContain('application/samlmetadata+xml');
+    expect(response.body).toContain('EntityDescriptor');
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes [#600](https://github.com/xBounceIT/praetor/issues/600): `getSamlMetadata` was using `getProviderBySlug` (no `enabled` filter) while every other SAML route went through `getEnabledProviderBySlug`. An IdP could fetch SP metadata for a slug that would then refuse to authenticate — a confusing footgun that inconsistently leaked the existence of disabled provider slugs.
- Switches `getSamlMetadata` to `getEnabledProviderBySlug` and removes the now-unused `getProviderBySlug` helper.
- Aligns the shared `getEnabledProviderBySlug` / `getEnabledProviderById` helpers on `NotFoundError` (the codebase-standard pattern used by `routes/projects.ts`, `routes/work-units.ts`, etc.), which the global error handler maps to 404. No route-level `try`/`catch` needed.

## Reviewer notes

- **Behavior change for OIDC/SAML `/start` routes**: previously, hitting `/api/auth/sso/<oidc|saml>/<slug>/start` with an unknown or disabled slug yielded a 500 with `"SSO provider is not enabled"`. It now yields a 404 with `"SSO provider not found"`. This is the correct user-facing semantic and matches what the metadata endpoint will now do.
- **Behavior change for OIDC/SAML callback routes**: these already `catch` errors and redirect to `buildFrontendErrorUrl(err.message)`. `NotFoundError` extends `Error` so the redirect still works — the displayed message just changes from `"SSO provider is not enabled"` to `"SSO provider not found"` (slightly less precise but also doesn't leak that the slug was specifically *disabled* vs. *missing*, which is arguably better).
- The metadata route file itself is **not** modified — only the service layer changed.

## Test plan

- [x] New test file `server/test/routes/sso-auth.test.ts` covers `GET /api/auth/sso/saml/:slug/metadata` returning 404 for disabled / missing / wrong-protocol providers, and 200 + `application/samlmetadata+xml` for an enabled SAML provider.
- [x] `bun test` (server): 2698 pass, 0 fail.
- [x] `bun run build` (server): clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)