### PR TITLE
ops(fix): propagate fastify.close() failures via shutdown exit code (#627)

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -3,6 +3,7 @@ import { ensureBootstrapAdmin } from './db/bootstrapAdmin.ts';
 import { runDemoSeedRefresh } from './db/demoSeed.ts';
 import { query } from './db/index.ts';
 import { prepareDatabaseForStartup } from './db/startup.ts';
+import { performShutdown } from './shutdown.ts';
 import { createChildLogger, serializeError } from './utils/logger.ts';
 import {
   INSECURE_DEFAULT_ENCRYPTION_KEYS,
@@ -34,14 +35,8 @@ const assertSecureRuntimeConfig = () => {
 };
 
 const shutdown = async (signal: string) => {
-  try {
-    logger.info({ signal }, 'Shutting down');
-    await fastify.close();
-  } catch (err) {
-    logger.error({ signal, err: serializeError(err) }, 'Shutdown error');
-  } finally {
-    process.exit(0);
-  }
+  const code = await performShutdown(fastify, signal, logger);
+  process.exit(code);
 };
 
 process.on('SIGINT', () => void shutdown('SIGINT'));

--- a/server/shutdown.ts
+++ b/server/shutdown.ts
@@ -1,0 +1,18 @@
+import type { FastifyInstance } from 'fastify';
+import type { Logger } from 'pino';
+import { serializeError } from './utils/logger.ts';
+
+export const performShutdown = async (
+  fastify: FastifyInstance,
+  signal: string,
+  log: Logger,
+): Promise<number> => {
+  try {
+    log.info({ signal }, 'Shutting down');
+    await fastify.close();
+    return 0;
+  } catch (err) {
+    log.error({ signal, err: serializeError(err) }, 'Shutdown error');
+    return 1;
+  }
+};

--- a/server/test/shutdown.test.ts
+++ b/server/test/shutdown.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'bun:test';
+import type { FastifyInstance } from 'fastify';
+import type { Logger } from 'pino';
+import { performShutdown } from '../shutdown.ts';
+
+interface LogCall {
+  level: 'info' | 'error';
+  obj: Record<string, unknown>;
+  msg: string;
+}
+
+const makeLogger = () => {
+  const calls: LogCall[] = [];
+  const record = (level: LogCall['level']) => (obj: object, msg: string) =>
+    calls.push({ level, obj: { ...obj }, msg });
+  const stub = { info: record('info'), error: record('error') };
+  return { calls, logger: stub as unknown as Logger };
+};
+
+const makeFastify = (close: () => Promise<void>): FastifyInstance =>
+  ({ close }) as unknown as FastifyInstance;
+
+describe('performShutdown', () => {
+  test('returns 0 when fastify.close() resolves', async () => {
+    let closeCalls = 0;
+    const fastify = makeFastify(async () => {
+      closeCalls += 1;
+    });
+    const { calls, logger } = makeLogger();
+
+    const code = await performShutdown(fastify, 'SIGINT', logger);
+
+    expect(code).toBe(0);
+    expect(closeCalls).toBe(1);
+    expect(calls).toEqual([{ level: 'info', obj: { signal: 'SIGINT' }, msg: 'Shutting down' }]);
+  });
+
+  test('returns 1 when fastify.close() throws', async () => {
+    const closeErr = new Error('connection pool drain failed');
+    const fastify = makeFastify(async () => {
+      throw closeErr;
+    });
+    const { calls, logger } = makeLogger();
+
+    const code = await performShutdown(fastify, 'SIGTERM', logger);
+
+    expect(code).toBe(1);
+    const errorEntry = calls.find((entry) => entry.level === 'error');
+    expect(errorEntry).toBeDefined();
+    expect(errorEntry?.msg).toBe('Shutdown error');
+    expect(errorEntry?.obj.signal).toBe('SIGTERM');
+    expect(errorEntry?.obj.err).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes [#627](https://github.com/xBounceIT/praetor/issues/627): the SIGINT/SIGTERM handler in `server/index.ts` always called `process.exit(0)` from a `finally` block, masking `fastify.close()` failures from process supervisors.
- Extracted the shutdown logic into `server/shutdown.ts` (`performShutdown`), which returns `1` when close throws and `0` on success. `server/index.ts` now exits with that code.
- Added `server/test/shutdown.test.ts` covering both branches; the failure-path assertion fails on the previous behavior and passes on the fix.

## Behavior change
- Before: failed shutdown (e.g. connection-pool drain error) exited `0`, hiding the failure from systemd/Docker/k8s.
- After: failed shutdown exits `1`. Supervisors will now observe the failed drain.

## Test plan
- [x] `bun test ./test/shutdown.test.ts` (server cwd) — 2 pass
- [x] `bun run build` (server) — clean tsc
- [x] Verified failing-path test fails when `performShutdown` is reverted to always-return-0

🤖 Generated with [Claude Code](https://claude.com/claude-code)