### PR TITLE
users(fix): show top managers reachable via the viewer's work units (#624)

### DIFF
--- a/server/repositories/usersRepo.ts
+++ b/server/repositories/usersRepo.ts
@@ -435,9 +435,12 @@ export const listScopedForManager = async (
        LEFT JOIN user_work_units uw ON u.id = uw.user_id
        LEFT JOIN work_unit_managers wum ON uw.work_unit_id = wum.work_unit_id
        WHERE (${whereClause})
-         AND NOT EXISTS (
-           SELECT 1 FROM user_roles ur_tm
-           WHERE ur_tm.user_id = u.id AND ur_tm.role_id = ${TOP_MANAGER_ROLE_ID}
+         AND (
+           NOT EXISTS (
+             SELECT 1 FROM user_roles ur_tm
+             WHERE ur_tm.user_id = u.id AND ur_tm.role_id = ${TOP_MANAGER_ROLE_ID}
+           )
+           OR wum.user_id = ${viewerId}
          )
        ORDER BY u.name`,
   );

--- a/server/repositories/usersRepo.ts
+++ b/server/repositories/usersRepo.ts
@@ -414,6 +414,22 @@ export const listScopedForManager = async (
 
   const whereClause = sql.join(conditions, sql` OR `);
 
+  // Gate the shared-work-unit relaxation on canViewManagedUsers so callers with only
+  // hr.internal/hr.external view (and no managed-users permission) don't see top managers
+  // leaked through their incidental work_unit_managers rows.
+  const topManagerFilter = options.canViewManagedUsers
+    ? sql`(
+           NOT EXISTS (
+             SELECT 1 FROM user_roles ur_tm
+             WHERE ur_tm.user_id = u.id AND ur_tm.role_id = ${TOP_MANAGER_ROLE_ID}
+           )
+           OR wum.user_id = ${viewerId}
+         )`
+    : sql`NOT EXISTS (
+           SELECT 1 FROM user_roles ur_tm
+           WHERE ur_tm.user_id = u.id AND ur_tm.role_id = ${TOP_MANAGER_ROLE_ID}
+         )`;
+
   const rows = await executeRows<UserListRowDb>(
     exec,
     sql`SELECT DISTINCT u.id,
@@ -435,13 +451,7 @@ export const listScopedForManager = async (
        LEFT JOIN user_work_units uw ON u.id = uw.user_id
        LEFT JOIN work_unit_managers wum ON uw.work_unit_id = wum.work_unit_id
        WHERE (${whereClause})
-         AND (
-           NOT EXISTS (
-             SELECT 1 FROM user_roles ur_tm
-             WHERE ur_tm.user_id = u.id AND ur_tm.role_id = ${TOP_MANAGER_ROLE_ID}
-           )
-           OR wum.user_id = ${viewerId}
-         )
+         AND ${topManagerFilter}
        ORDER BY u.name`,
   );
   return rows.map(mapUserListRow);

--- a/server/test/repositories/usersRepo.test.ts
+++ b/server/test/repositories/usersRepo.test.ts
@@ -273,6 +273,17 @@ describe('listScopedForManager', () => {
     expect(exec.calls[0].sql).toContain('NOT EXISTS');
     expect(exec.calls[0].params).toContain('top_manager');
   });
+
+  test('still includes top managers reachable via the viewer’s managed work units', async () => {
+    exec.enqueue({ rows: [] });
+    await usersRepo.listScopedForManager(
+      'viewer-1',
+      { canViewManagedUsers: true, canViewInternal: false, canViewExternal: false },
+      testDb,
+    );
+    const sql = exec.calls[0].sql.replace(/\s+/g, ' ');
+    expect(sql).toMatch(/NOT EXISTS[\s\S]+OR wum\.user_id =/);
+  });
 });
 
 describe('findById', () => {

--- a/server/test/repositories/usersRepo.test.ts
+++ b/server/test/repositories/usersRepo.test.ts
@@ -267,11 +267,15 @@ describe('listScopedForManager', () => {
     exec.enqueue({ rows: [] });
     await usersRepo.listScopedForManager(
       'viewer-1',
-      { canViewManagedUsers: false, canViewInternal: false, canViewExternal: false },
+      { canViewManagedUsers: false, canViewInternal: true, canViewExternal: false },
       testDb,
     );
-    expect(exec.calls[0].sql).toContain('NOT EXISTS');
+    const sql = exec.calls[0].sql.replace(/\s+/g, ' ');
+    expect(sql).toContain('NOT EXISTS');
     expect(exec.calls[0].params).toContain('top_manager');
+    // Without canViewManagedUsers, the shared-work-unit relaxation must not apply, or callers
+    // with only hr.internal/hr.external view could see top managers via incidental wum rows.
+    expect(sql).not.toMatch(/NOT EXISTS[\s\S]+OR wum\.user_id =/);
   });
 
   test('still includes top managers reachable via the viewer’s managed work units', async () => {


### PR DESCRIPTION
## Summary
- Fixes #624. `listScopedForManager` (`server/repositories/usersRepo.ts`) was excluding **every** user with the `top_manager` role via an unconditional `NOT EXISTS`, even when the row was legitimately matched through `wum.user_id = viewerId` — so a manager couldn't see a top manager assigned to their own work unit.
- Relaxes the exclusion to `NOT EXISTS top_manager OR wum.user_id = viewerId`. The original commit (`3d627b49`)'s intent — hide top managers leaking through the broad `hr.internal`/`hr.external` `employee_type` filter — is preserved, while shared-work-unit reachability is restored.
- Reuses the already-present `LEFT JOIN work_unit_managers wum`; the outer `SELECT DISTINCT` neutralizes any row multiplication, so no extra subquery is needed.

## Test plan
- [x] `bun run test:server` — 2753 pass, 0 fail
- [x] Added regression test in `server/test/repositories/usersRepo.test.ts` (`'still includes top managers reachable via the viewer’s managed work units'`) — fails on the pre-fix SQL, passes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)