### PR TITLE
invoices(perf): cap listAll at 1000 rows to prevent unbounded loads (#629)

### DIFF
--- a/server/repositories/invoicesRepo.ts
+++ b/server/repositories/invoicesRepo.ts
@@ -83,8 +83,16 @@ export const generateNextId = async (year: string, exec: DbExecutor = db): Promi
   return `INV-${year}-${formatSequenceSuffix(nextSequence)}`;
 };
 
+// Memory-side cap on unfiltered listAll. There is no index on `created_at`, so Postgres
+// still sorts the full table before applying LIMIT — this bounds heap usage, not DB work.
+export const LIST_ALL_LIMIT = 1000;
+
 export const listAll = async (exec: DbExecutor = db): Promise<Invoice[]> => {
-  const rows = await exec.select().from(invoices).orderBy(desc(invoices.createdAt));
+  const rows = await exec
+    .select()
+    .from(invoices)
+    .orderBy(desc(invoices.createdAt))
+    .limit(LIST_ALL_LIMIT);
   return rows.map(mapInvoice);
 };
 

--- a/server/repositories/supplierInvoicesRepo.ts
+++ b/server/repositories/supplierInvoicesRepo.ts
@@ -56,8 +56,16 @@ const mapItem = (row: typeof supplierInvoiceItems.$inferSelect): SupplierInvoice
   discount: parseDbNumber(row.discount, 0),
 });
 
+// Memory-side cap on unfiltered listAll. There is no index on `created_at`, so Postgres
+// still sorts the full table before applying LIMIT — this bounds heap usage, not DB work.
+export const LIST_ALL_LIMIT = 1000;
+
 export const listAll = async (exec: DbExecutor = db): Promise<SupplierInvoice[]> => {
-  const rows = await exec.select().from(supplierInvoices).orderBy(desc(supplierInvoices.createdAt));
+  const rows = await exec
+    .select()
+    .from(supplierInvoices)
+    .orderBy(desc(supplierInvoices.createdAt))
+    .limit(LIST_ALL_LIMIT);
   return rows.map(mapInvoice);
 };
 

--- a/server/test/repositories/invoicesRepo.test.ts
+++ b/server/test/repositories/invoicesRepo.test.ts
@@ -94,6 +94,13 @@ describe('listAll', () => {
     expect(result[0].total).toBe(110);
     expect(result[0].amountPaid).toBe(0);
   });
+
+  test('caps the result set with LIST_ALL_LIMIT to avoid unbounded loads', async () => {
+    exec.enqueue({ rows: [] });
+    await invoicesRepo.listAll(testDb);
+    expect(exec.calls[0].sql.toLowerCase()).toContain('limit');
+    expect(exec.calls[0].params).toContain(invoicesRepo.LIST_ALL_LIMIT);
+  });
 });
 
 describe('listAllItems', () => {

--- a/server/test/repositories/supplierInvoicesRepo.test.ts
+++ b/server/test/repositories/supplierInvoicesRepo.test.ts
@@ -67,6 +67,13 @@ describe('listAll mapInvoice', () => {
     expect(result[0].issueDate).toBe('2026-04-01');
     expect(result[0].dueDate).toBe('2026-04-30');
   });
+
+  test('caps the result set with LIST_ALL_LIMIT to avoid unbounded loads', async () => {
+    exec.enqueue({ rows: [] });
+    await supplierInvoicesRepo.listAll(testDb);
+    expect(exec.calls[0].sql.toLowerCase()).toContain('limit');
+    expect(exec.calls[0].params).toContain(supplierInvoicesRepo.LIST_ALL_LIMIT);
+  });
 });
 
 describe('listAllItems', () => {


### PR DESCRIPTION
## Summary
- Fixes [#629](https://github.com/xBounceIT/praetor/issues/629) — `invoicesRepo.listAll` and `supplierInvoicesRepo.listAll` issued `SELECT ... ORDER BY created_at DESC` with no LIMIT, so large tenants pulled the entire table into memory on every `GET /invoices` / `GET /supplier-invoices`.
- Adds an exported `LIST_ALL_LIMIT = 1000` safety cap on both `listAll` queries. The constant is exported so tests can bind to it; the cap value is larger than `auditLogsRepo`'s `LIMIT 500` because invoices are operational data shown in a single table view, not a paged event log.
- Tests assert `LIMIT` appears in the rendered SQL with the constant bound as a parameter. Verified both tests fail on the pre-fix source and pass on the fix.

## What a reviewer should know
- **Scope is intentionally narrow.** Other repos with the same unbounded `listAll` pattern (`clientOffersRepo`, `clientQuotesRepo`, `clientsOrdersRepo`, `supplierOrdersRepo`, `supplierQuotesRepo`, `projectsRepo`, etc.) are unchanged — issue #629 targets the invoice repos only.
- **The cap is memory-side, not DB-side.** There is no index on `invoices.created_at` or `supplier_invoices.created_at`, so Postgres still does a full Seq Scan + Sort before applying `LIMIT`. This is called out in the new comment so future readers don't assume the cap solves DB load. A `CREATE INDEX ... (created_at DESC)` migration would be a sensible follow-up.
- **`listAllItems` is still unbounded.** `listAllWithItems` caps the invoices side at 1000 but pulls every line item from `invoice_items` / `supplier_invoice_items`. For tenants with many items per invoice, the items query may still dominate memory. Out of scope here; flag for a follow-up if the cap alone proves insufficient.
- **Silent truncation.** Callers past 1000 rows are not signaled. The list endpoints `GET /invoices` and `GET /supplier-invoices` show the most recent 1000 only. This matches the existing audit-logs pattern; if a sorted/paged UI is needed it would be a separate change.

## Test plan
- [x] `bun test test/repositories/invoicesRepo.test.ts test/repositories/supplierInvoicesRepo.test.ts` → 66 / 66 pass
- [x] Verified new tests fail on the unfixed source (regression-catching)
- [ ] Reviewer: spot-check `GET /invoices` and `GET /supplier-invoices` return at most 1000 rows, sorted by `created_at DESC`

🤖 Generated with [Claude Code](https://claude.com/claude-code)