### PR TITLE
settings(fix): race-safe getOrCreateForUser via INSERT ON CONFLICT (#626)

### DIFF
--- a/server/repositories/settingsRepo.ts
+++ b/server/repositories/settingsRepo.ts
@@ -1,5 +1,5 @@
 import { eq, sql } from 'drizzle-orm';
-import { type DbExecutor, db } from '../db/drizzle.ts';
+import { type DbExecutor, db, runAtomically } from '../db/drizzle.ts';
 import { settings } from '../db/schema/settings.ts';
 
 export const LANGUAGES = ['en', 'it', 'auto'] as const;
@@ -26,22 +26,40 @@ const mapRow = (row: SettingsRow): Settings => ({
   language: (row.language as Language | null) ?? DEFAULT_LANGUAGE,
 });
 
+const findByUserId = async (userId: string, exec: DbExecutor): Promise<Settings | undefined> => {
+  const [row] = await exec
+    .select(SETTINGS_PROJECTION)
+    .from(settings)
+    .where(eq(settings.userId, userId));
+  return row ? mapRow(row) : undefined;
+};
+
 export const getOrCreateForUser = async (
   userId: string,
   defaults: { fullName: string | null; email: string | null },
   exec: DbExecutor = db,
 ): Promise<Settings> => {
-  const existing = await exec
-    .select(SETTINGS_PROJECTION)
-    .from(settings)
-    .where(eq(settings.userId, userId));
-  if (existing.length > 0) return mapRow(existing[0]);
+  // Hot path (called on every authenticated /api/settings GET): the row almost always exists,
+  // so stay outside a transaction and avoid the BEGIN/COMMIT round-trips runAtomically adds.
+  const existing = await findByUserId(userId, exec);
+  if (existing) return existing;
 
-  const inserted = await exec
-    .insert(settings)
-    .values({ userId, fullName: defaults.fullName, email: defaults.email })
-    .returning(SETTINGS_PROJECTION);
-  return mapRow(inserted[0]);
+  // First-access path: two concurrent calls can both miss the SELECT, so wrap the INSERT and
+  // race-loser re-SELECT in a single snapshot.
+  return runAtomically(exec, async (tx) => {
+    const inserted = await tx
+      .insert(settings)
+      .values({ userId, fullName: defaults.fullName, email: defaults.email })
+      .onConflictDoNothing({ target: settings.userId })
+      .returning(SETTINGS_PROJECTION);
+    if (inserted[0]) return mapRow(inserted[0]);
+
+    const winner = await findByUserId(userId, tx);
+    if (!winner) {
+      throw new Error('settingsRepo.getOrCreateForUser: row missing after insert');
+    }
+    return winner;
+  });
 };
 
 export const upsertForUser = async (

--- a/server/test/repositories/settingsRepo.test.ts
+++ b/server/test/repositories/settingsRepo.test.ts
@@ -33,7 +33,10 @@ describe('getOrCreateForUser', () => {
     );
     expect(result).toEqual({ fullName: 'Bob', email: 'b@x', language: 'auto' });
     expect(exec.calls).toHaveLength(2);
-    expect(exec.calls[1].sql.toLowerCase()).toContain('insert into "settings"');
+    const insertSql = exec.calls[1].sql.toLowerCase();
+    expect(insertSql).toContain('insert into "settings"');
+    expect(insertSql).toContain('on conflict');
+    expect(insertSql).toContain('do nothing');
     expect(exec.calls[1].params).toContain('user-2');
     expect(exec.calls[1].params).toContain('Bob');
     expect(exec.calls[1].params).toContain('b@x');
@@ -47,6 +50,33 @@ describe('getOrCreateForUser', () => {
       testDb,
     );
     expect(result.language).toBe(settingsRepo.DEFAULT_LANGUAGE);
+  });
+
+  test('falls back to the winning row when a concurrent insert wins the race', async () => {
+    exec.enqueue({ rows: [] }); // initial SELECT: no row yet
+    exec.enqueue({ rows: [] }); // INSERT ... ON CONFLICT DO NOTHING returns no row
+    exec.enqueue({ rows: [['Winner', 'w@x', 'en']] }); // re-SELECT returns the winner
+
+    const result = await settingsRepo.getOrCreateForUser(
+      'user-9',
+      { fullName: 'Loser', email: 'l@x' },
+      testDb,
+    );
+
+    expect(result).toEqual({ fullName: 'Winner', email: 'w@x', language: 'en' });
+    expect(exec.calls).toHaveLength(3);
+    expect(exec.calls[1].sql.toLowerCase()).toContain('on conflict');
+    expect(exec.calls[2].sql.toLowerCase()).toContain('select');
+  });
+
+  test('throws if the re-SELECT after a lost race returns no row', async () => {
+    exec.enqueue({ rows: [] }); // initial SELECT: no row yet
+    exec.enqueue({ rows: [] }); // INSERT no-op via ON CONFLICT
+    exec.enqueue({ rows: [] }); // re-SELECT also returns nothing
+
+    await expect(
+      settingsRepo.getOrCreateForUser('user-10', { fullName: null, email: null }, testDb),
+    ).rejects.toThrow(/row missing after insert/);
   });
 });
 


### PR DESCRIPTION
## Summary
Fixes #626. `settingsRepo.getOrCreateForUser` did a SELECT-then-INSERT against the `user_id`-unique `settings` table, so two concurrent first-access calls for the same new user could both miss the SELECT and the loser would throw on the unique constraint.

## Changes
- `server/repositories/settingsRepo.ts`: switched the insert path to `INSERT ... ON CONFLICT DO NOTHING` followed by a re-SELECT, wrapped only the slow path in `runAtomically` for a consistent snapshot. The common-case SELECT stays outside the transaction so the per-request `/api/settings` GET hot path doesn't pay a `BEGIN`/`COMMIT`.
- Extracted a private `findByUserId` helper to dedupe the projection block (now used for both the fast-path SELECT and the race-loser re-SELECT).
- Matches the existing precedent in `personalAccessTokensRepo.createForUserIfMissing` ([server/repositories/personalAccessTokensRepo.ts:50-81](https://github.com/xBounceIT/praetor/blob/main/server/repositories/personalAccessTokensRepo.ts#L50-L81)).

## Test plan
- [x] New test: race-loser path (`SELECT empty → INSERT no-op → re-SELECT returns winner`).
- [x] New test: re-SELECT returns nothing throws (`row missing after insert`).
- [x] Existing insert-path test now also asserts the SQL emits `ON CONFLICT DO NOTHING` — this assertion would fail on the old code.
- [x] All 140 related tests (`settingsRepo`, `routes/settings`, `routes/users`, `services/external-auth.resolve`) pass.
- [x] `tsc --noEmit` clean; `biome check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)