### PR TITLE
ldap(fix): skip sync entries with empty objectName (#639)

### DIFF
--- a/server/services/ldap.ts
+++ b/server/services/ldap.ts
@@ -684,6 +684,11 @@ class LDAPService {
           continue;
         }
 
+        if (!entry.objectName) {
+          logger.warn({ username }, 'Skipping LDAP entry with empty objectName');
+          continue;
+        }
+
         const nameValue: string | string[] | undefined = entry.cn || entry.displayName;
         let name: string;
         if (nameValue) {

--- a/server/test/services/ldap.test.ts
+++ b/server/test/services/ldap.test.ts
@@ -933,6 +933,34 @@ describe('syncUsers', () => {
     expect(result).toEqual({ synced: 0, created: 0 });
   });
 
+  test('skips entries with an empty objectName instead of running username-only group search', async () => {
+    nextFixture = {
+      bindResponses: [null],
+      searchResponses: [
+        {
+          entries: [
+            { objectName: '', object: { uid: 'ghost', cn: 'Ghost Entry' } },
+            { objectName: 'uid=ok,dc=x', object: { uid: 'ok', cn: 'Ok' } },
+          ],
+          status: 0,
+        },
+      ],
+    };
+    findLoginUserByUsernameMock.mockResolvedValue(null);
+    const result = await ldapService.syncUsers();
+    expect(result).toEqual({ synced: 0, created: 1 });
+    expect(createUserMock).toHaveBeenCalledTimes(1);
+    const created = createUserMock.mock.calls[0]?.[0] as { username: string };
+    expect(created.username).toBe('ok');
+    // The empty-objectName entry must NOT trigger a follow-up group search keyed on username only.
+    const groupSearchCalls = lastClientStats?.searchCalls.filter(
+      (call) => call.base === ENABLED_LDAP_CONFIG.groupBaseDn,
+    );
+    expect(groupSearchCalls?.some((call) => String(call.options.filter).includes('ghost'))).toBe(
+      false,
+    );
+  });
+
   test('skips entries without a username (no uid and no sAMAccountName)', async () => {
     nextFixture = {
       bindResponses: [null],


### PR DESCRIPTION
Closes #639.

## Summary
- During `syncUsers`, entries are pushed with `objectName: entry.objectName?.toString() ?? ''`. If the raw value is empty (malformed entry, or a `toString()` that yields `''`), the stored DN becomes `''`.
- `findUserGroups` then filters the empty DN out of its `searchValues` and falls back to a single username-only search. For `member=<DN>` group filters that returns zero groups, and `applyExternalRolesForUserIfMatched` silently preserves whatever role the user currently has — periodic sync stops refreshing role mappings for the affected entries and operators get no signal anything is wrong.
- Fix: detect `!entry.objectName` right after the existing missing-username skip and `continue` with a `logger.warn`. Mirrors the sibling guard a few lines above; affects both the existing-user and `autoProvisionAll` paths.

## Test plan
- [x] New unit test in `server/test/services/ldap.test.ts` feeds one empty-`objectName` entry alongside a valid one and asserts: only the valid entry is created (`created: 1`), and no group search filter ever contains the ghost username — i.e. the username-only fallback never runs.
- [x] Verified the test fails on `main` (`created: 2`, ghost auto-provisioned + username-only group search issued) and passes with the fix.
- [x] `bun test test/services/ldap.test.ts` — 67 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)