### PR TITLE
auth(fix): LDAP sync auto-provision skips users on group-search failure instead of silently demoting

### DIFF
--- a/server/services/ldap.ts
+++ b/server/services/ldap.ts
@@ -709,7 +709,21 @@ class LDAPService {
           }
           syncedCount++;
         } else if (config.autoProvisionAll) {
-          const groups = await this.findUserGroups(ldapClient, entry.objectName, username);
+          // throwOnError so a transient group-search failure skips this user instead of
+          // creating them with mapExternalGroupsToRoleIds([]) → [DEFAULT_ROLE_ID], which
+          // would silently demote a new admin/manager. Sibling of #637.
+          let groups: string[];
+          try {
+            groups = await this.findUserGroups(ldapClient, entry.objectName, username, {
+              throwOnError: true,
+            });
+          } catch (err) {
+            logger.warn(
+              { err: serializeError(err), username },
+              'LDAP sync skipped auto-provision for user: group search failed',
+            );
+            continue;
+          }
           const roleIds = mapExternalGroupsToRoleIds(groups, roleMappings);
           const id = generatePrefixedId('u');
           await usersRepo.createUser({

--- a/server/test/services/ldap.test.ts
+++ b/server/test/services/ldap.test.ts
@@ -1041,6 +1041,42 @@ describe('syncUsers', () => {
     await expect(ldapService.syncUsers()).rejects.toThrow('LDAP search failed status: 1');
     expect(lastClientStats?.unbindCalls).toBe(1);
   });
+
+  test('auto-provision skips users whose group search throws — sibling of #637', async () => {
+    // Without the throw guard, alice would be created with mapExternalGroupsToRoleIds([])
+    // → [DEFAULT_ROLE_ID], silently demoting a new admin. The sync continues with bob so
+    // a single transient error doesn't abort the whole run. findUserGroups issues the
+    // two identifier searches in parallel, so each user consumes two responses even when
+    // Promise.all rejects fast.
+    nextFixture = {
+      bindResponses: [null],
+      searchResponses: [
+        {
+          entries: [
+            { objectName: 'uid=alice,dc=x', object: { uid: 'alice', cn: 'Alice' } },
+            { objectName: 'uid=bob,dc=x', object: { uid: 'bob', cn: 'Bob' } },
+          ],
+          status: 0,
+        },
+        { err: new Error('group subtree timeout') }, // alice userDn → throws
+        { entries: [], status: 0 }, // alice username (parallel; result discarded)
+        { entries: [], status: 0 }, // bob userDn
+        { entries: [], status: 0 }, // bob username
+      ],
+    };
+    findLoginUserByUsernameMock.mockResolvedValue(null);
+
+    const result = await ldapService.syncUsers();
+
+    expect(result).toEqual({ synced: 0, created: 1 });
+    expect(createUserMock).toHaveBeenCalledTimes(1);
+    const created = createUserMock.mock.calls[0]?.[0] as { username: string };
+    expect(created.username).toBe('bob');
+    const createdUsernames = createUserMock.mock.calls.map(
+      (call) => (call[0] as { username: string }).username,
+    );
+    expect(createdUsernames).not.toContain('alice');
+  });
 });
 
 describe('lookupUserGroups', () => {


### PR DESCRIPTION
## Summary

Sibling fix to #637 / [PR #684](https://github.com/xBounceIT/praetor/pull/684), addressing the same silent-role-demotion bug class in the LDAP sync path.

[server/services/ldap.ts:721](server/services/ldap.ts:721) — `syncUsers`'s auto-provision branch called `findUserGroups` in non-strict mode. A transient group-subtree failure returned `[]`, which `mapExternalGroupsToRoleIds([], …)` translated into `[DEFAULT_ROLE_ID]`, creating the new user with role `'user'`. A new admin/manager synced from the directory during a transient LDAP hiccup got stuck as a regular user.

## Approach

Auth's first-login fix in #684 simply lets the throw propagate to `/login`'s 503 handler. Sync can't do the same — throwing aborts the entire run, so one transient subtree error for one user would block all subsequent users from syncing.

Instead:
- Pass `throwOnError: true` to `findUserGroups` in the auto-provision branch
- Wrap that single call in a per-user `try`/`catch`
- On error, log a warning naming the affected user and `continue` to the next entry

The existing-user branch at [server/services/ldap.ts:705](server/services/ldap.ts:705) is unaffected — `applyExternalRolesForUserIfMatched` already preserves the existing role on empty groups, so the demote risk doesn't apply there.

## Test plan

- [x] New regression test under `syncUsers`: 2 entries (alice, bob), alice's group search throws, assert `createUser` called exactly once with `bob` and never with `alice`. Validates both the no-demote contract and the continue-after-error contract.
- [x] `bun test test/services/ldap.test.ts` — 71/71 pass
- [x] `bun test` (full server suite) — 2775/2775 pass
- [x] Biome clean on touched files

## Notes for reviewer

- Independent of #684 — this PR is based on current `main` and doesn't depend on #684 landing first. The `throwOnError` option on `findUserGroups` exists on main today.
- The fixture provides 5 search responses (1 user-sync + 2 per user) because [#683](https://github.com/xBounceIT/praetor/pull/683) parallelized `findUserGroups` identifier lookups via `Promise.all` — each user consumes two responses even when the first rejects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)