### PR TITLE
auth(perf): use login response user, skip redundant /auth/me (#616)

### DIFF
--- a/services/api/auth.ts
+++ b/services/api/auth.ts
@@ -54,7 +54,15 @@ const runCanonicalAuthFlow = async (
     const token = ensureToken(response.token);
     setAuthToken(token);
 
-    const user = await fetchCanonicalAuthUser();
+    // Login/switch-role/sso-consume responses already carry the canonical user
+    // (server enforces loginResponseSchema). Fall back to /auth/me only if the
+    // payload fails our guards — i.e. on contract drift.
+    let user: User;
+    try {
+      user = normalizeAuthUser(response.user);
+    } catch {
+      user = await fetchCanonicalAuthUser();
+    }
     return {
       token: getAuthToken() || token,
       user,

--- a/test/services/auth.test.ts
+++ b/test/services/auth.test.ts
@@ -135,6 +135,29 @@ describe('authApi', () => {
     });
   });
 
+  describe('consumeSsoTicket', () => {
+    test('POSTs to /auth/sso/consume and uses response user without /auth/me', async () => {
+      programRoutes({
+        '/auth/sso/consume': { token: 'sso-token', user: { ...canonicalUser } },
+      });
+
+      const result = await authApi.consumeSsoTicket('ticket-abc');
+
+      // No fallback /auth/me when the response user is canonical (issue #616).
+      expect(fetchMock.mock.calls).toHaveLength(1);
+      const consumeCall = fetchMock.mock.calls[0];
+      expect(String(consumeCall[0])).toContain('/auth/sso/consume');
+      expect((consumeCall[1] as { method: string }).method).toBe('POST');
+      expect((consumeCall[1] as { body: string }).body).toBe(
+        JSON.stringify({ ticket: 'ticket-abc' }),
+      );
+
+      expect(getAuthToken()).toBe('sso-token');
+      expect(result.token).toBe('sso-token');
+      expect(result.user.id).toBe('u-1');
+    });
+  });
+
   describe('me', () => {
     test('fetches /auth/me and returns the normalized canonical user', async () => {
       programRoutes({ '/auth/me': { ...canonicalUser } });

--- a/test/services/auth.test.ts
+++ b/test/services/auth.test.ts
@@ -53,15 +53,16 @@ afterAll(() => {
 
 describe('authApi', () => {
   describe('login', () => {
-    test('POSTs to /auth/login, persists token, fetches /auth/me, returns canonical response', async () => {
+    test('POSTs to /auth/login, persists token, uses response user without /auth/me', async () => {
       programRoutes({
-        '/auth/login': { token: 'login-token', user: { id: 'ignored' } },
-        '/auth/me': { ...canonicalUser },
+        '/auth/login': { token: 'login-token', user: { ...canonicalUser } },
       });
 
       const result = await authApi.login('alice', 'secret');
 
-      // First call sends credentials.
+      // Exactly one network call — /auth/me must not be invoked when the
+      // login response already carries a canonical user (issue #616).
+      expect(fetchMock.mock.calls).toHaveLength(1);
       const loginCall = fetchMock.mock.calls[0];
       expect(String(loginCall[0])).toContain('/auth/login');
       expect((loginCall[1] as { method: string }).method).toBe('POST');
@@ -69,14 +70,24 @@ describe('authApi', () => {
         JSON.stringify({ username: 'alice', password: 'secret' }),
       );
 
-      // Second call fetches the canonical user.
-      expect(String(fetchMock.mock.calls[1][0])).toContain('/auth/me');
-
       // Token was persisted via setAuthToken (visible through getAuthToken).
       expect(getAuthToken()).toBe('login-token');
       expect(result.token).toBe('login-token');
       expect(result.user.id).toBe('u-1');
       expect(result.user.username).toBe('canonical');
+    });
+
+    test('falls back to /auth/me when the login response user fails normalization', async () => {
+      programRoutes({
+        '/auth/login': { token: 'login-token', user: { id: 'ignored' } },
+        '/auth/me': { ...canonicalUser },
+      });
+
+      const result = await authApi.login('alice', 'secret');
+
+      expect(fetchMock.mock.calls).toHaveLength(2);
+      expect(String(fetchMock.mock.calls[1][0])).toContain('/auth/me');
+      expect(result.user.id).toBe('u-1');
     });
 
     test('rejects when login response has a blank token, restores previous token', async () => {
@@ -141,14 +152,15 @@ describe('authApi', () => {
   });
 
   describe('switchRole', () => {
-    test('POSTs to /auth/switch-role with the requested roleId and returns canonical response', async () => {
+    test('POSTs to /auth/switch-role and uses response user without /auth/me', async () => {
       programRoutes({
-        '/auth/switch-role': { token: 'role-token', user: {} },
-        '/auth/me': { ...canonicalUser, role: 'admin' },
+        '/auth/switch-role': { token: 'role-token', user: { ...canonicalUser, role: 'admin' } },
       });
 
       const result = await authApi.switchRole('admin');
 
+      // No fallback /auth/me when the response user is canonical (issue #616).
+      expect(fetchMock.mock.calls).toHaveLength(1);
       const switchCall = fetchMock.mock.calls[0];
       expect(String(switchCall[0])).toContain('/auth/switch-role');
       expect((switchCall[1] as { method: string }).method).toBe('POST');
@@ -156,6 +168,19 @@ describe('authApi', () => {
 
       expect(getAuthToken()).toBe('role-token');
       expect(result.token).toBe('role-token');
+      expect(result.user.role).toBe('admin');
+    });
+
+    test('falls back to /auth/me when the switch-role response user fails normalization', async () => {
+      programRoutes({
+        '/auth/switch-role': { token: 'role-token', user: {} },
+        '/auth/me': { ...canonicalUser, role: 'admin' },
+      });
+
+      const result = await authApi.switchRole('admin');
+
+      expect(fetchMock.mock.calls).toHaveLength(2);
+      expect(String(fetchMock.mock.calls[1][0])).toContain('/auth/me');
       expect(result.user.role).toBe('admin');
     });
 


### PR DESCRIPTION
## Summary
- `runCanonicalAuthFlow` no longer discards the canonical user returned by `/auth/login`, `/auth/switch-role`, and `/auth/sso/consume` and re-fetches it via `/auth/me` — the server's `loginResponseSchema` already requires the full canonical user shape, so we trust the payload and run `normalizeAuthUser` on it directly.
- `/auth/me` is kept as a fallback only when the response user fails our guards (contract drift).
- Halves login latency: one round-trip instead of two, on every login and role switch.

## Why
Fixes [#616](https://github.com/xBounceIT/praetor/issues/616). The redundant `/auth/me` call doubled the latency of every login and role-switch with no benefit — the same canonical user shape is already returned by the originating endpoint.

## Test plan
- [x] `bun test test/services/auth.test.ts` — 11 pass (added happy-path tests asserting exactly one fetch call for both login and switchRole; added fallback tests asserting `/auth/me` is still hit when the response user fails normalization)
- [x] `bun test test/hooks/useAuth.test.ts` — 20 pass (consumers of `authApi.login`/`switchRole` unchanged)
- [x] Biome lint clean on changed files
- [ ] Manual: log in via username/password, verify only one `/auth/login` round-trip in network panel
- [ ] Manual: switch role from the role picker, verify only one `/auth/switch-role` round-trip
- [ ] Manual: complete an SSO login (OIDC or SAML), verify only one `/auth/sso/consume` round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)