### PR TITLE
release: bump app version to 0.6.5

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Praetor API",
     "description": "Praetor API documentation",
-    "version": "0.6.4"
+    "version": "0.6.5"
   },
   "components": {
     "securitySchemes": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praetor",
   "private": true,
-  "version": "0.6.4",
+  "version": "0.6.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server/app.ts
+++ b/server/app.ts
@@ -143,7 +143,7 @@ export const buildApp = async () => {
       info: {
         title: 'Praetor API',
         description: 'Praetor API documentation',
-        version: '0.6.4',
+        version: '0.6.5',
       },
       components: {
         securitySchemes: {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "praetor-server",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Praetor API Server",
   "main": "index.ts",
   "type": "module",

--- a/server/routes/mcp.ts
+++ b/server/routes/mcp.ts
@@ -239,7 +239,7 @@ const runBulkTimeEntryTool = async <T>(
 
 const buildServer = () => {
   const server = new McpServer(
-    { name: 'praetor', version: '0.6.4' },
+    { name: 'praetor', version: '0.6.5' },
     {
       instructions:
         'Use Praetor tools to inspect and update ERP data. Tool results are scoped to the authenticated MCP token user and their current Praetor role permissions.',

--- a/server/test/routes/mcp.test.ts
+++ b/server/test/routes/mcp.test.ts
@@ -357,7 +357,7 @@ describe('/api/mcp', () => {
 
     expect(res.statusCode).toBe(200);
     const body = parseMcpBody(res.body);
-    expect(body.result.serverInfo).toEqual({ name: 'praetor', version: '0.6.4' });
+    expect(body.result.serverInfo).toEqual({ name: 'praetor', version: '0.6.5' });
   });
 
   test('lists tools and calls permission-scoped list tools', async () => {


### PR DESCRIPTION
## Summary
- Bump the Praetor app version from `0.6.4` to `0.6.5` across the six lockstep locations: frontend + backend `package.json`, the Fastify Swagger `info.version` in `server/app.ts`, the MCP `serverInfo` in `server/routes/mcp.ts` (and the matching assertion in `server/test/routes/mcp.test.ts`), and the generated `docs/api/openapi.json`.
- No behavior changes — pure version-string bump.

## Test plan
- [x] `rg "0\.6\.4"` returns no matches; `rg "0\.6\.5"` returns six matches in the expected files.
- [x] `bun test ./test/routes/mcp.test.ts` passes (14/14), confirming the MCP `initialize` `serverInfo` assertion picks up the new version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)