### PR TITLE
ldap(tls): audit-log when LDAP_REJECT_UNAUTHORIZED disables validation (#642)

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -58,4 +58,9 @@ LOG_LEVEL=info
 # LDAP_TLS_CA_FILE=/app/certs/ca.crt
 # LDAP_TLS_CERT_FILE=/app/certs/client.crt
 # LDAP_TLS_KEY_FILE=/app/certs/client.key
+# DANGER: setting LDAP_REJECT_UNAUTHORIZED=false disables TLS certificate validation
+# for every LDAP connection. Bind credentials become vulnerable to an active MITM
+# attacker on the LDAP path. Only set this for local dev against self-signed certs;
+# never in staging or production. Prefer pinning a CA via LDAP_TLS_CA_FILE (or via
+# the DB-stored CA in the admin UI) instead.
 # LDAP_REJECT_UNAUTHORIZED=false

--- a/server/services/ldap.ts
+++ b/server/services/ldap.ts
@@ -209,6 +209,13 @@ class LDAPService {
       rejectUnauthorized: process.env.LDAP_REJECT_UNAUTHORIZED !== 'false',
     };
 
+    if (!tlsOptions.rejectUnauthorized) {
+      // Audit signal so an env var leaked from a dev machine into staging/prod is not silent.
+      createChildLogger({ module: 'ldap' }).warn(
+        'LDAP_REJECT_UNAUTHORIZED=false: TLS certificate validation disabled — credentials are vulnerable to MITM',
+      );
+    }
+
     // CA precedence: DB-stored PEM wins; otherwise fall back to LDAP_TLS_CA_FILE.
     // Node's TLS layer accepts a single Buffer with one or more concatenated
     // PEM blocks, so chain certs in the textarea work without extra parsing.

--- a/server/test/services/ldap.test.ts
+++ b/server/test/services/ldap.test.ts
@@ -104,9 +104,11 @@ const createClientMock = mock((opts: unknown) => {
 });
 
 const noop = () => {};
+// `warn` is a mock so we can assert on the LDAP_REJECT_UNAUTHORIZED=false audit signal.
+const loggerWarnMock = mock();
 const silentLogger = {
   info: noop,
-  warn: noop,
+  warn: loggerWarnMock,
   error: noop,
   debug: noop,
   fatal: noop,
@@ -216,6 +218,7 @@ beforeEach(() => {
   applyExternalRolesForUserMock.mockReset();
   applyExternalRolesForUserIfMatchedMock.mockReset();
   filterExistingRoleIdsMock.mockReset();
+  loggerWarnMock.mockReset();
   filterExistingRoleIdsMock.mockImplementation(async (ids: string[]) =>
     ids.length > 0 ? ids : ['user'],
   );
@@ -270,6 +273,28 @@ describe('getClient', () => {
       tlsOptions: { rejectUnauthorized: boolean };
     };
     expect(opts.tlsOptions.rejectUnauthorized).toBe(false);
+  });
+
+  test('LDAP_REJECT_UNAUTHORIZED="false" emits an audit warning about MITM exposure', async () => {
+    process.env.LDAP_REJECT_UNAUTHORIZED = 'false';
+    await ldapService.getClient();
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      expect.stringMatching(/LDAP_REJECT_UNAUTHORIZED=false.*MITM/),
+    );
+  });
+
+  test('default rejectUnauthorized=true does NOT emit the MITM warning', async () => {
+    await ldapService.getClient();
+    expect(loggerWarnMock).not.toHaveBeenCalled();
+  });
+
+  test('warning re-fires on every getClient() call (no stale-cache squelching)', async () => {
+    // Audit signal must be loud — every connection attempt logs, so operators see it in
+    // periodic sync runs and not only on first boot.
+    process.env.LDAP_REJECT_UNAUTHORIZED = 'false';
+    await ldapService.getClient();
+    await ldapService.getClient();
+    expect(loggerWarnMock).toHaveBeenCalledTimes(2);
   });
 
   test('passes config.serverUrl to ldapjs.createClient', async () => {


### PR DESCRIPTION
## Summary
- Resolves [#642](https://github.com/xBounceIT/praetor/issues/642). A leaked dev `LDAP_REJECT_UNAUTHORIZED=false` would silently disable TLS certificate validation for every LDAP connection — bind credentials were exposed to an active MITM with no audit signal in the logs.
- `getClient()` now emits a `logger.warn` naming the env var and the MITM risk on every connection where `rejectUnauthorized` resolves to `false`, so a value carried over from a dev `.env` into staging/prod is loud rather than silent.
- `server/.env.example` gains a DANGER block above the variable, pointing operators at `LDAP_TLS_CA_FILE` (or the DB-stored CA in the admin UI) as the safer alternative for self-signed certs.

## Notes for reviewers
- The warn is fired via a fresh `createChildLogger({ module: 'ldap' })` call rather than the module-level captured `logger` const, so the test mock can intercept it via `mock.module` (the captured pino child is bound at module load and can't be swapped). The path only runs when validation is disabled (rare misconfig), so the per-call child allocation is not a hot-path concern.
- Per-call (rather than once-per-process) logging is intentional per the issue's suggested fix — every periodic LDAP sync and every login re-emits the signal so it shows up in any log slice.
- No changes to the actual TLS behavior; this is purely an audit/observability fix.

## Test plan
- [x] New tests in `server/test/services/ldap.test.ts` assert the warn fires when `LDAP_REJECT_UNAUTHORIZED=false`, does not fire by default, and re-fires on every `getClient()` call.
- [x] Verified the new positive assertions fail against the unfixed `ldap.ts` and pass against the fix (true bug-fix test).
- [x] Full server test suite: 2772 pass / 0 fail / 28 skip across 128 files.
- [x] `tsc --noEmit` on `server/tsconfig.json` is clean; pre-commit `biome check` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)