### PR TITLE
hr(dipendenti): make employee table rows clickable to open edit view

### DIFF
--- a/components/HR/ExternalEmployeesView.tsx
+++ b/components/HR/ExternalEmployeesView.tsx
@@ -404,6 +404,7 @@ const ExternalEmployeesView: React.FC<ExternalEmployeesViewProps> = ({
         title={t('externalEmployees.title')}
         data={externalEmployees}
         columns={columns}
+        onRowClick={canUpdateEmployees ? openEditModal : undefined}
         emptyState={
           <EmptyState
             title={t('externalEmployees.noEmployees')}

--- a/components/HR/InternalEmployeesView.tsx
+++ b/components/HR/InternalEmployeesView.tsx
@@ -435,6 +435,7 @@ const InternalEmployeesView: React.FC<InternalEmployeesViewProps> = ({
         title={t('internalEmployees.allEmployees')}
         data={allEmployees}
         columns={columns}
+        onRowClick={canUpdateEmployees ? openEditModal : undefined}
         emptyState={
           <EmptyState
             title={t('internalEmployees.noEmployees')}

--- a/test/components/hr/ExternalEmployeesView.rowClick.test.tsx
+++ b/test/components/hr/ExternalEmployeesView.rowClick.test.tsx
@@ -1,0 +1,74 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { fireEvent, screen } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import type { User } from '../../../types';
+import { installI18nMock } from '../../helpers/i18n';
+import { render } from '../../helpers/render';
+
+installI18nMock();
+
+mock.module('../../../services/api', () => ({
+  usersApi: {
+    getAssignments: mock(async () => ({ clientIds: [], projectIds: [], taskIds: [] })),
+    updateAssignments: mock(async () => {}),
+  },
+}));
+
+const ExternalEmployeesView = (await import('../../../components/HR/ExternalEmployeesView'))
+  .default;
+
+const employee: User = {
+  id: 'u1',
+  name: 'Mario Rossi',
+  role: 'user',
+  avatarInitials: 'MR',
+  username: 'mrossi',
+  employeeType: 'external',
+  costPerHour: 25,
+};
+
+const renderView = (overrides: Partial<ComponentProps<typeof ExternalEmployeesView>> = {}) => {
+  const props: ComponentProps<typeof ExternalEmployeesView> = {
+    users: [employee],
+    clients: [],
+    projects: [],
+    tasks: [],
+    onAddEmployee: mock(async () => ({ success: true })),
+    onUpdateEmployee: mock(() => {}),
+    onDeleteEmployee: mock(() => {}),
+    currency: '€',
+    permissions: ['hr.external.view', 'hr.external.update'],
+    ...overrides,
+  };
+  render(<ExternalEmployeesView {...props} />);
+  return props;
+};
+
+describe('<ExternalEmployeesView /> row click', () => {
+  test('clicking a row opens the edit modal populated for that employee', () => {
+    renderView();
+    expect(screen.queryByDisplayValue('Mario Rossi')).not.toBeInTheDocument();
+
+    const row = screen.getByText('Mario Rossi').closest('tr');
+    if (!row) throw new Error('employee row not found');
+    // cursor-pointer is added by StandardTable only when onRowClick is defined.
+    expect(row).toHaveClass('cursor-pointer');
+
+    fireEvent.click(row);
+
+    expect(screen.getByDisplayValue('Mario Rossi')).toBeInTheDocument();
+  });
+
+  test('row is not clickable without update permission', () => {
+    renderView({ permissions: ['hr.external.view'] });
+
+    const row = screen.getByText('Mario Rossi').closest('tr');
+    if (!row) throw new Error('employee row not found');
+    // No onRowClick is wired when the user can't edit, so no clickable affordance.
+    expect(row).not.toHaveClass('cursor-pointer');
+
+    fireEvent.click(row);
+
+    expect(screen.queryByDisplayValue('Mario Rossi')).not.toBeInTheDocument();
+  });
+});

--- a/test/components/hr/ExternalEmployeesView.rowClick.test.tsx
+++ b/test/components/hr/ExternalEmployeesView.rowClick.test.tsx
@@ -7,11 +7,11 @@ import { render } from '../../helpers/render';
 
 installI18nMock();
 
-mock.module('../../../services/api', () => ({
-  usersApi: {
-    getAssignments: mock(async () => ({ clientIds: [], projectIds: [], taskIds: [] })),
-    updateAssignments: mock(async () => {}),
-  },
+// The view only touches services/api transitively via the assignments modal,
+// which this test never opens. Stub it so the view has no API dependency, which
+// also avoids cross-file mock-leak fragility in the shared test runner.
+mock.module('../../../components/HR/EmployeeAssignmentsModal', () => ({
+  default: () => null,
 }));
 
 const ExternalEmployeesView = (await import('../../../components/HR/ExternalEmployeesView'))

--- a/test/components/hr/InternalEmployeesView.rowClick.test.tsx
+++ b/test/components/hr/InternalEmployeesView.rowClick.test.tsx
@@ -7,11 +7,11 @@ import { render } from '../../helpers/render';
 
 installI18nMock();
 
-mock.module('../../../services/api', () => ({
-  usersApi: {
-    getAssignments: mock(async () => ({ clientIds: [], projectIds: [], taskIds: [] })),
-    updateAssignments: mock(async () => {}),
-  },
+// The view only touches services/api transitively via the assignments modal,
+// which this test never opens. Stub it so the view has no API dependency, which
+// also avoids cross-file mock-leak fragility in the shared test runner.
+mock.module('../../../components/HR/EmployeeAssignmentsModal', () => ({
+  default: () => null,
 }));
 
 const InternalEmployeesView = (await import('../../../components/HR/InternalEmployeesView'))

--- a/test/components/hr/InternalEmployeesView.rowClick.test.tsx
+++ b/test/components/hr/InternalEmployeesView.rowClick.test.tsx
@@ -1,0 +1,74 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { fireEvent, screen } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import type { User } from '../../../types';
+import { installI18nMock } from '../../helpers/i18n';
+import { render } from '../../helpers/render';
+
+installI18nMock();
+
+mock.module('../../../services/api', () => ({
+  usersApi: {
+    getAssignments: mock(async () => ({ clientIds: [], projectIds: [], taskIds: [] })),
+    updateAssignments: mock(async () => {}),
+  },
+}));
+
+const InternalEmployeesView = (await import('../../../components/HR/InternalEmployeesView'))
+  .default;
+
+const employee: User = {
+  id: 'u1',
+  name: 'Mario Rossi',
+  role: 'user',
+  avatarInitials: 'MR',
+  username: 'mrossi',
+  employeeType: 'internal',
+  costPerHour: 25,
+};
+
+const renderView = (overrides: Partial<ComponentProps<typeof InternalEmployeesView>> = {}) => {
+  const props: ComponentProps<typeof InternalEmployeesView> = {
+    users: [employee],
+    clients: [],
+    projects: [],
+    tasks: [],
+    onAddEmployee: mock(async () => ({ success: true })),
+    onUpdateEmployee: mock(() => {}),
+    onDeleteEmployee: mock(() => {}),
+    currency: '€',
+    permissions: ['hr.internal.view', 'hr.internal.update'],
+    ...overrides,
+  };
+  render(<InternalEmployeesView {...props} />);
+  return props;
+};
+
+describe('<InternalEmployeesView /> row click', () => {
+  test('clicking a row opens the edit modal populated for that employee', () => {
+    renderView();
+    expect(screen.queryByDisplayValue('Mario Rossi')).not.toBeInTheDocument();
+
+    const row = screen.getByText('Mario Rossi').closest('tr');
+    if (!row) throw new Error('employee row not found');
+    // cursor-pointer is added by StandardTable only when onRowClick is defined.
+    expect(row).toHaveClass('cursor-pointer');
+
+    fireEvent.click(row);
+
+    expect(screen.getByDisplayValue('Mario Rossi')).toBeInTheDocument();
+  });
+
+  test('row is not clickable without update permission', () => {
+    renderView({ permissions: ['hr.internal.view'] });
+
+    const row = screen.getByText('Mario Rossi').closest('tr');
+    if (!row) throw new Error('employee row not found');
+    // No onRowClick is wired when the user can't edit, so no clickable affordance.
+    expect(row).not.toHaveClass('cursor-pointer');
+
+    fireEvent.click(row);
+
+    expect(screen.queryByDisplayValue('Mario Rossi')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #718. In the **Dipendenti Interni** and **Dipendenti Esterni** tabs, clicking anywhere on a row (outside the `…` actions menu) now opens that employee's edit modal, removing the extra step of aiming at the small actions button.
- Implemented by wiring the shared `StandardTable`'s existing `onRowClick` prop to each view's `openEditModal`. `StandardTable` already provides the requested affordances (pointer cursor + hover highlight) and already stops propagation on the `…` menu trigger, its items, and the right-click context menu — so secondary actions (manage assignments, delete) do not trigger the row click.
- The handler is gated on update permission (`onRowClick={canUpdateEmployees ? openEditModal : undefined}`), so users who can't edit get no misleading clickable affordance.

## Why
The only way to edit a user was via the `…` actions menu, which is a small far-right target for a very common action. Most table UIs let you click the row itself.

## Tests
- New: `test/components/hr/InternalEmployeesView.rowClick.test.tsx` and `ExternalEmployeesView.rowClick.test.tsx`.
- Cover: (a) a row click opens the populated edit modal; (b) without update permission the row has no `cursor-pointer` affordance and the modal stays closed. The negative test asserts on the `cursor-pointer` class that `StandardTable` adds only when `onRowClick` is defined, so it genuinely verifies the permission gating (validated via mutation testing).

## Reviewer notes
- No changes to `StandardTable` itself — its generic `onRowClick` behavior and action-menu `stopPropagation` are already covered by `test/components/StandardTable.test.tsx`.
- Behavior for special rows is unchanged: row-click opens edit for exactly the rows whose edit pencil was already shown (gated by the same `canUpdateEmployees`); app_user rows still can't be deleted.
- Docs reviewed — the Dipendenti edit flow isn't documented step-by-step, and this is an additive affordance, so no docs change was needed.

## Test plan
- [ ] `bun run test` (frontend + backend) green
- [ ] `bun run lint` clean (i18n check, typecheck, Biome)
- [ ] Manual: in both Dipendenti tabs, a row shows pointer + hover highlight, a left-click opens the edit modal for that employee, and the `…` menu / its items / right-click context menu do **not** open it; a user without update permission sees no clickable rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)