### PR TITLE
ldap(tls): use module logger; spy on pino root in tests

### DIFF
--- a/server/services/ldap.ts
+++ b/server/services/ldap.ts
@@ -211,7 +211,7 @@ class LDAPService {
 
     if (!tlsOptions.rejectUnauthorized) {
       // Audit signal so an env var leaked from a dev machine into staging/prod is not silent.
-      createChildLogger({ module: 'ldap' }).warn(
+      logger.warn(
         'LDAP_REJECT_UNAUTHORIZED=false: TLS certificate validation disabled — credentials are vulnerable to MITM',
       );
     }

--- a/server/test/services/ldap.test.ts
+++ b/server/test/services/ldap.test.ts
@@ -1,4 +1,14 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from 'bun:test';
 import realLdap from 'ldapjs';
 import * as realLdapRepo from '../../repositories/ldapRepo.ts';
 import * as realUsersRepo from '../../repositories/usersRepo.ts';
@@ -104,11 +114,9 @@ const createClientMock = mock((opts: unknown) => {
 });
 
 const noop = () => {};
-// `warn` is a mock so we can assert on the LDAP_REJECT_UNAUTHORIZED=false audit signal.
-const loggerWarnMock = mock();
 const silentLogger = {
   info: noop,
-  warn: loggerWarnMock,
+  warn: noop,
   error: noop,
   debug: noop,
   fatal: noop,
@@ -218,7 +226,6 @@ beforeEach(() => {
   applyExternalRolesForUserMock.mockReset();
   applyExternalRolesForUserIfMatchedMock.mockReset();
   filterExistingRoleIdsMock.mockReset();
-  loggerWarnMock.mockReset();
   filterExistingRoleIdsMock.mockImplementation(async (ids: string[]) =>
     ids.length > 0 ? ids : ['user'],
   );
@@ -275,26 +282,39 @@ describe('getClient', () => {
     expect(opts.tlsOptions.rejectUnauthorized).toBe(false);
   });
 
-  test('LDAP_REJECT_UNAUTHORIZED="false" emits an audit warning about MITM exposure', async () => {
-    process.env.LDAP_REJECT_UNAUTHORIZED = 'false';
-    await ldapService.getClient();
-    expect(loggerWarnMock).toHaveBeenCalledWith(
-      expect.stringMatching(/LDAP_REJECT_UNAUTHORIZED=false.*MITM/),
-    );
-  });
+  describe('TLS audit warning', () => {
+    // ldap.ts's module-level `logger` is a pino child of `loggerSnapshot.logger` (the real
+    // root, captured before mock.module replaces the export). Pino children inherit `warn`
+    // from the root via the prototype chain, so spying on root.warn intercepts the child.
+    let warnSpy: ReturnType<typeof spyOn<typeof loggerSnapshot.logger, 'warn'>>;
+    beforeEach(() => {
+      warnSpy = spyOn(loggerSnapshot.logger, 'warn').mockImplementation(() => {});
+    });
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
 
-  test('default rejectUnauthorized=true does NOT emit the MITM warning', async () => {
-    await ldapService.getClient();
-    expect(loggerWarnMock).not.toHaveBeenCalled();
-  });
+    test('LDAP_REJECT_UNAUTHORIZED="false" emits an audit warning about MITM exposure', async () => {
+      process.env.LDAP_REJECT_UNAUTHORIZED = 'false';
+      await ldapService.getClient();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/LDAP_REJECT_UNAUTHORIZED=false.*MITM/),
+      );
+    });
 
-  test('warning re-fires on every getClient() call (no stale-cache squelching)', async () => {
-    // Audit signal must be loud — every connection attempt logs, so operators see it in
-    // periodic sync runs and not only on first boot.
-    process.env.LDAP_REJECT_UNAUTHORIZED = 'false';
-    await ldapService.getClient();
-    await ldapService.getClient();
-    expect(loggerWarnMock).toHaveBeenCalledTimes(2);
+    test('default rejectUnauthorized=true does NOT emit the MITM warning', async () => {
+      await ldapService.getClient();
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    test('warning re-fires on every getClient() call (no stale-cache squelching)', async () => {
+      // Audit signal must be loud — every connection attempt logs, so operators see it in
+      // periodic sync runs and not only on first boot.
+      process.env.LDAP_REJECT_UNAUTHORIZED = 'false';
+      await ldapService.getClient();
+      await ldapService.getClient();
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+    });
   });
 
   test('passes config.serverUrl to ldapjs.createClient', async () => {


### PR DESCRIPTION
## Summary
Follow-up to [#689](https://github.com/xBounceIT/praetor/pull/689) (issue [#642](https://github.com/xBounceIT/praetor/issues/642)).

#689 emitted the new `LDAP_REJECT_UNAUTHORIZED=false` audit warning via a fresh `createChildLogger({ module: 'ldap' })` allocation per `getClient()` call solely so the test mock could intercept it through `mock.module`. That choice broke style consistency with every other `logger.warn(...)` site in `ldap.ts` and let testability concerns leak into production code.

This PR reverts the warn site to the module-level `logger` const used everywhere else in the file, and switches the test to `spyOn(loggerSnapshot.logger, 'warn')`. Pino children inherit `warn` from the root via the prototype chain (verified directly — `child.warn === rootLogger.warn` because pino's child has the root as its `__proto__`), so spying on the captured real root cleanly intercepts the ldap.ts child's `warn` calls.

## Notes for reviewers
- Production diff: 1 line — `createChildLogger({module:'ldap'}).warn(...)` → `logger.warn(...)`.
- Test diff: moves the 3 TLS-warning cases into a nested `describe('TLS audit warning', …)` with `beforeEach`/`afterEach` that set up and restore the spy per test. No more module-level `loggerWarnMock`; `silentLogger.warn` is back to `noop`.
- `loggerSnapshot.logger` is captured at module top (before `beforeAll`'s `mock.module` replaces the export with `silentLogger`), so it still points to the real pino root.
- Behavior is identical to #689 — same warning string, same per-call audit cadence. No env var or `.env.example` changes.

## Test plan
- [x] `bun test test/services/ldap.test.ts`: 73 / 73 pass on the refactor; 2 of the 3 TLS-warning tests fail on the unfixed `ldap.ts` (true bug-fix coverage retained).
- [x] Full server suite: 2825 pass / 0 fail / 28 skip across 129 files.
- [x] `tsc --noEmit` clean; pre-commit `biome check` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)