### PR TITLE
fix(race): counter-based programmatic hash guard (#623)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -112,6 +112,10 @@ import {
   TOP_MANAGER_ROLE_ID,
   VIEW_PERMISSION_MAP,
 } from './utils/permissions';
+import {
+  createProgrammaticHashTracker,
+  type ProgrammaticHashTracker,
+} from './utils/programmaticHashTracker';
 import { retryTransient } from './utils/retry';
 import { applyTheme, getTheme } from './utils/theme';
 import { toastError } from './utils/toast';
@@ -837,11 +841,17 @@ const AppContent: React.FC = () => {
   // refs so in-flight awaits still observe the latest value.
   const activeViewRef = useRef<View | '404'>(activeView);
   activeViewRef.current = activeView;
-  // Tracks the full `#/...` value we last wrote to window.location.hash so
-  // the hashchange listener can short-circuit on events fired by our own
-  // writes. Prevents an infinite rewrite loop if canonicalizeLegacyHash ever
-  // becomes non-idempotent (see issue #540).
-  const programmaticHashRef = useRef<string | null>(null);
+  // Counts pending programmatic hash writes so the hashchange listener can
+  // short-circuit events fired by our own writes. Each write that actually
+  // changes the hash registers one expected event; each event consumes one
+  // pending entry. A single-value flag (the previous design) raced under
+  // rapid navigation — see issue #623. Still prevents an infinite rewrite
+  // loop if canonicalizeLegacyHash ever becomes non-idempotent (issue #540).
+  const programmaticHashTrackerRef = useRef<ProgrammaticHashTracker | null>(null);
+  if (programmaticHashTrackerRef.current === null) {
+    programmaticHashTrackerRef.current = createProgrammaticHashTracker();
+  }
+  const programmaticHashTracker = programmaticHashTrackerRef.current;
   const setActiveView = useCallback<React.Dispatch<React.SetStateAction<View | '404'>>>((next) => {
     const resolved =
       typeof next === 'function'
@@ -1139,10 +1149,10 @@ const AppContent: React.FC = () => {
     }
     const nextHash = currentUser ? `#/${activeView}` : '#/login';
     if (window.location.hash !== nextHash) {
-      programmaticHashRef.current = nextHash;
+      programmaticHashTracker.registerWrite();
       window.location.hash = nextHash.slice(1);
     }
-  }, [activeView, currentUser, isLoading]);
+  }, [activeView, currentUser, isLoading, programmaticHashTracker]);
 
   // Filter-id cleanup now happens inside `setActiveView` itself - any caller
   // (navigation handlers, hash-change listener, Layout menu) goes through that
@@ -1151,11 +1161,7 @@ const AppContent: React.FC = () => {
   // Sync state with hash (for back/forward buttons)
   useEffect(() => {
     const handleHashChange = () => {
-      if (programmaticHashRef.current === window.location.hash) {
-        programmaticHashRef.current = null;
-        return;
-      }
-      programmaticHashRef.current = null;
+      if (programmaticHashTracker.consumeIfPending()) return;
       const rawHash = window.location.hash.replace('#/', '').replace('#', '');
       const outcome = resolveHashChange({
         rawHash,
@@ -1168,14 +1174,14 @@ const AppContent: React.FC = () => {
         // Apply the resolved view in this same call: the follow-up hashchange
         // fired by the rewrite below will be short-circuited by the guard
         // above, so we cannot rely on it to set the view.
-        programmaticHashRef.current = outcome.newHash;
+        programmaticHashTracker.registerWrite();
         window.location.hash = outcome.newHash.slice(1);
       }
       setActiveView(outcome.view);
     };
     window.addEventListener('hashchange', handleHashChange);
     return () => window.removeEventListener('hashchange', handleHashChange);
-  }, [activeView, VALID_VIEWS, currentUser, setActiveView]);
+  }, [activeView, VALID_VIEWS, currentUser, setActiveView, programmaticHashTracker]);
 
   // Reset viewingUserId when navigating away from tracker
   useEffect(() => {

--- a/App.tsx
+++ b/App.tsx
@@ -841,11 +841,9 @@ const AppContent: React.FC = () => {
   // refs so in-flight awaits still observe the latest value.
   const activeViewRef = useRef<View | '404'>(activeView);
   activeViewRef.current = activeView;
-  // Counts pending programmatic hash writes so the hashchange listener can
-  // short-circuit events fired by our own writes. Each write that actually
-  // changes the hash registers one expected event; each event consumes one
-  // pending entry. A single-value flag (the previous design) raced under
-  // rapid navigation — see issue #623. Still prevents an infinite rewrite
+  // Short-circuits hashchange events fired by our own writes. See
+  // utils/programmaticHashTracker.ts for why this is a counter rather than a
+  // single-value marker (issue #623). Also still prevents an infinite rewrite
   // loop if canonicalizeLegacyHash ever becomes non-idempotent (issue #540).
   const programmaticHashTrackerRef = useRef<ProgrammaticHashTracker | null>(null);
   if (programmaticHashTrackerRef.current === null) {

--- a/test/utils/programmaticHashTracker.test.ts
+++ b/test/utils/programmaticHashTracker.test.ts
@@ -40,11 +40,16 @@ describe('createProgrammaticHashTracker', () => {
     expect(tracker.consumeIfPending()).toBe(false);
   });
 
-  test('a user-initiated event between programmatic writes is not swallowed', () => {
-    // Programmatic write → its hashchange fires and is consumed → counter
-    // back to 0 → next event (user-initiated) sees consumeIfPending → false
-    // and is processed normally.
+  test('a user-initiated event between programmatic writes is processed', () => {
+    // Programmatic write → its hashchange fires and is consumed (counter back
+    // to 0) → user-initiated hashchange fires and consumeIfPending returns
+    // false so the listener processes it → next programmatic write registers
+    // and is consumed on its event. The user event must not be swallowed and
+    // must not throw the counter out of sync with later writes.
     const tracker = createProgrammaticHashTracker();
+    tracker.registerWrite();
+    expect(tracker.consumeIfPending()).toBe(true);
+    expect(tracker.consumeIfPending()).toBe(false);
     tracker.registerWrite();
     expect(tracker.consumeIfPending()).toBe(true);
     expect(tracker.consumeIfPending()).toBe(false);

--- a/test/utils/programmaticHashTracker.test.ts
+++ b/test/utils/programmaticHashTracker.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from 'bun:test';
+import { createProgrammaticHashTracker } from '../../utils/programmaticHashTracker';
+
+describe('createProgrammaticHashTracker', () => {
+  test('starts with no pending writes', () => {
+    const tracker = createProgrammaticHashTracker();
+    expect(tracker.consumeIfPending()).toBe(false);
+  });
+
+  test('registerWrite then consumeIfPending pairs symmetrically', () => {
+    const tracker = createProgrammaticHashTracker();
+    tracker.registerWrite();
+    expect(tracker.consumeIfPending()).toBe(true);
+    expect(tracker.consumeIfPending()).toBe(false);
+  });
+
+  test('rapid back-to-back writes consume in order — regression for issue #623', () => {
+    // The pre-fix single-ref design silently dropped the first hashchange
+    // when a second programmatic write overwrote the marker before the
+    // first event fired. A counter must consume one pending entry per event
+    // regardless of how many writes have queued up.
+    const tracker = createProgrammaticHashTracker();
+    tracker.registerWrite();
+    tracker.registerWrite();
+    expect(tracker.consumeIfPending()).toBe(true);
+    expect(tracker.consumeIfPending()).toBe(true);
+    expect(tracker.consumeIfPending()).toBe(false);
+  });
+
+  test('interleaved writes and consumes do not lose events', () => {
+    const tracker = createProgrammaticHashTracker();
+    tracker.registerWrite();
+    expect(tracker.consumeIfPending()).toBe(true);
+    tracker.registerWrite();
+    tracker.registerWrite();
+    expect(tracker.consumeIfPending()).toBe(true);
+    tracker.registerWrite();
+    expect(tracker.consumeIfPending()).toBe(true);
+    expect(tracker.consumeIfPending()).toBe(true);
+    expect(tracker.consumeIfPending()).toBe(false);
+  });
+
+  test('a user-initiated event between programmatic writes is not swallowed', () => {
+    // Programmatic write → its hashchange fires and is consumed → counter
+    // back to 0 → next event (user-initiated) sees consumeIfPending → false
+    // and is processed normally.
+    const tracker = createProgrammaticHashTracker();
+    tracker.registerWrite();
+    expect(tracker.consumeIfPending()).toBe(true);
+    expect(tracker.consumeIfPending()).toBe(false);
+  });
+
+  test('separate tracker instances do not share state', () => {
+    const a = createProgrammaticHashTracker();
+    const b = createProgrammaticHashTracker();
+    a.registerWrite();
+    expect(b.consumeIfPending()).toBe(false);
+    expect(a.consumeIfPending()).toBe(true);
+  });
+});

--- a/utils/programmaticHashTracker.ts
+++ b/utils/programmaticHashTracker.ts
@@ -1,0 +1,30 @@
+// Tracks how many programmatic hash writes are still waiting for their
+// corresponding hashchange event. A single-value flag (the previous design)
+// races under rapid navigation: a second write overwrites the marker before
+// the first event fires, the listener sees `marker === window.location.hash`
+// for the first (older) event, short-circuits it, and then mis-classifies
+// the second event as user-initiated. See issue #623.
+//
+// A pending-write counter avoids the race because each programmatic write
+// registers exactly one expected event, and each event consumes exactly one
+// pending write, regardless of how their hash values shift between writes.
+export type ProgrammaticHashTracker = {
+  registerWrite: () => void;
+  consumeIfPending: () => boolean;
+};
+
+export const createProgrammaticHashTracker = (): ProgrammaticHashTracker => {
+  let pending = 0;
+  return {
+    registerWrite: () => {
+      pending += 1;
+    },
+    consumeIfPending: () => {
+      if (pending > 0) {
+        pending -= 1;
+        return true;
+      }
+      return false;
+    },
+  };
+};


### PR DESCRIPTION
## Summary

- Fixes [#623](https://github.com/xBounceIT/praetor/issues/623). The programmatic hash self-trigger guard in `App.tsx` used a single ref (`programmaticHashRef`) to remember the most recent hash we wrote ourselves. Under rapid successive `setActiveView` calls, the second write overwrote that marker before the first `hashchange` event fired — the listener then short-circuited the *first* event by mistake (its current marker matched `window.location.hash`, which had already been updated to the *second* value) and mis-classified the second event as user-initiated.
- Replaced the single-value marker with a pending-write counter encapsulated in a tiny utility (`utils/programmaticHashTracker.ts`): each programmatic write that actually changes the hash calls `registerWrite()`, and each `hashchange` calls `consumeIfPending()`. Each event is matched to its own write regardless of how the hash value shifts between writes.
- Tracker is constructed lazily via the standard React `useRef(null)` + first-render init pattern so the factory only runs on mount instead of on every `AppContent` render.

## What changed

- New `utils/programmaticHashTracker.ts` exporting `createProgrammaticHashTracker()` (returns `{ registerWrite, consumeIfPending }`).
- `App.tsx`: swapped `programmaticHashRef` for `programmaticHashTracker`, updated the hash-sync effect, hashchange listener, and the rewrite-hash branch to register/consume against the counter.
- New `test/utils/programmaticHashTracker.test.ts` with 6 unit tests including a regression for the back-to-back-writes scenario from #623.

## Test plan

- [x] `bun test test/utils/programmaticHashTracker.test.ts test/utils/hashCanonicalization.test.ts` — 17 pass.
- [x] Frontend `tsc --noEmit` clean.
- [x] `biome check` clean on all changed files.
- [ ] Manual smoke: trigger rapid back-to-back navigation (e.g. two `setActiveView` calls across separate renders) and verify both transitions are reflected without dropped or duplicated state updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)