### PR TITLE
ldap(ui): gate Save Configuration on form edits and add Save icon

### DIFF
--- a/components/administration/AuthSettings.tsx
+++ b/components/administration/AuthSettings.tsx
@@ -1,4 +1,4 @@
-import { CircleAlert } from 'lucide-react';
+import { CircleAlert, Save } from 'lucide-react';
 import type React from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -1190,7 +1190,8 @@ const AuthSettings: React.FC<AuthSettingsProps> = ({
             )}
 
             <div className="flex justify-end">
-              <Button type="submit" size="lg" disabled={isSavingLdap}>
+              <Button type="submit" size="lg" disabled={isSavingLdap || !isLdapDirty}>
+                <Save aria-hidden="true" />
                 {t('admin.ldap.saveConfiguration', 'Save Configuration')}
               </Button>
             </div>

--- a/test/components/administration/AuthSettings.test.tsx
+++ b/test/components/administration/AuthSettings.test.tsx
@@ -274,6 +274,10 @@ describe('<AuthSettings />', () => {
 
     renderAuthSettings({ onSave });
 
+    // Dirty the form so the save button is enabled — the production button is gated on edits.
+    fireEvent.change(inputForLabel('admin.ldap.bindDnLabel'), {
+      target: { value: 'cn=admin2,dc=example,dc=com' },
+    });
     fireEvent.click(screen.getByRole('button', { name: 'admin.ldap.saveConfiguration' }));
 
     await waitFor(() => {
@@ -281,6 +285,19 @@ describe('<AuthSettings />', () => {
       expect(screen.getByRole('alert')).toHaveTextContent('Role mapping references a missing role');
     });
     expect(screen.queryByText('admin.ldap.changesSaved')).not.toBeInTheDocument();
+  });
+
+  test('disables the LDAP save button until the admin edits the form', () => {
+    renderAuthSettings();
+
+    const saveButton = screen.getByRole('button', { name: 'admin.ldap.saveConfiguration' });
+    expect(saveButton).toBeDisabled();
+
+    fireEvent.change(inputForLabel('admin.ldap.bindDnLabel'), {
+      target: { value: 'cn=admin2,dc=example,dc=com' },
+    });
+
+    expect(saveButton).toBeEnabled();
   });
 
   test('renders the SAML ACS URL using the backend-authoritative template (issue #602)', async () => {


### PR DESCRIPTION
## Summary
- Disables the LDAP **Save Configuration** button until the form differs from the persisted config, so admins no longer fire no-op saves on an unchanged form.
- Adds a lucide `Save` icon to the button label, matching the sibling pattern at `components/administration/EmailSettings.tsx:411`.
- Reuses the pre-existing `isLdapDirty` flag (`AuthSettings.tsx:251`); no new state introduced.

## Test plan
- [x] `bun test test/components/administration/AuthSettings.test.tsx` — 21 pass, including the new `disables the LDAP save button until the admin edits the form` test that asserts disabled-on-mount and enabled-after-edit.
- [x] Updated the existing `shows the server error instead of the saved notification when LDAP save fails` test to dirty the form first, since it now needs to clear the gate to reach the submit handler.
- [x] `bunx biome check` — clean on the two changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)