### PR TITLE
sso(fix): enforce SAML idpIssuer so node-saml validates <Issuer> (#597)

### DIFF
--- a/components/administration/AuthSettings.tsx
+++ b/components/administration/AuthSettings.tsx
@@ -352,12 +352,21 @@ const AuthSettings: React.FC<AuthSettingsProps> = ({
         );
     }
     if (provider.enabled && provider.protocol === 'saml') {
-      const hasMetadata = !!provider.metadataUrl?.trim() || !!provider.metadataXml?.trim();
+      const hasMetadataXml = !!provider.metadataXml?.trim();
+      const hasMetadata = !!provider.metadataUrl?.trim() || hasMetadataXml;
       const hasManual = !!provider.entryPoint?.trim() && !!provider.idpCert?.trim();
       if (!hasMetadata && !hasManual) {
         nextErrors[`${prefix}samlConfig`] = t(
           'admin.sso.errors.samlConfigRequired',
           'Metadata or manual IdP fields are required',
+        );
+      }
+      // Mirror the server-side check in assertEnabledProviderConfig; the frontend cannot parse
+      // metadataXml, so it requires the field whenever inline XML is not supplied.
+      if (!hasMetadataXml && !provider.idpIssuer?.trim()) {
+        nextErrors[`${prefix}idpIssuer`] = t(
+          'admin.sso.errors.idpIssuerRequired',
+          'IdP Issuer is required unless inline metadata XML provides it',
         );
       }
     }
@@ -585,6 +594,7 @@ const AuthSettings: React.FC<AuthSettingsProps> = ({
                 label={t('admin.sso.idpIssuer', 'IdP Issuer')}
                 value={draft.idpIssuer || ''}
                 monospace
+                error={errors[`${prefix}idpIssuer`]}
                 onChange={(idpIssuer) => updateProviderDraft(protocol, { idpIssuer })}
               />
               <Field

--- a/docs-site/src/content/docs/administration.md
+++ b/docs-site/src/content/docs/administration.md
@@ -21,7 +21,7 @@ Quando salvi la configurazione LDAP, Praetor conferma il salvataggio solo dopo l
 
 Quando modifichi una configurazione LDAP già salvata, la password di bind resta mascherata. Puoi aggiornare il Bind DN senza reinserire la password se il segreto esistente resta valido; reinserisci la password solo quando vuoi cambiarla o cancellala insieme al Bind DN per rimuovere le credenziali di bind.
 
-Prima di abilitare un provider SAML, configura una sorgente metadata valida (URL o XML) oppure la configurazione manuale con **Entry Point** e **Certificato IdP**. Praetor rifiuta il salvataggio di provider SAML abilitati senza questi dati minimi.
+Prima di abilitare un provider SAML, configura una sorgente metadata valida (URL o XML) oppure la configurazione manuale con **Entry Point** e **Certificato IdP**. Praetor rifiuta il salvataggio di provider SAML abilitati senza questi dati minimi. È inoltre richiesto il campo **IdP Issuer** a meno che l'entity ID dell'IdP non sia ricavabile da un **Metadata XML** inline — altrimenti l'elemento `<Issuer>` delle risposte SAML in arrivo non può essere verificato.
 
 Se il salvataggio di un provider OIDC o SAML non riesce, la scheda del provider mostra un messaggio di errore con il dettaglio restituito dal server. Correggi i campi indicati o riprova quando il servizio torna disponibile prima di considerare la configurazione aggiornata.
 

--- a/docs-site/src/content/docs/en/administration.md
+++ b/docs-site/src/content/docs/en/administration.md
@@ -21,7 +21,7 @@ When saving LDAP configuration, Praetor confirms the save only after the setting
 
 When editing an already saved LDAP configuration, the bind password remains masked. You can update the Bind DN without re-entering the password when the existing secret is still valid; re-enter the password only when changing it, or clear it together with the Bind DN to remove bind credentials.
 
-Before enabling a SAML provider, configure either a valid metadata source (URL or XML) or manual settings with **Entry Point** and **IdP Certificate**. Praetor rejects enabled SAML providers that are missing this minimum configuration.
+Before enabling a SAML provider, configure either a valid metadata source (URL or XML) or manual settings with **Entry Point** and **IdP Certificate**. Praetor rejects enabled SAML providers that are missing this minimum configuration. Praetor also requires the **IdP Issuer** field unless the IdP entity ID can be extracted from an inline **Metadata XML** — otherwise the `<Issuer>` element of incoming SAML responses cannot be verified.
 
 If saving an OIDC or SAML provider fails, the provider tab shows an error message with the detail returned by the server. Correct the reported fields or retry when the service is available before treating the configuration as updated.
 

--- a/locales/en/auth.json
+++ b/locales/en/auth.json
@@ -166,6 +166,7 @@
         "clientIdRequired": "Client ID is required",
         "usernameAttributeRequired": "Username claim is required",
         "samlConfigRequired": "Metadata or manual IdP fields are required",
+        "idpIssuerRequired": "IdP Issuer is required unless inline metadata XML provides it",
         "externalGroupRequired": "External group is required",
         "saveFailedTitle": "Provider could not be saved",
         "saveFailed": "Could not save provider"

--- a/locales/it/auth.json
+++ b/locales/it/auth.json
@@ -166,6 +166,7 @@
         "clientIdRequired": "Il Client ID è obbligatorio",
         "usernameAttributeRequired": "Il claim nome utente è obbligatorio",
         "samlConfigRequired": "Metadata o campi IdP manuali sono obbligatori",
+        "idpIssuerRequired": "IdP Issuer è obbligatorio a meno che non sia fornito dal metadata XML inline",
         "externalGroupRequired": "Il gruppo esterno è obbligatorio",
         "saveFailedTitle": "Impossibile salvare il provider",
         "saveFailed": "Impossibile salvare il provider"

--- a/server/services/sso.ts
+++ b/server/services/sso.ts
@@ -81,11 +81,23 @@ const assertEnabledProviderConfig = (provider: ssoProvidersRepo.SsoProvider): vo
     return;
   }
 
-  const hasMetadata = hasConfigValue(provider.metadataUrl) || hasConfigValue(provider.metadataXml);
+  const hasMetadataXml = hasConfigValue(provider.metadataXml);
+  const hasMetadata = hasConfigValue(provider.metadataUrl) || hasMetadataXml;
   const hasManual = hasConfigValue(provider.entryPoint) && hasConfigValue(provider.idpCert);
   if (!hasMetadata && !hasManual) {
     throw new SsoProviderValidationError(
       'SAML requires metadata URL/XML or manual entryPoint and idpCert',
+    );
+  }
+
+  // node-saml silently skips <Issuer> validation when idpIssuer is empty, so the SP would accept
+  // an assertion from any IdP whose signing cert chains correctly. Require provider.idpIssuer
+  // unless we can derive it from inline metadata at save time. metadataUrl mode is caught by
+  // the runtime guard in createSamlClient instead.
+  const derivedIssuer = hasMetadataXml ? parseSamlMetadata(provider.metadataXml).idpIssuer : '';
+  if (!hasConfigValue(provider.idpIssuer) && !derivedIssuer) {
+    throw new SsoProviderValidationError(
+      'SAML requires idpIssuer when it cannot be derived from inline metadata',
     );
   }
 };
@@ -567,8 +579,9 @@ const createSamlClient = async (
   const issuer = provider.spIssuer || buildSamlMetadataUrl(provider.slug, baseUrl);
   const entryPoint = idp.entryPoint || provider.entryPoint;
   const idpCert = normalizeCertificate(idp.idpCert || provider.idpCert);
-  if (!entryPoint || !idpCert) {
-    throw new Error('SAML provider is missing entry point or IdP certificate');
+  const idpIssuer = idp.idpIssuer || provider.idpIssuer;
+  if (!entryPoint || !idpCert || !idpIssuer) {
+    throw new Error('SAML provider is missing entry point, IdP certificate, or IdP issuer');
   }
   return new SAML({
     callbackUrl,
@@ -576,7 +589,7 @@ const createSamlClient = async (
     audience: issuer,
     entryPoint,
     idpCert,
-    idpIssuer: idp.idpIssuer || provider.idpIssuer || undefined,
+    idpIssuer,
     privateKey: privateKey || undefined,
     publicCert: provider.publicCert || undefined,
     signatureAlgorithm: 'sha256',

--- a/server/services/sso.ts
+++ b/server/services/sso.ts
@@ -94,8 +94,10 @@ const assertEnabledProviderConfig = (provider: ssoProvidersRepo.SsoProvider): vo
   // an assertion from any IdP whose signing cert chains correctly. Require provider.idpIssuer
   // unless we can derive it from inline metadata at save time. metadataUrl mode is caught by
   // the runtime guard in createSamlClient instead.
-  const derivedIssuer = hasMetadataXml ? parseSamlMetadata(provider.metadataXml).idpIssuer : '';
-  if (!hasConfigValue(provider.idpIssuer) && !derivedIssuer) {
+  if (
+    !hasConfigValue(provider.idpIssuer) &&
+    !(hasMetadataXml && parseSamlMetadata(provider.metadataXml).idpIssuer)
+  ) {
     throw new SsoProviderValidationError(
       'SAML requires idpIssuer when it cannot be derived from inline metadata',
     );
@@ -580,8 +582,13 @@ const createSamlClient = async (
   const entryPoint = idp.entryPoint || provider.entryPoint;
   const idpCert = normalizeCertificate(idp.idpCert || provider.idpCert);
   const idpIssuer = idp.idpIssuer || provider.idpIssuer;
-  if (!entryPoint || !idpCert || !idpIssuer) {
-    throw new Error('SAML provider is missing entry point, IdP certificate, or IdP issuer');
+  const missing = [
+    !entryPoint && 'entry point',
+    !idpCert && 'IdP certificate',
+    !idpIssuer && 'IdP issuer',
+  ].filter(Boolean);
+  if (missing.length > 0) {
+    throw new Error(`SAML provider is missing ${missing.join(', ')}`);
   }
   return new SAML({
     callbackUrl,

--- a/server/test/routes/sso.test.ts
+++ b/server/test/routes/sso.test.ts
@@ -279,7 +279,9 @@ describe('PUT /api/sso/providers/:id — masked sentinel preserves existing secr
   test('metadataXml === MASKED_SECRET is dropped from patch', async () => {
     const existing = samlProvider({
       enabled: true,
-      metadataXml: '<EntityDescriptor />',
+      // entityID makes assertEnabledProviderConfig happy without forcing idpIssuer; the test
+      // is about MASKED_SECRET handling, not issuer validation.
+      metadataXml: '<EntityDescriptor entityID="https://idp.example.com/" />',
       idpCert: 'MIIDstoredcert',
     });
     findByIdMock.mockResolvedValue(existing);
@@ -346,6 +348,7 @@ describe('PUT /api/sso/providers/:id — enabled SAML configuration validation',
       enabled: false,
       entryPoint: 'https://idp.example.com/sso',
       idpCert: 'MIIDstoredcert',
+      idpIssuer: 'https://idp.example.com/',
     });
     findByIdMock.mockResolvedValue(existing);
     updateMock.mockImplementation(

--- a/server/test/services/sso.test.ts
+++ b/server/test/services/sso.test.ts
@@ -10,6 +10,8 @@ const ssoStatesRepoSnap = { ...realSsoStatesRepo };
 const dnsLookupMock = mock();
 const findBySlugMock = mock();
 const findByIdMock = mock();
+const insertMock = mock();
+const updateMock = mock();
 const statesConsumeMock = mock();
 
 let sso: typeof import('../../services/sso.ts');
@@ -24,6 +26,8 @@ beforeAll(async () => {
     ...ssoProvidersRepoSnap,
     findBySlug: findBySlugMock,
     findById: findByIdMock,
+    insert: insertMock,
+    update: updateMock,
   }));
   mock.module('../../repositories/ssoStatesRepo.ts', () => ({
     ...ssoStatesRepoSnap,
@@ -40,7 +44,15 @@ afterAll(() => {
 });
 
 beforeEach(() => {
-  for (const m of [dnsLookupMock, findBySlugMock, findByIdMock, statesConsumeMock]) m.mockReset();
+  for (const m of [
+    dnsLookupMock,
+    findBySlugMock,
+    findByIdMock,
+    insertMock,
+    updateMock,
+    statesConsumeMock,
+  ])
+    m.mockReset();
 });
 
 describe('isPrivateIp', () => {
@@ -376,5 +388,97 @@ describe('completeOidcLogin state-before-provider ordering', () => {
       'Invalid or expired SSO state',
     );
     expect(statesConsumeMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('SAML provider validation requires idpIssuer', () => {
+  // node-saml silently skips <Issuer> validation when idpIssuer is empty (issue #597). The
+  // service must refuse to save/enable a SAML provider that could end up calling the library
+  // without an issuer to enforce, and the runtime SAML client must refuse to be built in that
+  // shape even when validation was bypassed via a stale DB row.
+  const baseSamlInput = {
+    protocol: 'saml' as const,
+    slug: 'okta-test',
+    name: 'Okta',
+    enabled: true,
+    entryPoint: 'https://idp.example.com/sso',
+    idpCert: 'MIIBdummyCert',
+  };
+
+  test('createProvider rejects enabled manual SAML config with empty idpIssuer', async () => {
+    await expect(sso.createProvider(baseSamlInput)).rejects.toThrow(sso.SsoProviderValidationError);
+    await expect(sso.createProvider(baseSamlInput)).rejects.toThrow(/idpIssuer/);
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  test('createProvider accepts manual SAML config when idpIssuer is set', async () => {
+    insertMock.mockImplementation(async (provider: realSsoProvidersRepo.SsoProvider) => provider);
+    const created = await sso.createProvider({
+      ...baseSamlInput,
+      idpIssuer: 'https://idp.example.com/',
+    });
+    expect(created.idpIssuer).toBe('https://idp.example.com/');
+    expect(insertMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('createProvider accepts metadataXml whose entityID supplies the issuer', async () => {
+    insertMock.mockImplementation(async (provider: realSsoProvidersRepo.SsoProvider) => provider);
+    const metadataXml = `<?xml version="1.0"?>
+<EntityDescriptor entityID="https://idp.example.com/">
+  <IDPSSODescriptor>
+    <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp.example.com/sso"/>
+    <KeyDescriptor><KeyInfo><X509Data><X509Certificate>MIIBcert</X509Certificate></X509Data></KeyInfo></KeyDescriptor>
+  </IDPSSODescriptor>
+</EntityDescriptor>`;
+    const created = await sso.createProvider({
+      protocol: 'saml',
+      slug: 'okta-metadata',
+      name: 'Okta',
+      enabled: true,
+      metadataXml,
+    });
+    expect(created.idpIssuer).toBe('');
+    expect(insertMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('createProvider rejects metadataXml that does not expose an entityID', async () => {
+    const metadataXml = `<?xml version="1.0"?>
+<EntityDescriptor>
+  <IDPSSODescriptor>
+    <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp.example.com/sso"/>
+  </IDPSSODescriptor>
+</EntityDescriptor>`;
+    await expect(
+      sso.createProvider({
+        protocol: 'saml',
+        slug: 'okta-no-issuer',
+        name: 'Okta',
+        enabled: true,
+        metadataXml,
+      }),
+    ).rejects.toThrow(/idpIssuer/);
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  test('startSamlLogin refuses to build SAML client when resolved idpIssuer is empty', async () => {
+    // Simulates a metadataUrl provider that slipped past save-time validation (e.g. enabled in
+    // an older release before this fix). The runtime guard in createSamlClient must still
+    // refuse to construct a SAML instance whose idpIssuer would be undefined.
+    const originalBase = process.env.SSO_CALLBACK_BASE_URL;
+    process.env.SSO_CALLBACK_BASE_URL = 'https://app.example.com';
+    try {
+      findBySlugMock.mockResolvedValue({
+        ...SAML_PROVIDER,
+        metadataUrl: '',
+        metadataXml: '',
+        entryPoint: 'https://idp.example.com/sso',
+        idpCert: 'MIIBdummyCert',
+        idpIssuer: '',
+      });
+      await expect(sso.startSamlLogin('okta')).rejects.toThrow(/IdP issuer/);
+    } finally {
+      if (originalBase === undefined) delete process.env.SSO_CALLBACK_BASE_URL;
+      else process.env.SSO_CALLBACK_BASE_URL = originalBase;
+    }
   });
 });

--- a/test/components/administration/AuthSettings.test.tsx
+++ b/test/components/administration/AuthSettings.test.tsx
@@ -177,4 +177,39 @@ describe('<AuthSettings />', () => {
 
     expect(within(form).getByRole('button', { name: 'admin.sso.saveProvider' })).toBeEnabled();
   });
+
+  test('blocks save and surfaces idpIssuer error for enabled manual SAML missing the issuer', async () => {
+    // Issue #597: node-saml silently skips <Issuer> validation when idpIssuer is empty.
+    // The form must refuse to send a save request for an enabled manual SAML config that
+    // has not specified an IdP issuer.
+    const onSaveSsoProvider = mock(async (provider: Partial<SsoProvider>) =>
+      buildProvider(provider.protocol ?? 'saml', provider),
+    );
+    renderAuthSettings({
+      onSaveSsoProvider,
+      ssoProviders: [
+        buildProvider('saml', {
+          enabled: true,
+          entryPoint: 'https://idp.example.com/sso',
+          idpCert: 'MIIBdummyCert',
+          // idpIssuer left empty — the violation under test.
+        }),
+      ],
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'admin.tabs.saml' }));
+    // The form initially renders an empty "new provider" draft. Click the pen icon on the
+    // listed SAML provider to load its values into the form.
+    fireEvent.click(screen.getByRole('button', { name: 'admin.sso.editProvider' }));
+    const heading = screen.getByText('admin.sso.editProvider', { selector: 'h3' });
+    const form = heading.closest('form') as HTMLFormElement | null;
+    if (!form) throw new Error('SAML provider form not found');
+
+    fireEvent.submit(form);
+
+    await waitFor(() => {
+      expect(within(form).getByText('admin.sso.errors.idpIssuerRequired')).toBeInTheDocument();
+    });
+    expect(onSaveSsoProvider).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

Closes #597. `@node-saml/node-saml` silently skips `<Issuer>` validation when `idpIssuer` is empty, so a SAML provider configured with `entryPoint + idpCert` but no `idpIssuer` would accept assertions from any IdP whose signing cert chains correctly. Cert/signature checks still applied, so this was defense-in-depth weakening rather than immediate compromise — but the "this assertion came from the IdP we expect" trust anchor was incomplete.

## Changes

- **`server/services/sso.ts`** — `assertEnabledProviderConfig` now requires `provider.idpIssuer` for enabled SAML providers unless inline `metadataXml` exposes an `entityID`. `metadataUrl` mode is allowed to pass save-time validation (the URL is only fetched at login) but is then caught by a new runtime guard in `createSamlClient` that refuses to construct a SAML client with an empty `idpIssuer`. This means providers enabled before this fix still fail closed on the next login attempt.
- **`components/administration/AuthSettings.tsx`** — `validateProvider` mirrors the server rule: `idpIssuer` is required unless inline `metadataXml` is supplied (frontend can't parse XML, so it requires the field whenever inline XML isn't present). Error wired to the existing IdP Issuer `Field`.
- **Translations** — `admin.sso.errors.idpIssuerRequired` added in `locales/en/auth.json` and `locales/it/auth.json`.
- **Docs** — SAML configuration section updated in `docs-site/src/content/docs/administration.md` (it) and `docs-site/src/content/docs/en/administration.md`.

## Tests

- `server/test/services/sso.test.ts`: rejects manual SAML with empty `idpIssuer`, accepts manual with `idpIssuer`, accepts `metadataXml` whose `entityID` supplies the issuer, rejects `metadataXml` without `entityID`, and verifies the `createSamlClient` runtime guard fires when a legacy DB row slips through.
- `test/components/administration/AuthSettings.test.tsx`: saving an enabled manual SAML provider with empty `idpIssuer` surfaces `admin.sso.errors.idpIssuerRequired` and never calls `onSaveSsoProvider`.
- Two pre-existing route tests in `server/test/routes/sso.test.ts` were updated to set a valid `entityID`/`idpIssuer` — they were exercising masked-secret behavior on top of SAML configs that the new rule (correctly) now rejects.

Full suites: backend 2,699/2,699 pass, frontend 3,827/3,827 pass.

## Test plan

- [ ] Configure a SAML provider with metadata URL + empty IdP Issuer → save succeeds, login fails closed with "missing... IdP issuer".
- [ ] Configure a SAML provider in manual mode (Entry Point + IdP Certificate) with empty IdP Issuer → save is rejected with `idpIssuer` error on the field.
- [ ] Configure a SAML provider with inline Metadata XML that includes `entityID` → save succeeds without entering IdP Issuer.
- [ ] Existing SAML providers with `idpIssuer` set continue to log in successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)