### PR TITLE
administration(roles): keep sidebar style continuous in permissions editor

### DIFF
--- a/components/administration/RolesView.tsx
+++ b/components/administration/RolesView.tsx
@@ -373,26 +373,28 @@ const RolesView: React.FC<RolesViewProps> = ({
       orientation="vertical"
       className="flex max-h-[60vh] flex-row gap-0 overflow-hidden rounded-xl border border-border bg-card"
     >
-      <TabsList
-        variant="line"
-        className="h-full w-56 shrink-0 flex-col items-stretch justify-start gap-1 overflow-y-auto rounded-none border-r border-border bg-muted/40 p-2"
-      >
-        {moduleOrder.map((module) => {
-          const Icon = MODULE_ICONS[module];
-          return (
-            <TabsTrigger
-              key={module}
-              value={module}
-              className="justify-start gap-3 px-3 py-2 text-sm data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm"
-            >
-              {Icon ? <Icon className="size-4" /> : null}
-              <span className="truncate text-left">
-                {t(`layout:modules.${module}`, { defaultValue: toTitleCase(module) })}
-              </span>
-            </TabsTrigger>
-          );
-        })}
-      </TabsList>
+      <div className="flex w-56 shrink-0 flex-col border-r border-border bg-muted/40">
+        <TabsList
+          variant="line"
+          className="w-full min-h-0 flex-1 flex-col items-stretch justify-start gap-1 overflow-y-auto rounded-none bg-transparent p-2"
+        >
+          {moduleOrder.map((module) => {
+            const Icon = MODULE_ICONS[module];
+            return (
+              <TabsTrigger
+                key={module}
+                value={module}
+                className="justify-start gap-3 px-3 py-2 text-sm data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm"
+              >
+                {Icon ? <Icon className="size-4" /> : null}
+                <span className="truncate text-left">
+                  {t(`layout:modules.${module}`, { defaultValue: toTitleCase(module) })}
+                </span>
+              </TabsTrigger>
+            );
+          })}
+        </TabsList>
+      </div>
 
       <div className="flex-1 overflow-y-auto bg-background">
         {moduleOrder.map((module) => {


### PR DESCRIPTION
## Summary

- Wrap `TabsList` in a `div` that owns the sidebar's visual chrome (`w-56`, `bg-muted/40`, `border-r`) so the styling extends to the full dialog height — empty space below the last module no longer shows the dialog's `bg-card`.

## Why

In the Roles → Edit Permissions dialog, when the right-hand permissions table is taller than the sidebar (e.g. the `HR` module), the sidebar's background and right divider were ending at the last menu item ("Vendite"), exposing the dialog's `bg-card` below.

Root cause: `TabsList` had `h-full`, but `tabsListVariants` adds `group-data-[orientation=vertical]/tabs:h-fit`, which has higher CSS specificity (extra attribute selector on the group) than the unconditional `h-full` — `tailwind-merge` doesn't collapse them because they target different selectors. So `TabsList` shrank to fit its 8 items.

## Approach

Local change in `RolesView.tsx` only — no edits to the shared `tabs-variants.ts`, since other vertical `TabsList` usages may rely on `h-fit`. A sibling `div` around `TabsList` now carries the width, background, padding-ish, and right border. `TabsList` keeps tab behavior and scrolling (`flex-1 min-h-0 overflow-y-auto bg-transparent`).

## Test plan

- [ ] Run \`bun run dev\`, open Administration → Roles → Edit Permissions on any role
- [ ] Select \`HR\` — confirm the sidebar's muted background and right-side divider continue from the top of the dialog all the way to the bottom, with empty space below \`Vendite\` styled like the sidebar
- [ ] Switch to modules with shorter tables (e.g. \`Report\`) and confirm no visual regression
- [ ] Resize the window vertically to shrink the dialog; confirm the sidebar still tracks the right panel's height

🤖 Generated with [Claude Code](https://claude.com/claude-code)