### PR TITLE
validation(fix): reject Infinity/-Infinity in parseNumber (#613)

### DIFF
--- a/server/test/utils/validation.test.ts
+++ b/server/test/utils/validation.test.ts
@@ -175,9 +175,17 @@ describe('parseNumber', () => {
     expect(parseNumber('3.14')).toEqual({ ok: true, value: 3.14 });
   });
 
-  test('rejects NaN', () => {
-    const result = parseNumber(NaN);
-    expect(result.ok).toBe(false);
+  test('rejects non-finite number', () => {
+    expect(parseNumber(NaN).ok).toBe(false);
+    expect(parseNumber(Infinity).ok).toBe(false);
+    expect(parseNumber(-Infinity).ok).toBe(false);
+  });
+
+  test('rejects strings that parse to non-finite values', () => {
+    expect(parseNumber('Infinity').ok).toBe(false);
+    expect(parseNumber('-Infinity').ok).toBe(false);
+    expect(parseNumber('1e999').ok).toBe(false);
+    expect(parseNumber('-1e999').ok).toBe(false);
   });
 
   test('rejects empty trimmed string', () => {

--- a/server/utils/validation.ts
+++ b/server/utils/validation.ts
@@ -76,7 +76,7 @@ export function parseNumber(
   value: unknown,
   fieldName: string = 'value',
 ): { ok: true; value: number } | { ok: false; message: string } {
-  if (typeof value === 'number' && !Number.isNaN(value)) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
     return { ok: true, value };
   }
   if (typeof value === 'string') {
@@ -85,7 +85,7 @@ export function parseNumber(
       return { ok: false, message: `${fieldName} cannot be an empty string` };
     }
     const parsed = parseFloat(trimmed);
-    if (!Number.isNaN(parsed)) {
+    if (Number.isFinite(parsed)) {
       return { ok: true, value: parsed };
     }
   }


### PR DESCRIPTION
## Summary

Fixes [#613](https://github.com/xBounceIT/praetor/issues/613). `parseNumber` in `server/utils/validation.ts` only guarded against `NaN`, so:

- `parseNumber(Infinity)` → `{ ok: true, value: Infinity }`
- `parseNumber("Infinity")` / `parseNumber("-Infinity")` → accepted (via `parseFloat`)
- `parseNumber("1e999")` → accepted as `Infinity` (overflow)

This affected every caller — durations, costs, prices, quantities — since the same predicate gates `parseNonNegativeNumber`, `parsePositiveNumber`, and their `optional*` siblings.

## Fix

Switch both `!Number.isNaN(...)` checks to `Number.isFinite(...)` — once for the number branch (line 79) and once for the parsed-string branch (line 88). This aligns `parseNumber` with the existing `parseLocalizedNumber` contract, which already uses `Number.isFinite`.

## Test plan

- [x] Added regression tests in `server/test/utils/validation.test.ts` covering non-finite numbers (`NaN`, `Infinity`, `-Infinity`) and non-finite-producing strings (`"Infinity"`, `"-Infinity"`, `"1e999"`, `"-1e999"`).
- [x] Test shape mirrors the sibling `parseLocalizedNumber` test (`rejects non-finite number`).
- [x] `bun test test/utils/validation.test.ts` — 153/153 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)