### PR TITLE
ux(api): add 30s request timeout to fetchApi (#619)

### DIFF
--- a/services/api/client.ts
+++ b/services/api/client.ts
@@ -35,20 +35,34 @@ export class ApiError extends Error {
   }
 }
 
-export const fetchApi = async <T>(endpoint: string, options: RequestInit = {}): Promise<T> => {
+export interface FetchApiOptions extends RequestInit {
+  // Override the default 30s request timeout. `null` disables it — use for endpoints
+  // that may legitimately take longer (e.g. AI completions) and that supply their
+  // own AbortSignal for cancellation.
+  timeoutMs?: number | null;
+}
+
+export const fetchApi = async <T>(endpoint: string, options: FetchApiOptions = {}): Promise<T> => {
+  const { timeoutMs = DEFAULT_TIMEOUT_MS, signal: callerSignal, ...fetchOptions } = options;
+
   const headers: HeadersInit = {
-    ...(options.body ? { 'Content-Type': 'application/json' } : {}),
+    ...(fetchOptions.body ? { 'Content-Type': 'application/json' } : {}),
     ...(authToken ? { Authorization: `Bearer ${authToken}` } : {}),
-    ...options.headers,
+    ...fetchOptions.headers,
   };
 
-  const timeoutSignal = AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
-  const signal = options.signal ? AbortSignal.any([options.signal, timeoutSignal]) : timeoutSignal;
+  const timeoutSignal = timeoutMs == null ? null : AbortSignal.timeout(timeoutMs);
+  let signal: AbortSignal | undefined;
+  if (timeoutSignal && callerSignal) {
+    signal = AbortSignal.any([callerSignal, timeoutSignal]);
+  } else {
+    signal = timeoutSignal ?? callerSignal ?? undefined;
+  }
 
   let response: Response;
   try {
     response = await fetch(`${API_BASE}${endpoint}`, {
-      ...options,
+      ...fetchOptions,
       headers,
       signal,
     });

--- a/services/api/client.ts
+++ b/services/api/client.ts
@@ -1,5 +1,8 @@
 const API_BASE = import.meta.env.VITE_API_URL || '/api';
 
+// Without this, a hung server (no TCP reset) leaves the UI on a spinner forever.
+const DEFAULT_TIMEOUT_MS = 30_000;
+
 let authToken: string | null = localStorage.getItem('praetor_auth_token');
 
 export const setAuthToken = (token: string | null) => {
@@ -39,14 +42,20 @@ export const fetchApi = async <T>(endpoint: string, options: RequestInit = {}): 
     ...options.headers,
   };
 
+  const timeoutSignal = AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
+  const signal = options.signal ? AbortSignal.any([options.signal, timeoutSignal]) : timeoutSignal;
+
   let response: Response;
   try {
     response = await fetch(`${API_BASE}${endpoint}`, {
       ...options,
       headers,
+      signal,
     });
   } catch (err) {
-    // fetch() throws a TypeError on network failures (offline, DNS, refused).
+    if (err instanceof DOMException && err.name === 'TimeoutError') {
+      throw new ApiError('Request timed out', 0, true);
+    }
     const message = err instanceof Error ? err.message : 'Network request failed';
     throw new ApiError(message, 0, true);
   }

--- a/services/api/reports.ts
+++ b/services/api/reports.ts
@@ -169,6 +169,9 @@ export const reportsApi = {
       method: 'POST',
       body: JSON.stringify(data),
       signal,
+      // AI completions can exceed the default 30s budget; rely on the
+      // caller-supplied signal for cancellation instead.
+      timeoutMs: null,
     }),
 
   chatStream: async (

--- a/test/services/client.test.ts
+++ b/test/services/client.test.ts
@@ -171,6 +171,39 @@ describe('services/api/client', () => {
       await expect(fetchApi('/down')).rejects.toThrow('Failed to fetch');
     });
 
+    test('passes an AbortSignal to fetch so requests time out instead of hanging forever', async () => {
+      fetchMock.mockImplementationOnce(async (_input: unknown, init: unknown) => {
+        const sig = (init as { signal?: AbortSignal }).signal;
+        expect(sig).toBeInstanceOf(AbortSignal);
+        return buildResponse({ status: 200, json: () => ({}) });
+      });
+      await fetchApi('/with-timeout');
+    });
+
+    test('maps a fetch TimeoutError to ApiError "Request timed out"', async () => {
+      fetchMock.mockImplementationOnce(async () => {
+        throw new DOMException('timed out', 'TimeoutError');
+      });
+      await expect(fetchApi('/slow')).rejects.toMatchObject({
+        name: 'ApiError',
+        status: 0,
+        isNetworkError: true,
+        message: 'Request timed out',
+      });
+    });
+
+    test('combines caller-provided signal with the timeout signal', async () => {
+      const callerController = new AbortController();
+      fetchMock.mockImplementationOnce(async (_input: unknown, init: unknown) => {
+        const sig = (init as { signal: AbortSignal }).signal;
+        expect(sig.aborted).toBe(false);
+        callerController.abort(new DOMException('caller cancelled', 'AbortError'));
+        expect(sig.aborted).toBe(true);
+        return buildResponse({ status: 200, json: () => ({}) });
+      });
+      await fetchApi('/cancellable', { signal: callerController.signal });
+    });
+
     test('caller can override headers via options.headers', async () => {
       fetchMock.mockImplementationOnce(async (_input: unknown, init: unknown) => {
         const headers = (init as { headers: Record<string, string> }).headers;

--- a/test/services/client.test.ts
+++ b/test/services/client.test.ts
@@ -204,6 +204,33 @@ describe('services/api/client', () => {
       await fetchApi('/cancellable', { signal: callerController.signal });
     });
 
+    test('timeoutMs: null disables the timeout and forwards only the caller signal', async () => {
+      const callerController = new AbortController();
+      fetchMock.mockImplementationOnce(async (_input: unknown, init: unknown) => {
+        const sig = (init as { signal: AbortSignal | undefined }).signal;
+        expect(sig).toBe(callerController.signal);
+        return buildResponse({ status: 200, json: () => ({}) });
+      });
+      await fetchApi('/long', { signal: callerController.signal, timeoutMs: null });
+    });
+
+    test('timeoutMs: null with no caller signal leaves signal undefined', async () => {
+      fetchMock.mockImplementationOnce(async (_input: unknown, init: unknown) => {
+        const sig = (init as { signal: AbortSignal | undefined }).signal;
+        expect(sig).toBeUndefined();
+        return buildResponse({ status: 200, json: () => ({}) });
+      });
+      await fetchApi('/long', { timeoutMs: null });
+    });
+
+    test('timeoutMs is not forwarded to fetch', async () => {
+      fetchMock.mockImplementationOnce(async (_input: unknown, init: unknown) => {
+        expect((init as Record<string, unknown>).timeoutMs).toBeUndefined();
+        return buildResponse({ status: 200, json: () => ({}) });
+      });
+      await fetchApi('/x', { timeoutMs: 5000 });
+    });
+
     test('caller can override headers via options.headers', async () => {
       fetchMock.mockImplementationOnce(async (_input: unknown, init: unknown) => {
         const headers = (init as { headers: Record<string, string> }).headers;


### PR DESCRIPTION
## Summary
- Fixes [#619](https://github.com/xBounceIT/praetor/issues/619): `fetchApi` had no `AbortSignal`, so a hung server (no TCP reset) left the UI on a spinner forever.
- `fetchApi` now passes `AbortSignal.timeout(30_000)`, combined with any caller-provided `signal` via `AbortSignal.any()` so existing cancellation paths in [services/api/tasks.ts](services/api/tasks.ts), [services/api/projects.ts](services/api/projects.ts), and [services/api/workUnits.ts](services/api/workUnits.ts) keep working.
- A timeout abort is mapped to `ApiError("Request timed out", 0, isNetworkError=true)`, so existing network-error UI handles it without changes.

## Why this scope
- `fetchApiStream` is intentionally left untouched: it backs long-lived streams (AI chat in [services/api/reports.ts](services/api/reports.ts), file downloads in [services/api/supplierQuotes.ts](services/api/supplierQuotes.ts)) where a 30s blanket timeout would break them. Those callers already accept an explicit `signal`.

## Test plan
- [x] `bun test test/services/client.test.ts` — 26/26 pass
- [x] Verified the two new timeout tests **fail on the unpatched code** (stashed the `client.ts` change, reran tests, saw the expected 2 failures), then pass once restored — so the tests actually exercise the fix
- [ ] Manual: confirm a normal request still completes (no premature aborts)
- [ ] Manual: simulate a hung server (e.g. block the API port) and confirm the UI surfaces "Request timed out" within ~30s instead of spinning forever

🤖 Generated with [Claude Code](https://claude.com/claude-code)