### PR TITLE
ldap(types): add LDAP config contract guards

### DIFF
--- a/server/db/schema/ldapConfig.ts
+++ b/server/db/schema/ldapConfig.ts
@@ -13,8 +13,8 @@ import {
 // Single-row config table - `id` is pinned to 1 by both the column default and a CHECK.
 //
 // `role_mappings` uses a structural `$type<...>()` rather than importing the named
-// `LdapRoleMapping` from `ldapRepo.ts` - keeping schema → repo as a one-way dependency
-// (matches every other repo's convention of owning its domain types).
+// `LdapRoleMapping` from `server/types/ldap.ts`, keeping schema independent from domain
+// payload types (matches every other repo's convention of owning its domain types).
 export const ldapConfig = pgTable(
   'ldap_config',
   {

--- a/server/repositories/ldapRepo.ts
+++ b/server/repositories/ldapRepo.ts
@@ -1,26 +1,13 @@
 import { eq, type SQL, sql } from 'drizzle-orm';
 import { type DbExecutor, db } from '../db/drizzle.ts';
 import { ldapConfig } from '../db/schema/ldapConfig.ts';
+import type { LdapConfig, LdapRoleMapping } from '../types/ldap.ts';
 import { decrypt, encrypt, isEncrypted } from '../utils/crypto.ts';
 import { createChildLogger, serializeError } from '../utils/logger.ts';
 
 const logger = createChildLogger({ module: 'ldapRepo' });
 
-export type LdapRoleMapping = { ldapGroup: string; role: string };
-
-export type LdapConfig = {
-  enabled: boolean;
-  serverUrl: string;
-  baseDn: string;
-  bindDn: string;
-  bindPassword: string;
-  userFilter: string;
-  groupBaseDn: string;
-  groupFilter: string;
-  roleMappings: LdapRoleMapping[];
-  tlsCaCertificate: string;
-  autoProvisionAll: boolean;
-};
+export type { LdapConfig, LdapRoleMapping } from '../types/ldap.ts';
 
 export type LdapConfigPatch = Partial<LdapConfig>;
 

--- a/server/routes/ldap.ts
+++ b/server/routes/ldap.ts
@@ -72,51 +72,43 @@ const roleMappingSchema = {
   required: ['ldapGroup', 'role'],
 } as const;
 
+const ldapConfigSchemaProperties = {
+  enabled: { type: 'boolean' },
+  serverUrl: { type: 'string' },
+  baseDn: { type: 'string' },
+  bindDn: { type: 'string' },
+  bindPassword: { type: 'string' },
+  userFilter: { type: 'string' },
+  groupBaseDn: { type: 'string' },
+  groupFilter: { type: 'string' },
+  roleMappings: { type: 'array', items: roleMappingSchema },
+  tlsCaCertificate: { type: 'string' },
+  autoProvisionAll: { type: 'boolean' },
+} as const satisfies Record<keyof ldapRepo.LdapConfig, unknown>;
+
 const ldapConfigSchema = {
   type: 'object',
-  properties: {
-    enabled: { type: 'boolean' },
-    serverUrl: { type: 'string' },
-    baseDn: { type: 'string' },
-    bindDn: { type: 'string' },
-    bindPassword: { type: 'string' },
-    userFilter: { type: 'string' },
-    groupBaseDn: { type: 'string' },
-    groupFilter: { type: 'string' },
-    roleMappings: { type: 'array', items: roleMappingSchema },
-    tlsCaCertificate: { type: 'string' },
-    autoProvisionAll: { type: 'boolean' },
-  },
-  required: [
-    'enabled',
-    'serverUrl',
-    'baseDn',
-    'bindDn',
-    'bindPassword',
-    'userFilter',
-    'groupBaseDn',
-    'groupFilter',
-    'roleMappings',
-    'tlsCaCertificate',
-    'autoProvisionAll',
-  ],
+  properties: ldapConfigSchemaProperties,
+  required: Object.keys(ldapConfigSchemaProperties),
 } as const;
+
+const ldapConfigUpdateBodySchemaProperties = {
+  enabled: { type: 'boolean' },
+  serverUrl: { type: 'string' },
+  baseDn: { type: 'string' },
+  bindDn: { type: 'string' },
+  bindPassword: { type: 'string' },
+  userFilter: { type: 'string' },
+  groupBaseDn: { type: 'string' },
+  groupFilter: { type: 'string' },
+  roleMappings: { type: 'array', items: roleMappingSchema },
+  tlsCaCertificate: { type: ['string', 'null'], maxLength: TLS_CA_MAX_LENGTH },
+  autoProvisionAll: { type: 'boolean' },
+} as const satisfies Record<keyof ldapRepo.LdapConfig, unknown>;
 
 const ldapConfigUpdateBodySchema = {
   type: 'object',
-  properties: {
-    enabled: { type: 'boolean' },
-    serverUrl: { type: 'string' },
-    baseDn: { type: 'string' },
-    bindDn: { type: 'string' },
-    bindPassword: { type: 'string' },
-    userFilter: { type: 'string' },
-    groupBaseDn: { type: 'string' },
-    groupFilter: { type: 'string' },
-    roleMappings: { type: 'array', items: roleMappingSchema },
-    tlsCaCertificate: { type: ['string', 'null'], maxLength: TLS_CA_MAX_LENGTH },
-    autoProvisionAll: { type: 'boolean' },
-  },
+  properties: ldapConfigUpdateBodySchemaProperties,
 } as const;
 
 const ldapTestBodySchema = {

--- a/server/test/repositories/ldapRepo.test.ts
+++ b/server/test/repositories/ldapRepo.test.ts
@@ -41,6 +41,7 @@ const PROJECTION_KEYS = [
   'groupFilter',
   'roleMappings',
   'tlsCaCertificate',
+  'autoProvisionAll',
 ] as const;
 type ProjectionKey = (typeof PROJECTION_KEYS)[number];
 type RowFields = Record<ProjectionKey, unknown>;
@@ -56,6 +57,7 @@ const baseFields: RowFields = {
   groupFilter: '(member={0})',
   roleMappings: [] as ldapRepo.LdapRoleMapping[],
   tlsCaCertificate: null,
+  autoProvisionAll: false,
 };
 
 const buildRow = (overrides: Partial<RowFields> = {}): unknown[] => {

--- a/server/types/ldap.ts
+++ b/server/types/ldap.ts
@@ -1,0 +1,15 @@
+export type LdapRoleMapping = { ldapGroup: string; role: string };
+
+export type LdapConfig = {
+  enabled: boolean;
+  serverUrl: string;
+  baseDn: string;
+  bindDn: string;
+  bindPassword: string;
+  userFilter: string;
+  groupBaseDn: string;
+  groupFilter: string;
+  roleMappings: LdapRoleMapping[];
+  tlsCaCertificate: string;
+  autoProvisionAll: boolean;
+};

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -1,12 +1,27 @@
 import { describe, expect, test } from 'bun:test';
-import type { KnownPermission, KnownUserRole, Permission, UserRole } from '../types';
+import type {
+  LdapConfig as BackendLdapConfig,
+  LdapRoleMapping as BackendLdapRoleMapping,
+} from '../server/types/ldap.ts';
+import type {
+  LdapConfig as FrontendLdapConfig,
+  LdapRoleMapping as FrontendLdapRoleMapping,
+  KnownPermission,
+  KnownUserRole,
+  Permission,
+  UserRole,
+} from '../types';
 
 // Compile-time assertion helpers. These checks run during `tsc --noEmit`: any failure
 // here surfaces as a TypeScript error, which prevents `bun run lint` / typecheck from
 // succeeding. The runtime `expect(true).toBe(true)` keeps Bun's test reporter happy.
 type AssertExtends<T, U> = T extends U ? true : false;
 type AssertEqual<T, U> =
-  AssertExtends<T, U> extends true ? (AssertExtends<U, T> extends true ? true : false) : false;
+  (<V>() => V extends T ? 1 : 2) extends <V>() => V extends U ? 1 : 2
+    ? (<V>() => V extends U ? 1 : 2) extends <V>() => V extends T ? 1 : 2
+      ? true
+      : false
+    : false;
 
 const trueValue: true = true;
 
@@ -74,5 +89,26 @@ describe('Permission literal union', () => {
     > = trueValue;
     // Compile-time assertion of a type relationship; runtime value is trivially true.
     expect(knownExtendsPermission).toBe(true);
+  });
+});
+
+describe('LDAP config contract', () => {
+  test('frontend and backend role mapping shapes stay aligned', () => {
+    const sameRoleMappingShape: AssertEqual<BackendLdapRoleMapping, FrontendLdapRoleMapping> =
+      trueValue;
+    expect(sameRoleMappingShape).toBe(true);
+  });
+
+  test('frontend and backend config shapes stay aligned', () => {
+    type BackendOnlyKey = Exclude<keyof BackendLdapConfig, keyof FrontendLdapConfig>;
+    type FrontendOnlyKey = Exclude<keyof FrontendLdapConfig, keyof BackendLdapConfig>;
+
+    const noBackendOnlyKeys: AssertEqual<BackendOnlyKey, never> = trueValue;
+    const noFrontendOnlyKeys: AssertEqual<FrontendOnlyKey, never> = trueValue;
+    const sameConfigShape: AssertEqual<BackendLdapConfig, FrontendLdapConfig> = trueValue;
+
+    expect(noBackendOnlyKeys).toBe(true);
+    expect(noFrontendOnlyKeys).toBe(true);
+    expect(sameConfigShape).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Adds compile-time guards so frontend and backend LDAP config types stay aligned.
- Links LDAP route request/response schema keys to the backend LDAP config shape to reduce API schema drift.

## Changes
- Moves backend LDAP payload types into `server/types/ldap.ts` and re-exports them from `ldapRepo`.
- Adds LDAP role mapping and config shape assertions in `test/types.test.ts`.
- Adds `satisfies Record<keyof ldapRepo.LdapConfig, unknown>` guards to LDAP route schemas.
- Updates the LDAP repository test fixture projection to include `autoProvisionAll`.

## Testing
- `bun test test/types.test.ts`
- `bun test server/test/repositories/ldapRepo.test.ts`
- `bun test server/test/routes/ldap.test.ts`
- `bun run typecheck`
- `bunx biome check server/routes/ldap.ts server/types/ldap.ts server/repositories/ldapRepo.ts server/db/schema/ldapConfig.ts server/test/repositories/ldapRepo.test.ts test/types.test.ts`
- `git diff --check`

## Risks / Rollout
- Low risk. Type/test/schema-guard change only; no runtime LDAP behavior or database migration.

## Issues
Fixes #647