### PR TITLE
data-integrity(fix): block PK mutation through generic update() (#621)

### DIFF
--- a/server/repositories/clientOffersRepo.ts
+++ b/server/repositories/clientOffersRepo.ts
@@ -268,7 +268,6 @@ export const create = async (
 };
 
 export type ClientOfferUpdate = {
-  id?: string | null;
   clientId?: string | null;
   clientName?: string | null;
   paymentTerms?: string | null;
@@ -321,7 +320,6 @@ export const update = async (
   const [row] = await exec
     .update(customerOffers)
     .set({
-      id: sql`COALESCE(${patch.id ?? null}, ${customerOffers.id})`,
       clientId: sql`COALESCE(${patch.clientId ?? null}, ${customerOffers.clientId})`,
       clientName: sql`COALESCE(${patch.clientName ?? null}, ${customerOffers.clientName})`,
       paymentTerms: sql`COALESCE(${patch.paymentTerms ?? null}, ${customerOffers.paymentTerms})`,
@@ -334,6 +332,21 @@ export const update = async (
       updatedAt: sql`CURRENT_TIMESTAMP`,
     })
     .where(eq(customerOffers.id, id))
+    .returning();
+  return row ? mapOffer(row) : null;
+};
+
+// Separate from update() so generic patches can't mutate the PK (issue #621). Relies on
+// ON UPDATE CASCADE on every incoming FK; see server/test/db/renamablePkFkCascade.test.ts.
+export const rename = async (
+  currentId: string,
+  newId: string,
+  exec: DbExecutor = db,
+): Promise<ClientOffer | null> => {
+  const [row] = await exec
+    .update(customerOffers)
+    .set({ id: newId, updatedAt: sql`CURRENT_TIMESTAMP` })
+    .where(eq(customerOffers.id, currentId))
     .returning();
   return row ? mapOffer(row) : null;
 };

--- a/server/repositories/clientQuotesRepo.ts
+++ b/server/repositories/clientQuotesRepo.ts
@@ -394,7 +394,6 @@ export const create = async (
 };
 
 export type ClientQuoteUpdate = {
-  id?: string | null;
   clientId?: string | null;
   clientName?: string | null;
   paymentTerms?: string | null;
@@ -421,7 +420,6 @@ export const update = async (
   const rows = await exec
     .update(quotes)
     .set({
-      id: sql`COALESCE(${patch.id ?? null}, ${quotes.id})`,
       clientId: sql`COALESCE(${patch.clientId ?? null}, ${quotes.clientId})`,
       clientName: sql`COALESCE(${patch.clientName ?? null}, ${quotes.clientName})`,
       paymentTerms: sql`COALESCE(${patch.paymentTerms ?? null}, ${quotes.paymentTerms})`,
@@ -433,6 +431,21 @@ export const update = async (
       updatedAt: sql`CURRENT_TIMESTAMP`,
     })
     .where(eq(quotes.id, id))
+    .returning(QUOTE_BASE_PROJECTION);
+  return rows[0] ? mapQuote(rows[0]) : null;
+};
+
+// Separate from update() so generic patches can't mutate the PK (issue #621). Relies on
+// ON UPDATE CASCADE on every incoming FK; see server/test/db/renamablePkFkCascade.test.ts.
+export const rename = async (
+  currentId: string,
+  newId: string,
+  exec: DbExecutor = db,
+): Promise<ClientQuote | null> => {
+  const rows = await exec
+    .update(quotes)
+    .set({ id: newId, updatedAt: sql`CURRENT_TIMESTAMP` })
+    .where(eq(quotes.id, currentId))
     .returning(QUOTE_BASE_PROJECTION);
   return rows[0] ? mapQuote(rows[0]) : null;
 };

--- a/server/repositories/clientsOrdersRepo.ts
+++ b/server/repositories/clientsOrdersRepo.ts
@@ -275,7 +275,6 @@ export const create = async (
 };
 
 export type ClientOrderUpdate = {
-  id?: string;
   linkedOfferId?: string | null;
   linkedQuoteId?: string | null;
   clientId?: string;
@@ -289,7 +288,6 @@ export type ClientOrderUpdate = {
 
 const orderUpdateValues = (patch: ClientOrderUpdate) => {
   const set: Record<string, unknown> = {};
-  if (patch.id !== undefined) set.id = patch.id;
   if (patch.linkedOfferId !== undefined) set.linkedOfferId = patch.linkedOfferId;
   if (patch.linkedQuoteId !== undefined) set.linkedQuoteId = patch.linkedQuoteId;
   if (patch.clientId !== undefined) set.clientId = patch.clientId;
@@ -312,6 +310,21 @@ export const update = async (
     .update(sales)
     .set(orderUpdateValues(patch))
     .where(eq(sales.id, id))
+    .returning();
+  return rows[0] ? mapOrder(rows[0]) : null;
+};
+
+// Separate from update() so generic patches can't mutate the PK (issue #621). Relies on
+// ON UPDATE CASCADE on every incoming FK; see server/test/db/renamablePkFkCascade.test.ts.
+export const rename = async (
+  currentId: string,
+  newId: string,
+  exec: DbExecutor = db,
+): Promise<ClientOrder | null> => {
+  const rows = await exec
+    .update(sales)
+    .set({ id: newId, updatedAt: sql`CURRENT_TIMESTAMP` })
+    .where(eq(sales.id, currentId))
     .returning();
   return rows[0] ? mapOrder(rows[0]) : null;
 };

--- a/server/repositories/invoicesRepo.ts
+++ b/server/repositories/invoicesRepo.ts
@@ -229,7 +229,6 @@ export const create = async (input: NewInvoice, exec: DbExecutor = db): Promise<
 };
 
 export type InvoiceUpdate = {
-  id?: string;
   clientId?: string;
   clientName?: string;
   issueDate?: string;
@@ -244,7 +243,6 @@ export type InvoiceUpdate = {
 
 const invoiceUpdateValues = (patch: InvoiceUpdate) => {
   const set: Record<string, unknown> = {};
-  if (patch.id !== undefined) set.id = patch.id;
   if (patch.clientId !== undefined) set.clientId = patch.clientId;
   if (patch.clientName !== undefined) set.clientName = patch.clientName;
   if (patch.issueDate !== undefined) set.issueDate = patch.issueDate;
@@ -281,6 +279,22 @@ export const updateDraft = async (
     .update(invoices)
     .set(invoiceUpdateValues(patch))
     .where(and(eq(invoices.id, id), eq(invoices.status, 'draft')))
+    .returning();
+  return rows[0] ? mapInvoice(rows[0]) : null;
+};
+
+// Separate from updateDraft() so generic patches can't mutate the PK (issue #621). The
+// draft-only predicate keeps non-draft invoices immutable. Relies on ON UPDATE CASCADE on
+// every incoming FK; see server/test/db/renamablePkFkCascade.test.ts.
+export const renameDraft = async (
+  currentId: string,
+  newId: string,
+  exec: DbExecutor = db,
+): Promise<Invoice | null> => {
+  const rows = await exec
+    .update(invoices)
+    .set({ id: newId, updatedAt: sql`CURRENT_TIMESTAMP` })
+    .where(and(eq(invoices.id, currentId), eq(invoices.status, 'draft')))
     .returning();
   return rows[0] ? mapInvoice(rows[0]) : null;
 };

--- a/server/repositories/supplierInvoicesRepo.ts
+++ b/server/repositories/supplierInvoicesRepo.ts
@@ -216,7 +216,6 @@ export const create = async (
 };
 
 export type SupplierInvoiceUpdate = {
-  id?: string;
   supplierId?: string;
   supplierName?: string;
   issueDate?: string;
@@ -242,7 +241,6 @@ export const update = async (
   const [row] = await exec
     .update(supplierInvoices)
     .set({
-      id: sql`COALESCE(${patch.id ?? null}, ${supplierInvoices.id})`,
       supplierId: sql`COALESCE(${patch.supplierId ?? null}, ${supplierInvoices.supplierId})`,
       supplierName: sql`COALESCE(${patch.supplierName ?? null}, ${supplierInvoices.supplierName})`,
       issueDate: sql`COALESCE(${patch.issueDate ?? null}::date, ${supplierInvoices.issueDate})`,
@@ -255,6 +253,21 @@ export const update = async (
       updatedAt: sql`CURRENT_TIMESTAMP`,
     })
     .where(eq(supplierInvoices.id, id))
+    .returning();
+  return row ? mapInvoice(row) : null;
+};
+
+// Separate from update() so generic patches can't mutate the PK (issue #621). Relies on
+// ON UPDATE CASCADE on every incoming FK; see server/test/db/renamablePkFkCascade.test.ts.
+export const rename = async (
+  currentId: string,
+  newId: string,
+  exec: DbExecutor = db,
+): Promise<SupplierInvoice | null> => {
+  const [row] = await exec
+    .update(supplierInvoices)
+    .set({ id: newId, updatedAt: sql`CURRENT_TIMESTAMP` })
+    .where(eq(supplierInvoices.id, currentId))
     .returning();
   return row ? mapInvoice(row) : null;
 };

--- a/server/repositories/supplierOrdersRepo.ts
+++ b/server/repositories/supplierOrdersRepo.ts
@@ -242,7 +242,6 @@ export const create = async (
 };
 
 export type SupplierOrderUpdate = {
-  id?: string;
   supplierId?: string;
   supplierName?: string;
   paymentTerms?: string;
@@ -266,7 +265,6 @@ export const update = async (
   const [row] = await exec
     .update(supplierSales)
     .set({
-      id: sql`COALESCE(${patch.id ?? null}, ${supplierSales.id})`,
       supplierId: sql`COALESCE(${patch.supplierId ?? null}, ${supplierSales.supplierId})`,
       supplierName: sql`COALESCE(${patch.supplierName ?? null}, ${supplierSales.supplierName})`,
       paymentTerms: sql`COALESCE(${patch.paymentTerms ?? null}, ${supplierSales.paymentTerms})`,
@@ -277,6 +275,21 @@ export const update = async (
       updatedAt: sql`CURRENT_TIMESTAMP`,
     })
     .where(eq(supplierSales.id, id))
+    .returning();
+  return row ? mapOrder(row) : null;
+};
+
+// Separate from update() so generic patches can't mutate the PK (issue #621). Relies on
+// ON UPDATE CASCADE on every incoming FK; see server/test/db/renamablePkFkCascade.test.ts.
+export const rename = async (
+  currentId: string,
+  newId: string,
+  exec: DbExecutor = db,
+): Promise<SupplierOrder | null> => {
+  const [row] = await exec
+    .update(supplierSales)
+    .set({ id: newId, updatedAt: sql`CURRENT_TIMESTAMP` })
+    .where(eq(supplierSales.id, currentId))
     .returning();
   return row ? mapOrder(row) : null;
 };

--- a/server/repositories/supplierQuotesRepo.ts
+++ b/server/repositories/supplierQuotesRepo.ts
@@ -191,7 +191,6 @@ export const create = async (
 };
 
 export type SupplierQuoteUpdate = {
-  id?: string;
   supplierId?: string | null;
   supplierName?: string | null;
   paymentTerms?: string;
@@ -214,7 +213,6 @@ export const update = async (
   const [row] = await exec
     .update(supplierQuotes)
     .set({
-      id: sql`COALESCE(${patch.id ?? null}, ${supplierQuotes.id})`,
       supplierId: sql`COALESCE(${patch.supplierId ?? null}, ${supplierQuotes.supplierId})`,
       supplierName: sql`COALESCE(${patch.supplierName ?? null}, ${supplierQuotes.supplierName})`,
       paymentTerms: sql`COALESCE(${patch.paymentTerms ?? null}, ${supplierQuotes.paymentTerms})`,
@@ -224,6 +222,21 @@ export const update = async (
       updatedAt: sql`CURRENT_TIMESTAMP`,
     })
     .where(eq(supplierQuotes.id, id))
+    .returning();
+  return row ? mapQuote(row) : null;
+};
+
+// Separate from update() so generic patches can't mutate the PK (issue #621). Relies on
+// ON UPDATE CASCADE on every incoming FK; see server/test/db/renamablePkFkCascade.test.ts.
+export const rename = async (
+  currentId: string,
+  newId: string,
+  exec: DbExecutor = db,
+): Promise<SupplierQuote | null> => {
+  const [row] = await exec
+    .update(supplierQuotes)
+    .set({ id: newId, updatedAt: sql`CURRENT_TIMESTAMP` })
+    .where(eq(supplierQuotes.id, currentId))
     .returning();
   return row ? mapQuote(row) : null;
 };

--- a/server/routes/client-offers.ts
+++ b/server/routes/client-offers.ts
@@ -825,23 +825,33 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           if (!isIdOnlyUpdate) {
             await snapshotPreState(idResult.value, 'update', request, tx);
           }
-          const offer = await clientOffersRepo.update(
-            idResult.value,
-            {
-              id: (nextIdValue as string | null | undefined) ?? null,
-              clientId: (clientIdValue as string | null | undefined) ?? null,
-              clientName: (clientNameValue as string | null | undefined) ?? null,
-              paymentTerms: (paymentTerms as string | null | undefined) ?? null,
-              discount: (discountValue as number | null | undefined) ?? null,
-              discountType: discountTypeValue ?? null,
-              status: (status as string | null | undefined) ?? null,
-              deliveryDate:
-                (deliveryDateValue as string | null | undefined) ?? automaticDeliveryDate ?? null,
-              expirationDate: (expirationDateValue as string | null | undefined) ?? null,
-              notes: (notes as string | null | undefined) ?? null,
-            },
-            tx,
-          );
+          let renamedOffer: clientOffersRepo.ClientOffer | null = null;
+          if (nextIdValue && nextIdValue !== idResult.value) {
+            renamedOffer = await clientOffersRepo.rename(idResult.value, nextIdValue, tx);
+            if (!renamedOffer) return { offer: null, items: [] };
+          }
+          // id-only renames have nothing left to write — reuse the row returned by rename().
+          const offer =
+            isIdOnlyUpdate && renamedOffer
+              ? renamedOffer
+              : await clientOffersRepo.update(
+                  renamedOffer?.id ?? idResult.value,
+                  {
+                    clientId: (clientIdValue as string | null | undefined) ?? null,
+                    clientName: (clientNameValue as string | null | undefined) ?? null,
+                    paymentTerms: (paymentTerms as string | null | undefined) ?? null,
+                    discount: (discountValue as number | null | undefined) ?? null,
+                    discountType: discountTypeValue ?? null,
+                    status: (status as string | null | undefined) ?? null,
+                    deliveryDate:
+                      (deliveryDateValue as string | null | undefined) ??
+                      automaticDeliveryDate ??
+                      null,
+                    expirationDate: (expirationDateValue as string | null | undefined) ?? null,
+                    notes: (notes as string | null | undefined) ?? null,
+                  },
+                  tx,
+                );
           if (!offer) return { offer: null, items: [] };
           const updatedItems = normalizedItemsForUpdate
             ? await clientOffersRepo.replaceItems(

--- a/server/routes/client-quotes.ts
+++ b/server/routes/client-quotes.ts
@@ -890,21 +890,29 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           if (!isIdOnlyUpdate) {
             await snapshotPreState(idResult.value, 'update', request, tx);
           }
-          const quote = await clientQuotesRepo.update(
-            idResult.value,
-            {
-              id: nextIdValue ?? null,
-              clientId: (clientIdValue as string | null | undefined) ?? null,
-              clientName: (clientNameValue as string | null | undefined) ?? null,
-              paymentTerms: (paymentTerms as string | null | undefined) ?? null,
-              discount: (discountValue as number | null | undefined) ?? null,
-              discountType: discountTypeValue ?? null,
-              status: (status as string | null | undefined) ?? null,
-              expirationDate: (expirationDateValue as string | null | undefined) ?? null,
-              notes: (notes as string | null | undefined) ?? null,
-            },
-            tx,
-          );
+          let renamedQuote: clientQuotesRepo.ClientQuote | null = null;
+          if (nextIdValue && nextIdValue !== idResult.value) {
+            renamedQuote = await clientQuotesRepo.rename(idResult.value, nextIdValue, tx);
+            if (!renamedQuote) return { quote: null, items: [] };
+          }
+          // id-only renames have nothing left to write — reuse the row returned by rename().
+          const quote =
+            isIdOnlyUpdate && renamedQuote
+              ? renamedQuote
+              : await clientQuotesRepo.update(
+                  renamedQuote?.id ?? idResult.value,
+                  {
+                    clientId: (clientIdValue as string | null | undefined) ?? null,
+                    clientName: (clientNameValue as string | null | undefined) ?? null,
+                    paymentTerms: (paymentTerms as string | null | undefined) ?? null,
+                    discount: (discountValue as number | null | undefined) ?? null,
+                    discountType: discountTypeValue ?? null,
+                    status: (status as string | null | undefined) ?? null,
+                    expirationDate: (expirationDateValue as string | null | undefined) ?? null,
+                    notes: (notes as string | null | undefined) ?? null,
+                  },
+                  tx,
+                );
           if (!quote) return { quote: null, items: [] };
           const items = normalizedItems
             ? await clientQuotesRepo.replaceItems(

--- a/server/routes/clients-orders.ts
+++ b/server/routes/clients-orders.ts
@@ -1102,7 +1102,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
             await snapshotPreState(idResult.value, 'update', request, tx);
           }
           const patch: clientsOrdersRepo.ClientOrderUpdate = {};
-          if (nextIdValue !== null) patch.id = nextIdValue;
           if (linkedOfferId !== undefined && linkedOfferIdValue) {
             patch.linkedOfferId = linkedOfferIdValue;
             patch.linkedQuoteId = linkedQuoteIdValue;
@@ -1121,7 +1120,16 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           if (typeof status === 'string') patch.status = status;
           if (notes !== undefined) patch.notes = notes as string | null;
 
-          const order = await clientsOrdersRepo.update(idResult.value, patch, tx);
+          let renamedOrder: clientsOrdersRepo.ClientOrder | null = null;
+          if (nextIdValue && nextIdValue !== idResult.value) {
+            renamedOrder = await clientsOrdersRepo.rename(idResult.value, nextIdValue, tx);
+            if (!renamedOrder) return { order: null, items: [] };
+          }
+          // id-only renames have nothing left to write — reuse the row returned by rename().
+          const order =
+            Object.keys(patch).length === 0 && renamedOrder
+              ? renamedOrder
+              : await clientsOrdersRepo.update(renamedOrder?.id ?? idResult.value, patch, tx);
           if (!order) return { order: null, items: [] };
 
           let nextItems: clientsOrdersRepo.ClientOrderItem[];

--- a/server/routes/invoices.ts
+++ b/server/routes/invoices.ts
@@ -538,6 +538,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         if (clientNameResult.value) patch.clientName = clientNameResult.value;
       }
 
+      let nextIdValue: string | null = null;
       if (nextId !== undefined) {
         const nextIdResult = optionalNonEmptyString(nextId, 'id');
         if (!nextIdResult.ok) return badRequest(reply, nextIdResult.message);
@@ -552,7 +553,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
               details: { secondaryLabel: 'duplicate_id', toValue: nextIdResult.value },
             });
           }
-          patch.id = nextIdResult.value;
+          nextIdValue = nextIdResult.value;
         }
       }
 
@@ -700,7 +701,16 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       };
       try {
         result = await withDbTransaction(async (tx) => {
-          const updated = await invoicesRepo.updateDraft(idResult.value, patch, tx);
+          let renamedInvoice: invoicesRepo.Invoice | null = null;
+          if (nextIdValue && nextIdValue !== idResult.value) {
+            renamedInvoice = await invoicesRepo.renameDraft(idResult.value, nextIdValue, tx);
+            if (!renamedInvoice) return { invoice: null, items: [] };
+          }
+          // id-only renames have nothing left to write — reuse the row returned by renameDraft().
+          const updated =
+            Object.keys(patch).length === 0 && renamedInvoice
+              ? renamedInvoice
+              : await invoicesRepo.updateDraft(renamedInvoice?.id ?? idResult.value, patch, tx);
           if (!updated) return { invoice: null, items: [] };
           const itemsOut = normalizedItemsForUpdate
             ? await invoicesRepo.replaceItems(

--- a/server/routes/supplier-invoices.ts
+++ b/server/routes/supplier-invoices.ts
@@ -608,8 +608,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           details: { secondaryLabel: 'duplicate_id' },
         });
       }
-      if (nextIdValue !== null) patch.id = nextIdValue;
-
       const hasLockedFieldUpdates =
         supplierId !== undefined ||
         supplierName !== undefined ||
@@ -685,7 +683,18 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       let resultItems: supplierInvoicesRepo.SupplierInvoiceItem[];
       try {
         const txResult = await withDbTransaction(async (tx) => {
-          const invoice = await supplierInvoicesRepo.update(idResult.value, patch, tx);
+          let renamedInvoice: supplierInvoicesRepo.SupplierInvoice | null = null;
+          if (nextIdValue && nextIdValue !== idResult.value) {
+            renamedInvoice = await supplierInvoicesRepo.rename(idResult.value, nextIdValue, tx);
+            if (!renamedInvoice) {
+              return { invoice: null, items: [] as supplierInvoicesRepo.SupplierInvoiceItem[] };
+            }
+          }
+          // id-only renames have nothing left to write — reuse the row returned by rename().
+          const invoice =
+            Object.keys(patch).length === 0 && renamedInvoice
+              ? renamedInvoice
+              : await supplierInvoicesRepo.update(renamedInvoice?.id ?? idResult.value, patch, tx);
           if (!invoice)
             return { invoice: null, items: [] as supplierInvoicesRepo.SupplierInvoiceItem[] };
           const finalItems = normalizedItems

--- a/server/routes/supplier-orders.ts
+++ b/server/routes/supplier-orders.ts
@@ -549,8 +549,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           details: { secondaryLabel: 'duplicate_id' },
         });
       }
-      if (nextIdValue !== null) patch.id = nextIdValue;
-
       const hasLockedFieldUpdates =
         supplierId !== undefined ||
         supplierName !== undefined ||
@@ -643,7 +641,18 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           if (shouldSnapshot) {
             await snapshotPreState(idResult.value, 'update', request, tx);
           }
-          const order = await supplierOrdersRepo.update(idResult.value, patch, tx);
+          let renamedOrder: supplierOrdersRepo.SupplierOrder | null = null;
+          if (nextIdValue && nextIdValue !== idResult.value) {
+            renamedOrder = await supplierOrdersRepo.rename(idResult.value, nextIdValue, tx);
+            if (!renamedOrder) {
+              return { order: null, items: [] as supplierOrdersRepo.SupplierOrderItem[] };
+            }
+          }
+          // id-only renames have nothing left to write — reuse the row returned by rename().
+          const order =
+            Object.keys(patch).length === 0 && renamedOrder
+              ? renamedOrder
+              : await supplierOrdersRepo.update(renamedOrder?.id ?? idResult.value, patch, tx);
           if (!order) return { order: null, items: [] as supplierOrdersRepo.SupplierOrderItem[] };
           const finalItems = normalizedItems
             ? await supplierOrdersRepo.replaceItems(order.id, normalizedItems, tx)

--- a/server/routes/supplier-quotes.ts
+++ b/server/routes/supplier-quotes.ts
@@ -509,8 +509,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           details: { secondaryLabel: 'duplicate_id' },
         });
       }
-      if (nextIdValue !== null) patch.id = nextIdValue;
-
       let updated: supplierQuotesRepo.SupplierQuote | null;
       let resultItems: supplierQuotesRepo.SupplierQuoteItem[];
       try {
@@ -521,7 +519,18 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           if (hasContentUpdate) {
             await snapshotPreState(idResult.value, 'update', request, tx);
           }
-          const quote = await supplierQuotesRepo.update(idResult.value, patch, tx);
+          let renamedQuote: supplierQuotesRepo.SupplierQuote | null = null;
+          if (nextIdValue && nextIdValue !== idResult.value) {
+            renamedQuote = await supplierQuotesRepo.rename(idResult.value, nextIdValue, tx);
+            if (!renamedQuote) {
+              return { quote: null, items: [] as supplierQuotesRepo.SupplierQuoteItem[] };
+            }
+          }
+          // id-only renames have nothing left to write — reuse the row returned by rename().
+          const quote =
+            Object.keys(patch).length === 0 && renamedQuote
+              ? renamedQuote
+              : await supplierQuotesRepo.update(renamedQuote?.id ?? idResult.value, patch, tx);
           if (!quote) return { quote: null, items: [] as supplierQuotesRepo.SupplierQuoteItem[] };
           const finalItems = normalizedItems
             ? await supplierQuotesRepo.replaceItems(quote.id, normalizedItems, tx)

--- a/server/test/db/migration0048ProjectsOrderIdCascade.test.ts
+++ b/server/test/db/migration0048ProjectsOrderIdCascade.test.ts
@@ -1,41 +1,10 @@
 import { describe, expect, test } from 'bun:test';
-import { listSchemaFiles, readMigrationFile, readSchemaFile } from '../helpers/schemaFiles.ts';
+import { readMigrationFile } from '../helpers/schemaFiles.ts';
 
-// PUT /api/clients-orders/:id renames a sales.id (the route accepts a new `id` and
-// validates it through `clientsOrdersRepo.findIdConflict`). Every FK that references
-// `sales.id` must therefore declare `onUpdate: 'cascade'`, otherwise the rename fails
-// mid-transaction with a FK violation from whichever child table didn't cascade.
-
-// The options object is intentionally optional in the capture group: Drizzle accepts a
-// bare `.references(() => sales.id)` with no second arg. We still want to surface such a
-// FK (it would default to NO ACTION on update and silently break the rename chain), so
-// match it here and let the per-FK assertion fail because the empty options block can't
-// contain `onUpdate: 'cascade'`.
-const SALES_ID_REFERENCE =
-  /\.references\(\s*\(\s*\)\s*=>\s*sales\.id\s*(?:,\s*\{([\s\S]*?)\})?\s*\)/g;
-
-const salesIdFks = listSchemaFiles().flatMap((file) => {
-  const content = readSchemaFile(file);
-  return [...content.matchAll(SALES_ID_REFERENCE)].map((match, index) => ({
-    file,
-    index,
-    optionsBlock: match[1] ?? '',
-  }));
-});
-
-describe('every FK to sales.id declares onUpdate: cascade', () => {
-  // Sanity check: if the regex above ever silently stops matching (formatter rewrite,
-  // Drizzle API change), `salesIdFks` would be empty and `test.each` would emit zero
-  // tests — a silent pass. Pin a floor matching the known FK count so a regression in
-  // the discovery regex fails loudly.
-  test('discovers at least 4 FKs (sale_items, invoices, order_versions, projects)', () => {
-    expect(salesIdFks.length).toBeGreaterThanOrEqual(4);
-  });
-
-  test.each(salesIdFks)('FK #$index in $file declares onUpdate: cascade', ({ optionsBlock }) => {
-    expect(optionsBlock).toMatch(/onUpdate:\s*'cascade'/);
-  });
-});
+// Migration 0048 retrofitted ON UPDATE CASCADE onto `projects.order_id` → `sales(id)`.
+// The generic FK-cascade invariant for `sales.id` lives in `renamablePkFkCascade.test.ts`;
+// this file pins migration-specific shape so a replay against a correct DB stays a no-op
+// and the probe stays scoped to the right table.
 
 describe('migration 0048: adds ON UPDATE CASCADE to projects.order_id → sales(id)', () => {
   const MIGRATION = readMigrationFile('0048_add_projects_order_id_on_update_cascade.sql');

--- a/server/test/db/renamablePkFkCascade.test.ts
+++ b/server/test/db/renamablePkFkCascade.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from 'bun:test';
+import { listSchemaFiles, readSchemaFile } from '../helpers/schemaFiles.ts';
+
+// Every PK that supports renaming via a repo `rename()` function must have all incoming FKs
+// declared with `onUpdate: 'cascade'`. Without that, the rename will fail mid-transaction
+// when a child row's FK can't follow the parent id change.
+
+type RenamablePk = {
+  /** Drizzle table identifier as it appears in `.references(() => <table>.id)`. */
+  tableIdentifier: string;
+  /** Minimum FK count expected — pinned so a regression in the discovery regex fails loudly. */
+  minimumFks: number;
+};
+
+// Update this list when adding a new repo `rename()` function.
+const RENAMABLE_PKS: readonly RenamablePk[] = [
+  // clientOffersRepo.rename — FKs from customer_offer_items, offer_versions, projects,
+  // sales (linked_offer_id).
+  { tableIdentifier: 'customerOffers', minimumFks: 4 },
+  // clientQuotesRepo.rename — FKs from quote_items, quote_versions, customer_offers
+  // (linked_quote_id), sales (linked_quote_id).
+  { tableIdentifier: 'quotes', minimumFks: 4 },
+  // invoicesRepo.renameDraft — FK from invoice_items.
+  { tableIdentifier: 'invoices', minimumFks: 1 },
+  // clientsOrdersRepo.rename — FKs from sale_items, invoices, sales_versions, projects.order_id.
+  { tableIdentifier: 'sales', minimumFks: 4 },
+  // supplierOrdersRepo.rename — FKs from supplier_sale_items, supplier_order_versions,
+  // supplier_invoices (linked_sale_id).
+  { tableIdentifier: 'supplierSales', minimumFks: 3 },
+  // supplierQuotesRepo.rename — FKs from supplier_quote_items, supplier_quote_attachments,
+  // supplier_quote_versions, supplier_sales (linked_quote_id).
+  { tableIdentifier: 'supplierQuotes', minimumFks: 4 },
+  // supplierInvoicesRepo.rename — FK from supplier_invoice_items.
+  { tableIdentifier: 'supplierInvoices', minimumFks: 1 },
+];
+
+// Drizzle accepts a bare `.references(() => table.id)` with no second arg (defaulting to
+// NO ACTION on update). The options object is intentionally optional in the capture group
+// so such an FK still surfaces here — the per-FK assertion will fail because an empty
+// options block can't contain `onUpdate: 'cascade'`.
+const referenceRegex = (tableIdentifier: string) =>
+  new RegExp(
+    `\\.references\\(\\s*\\(\\s*\\)\\s*=>\\s*${tableIdentifier}\\.id\\s*(?:,\\s*\\{([\\s\\S]*?)\\})?\\s*\\)`,
+    'g',
+  );
+
+const schemaFiles = listSchemaFiles();
+
+for (const { tableIdentifier, minimumFks } of RENAMABLE_PKS) {
+  describe(`every FK to ${tableIdentifier}.id declares onUpdate: cascade`, () => {
+    const fks = schemaFiles.flatMap((file) => {
+      const content = readSchemaFile(file);
+      return [...content.matchAll(referenceRegex(tableIdentifier))].map((match, index) => ({
+        file,
+        index,
+        optionsBlock: match[1] ?? '',
+      }));
+    });
+
+    test(`discovers at least ${minimumFks} FK(s)`, () => {
+      expect(fks.length).toBeGreaterThanOrEqual(minimumFks);
+    });
+
+    test.each(fks)(`FK #$index in $file declares onUpdate: cascade`, ({ optionsBlock }) => {
+      expect(optionsBlock).toMatch(/onUpdate:\s*'cascade'/);
+    });
+  });
+}

--- a/server/test/db/renamablePkFkCascade.test.ts
+++ b/server/test/db/renamablePkFkCascade.test.ts
@@ -38,6 +38,11 @@ const RENAMABLE_PKS: readonly RenamablePk[] = [
 // NO ACTION on update). The options object is intentionally optional in the capture group
 // so such an FK still surfaces here — the per-FK assertion will fail because an empty
 // options block can't contain `onUpdate: 'cascade'`.
+//
+// Limitation: the lazy `[\s\S]*?` capture stops at the first `}`. If a future Drizzle
+// FK option ever introduces a nested object (e.g. `{ onDelete: 'cascade', meta: { x: 1 } }`),
+// this regex would truncate at the inner `}` and miss `onUpdate` after it. None of the
+// current Drizzle FK options nest, so keep options blocks flat or upgrade this matcher.
 const referenceRegex = (tableIdentifier: string) =>
   new RegExp(
     `\\.references\\(\\s*\\(\\s*\\)\\s*=>\\s*${tableIdentifier}\\.id\\s*(?:,\\s*\\{([\\s\\S]*?)\\})?\\s*\\)`,

--- a/server/test/repositories/clientOffersRepo.test.ts
+++ b/server/test/repositories/clientOffersRepo.test.ts
@@ -217,17 +217,19 @@ describe('create', () => {
 });
 
 describe('update', () => {
-  test('binds 10 patch values via COALESCE, WHERE id last', async () => {
+  test('binds 9 patch values via COALESCE, WHERE id last - no id in SET', async () => {
     exec.enqueue({ rows: [offerRow()] });
     await clientOffersRepo.update('co-1', { status: 'accepted' }, testDb);
     const sql = exec.calls[0].sql;
     expect(sql).toContain('update "customer_offers"');
     expect(sql).toContain('COALESCE');
     expect(sql).toContain('CURRENT_TIMESTAMP');
-    expect(sql).toContain('"id" = $11');
-    expect(exec.calls[0].params).toHaveLength(11);
-    expect(exec.calls[0].params[6]).toBe('accepted'); // status
-    expect(exec.calls[0].params[10]).toBe('co-1'); // where id
+    // The SET clause must NOT touch the primary key column (issue #621).
+    expect(sql).not.toMatch(/set[^"]*"id"\s*=/i);
+    expect(sql).toContain('"id" = $10');
+    expect(exec.calls[0].params).toHaveLength(10);
+    expect(exec.calls[0].params[5]).toBe('accepted'); // status
+    expect(exec.calls[0].params[9]).toBe('co-1'); // where id
   });
 
   test('returns null when no row updated', async () => {
@@ -238,8 +240,28 @@ describe('update', () => {
   test('numericForDb stringifies discount before COALESCE', async () => {
     exec.enqueue({ rows: [offerRow()] });
     await clientOffersRepo.update('co-1', { discount: 12.5 }, testDb);
-    // Discount is the 5th COALESCE argument (id, clientId, clientName, paymentTerms, discount, ...).
-    expect(exec.calls[0].params[4]).toBe('12.5');
+    // Discount is the 4th COALESCE argument (clientId, clientName, paymentTerms, discount, ...).
+    expect(exec.calls[0].params[3]).toBe('12.5');
+  });
+});
+
+describe('rename', () => {
+  test('issues a dedicated UPDATE that sets the id column and returns the mapped offer', async () => {
+    exec.enqueue({ rows: [offerRow({ 0: 'co-2' })] });
+    const result = await clientOffersRepo.rename('co-1', 'co-2', testDb);
+    const sql = exec.calls[0].sql;
+    expect(sql).toContain('update "customer_offers"');
+    expect(sql).toMatch(/set[^"]*"id"\s*=/i);
+    expect(sql).toContain('CURRENT_TIMESTAMP');
+    expect(sql).toContain('"id" = $');
+    expect(exec.calls[0].params).toContain('co-2'); // new id
+    expect(exec.calls[0].params).toContain('co-1'); // where current id
+    expect(result?.id).toBe('co-2');
+  });
+
+  test('returns null when no row matched currentId', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await clientOffersRepo.rename('co-x', 'co-y', testDb)).toBeNull();
   });
 });
 

--- a/server/test/repositories/clientQuotesRepo.test.ts
+++ b/server/test/repositories/clientQuotesRepo.test.ts
@@ -232,9 +232,35 @@ describe('update', () => {
     expect(exec.calls[0].params).toContain('cq-1');
   });
 
+  test('does not include id in the SET clause (issue #621)', async () => {
+    exec.enqueue({ rows: [quoteRow()] });
+    await clientQuotesRepo.update('cq-1', { status: 'accepted' }, testDb);
+    const sql = exec.calls[0].sql.toLowerCase();
+    expect(sql).not.toMatch(/set[^"]*"id"\s*=/);
+  });
+
   test('returns null when no row updated', async () => {
     exec.enqueue({ rows: [] });
     expect(await clientQuotesRepo.update('cq-x', { status: 'accepted' }, testDb)).toBeNull();
+  });
+});
+
+describe('rename', () => {
+  test('issues a dedicated UPDATE that sets the id column and returns the mapped quote', async () => {
+    exec.enqueue({ rows: [quoteRow({ 0: 'cq-2' })] });
+    const result = await clientQuotesRepo.rename('cq-1', 'cq-2', testDb);
+    const sql = exec.calls[0].sql.toLowerCase();
+    expect(sql).toContain('update "quotes"');
+    expect(sql).toMatch(/set[^"]*"id"\s*=/);
+    expect(sql).toContain('current_timestamp');
+    expect(exec.calls[0].params).toContain('cq-2'); // new id
+    expect(exec.calls[0].params).toContain('cq-1'); // current id (WHERE)
+    expect(result?.id).toBe('cq-2');
+  });
+
+  test('returns null when no row matched currentId', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await clientQuotesRepo.rename('cq-x', 'cq-y', testDb)).toBeNull();
   });
 });
 

--- a/server/test/repositories/clientsOrdersRepo.test.ts
+++ b/server/test/repositories/clientsOrdersRepo.test.ts
@@ -120,7 +120,7 @@ describe('create / update', () => {
     expect(result.id).toBe('co-1');
   });
 
-  test('update writes only provided columns and includes id in WHERE', async () => {
+  test('update writes only provided columns, never id (issue #621), includes id in WHERE', async () => {
     exec.enqueue({ rows: [orderRow()] });
     await repo.update('co-1', { status: 'confirmed' }, testDb);
     const sql = exec.calls[0].sql.toLowerCase();
@@ -130,6 +130,7 @@ describe('create / update', () => {
     expect(setClause).toContain('"status"');
     expect(setClause).not.toContain('"notes"');
     expect(setClause).not.toContain('"linked_offer_id"');
+    expect(setClause).not.toMatch(/"id"\s*=/);
     expect(exec.calls[0].params).toContain('confirmed');
     expect(exec.calls[0].params).toContain('co-1');
   });
@@ -159,6 +160,25 @@ describe('create / update', () => {
   test('update returns null when no row matches', async () => {
     exec.enqueue({ rows: [] });
     expect(await repo.update('co-x', { status: 'confirmed' }, testDb)).toBeNull();
+  });
+});
+
+describe('rename', () => {
+  test('issues a dedicated UPDATE that sets the id column and returns the mapped order', async () => {
+    exec.enqueue({ rows: [orderRow({ 0: 'co-2' })] });
+    const result = await repo.rename('co-1', 'co-2', testDb);
+    const sql = exec.calls[0].sql.toLowerCase();
+    expect(sql).toContain('update "sales"');
+    expect(sql).toMatch(/set[^"]*"id"\s*=/);
+    expect(sql).toContain('current_timestamp');
+    expect(exec.calls[0].params).toContain('co-2'); // new id
+    expect(exec.calls[0].params).toContain('co-1'); // where current id
+    expect(result?.id).toBe('co-2');
+  });
+
+  test('returns null when no row matched currentId', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await repo.rename('co-x', 'co-y', testDb)).toBeNull();
   });
 });
 

--- a/server/test/repositories/invoicesRepo.test.ts
+++ b/server/test/repositories/invoicesRepo.test.ts
@@ -269,7 +269,7 @@ describe('create', () => {
 });
 
 describe('update', () => {
-  test('updates only provided columns, sets updated_at, and includes id in WHERE', async () => {
+  test('updates only provided columns, never id (issue #621), sets updated_at, id in WHERE', async () => {
     exec.enqueue({ rows: [invoiceRow()] });
     await invoicesRepo.update('INV-2026-0001', { status: 'sent', total: 200 }, testDb);
     const sql = exec.calls[0].sql.toLowerCase();
@@ -279,6 +279,7 @@ describe('update', () => {
     expect(setClause).toContain('"status"');
     expect(setClause).toContain('"total"');
     expect(setClause).not.toContain('"notes"');
+    expect(setClause).not.toMatch(/"id"\s*=/);
     expect(sql).toContain('current_timestamp');
     expect(exec.calls[0].params).toContain('sent');
     expect(exec.calls[0].params).toContain('200');
@@ -310,6 +311,26 @@ describe('update', () => {
     expect(setClause).not.toContain('"notes"');
     expect(setClause).not.toContain('coalesce');
     expect(exec.calls[0].params).toContain('INV-1');
+  });
+});
+
+describe('renameDraft', () => {
+  test('issues a draft-scoped UPDATE that sets the id column and returns the mapped invoice', async () => {
+    exec.enqueue({ rows: [invoiceRow({ 0: 'INV-2026-0002' })] });
+    const result = await invoicesRepo.renameDraft('INV-2026-0001', 'INV-2026-0002', testDb);
+    const sql = exec.calls[0].sql.toLowerCase();
+    expect(sql).toContain('update "invoices"');
+    expect(sql).toMatch(/set[^"]*"id"\s*=/);
+    expect(sql).toContain('current_timestamp');
+    expect(exec.calls[0].params).toContain('INV-2026-0002'); // new id
+    expect(exec.calls[0].params).toContain('INV-2026-0001'); // where current id
+    expect(exec.calls[0].params).toContain('draft'); // draft-only predicate
+    expect(result?.id).toBe('INV-2026-0002');
+  });
+
+  test('returns null when no draft row matched currentId', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await invoicesRepo.renameDraft('INV-X', 'INV-Y', testDb)).toBeNull();
   });
 });
 

--- a/server/test/repositories/supplierInvoicesRepo.test.ts
+++ b/server/test/repositories/supplierInvoicesRepo.test.ts
@@ -224,7 +224,7 @@ describe('create', () => {
 });
 
 describe('update', () => {
-  test('binds patch values via COALESCE, WHERE id last', async () => {
+  test('binds patch values via COALESCE, WHERE id last - no id in SET (issue #621)', async () => {
     exec.enqueue({ rows: [invoiceRow()] });
     await supplierInvoicesRepo.update(
       'SINV-2026-0001',
@@ -235,11 +235,13 @@ describe('update', () => {
     expect(sql).toContain('update "supplier_invoices"');
     expect(sql).toContain('COALESCE');
     expect(sql).toContain('CURRENT_TIMESTAMP');
-    expect(sql).toContain('"id" = $11');
-    expect(exec.calls[0].params).toHaveLength(11);
-    expect(exec.calls[0].params[5]).toBe('paid'); // status
-    expect(exec.calls[0].params[8]).toBe('100'); // amountPaid via numericForDb
-    expect(exec.calls[0].params[10]).toBe('SINV-2026-0001'); // where id
+    // The SET clause must NOT touch the primary key column.
+    expect(sql).not.toMatch(/set[^"]*"id"\s*=/i);
+    expect(sql).toContain('"id" = $10');
+    expect(exec.calls[0].params).toHaveLength(10);
+    expect(exec.calls[0].params[4]).toBe('paid'); // status
+    expect(exec.calls[0].params[7]).toBe('100'); // amountPaid via numericForDb
+    expect(exec.calls[0].params[9]).toBe('SINV-2026-0001'); // where id
   });
 
   test('returns null when no row updated', async () => {
@@ -264,6 +266,25 @@ describe('update', () => {
       testDb,
     );
     expect(exec.calls[0].sql.toLowerCase()).not.toContain('update "supplier_invoices"');
+  });
+});
+
+describe('rename', () => {
+  test('issues a dedicated UPDATE that sets the id column and returns the mapped invoice', async () => {
+    exec.enqueue({ rows: [invoiceRow({ 0: 'SINV-2026-0002' })] });
+    const result = await supplierInvoicesRepo.rename('SINV-2026-0001', 'SINV-2026-0002', testDb);
+    const sql = exec.calls[0].sql.toLowerCase();
+    expect(sql).toContain('update "supplier_invoices"');
+    expect(sql).toMatch(/set[^"]*"id"\s*=/);
+    expect(sql).toContain('current_timestamp');
+    expect(exec.calls[0].params).toContain('SINV-2026-0002'); // new id
+    expect(exec.calls[0].params).toContain('SINV-2026-0001'); // where current id
+    expect(result?.id).toBe('SINV-2026-0002');
+  });
+
+  test('returns null when no row matched currentId', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await supplierInvoicesRepo.rename('SINV-X', 'SINV-Y', testDb)).toBeNull();
   });
 });
 

--- a/server/test/repositories/supplierOrdersRepo.test.ts
+++ b/server/test/repositories/supplierOrdersRepo.test.ts
@@ -143,18 +143,20 @@ describe('findIdConflict', () => {
 });
 
 describe('update', () => {
-  test('binds patch values via COALESCE, WHERE id last', async () => {
+  test('binds patch values via COALESCE, WHERE id last - no id in SET (issue #621)', async () => {
     exec.enqueue({ rows: [orderRow()] });
     await supplierOrdersRepo.update('so-1', { status: 'sent', discount: 10 }, testDb);
     const sql = exec.calls[0].sql;
     expect(sql).toContain('update "supplier_sales"');
     expect(sql).toContain('COALESCE');
     expect(sql).toContain('CURRENT_TIMESTAMP');
-    expect(sql).toContain('"id" = $9');
-    expect(exec.calls[0].params).toHaveLength(9);
-    expect(exec.calls[0].params[4]).toBe('10'); // discount via numericForDb
-    expect(exec.calls[0].params[6]).toBe('sent'); // status
-    expect(exec.calls[0].params[8]).toBe('so-1'); // where id
+    // The SET clause must NOT touch the primary key column.
+    expect(sql).not.toMatch(/set[^"]*"id"\s*=/i);
+    expect(sql).toContain('"id" = $8');
+    expect(exec.calls[0].params).toHaveLength(8);
+    expect(exec.calls[0].params[3]).toBe('10'); // discount via numericForDb
+    expect(exec.calls[0].params[5]).toBe('sent'); // status
+    expect(exec.calls[0].params[7]).toBe('so-1'); // where id
   });
 
   test('returns null when no row updated', async () => {
@@ -169,6 +171,25 @@ describe('update', () => {
     expect(sqlText).not.toContain('update "supplier_sales"');
     expect(sqlText).toContain('select');
     expect(result?.id).toBe('so-1');
+  });
+});
+
+describe('rename', () => {
+  test('issues a dedicated UPDATE that sets the id column and returns the mapped order', async () => {
+    exec.enqueue({ rows: [orderRow({ 0: 'so-2' })] });
+    const result = await supplierOrdersRepo.rename('so-1', 'so-2', testDb);
+    const sql = exec.calls[0].sql.toLowerCase();
+    expect(sql).toContain('update "supplier_sales"');
+    expect(sql).toMatch(/set[^"]*"id"\s*=/);
+    expect(sql).toContain('current_timestamp');
+    expect(exec.calls[0].params).toContain('so-2'); // new id
+    expect(exec.calls[0].params).toContain('so-1'); // where current id
+    expect(result?.id).toBe('so-2');
+  });
+
+  test('returns null when no row matched currentId', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await supplierOrdersRepo.rename('so-x', 'so-y', testDb)).toBeNull();
   });
 });
 

--- a/server/test/repositories/supplierQuotesRepo.test.ts
+++ b/server/test/repositories/supplierQuotesRepo.test.ts
@@ -109,18 +109,20 @@ describe('findIdConflict', () => {
 });
 
 describe('update', () => {
-  test('binds patch values via COALESCE, WHERE id last', async () => {
+  test('binds patch values via COALESCE, WHERE id last - no id in SET (issue #621)', async () => {
     exec.enqueue({ rows: [quoteRow()] });
     await supplierQuotesRepo.update('q-1', { status: 'sent', notes: 'hi' }, testDb);
     const sql = exec.calls[0].sql;
     expect(sql).toContain('update "supplier_quotes"');
     expect(sql).toContain('COALESCE');
     expect(sql).toContain('CURRENT_TIMESTAMP');
-    expect(sql).toContain('"id" = $8');
-    expect(exec.calls[0].params).toHaveLength(8);
-    expect(exec.calls[0].params[4]).toBe('sent'); // status
-    expect(exec.calls[0].params[6]).toBe('hi'); // notes
-    expect(exec.calls[0].params[7]).toBe('q-1'); // where id
+    // The SET clause must NOT touch the primary key column.
+    expect(sql).not.toMatch(/set[^"]*"id"\s*=/i);
+    expect(sql).toContain('"id" = $7');
+    expect(exec.calls[0].params).toHaveLength(7);
+    expect(exec.calls[0].params[3]).toBe('sent'); // status
+    expect(exec.calls[0].params[5]).toBe('hi'); // notes
+    expect(exec.calls[0].params[6]).toBe('q-1'); // where id
   });
 
   test('returns null when no row updated', async () => {
@@ -135,6 +137,25 @@ describe('update', () => {
     expect(sqlText).not.toContain('update "supplier_quotes"');
     expect(sqlText).toContain('select');
     expect(result?.id).toBe('q-1');
+  });
+});
+
+describe('rename', () => {
+  test('issues a dedicated UPDATE that sets the id column and returns the mapped quote', async () => {
+    exec.enqueue({ rows: [quoteRow({ 0: 'q-2' })] });
+    const result = await supplierQuotesRepo.rename('q-1', 'q-2', testDb);
+    const sql = exec.calls[0].sql.toLowerCase();
+    expect(sql).toContain('update "supplier_quotes"');
+    expect(sql).toMatch(/set[^"]*"id"\s*=/);
+    expect(sql).toContain('current_timestamp');
+    expect(exec.calls[0].params).toContain('q-2'); // new id
+    expect(exec.calls[0].params).toContain('q-1'); // where current id
+    expect(result?.id).toBe('q-2');
+  });
+
+  test('returns null when no row matched currentId', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await supplierQuotesRepo.rename('q-x', 'q-y', testDb)).toBeNull();
   });
 });
 

--- a/server/test/routes/client-offers-versions.test.ts
+++ b/server/test/routes/client-offers-versions.test.ts
@@ -43,6 +43,7 @@ const coFindFullForSnapshotMock = mock();
 const coFindItemsForOfferMock = mock();
 const coFindIdConflictMock = mock();
 const coUpdateMock = mock();
+const coRenameMock = mock();
 const coRestoreSnapshotOfferMock = mock();
 const coReplaceItemsMock = mock();
 
@@ -88,6 +89,7 @@ beforeAll(async () => {
     findItemsForOffer: coFindItemsForOfferMock,
     findIdConflict: coFindIdConflictMock,
     update: coUpdateMock,
+    rename: coRenameMock,
     restoreSnapshotOffer: coRestoreSnapshotOfferMock,
     replaceItems: coReplaceItemsMock,
   }));
@@ -210,6 +212,7 @@ const allMocks = [
   coFindItemsForOfferMock,
   coFindIdConflictMock,
   coUpdateMock,
+  coRenameMock,
   coRestoreSnapshotOfferMock,
   coReplaceItemsMock,
   clientsExistsByIdMock,
@@ -688,7 +691,7 @@ describe('PUT /api/sales/client-offers/:id snapshots pre-update state', () => {
       clientName: 'Client',
       status: 'draft',
     });
-    coUpdateMock.mockResolvedValue({ ...SAMPLE_OFFER, id: 'off-1-renamed' });
+    coRenameMock.mockResolvedValue({ ...SAMPLE_OFFER, id: 'off-1-renamed' });
 
     const res = await testApp.inject({
       method: 'PUT',
@@ -700,6 +703,9 @@ describe('PUT /api/sales/client-offers/:id snapshots pre-update state', () => {
     expect(res.statusCode).toBe(200);
     expect(ovInsertMock).not.toHaveBeenCalled();
     expect(coFindFullForSnapshotMock).not.toHaveBeenCalled();
+    // PK rename goes through the dedicated repo call (issue #621), not the generic update().
+    expect(coRenameMock).toHaveBeenCalledWith('off-1', 'off-1-renamed', TX_SENTINEL);
+    expect(coUpdateMock).not.toHaveBeenCalled();
   });
 
   test('PUT terminal-to-draft rejects ordinary manager before generic update', async () => {

--- a/server/test/routes/client-quotes-versions.test.ts
+++ b/server/test/routes/client-quotes-versions.test.ts
@@ -45,6 +45,7 @@ const cqFindFullForSnapshotMock = mock();
 const cqFindItemsForQuoteMock = mock();
 const cqFindIdConflictMock = mock();
 const cqUpdateMock = mock();
+const cqRenameMock = mock();
 const cqRestoreSnapshotQuoteMock = mock();
 const cqReplaceItemsMock = mock();
 
@@ -93,6 +94,7 @@ beforeAll(async () => {
     findItemsForQuote: cqFindItemsForQuoteMock,
     findIdConflict: cqFindIdConflictMock,
     update: cqUpdateMock,
+    rename: cqRenameMock,
     restoreSnapshotQuote: cqRestoreSnapshotQuoteMock,
     replaceItems: cqReplaceItemsMock,
   }));
@@ -217,6 +219,7 @@ const allMocks = [
   cqFindItemsForQuoteMock,
   cqFindIdConflictMock,
   cqUpdateMock,
+  cqRenameMock,
   cqRestoreSnapshotQuoteMock,
   cqReplaceItemsMock,
   clientsExistsByIdMock,
@@ -593,7 +596,7 @@ describe('PUT /api/sales/client-quotes/:id snapshots pre-update state', () => {
       discount: 0,
       discountType: 'percentage',
     });
-    cqUpdateMock.mockResolvedValue({ ...SAMPLE_QUOTE, id: 'q-1-renamed' });
+    cqRenameMock.mockResolvedValue({ ...SAMPLE_QUOTE, id: 'q-1-renamed' });
 
     const res = await testApp.inject({
       method: 'PUT',
@@ -605,5 +608,8 @@ describe('PUT /api/sales/client-quotes/:id snapshots pre-update state', () => {
     expect(res.statusCode).toBe(200);
     expect(qvInsertMock).not.toHaveBeenCalled();
     expect(cqFindFullForSnapshotMock).not.toHaveBeenCalled();
+    // PK rename goes through the dedicated repo call (issue #621), not the generic update().
+    expect(cqRenameMock).toHaveBeenCalledWith('q-1', 'q-1-renamed', TX_SENTINEL);
+    expect(cqUpdateMock).not.toHaveBeenCalled();
   });
 });

--- a/server/test/routes/clients-orders-versions.test.ts
+++ b/server/test/routes/clients-orders-versions.test.ts
@@ -40,6 +40,7 @@ const coFindFullForSnapshotMock = mock();
 const coFindItemsForOrderMock = mock();
 const coFindIdConflictMock = mock();
 const coUpdateMock = mock();
+const coRenameMock = mock();
 const coRestoreSnapshotOrderMock = mock();
 const coReplaceItemsMock = mock();
 
@@ -83,6 +84,7 @@ beforeAll(async () => {
     findItemsForOrder: coFindItemsForOrderMock,
     findIdConflict: coFindIdConflictMock,
     update: coUpdateMock,
+    rename: coRenameMock,
     restoreSnapshotOrder: coRestoreSnapshotOrderMock,
     replaceItems: coReplaceItemsMock,
   }));
@@ -205,6 +207,7 @@ const allMocks = [
   coFindItemsForOrderMock,
   coFindIdConflictMock,
   coUpdateMock,
+  coRenameMock,
   coRestoreSnapshotOrderMock,
   coReplaceItemsMock,
   clientsExistsByIdMock,

--- a/server/test/routes/invoices.test.ts
+++ b/server/test/routes/invoices.test.ts
@@ -40,6 +40,7 @@ const findAmountPaidMock = mock();
 const findStatusMock = mock();
 const findStatusAndClientNameMock = mock();
 const findIdConflictMock = mock();
+const renameDraftMock = mock();
 const deleteByIdMock = mock();
 const logAuditMock = mock(async () => undefined);
 const { withDbTransactionMock, resetWithDbTransactionMock } = makeWithDbTransactionMock();
@@ -77,6 +78,7 @@ beforeAll(async () => {
     findStatus: findStatusMock,
     findStatusAndClientName: findStatusAndClientNameMock,
     findIdConflict: findIdConflictMock,
+    renameDraft: renameDraftMock,
     deleteById: deleteByIdMock,
     deleteDraftById: deleteByIdMock,
   }));
@@ -165,6 +167,7 @@ const allMocks = [
   findStatusMock,
   findStatusAndClientNameMock,
   findIdConflictMock,
+  renameDraftMock,
   deleteByIdMock,
   logAuditMock,
   withDbTransactionMock,

--- a/server/test/routes/supplier-invoices.test.ts
+++ b/server/test/routes/supplier-invoices.test.ts
@@ -37,6 +37,7 @@ const insertItemsMock = mock();
 const findExistingMock = mock();
 const findIdConflictMock = mock();
 const updateMock = mock();
+const renameMock = mock();
 const replaceItemsMock = mock();
 const findItemsForInvoiceMock = mock();
 const findStatusAndSupplierNameMock = mock();
@@ -75,6 +76,7 @@ beforeAll(async () => {
     findExisting: findExistingMock,
     findIdConflict: findIdConflictMock,
     update: updateMock,
+    rename: renameMock,
     replaceItems: replaceItemsMock,
     findItemsForInvoice: findItemsForInvoiceMock,
     findStatusAndSupplierName: findStatusAndSupplierNameMock,
@@ -182,6 +184,7 @@ const allMocks = [
   findExistingMock,
   findIdConflictMock,
   updateMock,
+  renameMock,
   replaceItemsMock,
   findItemsForInvoiceMock,
   findStatusAndSupplierNameMock,

--- a/server/test/routes/supplier-orders-versions.test.ts
+++ b/server/test/routes/supplier-orders-versions.test.ts
@@ -42,6 +42,7 @@ const soFindFullForSnapshotMock = mock();
 const soFindItemsForOrderMock = mock();
 const soFindIdConflictMock = mock();
 const soUpdateMock = mock();
+const soRenameMock = mock();
 const soRestoreSnapshotOrderMock = mock();
 const soReplaceItemsMock = mock();
 
@@ -83,6 +84,7 @@ beforeAll(async () => {
     findItemsForOrder: soFindItemsForOrderMock,
     findIdConflict: soFindIdConflictMock,
     update: soUpdateMock,
+    rename: soRenameMock,
     restoreSnapshotOrder: soRestoreSnapshotOrderMock,
     replaceItems: soReplaceItemsMock,
   }));
@@ -203,6 +205,7 @@ const allMocks = [
   soFindItemsForOrderMock,
   soFindIdConflictMock,
   soUpdateMock,
+  soRenameMock,
   soRestoreSnapshotOrderMock,
   soReplaceItemsMock,
   suppliersExistsByIdMock,
@@ -567,7 +570,7 @@ describe('PUT /api/accounting/supplier-orders/:id snapshots pre-update state', (
       supplierName: 'Acme',
       status: 'draft',
     });
-    soUpdateMock.mockResolvedValue({ ...SAMPLE_ORDER, id: 'so-1-renamed' });
+    soRenameMock.mockResolvedValue({ ...SAMPLE_ORDER, id: 'so-1-renamed' });
 
     const res = await testApp.inject({
       method: 'PUT',
@@ -579,5 +582,8 @@ describe('PUT /api/accounting/supplier-orders/:id snapshots pre-update state', (
     expect(res.statusCode).toBe(200);
     expect(sovInsertMock).not.toHaveBeenCalled();
     expect(soFindFullForSnapshotMock).not.toHaveBeenCalled();
+    // PK rename goes through the dedicated repo call (issue #621), not the generic update().
+    expect(soRenameMock).toHaveBeenCalledWith('so-1', 'so-1-renamed', TX_SENTINEL);
+    expect(soUpdateMock).not.toHaveBeenCalled();
   });
 });

--- a/server/test/routes/supplier-quotes-versions.test.ts
+++ b/server/test/routes/supplier-quotes-versions.test.ts
@@ -39,6 +39,7 @@ const sqFindFullForSnapshotMock = mock();
 const sqFindItemsForQuoteMock = mock();
 const sqFindIdConflictMock = mock();
 const sqUpdateMock = mock();
+const sqRenameMock = mock();
 const sqRestoreSnapshotQuoteMock = mock();
 const sqReplaceItemsMock = mock();
 
@@ -83,6 +84,7 @@ beforeAll(async () => {
     findItemsForQuote: sqFindItemsForQuoteMock,
     findIdConflict: sqFindIdConflictMock,
     update: sqUpdateMock,
+    rename: sqRenameMock,
     restoreSnapshotQuote: sqRestoreSnapshotQuoteMock,
     replaceItems: sqReplaceItemsMock,
   }));
@@ -193,6 +195,7 @@ const allMocks = [
   sqFindItemsForQuoteMock,
   sqFindIdConflictMock,
   sqUpdateMock,
+  sqRenameMock,
   sqRestoreSnapshotQuoteMock,
   sqReplaceItemsMock,
   suppliersFindByIdMock,
@@ -473,7 +476,7 @@ describe('PUT /api/sales/supplier-quotes/:id snapshots pre-update state', () => 
   });
 
   test('PUT with id-only rename does NOT snapshot (no content change)', async () => {
-    sqUpdateMock.mockResolvedValue({ ...SAMPLE_QUOTE, id: 'sq-1-renamed' });
+    sqRenameMock.mockResolvedValue({ ...SAMPLE_QUOTE, id: 'sq-1-renamed' });
 
     const res = await testApp.inject({
       method: 'PUT',
@@ -485,6 +488,9 @@ describe('PUT /api/sales/supplier-quotes/:id snapshots pre-update state', () => 
     expect(res.statusCode).toBe(200);
     expect(sqvInsertMock).not.toHaveBeenCalled();
     expect(sqFindFullForSnapshotMock).not.toHaveBeenCalled();
+    // PK rename goes through the dedicated repo call (issue #621), not the generic update().
+    expect(sqRenameMock).toHaveBeenCalledWith('sq-1', 'sq-1-renamed', TX_SENTINEL);
+    expect(sqUpdateMock).not.toHaveBeenCalled();
   });
 
   test('PUT with empty body does NOT snapshot (no content change, repo treats as no-op)', async () => {

--- a/server/test/routes/supplier-quotes.test.ts
+++ b/server/test/routes/supplier-quotes.test.ts
@@ -33,6 +33,7 @@ const sqFindIdConflictMock = mock();
 const sqFindFullForSnapshotMock = mock();
 const sqFindItemsForQuoteMock = mock();
 const sqUpdateMock = mock();
+const sqRenameMock = mock();
 const sqReplaceItemsMock = mock();
 
 const sqvInsertMock = mock();
@@ -66,6 +67,7 @@ beforeAll(async () => {
     findFullForSnapshot: sqFindFullForSnapshotMock,
     findItemsForQuote: sqFindItemsForQuoteMock,
     update: sqUpdateMock,
+    rename: sqRenameMock,
     replaceItems: sqReplaceItemsMock,
   }));
   mock.module('../../repositories/supplierQuoteVersionsRepo.ts', () => ({
@@ -150,6 +152,7 @@ const allMocks = [
   sqFindFullForSnapshotMock,
   sqFindItemsForQuoteMock,
   sqUpdateMock,
+  sqRenameMock,
   sqReplaceItemsMock,
   sqvInsertMock,
   sqvBuildSnapshotMock,


### PR DESCRIPTION
## Summary

Issue [#621](https://github.com/xBounceIT/praetor/issues/621) reported that `clientOffersRepo.update` and `clientQuotesRepo.update` accepted `id` in their patch and applied it via `COALESCE`, so any caller passing `id` silently mutated the primary key. **The same defect existed in 5 sibling repos** — this PR fixes all 7.

## What changed

For each of these 7 repos:

- `clientOffersRepo`, `clientQuotesRepo` (the original two from #621)
- `clientsOrdersRepo`, `invoicesRepo`, `supplierOrdersRepo`, `supplierQuotesRepo`, `supplierInvoicesRepo` (sibling defects)

1. Removed `id?` from the `*Update` patch type and from the `SET` clause.
2. Added a dedicated `rename(currentId, newId, exec)` function that returns the full mapped row (or `null`). Invoices uses `renameDraft` to preserve the existing draft-only predicate from `updateDraft`.
3. Updated the corresponding PUT route to call `rename()` separately inside the transaction. When the patch is id-only, the follow-up `update()` is skipped — the row returned by `rename()` is reused directly.

## Why a separate function

The PK rename is intentional functionality on these PUT endpoints (callers can change `INV-2026-0001` → `INV-2026-0002` etc.), so the fix isolates that into one explicit operation rather than letting it sneak through generic patches.

The rename relies on every incoming FK declaring `ON UPDATE CASCADE`. To pin that invariant:

- Added `server/test/db/renamablePkFkCascade.test.ts` — a parameterized regression test that walks every incoming FK reference for all 7 renamable PKs and asserts `onUpdate: 'cascade'`.
- The pre-existing `salesIdFkCascade.test.ts` had two responsibilities (generic FK cascade + migration-0048 specifics); split the migration assertions out into `migration0048ProjectsOrderIdCascade.test.ts` and deleted the redundant FK-discovery block.

## Test plan

- [x] `bun test` — full server suite: **2790 pass, 0 fail, 28 skip**
- [x] `bunx tsc -p server/tsconfig.json --noEmit` — clean
- [x] `bunx biome check server/` — clean
- [x] Repo unit tests assert the SET clause no longer writes `"id"`
- [x] Route-version tests assert the PUT-with-id-only-rename path goes through `rename` (not `update`)
- [x] New cascade regression test covers all 7 renamable PKs (23 assertions)

## Notes for review

- The `findIdConflict` pre-check outside the transaction is redundant with the unique-violation `catch` handler inside, but that's pre-existing across these routes — left untouched.
- Each `rename` function returns the full mapped row rather than just the id so the route can skip the follow-up `update()` SQL roundtrip on id-only renames.
- The route-level rename-then-update block is structurally similar across the 5 PUT handlers but lives among heavy route-specific logic (snapshot decisions, item replacement, error mapping); extracting it into a helper would relocate complexity rather than remove it. Same reasoning applies to the 7 `rename()` repo functions individually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)