### PR TITLE
sso(fix): backend-authoritative SAML ACS URL preview (#602)

### DIFF
--- a/components/administration/AuthSettings.tsx
+++ b/components/administration/AuthSettings.tsx
@@ -122,16 +122,18 @@ const AuthSettings: React.FC<AuthSettingsProps> = ({
     | { status: 'ready'; template: string }
     | { status: 'error'; message: string };
   const [acsUrlState, setAcsUrlState] = useState<AcsUrlState>({ status: 'loading' });
-  const acsUrlFetchedRef = useRef(false);
   const tlsCaFileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     setLdapForm(config || DEFAULT_LDAP_CONFIG);
   }, [config]);
 
+  // Status-gated rather than ref-gated: if the user leaves the SAML tab mid-flight, the
+  // cleanup discards the result and the state stays 'loading', so re-entering the tab kicks
+  // off a fresh fetch. A ref locked before the fetch settled would strand the preview in
+  // 'loading' forever.
   useEffect(() => {
-    if (activeTab !== 'saml' || acsUrlFetchedRef.current) return;
-    acsUrlFetchedRef.current = true;
+    if (activeTab !== 'saml' || acsUrlState.status !== 'loading') return;
     let cancelled = false;
     ssoApi
       .getSamlAcsUrlInfo()
@@ -149,7 +151,7 @@ const AuthSettings: React.FC<AuthSettingsProps> = ({
     return () => {
       cancelled = true;
     };
-  }, [activeTab]);
+  }, [activeTab, acsUrlState.status]);
 
   const handleTlsCaFileImport = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];

--- a/components/administration/AuthSettings.tsx
+++ b/components/administration/AuthSettings.tsx
@@ -128,6 +128,14 @@ const AuthSettings: React.FC<AuthSettingsProps> = ({
     setLdapForm(config || DEFAULT_LDAP_CONFIG);
   }, [config]);
 
+  // Re-entering the SAML tab after a transient failure resets the state to 'loading' so the
+  // fetch effect below retries. Without this, a one-off 503/network error would permanently
+  // disable the preview until a full page reload.
+  useEffect(() => {
+    if (activeTab !== 'saml') return;
+    setAcsUrlState((prev) => (prev.status === 'error' ? { status: 'loading' } : prev));
+  }, [activeTab]);
+
   // Status-gated rather than ref-gated: if the user leaves the SAML tab mid-flight, the
   // cleanup discards the result and the state stays 'loading', so re-entering the tab kicks
   // off a fresh fetch. A ref locked before the fetch settled would strand the preview in

--- a/components/administration/AuthSettings.tsx
+++ b/components/administration/AuthSettings.tsx
@@ -3,8 +3,8 @@ import type React from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { siOpenid } from 'simple-icons';
-import { getApiBase } from '../../services/api/client';
 import { ldapApi } from '../../services/api/ldap';
+import { ssoApi } from '../../services/api/sso';
 import type {
   LdapConfig,
   LdapTestResponse,
@@ -82,8 +82,13 @@ const renderProviderIcon = (protocol: SsoProtocol, className?: string) =>
     <i className={`fa-solid fa-building-shield ${className ?? ''}`.trim()}></i>
   );
 
-const buildSamlAcsUrl = (slug: string): string =>
-  `${getApiBase()}/auth/sso/saml/${encodeURIComponent(slug)}/callback`;
+// The backend builds the SAML callback URL from SSO_CALLBACK_BASE_URL/FRONTEND_URL, not from
+// the frontend's API base. In split-host deployments those origins differ, so we ask the server
+// for the templated URL and render that — otherwise admins copy a URL the SAML library will
+// later reject. See issue #602.
+const SLUG_PLACEHOLDER = '{slug}';
+const fillSlugTemplate = (template: string, slug: string): string =>
+  template.replace(SLUG_PLACEHOLDER, encodeURIComponent(slug));
 
 const AuthSettings: React.FC<AuthSettingsProps> = ({
   config,
@@ -112,11 +117,39 @@ const AuthSettings: React.FC<AuthSettingsProps> = ({
   const [providerSaveErrors, setProviderSaveErrors] = useState<
     Partial<Record<SsoProtocol, string>>
   >({});
+  type AcsUrlState =
+    | { status: 'loading' }
+    | { status: 'ready'; template: string }
+    | { status: 'error'; message: string };
+  const [acsUrlState, setAcsUrlState] = useState<AcsUrlState>({ status: 'loading' });
+  const acsUrlFetchedRef = useRef(false);
   const tlsCaFileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     setLdapForm(config || DEFAULT_LDAP_CONFIG);
   }, [config]);
+
+  useEffect(() => {
+    if (activeTab !== 'saml' || acsUrlFetchedRef.current) return;
+    acsUrlFetchedRef.current = true;
+    let cancelled = false;
+    ssoApi
+      .getSamlAcsUrlInfo()
+      .then(({ acsUrlTemplate }) => {
+        if (cancelled) return;
+        setAcsUrlState({ status: 'ready', template: acsUrlTemplate });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setAcsUrlState({
+          status: 'error',
+          message: err instanceof Error ? err.message : '',
+        });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [activeTab]);
 
   const handleTlsCaFileImport = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
@@ -613,12 +646,32 @@ const AuthSettings: React.FC<AuthSettingsProps> = ({
                 value={draft.publicCert || ''}
                 onChange={(publicCert) => updateProviderDraft(protocol, { publicCert })}
               />
-              {!!draft.slug?.trim() && (
-                <ReadOnlyField
-                  label={t('admin.sso.acsUrl', 'ACS URL')}
-                  value={buildSamlAcsUrl(draft.slug.trim().toLowerCase())}
-                  monospace
-                />
+              {!!draft.slug?.trim() && acsUrlState.status !== 'loading' && (
+                <div className="md:col-span-2">
+                  {acsUrlState.status === 'ready' ? (
+                    <ReadOnlyField
+                      label={t('admin.sso.acsUrl', 'ACS URL')}
+                      value={fillSlugTemplate(
+                        acsUrlState.template,
+                        draft.slug.trim().toLowerCase(),
+                      )}
+                      monospace
+                    />
+                  ) : (
+                    <>
+                      <label className="block text-xs font-bold text-zinc-400 uppercase tracking-wider mb-2">
+                        {t('admin.sso.acsUrl', 'ACS URL')}
+                      </label>
+                      <p className="text-xs text-red-500 font-bold">
+                        {acsUrlState.message ||
+                          t(
+                            'admin.sso.errors.acsUrlUnavailable',
+                            'ACS URL unavailable: configure SSO_CALLBACK_BASE_URL on the backend.',
+                          )}
+                      </p>
+                    </>
+                  )}
+                </div>
               )}
               {errors[`${prefix}samlConfig`] && (
                 <p className="md:col-span-2 text-red-500 text-xs font-bold">

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -7796,7 +7796,8 @@
                     "type": "string"
                   },
                   "recurrenceDuration": {
-                    "type": "number"
+                    "type": "number",
+                    "maximum": 24
                   },
                   "expectedEffort": {
                     "type": "number"
@@ -8410,7 +8411,8 @@
                     "type": "string"
                   },
                   "recurrenceDuration": {
-                    "type": "number"
+                    "type": "number",
+                    "maximum": 24
                   },
                   "expectedEffort": {
                     "type": "number"
@@ -9490,10 +9492,12 @@
                     "type": "string"
                   },
                   "notes": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 2000
                   },
                   "duration": {
-                    "type": "number"
+                    "type": "number",
+                    "maximum": 24
                   },
                   "isPlaceholder": {
                     "type": "boolean"
@@ -9689,6 +9693,27 @@
             }
           },
           "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
             "description": "Default Response",
             "content": {
               "application/json": {
@@ -9953,13 +9978,15 @@
                     "type": "string"
                   },
                   "duration": {
-                    "type": "number"
+                    "type": "number",
+                    "maximum": 24
                   },
                   "notes": {
                     "type": [
                       "string",
                       "null"
-                    ]
+                    ],
+                    "maxLength": 2000
                   },
                   "isPlaceholder": {
                     "type": "boolean"
@@ -12831,6 +12858,181 @@
                     "name",
                     "enabled",
                     "roleMappings"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/sso/saml/acs-url-info": {
+      "get": {
+        "summary": "SAML ACS URL templates the backend will validate against",
+        "tags": [
+          "sso"
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "acsUrlTemplate": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "acsUrlTemplate"
                   ]
                 }
               }

--- a/locales/en/auth.json
+++ b/locales/en/auth.json
@@ -168,7 +168,8 @@
         "samlConfigRequired": "Metadata or manual IdP fields are required",
         "externalGroupRequired": "External group is required",
         "saveFailedTitle": "Provider could not be saved",
-        "saveFailed": "Could not save provider"
+        "saveFailed": "Could not save provider",
+        "acsUrlUnavailable": "ACS URL unavailable: configure SSO_CALLBACK_BASE_URL on the backend."
       }
     }
   },

--- a/locales/it/auth.json
+++ b/locales/it/auth.json
@@ -168,7 +168,8 @@
         "samlConfigRequired": "Metadata o campi IdP manuali sono obbligatori",
         "externalGroupRequired": "Il gruppo esterno è obbligatorio",
         "saveFailedTitle": "Impossibile salvare il provider",
-        "saveFailed": "Impossibile salvare il provider"
+        "saveFailed": "Impossibile salvare il provider",
+        "acsUrlUnavailable": "URL ACS non disponibile: configura SSO_CALLBACK_BASE_URL sul backend."
       }
     }
   },

--- a/server/routes/sso.ts
+++ b/server/routes/sso.ts
@@ -213,6 +213,34 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
     async () => ssoService.listAdminProviders(),
   );
 
+  fastify.get(
+    '/saml/acs-url-info',
+    {
+      onRequest: [authenticateToken, requirePermission('administration.authentication.view')],
+      schema: {
+        tags: ['sso'],
+        summary: 'SAML ACS URL templates the backend will validate against',
+        response: {
+          200: {
+            type: 'object',
+            properties: { acsUrlTemplate: { type: 'string' } },
+            required: ['acsUrlTemplate'],
+          },
+          ...standardRateLimitedErrorResponses,
+        },
+      },
+    },
+    async (_request: FastifyRequest, reply: FastifyReply) => {
+      try {
+        return ssoService.getSamlAcsUrlInfo();
+      } catch (err) {
+        return reply.code(503).send({
+          error: err instanceof Error ? err.message : 'SSO public base URL is not configured',
+        });
+      }
+    },
+  );
+
   fastify.post(
     '/providers',
     {

--- a/server/services/sso.ts
+++ b/server/services/sso.ts
@@ -587,6 +587,21 @@ const createSamlClient = async (
   });
 };
 
+// Routed through buildCallbackUrl so the admin preview can't drift from the URL the SAML
+// library validates against. The slug is substituted via a URL-safe sentinel because new URL()
+// would percent-encode the `{}` in a literal `{slug}` placeholder.
+const SAML_SLUG_SENTINEL = 'praetor-slug-placeholder';
+
+export const getSamlAcsUrlInfo = (): { acsUrlTemplate: string } => {
+  const baseUrl = resolvePublicBaseUrl();
+  return {
+    acsUrlTemplate: buildCallbackUrl('saml', SAML_SLUG_SENTINEL, baseUrl).replace(
+      SAML_SLUG_SENTINEL,
+      '{slug}',
+    ),
+  };
+};
+
 export const listAdminProviders = async (): Promise<AdminSsoProvider[]> =>
   (await ssoProvidersRepo.list()).map(maskProvider);
 

--- a/server/services/sso.ts
+++ b/server/services/sso.ts
@@ -589,16 +589,17 @@ const createSamlClient = async (
 
 // Routed through buildCallbackUrl so the admin preview can't drift from the URL the SAML
 // library validates against. The slug is substituted via a URL-safe sentinel because new URL()
-// would percent-encode the `{}` in a literal `{slug}` placeholder.
+// would percent-encode the `{}` in a literal `{slug}` placeholder. We splice the sentinel out
+// at its LAST occurrence — the one we just injected into the path — so a sentinel substring
+// in baseUrl's host can't be rewritten by accident.
 const SAML_SLUG_SENTINEL = 'praetor-slug-placeholder';
 
 export const getSamlAcsUrlInfo = (): { acsUrlTemplate: string } => {
   const baseUrl = resolvePublicBaseUrl();
+  const built = buildCallbackUrl('saml', SAML_SLUG_SENTINEL, baseUrl);
+  const idx = built.lastIndexOf(SAML_SLUG_SENTINEL);
   return {
-    acsUrlTemplate: buildCallbackUrl('saml', SAML_SLUG_SENTINEL, baseUrl).replace(
-      SAML_SLUG_SENTINEL,
-      '{slug}',
-    ),
+    acsUrlTemplate: built.slice(0, idx) + '{slug}' + built.slice(idx + SAML_SLUG_SENTINEL.length),
   };
 };
 

--- a/server/test/routes/sso.test.ts
+++ b/server/test/routes/sso.test.ts
@@ -511,3 +511,49 @@ describe('POST /api/sso/providers — validateProviderBody', () => {
     expect(insertMock).not.toHaveBeenCalled();
   });
 });
+
+// Issue #602: the admin UI previously built the ACS URL from the frontend's API base, which
+// can diverge from the backend's resolved callback origin in split-host deployments. This
+// endpoint surfaces the backend-authoritative URL templates so the admin form renders what
+// the SAML library will actually validate against.
+describe('GET /api/sso/saml/acs-url-info', () => {
+  const originalSsoBase = process.env.SSO_CALLBACK_BASE_URL;
+  const originalFrontend = process.env.FRONTEND_URL;
+
+  afterAll(() => {
+    if (originalSsoBase === undefined) delete process.env.SSO_CALLBACK_BASE_URL;
+    else process.env.SSO_CALLBACK_BASE_URL = originalSsoBase;
+    if (originalFrontend === undefined) delete process.env.FRONTEND_URL;
+    else process.env.FRONTEND_URL = originalFrontend;
+  });
+
+  test('returns a template anchored to the backend-configured base URL', async () => {
+    process.env.SSO_CALLBACK_BASE_URL = 'https://api.example.com';
+    process.env.FRONTEND_URL = 'https://app.example.com';
+
+    const response = await testApp.inject({
+      method: 'GET',
+      url: '/api/sso/saml/acs-url-info',
+      headers: authHeader(),
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body)).toEqual({
+      acsUrlTemplate: 'https://api.example.com/api/auth/sso/saml/{slug}/callback',
+    });
+  });
+
+  test('returns 503 with a configuration hint when no base URL is set', async () => {
+    process.env.SSO_CALLBACK_BASE_URL = '';
+    process.env.FRONTEND_URL = '';
+
+    const response = await testApp.inject({
+      method: 'GET',
+      url: '/api/sso/saml/acs-url-info',
+      headers: authHeader(),
+    });
+
+    expect(response.statusCode).toBe(503);
+    expect(JSON.parse(response.body).error).toMatch(/SSO_CALLBACK_BASE_URL or FRONTEND_URL/);
+  });
+});

--- a/server/test/services/sso.test.ts
+++ b/server/test/services/sso.test.ts
@@ -192,6 +192,17 @@ describe('getSamlAcsUrlInfo', () => {
     expect(acsUrlTemplate).not.toContain('%7B');
     expect(acsUrlTemplate).not.toContain('placeholder');
   });
+
+  // PR #649 review: a naive replace() on the full URL would rewrite the first sentinel
+  // occurrence anywhere, including the host. Splice the LAST occurrence (the one we injected
+  // into the path) so a host coincidentally containing the sentinel stays intact.
+  test('preserves the base URL host even when it contains the placeholder sentinel', () => {
+    process.env.SSO_CALLBACK_BASE_URL = 'https://praetor-slug-placeholder.example.com';
+    const { acsUrlTemplate } = sso.getSamlAcsUrlInfo();
+    expect(acsUrlTemplate).toBe(
+      'https://praetor-slug-placeholder.example.com/api/auth/sso/saml/{slug}/callback',
+    );
+  });
 });
 
 const SAML_PROVIDER: realSsoProvidersRepo.SsoProvider = {

--- a/server/test/services/sso.test.ts
+++ b/server/test/services/sso.test.ts
@@ -147,6 +147,53 @@ describe('resolvePublicBaseUrl', () => {
   });
 });
 
+describe('getSamlAcsUrlInfo', () => {
+  const originalSsoBase = process.env.SSO_CALLBACK_BASE_URL;
+  const originalFrontend = process.env.FRONTEND_URL;
+
+  beforeEach(() => {
+    process.env.SSO_CALLBACK_BASE_URL = '';
+    process.env.FRONTEND_URL = '';
+  });
+
+  afterAll(() => {
+    if (originalSsoBase === undefined) delete process.env.SSO_CALLBACK_BASE_URL;
+    else process.env.SSO_CALLBACK_BASE_URL = originalSsoBase;
+    if (originalFrontend === undefined) delete process.env.FRONTEND_URL;
+    else process.env.FRONTEND_URL = originalFrontend;
+  });
+
+  // Issue #602: the admin UI used to build the ACS URL from the frontend's API base, which in
+  // split-host deployments doesn't match the backend's resolved SSO callback origin. The
+  // template returned here must be anchored to the backend's resolved base URL.
+  test('returns a template anchored to SSO_CALLBACK_BASE_URL, not the frontend origin', () => {
+    process.env.SSO_CALLBACK_BASE_URL = 'https://api.example.com';
+    process.env.FRONTEND_URL = 'https://app.example.com';
+    expect(sso.getSamlAcsUrlInfo()).toEqual({
+      acsUrlTemplate: 'https://api.example.com/api/auth/sso/saml/{slug}/callback',
+    });
+  });
+
+  test('falls back to FRONTEND_URL when SSO_CALLBACK_BASE_URL is unset', () => {
+    process.env.FRONTEND_URL = 'https://app.example.com';
+    expect(sso.getSamlAcsUrlInfo().acsUrlTemplate).toBe(
+      'https://app.example.com/api/auth/sso/saml/{slug}/callback',
+    );
+  });
+
+  test('throws when no base URL is configured (callers should map to 503)', () => {
+    expect(() => sso.getSamlAcsUrlInfo()).toThrow(/SSO_CALLBACK_BASE_URL or FRONTEND_URL/);
+  });
+
+  test('template leaves `{slug}` literal so the client can interpolate', () => {
+    process.env.SSO_CALLBACK_BASE_URL = 'https://api.example.com';
+    const { acsUrlTemplate } = sso.getSamlAcsUrlInfo();
+    expect(acsUrlTemplate).toContain('{slug}');
+    expect(acsUrlTemplate).not.toContain('%7B');
+    expect(acsUrlTemplate).not.toContain('placeholder');
+  });
+});
+
 const SAML_PROVIDER: realSsoProvidersRepo.SsoProvider = {
   id: 'sso-1',
   protocol: 'saml',

--- a/services/api/sso.ts
+++ b/services/api/sso.ts
@@ -6,6 +6,8 @@ export const ssoApi = {
 
   listProviders: (): Promise<SsoProvider[]> => fetchApi('/sso/providers'),
 
+  getSamlAcsUrlInfo: (): Promise<{ acsUrlTemplate: string }> => fetchApi('/sso/saml/acs-url-info'),
+
   createProvider: (provider: Partial<SsoProvider>): Promise<SsoProvider> =>
     fetchApi('/sso/providers', {
       method: 'POST',

--- a/test/components/administration/AuthSettings.test.tsx
+++ b/test/components/administration/AuthSettings.test.tsx
@@ -200,6 +200,42 @@ describe('<AuthSettings />', () => {
     expect(acsField.value).toBe('https://api.example.com/api/auth/sso/saml/okta/callback');
   });
 
+  test('retries the ACS URL fetch if the user left SAML before the first request settled (#649 review)', async () => {
+    ssoApiMock.getSamlAcsUrlInfo.mockClear();
+    // First attempt never settles, simulating a slow network the user gives up on. The bug
+    // guarded by this test: a ref-based lock set before settle would prevent the second
+    // visit from refetching, stranding the preview in 'loading' forever.
+    ssoApiMock.getSamlAcsUrlInfo.mockImplementationOnce(() => new Promise(() => {}));
+
+    renderAuthSettings();
+
+    fireEvent.click(screen.getByRole('button', { name: 'admin.tabs.saml' }));
+    await waitFor(() => expect(ssoApiMock.getSamlAcsUrlInfo).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole('button', { name: 'admin.tabs.ldap' }));
+    fireEvent.click(screen.getByRole('button', { name: 'admin.tabs.saml' }));
+
+    await waitFor(() => expect(ssoApiMock.getSamlAcsUrlInfo).toHaveBeenCalledTimes(2));
+
+    // And the retry produces a usable URL.
+    const form = screen.getByText('admin.sso.newProvider').closest('form') as HTMLFormElement;
+    const slugLabel = [...form.querySelectorAll('label')].find(
+      (el) => el.textContent === 'admin.sso.slug',
+    );
+    const slugInput = slugLabel?.parentElement?.querySelector('input') as HTMLInputElement;
+    fireEvent.change(slugInput, { target: { value: 'okta' } });
+
+    const acsField = await waitFor(() => {
+      const label = [...form.querySelectorAll('label')].find(
+        (el) => el.textContent === 'admin.sso.acsUrl',
+      );
+      const input = label?.parentElement?.querySelector('input') as HTMLInputElement | null;
+      if (!input?.readOnly) throw new Error('ACS URL field not yet rendered');
+      return input;
+    });
+    expect(acsField.value).toBe('https://api.example.com/api/auth/sso/saml/okta/callback');
+  });
+
   test('shows an error message when the backend cannot resolve the ACS URL (issue #602)', async () => {
     ssoApiMock.getSamlAcsUrlInfo.mockClear();
     ssoApiMock.getSamlAcsUrlInfo.mockImplementationOnce(async () => {

--- a/test/components/administration/AuthSettings.test.tsx
+++ b/test/components/administration/AuthSettings.test.tsx
@@ -19,8 +19,21 @@ const ldapApiMock = {
   })),
 };
 
+const ssoApiMock = {
+  // Issue #602: the admin form must render the URL the backend will validate against, not
+  // one built from the frontend's API base. Default the mock to a split-host setup so any
+  // test that surfaces the ACS URL exercises the divergent-origin path.
+  getSamlAcsUrlInfo: mock(async () => ({
+    acsUrlTemplate: 'https://api.example.com/api/auth/sso/saml/{slug}/callback',
+  })),
+};
+
 mock.module('../../../services/api/ldap', () => ({
   ldapApi: ldapApiMock,
+}));
+
+mock.module('../../../services/api/sso', () => ({
+  ssoApi: ssoApiMock,
 }));
 
 clearSpyStateAfterAll();
@@ -157,6 +170,64 @@ describe('<AuthSettings />', () => {
       expect(screen.getByRole('alert')).toHaveTextContent('Role mapping references a missing role');
     });
     expect(screen.queryByText('admin.ldap.changesSaved')).not.toBeInTheDocument();
+  });
+
+  test('renders the SAML ACS URL using the backend-authoritative template (issue #602)', async () => {
+    ssoApiMock.getSamlAcsUrlInfo.mockClear();
+    renderAuthSettings();
+
+    // Open SAML tab and type a slug into the new-provider form.
+    fireEvent.click(screen.getByRole('button', { name: 'admin.tabs.saml' }));
+    const form = screen.getByText('admin.sso.newProvider').closest('form') as HTMLFormElement;
+    const slugLabel = [...form.querySelectorAll('label')].find(
+      (el) => el.textContent === 'admin.sso.slug',
+    );
+    const slugInput = slugLabel?.parentElement?.querySelector('input') as HTMLInputElement;
+    fireEvent.change(slugInput, { target: { value: 'okta' } });
+
+    // The endpoint resolves asynchronously on mount, so wait for the URL to appear.
+    const acsField = await waitFor(() => {
+      const label = [...form.querySelectorAll('label')].find(
+        (el) => el.textContent === 'admin.sso.acsUrl',
+      );
+      const input = label?.parentElement?.querySelector('input') as HTMLInputElement | null;
+      if (!input?.readOnly) throw new Error('ACS URL field not yet rendered');
+      return input;
+    });
+
+    expect(ssoApiMock.getSamlAcsUrlInfo).toHaveBeenCalledTimes(1);
+    // Backend origin (api.example.com) wins over any frontend-derived value.
+    expect(acsField.value).toBe('https://api.example.com/api/auth/sso/saml/okta/callback');
+  });
+
+  test('shows an error message when the backend cannot resolve the ACS URL (issue #602)', async () => {
+    ssoApiMock.getSamlAcsUrlInfo.mockClear();
+    ssoApiMock.getSamlAcsUrlInfo.mockImplementationOnce(async () => {
+      throw new Error('SSO_CALLBACK_BASE_URL or FRONTEND_URL must be configured for SSO');
+    });
+
+    renderAuthSettings();
+
+    fireEvent.click(screen.getByRole('button', { name: 'admin.tabs.saml' }));
+    const form = screen.getByText('admin.sso.newProvider').closest('form') as HTMLFormElement;
+    const slugLabel = [...form.querySelectorAll('label')].find(
+      (el) => el.textContent === 'admin.sso.slug',
+    );
+    const slugInput = slugLabel?.parentElement?.querySelector('input') as HTMLInputElement;
+    fireEvent.change(slugInput, { target: { value: 'okta' } });
+
+    const message = await waitFor(() => {
+      const node = within(form).queryByText(/SSO_CALLBACK_BASE_URL or FRONTEND_URL/);
+      if (!node) throw new Error('Configuration hint not rendered');
+      return node;
+    });
+    expect(message).toBeInTheDocument();
+
+    // The misleading editable ACS URL field must NOT appear when the backend can't resolve it.
+    const acsLabel = [...form.querySelectorAll('label')].find(
+      (el) => el.textContent === 'admin.sso.acsUrl',
+    );
+    expect(acsLabel?.parentElement?.querySelector('input')).toBeNull();
   });
 
   test('surfaces SSO provider save failures inline and restores the save button', async () => {

--- a/test/components/administration/AuthSettings.test.tsx
+++ b/test/components/administration/AuthSettings.test.tsx
@@ -236,6 +236,50 @@ describe('<AuthSettings />', () => {
     expect(acsField.value).toBe('https://api.example.com/api/auth/sso/saml/okta/callback');
   });
 
+  test('retries the ACS URL fetch on SAML re-entry after a transient error (#649 review)', async () => {
+    ssoApiMock.getSamlAcsUrlInfo.mockClear();
+    // First attempt fails (transient 503), second attempt succeeds. Without retry-on-reentry,
+    // a one-off failure would permanently disable the preview until a full page reload.
+    ssoApiMock.getSamlAcsUrlInfo.mockImplementationOnce(async () => {
+      throw new Error('temporary network failure');
+    });
+
+    renderAuthSettings();
+
+    fireEvent.click(screen.getByRole('button', { name: 'admin.tabs.saml' }));
+    await waitFor(() => expect(ssoApiMock.getSamlAcsUrlInfo).toHaveBeenCalledTimes(1));
+
+    // Wait for the error UI so we know the first attempt resolved into the 'error' state.
+    const form = screen.getByText('admin.sso.newProvider').closest('form') as HTMLFormElement;
+    const slugLabel = [...form.querySelectorAll('label')].find(
+      (el) => el.textContent === 'admin.sso.slug',
+    );
+    const slugInput = slugLabel?.parentElement?.querySelector('input') as HTMLInputElement;
+    fireEvent.change(slugInput, { target: { value: 'okta' } });
+    await waitFor(() => {
+      if (!within(form).queryByText(/temporary network failure/)) {
+        throw new Error('Error not yet rendered');
+      }
+    });
+
+    // Leave SAML and return — the retry should fire.
+    fireEvent.click(screen.getByRole('button', { name: 'admin.tabs.ldap' }));
+    fireEvent.click(screen.getByRole('button', { name: 'admin.tabs.saml' }));
+
+    await waitFor(() => expect(ssoApiMock.getSamlAcsUrlInfo).toHaveBeenCalledTimes(2));
+
+    const acsField = await waitFor(() => {
+      const refreshedForm = screen.getByText('admin.sso.newProvider').closest('form');
+      const label = [...(refreshedForm?.querySelectorAll('label') ?? [])].find(
+        (el) => el.textContent === 'admin.sso.acsUrl',
+      );
+      const input = label?.parentElement?.querySelector('input') as HTMLInputElement | null;
+      if (!input?.readOnly) throw new Error('ACS URL field not yet rendered');
+      return input;
+    });
+    expect(acsField.value).toBe('https://api.example.com/api/auth/sso/saml/okta/callback');
+  });
+
   test('shows an error message when the backend cannot resolve the ACS URL (issue #602)', async () => {
     ssoApiMock.getSamlAcsUrlInfo.mockClear();
     ssoApiMock.getSamlAcsUrlInfo.mockImplementationOnce(async () => {


### PR DESCRIPTION
## Summary

Closes #602. The admin form built the SAML ACS URL preview from `getApiBase()` (the frontend's API base), but the backend builds the **real** ACS URL from `SSO_CALLBACK_BASE_URL`/`FRONTEND_URL`. In split-host deployments those origins diverge, so admins were registering URLs with the IdP that the SAML library would later reject (`Destination`/`AudienceRestriction` mismatch — a hard-to-diagnose failure).

The fix makes the preview backend-authoritative.

## What changed

- **New endpoint** `GET /api/sso/saml/acs-url-info` (admin-only, `administration.authentication.view`) returns `{ acsUrlTemplate }` — an `{slug}`-templated URL anchored to the backend's resolved base, routed through the same `buildCallbackUrl` helper used at runtime so the preview can't drift from what the SAML library validates against. Returns 503 with a configuration hint when neither env var is set.
- **Frontend** ([`components/administration/AuthSettings.tsx`](https://github.com/xBounceIT/praetor/blob/claude/blissful-matsumoto-c87a26/components/administration/AuthSettings.tsx)) fetches the template on first SAML-tab activation (deferred so LDAP/OIDC-only admins don't trigger it) and interpolates the slug. If the backend can't resolve the URL, the field shows the configuration error inline instead of a misleading copyable value.
- **Translations** added for the inline configuration-error message (en/it).

## Why this approach

The issue suggested either adding `acsUrl` to the provider listing (works only after save) or exposing a small read-only endpoint. The endpoint approach is used because the admin needs to see the URL **before** saving in order to register it with the IdP. Returning a slug-templated URL lets the frontend re-render the preview on every keystroke without per-keystroke fetches.

## Test plan

- [x] `bun test test/components/administration/AuthSettings.test.tsx` — 5 pass (covers the success-path URL anchored to `api.example.com` and the unconfigured-backend fallback)
- [x] `bun test server/test/services/sso.test.ts server/test/routes/sso.test.ts` — 48 pass (covers SSO_CALLBACK_BASE_URL precedence over FRONTEND_URL, fallback, throws-when-unconfigured, literal `{slug}` placeholder, and the route's 200/503 paths)
- [x] `bun run lint` — clean (only two pre-existing warnings in unrelated files)
- [x] `docs/api/openapi.json` regenerated with the new endpoint
- [ ] Manual verification per the issue: set `SSO_CALLBACK_BASE_URL=https://api.example.com` while loading the UI from `https://app.example.com`; ACS URL field shows the `api` host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)