### PR TITLE
users(ui): drop redundant searchbar from UserManagement

### DIFF
--- a/components/administration/UserManagement.tsx
+++ b/components/administration/UserManagement.tsx
@@ -746,8 +746,10 @@ const UserManagement: React.FC<UserManagementProps> = ({
 
   const { visibleClients, visibleProjects, visibleTasks } = getFilteredData();
 
-  const sortedUsers = [...users].sort((a, b) =>
-    a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }),
+  const sortedUsers = React.useMemo(
+    () =>
+      [...users].sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })),
+    [users],
   );
 
   const emptyEmailLabel = t('common:common.none');

--- a/components/administration/UserManagement.tsx
+++ b/components/administration/UserManagement.tsx
@@ -200,7 +200,6 @@ const UserManagement: React.FC<UserManagementProps> = ({
   const [editFormErrors, setEditFormErrors] = useState<Record<string, string>>({});
   const [editCostPerHour, setEditCostPerHour] = useState<string>('0');
   const [editIsDisabled, setEditIsDisabled] = useState(false);
-  const [userSearch, setUserSearch] = useState('');
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const [authMethodUser, setAuthMethodUser] = useState<User | null>(null);
   const [authMethodDraft, setAuthMethodDraft] = useState<UserAuthMethod>('local');
@@ -747,18 +746,9 @@ const UserManagement: React.FC<UserManagementProps> = ({
 
   const { visibleClients, visibleProjects, visibleTasks } = getFilteredData();
 
-  const userSearchValue = userSearch.trim().toLowerCase();
-  const matchesUserSearch = (user: User, term: string) => {
-    if (!term) return true;
-    return (
-      user.name.toLowerCase().includes(term) ||
-      user.username.toLowerCase().includes(term) ||
-      (user.email?.toLowerCase() || '').includes(term)
-    );
-  };
-  const usersFiltered = [...users]
-    .sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }))
-    .filter((user) => matchesUserSearch(user, userSearchValue));
+  const sortedUsers = [...users].sort((a, b) =>
+    a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }),
+  );
 
   const emptyEmailLabel = t('common:common.none');
   const noUsersFoundLabel = t('hr:workforce.noUsers');
@@ -1556,28 +1546,17 @@ const UserManagement: React.FC<UserManagementProps> = ({
         </Dialog>
       )}
 
-      {/* Page header: search + add button */}
-      <div className="flex justify-between items-center gap-4">
-        <div className="relative flex-1">
-          <i className="fa-solid fa-magnifying-glass absolute left-3 top-1/2 -translate-y-1/2 text-zinc-300 text-xs"></i>
-          <input
-            type="text"
-            placeholder={t('hr:workforce.searchUsers')}
-            value={userSearch}
-            onChange={(e) => setUserSearch(e.target.value)}
-            className="w-full pl-8 pr-3 py-2 bg-white border border-zinc-200 rounded-xl text-sm font-semibold focus:ring-2 focus:ring-praetor outline-none shadow-sm"
-          />
-        </div>
-        {canCreateUsers && (
+      {canCreateUsers && (
+        <div className="flex justify-end">
           <HeaderAddButton onClick={() => setIsCreateModalOpen(true)}>
             {t('hr:workforce.addUser')}
           </HeaderAddButton>
-        )}
-      </div>
+        </div>
+      )}
 
       <StandardTable<User>
         title={t('hr:workforce.title')}
-        data={usersFiltered}
+        data={sortedUsers}
         columns={userColumns}
         defaultRowsPerPage={5}
         emptyState={noUsersFoundLabel}

--- a/locales/en/hr.json
+++ b/locales/en/hr.json
@@ -48,7 +48,6 @@
     "you": "You",
     "user": "User",
     "actions": "Actions",
-    "searchUsers": "Search users...",
     "searchActiveUsers": "Search active users...",
     "searchDisabledUsers": "Search disabled users...",
     "filterByClient": "Filter by Client",

--- a/locales/it/hr.json
+++ b/locales/it/hr.json
@@ -48,7 +48,6 @@
     "you": "Tu",
     "user": "Utente",
     "actions": "Azioni",
-    "searchUsers": "Cerca utenti...",
     "searchActiveUsers": "Cerca utenti attivi...",
     "searchDisabledUsers": "Cerca utenti disabilitati...",
     "filterByClient": "Filtra per Cliente",

--- a/test/components/administration/UserManagement.test.tsx
+++ b/test/components/administration/UserManagement.test.tsx
@@ -187,17 +187,6 @@ describe('<UserManagement />', () => {
     expect(oidcBadge.querySelector('i')).toBeNull();
   });
 
-  test('filters users with the external search input', () => {
-    renderUserManagement();
-
-    fireEvent.change(screen.getByPlaceholderText('hr:workforce.searchUsers'), {
-      target: { value: 'alice' },
-    });
-
-    expect(screen.getByText('Alice Admin')).toBeInTheDocument();
-    expect(screen.queryByText('Bob Brown')).not.toBeInTheDocument();
-  });
-
   test('opens edit modal when an editable row is clicked', () => {
     renderUserManagement();
 
@@ -220,18 +209,6 @@ describe('<UserManagement />', () => {
 
     expect(props.onUpdateUser).toHaveBeenCalledWith('u2', { isDisabled: true });
     expect(usersApiMock.getRoles).not.toHaveBeenCalled();
-  });
-
-  test('shows empty state when no users match the search', () => {
-    renderUserManagement();
-
-    fireEvent.change(screen.getByPlaceholderText('hr:workforce.searchUsers'), {
-      target: { value: 'nobody' },
-    });
-
-    expect(screen.getByText('hr:workforce.noUsers')).toBeInTheDocument();
-    expect(screen.queryByText('Alice Admin')).not.toBeInTheDocument();
-    expect(screen.queryByText('Bob Brown')).not.toBeInTheDocument();
   });
 
   const openAuthMethodDialog = async (


### PR DESCRIPTION
## Summary
- Remove the top-level search input from `UserManagement.tsx` — the `StandardTable` already provides per-column filters, so the input was duplicate UX.
- Drop the associated `userSearch` state, `matchesUserSearch` filter, and the orphaned `hr:workforce.searchUsers` translation key (`en` + `it`). Rename the remaining sorted list from `usersFiltered` to `sortedUsers` since no filtering happens anymore.
- Delete the two tests that drove the removed search input; the column-filter path is the supported behavior going forward.

## Test plan
- [x] `bun test test/components/administration/UserManagement.test.tsx` — 11 pass, 0 fail.
- [ ] Manual: open Administration → Users, confirm the searchbar is gone and the per-column filters still narrow the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)