### PR TITLE
ldap(fix): race recovery uses with-default helper for consistency (#641)

### DIFF
--- a/server/services/ldap.ts
+++ b/server/services/ldap.ts
@@ -403,18 +403,12 @@ class LDAPService {
       if (isUniqueViolationError(err)) {
         const racedUser = await usersRepo.findLoginUserByUsername(canonicalUsername);
         if (racedUser && racedUser.employeeType === 'app_user' && racedUser.authMethod === 'ldap') {
-          const applied = await applyExternalRolesForUserIfMatched(
-            racedUser.id,
-            result.groups,
-            roleMappings,
-          );
-          if (!applied.applied) {
-            warnRoleMappingNoMatch(
-              'LDAP login (race recovery)',
-              { id: racedUser.id, username: canonicalUsername, role: racedUser.role },
-              result.groups,
-            );
-          }
+          // Race recovery is functionally a fresh first-login for the loser: use the same
+          // with-default helper as the winner's create path below (#641), so the loser's
+          // group view always materializes into user_roles even if it diverges from the
+          // winner's view. Using the IfMatched variant here would silently drop the loser's
+          // groups when their bind returned no matched mapping.
+          await applyExternalRolesForUser(racedUser.id, result.groups, roleMappings);
           return {
             authenticated: true,
             userId: racedUser.id,

--- a/server/test/services/ldap.test.ts
+++ b/server/test/services/ldap.test.ts
@@ -1343,6 +1343,29 @@ describe('authenticateAndProvision', () => {
     });
   });
 
+  test('race recovery applies roles via the with-default helper (#641), matching the winner path', async () => {
+    nextFixture = {
+      bindResponses: [null, null],
+      searchResponses: [
+        {
+          entries: [
+            { objectName: 'uid=alice,dc=test,dc=com', object: { uid: 'alice', cn: 'Alice' } },
+          ],
+          status: 0,
+        },
+        { entries: [], status: 0 }, // loser sees no groups
+      ],
+    };
+    findLoginUserByUsernameMock.mockResolvedValueOnce(null).mockResolvedValueOnce(LDAP_LOGIN_USER);
+    const uniqueErr = Object.assign(new Error('duplicate key'), { code: '23505' });
+    createUserMock.mockRejectedValueOnce(uniqueErr);
+
+    await ldapService.authenticateAndProvision('alice', 'pw');
+
+    expect(applyExternalRolesForUserMock).toHaveBeenCalledWith(LDAP_LOGIN_USER.id, [], []);
+    expect(applyExternalRolesForUserIfMatchedMock).not.toHaveBeenCalled();
+  });
+
   test('uses displayName when cn is absent', async () => {
     nextFixture = {
       bindResponses: [null, null],


### PR DESCRIPTION
## Summary
- Fix [#641](https://github.com/xBounceIT/praetor/issues/641): the race-recovery branch in `authenticateAndProvision` used `applyExternalRolesForUserIfMatched` (no-default), while the winner's create path used `applyExternalRolesForUser` (with-default). On concurrent first logins, if the loser's LDAP group view returned no matched mappings, the loser's groups were silently dropped — non-deterministic role outcomes that are hard to reproduce.
- Recovery is functionally a fresh first-login for the loser, so it now calls the same with-default helper as the winner's create path. Added a comment documenting the policy and the `#641` reference so a future reader doesn't flip it back.
- Removed the now-dead `warnRoleMappingNoMatch` call in this branch — the with-default helper always writes (the winner path doesn't warn either).

## Test plan
- [x] New regression test in `server/test/services/ldap.test.ts` simulates the unique-violation recovery path and asserts `applyExternalRolesForUser` is invoked (and `applyExternalRolesForUserIfMatched` is not). Fails on old code; passes on the fix.
- [x] `bun test` in `server/`: 2770 pass, 28 skip, 0 fail.
- [x] `bun run build` (tsc): clean.

Fixes #641

🤖 Generated with [Claude Code](https://claude.com/claude-code)