### PR TITLE
state(fix): keep entriesLoaded reachable when entries fetch fails (#620)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1600,6 +1600,12 @@ const AppContent: React.FC = () => {
               ],
               { shouldApply: isCurrentModuleLoad },
             );
+            // The recurring-entry generator gates on entriesLoaded but
+            // fetches from the server independently of the local entries
+            // array, so unblock it even when the initial entries fetch fails.
+            if (failedDatasets.includes('entries')) {
+              setEntriesLoaded(true);
+            }
             await loadOptionalDataset(
               module,
               'general settings',

--- a/test/App.entriesLoadedOnFailure.test.ts
+++ b/test/App.entriesLoadedOnFailure.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Source-text contract test for issue #620 — locks both the success-path and
+// failure-path setEntriesLoaded(true) flips inside the timesheets module-load
+// case closure. Same style as App.streamRemainingEntries.test.ts and
+// App.moduleLoadCancellation.test.ts.
+describe('App.tsx entriesLoaded recovery on entries fetch failure (#620)', () => {
+  const source = readFileSync(join(import.meta.dir, '..', 'App.tsx'), 'utf8');
+
+  // Scope to the timesheets case body in the module-loading effect.
+  const caseStart = source.indexOf("case 'timesheets': {");
+  const caseEnd = source.indexOf("case 'hr': {", caseStart);
+
+  test('locates the timesheets case in the module-loading effect', () => {
+    expect(caseStart).toBeGreaterThan(-1);
+    expect(caseEnd).toBeGreaterThan(caseStart);
+  });
+
+  const caseBody = source.slice(caseStart, caseEnd);
+
+  test('flips entriesLoaded=true when the entries dataset is in the failure list', () => {
+    expect(caseBody).toMatch(
+      /if\s*\(\s*failedDatasets\.includes\(\s*['"]entries['"]\s*\)\s*\)\s*\{\s*setEntriesLoaded\(true\);\s*\}/,
+    );
+  });
+
+  test('still flips entriesLoaded=true on the success-path apply (existing contract)', () => {
+    expect(caseBody).toContain('setEntriesLoaded(true);');
+    // Both branches present: at minimum two occurrences inside this case body.
+    const occurrences = caseBody.match(/setEntriesLoaded\(true\)/g) ?? [];
+    expect(occurrences.length).toBeGreaterThanOrEqual(2);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes [#620](https://github.com/xBounceIT/praetor/issues/620): when the timesheets entries fetch failed, `setEntriesLoaded(true)` was never called (it lived only on the success-path `apply()`), while `markModuleLoaded` still ran in the `finally`. The recurring-entry generator effect gates on `entriesLoaded`, so a single transient failure permanently disabled recurring generation until manual refresh.
- Flip `entriesLoaded` to `true` after `loadDatasets` when the entries dataset is in the failure list. `generateRecurringEntries` hits the server directly and does not depend on the local entries array, so running it against an empty/partial state is safe.

## Why this approach
- The alternative ("don't mark module as loaded when entries fail and retry") would conflict with the existing module-loader contract — `markModuleLoaded` runs unconditionally in `finally` and per-dataset failures are surfaced via `recordFailures`. Following the existing contract keeps the fix local.
- `loadDatasets` already returns `[]` when the load is cancelled (`hooks/useModuleLoader.ts:68`), so an explicit `isCurrentModuleLoad()` guard would be dead defense — dropped for consistency with the success-path `apply()`.

## Test plan
- [x] New regression test `test/App.entriesLoadedOnFailure.test.ts` — source-text contract test in the style of `App.streamRemainingEntries.test.ts` and `App.moduleLoadCancellation.test.ts`. Locks both the success-path and failure-path `setEntriesLoaded(true)` calls inside the timesheets case body.
- [x] `bun run test:frontend` — 1139/1139 pass.
- [x] `bun run typecheck` — clean.
- [x] `bun run lint` — no new warnings (2 pre-existing warnings unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)