### PR TITLE
sso(diag): audit script for duplicate external_identities rows (#606)

### DIFF
--- a/server/db/README.md
+++ b/server/db/README.md
@@ -115,6 +115,7 @@ From `server/`:
 | `bun run db:migrate` | Apply pending migrations to the DB pointed to by `DB_*` env vars. |
 | `bun run db:check` | Verify that snapshots and migration SQL are consistent (run in CI to catch drift). |
 | `bun run db:studio` | Open Drizzle Studio (browser-based DB explorer). **Local dev only — never point at prod credentials.** |
+| `bun run db:audit:external-identities` | Read-only diagnostic for [#606](https://github.com/xBounceIT/praetor/issues/606): lists every `external_identities` group where one Praetor user is bound to >1 IdP subject on the same `(provider_id, protocol)`. Exits 1 when duplicates exist. Run before adding any future `UNIQUE (user_id, provider_id, protocol)` constraint. |
 
 ### Why not `drizzle-kit migrate`?
 

--- a/server/package.json
+++ b/server/package.json
@@ -14,6 +14,7 @@
     "db:generate:custom": "drizzle-kit generate --custom",
     "db:migrate": "bun run scripts/run-migrations.ts",
     "db:ready": "bun run scripts/check-db-ready.ts",
+    "db:audit:external-identities": "bun run scripts/audit-external-identities-duplicates.ts",
     "db:check": "drizzle-kit check",
     "db:studio": "drizzle-kit studio"
   },

--- a/server/scripts/audit-external-identities-duplicates.ts
+++ b/server/scripts/audit-external-identities-duplicates.ts
@@ -1,0 +1,93 @@
+#!/usr/bin/env bun
+// Diagnostic for #606 (and the spawned defense-in-depth follow-up): finds any
+// `external_identities` rows where the same Praetor user is bound to more than
+// one IdP subject for the same `(provider_id, protocol)`. Pre-fix, the SSO
+// resolver could silently merge two distinct IdP accounts that happened to
+// share a `preferred_username`; the audit surfaces accounts already affected
+// in the wild so admins can manually reconcile them.
+//
+// Exits 0 when no duplicates exist (safe to chain into CI / pre-migration
+// checks); exits 1 when duplicates are found OR the query itself fails.
+//
+// Read-only: this script never modifies data. Cleanup is intentionally left
+// to an admin so the wrong account isn't accidentally merged.
+import 'dotenv/config';
+import pool from '../db/index.ts';
+
+type DuplicateGroup = {
+  user_id: string;
+  username: string | null;
+  provider_id: string;
+  protocol: string;
+  row_count: string;
+  identities: Array<{
+    id: string;
+    subject: string;
+    issuer: string;
+    created_at: string | null;
+  }>;
+};
+
+const AUDIT_QUERY = `
+  SELECT
+    ei.user_id,
+    u.username,
+    ei.provider_id,
+    ei.protocol,
+    COUNT(*) AS row_count,
+    json_agg(
+      json_build_object(
+        'id', ei.id,
+        'subject', ei.subject,
+        'issuer', ei.issuer,
+        'created_at', ei.created_at
+      )
+      ORDER BY ei.created_at
+    ) AS identities
+  FROM external_identities ei
+  LEFT JOIN users u ON u.id = ei.user_id
+  GROUP BY ei.user_id, u.username, ei.provider_id, ei.protocol
+  HAVING COUNT(*) > 1
+  ORDER BY ei.user_id, ei.provider_id, ei.protocol;
+`;
+
+const formatGroup = (group: DuplicateGroup): string => {
+  const header = `user=${group.user_id} (${group.username ?? '<orphan>'}) provider=${group.provider_id} protocol=${group.protocol} rows=${group.row_count}`;
+  const lines = group.identities.map(
+    (id) =>
+      `    - id=${id.id} subject=${id.subject} issuer=${id.issuer} created_at=${id.created_at}`,
+  );
+  return [header, ...lines].join('\n');
+};
+
+try {
+  const result = await pool.query<DuplicateGroup>(AUDIT_QUERY);
+  if (result.rows.length === 0) {
+    console.info(
+      'external_identities audit: no duplicate (user_id, provider_id, protocol) bindings found.',
+    );
+    process.exitCode = 0;
+  } else {
+    console.error(
+      `external_identities audit: found ${result.rows.length} affected (user_id, provider_id, protocol) tuple(s).`,
+    );
+    console.error(
+      'Each group below represents one Praetor user bound to multiple IdP subjects for the same provider.',
+    );
+    console.error(
+      'Manual reconciliation is required (see PR #659 / issue #606). Do NOT auto-delete.',
+    );
+    console.error('');
+    for (const group of result.rows) {
+      console.error(formatGroup(group));
+      console.error('');
+    }
+    process.exitCode = 1;
+  }
+} catch (err) {
+  console.error('external_identities audit: query failed');
+  console.error(err);
+  process.exitCode = 1;
+} finally {
+  await pool.end();
+}


### PR DESCRIPTION
## Summary

- Follow-up to [#659](https://github.com/xBounceIT/praetor/pull/659) (fix for [#606](https://github.com/xBounceIT/praetor/issues/606)). #659 closed the silent-merge bug going forward, but cannot retroactively repair rows already merged by the bug in any deployment that ran the buggy resolver. This PR adds a read-only diagnostic that surfaces those rows so admins can reconcile manually.
- New script `server/scripts/audit-external-identities-duplicates.ts`, wired up as `bun run db:audit:external-identities`. Lists every `(user_id, provider_id, protocol)` group with more than one row in `external_identities`, including each row's id / subject / issuer / created_at. Exits 1 when duplicates exist, 0 otherwise — safe to chain into CI or a pre-migration gate.
- Documented in `server/db/README.md` under the existing scripts table.

## Why this is read-only

The script intentionally never deletes. When two IdP subjects are bound to one Praetor user, the script cannot know which one is the legitimate binding — that determination depends on which IdP account the human end-user actually controls. An admin needs to compare the affected subjects against IdP records and either delete the wrong `external_identities` row or split the merged data into separate Praetor users before deletion.

## Follow-up (not in this PR)

Once an operator confirms `db:audit:external-identities` returns clean on every production deployment, a separate migration can add a partial unique index `UNIQUE (user_id, provider_id, protocol)` on `external_identities` to make the application-level check in #659 race-proof at the DB level. That migration is intentionally deferred because applying it before cleanup would fail on any tenant that already has duplicates.

## Test plan

- [x] `bun run typecheck` passes.
- [x] `biome check` passes on new/changed files.
- [x] No production code paths changed — the script is invocation-only and read-only.
- [x] Manual smoke check deferred to a deployment with a real DB; the SQL is standard `GROUP BY … HAVING COUNT(*) > 1` over an already-indexed table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)