### PR TITLE
users(fix): atomic user-update + settings upsert in one transaction (#615)

### DIFF
--- a/server/routes/users.ts
+++ b/server/routes/users.ts
@@ -756,19 +756,37 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         return badRequest(reply, 'No fields to update');
       }
 
-      if (hasFieldUpdates) {
-        // Sync runs inside the transaction so the role replacement and the resulting
-        // top-manager auto-assignments commit (or roll back) together.
-        const updatedRow = await withDbTransaction(async (tx) => {
-          const row = await usersRepo.updateUserDynamic(idResult.value, fields, tx);
-          if (row && roleValue !== null) {
-            await usersRepo.replaceUserRoles(idResult.value, [roleValue], tx);
-            await userAssignmentsRepo.syncTopManagerAssignmentsForUser(idResult.value, tx);
+      const needsSettingsUpsert = fields.name !== undefined || validatedEmail !== undefined;
+
+      if (hasFieldUpdates || needsSettingsUpsert) {
+        // Single transaction so users.name/email and the mirrored settings row commit (or
+        // roll back) together. Previously the settings upsert ran after the users-update
+        // transaction had already committed, so a failed upsert left users updated while
+        // settings stayed stale, and findById's LEFT JOIN returned an inconsistent row.
+        const txResult = await withDbTransaction(async (tx) => {
+          if (hasFieldUpdates) {
+            const row = await usersRepo.updateUserDynamic(idResult.value, fields, tx);
+            if (!row) return { userExists: false };
+            if (roleValue !== null) {
+              await usersRepo.replaceUserRoles(idResult.value, [roleValue], tx);
+              await userAssignmentsRepo.syncTopManagerAssignmentsForUser(idResult.value, tx);
+            }
           }
-          return row;
+          if (needsSettingsUpsert) {
+            await settingsRepo.upsertForUser(
+              idResult.value,
+              {
+                fullName: fields.name ?? null,
+                email: validatedEmail ?? null,
+                language: null,
+              },
+              tx,
+            );
+          }
+          return { userExists: true };
         });
 
-        if (!updatedRow) {
+        if (!txResult.userExists) {
           return replyError(request, reply, {
             statusCode: 404,
             message: 'User not found',
@@ -796,16 +814,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         }
       }
 
-      // Settings upsert must complete before findById - findById LEFT JOINs settings to
-      // populate `email`, and parallel reads on different pool connections can observe the
-      // pre-update row under read-committed isolation, returning stale email in the response.
-      if (fields.name !== undefined || validatedEmail !== undefined) {
-        await settingsRepo.upsertForUser(idResult.value, {
-          fullName: fields.name ?? null,
-          email: validatedEmail ?? null,
-          language: null,
-        });
-      }
       const fullUser = await usersRepo.findById(idResult.value);
       if (!fullUser) {
         return replyError(request, reply, {

--- a/server/test/routes/users.test.ts
+++ b/server/test/routes/users.test.ts
@@ -937,9 +937,76 @@ describe('PUT /api/users/:id', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(settingsUpsertForUserMock).toHaveBeenCalled();
+    // Even with only an email change, settings upsert must run inside the same
+    // withDbTransaction wrapper so users.email and settings.email stay consistent.
+    expect(settingsUpsertForUserMock).toHaveBeenCalledWith(
+      'u-target',
+      expect.objectContaining({ email: 'new@x.com' }),
+      TX_SENTINEL,
+    );
     // No dynamic field update needed → updateUserDynamic not called
     expect(updateUserDynamicMock).not.toHaveBeenCalled();
+  });
+
+  test('200 name + email change: settings upsert runs inside the user-update transaction', async () => {
+    findCoreByIdMock.mockResolvedValue(SAMPLE_USER_CORE);
+    updateUserDynamicMock.mockResolvedValue({
+      ...SAMPLE_USER_CORE,
+      name: 'Renamed',
+      avatarInitials: 'R',
+      costPerHour: 50,
+      isDisabled: false,
+    });
+    findByIdMock.mockResolvedValue({
+      ...SAMPLE_USER_ROW,
+      name: 'Renamed',
+      email: 'new@x.com',
+    });
+    settingsUpsertForUserMock.mockResolvedValue({});
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/users/u-target',
+      headers: adminAuth(),
+      payload: { name: 'Renamed', email: 'new@x.com' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(updateUserDynamicMock).toHaveBeenCalledWith(
+      'u-target',
+      expect.objectContaining({ name: 'Renamed' }),
+      TX_SENTINEL,
+    );
+    expect(settingsUpsertForUserMock).toHaveBeenCalledWith(
+      'u-target',
+      expect.objectContaining({ fullName: 'Renamed', email: 'new@x.com' }),
+      TX_SENTINEL,
+    );
+  });
+
+  test('settings upsert failure aborts the request before post-commit work runs', async () => {
+    findCoreByIdMock.mockResolvedValue(SAMPLE_USER_CORE);
+    updateUserDynamicMock.mockResolvedValue({
+      ...SAMPLE_USER_CORE,
+      name: 'Renamed',
+      avatarInitials: 'R',
+      costPerHour: 50,
+      isDisabled: false,
+    });
+    settingsUpsertForUserMock.mockRejectedValue(new Error('settings upsert failed'));
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/users/u-target',
+      headers: adminAuth(),
+      payload: { name: 'Renamed', email: 'new@x.com' },
+    });
+
+    // The error propagating out of the tx callback prevents findById/audit from running;
+    // if it didn't, we'd be responding with stale data after a partial commit.
+    expect(res.statusCode).not.toBe(200);
+    expect(findByIdMock).not.toHaveBeenCalled();
+    expect(logAuditMock).not.toHaveBeenCalled();
   });
 
   test('400 invalid email', async () => {

--- a/server/test/routes/users.test.ts
+++ b/server/test/routes/users.test.ts
@@ -984,7 +984,7 @@ describe('PUT /api/users/:id', () => {
     );
   });
 
-  test('settings upsert failure aborts the request before post-commit work runs', async () => {
+  test('settings upsert failure rolls back the user update (regression for #615)', async () => {
     findCoreByIdMock.mockResolvedValue(SAMPLE_USER_CORE);
     updateUserDynamicMock.mockResolvedValue({
       ...SAMPLE_USER_CORE,
@@ -1002,9 +1002,16 @@ describe('PUT /api/users/:id', () => {
       payload: { name: 'Renamed', email: 'new@x.com' },
     });
 
-    // The error propagating out of the tx callback prevents findById/audit from running;
-    // if it didn't, we'd be responding with stale data after a partial commit.
     expect(res.statusCode).not.toBe(200);
+    // The load-bearing assertion: when the upsert fails, it must have been called with the
+    // transaction handle (TX_SENTINEL). On the pre-fix code the upsert ran outside the tx
+    // with no executor, so the user update would have already committed — this assertion
+    // would fail on that buggy code path.
+    expect(settingsUpsertForUserMock).toHaveBeenCalledWith(
+      'u-target',
+      expect.anything(),
+      TX_SENTINEL,
+    );
     expect(findByIdMock).not.toHaveBeenCalled();
     expect(logAuditMock).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- Closes #615. PUT `/api/users/:id` ran the `users` update inside `withDbTransaction` and then called `settingsRepo.upsertForUser` on a separate connection. If the upsert failed, `users.name`/`email` was already changed while `settings.fullName`/`email` stayed stale, and `findById`'s LEFT JOIN returned an inconsistent row to the client.
- Moves the settings upsert into the same `withDbTransaction` block. The email-only update path now also enters the transaction (it previously skipped the user-update tx entirely).
- `findById` and the audit log stay outside the tx and run only after a successful commit; the user-existence 404 short-circuit is folded into the transaction's return value.

## Test plan
- [x] `bun test test/routes/users.test.ts` — 77/77 pass, including:
  - existing "200 only email change" tightened to assert the upsert receives `TX_SENTINEL`
  - new "name + email change: settings upsert runs inside the user-update transaction" — asserts both writes receive `TX_SENTINEL`
  - new "settings upsert failure aborts the request before post-commit work runs" — asserts `findById` and `logAudit` are never called when the upsert rejects
- [x] Full backend suite `bun test` — 2737 pass, 0 fail
- [x] `bun run lint` — exit 0 (2 pre-existing warnings unrelated to this change)
- [x] `bunx tsc -p server/tsconfig.json --noEmit` — clean

## Notes for reviewers
- The fix mirrors the symmetry already present in the POST `/api/users` handler ([server/routes/users.ts:479-511](https://github.com/xBounceIT/praetor/blob/claude/frosty-napier-b3e721/server/routes/users.ts#L479-L511)), where user creation already commits the users row + roles + settings + top-manager sync in one transaction.
- `settingsRepo.upsertForUser` already accepted an optional `DbExecutor` parameter, so no repo signature changes were needed.
- No semantic change for the empty-email payload (`PUT { email: '' }`): the existing `COALESCE` in `settingsRepo.upsertForUser` means a `null` email patch is a no-op, same as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)