### PR TITLE
notifications(fix): cancel in-flight polling fetch on logout to prevent stale state (#618)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2019,11 +2019,15 @@ const AppContent: React.FC = () => {
       return;
     }
 
+    let isCancelled = false;
+
     const loadNotifications = async () => {
       try {
         const data = await api.notifications.list();
+        if (isCancelled) return;
         setNotificationsState({ items: data.notifications, unreadCount: data.unreadCount });
       } catch (err) {
+        if (isCancelled) return;
         console.error('Failed to load notifications:', err);
       }
     };
@@ -2031,7 +2035,10 @@ const AppContent: React.FC = () => {
     // Load immediately and then poll every 60 seconds
     loadNotifications();
     const interval = setInterval(loadNotifications, 60000);
-    return () => clearInterval(interval);
+    return () => {
+      isCancelled = true;
+      clearInterval(interval);
+    };
   }, [currentUser]);
 
   // Notification handlers

--- a/test/App.notificationsPolling.test.tsx
+++ b/test/App.notificationsPolling.test.tsx
@@ -1,0 +1,114 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useEffect, useState } from 'react';
+import type { Notification } from '../types';
+import { ApiErrorStub } from './helpers/apiErrorStub';
+import { clearSpyStateAfterAll } from './helpers/mockCleanup.ts';
+
+/**
+ * App.tsx is too tangled to mount the full tree, so we mirror the
+ * notifications-polling `useEffect` here 1:1. The test pins the regression
+ * from issue #618: when `currentUser` becomes null (logout) while an
+ * `api.notifications.list()` call is in flight, the cleanup must mark the
+ * effect as cancelled so the late-resolving promise cannot overwrite the
+ * cleared state with stale notifications from the previous session.
+ */
+
+type NotificationsListResult = { notifications: Notification[]; unreadCount: number };
+
+let resolveList: ((value: NotificationsListResult) => void) | null = null;
+const apiList = mock(
+  (): Promise<NotificationsListResult> =>
+    new Promise<NotificationsListResult>((resolve) => {
+      resolveList = resolve;
+    }),
+);
+
+mock.module('../services/api', () => ({
+  default: {
+    notifications: {
+      list: () => apiList(),
+    },
+  },
+  ApiError: ApiErrorStub,
+  getAuthToken: () => null,
+  setAuthToken: () => {},
+}));
+
+clearSpyStateAfterAll();
+
+type NotificationsState = { items: Notification[]; unreadCount: number };
+
+/** Mirrors the App.tsx notifications-polling effect 1:1. */
+const useNotificationsPolling = (
+  currentUser: { id: string } | null,
+): { state: NotificationsState } => {
+  const [state, setState] = useState<NotificationsState>({ items: [], unreadCount: 0 });
+
+  useEffect(() => {
+    if (!currentUser) {
+      setState({ items: [], unreadCount: 0 });
+      return;
+    }
+
+    let isCancelled = false;
+
+    const loadNotifications = async () => {
+      try {
+        const { default: api } = await import('../services/api');
+        const data = await api.notifications.list();
+        if (isCancelled) return;
+        setState({ items: data.notifications, unreadCount: data.unreadCount });
+      } catch (err) {
+        if (isCancelled) return;
+        console.error('Failed to load notifications:', err);
+      }
+    };
+
+    loadNotifications();
+    const interval = setInterval(loadNotifications, 60000);
+    return () => {
+      isCancelled = true;
+      clearInterval(interval);
+    };
+  }, [currentUser]);
+
+  return { state };
+};
+
+const makeNotification = (id: string, isRead = false): Notification => ({
+  id,
+  userId: 'u1',
+  type: 'generic',
+  title: `notification ${id}`,
+  isRead,
+  createdAt: 0,
+});
+
+describe('App notifications polling cancellation (#618)', () => {
+  test('in-flight list() that resolves after logout does not overwrite cleared state', async () => {
+    apiList.mockClear();
+    resolveList = null;
+
+    const { result, rerender } = renderHook(
+      ({ user }: { user: { id: string } | null }) => useNotificationsPolling(user),
+      { initialProps: { user: { id: 'u1' } as { id: string } | null } },
+    );
+
+    await waitFor(() => expect(apiList).toHaveBeenCalledTimes(1));
+    const pendingResolve = resolveList as ((value: NotificationsListResult) => void) | null;
+    if (!pendingResolve) throw new Error('expected list() to have stored its resolver');
+
+    rerender({ user: null });
+    expect(result.current.state).toEqual({ items: [], unreadCount: 0 });
+
+    await act(async () => {
+      pendingResolve({
+        notifications: [makeNotification('stale-1'), makeNotification('stale-2')],
+        unreadCount: 2,
+      });
+    });
+
+    expect(result.current.state).toEqual({ items: [], unreadCount: 0 });
+  });
+});

--- a/test/App.notificationsPolling.test.tsx
+++ b/test/App.notificationsPolling.test.tsx
@@ -111,4 +111,28 @@ describe('App notifications polling cancellation (#618)', () => {
 
     expect(result.current.state).toEqual({ items: [], unreadCount: 0 });
   });
+
+  // Positive control: guards against a future regression where the
+  // cancellation flag is always-firing (e.g. flipped on the wrong code path)
+  // which would silently break the steady-state polling.
+  test('resolved list() applies to state when the user stays logged in', async () => {
+    apiList.mockClear();
+    resolveList = null;
+
+    const { result } = renderHook(() => useNotificationsPolling({ id: 'u1' }));
+
+    await waitFor(() => expect(apiList).toHaveBeenCalledTimes(1));
+    const pendingResolve = resolveList as ((value: NotificationsListResult) => void) | null;
+    if (!pendingResolve) throw new Error('expected list() to have stored its resolver');
+
+    await act(async () => {
+      pendingResolve({
+        notifications: [makeNotification('n1'), makeNotification('n2', true)],
+        unreadCount: 1,
+      });
+    });
+
+    expect(result.current.state.items.map((n) => n.id)).toEqual(['n1', 'n2']);
+    expect(result.current.state.unreadCount).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary

- Fixes [#618](https://github.com/xBounceIT/praetor/issues/618). The notifications-polling `useEffect` in `App.tsx` had no cancellation, so a late-resolving `api.notifications.list()` could overwrite the cleared `{items: [], unreadCount: 0}` state after logout — briefly leaking the previous session's notifications back into the UI.
- Added an `isCancelled` boolean flag (matching the dominant repo convention for non-fetch async cancellation — see the adjacent assignments-loading effect immediately above the changed code). The cleanup flips the flag alongside `clearInterval`; the loader bails before `setNotificationsState` when cancelled, and the `catch` short-circuits to avoid `console.error` spam from rejections triggered by logout/route changes.
- Added a regression test at `test/App.notificationsPolling.test.tsx` that mirrors the effect 1:1 (same approach the sibling `test/App.notifications.test.tsx` already uses, since `App.tsx` is too tangled to mount end-to-end). It pins: an in-flight `list()` resolving after `currentUser → null` must not overwrite cleared state.

## Why this design

- A boolean `isCancelled` flag was chosen over `AbortController` because `api.notifications.list()` does not accept a `signal`, and the codebase consistently uses the flag pattern wherever a signal can't be threaded through the API (e.g. `hooks/useAuth.ts`, `components/Login.tsx`, `components/HR/EmployeeAssignmentsModal.tsx`, the adjacent effect in `App.tsx`). `AbortController` is reserved for call sites that pass a `signal` into the fetch itself.

## Test plan

- [x] `bun test test/App.notificationsPolling.test.tsx` — passes on the fix.
- [x] Manually reverted the cancellation guard in the test's effect mirror and re-ran the test — confirmed it **fails on the old (buggy) code**, asserting items reverted to the resolved-after-logout values.
- [x] `bun test test/App.notifications.test.tsx test/App.notificationsPolling.test.tsx` — all 7 notification-related tests green together.
- [ ] Manual smoke test: log in, observe notifications populate, log out, confirm the bell stays empty (no flash of previous-session notifications).

🤖 Generated with [Claude Code](https://claude.com/claude-code)