### PR TITLE
ux(fix): replace alert() with toastError() in error handlers (#630)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -964,7 +964,7 @@ const AppContent: React.FC = () => {
         await switchRole(roleId);
       } catch (err) {
         console.error('Failed to switch role:', err);
-        alert('Failed to switch role: ' + (err as Error).message);
+        toastError(`Failed to switch role: ${getErrorMessage(err)}`);
       }
     },
     [switchRole],
@@ -2255,7 +2255,7 @@ const AppContent: React.FC = () => {
       });
     } catch (err) {
       console.error('Failed to update general settings:', err);
-      alert('Failed to update settings');
+      toastError('Failed to update settings');
     }
   };
 
@@ -2265,7 +2265,7 @@ const AppContent: React.FC = () => {
       setUserSettings((prev) => ({ ...prev, ...updated }));
     } catch (err) {
       console.error('Failed to update user settings:', err);
-      alert('Failed to update settings');
+      toastError('Failed to update settings');
       throw err;
     }
   };
@@ -2799,7 +2799,7 @@ const AppContent: React.FC = () => {
                       setProjectTasks((prev) => prev.filter((t) => t.id !== id));
                     } catch (err) {
                       console.error('Failed to delete task:', err);
-                      alert('Failed to delete task');
+                      toastError('Failed to delete task');
                     }
                   }}
                   onViewOrder={(orderId) => {

--- a/components/administration/UserManagement.tsx
+++ b/components/administration/UserManagement.tsx
@@ -29,6 +29,7 @@ import type {
   UserAuthMethod,
 } from '../../types';
 import { buildPermission, hasPermission, TOP_MANAGER_ROLE_ID } from '../../utils/permissions';
+import { toastError } from '../../utils/toast';
 import Checkbox from '../shared/Checkbox';
 import HeaderAddButton from '../shared/HeaderAddButton';
 import Modal from '../shared/Modal';
@@ -327,7 +328,7 @@ const UserManagement: React.FC<UserManagementProps> = ({
       closeAssignments();
     } catch (err) {
       console.error('Failed to save assignments', err);
-      alert(t('hr:workUnits.failedToSaveAssignments'));
+      toastError(t('hr:workUnits.failedToSaveAssignments'));
     }
   };
 

--- a/components/shared/UserAssignmentModal.tsx
+++ b/components/shared/UserAssignmentModal.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import type { Role, User } from '../../types';
 import { TOP_MANAGER_ROLE_ID } from '../../utils/permissions';
+import { toastError } from '../../utils/toast';
 import Modal from './Modal';
 import {
   ModalBody,
@@ -185,7 +186,7 @@ const UserAssignmentModal: React.FC<UserAssignmentModalProps> = ({
       handleClose();
     } catch (err) {
       console.error('Failed to save assignments', err);
-      alert(t('assignment.saveFailed'));
+      toastError(t('assignment.saveFailed'));
     }
   }, [disabled, saveAssignedUserIds, assignedUserIds, handleClose, t]);
 

--- a/hooks/handlers/clientHandlers.ts
+++ b/hooks/handlers/clientHandlers.ts
@@ -7,6 +7,7 @@ import type {
   Project,
   ProjectTask,
 } from '../../types';
+import { toastError } from '../../utils/toast';
 
 /**
  * Client handlers read `projects` AFTER an awaited delete to compute which
@@ -61,7 +62,7 @@ export const makeClientHandlers = (deps: ClientHandlersDeps) => {
       setProjectTasks((prev) => prev.filter((t) => !projectIdsForClient.includes(t.projectId)));
     } catch (err) {
       console.error('Failed to delete client:', err);
-      alert('Failed to delete client');
+      toastError('Failed to delete client');
     }
   };
 

--- a/hooks/handlers/entryHandlers.ts
+++ b/hooks/handlers/entryHandlers.ts
@@ -1,6 +1,7 @@
 import type React from 'react';
 import api from '../../services/api';
 import type { TimeEntry, User } from '../../types';
+import { toastError } from '../../utils/toast';
 
 type TimeEntryDraft = Omit<
   TimeEntry,
@@ -35,7 +36,7 @@ export const makeEntryHandlers = (deps: EntryHandlersDeps) => {
       setEntries((prev) => [entry, ...prev]);
     } catch (err) {
       console.error('Failed to add entry:', err);
-      alert('Failed to add time entry');
+      toastError('Failed to add time entry');
     }
   };
 
@@ -64,7 +65,7 @@ export const makeEntryHandlers = (deps: EntryHandlersDeps) => {
 
     if (failures.length > 0) {
       for (const err of failures) console.error('Failed to add bulk entry:', err);
-      alert('Failed to add some time entries');
+      toastError('Failed to add some time entries');
     }
   };
 

--- a/hooks/handlers/projectHandlers.ts
+++ b/hooks/handlers/projectHandlers.ts
@@ -2,6 +2,8 @@ import type React from 'react';
 import type { AddProjectFormInput } from '../../components/projects/ProjectsView';
 import api from '../../services/api';
 import type { Project, ProjectTask, TimeEntry } from '../../types';
+import { getErrorMessage } from '../../utils/errors';
+import { toastError } from '../../utils/toast';
 
 export type ProjectHandlersDeps = {
   setProjects: React.Dispatch<React.SetStateAction<Project[]>>;
@@ -55,7 +57,7 @@ export const makeProjectHandlers = (deps: ProjectHandlersDeps) => {
       }
     } catch (err) {
       console.error('Failed to add project:', err);
-      alert('Failed to add project: ' + (err as Error).message);
+      toastError(`Failed to add project: ${getErrorMessage(err)}`);
     }
   };
 
@@ -87,7 +89,7 @@ export const makeProjectHandlers = (deps: ProjectHandlersDeps) => {
       return task;
     } catch (err) {
       console.error('Failed to add task:', err);
-      alert('Failed to add task: ' + (err as Error).message);
+      toastError(`Failed to add task: ${getErrorMessage(err)}`);
       throw err;
     }
   };
@@ -98,7 +100,7 @@ export const makeProjectHandlers = (deps: ProjectHandlersDeps) => {
       setProjects((prev) => prev.map((p) => (p.id === id ? updated : p)));
     } catch (err) {
       console.error('Failed to update project:', err);
-      alert('Failed to update project');
+      toastError('Failed to update project');
     }
   };
 
@@ -110,7 +112,7 @@ export const makeProjectHandlers = (deps: ProjectHandlersDeps) => {
       setEntries((prev) => prev.filter((e) => e.projectId !== id));
     } catch (err) {
       console.error('Failed to delete project:', err);
-      alert('Failed to delete project');
+      toastError('Failed to delete project');
     }
   };
 

--- a/hooks/handlers/supplierInvoiceHandlers.ts
+++ b/hooks/handlers/supplierInvoiceHandlers.ts
@@ -3,6 +3,7 @@ import api from '../../services/api';
 import type { SupplierInvoice, SupplierSaleOrder, View } from '../../types';
 import { addDaysToDateOnly, getLocalDateString } from '../../utils/date';
 import { makeTempId } from '../../utils/tempId';
+import { toastError } from '../../utils/toast';
 
 export type SupplierInvoiceHandlersDeps = {
   setSupplierInvoices: React.Dispatch<React.SetStateAction<SupplierInvoice[]>>;
@@ -73,7 +74,11 @@ export const makeSupplierInvoiceHandlers = (deps: SupplierInvoiceHandlersDeps) =
       setActiveView('accounting/supplier-invoices');
     } catch (err) {
       console.error('Failed to create supplier invoice from order:', err);
-      alert((err as Error).message || 'Failed to create supplier invoice from order');
+      toastError(
+        err instanceof Error && err.message
+          ? err.message
+          : 'Failed to create supplier invoice from order',
+      );
     }
   };
 

--- a/hooks/handlers/userHandlers.ts
+++ b/hooks/handlers/userHandlers.ts
@@ -1,7 +1,9 @@
 import type React from 'react';
 import api from '../../services/api';
 import type { Role, User, UserAuthMethod, WorkUnit } from '../../types';
+import { getErrorMessage } from '../../utils/errors';
 import { TOP_MANAGER_ROLE_ID } from '../../utils/permissions';
+import { toastError } from '../../utils/toast';
 
 export type UserHandlersDeps = {
   currentUser: User | null;
@@ -38,7 +40,7 @@ export const makeUserHandlers = (deps: UserHandlersDeps) => {
       setUsers((prev) => prev.map((u) => (u.id === id ? updated : u)));
     } catch (err) {
       console.error('Failed to update user:', err);
-      alert('Failed to update user: ' + (err as Error).message);
+      toastError(`Failed to update user: ${getErrorMessage(err)}`);
     }
   };
 
@@ -61,7 +63,7 @@ export const makeUserHandlers = (deps: UserHandlersDeps) => {
       );
     } catch (err) {
       console.error('Failed to update user roles:', err);
-      alert('Failed to update user roles: ' + (err as Error).message);
+      toastError(`Failed to update user roles: ${getErrorMessage(err)}`);
       throw err;
     }
   };
@@ -76,7 +78,7 @@ export const makeUserHandlers = (deps: UserHandlersDeps) => {
       setUsers((prev) => prev.map((u) => (u.id === id ? updated : u)));
     } catch (err) {
       console.error('Failed to update user authentication method:', err);
-      alert('Failed to update user authentication method: ' + (err as Error).message);
+      toastError(`Failed to update user authentication method: ${getErrorMessage(err)}`);
       throw err;
     }
   };
@@ -91,7 +93,7 @@ export const makeUserHandlers = (deps: UserHandlersDeps) => {
       setUsers((prev) => prev.filter((u) => u.id !== id));
     } catch (err) {
       console.error('Failed to delete user:', err);
-      alert('Failed to delete user: ' + (err as Error).message);
+      toastError(`Failed to delete user: ${getErrorMessage(err)}`);
     }
   };
 

--- a/test/handlers/clientHandlers.test.ts
+++ b/test/handlers/clientHandlers.test.ts
@@ -21,6 +21,14 @@ const apiMocks = {
   clientsDeleteProfileOption: mock((..._args: unknown[]): Promise<void> => Promise.resolve()),
 };
 
+const toastErrorMock = mock((_message: string) => {});
+
+mock.module('../../utils/toast', () => ({
+  toastError: (message: string) => toastErrorMock(message),
+  toastSuccess: () => {},
+  toast: { error: () => {}, success: () => {}, info: () => {} },
+}));
+
 mock.module('../../services/api', () => ({
   default: {
     clients: {
@@ -66,6 +74,7 @@ describe('makeClientHandlers', () => {
     apiMocks.clientsCreateProfileOption.mockClear();
     apiMocks.clientsUpdateProfileOption.mockClear();
     apiMocks.clientsDeleteProfileOption.mockClear();
+    toastErrorMock.mockClear();
   });
 
   afterEach(() => {
@@ -122,6 +131,30 @@ describe('makeClientHandlers', () => {
     await handlers.update('c1', { name: 'Alpha-renamed' });
     expect(clients.get()[0]).toEqual({ id: 'c1', name: 'Alpha-renamed' });
     expect(clients.get()[1]).toEqual({ id: 'c2', name: 'Beta' });
+  });
+
+  test('delete surfaces error via toast and swallows on api error', async () => {
+    apiMocks.clientsDelete.mockImplementation(() => Promise.reject(new Error('boom')));
+    const clients = makeStubSetter<ClientLike>([{ id: 'c1' }]);
+    const handlers = makeClientHandlers({
+      getProjects: () => [],
+      setClients: clients.setter,
+      setProjects: makeStubSetter<ProjectLike>([]).setter,
+      setProjectTasks: makeStubSetter<TaskLike>([]).setter,
+    });
+
+    const originalError = console.error;
+    console.error = mock(() => {}) as unknown as typeof console.error;
+    try {
+      await handlers.delete('c1');
+      expect(clients.get()).toEqual([{ id: 'c1' }]);
+      expect(toastErrorMock).toHaveBeenCalledTimes(1);
+      expect((toastErrorMock.mock.calls[0]?.[0] as string) ?? '').toContain(
+        'Failed to delete client',
+      );
+    } finally {
+      console.error = originalError;
+    }
   });
 
   test('delete cascades to projects and projectTasks', async () => {

--- a/test/handlers/entryHandlers.test.ts
+++ b/test/handlers/entryHandlers.test.ts
@@ -14,6 +14,14 @@ const apiMocks = {
   entriesDelete: mock((_id: string): Promise<void> => Promise.resolve()),
 };
 
+const toastErrorMock = mock((_message: string) => {});
+
+mock.module('../../utils/toast', () => ({
+  toastError: (message: string) => toastErrorMock(message),
+  toastSuccess: () => {},
+  toast: { error: () => {}, success: () => {}, info: () => {} },
+}));
+
 mock.module('../../services/api', () => ({
   default: {
     entries: {
@@ -52,12 +60,10 @@ const makeStubSetter = <T>(initial: T[]) => {
 
 const silenceConsole = () => {
   const originalError = console.error;
-  const originalAlert = globalThis.alert;
   console.error = mock(() => {}) as unknown as typeof console.error;
-  globalThis.alert = mock(() => {}) as unknown as typeof globalThis.alert;
+  toastErrorMock.mockClear();
   return () => {
     console.error = originalError;
-    globalThis.alert = originalAlert;
   };
 };
 
@@ -120,7 +126,7 @@ describe('makeEntryHandlers', () => {
     expect(callArg).not.toHaveProperty('hourlyCost');
   });
 
-  test('add swallows errors and alerts user', async () => {
+  test('add swallows errors and surfaces via toast', async () => {
     apiMocks.entriesCreate.mockImplementation(() => Promise.reject(new Error('boom')));
     const entries = makeStubSetter<EntryLike>([{ id: 'e1', createdAt: 1 }]);
     const handlers = makeEntryHandlers({
@@ -133,6 +139,10 @@ describe('makeEntryHandlers', () => {
     try {
       await handlers.add({ task: 'fail' } as never);
       expect(entries.get()).toEqual([{ id: 'e1', createdAt: 1 }]);
+      expect(toastErrorMock).toHaveBeenCalledTimes(1);
+      expect((toastErrorMock.mock.calls[0]?.[0] as string) ?? '').toContain(
+        'Failed to add time entry',
+      );
     } finally {
       restore();
     }

--- a/test/handlers/projectHandlers.test.ts
+++ b/test/handlers/projectHandlers.test.ts
@@ -16,6 +16,14 @@ const apiMocks = {
   ),
 };
 
+const toastErrorMock = mock((_message: string) => {});
+
+mock.module('../../utils/toast', () => ({
+  toastError: (message: string) => toastErrorMock(message),
+  toastSuccess: () => {},
+  toast: { error: () => {}, success: () => {}, info: () => {} },
+}));
+
 mock.module('../../services/api', () => ({
   default: {
     projects: {
@@ -56,6 +64,7 @@ describe('makeProjectHandlers', () => {
     Object.values(apiMocks).forEach((m) => {
       m.mockClear();
     });
+    toastErrorMock.mockClear();
   });
 
   afterEach(() => {
@@ -163,7 +172,7 @@ describe('makeProjectHandlers', () => {
     expect(tasks.get()).toHaveLength(2);
   });
 
-  test('add surfaces error when clientId is missing', async () => {
+  test('add surfaces error to user via toast when clientId is missing', async () => {
     const projects = makeStubSetter<ProjectLike>([]);
     const handlers = makeProjectHandlers({
       setProjects: projects.setter,
@@ -172,23 +181,19 @@ describe('makeProjectHandlers', () => {
     });
 
     const originalError = console.error;
-    const originalAlert = globalThis.alert;
     console.error = mock(() => {}) as unknown as typeof console.error;
-    const alertMock = mock((_msg?: string) => {});
-    globalThis.alert = alertMock as unknown as typeof globalThis.alert;
     try {
       await handlers.add({ name: 'P', clientId: '', offerId: 'of-1' });
       expect(apiMocks.projectsCreate).not.toHaveBeenCalled();
       expect(projects.get()).toEqual([]);
-      expect(alertMock).toHaveBeenCalledTimes(1);
-      expect((alertMock.mock.calls[0]?.[0] as string) ?? '').toContain('Client is required');
+      expect(toastErrorMock).toHaveBeenCalledTimes(1);
+      expect((toastErrorMock.mock.calls[0]?.[0] as string) ?? '').toContain('Client is required');
     } finally {
       console.error = originalError;
-      globalThis.alert = originalAlert;
     }
   });
 
-  test('add surfaces api error to user', async () => {
+  test('add surfaces api error to user via toast', async () => {
     apiMocks.projectsCreate.mockImplementation(() => Promise.reject(new Error('api down')));
     const projects = makeStubSetter<ProjectLike>([]);
     const handlers = makeProjectHandlers({
@@ -198,18 +203,14 @@ describe('makeProjectHandlers', () => {
     });
 
     const originalError = console.error;
-    const originalAlert = globalThis.alert;
     console.error = mock(() => {}) as unknown as typeof console.error;
-    const alertMock = mock((_msg?: string) => {});
-    globalThis.alert = alertMock as unknown as typeof globalThis.alert;
     try {
       await handlers.add({ name: 'P', clientId: 'c1', orderId: 'order-1', offerId: 'of-1' });
       expect(projects.get()).toEqual([]);
-      expect(alertMock).toHaveBeenCalledTimes(1);
-      expect((alertMock.mock.calls[0]?.[0] as string) ?? '').toContain('api down');
+      expect(toastErrorMock).toHaveBeenCalledTimes(1);
+      expect((toastErrorMock.mock.calls[0]?.[0] as string) ?? '').toContain('api down');
     } finally {
       console.error = originalError;
-      globalThis.alert = originalAlert;
     }
   });
 

--- a/test/handlers/supplierInvoiceHandlers.test.ts
+++ b/test/handlers/supplierInvoiceHandlers.test.ts
@@ -13,6 +13,14 @@ const apiMocks = {
   ),
 };
 
+const toastErrorMock = mock((_message: string) => {});
+
+mock.module('../../utils/toast', () => ({
+  toastError: (message: string) => toastErrorMock(message),
+  toastSuccess: () => {},
+  toast: { error: () => {}, success: () => {}, info: () => {} },
+}));
+
 mock.module('../../services/api', () => ({
   default: {
     supplierInvoices: {
@@ -52,12 +60,10 @@ const makeStubSetter = <T>(initial: T[]) => {
 
 const silenceConsole = () => {
   const originalError = console.error;
-  const originalAlert = globalThis.alert;
   console.error = mock(() => {}) as unknown as typeof console.error;
-  globalThis.alert = mock(() => {}) as unknown as typeof globalThis.alert;
+  toastErrorMock.mockClear();
   return () => {
     console.error = originalError;
-    globalThis.alert = originalAlert;
   };
 };
 
@@ -215,7 +221,7 @@ describe('makeSupplierInvoiceHandlers', () => {
     expect(callArg.total).toBe(0);
   });
 
-  test('createFromOrder alerts and swallows on api error', async () => {
+  test('createFromOrder surfaces error via toast and swallows on api error', async () => {
     apiMocks.supplierInvoicesCreate.mockImplementation(() => Promise.reject(new Error('boom')));
     const invoices = makeStubSetter<SupplierInvoiceLike>([{ id: 'si-existing' }]);
     const setActiveView = mock(() => {});
@@ -236,6 +242,8 @@ describe('makeSupplierInvoiceHandlers', () => {
       } as never);
       expect(invoices.get()).toEqual([{ id: 'si-existing' }]);
       expect(setActiveView).not.toHaveBeenCalled();
+      expect(toastErrorMock).toHaveBeenCalledTimes(1);
+      expect((toastErrorMock.mock.calls[0]?.[0] as string) ?? '').toContain('boom');
     } finally {
       restore();
     }

--- a/test/handlers/userHandlers.test.ts
+++ b/test/handlers/userHandlers.test.ts
@@ -49,6 +49,14 @@ const apiMocks = {
   workUnitsList: mock((): Promise<unknown[]> => Promise.resolve([])),
 };
 
+const toastErrorMock = mock((_message: string) => {});
+
+mock.module('../../utils/toast', () => ({
+  toastError: (message: string) => toastErrorMock(message),
+  toastSuccess: () => {},
+  toast: { error: () => {}, success: () => {}, info: () => {} },
+}));
+
 mock.module('../../services/api', () => ({
   default: {
     users: {
@@ -135,12 +143,10 @@ const buildHandlers = (overrides: Record<string, unknown> = {}) => {
 
 const silenceConsole = () => {
   const originalError = console.error;
-  const originalAlert = globalThis.alert;
   console.error = mock(() => {}) as unknown as typeof console.error;
-  globalThis.alert = mock(() => {}) as unknown as typeof globalThis.alert;
+  toastErrorMock.mockClear();
   return () => {
     console.error = originalError;
-    globalThis.alert = originalAlert;
   };
 };
 
@@ -185,13 +191,15 @@ describe('makeUserHandlers - users', () => {
     expect(ctx.users.get()[0]).toEqual({ id: 'u1', name: 'New' });
   });
 
-  test('updateUser alerts and swallows on error', async () => {
+  test('updateUser surfaces error via toast and swallows', async () => {
     apiMocks.usersUpdate.mockImplementation(() => Promise.reject(new Error('boom')));
     const ctx = buildHandlers({ users: [{ id: 'u1' }] });
     const restore = silenceConsole();
     try {
       await ctx.handlers.updateUser('u1', { name: 'X' });
       expect(ctx.users.get()).toEqual([{ id: 'u1' }]);
+      expect(toastErrorMock).toHaveBeenCalledTimes(1);
+      expect((toastErrorMock.mock.calls[0]?.[0] as string) ?? '').toContain('boom');
     } finally {
       restore();
     }


### PR DESCRIPTION
## Summary
Closes #630.

- Swap the remaining 18 blocking `alert()` calls in [App.tsx](App.tsx), [UserManagement.tsx](components/administration/UserManagement.tsx), [UserAssignmentModal.tsx](components/shared/UserAssignmentModal.tsx), and the six handler modules under [hooks/handlers/](hooks/handlers/) for `toastError()` from [utils/toast.ts](utils/toast.ts), so failures render as themed sonner toasts instead of unstyled, blocking browser modals.
- While editing those catch blocks, replace the unsafe `(err as Error).message` cast with [`getErrorMessage(err)`](utils/errors.ts) at 7 sites so a non-`Error` throw no longer surfaces as `"Failed to …: undefined"`.
- The only remaining `alert(` match in the codebase is the deliberate `javascript:alert(1)` XSS test fixture in `server/test/services/sso.test.ts`.

## Tests
- Add `mock.module('../../utils/toast', …)` to the five affected handler test files and rewrite the assertions that previously checked `globalThis.alert` to verify `toastError` is invoked with the expected message.
- New tests for the error paths in `clientHandlers.delete` and `supplierInvoiceHandlers.createFromOrder`.

## Test plan
- [x] `bun test test/handlers/` → 140 pass, 0 fail
- [x] `bunx --bun biome check` on all touched files → no new warnings (the lone pre-existing `viewingUserId` unused-variable warning in `userHandlers.ts` is untouched and out of scope)
- [ ] Manual: trigger any error path in the UI (e.g. attempt to update settings while the API is down) and confirm a sonner toast appears in place of the old browser modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)