### PR TITLE
release: bump app version to 0.7.0

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Praetor API",
     "description": "Praetor API documentation",
-    "version": "0.6.5"
+    "version": "0.7.0"
   },
   "components": {
     "securitySchemes": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praetor",
   "private": true,
-  "version": "0.6.5",
+  "version": "0.7.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server/app.ts
+++ b/server/app.ts
@@ -143,7 +143,7 @@ export const buildApp = async () => {
       info: {
         title: 'Praetor API',
         description: 'Praetor API documentation',
-        version: '0.6.5',
+        version: '0.7.0',
       },
       components: {
         securitySchemes: {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "praetor-server",
-  "version": "0.6.5",
+  "version": "0.7.0",
   "description": "Praetor API Server",
   "main": "index.ts",
   "type": "module",

--- a/server/routes/mcp.ts
+++ b/server/routes/mcp.ts
@@ -249,7 +249,7 @@ const runBulkTimeEntryTool = async <T>(
 
 const buildServer = () => {
   const server = new McpServer(
-    { name: 'praetor', version: '0.6.5' },
+    { name: 'praetor', version: '0.7.0' },
     {
       instructions:
         'Use Praetor tools to inspect and update ERP data. Tool results are scoped to the authenticated MCP token user and their current Praetor role permissions.',

--- a/server/test/routes/mcp.test.ts
+++ b/server/test/routes/mcp.test.ts
@@ -357,7 +357,7 @@ describe('/api/mcp', () => {
 
     expect(res.statusCode).toBe(200);
     const body = parseMcpBody(res.body);
-    expect(body.result.serverInfo).toEqual({ name: 'praetor', version: '0.6.5' });
+    expect(body.result.serverInfo).toEqual({ name: 'praetor', version: '0.7.0' });
   });
 
   test('lists tools and calls permission-scoped list tools', async () => {


### PR DESCRIPTION
## Summary
- Bump app version from `0.6.5` to `0.7.0` across the same six files updated in the previous release commit ([680f0d3b](https://github.com/xBounceIT/praetor/commit/680f0d3b)): root + server `package.json`, Swagger info in `server/app.ts`, MCP `serverInfo` in `server/routes/mcp.ts` (and its test), and `docs/api/openapi.json`.

## Test plan
- [ ] CI green (lint, typecheck, backend + frontend tests).
- [ ] `grep -r "0\.6\.5" .` returns no results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)