### PR TITLE
users(fix): replaceUserRoles DELETE+INSERT now atomic (#611)

### DIFF
--- a/server/repositories/usersRepo.ts
+++ b/server/repositories/usersRepo.ts
@@ -1,5 +1,5 @@
 import { eq, sql } from 'drizzle-orm';
-import { type DbExecutor, db, executeRows } from '../db/drizzle.ts';
+import { type DbExecutor, db, executeRows, runAtomically } from '../db/drizzle.ts';
 import type { UserAuthMethod } from '../db/schema/users.ts';
 import { users } from '../db/schema/users.ts';
 import { NotFoundError } from '../utils/http-errors.ts';
@@ -580,14 +580,18 @@ export const replaceUserRoles = async (
   roleIds: string[],
   exec: DbExecutor = db,
 ): Promise<void> => {
-  await executeRows(exec, sql`DELETE FROM user_roles WHERE user_id = ${userId}`);
-  if (roleIds.length === 0) return;
+  // A partial failure (INSERT throws after the DELETE commits) would otherwise wipe
+  // the user's secondary roles.
+  await runAtomically(exec, async (tx) => {
+    await executeRows(tx, sql`DELETE FROM user_roles WHERE user_id = ${userId}`);
+    if (roleIds.length === 0) return;
 
-  const valueRows = roleIds.map((roleId) => sql`(${userId}, ${roleId})`);
-  await executeRows(
-    exec,
-    sql`INSERT INTO user_roles (user_id, role_id) VALUES ${sql.join(valueRows, sql`, `)} ON CONFLICT DO NOTHING`,
-  );
+    const valueRows = roleIds.map((roleId) => sql`(${userId}, ${roleId})`);
+    await executeRows(
+      tx,
+      sql`INSERT INTO user_roles (user_id, role_id) VALUES ${sql.join(valueRows, sql`, `)} ON CONFLICT DO NOTHING`,
+    );
+  });
 };
 
 export const setPrimaryRole = async (

--- a/server/test/repositories/replaceUserRolesTransactional.test.ts
+++ b/server/test/repositories/replaceUserRolesTransactional.test.ts
@@ -1,0 +1,126 @@
+// Asserts `replaceUserRoles` runs its DELETE/INSERT pair inside a single transaction when
+// called without a caller-supplied executor: a failing INSERT must roll back the prior
+// DELETE so the user does not silently lose every secondary role assignment.
+
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import * as realDrizzle from '../../db/drizzle.ts';
+
+type Row = { userId: string; roleId: string };
+
+let table: Row[] = [];
+let pending: Row[] | null = null;
+let forcedFailure: 'INSERT' | 'DELETE' | null = null;
+
+const dialect = new PgDialect();
+
+const live = (): Row[] => pending ?? table;
+
+const detectOp = (sqlText: string): 'INSERT' | 'DELETE' => {
+  const head = sqlText.trimStart().toUpperCase();
+  if (head.startsWith('INSERT')) return 'INSERT';
+  if (head.startsWith('DELETE')) return 'DELETE';
+  throw new Error(`replaceUserRoles test: unrecognized SQL: ${sqlText}`);
+};
+
+const fakeDb = {
+  async execute(sqlObj: unknown) {
+    const { sql: text, params } = dialect.sqlToQuery(sqlObj as SQL);
+    const op = detectOp(text);
+
+    if (forcedFailure === op) {
+      // Self-clear so a single forced failure doesn't keep firing inside the same tx.
+      forcedFailure = null;
+      throw new Error(`forced ${op} failure on user_roles`);
+    }
+
+    if (op === 'DELETE') {
+      live().length = 0;
+    } else {
+      // Repo emits VALUES ($1,$2),($3,$4),... in (userId, roleId) order — read pairs.
+      for (let i = 0; i < params.length; i += 2) {
+        live().push({ userId: String(params[i]), roleId: String(params[i + 1]) });
+      }
+    }
+    return { rows: [] };
+  },
+};
+
+// Re-entry as no-op so a `runAtomically(tx, ...)` passthrough doesn't double-snapshot.
+const fakeWithDbTransaction = async <T>(cb: (tx: unknown) => Promise<T>): Promise<T> => {
+  if (pending) return cb(fakeDb);
+  pending = table.slice();
+  try {
+    const result = await cb(fakeDb);
+    table = pending;
+    return result;
+  } finally {
+    pending = null;
+  }
+};
+
+const fakeRunAtomically = <T>(exec: unknown, cb: (tx: unknown) => Promise<T>): Promise<T> =>
+  exec === fakeDb ? fakeWithDbTransaction(cb) : cb(exec);
+
+// Snapshot the real exports BEFORE mocking so afterAll fully restores them — otherwise
+// the mock leaks into later tests in the same Bun process.
+const drizzleSnap = { ...realDrizzle };
+
+mock.module('../../db/drizzle.ts', () => ({
+  ...drizzleSnap,
+  db: fakeDb,
+  withDbTransaction: fakeWithDbTransaction,
+  runAtomically: fakeRunAtomically,
+}));
+
+let usersRepo: typeof import('../../repositories/usersRepo.ts');
+
+beforeAll(async () => {
+  usersRepo = await import('../../repositories/usersRepo.ts');
+});
+
+afterAll(() => {
+  mock.module('../../db/drizzle.ts', () => drizzleSnap);
+});
+
+beforeEach(() => {
+  table = [];
+  pending = null;
+  forcedFailure = null;
+});
+
+describe('replaceUserRoles atomicity', () => {
+  test('failed INSERT leaves prior roles intact (DELETE rolled back)', async () => {
+    table = [
+      { userId: 'u-1', roleId: 'manager' },
+      { userId: 'u-1', roleId: 'user' },
+    ];
+    forcedFailure = 'INSERT';
+
+    await expect(usersRepo.replaceUserRoles('u-1', ['ghost-role'])).rejects.toThrow(
+      'forced INSERT failure on user_roles',
+    );
+
+    expect(table.map((r) => r.roleId)).toEqual(['manager', 'user']);
+  });
+
+  test('successful replace commits new roles and drops old ones', async () => {
+    table = [{ userId: 'u-1', roleId: 'old-role' }];
+
+    await usersRepo.replaceUserRoles('u-1', ['manager', 'user']);
+
+    expect(table).toEqual([
+      { userId: 'u-1', roleId: 'manager' },
+      { userId: 'u-1', roleId: 'user' },
+    ]);
+  });
+
+  test('empty role list commits the DELETE (no INSERT)', async () => {
+    table = [{ userId: 'u-1', roleId: 'old-role' }];
+
+    await usersRepo.replaceUserRoles('u-1', []);
+
+    expect(table).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Wrap the DELETE + bulk-INSERT pair in [server/repositories/usersRepo.ts](server/repositories/usersRepo.ts) inside `runAtomically`, so a failed INSERT rolls back the prior DELETE instead of silently wiping the user's secondary roles.
- Add a transactional regression test that drives the repo against an in-memory fake `db` / `withDbTransaction` / `runAtomically`, asserting (a) a forced INSERT failure leaves prior rows intact, (b) the success path commits the real `(userId, roleId)` pairs, (c) an empty role list still commits the DELETE.

## Why

`replaceUserRoles` ran two `executeRows` calls back-to-back on the caller-supplied `exec`. All three current callers happen to pass a `tx`, but the default-`exec` path was unguarded — an INSERT failure (FK violation, dropped connection, etc.) after a committed DELETE would leave the user with zero secondary roles. Sibling `replace*` operations (`userAssignmentsRepo.replaceAssignments`, the `replaceItems` family across seven repos) already use `runAtomically`; this was a clear omission, exactly as called out in [#611](https://github.com/xBounceIT/praetor/issues/611).

## Test plan

- [x] `bun test` (server suite): 2738 pass / 0 fail / 28 skip
- [x] New test fails on the pre-fix code (the rejected INSERT is observed but the prior rows are gone) and passes on the fix
- [x] `biome check` clean on touched files

Closes #611

🤖 Generated with [Claude Code](https://claude.com/claude-code)