### PR TITLE
ldap(fix): persist only validated CERTIFICATE blocks in tlsCaCertificate (#643)

### DIFF
--- a/server/routes/ldap.ts
+++ b/server/routes/ldap.ts
@@ -60,7 +60,10 @@ const parseTlsCaForPatch = (
       return { ok: false, message: 'tlsCaCertificate is not a valid PEM certificate' };
     }
   }
-  return { ok: true, patch: { tlsCaCertificate: normalized } };
+  // Persist only validated CERTIFICATE blocks; drop comments, stray text, or an
+  // accidentally-pasted PRIVATE KEY block instead of writing them to the DB.
+  const sanitized = `${blocks.join('\n')}\n`;
+  return { ok: true, patch: { tlsCaCertificate: sanitized } };
 };
 
 const roleMappingSchema = {

--- a/server/test/routes/ldap.test.ts
+++ b/server/test/routes/ldap.test.ts
@@ -113,19 +113,24 @@ const allMocks = [
 
 let testApp: FastifyInstance;
 let validPemCert: string;
+let validPemCert2: string;
 
 beforeAll(async () => {
-  // Generate a real, parseable self-signed cert once per file. `selfsigned.generate` is async
+  // Generate real, parseable self-signed certs once per file. `selfsigned.generate` is async
   // when called without a callback. Using `selfsigned` (already a server dependency for the
   // dev HTTPS cert) avoids hand-rolled fake PEMs that X509Certificate would correctly reject.
   // `days` is supported at runtime but missing from the package's TS typing.
-  const pems = await selfsigned.generate([{ name: 'commonName', value: 'praetor-test-ca' }], {
-    keySize: 2048,
-    days: 1,
-  } as Parameters<typeof selfsigned.generate>[1]);
+  type SelfsignedOpts = Parameters<typeof selfsigned.generate>[1];
+  const opts: SelfsignedOpts = { keySize: 2048, days: 1 } as SelfsignedOpts;
+  const [pems, pems2] = await Promise.all([
+    selfsigned.generate([{ name: 'commonName', value: 'praetor-test-ca' }], opts),
+    selfsigned.generate([{ name: 'commonName', value: 'praetor-test-ca-2' }], opts),
+  ]);
   validPemCert = pems.cert;
-  // Sanity check: the generated PEM must round-trip through node:crypto.
+  validPemCert2 = pems2.cert;
+  // Sanity check: the generated PEMs must round-trip through node:crypto.
   new X509Certificate(validPemCert);
+  new X509Certificate(validPemCert2);
 });
 
 beforeEach(async () => {
@@ -487,6 +492,31 @@ describe('PUT /api/ldap/config - tlsCaCertificate', () => {
     expect(response.statusCode).toBe(400);
     expect(ldapUpdateMock).not.toHaveBeenCalled();
     expect(JSON.parse(response.body).error).toMatch(/not a valid PEM certificate/i);
+  });
+
+  test('strips non-CERTIFICATE blocks (incl. accidental PRIVATE KEY) and surrounding text before persistence', async () => {
+    const accidentalPrivateKey =
+      '-----BEGIN PRIVATE KEY-----\nMIIBVQIBADANBgkqhkiG9w0BAQEFAASCAT8wggE7AgEAAkEA\n-----END PRIVATE KEY-----';
+    const payload = [
+      '# operator note: trust chain assembled 2026-05-16',
+      validPemCert.trim(),
+      'free-text-between-blocks',
+      accidentalPrivateKey,
+      validPemCert2.trim(),
+      '# trailing comment',
+    ].join('\n');
+
+    const response = await putConfig({ enabled: false, tlsCaCertificate: payload });
+
+    expect(response.statusCode).toBe(200);
+    expect(ldapUpdateMock).toHaveBeenCalledTimes(1);
+    const patch = ldapUpdateMock.mock.calls[0][0] as Partial<realLdapRepo.LdapConfig>;
+    const persisted = patch.tlsCaCertificate ?? '';
+    expect(persisted.match(/-----BEGIN CERTIFICATE-----/g)?.length).toBe(2);
+    expect(persisted.match(/-----END CERTIFICATE-----/g)?.length).toBe(2);
+    expect(persisted).not.toMatch(
+      /PRIVATE KEY|operator note|free-text-between-blocks|trailing comment/,
+    );
   });
 
   test('successful update invalidates the LDAP service config cache', async () => {


### PR DESCRIPTION
## Summary

Fixes [#643](https://github.com/xBounceIT/praetor/issues/643).

`parseTlsCaForPatch` in [server/routes/ldap.ts](server/routes/ldap.ts) extracted `CERTIFICATE` PEM blocks and validated each one with `X509Certificate`, but then persisted the raw normalized input. If an operator assembling a CA chain accidentally pasted a `PRIVATE KEY` block — or comments, stray text, etc. — it would land in `ldap_config.tls_ca_certificate`. Node's TLS layer ignored the extras, but they sat unintentionally in the DB, backups, and audit dumps.

The fix returns `blocks.join('\n') + '\n'` — only validated `CERTIFICATE` blocks survive; everything else is dropped.

## Changes

- [server/routes/ldap.ts](server/routes/ldap.ts): join validated blocks instead of returning the normalized raw input.
- [server/test/routes/ldap.test.ts](server/test/routes/ldap.test.ts): regression test that pastes `[comment, cert1, free text, PRIVATE KEY, cert2, trailing comment]` and asserts only the two `CERTIFICATE` blocks survive (verified to fail on pre-fix code, pass on the fix). Second self-signed cert hoisted into the existing `beforeAll` and generated in parallel with the first via `Promise.all` — no per-test keygen overhead.

## Test plan

- [x] `bun test test/routes/ldap.test.ts` (in `server/`) — 34/34 pass
- [x] `bunx biome check server/routes/ldap.ts server/test/routes/ldap.test.ts` clean
- [x] `bunx tsc -p server/tsconfig.json --noEmit` clean
- [x] Verified the new test fails on the pre-fix `tlsCaCertificate: normalized` code (it caught the leaked `PRIVATE KEY` block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)