### PR TITLE
auth(docs): clarify availableUsers trust model (#617)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2079,7 +2079,15 @@ const AppContent: React.FC = () => {
     }
   }, []);
 
-  // Determine available users for the dropdown based on permissions
+  // `users` comes from GET /api/users, which is already scoped server-side to
+  // what the caller is allowed to see (self, managed work-unit members,
+  // visible internal/external employees, or all users for admins). The server
+  // also re-validates every downstream action (view/create/update/delete of
+  // entries, assignments, tracker catalogs), so we trust the scoped list here
+  // rather than re-filtering by `currentUser.permissions` — a client-side
+  // filter cannot tell which users the caller manages and would regress
+  // managers who don't have `_all` permissions. Fall back to [currentUser]
+  // when /api/users wasn't loaded.
   const availableUsers = useMemo(() => {
     if (!currentUser) return [];
     if (users.length > 0) return users;


### PR DESCRIPTION
## Summary
- Fixes #617. The reported "authorization bypass / user enumeration" in [App.tsx:2083-2087](https://github.com/xBounceIT/praetor/blob/main/App.tsx#L2083-L2087) is not an actual exposure — server-side scoping already constrains `GET /api/users` and every downstream action re-validates authorization. The bug is that the inline comment promised client-side permission filtering that the code never implemented.
- Replace the misleading `// Determine available users for the dropdown based on permissions` comment with one that documents the actual server-side scoping trust model and explains why an over-broad client-side filter (as #617's proposed fix suggested) would regress the seeded `manager` role.
- No behavioral change.

## Why the issue's "fix" was rejected
The issue suggested gating on `administration.user_management.view`. The seeded `manager` role (`server/db/schema.sql:31-92`) has `timesheets.tracker.view` + `hr.internal.view` + manages work units, but **does not** have `administration.user_management.view`. The server returns their managed users in `/api/users` via `listScopedForManager`, and `listTimeEntries` allows them to view those users' trackers via `isUserManagedBy`. A client filter on `user_management.view` would collapse their dropdown despite legitimate access.

## Validation evidence
- `server/routes/users.ts:367-373` routes non-admins to `listScopedForManager`, not `listAllForAdmin`.
- `server/repositories/usersRepo.ts:405-444` scopes results to `u.id = viewerId` OR managed work-unit members OR (if `hr.internal.view`) internal OR (if `hr.external.view`) external; top managers excluded.
- `server/services/timeEntries.ts:155-159` requires `tracker_all.view` OR `isUserManagedBy(actor, target)` for every list/read.
- `server/routes/users.ts:224-238` `canViewTargetUserAssignments` gates assignments and tracker-catalogs endpoints.
- The dropdown is gated by `availableUsers.length > 1` at `App.tsx:443`, so a plain `tracker.view`-only user (server returns `[self]`) sees no dropdown.

## Test plan
- [x] `bunx biome check App.tsx` passes
- [x] Pre-commit hook (`biome check --write --no-errors-on-unmatched`) passes
- [ ] No automated test added: this is a documentation correction, not a bug fix; behavior is unchanged. Extracting the inline `useMemo` purely to test a comment would be over-engineering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)