### PR TITLE
auth(fix): wipe external_identities when auth method or provider changes

### DIFF
--- a/server/repositories/externalIdentitiesRepo.ts
+++ b/server/repositories/externalIdentitiesRepo.ts
@@ -63,3 +63,11 @@ export const hasOtherSubjectForUserAndProvider = async (
     .limit(1);
   return rows.length > 0;
 };
+
+export const deleteAllForUser = async (userId: string, exec: DbExecutor = db): Promise<number> => {
+  const rows = await exec
+    .delete(externalIdentities)
+    .where(eq(externalIdentities.userId, userId))
+    .returning({ id: externalIdentities.id });
+  return rows.length;
+};

--- a/server/routes/users.ts
+++ b/server/routes/users.ts
@@ -4,6 +4,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import { withDbTransaction } from '../db/drizzle.ts';
 import { authenticateToken, requireAnyPermission, requirePermission } from '../middleware/auth.ts';
 import * as clientsRepo from '../repositories/clientsRepo.ts';
+import * as externalIdentitiesRepo from '../repositories/externalIdentitiesRepo.ts';
 import * as projectsRepo from '../repositories/projectsRepo.ts';
 import * as rolesRepo from '../repositories/rolesRepo.ts';
 import * as settingsRepo from '../repositories/settingsRepo.ts';
@@ -934,11 +935,29 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         return badRequest(reply, 'authProviderId is allowed only for OIDC or SAML');
       }
 
-      const updated = await usersRepo.updateAuthMethod(
-        idResult.value,
-        methodResult.value,
-        resolvedProviderId,
-      );
+      // Changing auth method or provider invalidates any prior external_identities rows:
+      // those rows are keyed on the IdP subject that was bound *before* the switch, and
+      // would silently re-authenticate the same user if the admin ever flips back to the
+      // original provider (A → B → A). Wipe them inside the same transaction as the user
+      // update so the auth-method change either fully succeeds (clean slate) or rolls back
+      // (no orphaned writes).
+      const authStateChanged =
+        targetUser.authMethod !== methodResult.value ||
+        targetUser.authProviderId !== resolvedProviderId;
+
+      const updated = await withDbTransaction(async (tx) => {
+        const result = await usersRepo.updateAuthMethod(
+          idResult.value,
+          methodResult.value,
+          resolvedProviderId,
+          tx,
+        );
+        if (!result) return null;
+        if (authStateChanged) {
+          await externalIdentitiesRepo.deleteAllForUser(idResult.value, tx);
+        }
+        return result;
+      });
       if (!updated) {
         return replyError(request, reply, {
           statusCode: 404,

--- a/server/test/routes/users.test.ts
+++ b/server/test/routes/users.test.ts
@@ -2,6 +2,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, tes
 import type { FastifyInstance, FastifyPluginAsync } from 'fastify';
 import * as realDrizzle from '../../db/drizzle.ts';
 import * as realClientsRepo from '../../repositories/clientsRepo.ts';
+import * as realExternalIdentitiesRepo from '../../repositories/externalIdentitiesRepo.ts';
 import * as realProjectsRepo from '../../repositories/projectsRepo.ts';
 import * as realRolesRepo from '../../repositories/rolesRepo.ts';
 import * as realSettingsRepo from '../../repositories/settingsRepo.ts';
@@ -24,6 +25,7 @@ import { makeWithDbTransactionMock } from '../helpers/withDbTransactionMock.ts';
 
 const usersRepoSnap = { ...realUsersRepo };
 const clientsRepoSnap = { ...realClientsRepo };
+const externalIdentitiesRepoSnap = { ...realExternalIdentitiesRepo };
 const projectsRepoSnap = { ...realProjectsRepo };
 const tasksRepoSnap = { ...realTasksRepo };
 const rolesRepoSnap = { ...realRolesRepo };
@@ -91,6 +93,9 @@ const filterAssignedTaskIdsMock = mock();
 const ldapLookupUserGroupsMock = mock();
 const applyExternalRolesForUserMock = mock();
 
+// externalIdentitiesRepo
+const deleteAllForUserMock = mock();
+
 // audit / drizzle
 const logAuditMock = mock(async () => undefined);
 const { withDbTransactionMock, resetWithDbTransactionMock } = makeWithDbTransactionMock();
@@ -123,6 +128,10 @@ beforeAll(async () => {
     ...clientsRepoSnap,
     list: listClientsMock,
     listByIds: listClientsByIdsMock,
+  }));
+  mock.module('../../repositories/externalIdentitiesRepo.ts', () => ({
+    ...externalIdentitiesRepoSnap,
+    deleteAllForUser: deleteAllForUserMock,
   }));
   mock.module('../../repositories/projectsRepo.ts', () => ({
     ...projectsRepoSnap,
@@ -189,6 +198,7 @@ afterAll(() => {
   restoreAuthMiddlewareMock();
   mock.module('../../repositories/usersRepo.ts', () => usersRepoSnap);
   mock.module('../../repositories/clientsRepo.ts', () => clientsRepoSnap);
+  mock.module('../../repositories/externalIdentitiesRepo.ts', () => externalIdentitiesRepoSnap);
   mock.module('../../repositories/projectsRepo.ts', () => projectsRepoSnap);
   mock.module('../../repositories/tasksRepo.ts', () => tasksRepoSnap);
   mock.module('../../repositories/rolesRepo.ts', () => rolesRepoSnap);
@@ -324,6 +334,7 @@ const allMocks = [
   filterAssignedTaskIdsMock,
   ldapLookupUserGroupsMock,
   applyExternalRolesForUserMock,
+  deleteAllForUserMock,
   logAuditMock,
   withDbTransactionMock,
 ];
@@ -351,6 +362,7 @@ beforeEach(async () => {
   // Default: LDAP unreachable / disabled — route falls back to existing role.
   ldapLookupUserGroupsMock.mockResolvedValue(null);
   applyExternalRolesForUserMock.mockResolvedValue(['user']);
+  deleteAllForUserMock.mockResolvedValue(0);
 
   testApp = await buildRouteTestApp(routePlugin, '/api/users');
 });
@@ -1065,7 +1077,7 @@ describe('PUT /api/users/:id/auth-method', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(updateAuthMethodMock).toHaveBeenCalledWith('u-target', 'ldap', null);
+    expect(updateAuthMethodMock).toHaveBeenCalledWith('u-target', 'ldap', null, TX_SENTINEL);
     expect(ldapLookupUserGroupsMock).toHaveBeenCalledWith('target');
     expect(applyExternalRolesForUserMock).toHaveBeenCalledWith(
       'u-target',
@@ -1169,7 +1181,7 @@ describe('PUT /api/users/:id/auth-method', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(updateAuthMethodMock).toHaveBeenCalledWith('u-target', 'oidc', 'sso-1');
+    expect(updateAuthMethodMock).toHaveBeenCalledWith('u-target', 'oidc', 'sso-1', TX_SENTINEL);
     expect(JSON.parse(res.body)).toMatchObject({
       authMethod: 'oidc',
       authProviderId: 'sso-1',
@@ -1308,6 +1320,126 @@ describe('PUT /api/users/:id/auth-method', () => {
 
     expect(res.statusCode).toBe(403);
     expect(updateAuthMethodMock).not.toHaveBeenCalled();
+  });
+
+  // Regression: spawned follow-up from PR #659 review. Stale external_identities rows
+  // from a prior SSO binding must be wiped when an admin changes the auth method or
+  // provider, or an A → B → A flip will silently re-authenticate via the original
+  // subject. See server/services/external-auth.ts:resolveExternalIdentity.
+  describe('external_identities cleanup on auth-method change', () => {
+    test('wipes external_identities when changing OIDC user to local', async () => {
+      findCoreByIdMock.mockResolvedValue({
+        ...SAMPLE_USER_CORE,
+        authMethod: 'oidc',
+        authProviderId: 'sso-1',
+      });
+      updateAuthMethodMock.mockResolvedValue({ ...SAMPLE_USER_ROW, authMethod: 'local' });
+      deleteAllForUserMock.mockResolvedValue(2);
+
+      const res = await testApp.inject({
+        method: 'PUT',
+        url: '/api/users/u-target/auth-method',
+        headers: adminAuth(),
+        payload: { authMethod: 'local' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(updateAuthMethodMock).toHaveBeenCalledWith('u-target', 'local', null, TX_SENTINEL);
+      expect(deleteAllForUserMock).toHaveBeenCalledWith('u-target', TX_SENTINEL);
+      expect(withDbTransactionMock).toHaveBeenCalled();
+    });
+
+    test('wipes external_identities when switching OIDC provider sso-1 → sso-2', async () => {
+      findCoreByIdMock.mockResolvedValue({
+        ...SAMPLE_USER_CORE,
+        authMethod: 'oidc',
+        authProviderId: 'sso-1',
+      });
+      ssoFindByIdMock.mockResolvedValue({
+        id: 'sso-2',
+        protocol: 'oidc',
+        name: 'Other OIDC',
+        enabled: true,
+      });
+      updateAuthMethodMock.mockResolvedValue({
+        ...SAMPLE_USER_ROW,
+        authMethod: 'oidc',
+        authProviderId: 'sso-2',
+      });
+      deleteAllForUserMock.mockResolvedValue(1);
+
+      const res = await testApp.inject({
+        method: 'PUT',
+        url: '/api/users/u-target/auth-method',
+        headers: adminAuth(),
+        payload: { authMethod: 'oidc', authProviderId: 'sso-2' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(deleteAllForUserMock).toHaveBeenCalledWith('u-target', TX_SENTINEL);
+    });
+
+    test('wipes external_identities on A → B → A flip back to original provider', async () => {
+      // Admin had previously flipped this user away from sso-1 (so external_identities still
+      // holds the old sub). Now they're flipping back. Without the wipe, the original
+      // subject would re-authenticate the user via findByIdentity on the next login.
+      findCoreByIdMock.mockResolvedValue({
+        ...SAMPLE_USER_CORE,
+        authMethod: 'local',
+        authProviderId: null,
+      });
+      ssoFindByIdMock.mockResolvedValue({
+        id: 'sso-1',
+        protocol: 'oidc',
+        name: 'Keycloak',
+        enabled: true,
+      });
+      updateAuthMethodMock.mockResolvedValue({
+        ...SAMPLE_USER_ROW,
+        authMethod: 'oidc',
+        authProviderId: 'sso-1',
+      });
+      deleteAllForUserMock.mockResolvedValue(1);
+
+      const res = await testApp.inject({
+        method: 'PUT',
+        url: '/api/users/u-target/auth-method',
+        headers: adminAuth(),
+        payload: { authMethod: 'oidc', authProviderId: 'sso-1' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(deleteAllForUserMock).toHaveBeenCalledWith('u-target', TX_SENTINEL);
+    });
+
+    test('skips wipe when method and provider are unchanged (idempotent PUT)', async () => {
+      findCoreByIdMock.mockResolvedValue({
+        ...SAMPLE_USER_CORE,
+        authMethod: 'oidc',
+        authProviderId: 'sso-1',
+      });
+      ssoFindByIdMock.mockResolvedValue({
+        id: 'sso-1',
+        protocol: 'oidc',
+        name: 'Keycloak',
+        enabled: true,
+      });
+      updateAuthMethodMock.mockResolvedValue({
+        ...SAMPLE_USER_ROW,
+        authMethod: 'oidc',
+        authProviderId: 'sso-1',
+      });
+
+      const res = await testApp.inject({
+        method: 'PUT',
+        url: '/api/users/u-target/auth-method',
+        headers: adminAuth(),
+        payload: { authMethod: 'oidc', authProviderId: 'sso-1' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(deleteAllForUserMock).not.toHaveBeenCalled();
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- Discovered while reviewing [#659](https://github.com/xBounceIT/praetor/pull/659) (fix for [#606](https://github.com/xBounceIT/praetor/issues/606)). When an admin flips a user A → B → A on the same SSO provider, the stale `external_identities` rows from the original A binding survive the auth-method change. The SSO resolver in `external-auth.ts` looks up identities by `(provider_id, protocol, issuer, subject)` first, so on the next login the original IdP subject silently re-authenticates the user without going through the username-anchored safety check.
- Admin-mediated (not a user-driven takeover), but admins changing `auth_method` reasonably expect a clean slate.

## Fix

- New `externalIdentitiesRepo.deleteAllForUser(userId, exec?)` helper, matching the existing repo style.
- `PUT /api/users/:id/auth-method` now wraps the existing `usersRepo.updateAuthMethod` call and the new `deleteAllForUser` call in a single `withDbTransaction`. Either both succeed or both roll back — the auth-method update never lands without the cleanup.
- The cleanup runs only when `authMethod` or `authProviderId` actually changed (`authStateChanged`). Idempotent re-submission of the same payload stays a true no-op so it cannot race with an in-flight SSO login on the same provider.
- The next successful SSO login provisions a fresh `external_identities` row from the current IdP subject.

## Why \`deleteAllForUser\` and not \`deleteForUserAndProvider\`

The bug is about the original (now-stale) subject being preserved across an auth-method round trip. After any genuine auth-method or provider change, there is no scenario where a row from the *previous* provider/protocol is legitimately useful: the user's current `(authMethod, authProviderId)` columns name exactly one provider, and any other row is dead data that will only ever feed `findByIdentity` lookups. Wiping all of them is conservative and self-documenting.

## Test plan

- [x] Added 4 regression tests under `server/test/routes/users.test.ts` → \"external_identities cleanup on auth-method change\":
  - OIDC user demoted to local → cleanup runs
  - OIDC provider sso-1 → sso-2 switch → cleanup runs
  - local → OIDC sso-1 flip back to original provider (the A → B → A scenario) → cleanup runs
  - idempotent re-submission of the same `(authMethod, authProviderId)` → cleanup does **not** run
- [x] Verified the first three regression tests fail on the pre-fix code (\`deleteAllForUser\` is never called).
- [x] Updated two existing assertions (\`updateAuthMethod\` is now called with the `tx` arg).
- [x] \`bun test\` server suite: 2749 pass, 28 skip, 0 fail (across 126 files).
- [x] \`bun run typecheck\` clean. \`biome check\` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)