### PR TITLE
auth(login): restyle login page with shadcn login-02 block

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "praetor",
       "dependencies": {
+        "@hookform/resolvers": "^5.4.0",
         "@tanstack/react-table": "^8.21.3",
         "bcryptjs": "^3.0.3",
         "class-variance-authority": "^0.7.1",
@@ -18,6 +19,7 @@
         "radix-ui": "^1.4.3",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
+        "react-hook-form": "^7.76.1",
         "react-i18next": "^17.0.6",
         "react-markdown": "^10.1.0",
         "recharts": "^3.8.1",
@@ -27,6 +29,7 @@
         "sonner": "^2.0.7",
         "swagger-ui-react": "^5.32.5",
         "tailwind-merge": "^3.5.0",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@astrojs/starlight": "^0.39.2",
@@ -199,6 +202,8 @@
     "@gerrit0/mini-shiki": ["@gerrit0/mini-shiki@3.23.0", "", { "dependencies": { "@shikijs/engine-oniguruma": "^3.23.0", "@shikijs/langs": "^3.23.0", "@shikijs/themes": "^3.23.0", "@shikijs/types": "^3.23.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg=="],
 
     "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.9.0", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.9.0" } }, "sha512-lBW6/m5BIFl3pMuWPNN0lIOYw9LMCmPfix53ExS3FBi4E+NELEljQ3xH6aAV9IYiQRfn9YIIgzzMrD0vIcD7tw=="],
+
+    "@hookform/resolvers": ["@hookform/resolvers@5.4.0", "", { "dependencies": { "@standard-schema/utils": "^0.3.0" }, "peerDependencies": { "react-hook-form": "^7.55.0" } }, "sha512-EIsqr/t/qbinPIhGjMdtvutIN1Kk4uwbROE9/UQ93CAVGR7GkA7Y92+fX80OzXi/OB67jVFYwKGO1WzkxmkFZw=="],
 
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
@@ -1499,6 +1504,8 @@
     "react-debounce-input": ["react-debounce-input@3.3.0", "", { "dependencies": { "lodash.debounce": "^4", "prop-types": "^15.8.1" }, "peerDependencies": { "react": "^15.3.0 || 16 || 17 || 18" } }, "sha512-VEqkvs8JvY/IIZvh71Z0TC+mdbxERvYF33RcebnodlsUZ8RSgyKe2VWaHXv4+/8aoOgXLxWrdsYs2hDhcwbUgA=="],
 
     "react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
+
+    "react-hook-form": ["react-hook-form@7.76.1", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-rYM7tPiWlu3nZchkR/ex7piyzui2vFPyaLnXnI/RnblB/L4qfMmyses8llJVtF1NpE9WBBsJlGtcSZzPCXW1qQ=="],
 
     "react-i18next": ["react-i18next@17.0.6", "", { "dependencies": { "@babel/runtime": "^7.29.2", "html-parse-stringify": "^3.0.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "i18next": ">= 26.0.1", "react": ">= 16.8.0", "typescript": "^5 || ^6" }, "optionalPeers": ["typescript"] }, "sha512-WzJ6SMKF+GTD7JZZqxSR1AKKmXjaSu39sClUrNlwxS4Tl7a99O+ltFy6yhPMO+wgZuxpQjJ2PZkfrQKmAqrLhw=="],
 

--- a/components/Login.tsx
+++ b/components/Login.tsx
@@ -1,6 +1,13 @@
+import { zodResolver } from '@hookform/resolvers/zod';
 import type React from 'react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
+import { z } from 'zod';
+import { Button } from '@/components/ui/button';
+import { Field, FieldError, FieldLabel } from '@/components/ui/field';
+import { Input } from '@/components/ui/input';
+import { Separator } from '@/components/ui/separator';
 import api, { ApiError } from '../services/api';
 import { type PublicSsoProvider, SSO_LOGIN_ERROR_CODES, type User } from '../types';
 
@@ -12,9 +19,37 @@ export interface LoginProps {
   onDismissServerUnreachable?: () => void;
 }
 
+interface LoginFormValues {
+  username: string;
+  password: string;
+}
+
 // Validates the URL-borne `sso_error` value against the canonical code list from `types.ts` so
 // anything outside the set (e.g. a hand-crafted URL) safely falls back to the generic message.
 const KNOWN_SSO_ERROR_CODES = new Set<string>(SSO_LOGIN_ERROR_CODES);
+
+// Faint dotted-grid overlay from the shadcn login-02 block; driven by the theme's
+// `--card-foreground` token so it adapts to every theme.
+const gridOverlayStyle: React.CSSProperties = {
+  backgroundImage: `
+    linear-gradient(to right, color-mix(in srgb, var(--card-foreground) 8%, transparent) 1px, transparent 1px),
+    linear-gradient(to bottom, color-mix(in srgb, var(--card-foreground) 8%, transparent) 1px, transparent 1px)
+  `,
+  backgroundSize: '20px 20px',
+  backgroundPosition: '0 0, 0 0',
+  maskImage: `
+    repeating-linear-gradient(to right, black 0px, black 3px, transparent 3px, transparent 8px),
+    repeating-linear-gradient(to bottom, black 0px, black 3px, transparent 3px, transparent 8px),
+    radial-gradient(ellipse 70% 50% at 50% 0%, #000 60%, transparent 100%)
+  `,
+  WebkitMaskImage: `
+    repeating-linear-gradient(to right, black 0px, black 3px, transparent 3px, transparent 8px),
+    repeating-linear-gradient(to bottom, black 0px, black 3px, transparent 3px, transparent 8px),
+    radial-gradient(ellipse 70% 50% at 50% 0%, #000 60%, transparent 100%)
+  `,
+  maskComposite: 'intersect',
+  WebkitMaskComposite: 'source-in',
+};
 
 const Login: React.FC<LoginProps> = ({
   onLogin,
@@ -24,13 +59,26 @@ const Login: React.FC<LoginProps> = ({
   onDismissServerUnreachable,
 }) => {
   const { t } = useTranslation(['auth', 'common', 'notifications']);
-  const [username, setUsername] = useState('');
-  const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
-  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [ssoProviders, setSsoProviders] = useState<PublicSsoProvider[]>([]);
+
+  const formSchema = useMemo(
+    () =>
+      z.object({
+        username: z.string().trim().min(1, t('common:validation.usernameRequired')),
+        password: z.string().min(1, t('common:validation.passwordRequired')),
+      }),
+    [t],
+  );
+
+  const form = useForm<LoginFormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { username: '', password: '' },
+  });
+
+  const busy = isLoading || form.formState.isSubmitting;
 
   // Stash callback in a ref so the SSO-providers fetch effect can run exactly
   // once on mount even when the parent recreates `onLogin` each render.
@@ -98,30 +146,20 @@ const Login: React.FC<LoginProps> = ({
     return (err as Error).message || t('auth:login.errors.invalidCredentials');
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setFieldErrors({});
-    setError('');
-
-    const newErrors: Record<string, string> = {};
-    if (!username.trim()) newErrors.username = t('common:validation.usernameRequired');
-    if (!password.trim()) newErrors.password = t('common:validation.passwordRequired');
-
-    if (Object.keys(newErrors).length > 0) {
-      setFieldErrors(newErrors);
-      return;
-    }
-
-    setIsLoading(true);
-
+  const submitLogin = form.handleSubmit(async ({ username, password }) => {
     try {
       const response = await api.auth.login(username, password);
       onLogin(response.user, response.token);
     } catch (err) {
       setError(messageForLoginError(err));
-    } finally {
-      setIsLoading(false);
     }
+  });
+
+  // Clear any prior API/SSO error banner on every submit attempt — including when
+  // field validation fails — so a stale banner never lingers behind new field errors.
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    setError('');
+    void submitLogin(e);
   };
 
   const handleSsoLogin = (provider: PublicSsoProvider) => {
@@ -130,161 +168,166 @@ const Login: React.FC<LoginProps> = ({
   };
 
   return (
-    <div className="min-h-screen bg-praetor flex items-center justify-center p-4">
-      <div className="bg-white rounded-2xl shadow-xl border border-zinc-200 p-6 w-full max-w-md">
-        <div className="text-center mb-6">
-          <img src="/praetor-logo.png" alt="Praetor Logo" className="h-32 mx-auto object-contain" />
-          <p className="text-zinc-500 text-sm">{t('auth:login.title')}</p>
-        </div>
+    <div className="flex min-h-screen items-center justify-center bg-muted/70 p-4">
+      <div className="relative w-full max-w-md overflow-hidden rounded-xl border bg-card px-8 py-8 shadow-lg">
+        <div className="absolute inset-0 -top-px -left-px z-0" style={gridOverlayStyle} />
 
-        {logoutReason === 'inactivity' && (
-          <div className="mb-6 p-4 bg-amber-50 border border-amber-200 rounded-xl flex items-start gap-3 animate-in fade-in slide-in-from-top-2">
-            <i className="fa-solid fa-clock text-amber-500 mt-0.5"></i>
-            <div className="flex-1">
-              <p className="text-sm font-bold text-amber-800">{t('auth:session.expired')}</p>
-              <p className="text-xs text-amber-600">{t('auth:session.expiredMessage')}</p>
-            </div>
-            {onClearLogoutReason && (
-              <button
-                type="button"
-                onClick={onClearLogoutReason}
-                aria-label={t('common:buttons.close')}
-                className="text-amber-400 hover:text-amber-600 transition-colors"
-              >
-                <i className="fa-solid fa-xmark"></i>
-              </button>
-            )}
-          </div>
-        )}
+        <div className="relative isolate flex w-full flex-col items-center">
+          <img src="/praetor-logo.png" alt="Praetor Logo" className="h-24 object-contain" />
+          <p className="mt-2 text-sm text-muted-foreground">{t('auth:login.title')}</p>
 
-        {serverUnreachable && (
-          <div
-            role="alert"
-            className="mb-6 p-4 bg-red-50 border border-red-200 rounded-xl flex items-start gap-3 animate-in fade-in slide-in-from-top-2"
-          >
-            <i className="fa-solid fa-triangle-exclamation text-red-500 mt-0.5"></i>
-            <div className="flex-1">
-              <p className="text-sm font-bold text-red-800">
-                {t('auth:session.serverUnreachableTitle')}
-              </p>
-              <p className="text-xs text-red-600">{t('auth:session.serverUnreachableMessage')}</p>
-            </div>
-            {onDismissServerUnreachable && (
-              <button
-                type="button"
-                aria-label={t('common:buttons.close')}
-                onClick={onDismissServerUnreachable}
-                className="text-red-400 hover:text-red-600 transition-colors"
-              >
-                <i className="fa-solid fa-xmark"></i>
-              </button>
-            )}
-          </div>
-        )}
-
-        {ssoProviders.length > 0 && (
-          <div className="space-y-3 mb-5">
-            {ssoProviders.map((provider) => (
-              <button
-                key={`${provider.protocol}-${provider.slug}`}
-                type="button"
-                onClick={() => handleSsoLogin(provider)}
-                disabled={isLoading}
-                className="w-full py-2.5 text-sm bg-white text-zinc-700 font-bold rounded-xl border border-zinc-200 hover:border-praetor hover:text-praetor transition-all shadow-sm flex items-center justify-center gap-2 active:scale-[0.98] disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                <i
-                  className={`fa-solid ${provider.protocol === 'saml' ? 'fa-building-shield' : 'fa-key'}`}
-                ></i>
-                {provider.name}
-              </button>
-            ))}
-            <div className="flex items-center gap-3 text-[10px] font-bold uppercase tracking-wider text-zinc-300">
-              <div className="h-px flex-1 bg-zinc-100"></div>
-              <span>{t('auth:login.orPassword', 'or use password')}</span>
-              <div className="h-px flex-1 bg-zinc-100"></div>
-            </div>
-          </div>
-        )}
-
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div>
-            <label className="block text-xs font-bold text-zinc-400 uppercase tracking-wider mb-1">
-              {t('common:labels.username')}
-            </label>
-            <input
-              type="text"
-              value={username}
-              onChange={(e) => {
-                setUsername(e.target.value);
-                if (fieldErrors.username) setFieldErrors((prev) => ({ ...prev, username: '' }));
-              }}
-              className={`w-full px-3 py-2 text-sm bg-zinc-50 border rounded-xl focus:ring-2 outline-none transition-all font-semibold text-zinc-700 ${fieldErrors.username ? 'border-red-500 bg-red-50 focus:ring-red-200' : 'border-zinc-200 focus:ring-praetor'}`}
-              placeholder={t('auth:login.username')}
-              aria-label={t('common:labels.username')}
-              disabled={isLoading}
-            />
-            {fieldErrors.username && (
-              <p className="text-red-500 text-[10px] font-bold mt-1">{fieldErrors.username}</p>
-            )}
-          </div>
-
-          <div>
-            <label className="block text-xs font-bold text-zinc-400 uppercase tracking-wider mb-1">
-              {t('common:labels.password')}
-            </label>
-            <div className="relative">
-              <input
-                type={showPassword ? 'text' : 'password'}
-                value={password}
-                onChange={(e) => {
-                  setPassword(e.target.value);
-                  if (fieldErrors.password) setFieldErrors((prev) => ({ ...prev, password: '' }));
-                }}
-                className={`w-full px-3 py-2 text-sm bg-zinc-50 border rounded-xl focus:ring-2 outline-none transition-all pr-9 font-semibold text-zinc-700 ${fieldErrors.password ? 'border-red-500 bg-red-50 focus:ring-red-200' : 'border-zinc-200 focus:ring-praetor'}`}
-                placeholder={t('auth:login.password')}
-                aria-label={t('common:labels.password')}
-                disabled={isLoading}
-              />
-              <button
-                type="button"
-                onClick={() => setShowPassword(!showPassword)}
-                aria-label={t(
-                  showPassword ? 'common:labels.hidePassword' : 'common:labels.showPassword',
-                )}
-                className="absolute right-3 top-1/2 -translate-y-1/2 text-zinc-400 hover:text-zinc-600 transition-colors p-1"
-              >
-                <i className={`fa-solid ${showPassword ? 'fa-eye-slash' : 'fa-eye'}`}></i>
-              </button>
-            </div>
-            {fieldErrors.password && (
-              <p className="text-red-500 text-[10px] font-bold mt-1">{fieldErrors.password}</p>
-            )}
-          </div>
-
-          {error && (
-            <div className="text-red-500 text-xs font-bold bg-red-50 p-3 rounded-lg flex items-center gap-2 animate-in fade-in slide-in-from-top-1">
-              <i className="fa-solid fa-circle-exclamation"></i>
-              {error}
+          {logoutReason === 'inactivity' && (
+            <div className="mt-6 flex w-full items-start gap-3 rounded-xl border border-amber-200 bg-amber-50 p-4 animate-in fade-in slide-in-from-top-2">
+              <i className="fa-solid fa-clock mt-0.5 text-amber-500"></i>
+              <div className="flex-1">
+                <p className="text-sm font-bold text-amber-800">{t('auth:session.expired')}</p>
+                <p className="text-xs text-amber-600">{t('auth:session.expiredMessage')}</p>
+              </div>
+              {onClearLogoutReason && (
+                <button
+                  type="button"
+                  onClick={onClearLogoutReason}
+                  aria-label={t('common:buttons.close')}
+                  className="text-amber-400 transition-colors hover:text-amber-600"
+                >
+                  <i className="fa-solid fa-xmark"></i>
+                </button>
+              )}
             </div>
           )}
 
-          <button
-            type="submit"
-            disabled={isLoading}
-            className="w-full py-2.5 text-sm bg-praetor text-white font-bold rounded-xl hover:bg-zinc-800 transition-all shadow-md shadow-zinc-200 flex items-center justify-center gap-2 active:scale-[0.98] mt-2 disabled:opacity-50 disabled:cursor-not-allowed"
+          {serverUnreachable && (
+            <div
+              role="alert"
+              className="mt-6 flex w-full items-start gap-3 rounded-xl border border-red-200 bg-red-50 p-4 animate-in fade-in slide-in-from-top-2"
+            >
+              <i className="fa-solid fa-triangle-exclamation mt-0.5 text-red-500"></i>
+              <div className="flex-1">
+                <p className="text-sm font-bold text-red-800">
+                  {t('auth:session.serverUnreachableTitle')}
+                </p>
+                <p className="text-xs text-red-600">{t('auth:session.serverUnreachableMessage')}</p>
+              </div>
+              {onDismissServerUnreachable && (
+                <button
+                  type="button"
+                  aria-label={t('common:buttons.close')}
+                  onClick={onDismissServerUnreachable}
+                  className="text-red-400 transition-colors hover:text-red-600"
+                >
+                  <i className="fa-solid fa-xmark"></i>
+                </button>
+              )}
+            </div>
+          )}
+
+          {ssoProviders.length > 0 && (
+            <div className="mt-8 w-full space-y-3">
+              {ssoProviders.map((provider) => (
+                <Button
+                  key={`${provider.protocol}-${provider.slug}`}
+                  type="button"
+                  variant="outline"
+                  className="w-full"
+                  onClick={() => handleSsoLogin(provider)}
+                  disabled={busy}
+                >
+                  <i
+                    className={`fa-solid ${provider.protocol === 'saml' ? 'fa-building-shield' : 'fa-key'}`}
+                  ></i>
+                  {provider.name}
+                </Button>
+              ))}
+              <div className="flex w-full items-center justify-center overflow-hidden">
+                <Separator />
+                <span className="px-2 text-sm whitespace-nowrap text-muted-foreground">
+                  {t('auth:login.orPassword', 'or use password')}
+                </span>
+                <Separator />
+              </div>
+            </div>
+          )}
+
+          <form
+            onSubmit={onSubmit}
+            className={`w-full space-y-5 ${ssoProviders.length > 0 ? 'mt-0' : 'mt-8'}`}
           >
-            {isLoading ? (
-              <>
-                <i className="fa-solid fa-circle-notch fa-spin"></i>
-                {t('auth:login.signingIn')}
-              </>
-            ) : (
-              <>
-                {t('auth:login.signIn')} <i className="fa-solid fa-arrow-right"></i>
-              </>
+            <Controller
+              control={form.control}
+              name="username"
+              render={({ field, fieldState }) => (
+                <Field data-invalid={fieldState.invalid}>
+                  <FieldLabel className="text-xs font-bold uppercase tracking-wider text-muted-foreground">
+                    {t('common:labels.username')}
+                  </FieldLabel>
+                  <Input
+                    {...field}
+                    type="text"
+                    aria-invalid={fieldState.invalid}
+                    placeholder={t('auth:login.username')}
+                    aria-label={t('common:labels.username')}
+                    disabled={busy}
+                  />
+                  <FieldError errors={[fieldState.error]} />
+                </Field>
+              )}
+            />
+
+            <Controller
+              control={form.control}
+              name="password"
+              render={({ field, fieldState }) => (
+                <Field data-invalid={fieldState.invalid}>
+                  <FieldLabel className="text-xs font-bold uppercase tracking-wider text-muted-foreground">
+                    {t('common:labels.password')}
+                  </FieldLabel>
+                  <div className="relative">
+                    <Input
+                      {...field}
+                      type={showPassword ? 'text' : 'password'}
+                      aria-invalid={fieldState.invalid}
+                      className="pr-9"
+                      placeholder={t('auth:login.password')}
+                      aria-label={t('common:labels.password')}
+                      disabled={busy}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setShowPassword(!showPassword)}
+                      aria-label={t(
+                        showPassword ? 'common:labels.hidePassword' : 'common:labels.showPassword',
+                      )}
+                      className="absolute right-3 top-1/2 -translate-y-1/2 p-1 text-muted-foreground transition-colors hover:text-foreground"
+                    >
+                      <i className={`fa-solid ${showPassword ? 'fa-eye-slash' : 'fa-eye'}`}></i>
+                    </button>
+                  </div>
+                  <FieldError errors={[fieldState.error]} />
+                </Field>
+              )}
+            />
+
+            {error && (
+              <div className="flex items-center gap-2 rounded-lg bg-destructive/10 p-3 text-xs font-bold text-destructive animate-in fade-in slide-in-from-top-1">
+                <i className="fa-solid fa-circle-exclamation"></i>
+                {error}
+              </div>
             )}
-          </button>
-        </form>
+
+            <Button type="submit" className="w-full" disabled={busy}>
+              {busy ? (
+                <>
+                  <i className="fa-solid fa-circle-notch fa-spin"></i>
+                  {t('auth:login.signingIn')}
+                </>
+              ) : (
+                <>
+                  {t('auth:login.signIn')} <i className="fa-solid fa-arrow-right"></i>
+                </>
+              )}
+            </Button>
+          </form>
+        </div>
       </div>
     </div>
   );

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     ]
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.4.0",
     "@tanstack/react-table": "^8.21.3",
     "bcryptjs": "^3.0.3",
     "class-variance-authority": "^0.7.1",
@@ -43,6 +44,7 @@
     "radix-ui": "^1.4.3",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
+    "react-hook-form": "^7.76.1",
     "react-i18next": "^17.0.6",
     "react-markdown": "^10.1.0",
     "recharts": "^3.8.1",
@@ -51,7 +53,8 @@
     "simple-icons": "^16.19.0",
     "sonner": "^2.0.7",
     "swagger-ui-react": "^5.32.5",
-    "tailwind-merge": "^3.5.0"
+    "tailwind-merge": "^3.5.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@astrojs/starlight": "^0.39.2",

--- a/test/components/Login.test.tsx
+++ b/test/components/Login.test.tsx
@@ -80,11 +80,11 @@ describe('<Login />', () => {
     expect(screen.getByPlaceholderText('auth:login.password')).toBeInTheDocument();
   });
 
-  test('submitting empty fields shows usernameRequired and passwordRequired errors', () => {
+  test('submitting empty fields shows usernameRequired and passwordRequired errors', async () => {
     render(<Login onLogin={() => {}} />);
     const submit = screen.getByRole('button', { name: /auth:login.signIn/ });
     fireEvent.click(submit);
-    expect(screen.getByText('common:validation.usernameRequired')).toBeInTheDocument();
+    expect(await screen.findByText('common:validation.usernameRequired')).toBeInTheDocument();
     expect(screen.getByText('common:validation.passwordRequired')).toBeInTheDocument();
     expect(apiAuthLogin).not.toHaveBeenCalled();
   });
@@ -103,10 +103,8 @@ describe('<Login />', () => {
     const submit = screen.getByRole('button', { name: /auth:login.signIn/ });
     fireEvent.click(submit);
 
-    await new Promise((resolve) => setTimeout(resolve, 0));
-
-    expect(apiAuthLogin).toHaveBeenCalledWith('admin', 'password');
-    expect(onLogin).toHaveBeenCalledWith({ id: 'u1', name: 'Test' }, 'tok');
+    await waitFor(() => expect(apiAuthLogin).toHaveBeenCalledWith('admin', 'password'));
+    await waitFor(() => expect(onLogin).toHaveBeenCalledWith({ id: 'u1', name: 'Test' }, 'tok'));
   });
 
   test('login rejection surfaces error message', async () => {
@@ -121,9 +119,7 @@ describe('<Login />', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: /auth:login.signIn/ }));
 
-    await new Promise((resolve) => setTimeout(resolve, 0));
-
-    expect(screen.getByText('Bad credentials')).toBeInTheDocument();
+    expect(await screen.findByText('Bad credentials')).toBeInTheDocument();
   });
 
   test('503 ldap_unavailable shows specific i18n message instead of server text', async () => {
@@ -147,9 +143,7 @@ describe('<Login />', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: /auth:login.signIn/ }));
 
-    await new Promise((resolve) => setTimeout(resolve, 0));
-
-    expect(screen.getByText('auth:login.errors.ldapUnavailable')).toBeInTheDocument();
+    expect(await screen.findByText('auth:login.errors.ldapUnavailable')).toBeInTheDocument();
   });
 
   test('password toggle flips input type between password and text', () => {
@@ -157,15 +151,11 @@ describe('<Login />', () => {
     const passwordInput = screen.getByPlaceholderText('auth:login.password') as HTMLInputElement;
     expect(passwordInput.type).toBe('password');
 
-    // The toggle button is the only button without text - sibling of the password input.
-    const toggleButtons = screen.getAllByRole('button');
-    const toggle = toggleButtons.find((btn) => btn.querySelector('i.fa-eye, i.fa-eye-slash'));
-    if (!toggle) throw new Error('toggle button not found');
-
-    fireEvent.click(toggle);
+    // The toggle is identified by its aria-label, which flips with the revealed state.
+    fireEvent.click(screen.getByLabelText('common:labels.showPassword'));
     expect(passwordInput.type).toBe('text');
 
-    fireEvent.click(toggle);
+    fireEvent.click(screen.getByLabelText('common:labels.hidePassword'));
     expect(passwordInput.type).toBe('password');
   });
 
@@ -208,21 +198,40 @@ describe('<Login />', () => {
     });
     fireEvent.click(screen.getByRole('button', { name: /auth:login.signIn/ }));
 
-    expect(screen.getByText('auth:login.signingIn')).toBeInTheDocument();
+    expect(await screen.findByText('auth:login.signingIn')).toBeInTheDocument();
 
     if (resolveLogin) resolveLogin({ user: { id: 'u', name: 'u' }, token: 't' });
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await waitFor(() => expect(screen.queryByText('auth:login.signingIn')).not.toBeInTheDocument());
   });
 
-  test('typing clears the field error', () => {
+  test('typing clears the field error', async () => {
     render(<Login onLogin={() => {}} />);
     fireEvent.click(screen.getByRole('button', { name: /auth:login.signIn/ }));
-    expect(screen.getByText('common:validation.usernameRequired')).toBeInTheDocument();
+    expect(await screen.findByText('common:validation.usernameRequired')).toBeInTheDocument();
 
     fireEvent.change(screen.getByPlaceholderText('auth:login.username'), {
       target: { value: 'admin' },
     });
-    expect(screen.queryByText('common:validation.usernameRequired')).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.queryByText('common:validation.usernameRequired')).not.toBeInTheDocument(),
+    );
+  });
+
+  test('submitting empty fields clears a pre-existing error banner', async () => {
+    // A pre-existing SSO error banner must not linger once the user re-attempts login,
+    // even when field validation blocks the submit.
+    setTestUrl('http://localhost/?sso_error=invalid_response');
+    render(<Login onLogin={() => {}} />);
+    expect(screen.getByText('auth:admin.sso.loginErrors.invalid_response')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /auth:login.signIn/ }));
+
+    await waitFor(() =>
+      expect(
+        screen.queryByText('auth:admin.sso.loginErrors.invalid_response'),
+      ).not.toBeInTheDocument(),
+    );
+    expect(await screen.findByText('common:validation.usernameRequired')).toBeInTheDocument();
   });
 
   test('renders public SSO providers and redirects to provider start URL', async () => {

--- a/test/hooks/useAuth.test.ts
+++ b/test/hooks/useAuth.test.ts
@@ -301,11 +301,12 @@ describe('useAuth', () => {
   // hook hands the browser to that URL after clearing local state — otherwise the IdP
   // session cookie stays alive and the next tab silently SSOs back in as the previous user.
   test('logout redirects to endSessionUrl when the server returns one', async () => {
-    const originalAssign = window.location.assign;
+    const realLocation = window.location;
     const assignMock = mock((_url: string) => {});
     Object.defineProperty(window, 'location', {
+      configurable: true,
       writable: true,
-      value: { ...window.location, assign: assignMock },
+      value: { ...realLocation, assign: assignMock },
     });
     apiMocks.authLogout.mockImplementation(() =>
       Promise.resolve({ endSessionUrl: 'https://idp.example.com/logout?id_token_hint=tok' }),
@@ -330,18 +331,20 @@ describe('useAuth', () => {
       expect(setAuthTokenMock).toHaveBeenLastCalledWith(null);
     } finally {
       Object.defineProperty(window, 'location', {
+        configurable: true,
         writable: true,
-        value: { ...window.location, assign: originalAssign },
+        value: realLocation,
       });
     }
   });
 
   test('logout does NOT redirect when endSessionUrl is null', async () => {
-    const originalAssign = window.location.assign;
+    const realLocation = window.location;
     const assignMock = mock((_url: string) => {});
     Object.defineProperty(window, 'location', {
+      configurable: true,
       writable: true,
-      value: { ...window.location, assign: assignMock },
+      value: { ...realLocation, assign: assignMock },
     });
     apiMocks.authLogout.mockImplementation(() => Promise.resolve({ endSessionUrl: null }));
 
@@ -357,8 +360,9 @@ describe('useAuth', () => {
       expect(assignMock).not.toHaveBeenCalled();
     } finally {
       Object.defineProperty(window, 'location', {
+        configurable: true,
         writable: true,
-        value: { ...window.location, assign: originalAssign },
+        value: realLocation,
       });
     }
   });


### PR DESCRIPTION
## Summary
- Restyle the login page to the shadcn **login-02** design: muted background, a theme-aware `bg-card` card with the signature decorative dotted-grid overlay, a `Separator`-based "OR" divider, and the shadcn `Field` / `FieldLabel` / `FieldError` layout built on the `Button` and `Input` primitives.
- The login-02 block is Next.js/3rd-party-registry code (uses `next/link`, an email field, a Google button + signup links) and can't drop in as-is, so its **design** was adapted onto the existing component using primitives this repo already has.
- Refactor the form to **react-hook-form + zod** (`@hookform/resolvers`) for field validation, keeping a separate error banner for API/SSO errors.

## Behavior preserved
Username/password auth (not email), show/hide password toggle, dynamic OIDC/SAML SSO buttons, session-expired and server-unreachable banners, `sso_ticket`/`sso_error` URL handling, i18n keys, and loading state. The block's email field, Google button, and forgot-password/create-account links were intentionally dropped (no such routes exist).

## Notable for reviewers
- New deps: `react-hook-form`, `zod`, `@hookform/resolvers` (bundled by Vite; not in the `index.html` importmap).
- Theme tokens (`bg-muted`, `bg-card`, `text-muted-foreground`, `text-destructive`) are used so the login respects the selected theme; the grid overlay is driven by `--card-foreground`.
- The error banner is cleared on **every** submit attempt (including when field validation fails) so a stale API/SSO banner never lingers behind new field errors — matches pre-refactor behavior. Covered by a new regression test.
- Pure visual restyle with identical behavior/fields/flows — no API change, and login docs (behavioral only, no screenshots) need no update.

## Test plan
- [x] `bun test test/components/Login.test.tsx` — 15/15 pass (incl. new banner-clear regression test)
- [x] `bun test test/components/` — 466/466 frontend component tests pass
- [x] `tsc -p tsconfig.json` (frontend) clean; Biome clean on changed files
- [ ] Manual visual check in the running app across light/dark/praetor/zebra themes (app runs on remote Docker; not verifiable locally)

Note: the worktree is missing server deps, so backend `tsc`/tests can't run here — unrelated to this frontend-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)