### PR TITLE
auth(fix): preserve LDAP password whitespace

### DIFF
--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -15,7 +15,11 @@ import { logAudit } from '../utils/audit.ts';
 import { getRolePermissions } from '../utils/permissions.ts';
 import { LOGIN_RATE_LIMIT } from '../utils/rate-limit.ts';
 import { replyError } from '../utils/replyError.ts';
-import { badRequest, requireNonEmptyString } from '../utils/validation.ts';
+import {
+  badRequest,
+  requireNonEmptyString,
+  requireNonEmptyStringRaw,
+} from '../utils/validation.ts';
 
 const authUserSchema = {
   type: 'object',
@@ -99,7 +103,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         return badRequest(reply, usernameResult.message);
       }
 
-      const passwordResult = requireNonEmptyString(password, 'password');
+      const passwordResult = requireNonEmptyStringRaw(password, 'password');
       if (!passwordResult.ok) {
         return badRequest(reply, passwordResult.message);
       }
@@ -162,7 +166,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       if (ldapAuthSuccess) {
         validPassword = true;
       } else if (authMethod === 'local' && user.passwordHash) {
-        validPassword = await bcrypt.compare(passwordResult.value, user.passwordHash);
+        validPassword = await bcrypt.compare(passwordResult.value.trim(), user.passwordHash);
       }
 
       if (!validPassword) {

--- a/server/routes/ldap.ts
+++ b/server/routes/ldap.ts
@@ -10,7 +10,12 @@ import { getAuditCounts, logAudit } from '../utils/audit.ts';
 import { MASKED_SECRET } from '../utils/crypto.ts';
 import { validateGroupFilterTemplate, validateUserFilterTemplate } from '../utils/ldap-filter.ts';
 import { replyError } from '../utils/replyError.ts';
-import { badRequest, parseBooleanField, requireNonEmptyString } from '../utils/validation.ts';
+import {
+  badRequest,
+  parseBooleanField,
+  requireNonEmptyString,
+  requireNonEmptyStringRaw,
+} from '../utils/validation.ts';
 
 // 64 KB matches the UI's file-import size cap (AuthSettings.tsx); keeping these in
 // sync prevents a save flow where a 32-64 KB chain passes the picker but fails the API.
@@ -416,7 +421,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const usernameResult = requireNonEmptyString(username, 'username');
       if (!usernameResult.ok) return badRequest(reply, usernameResult.message);
 
-      const passwordResult = requireNonEmptyString(password, 'password');
+      const passwordResult = requireNonEmptyStringRaw(password, 'password');
       if (!passwordResult.ok) return badRequest(reply, passwordResult.message);
 
       const ldapService = (await import('../services/ldap.ts')).default;

--- a/server/test/routes/auth.test.ts
+++ b/server/test/routes/auth.test.ts
@@ -261,6 +261,20 @@ describe('POST /api/auth/login', () => {
     );
   });
 
+  test('200: local password comparison keeps existing trim normalization', async () => {
+    findLoginUserByNormalizedUsernameMock.mockResolvedValue(LOGIN_USER);
+    bcryptCompareMock.mockResolvedValue(true);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/auth/login',
+      payload: { username: 'alice', password: ' secret ' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(bcryptCompareMock).toHaveBeenCalledWith('secret', LOGIN_USER.passwordHash);
+  });
+
   test('200: LDAP success skips bcrypt', async () => {
     findLoginUserByNormalizedUsernameMock.mockResolvedValue({ ...LOGIN_USER, authMethod: 'ldap' });
     ldapAuthenticateWithProfileMock.mockResolvedValue({
@@ -281,6 +295,27 @@ describe('POST /api/auth/login', () => {
     expect(bcryptCompareMock).not.toHaveBeenCalled();
     const body = JSON.parse(res.body);
     expect(body.user.role).toBe('admin');
+  });
+
+  test('200: LDAP login sends the untrimmed password to the directory bind (#697)', async () => {
+    const rawPassword = '   spaces   ';
+    findLoginUserByNormalizedUsernameMock.mockResolvedValue({ ...LOGIN_USER, authMethod: 'ldap' });
+    ldapAuthenticateWithProfileMock.mockResolvedValue({
+      authenticated: true,
+      groups: [],
+      matchedRoleIds: [],
+    });
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/auth/login',
+      payload: { username: ' alice ', password: rawPassword },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(findLoginUserByNormalizedUsernameMock).toHaveBeenCalledWith('alice');
+    expect(ldapAuthenticateWithProfileMock).toHaveBeenCalledWith('alice', rawPassword);
+    expect(bcryptCompareMock).not.toHaveBeenCalled();
   });
 
   test('200: LDAP login with no matching role mapping preserves admin-assigned role (regression #318)', async () => {
@@ -398,19 +433,20 @@ describe('POST /api/auth/login', () => {
     ]);
   });
 
-  test('401 user not found (LDAP auto-provision also fails)', async () => {
+  test('401 user not found (LDAP auto-provision also fails with untrimmed password)', async () => {
+    const rawPassword = '   spaces   ';
     findLoginUserByNormalizedUsernameMock.mockResolvedValue(null);
     ldapAuthenticateAndProvisionMock.mockResolvedValue({ authenticated: false });
 
     const res = await testApp.inject({
       method: 'POST',
       url: '/api/auth/login',
-      payload: { username: 'ghost', password: 'whatever' },
+      payload: { username: 'ghost', password: rawPassword },
     });
 
     expect(res.statusCode).toBe(401);
     expect(JSON.parse(res.body)).toEqual({ error: 'Invalid username or password' });
-    expect(ldapAuthenticateAndProvisionMock).toHaveBeenCalledWith('ghost', 'whatever');
+    expect(ldapAuthenticateAndProvisionMock).toHaveBeenCalledWith('ghost', rawPassword);
     expect(logAuditMock).not.toHaveBeenCalled();
   });
 

--- a/server/test/routes/ldap.test.ts
+++ b/server/test/routes/ldap.test.ts
@@ -622,6 +622,23 @@ describe('POST /api/ldap/test', () => {
     });
   });
 
+  test('sends the untrimmed password to LDAP authentication (#697)', async () => {
+    const rawPassword = '   spaces   ';
+    authenticateWithProfileMock.mockResolvedValue({
+      authenticated: false,
+      groups: [],
+      matchedRoleIds: [],
+    });
+
+    const response = await testLdapAuth({ username: ' alice ', password: rawPassword });
+
+    expect(response.statusCode).toBe(200);
+    expect(authenticateWithProfileMock).toHaveBeenCalledWith('alice', rawPassword, {
+      allowDisabledConfig: true,
+      reloadConfig: true,
+    });
+  });
+
   test('returns an unsuccessful server response without groups or roles for failed auth', async () => {
     authenticateWithProfileMock.mockResolvedValue({
       authenticated: false,

--- a/server/test/utils/validation.test.ts
+++ b/server/test/utils/validation.test.ts
@@ -33,6 +33,7 @@ import {
   parseQueryBoolean,
   requireNonEmptyArrayOfStrings,
   requireNonEmptyString,
+  requireNonEmptyStringRaw,
   validateClientIdentifier,
   validateEmail,
   validateEnum,
@@ -84,6 +85,21 @@ describe('requireNonEmptyString', () => {
     const result = requireNonEmptyString('   ', 'title');
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.message).toBe('title is required');
+  });
+});
+
+describe('requireNonEmptyStringRaw', () => {
+  test('accepts a valid non-empty string and preserves surrounding whitespace', () => {
+    expect(requireNonEmptyStringRaw('  abc  ', 'password')).toEqual({
+      ok: true,
+      value: '  abc  ',
+    });
+  });
+
+  test('returns required-message for whitespace-only string', () => {
+    const result = requireNonEmptyStringRaw('   ', 'password');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.message).toBe('password is required');
   });
 });
 

--- a/server/utils/validation.ts
+++ b/server/utils/validation.ts
@@ -32,6 +32,20 @@ export function requireNonEmptyString(
 }
 
 /**
+ * Validate a required non-empty string but preserve the original value.
+ * Use for external credentials where leading/trailing whitespace can be meaningful.
+ */
+export function requireNonEmptyStringRaw(
+  value: unknown,
+  fieldName: string,
+): { ok: true; value: string } | { ok: false; message: string } {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    return { ok: false, message: `${fieldName} is required` };
+  }
+  return { ok: true, value };
+}
+
+/**
  * Validate optional non-empty string (if provided, must be valid)
  */
 export function optionalNonEmptyString(


### PR DESCRIPTION
## Summary
- Preserve leading and trailing whitespace in LDAP passwords passed through `/login` and `/ldap/test`.
- Keep existing local-password trim normalization for bcrypt comparisons.

## Changes
- Adds `requireNonEmptyStringRaw` for credential fields where surrounding whitespace is meaningful.
- Switches LDAP login, LDAP auto-provision, and LDAP tester binds to use the untrimmed password value.
- Adds regression coverage for LDAP whitespace preservation and helper behavior.

## Testing
- `bun test server/test/utils/validation.test.ts server/test/routes/auth.test.ts server/test/routes/ldap.test.ts`
- `bun x biome check server/routes/auth.ts server/routes/ldap.ts server/utils/validation.ts server/test/routes/auth.test.ts server/test/routes/ldap.test.ts server/test/utils/validation.test.ts`
- `bun run test:server`

## Risks / Rollout
- Low risk. Change is scoped to authentication request validation and preserves existing local-auth behavior.
- No migrations or configuration changes.

## Issues
Fixes #697