### PR TITLE
ldap(perf): parallelize findUserGroups identifier lookups (#645)

### DIFF
--- a/server/services/ldap.ts
+++ b/server/services/ldap.ts
@@ -550,55 +550,52 @@ class LDAPService {
     const groups = new Set<string>();
     const username = usernameList[0] ?? userDn;
 
-    for (const searchValue of searchValues) {
-      let searchOptions: {
-        scope: 'sub';
-        filter: ReturnType<typeof buildGroupLookupFilter>;
-        attributes: string[];
-      };
-
-      try {
-        searchOptions = {
-          scope: 'sub',
-          filter: buildGroupLookupFilter(config.groupFilter, searchValue),
-          attributes: ['cn', 'dn', 'distinguishedName'],
+    const searchFor = (searchValue: string) =>
+      new Promise<void>((resolve, reject) => {
+        let searchOptions: {
+          scope: 'sub';
+          filter: ReturnType<typeof buildGroupLookupFilter>;
+          attributes: string[];
         };
-      } catch (err) {
-        if (options.throwOnError) throw err;
-        if (groups.size > 0) return [...groups];
-        logger.warn(
-          { err: serializeError(err), username },
-          'LDAP group filter is invalid; skipping group role mapping',
-        );
-        return [];
-      }
-
-      try {
-        await new Promise<void>((resolve, reject) => {
-          client.search(config.groupBaseDn, searchOptions, (err, res) => {
-            if (err) return reject(err);
-
-            res.on('searchEntry', (entry: LdapSearchEntry) => {
-              const objectName = entry.objectName?.toString();
-              const attributes = flattenSearchEntryAttributes(entry);
-              addGroupEntryAliases(groups, attributes, objectName);
-            });
-
-            res.on('error', (err: Error) => reject(err));
-            res.on('end', () => resolve());
+        try {
+          searchOptions = {
+            scope: 'sub',
+            filter: buildGroupLookupFilter(config.groupFilter, searchValue),
+            attributes: ['cn', 'dn', 'distinguishedName'],
+          };
+        } catch (err) {
+          return reject(err);
+        }
+        client.search(config.groupBaseDn, searchOptions, (err, res) => {
+          if (err) return reject(err);
+          res.on('searchEntry', (entry: LdapSearchEntry) => {
+            const objectName = entry.objectName?.toString();
+            const attributes = flattenSearchEntryAttributes(entry);
+            addGroupEntryAliases(groups, attributes, objectName);
           });
+          res.on('error', (err: Error) => reject(err));
+          res.on('end', () => resolve());
         });
-      } catch (err) {
-        if (options.throwOnError) throw err;
-        if (groups.size > 0) return [...groups];
+      });
+
+    // Issue identifier searches in parallel. Mixed configs like
+    // `(|(member={0})(memberUid={0}))` need results unioned across DN and uid
+    // forms — a short-circuit would silently drop the groups that only the
+    // second form matches.
+    if (options.throwOnError) {
+      await Promise.all(searchValues.map(searchFor));
+      return [...groups];
+    }
+    const results = await Promise.allSettled(searchValues.map(searchFor));
+    if (groups.size === 0) {
+      const failure = results.find((r): r is PromiseRejectedResult => r.status === 'rejected');
+      if (failure) {
         logger.warn(
-          { err: serializeError(err), username },
+          { err: serializeError(failure.reason), username },
           'LDAP group lookup failed; skipping group role mapping',
         );
-        return [];
       }
     }
-
     return [...groups];
   }
 

--- a/server/test/services/ldap.test.ts
+++ b/server/test/services/ldap.test.ts
@@ -1135,6 +1135,36 @@ describe('lookupUserGroups', () => {
     expect(result).toBeNull();
     expect(lastClientStats?.unbindCalls).toBe(1);
   });
+
+  test('issues identifier searches in parallel and unions groups across forms', async () => {
+    // Mixed-filter config: one group lists the user by DN under `member`, the
+    // other by uid under `memberUid`. Each identifier-form search matches only
+    // one group; the result must contain both.
+    const dnGroup = 'cn=dn-matched,ou=groups,dc=test,dc=com';
+    const uidGroup = 'cn=uid-matched,ou=groups,dc=test,dc=com';
+    ldapRepoGetMock.mockResolvedValue({
+      ...ENABLED_LDAP_CONFIG,
+      groupFilter: '(|(member={0})(memberUid={0}))',
+    });
+    nextFixture = {
+      bindResponses: [null],
+      searchResponses: [
+        {
+          entries: [{ objectName: 'uid=alice,dc=test,dc=com', object: { uid: 'alice' } }],
+          status: 0,
+        },
+        { entries: [{ objectName: dnGroup, object: { cn: 'dn-matched' } }], status: 0 },
+        { entries: [{ objectName: uidGroup, object: { cn: 'uid-matched' } }], status: 0 },
+      ],
+    };
+
+    const result = await ldapService.lookupUserGroups('alice');
+
+    expect(result?.groups).toContain(dnGroup);
+    expect(result?.groups).toContain(uidGroup);
+    // One user lookup + two parallel group searches (DN form + uid form).
+    expect(lastClientStats?.searchCalls).toHaveLength(3);
+  });
 });
 
 describe('authenticateAndProvision', () => {

--- a/server/test/services/ldap.test.ts
+++ b/server/test/services/ldap.test.ts
@@ -592,6 +592,36 @@ describe('authenticate', () => {
     expect(result.matchedRoleIds).toEqual(['admin']);
   });
 
+  test('returns empty groups when every parallel group search fails (non-strict auth path)', async () => {
+    ldapRepoGetMock.mockResolvedValue({
+      ...ENABLED_LDAP_CONFIG,
+      groupFilter: '(member={0})',
+    });
+    nextFixture = {
+      bindResponses: [null, null, null],
+      searchResponses: [
+        {
+          entries: [
+            {
+              objectName: "CN=Daniel D'Angeli,OU=Internal Accounts,OU=Accounts,DC=syncsec,DC=coll",
+              object: { sAMAccountName: 'daniel.dangeli' },
+            },
+          ],
+          status: 0,
+        },
+        { err: new Error('first group search failed') },
+        { err: new Error('second group search failed') },
+      ],
+    };
+
+    const result = await ldapService.authenticateWithProfile('daniel.dangeli', 'pw');
+
+    // Auth still succeeds — the credential check passed — but no groups can be mapped.
+    expect(result.authenticated).toBe(true);
+    expect(result.groups).toEqual([]);
+    expect(result.matchedRoleIds).toEqual([]);
+  });
+
   test('rejects when the user-search stream emits an error (LDAP outage during search)', async () => {
     nextFixture = {
       bindResponses: [null],


### PR DESCRIPTION
## Summary
- Closes #645. `findUserGroups` ran one LDAP search per identifier (`userDn`, canonical username, typed username) in a serial `for await` loop — 2–3 sequential round trips on every `/login`.
- Switched to parallel execution: `Promise.all` (strict, `throwOnError`) or `Promise.allSettled` (lenient) over `searchValues.map(searchFor)`. All forms now complete in one round-trip's wall time and results are unioned into the existing `groups` Set.
- Rejected the simpler short-circuit option suggested in the issue: the comment at [server/services/ldap.ts:305-307](https://github.com/xBounceIT/praetor/blob/main/server/services/ldap.ts#L305-L307) explicitly documents that multiple identifier forms exist for *correctness*, not just fallback — configs like `(|(member={0})(memberUid={0}))` need both DN-form and uid-form searches to find all groups, so short-circuiting would silently drop groups.

## Why parallel and not short-circuit
A short-circuit ("once one form returns groups, stop") is strictly faster but semantically lossy. A mixed config where group A lists the user by DN under `member` and group B lists the user by uid under `memberUid` would lose B whenever A is found first. Parallelization preserves the existing union semantics and still removes the wasted-round-trip cost the issue targeted.

## Error handling
- `throwOnError: true` (used by `lookupUserGroups`): `Promise.all` rejects on the first failure, so a transient group-search error still surfaces as `null` for the caller and the user keeps their existing role. Behavior unchanged vs. the serial loop.
- `throwOnError: false` (the auth path): `Promise.allSettled` collects partial successes. If at least one search returned groups, those are returned; if all failed, a single warn log is emitted and `[]` is returned. The pre-fix code logged once per failed iteration; the new code logs once total, which is a minor improvement.

## Tests
- Restored `returns null on fallback group-search errors in strict lookup mode` — confirms `Promise.all` + `throwOnError` still rejects on any failure.
- Added `issues identifier searches in parallel and unions groups across forms` — fixture has one DN-matched group and one uid-matched group; assertion that both appear in the result. This test would fail under a short-circuit implementation.
- 169/169 server service tests pass (67 LDAP).

## Test plan
- [x] `bun test test/services/ldap.test.ts` — 67 pass
- [x] `bun test test/services/` — 169 pass
- [ ] Smoke-test `/login` against a real LDAP backend (deferred — backend test rig only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)