### PR TITLE
ux(fix): keep hashchange listener mounted across navigation (#622)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -94,7 +94,11 @@ import { clearAuthScopedState } from './utils/authScopedState';
 import { formatDateOnlyForLocale, getLocalDateString } from './utils/date';
 import { getTechnicalDocsViewFromPathname } from './utils/docsRoutes';
 import { getErrorMessage } from './utils/errors';
-import { canonicalizeLegacyHash, resolveHashChange } from './utils/hashCanonicalization';
+import {
+  canonicalizeLegacyHash,
+  resolveHashChange,
+  stripHashPrefix,
+} from './utils/hashCanonicalization';
 import {
   clearStaleModuleScopedState,
   getStaleModulesAfterNavigation,
@@ -779,7 +783,7 @@ const AppContent: React.FC = () => {
   const [activeView, setActiveViewState] = useState<View | '404'>(() => {
     const technicalDocsView = getTechnicalDocsViewFromPathname(window.location.pathname);
     if (technicalDocsView) return technicalDocsView;
-    const rawHash = window.location.hash.replace('#/', '').replace('#', '');
+    const rawHash = stripHashPrefix(window.location.hash);
     // We can't use the memoized VALID_VIEWS here because this runs before the initial render
     // So we define the list once for initialization
     const validViews: View[] = [
@@ -955,6 +959,11 @@ const AppContent: React.FC = () => {
       setViewingUserId('');
     },
   });
+
+  // Read by the hashchange listener (mounted once) so it sees the latest user
+  // without the effect resubscribing — events fired during teardown are lost.
+  const currentUserRef = useRef(currentUser);
+  currentUserRef.current = currentUser;
 
   const handleLogin = login;
   const handleLogout = logout;
@@ -1148,7 +1157,10 @@ const AppContent: React.FC = () => {
   // (navigation handlers, hash-change listener, Layout menu) goes through that
   // wrapper, so the four *FilterId values can never outlive a view change.
 
-  // Sync state with hash (for back/forward buttons)
+  // Sync state with hash (for back/forward buttons). Listener is mounted once
+  // and reads latest values via refs — resubscribing on every navigation would
+  // drop hashchange events that fire between removeEventListener and the next
+  // addEventListener call during rapid back/forward clicking.
   useEffect(() => {
     const handleHashChange = () => {
       if (programmaticHashRef.current === window.location.hash) {
@@ -1156,12 +1168,12 @@ const AppContent: React.FC = () => {
         return;
       }
       programmaticHashRef.current = null;
-      const rawHash = window.location.hash.replace('#/', '').replace('#', '');
+      const rawHash = stripHashPrefix(window.location.hash);
       const outcome = resolveHashChange({
         rawHash,
-        activeView,
+        activeView: activeViewRef.current,
         validViews: VALID_VIEWS,
-        hasUser: !!currentUser,
+        hasUser: !!currentUserRef.current,
       });
       if (outcome.kind === 'noop') return;
       if (outcome.kind === 'rewrite-hash') {
@@ -1175,7 +1187,7 @@ const AppContent: React.FC = () => {
     };
     window.addEventListener('hashchange', handleHashChange);
     return () => window.removeEventListener('hashchange', handleHashChange);
-  }, [activeView, VALID_VIEWS, currentUser, setActiveView]);
+  }, [VALID_VIEWS, setActiveView]);
 
   // Reset viewingUserId when navigating away from tracker
   useEffect(() => {

--- a/test/App.hashchangeListenerStable.test.tsx
+++ b/test/App.hashchangeListenerStable.test.tsx
@@ -1,0 +1,91 @@
+import { afterAll, describe, expect, spyOn, test } from 'bun:test';
+import { act, renderHook } from '@testing-library/react';
+import { useEffect, useRef, useState } from 'react';
+import type { User, View } from '../types';
+import { resolveHashChange, stripHashPrefix } from '../utils/hashCanonicalization';
+import { clearSpyStateAfterAll } from './helpers/mockCleanup.ts';
+
+// App.tsx is too tangled to mount the full tree (see test/App.notifications.test.tsx),
+// so we mirror the hashchange-sync effect 1:1 and assert it mounts once.
+
+clearSpyStateAfterAll();
+
+const VALID_VIEWS: View[] = ['timesheets/tracker', 'crm/clients', 'crm/suppliers'];
+
+const useHashSync = (initialView: View | '404', initialUser: Pick<User, 'id'> | null) => {
+  const [activeView, setActiveView] = useState<View | '404'>(initialView);
+  const programmaticHashRef = useRef<string | null>(null);
+
+  const activeViewRef = useRef<View | '404'>(activeView);
+  activeViewRef.current = activeView;
+  const currentUserRef = useRef(initialUser);
+
+  useEffect(() => {
+    const handleHashChange = () => {
+      if (programmaticHashRef.current === window.location.hash) {
+        programmaticHashRef.current = null;
+        return;
+      }
+      programmaticHashRef.current = null;
+      const outcome = resolveHashChange({
+        rawHash: stripHashPrefix(window.location.hash),
+        activeView: activeViewRef.current,
+        validViews: VALID_VIEWS,
+        hasUser: !!currentUserRef.current,
+      });
+      if (outcome.kind === 'noop') return;
+      if (outcome.kind === 'rewrite-hash') {
+        programmaticHashRef.current = outcome.newHash;
+        window.location.hash = outcome.newHash.slice(1);
+      }
+      setActiveView(outcome.view);
+    };
+    window.addEventListener('hashchange', handleHashChange);
+    return () => window.removeEventListener('hashchange', handleHashChange);
+  }, []);
+
+  return { activeView, setActiveView };
+};
+
+afterAll(() => {
+  window.location.hash = '';
+});
+
+describe('App hashchange listener', () => {
+  test('listener is attached exactly once and survives navigation', () => {
+    const addSpy = spyOn(window, 'addEventListener');
+    const removeSpy = spyOn(window, 'removeEventListener');
+    addSpy.mockClear();
+    removeSpy.mockClear();
+
+    const { result, unmount } = renderHook(() => useHashSync('timesheets/tracker', { id: 'u1' }));
+
+    act(() => result.current.setActiveView('crm/clients'));
+    act(() => result.current.setActiveView('crm/suppliers'));
+    act(() => result.current.setActiveView('timesheets/tracker'));
+
+    expect(addSpy.mock.calls.filter((c) => c[0] === 'hashchange').length).toBe(1);
+    expect(removeSpy.mock.calls.filter((c) => c[0] === 'hashchange').length).toBe(0);
+
+    unmount();
+    expect(removeSpy.mock.calls.filter((c) => c[0] === 'hashchange').length).toBe(1);
+
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
+  });
+
+  test('handler reads the latest activeView via ref after navigation', () => {
+    window.location.hash = '';
+
+    const { result } = renderHook(() => useHashSync('timesheets/tracker', { id: 'u1' }));
+
+    act(() => result.current.setActiveView('crm/clients'));
+
+    act(() => {
+      window.location.hash = '#/crm/suppliers';
+      window.dispatchEvent(new HashChangeEvent('hashchange'));
+    });
+
+    expect(result.current.activeView).toBe('crm/suppliers');
+  });
+});

--- a/test/App.hashchangeListenerStable.test.tsx
+++ b/test/App.hashchangeListenerStable.test.tsx
@@ -19,6 +19,7 @@ const useHashSync = (initialView: View | '404', initialUser: Pick<User, 'id'> | 
   const activeViewRef = useRef<View | '404'>(activeView);
   activeViewRef.current = activeView;
   const currentUserRef = useRef(initialUser);
+  currentUserRef.current = initialUser;
 
   useEffect(() => {
     const handleHashChange = () => {

--- a/utils/hashCanonicalization.ts
+++ b/utils/hashCanonicalization.ts
@@ -1,5 +1,7 @@
 import type { View } from '../types';
 
+export const stripHashPrefix = (hash: string): string => hash.replace('#/', '').replace('#', '');
+
 // Maps legacy hash aliases to their current canonical form. Must remain
 // idempotent: canonicalize(canonicalize(x)) === canonicalize(x) for all x.
 // Non-idempotent additions would, in concert with the bidirectional


### PR DESCRIPTION
## Summary

Fixes [#622](https://github.com/xBounceIT/praetor/issues/622). The `hashchange` listener in `App.tsx` had `activeView` and `currentUser` in its dep array, so it was torn down and re-registered on every navigation. Any `hashchange` event that fired in the gap between `removeEventListener` and the next `addEventListener` (rapid back/forward clicking) was silently dropped.

## What changed

- `App.tsx`: added `currentUserRef` (mirrors the existing `activeViewRef` pattern), changed the handler to read latest values via refs, and reduced the effect's dep array to `[VALID_VIEWS, setActiveView]` — both stable references — so the listener is mounted once.
- `utils/hashCanonicalization.ts`: extracted `stripHashPrefix(hash)` to dedupe the `hash.replace('#/', '').replace('#', '')` snippet that appeared at three sites (initial-view computation, the hashchange handler, and the new test).

## Test plan

- [x] New regression test `test/App.hashchangeListenerStable.test.tsx` — spies on `addEventListener`/`removeEventListener` and asserts the listener is registered exactly once across three navigations, and that a `hashchange` event after `setActiveView` is handled with the latest view.
- [x] `bun test test/App.hashchangeListenerStable.test.tsx test/utils/hashCanonicalization.test.ts` passes (13 tests).
- [x] `bun run lint` — no new errors (361 pre-existing, all in `server/` unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)