### PR TITLE
notifications(fix): per-user admin password warning id (#612)

### DIFF
--- a/server/db/bootstrapAdmin.ts
+++ b/server/db/bootstrapAdmin.ts
@@ -37,7 +37,7 @@ export const syncDefaultAdminPasswordWarning = async (
   if (usesInsecurePassword) {
     await notificationsRepo.upsertAdminPasswordWarning(adminId);
   } else {
-    await notificationsRepo.deleteAdminPasswordWarning();
+    await notificationsRepo.deleteAdminPasswordWarning(adminId);
   }
 };
 

--- a/server/repositories/notificationsRepo.ts
+++ b/server/repositories/notificationsRepo.ts
@@ -1,4 +1,4 @@
-import { and, count, desc, eq, sql } from 'drizzle-orm';
+import { and, count, desc, eq, inArray, sql } from 'drizzle-orm';
 import { type DbExecutor, db } from '../db/drizzle.ts';
 import { notifications } from '../db/schema/notifications.ts';
 
@@ -20,8 +20,13 @@ export type Notification = {
   createdAt: number;
 };
 
-export const ADMIN_PASSWORD_WARNING_NOTIFICATION_ID = 'admin-default-password-warning';
+// Sweep rows written under the pre-#612 global id; can be removed once no
+// pre-#612 binary is in service.
+const LEGACY_ADMIN_PASSWORD_WARNING_NOTIFICATION_ID = 'admin-default-password-warning';
 export const ADMIN_PASSWORD_WARNING_TYPE = 'admin_password_warning';
+
+export const adminPasswordWarningNotificationId = (userId: string): string =>
+  `${userId}-admin-default-password-warning`;
 
 const ADMIN_PASSWORD_WARNING_TITLE = 'Change the default admin password';
 const ADMIN_PASSWORD_WARNING_MESSAGE =
@@ -110,9 +115,13 @@ export const upsertAdminPasswordWarning = async (
   };
 
   await exec
+    .delete(notifications)
+    .where(eq(notifications.id, LEGACY_ADMIN_PASSWORD_WARNING_NOTIFICATION_ID));
+
+  await exec
     .insert(notifications)
     .values({
-      id: ADMIN_PASSWORD_WARNING_NOTIFICATION_ID,
+      id: adminPasswordWarningNotificationId(userId),
       ...warning,
     })
     .onConflictDoUpdate({
@@ -124,8 +133,16 @@ export const upsertAdminPasswordWarning = async (
     });
 };
 
-export const deleteAdminPasswordWarning = async (exec: DbExecutor = db): Promise<void> => {
+export const deleteAdminPasswordWarning = async (
+  userId: string,
+  exec: DbExecutor = db,
+): Promise<void> => {
   await exec
     .delete(notifications)
-    .where(eq(notifications.id, ADMIN_PASSWORD_WARNING_NOTIFICATION_ID));
+    .where(
+      inArray(notifications.id, [
+        adminPasswordWarningNotificationId(userId),
+        LEGACY_ADMIN_PASSWORD_WARNING_NOTIFICATION_ID,
+      ]),
+    );
 };

--- a/server/repositories/notificationsRepo.ts
+++ b/server/repositories/notificationsRepo.ts
@@ -25,8 +25,9 @@ export type Notification = {
 const LEGACY_ADMIN_PASSWORD_WARNING_NOTIFICATION_ID = 'admin-default-password-warning';
 export const ADMIN_PASSWORD_WARNING_TYPE = 'admin_password_warning';
 
-export const adminPasswordWarningNotificationId = (userId: string): string =>
-  `${userId}-admin-default-password-warning`;
+// Short prefix so that `apw-${userId}` fits inside `notifications.id`'s varchar(50)
+// even when `userId` is a `u-<uuid>` (38 chars) — full id stays at 42 chars.
+export const adminPasswordWarningNotificationId = (userId: string): string => `apw-${userId}`;
 
 const ADMIN_PASSWORD_WARNING_TITLE = 'Change the default admin password';
 const ADMIN_PASSWORD_WARNING_MESSAGE =

--- a/server/routes/settings.ts
+++ b/server/routes/settings.ts
@@ -407,7 +407,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         if (newPasswordResult.value === DEFAULT_ADMIN_PASSWORD) {
           await notificationsRepo.upsertAdminPasswordWarning(request.user.id);
         } else {
-          await notificationsRepo.deleteAdminPasswordWarning();
+          await notificationsRepo.deleteAdminPasswordWarning(request.user.id);
         }
       }
 

--- a/server/test/db/bootstrapAdmin.test.ts
+++ b/server/test/db/bootstrapAdmin.test.ts
@@ -134,6 +134,7 @@ describe('ensureBootstrapAdmin', () => {
     );
     expect(upsertAdminPasswordWarningMock).not.toHaveBeenCalled();
     expect(deleteAdminPasswordWarningMock).toHaveBeenCalledTimes(1);
+    expect(deleteAdminPasswordWarningMock).toHaveBeenCalledWith('u1');
   });
 
   test('fresh admin uses ADMIN_DEFAULT_PASSWORD when set', async () => {
@@ -154,6 +155,7 @@ describe('ensureBootstrapAdmin', () => {
     );
     expect(upsertAdminPasswordWarningMock).not.toHaveBeenCalled();
     expect(deleteAdminPasswordWarningMock).toHaveBeenCalledTimes(1);
+    expect(deleteAdminPasswordWarningMock).toHaveBeenCalledWith('u1');
   });
 
   test('fresh admin falls back to literal default when env var is whitespace', async () => {

--- a/server/test/repositories/notificationsRepo.test.ts
+++ b/server/test/repositories/notificationsRepo.test.ts
@@ -110,30 +110,45 @@ describe('markAllReadForUser', () => {
   });
 });
 
+const LEGACY_ADMIN_WARNING_ID = 'admin-default-password-warning';
+
 describe('admin password warning helpers', () => {
-  test('upsertAdminPasswordWarning inserts a deterministic unread warning', async () => {
+  test('upsertAdminPasswordWarning inserts a per-user unread warning', async () => {
+    exec.enqueue({ rows: [], rowCount: 0 });
     exec.enqueue({ rows: [], rowCount: 1 });
 
     const result = await notificationsRepo.upsertAdminPasswordWarning('admin-1', testDb);
+    const expectedId = notificationsRepo.adminPasswordWarningNotificationId('admin-1');
 
     expect(result).toBeUndefined();
-    expect(exec.calls[0].sql.toLowerCase()).toContain('on conflict');
-    expect(exec.calls[0].params).toContain(
-      notificationsRepo.ADMIN_PASSWORD_WARNING_NOTIFICATION_ID,
-    );
-    expect(exec.calls[0].params).toContain(notificationsRepo.ADMIN_PASSWORD_WARNING_TYPE);
-    expect(exec.calls[0].params).toContain('admin-1');
-    expect(exec.calls[0].params).toContain(false);
+    expect(exec.calls).toHaveLength(2);
+    expect(exec.calls[0].sql.toLowerCase()).toContain('delete from');
+    expect(exec.calls[0].params).toContain(LEGACY_ADMIN_WARNING_ID);
+    expect(exec.calls[1].sql.toLowerCase()).toContain('on conflict');
+    expect(exec.calls[1].params).toContain(expectedId);
+    expect(exec.calls[1].params).toContain(notificationsRepo.ADMIN_PASSWORD_WARNING_TYPE);
+    expect(exec.calls[1].params).toContain('admin-1');
+    expect(exec.calls[1].params).toContain(false);
   });
 
-  test('deleteAdminPasswordWarning deletes by deterministic id', async () => {
+  // Regression for issue #612: per-user ids must not collide across admins.
+  test('upsertAdminPasswordWarning uses distinct ids for different admins', async () => {
+    const idA = notificationsRepo.adminPasswordWarningNotificationId('admin-a');
+    const idB = notificationsRepo.adminPasswordWarningNotificationId('admin-b');
+    expect(idA).not.toEqual(idB);
+    expect(idA).not.toEqual(LEGACY_ADMIN_WARNING_ID);
+    expect(idB).not.toEqual(LEGACY_ADMIN_WARNING_ID);
+  });
+
+  test('deleteAdminPasswordWarning targets per-user id and cleans up the legacy id', async () => {
     exec.enqueue({ rows: [], rowCount: 1 });
 
-    const result = await notificationsRepo.deleteAdminPasswordWarning(testDb);
+    const result = await notificationsRepo.deleteAdminPasswordWarning('admin-1', testDb);
 
     expect(result).toBeUndefined();
     expect(exec.calls[0].params).toContain(
-      notificationsRepo.ADMIN_PASSWORD_WARNING_NOTIFICATION_ID,
+      notificationsRepo.adminPasswordWarningNotificationId('admin-1'),
     );
+    expect(exec.calls[0].params).toContain(LEGACY_ADMIN_WARNING_ID);
   });
 });

--- a/server/test/repositories/notificationsRepo.test.ts
+++ b/server/test/repositories/notificationsRepo.test.ts
@@ -140,6 +140,16 @@ describe('admin password warning helpers', () => {
     expect(idB).not.toEqual(LEGACY_ADMIN_WARNING_ID);
   });
 
+  // The generated id is stored in notifications.id which is varchar(50). A naive
+  // `${userId}-<long-suffix>` overflows for `u-<uuid>` shaped user ids; keep this
+  // assertion in place so the helper can't grow back past the column limit.
+  test('adminPasswordWarningNotificationId fits notifications.id varchar(50)', () => {
+    const uuidShapedUserId = 'u-00000000-0000-0000-0000-000000000000'; // 38 chars, generatePrefixedId('u') shape
+    expect(uuidShapedUserId.length).toBe(38);
+    const id = notificationsRepo.adminPasswordWarningNotificationId(uuidShapedUserId);
+    expect(id.length).toBeLessThanOrEqual(50);
+  });
+
   test('deleteAdminPasswordWarning targets per-user id and cleans up the legacy id', async () => {
     exec.enqueue({ rows: [], rowCount: 1 });
 

--- a/server/test/routes/settings.test.ts
+++ b/server/test/routes/settings.test.ts
@@ -605,6 +605,7 @@ describe('PUT /api/settings/password', () => {
 
     expect(res.statusCode).toBe(200);
     expect(deleteAdminPasswordWarningMock).toHaveBeenCalledTimes(1);
+    expect(deleteAdminPasswordWarningMock).toHaveBeenCalledWith('u1');
     expect(upsertAdminPasswordWarningMock).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary
- Fixes [#612](https://github.com/xBounceIT/praetor/issues/612). `upsertAdminPasswordWarning` stored the warning under a single global id (`admin-default-password-warning`), and the `ON CONFLICT DO UPDATE` set `user_id` -- so when a second admin's id ever reached this path, it would silently re-home the row away from the first admin. In current code the only callers are `bootstrapAdmin` and the `username='admin'`-gated branch of `PUT /api/settings/password`, so the bug is latent today, but the row shape is fragile.
- Derive the warning id from the caller's `userId` (`adminPasswordWarningNotificationId`). Each admin now owns a distinct row.
- `deleteAdminPasswordWarning` now requires a `userId` and deletes both the per-user id and any legacy global-id row. `upsertAdminPasswordWarning` sweeps the legacy id too so a deploy from a pre-#612 binary doesn't leave the user staring at two warnings.
- Call sites updated in [server/db/bootstrapAdmin.ts:40](server/db/bootstrapAdmin.ts) and [server/routes/settings.ts:410](server/routes/settings.ts).

## Test plan
- [x] `cd server && bun run build` -- clean tsc
- [x] `cd server && bun test` -- 2736 pass / 0 fail
- [x] New regression in [server/test/repositories/notificationsRepo.test.ts](server/test/repositories/notificationsRepo.test.ts) asserts `adminPasswordWarningNotificationId('admin-a') !== adminPasswordWarningNotificationId('admin-b')` so the row can't be reassigned again
- [x] Tightened `deleteAdminPasswordWarningMock` assertions in [server/test/db/bootstrapAdmin.test.ts](server/test/db/bootstrapAdmin.test.ts) and [server/test/routes/settings.test.ts](server/test/routes/settings.test.ts) to verify the `userId` is now passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)