### PR TITLE
auth(fix): throw on LDAP group-search failure to prevent silent role demotion (#637)

### DIFF
--- a/server/services/ldap.ts
+++ b/server/services/ldap.ts
@@ -304,8 +304,11 @@ class LDAPService {
 
       // Search groups under both the canonical and typed identifiers so configs whose
       // groupFilter expects e.g. `memberUid={0}` work even when the user typed an alias
-      // (email/UPN) that userFilter accepted.
-      const groups = await this.findUserGroups(ldapClient, userDn, [canonicalUsername, username]);
+      // (email/UPN) that userFilter accepted. throwOnError: a transient subtree error
+      // returning [] would silently demote new admins/managers to the default role (#637).
+      const groups = await this.findUserGroups(ldapClient, userDn, [canonicalUsername, username], {
+        throwOnError: true,
+      });
 
       return {
         authenticated: true,

--- a/server/test/services/ldap.test.ts
+++ b/server/test/services/ldap.test.ts
@@ -480,7 +480,10 @@ describe('authenticate', () => {
     expect(String(search?.options.filter)).toBe('(uid=alice)');
   });
 
-  test('invalid stored group filter does not block a valid LDAP bind', async () => {
+  test('rejects when stored group filter is invalid (no silent default-role demote)', async () => {
+    // Strict-mode findUserGroups (post-#637) surfaces the build-filter error so the
+    // /login route returns 503. The alternative — auth-with-empty-groups — would
+    // silently create new admins as 'user' until the operator notices the bad config.
     ldapRepoGetMock.mockResolvedValue({
       ...ENABLED_LDAP_CONFIG,
       groupFilter: '(member=uid=alice,dc=test,dc=com)',
@@ -495,11 +498,7 @@ describe('authenticate', () => {
       ],
     };
 
-    const result = await ldapService.authenticateWithProfile('alice', 'pw');
-
-    expect(result.authenticated).toBe(true);
-    expect(result.groups).toEqual([]);
-    expect(result.matchedRoleIds).toEqual([]);
+    await expect(ldapService.authenticateWithProfile('alice', 'pw')).rejects.toThrow(/groupFilter/);
   });
 
   test('maps AD groups from the configured group search base and filter', async () => {
@@ -558,41 +557,9 @@ describe('authenticate', () => {
     ]);
   });
 
-  test('keeps groups found before a later non-strict fallback search fails', async () => {
-    const syncSecAdmins = 'CN=SyncSecAdmins,OU=Internal Groups,OU=Accounts,DC=syncsec,DC=coll';
-    ldapRepoGetMock.mockResolvedValue({
-      ...ENABLED_LDAP_CONFIG,
-      groupFilter: '(member={0})',
-      roleMappings: [{ ldapGroup: syncSecAdmins, role: 'admin' }],
-    });
-    nextFixture = {
-      bindResponses: [null, null, null],
-      searchResponses: [
-        {
-          entries: [
-            {
-              objectName: "CN=Daniel D'Angeli,OU=Internal Accounts,OU=Accounts,DC=syncsec,DC=coll",
-              object: { sAMAccountName: 'daniel.dangeli' },
-            },
-          ],
-          status: 0,
-        },
-        {
-          entries: [{ objectName: syncSecAdmins, object: { distinguishedName: syncSecAdmins } }],
-          status: 0,
-        },
-        { err: new Error('fallback group search failed') },
-      ],
-    };
-
-    const result = await ldapService.authenticateWithProfile('daniel.dangeli', 'pw');
-
-    expect(result.authenticated).toBe(true);
-    expect(result.groups).toContain(syncSecAdmins);
-    expect(result.matchedRoleIds).toEqual(['admin']);
-  });
-
-  test('returns empty groups when every parallel group search fails (non-strict auth path)', async () => {
+  test('rejects when any parallel group search fails (strict auth path, #637)', async () => {
+    // Auth uses strict findUserGroups so a transient subtree failure surfaces as a 503
+    // instead of returning [] and demoting new admins to the default role.
     ldapRepoGetMock.mockResolvedValue({
       ...ENABLED_LDAP_CONFIG,
       groupFilter: '(member={0})',
@@ -614,12 +581,9 @@ describe('authenticate', () => {
       ],
     };
 
-    const result = await ldapService.authenticateWithProfile('daniel.dangeli', 'pw');
-
-    // Auth still succeeds — the credential check passed — but no groups can be mapped.
-    expect(result.authenticated).toBe(true);
-    expect(result.groups).toEqual([]);
-    expect(result.matchedRoleIds).toEqual([]);
+    await expect(ldapService.authenticateWithProfile('daniel.dangeli', 'pw')).rejects.toThrow(
+      /group search failed/,
+    );
   });
 
   test('rejects when the user-search stream emits an error (LDAP outage during search)', async () => {
@@ -1162,7 +1126,11 @@ describe('lookupUserGroups', () => {
     expect(lastClientStats?.unbindCalls).toBe(1);
   });
 
-  test('returns null on fallback group-search errors in strict lookup mode', async () => {
+  test('returns null when any parallel group-search errors (strict lookup)', async () => {
+    // Strict-mode Promise.all rejects on any failure, so a fallback-identifier error
+    // — even after another identifier search returned groups — surfaces as null.
+    // The caller (admin auth-method toggle) then preserves the user's existing role
+    // rather than overwriting it from partial data.
     const syncSecAdmins = 'CN=SyncSecAdmins,OU=Internal Groups,OU=Accounts,DC=syncsec,DC=coll';
     ldapRepoGetMock.mockResolvedValue({
       ...ENABLED_LDAP_CONFIG,
@@ -1246,6 +1214,31 @@ describe('authenticateAndProvision', () => {
     nextFixture = { bindResponses: [new Error('bad creds')] };
     await expect(ldapService.authenticateAndProvision('alice', 'pw')).rejects.toThrow('bad creds');
     expect(createUserMock).not.toHaveBeenCalled();
+  });
+
+  test('rejects when group search throws — no silent demote on first login (#637)', async () => {
+    // Without the throw, an empty group list would map to [DEFAULT_ROLE_ID], silently
+    // demoting an admin/manager. The /login route turns this throw into a 503.
+    nextFixture = {
+      bindResponses: [null, null, null],
+      searchResponses: [
+        {
+          entries: [
+            { objectName: 'uid=alice,dc=test,dc=com', object: { uid: 'alice', cn: 'Alice' } },
+          ],
+          status: 0,
+        },
+        // First group search (by userDn) fails before any groups are collected → throw.
+        { err: new Error('group subtree timeout') },
+      ],
+    };
+    findLoginUserByUsernameMock.mockResolvedValue(null);
+
+    await expect(ldapService.authenticateAndProvision('alice', 'pw')).rejects.toThrow(
+      'group subtree timeout',
+    );
+    expect(createUserMock).not.toHaveBeenCalled();
+    expect(applyExternalRolesForUserMock).not.toHaveBeenCalled();
   });
 
   test('creates a new app_user using the canonical uid (not the typed alias)', async () => {


### PR DESCRIPTION
## Summary

Fixes #637 — LDAP first-login provisioning silently demotes admins/managers to the default `'user'` role when a transient group-subtree failure occurs.

`authenticateWithProfile` now passes `throwOnError: true` to `findUserGroups`, so a transient group-search failure propagates up and the `/login` route's existing handler maps it to `503 ldap_unavailable` (same path as the #368 regression). With [#683](https://github.com/xBounceIT/praetor/pull/683) on main, strict mode is `Promise.all` — throws on any rejection — so behavior is consistent for all callers (`lookupUserGroups` already used strict mode and was unaffected by #637).

## Why

Before this fix, `authenticateWithProfile` called `findUserGroups` in non-strict mode. A transient timeout / referral / ACL on `groupBaseDn` was swallowed and returned `[]`. `authenticateAndProvision` then ran `mapExternalGroupsToRoleIds([], …)` → `[DEFAULT_ROLE_ID]` and created the new user with role `'user'`. Subsequent logins used `applyExternalRoleIdsForUserIfMatched`, which preserves the wrong role — so the demotion was sticky until an admin intervened. There was no audit signal.

`lookupUserGroups` already passed `throwOnError: true` for exactly this reason; the auth path was the missing companion.

## Behavior change for misconfigured `groupFilter`

A saved invalid `groupFilter` (e.g., missing `{0}` placeholder) now causes `/login` to return 503 instead of letting users in with no groups mapped. This is the deliberate trade-off: silent default-role assignment for new admins (today) vs. visible denial-of-service until the operator fixes the config (after fix). Failing loudly is the safer default — the test `rejects when stored group filter is invalid (no silent default-role demote)` pins this in.

## Test plan

- [x] `bun test test/services/ldap.test.ts` — 70/70 pass, including new `authenticateAndProvision > rejects when group search throws — no silent demote on first login (#637)`
- [x] `bun test test/routes/auth.test.ts` — pass; existing `503 ldap_unavailable` regression (#368 family) still covers the route-level contract
- [x] `bun test` (full server suite) — 2774/2774 pass
- [x] Biome clean on touched files

## Note for reviewer

Rebased onto current main after [#683](https://github.com/xBounceIT/praetor/pull/683) landed. The runtime change is now a one-line argument addition; the test updates reflect the new strict-mode semantics on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)