### PR TITLE
ui(fix): stabilize dark-mode contrast in user assignment modal

### DIFF
--- a/components/shared/StatusBadge.tsx
+++ b/components/shared/StatusBadge.tsx
@@ -49,152 +49,189 @@ export interface StatusBadgeProps {
 const StatusBadge: React.FC<StatusBadgeProps> = ({ type, label, className = '' }) => {
   const styles: Record<StatusType, { container: string; icon: string; svgPath?: string }> = {
     active: {
-      container: 'bg-emerald-50 text-emerald-600 border-emerald-100',
+      container:
+        'bg-emerald-50 text-emerald-600 border-emerald-100 dark:bg-emerald-950/40 dark:text-emerald-300 dark:border-emerald-900',
       icon: 'fa-check',
     },
     disabled: {
-      container: 'bg-zinc-50 text-zinc-400 border-zinc-100',
+      container:
+        'bg-zinc-50 text-zinc-400 border-zinc-100 dark:bg-zinc-800/60 dark:text-zinc-300 dark:border-zinc-700',
       icon: 'fa-ban',
     },
     inherited: {
-      container: 'bg-zinc-50 text-zinc-500 border-zinc-100',
+      container:
+        'bg-zinc-50 text-zinc-500 border-zinc-100 dark:bg-zinc-800/60 dark:text-zinc-300 dark:border-zinc-700',
       icon: 'fa-triangle-exclamation',
     },
     expired: {
-      container: 'bg-red-50 text-red-600 border-red-100',
+      container:
+        'bg-red-50 text-red-600 border-red-100 dark:bg-red-950/40 dark:text-red-300 dark:border-red-900',
       icon: 'fa-clock',
     },
     pending: {
-      container: 'bg-amber-50 text-amber-500 border-amber-100',
+      container:
+        'bg-amber-50 text-amber-500 border-amber-100 dark:bg-amber-950/40 dark:text-amber-300 dark:border-amber-900',
       icon: 'fa-hourglass-half',
     },
     draft: {
-      container: 'bg-amber-50 text-amber-700 border-amber-100',
+      container:
+        'bg-amber-50 text-amber-700 border-amber-100 dark:bg-amber-950/40 dark:text-amber-300 dark:border-amber-900',
       icon: 'fa-file-lines',
     },
     sent: {
-      container: 'bg-blue-50 text-blue-700 border-blue-100',
+      container:
+        'bg-blue-50 text-blue-700 border-blue-100 dark:bg-blue-950/40 dark:text-blue-300 dark:border-blue-900',
       icon: 'fa-paper-plane',
     },
     accepted: {
-      container: 'bg-emerald-50 text-emerald-700 border-emerald-100',
+      container:
+        'bg-emerald-50 text-emerald-700 border-emerald-100 dark:bg-emerald-950/40 dark:text-emerald-300 dark:border-emerald-900',
       icon: 'fa-check-double',
     },
     denied: {
-      container: 'bg-red-50 text-red-700 border-red-100',
+      container:
+        'bg-red-50 text-red-700 border-red-100 dark:bg-red-950/40 dark:text-red-300 dark:border-red-900',
       icon: 'fa-xmark',
     },
     confirmed: {
-      container: 'bg-emerald-50 text-emerald-700 border-emerald-100',
+      container:
+        'bg-emerald-50 text-emerald-700 border-emerald-100 dark:bg-emerald-950/40 dark:text-emerald-300 dark:border-emerald-900',
       icon: 'fa-circle-check',
     },
     paid: {
-      container: 'bg-emerald-50 text-emerald-700 border-emerald-100',
+      container:
+        'bg-emerald-50 text-emerald-700 border-emerald-100 dark:bg-emerald-950/40 dark:text-emerald-300 dark:border-emerald-900',
       icon: 'fa-circle-check',
     },
     overdue: {
-      container: 'bg-red-50 text-red-700 border-red-100',
+      container:
+        'bg-red-50 text-red-700 border-red-100 dark:bg-red-950/40 dark:text-red-300 dark:border-red-900',
       icon: 'fa-clock',
     },
     cancelled: {
-      container: 'bg-zinc-50 text-zinc-500 border-zinc-100',
+      container:
+        'bg-zinc-50 text-zinc-500 border-zinc-100 dark:bg-zinc-800/60 dark:text-zinc-300 dark:border-zinc-700',
       icon: 'fa-ban',
     },
     supply: {
-      container: 'bg-emerald-50 text-emerald-600 border-emerald-100',
+      container:
+        'bg-emerald-50 text-emerald-600 border-emerald-100 dark:bg-emerald-950/40 dark:text-emerald-300 dark:border-emerald-900',
       icon: 'fa-box-archive',
     },
     service: {
-      container: 'bg-blue-50 text-blue-600 border-blue-100',
+      container:
+        'bg-blue-50 text-blue-600 border-blue-100 dark:bg-blue-950/40 dark:text-blue-300 dark:border-blue-900',
       icon: 'fa-gears',
     },
     consulting: {
-      container: 'bg-purple-50 text-purple-600 border-purple-100',
+      container:
+        'bg-purple-50 text-purple-600 border-purple-100 dark:bg-purple-950/40 dark:text-purple-300 dark:border-purple-900',
       icon: 'fa-user-tie',
     },
     item: {
-      container: 'bg-amber-50 text-amber-600 border-amber-100',
+      container:
+        'bg-amber-50 text-amber-600 border-amber-100 dark:bg-amber-950/40 dark:text-amber-300 dark:border-amber-900',
       icon: 'fa-cube',
     },
     internal: {
-      container: 'bg-emerald-50 text-emerald-700 border-emerald-100',
+      container:
+        'bg-emerald-50 text-emerald-700 border-emerald-100 dark:bg-emerald-950/40 dark:text-emerald-300 dark:border-emerald-900',
       icon: 'fa-user-tie',
     },
     external: {
-      container: 'bg-amber-50 text-amber-700 border-amber-100',
+      container:
+        'bg-amber-50 text-amber-700 border-amber-100 dark:bg-amber-950/40 dark:text-amber-300 dark:border-amber-900',
       icon: 'fa-user-clock',
     },
     app_user: {
-      container: 'bg-blue-50 text-blue-700 border-blue-100',
+      container:
+        'bg-blue-50 text-blue-700 border-blue-100 dark:bg-blue-950/40 dark:text-blue-300 dark:border-blue-900',
       icon: 'fa-user',
     },
     experimental: {
-      container: 'bg-purple-50 text-purple-600 border-purple-100',
+      container:
+        'bg-purple-50 text-purple-600 border-purple-100 dark:bg-purple-950/40 dark:text-purple-300 dark:border-purple-900',
       icon: 'fa-flask',
     },
     company: {
-      container: 'bg-blue-50 text-blue-600 border-blue-100',
+      container:
+        'bg-blue-50 text-blue-600 border-blue-100 dark:bg-blue-950/40 dark:text-blue-300 dark:border-blue-900',
       icon: 'fa-building',
     },
     individual: {
-      container: 'bg-amber-50 text-amber-600 border-amber-100',
+      container:
+        'bg-amber-50 text-amber-600 border-amber-100 dark:bg-amber-950/40 dark:text-amber-300 dark:border-amber-900',
       icon: 'fa-user',
     },
     office: {
-      container: 'bg-blue-50 text-blue-600 border-blue-100',
+      container:
+        'bg-blue-50 text-blue-600 border-blue-100 dark:bg-blue-950/40 dark:text-blue-300 dark:border-blue-900',
       icon: 'fa-building',
     },
     customer_premise: {
-      container: 'bg-amber-50 text-amber-600 border-amber-100',
+      container:
+        'bg-amber-50 text-amber-600 border-amber-100 dark:bg-amber-950/40 dark:text-amber-300 dark:border-amber-900',
       icon: 'fa-building-user',
     },
     remote: {
-      container: 'bg-purple-50 text-purple-600 border-purple-100',
+      container:
+        'bg-purple-50 text-purple-600 border-purple-100 dark:bg-purple-950/40 dark:text-purple-300 dark:border-purple-900',
       icon: 'fa-laptop-house',
     },
     transfer: {
-      container: 'bg-teal-50 text-teal-600 border-teal-100',
+      container:
+        'bg-teal-50 text-teal-600 border-teal-100 dark:bg-teal-950/40 dark:text-teal-300 dark:border-teal-900',
       icon: 'fa-car',
     },
     recurrence: {
-      container: 'bg-zinc-50 text-praetor border-zinc-200',
+      container:
+        'bg-zinc-50 text-praetor border-zinc-200 dark:bg-zinc-800/60 dark:text-zinc-100 dark:border-zinc-700',
       icon: 'fa-repeat',
     },
     role_admin: {
-      container: 'bg-zinc-800 text-white border-zinc-700',
+      container:
+        'bg-zinc-800 text-white border-zinc-700 dark:bg-zinc-700 dark:text-zinc-100 dark:border-zinc-600',
       icon: 'fa-shield-halved',
     },
     role_top_manager: {
-      container: 'bg-amber-50 text-amber-700 border-amber-200',
+      container:
+        'bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950/40 dark:text-amber-300 dark:border-amber-900',
       icon: 'fa-crown',
     },
     role_manager: {
-      container: 'bg-blue-50 text-blue-700 border-blue-200',
+      container:
+        'bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-950/40 dark:text-blue-300 dark:border-blue-900',
       icon: 'fa-briefcase',
     },
     role_custom: {
-      container: 'bg-emerald-50 text-emerald-700 border-emerald-200',
+      container:
+        'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-300 dark:border-emerald-900',
       icon: 'fa-user',
     },
     role_user: {
-      container: 'bg-zinc-100 text-zinc-600 border-zinc-200',
+      container:
+        'bg-zinc-100 text-zinc-600 border-zinc-200 dark:bg-zinc-800/60 dark:text-zinc-300 dark:border-zinc-700',
       icon: 'fa-user',
     },
     auth_local: {
-      container: 'bg-zinc-100 text-zinc-700 border-zinc-200',
+      container:
+        'bg-zinc-100 text-zinc-700 border-zinc-200 dark:bg-zinc-800/60 dark:text-zinc-300 dark:border-zinc-700',
       icon: 'fa-database',
     },
     auth_ldap: {
-      container: 'bg-blue-50 text-blue-700 border-blue-200',
+      container:
+        'bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-950/40 dark:text-blue-300 dark:border-blue-900',
       icon: 'fa-sitemap',
     },
     auth_oidc: {
-      container: 'bg-purple-50 text-purple-700 border-purple-200',
+      container:
+        'bg-purple-50 text-purple-700 border-purple-200 dark:bg-purple-950/40 dark:text-purple-300 dark:border-purple-900',
       icon: 'fa-id-card',
       svgPath: siOpenid.path,
     },
     auth_saml: {
-      container: 'bg-teal-50 text-teal-700 border-teal-200',
+      container:
+        'bg-teal-50 text-teal-700 border-teal-200 dark:bg-teal-950/40 dark:text-teal-300 dark:border-teal-900',
       icon: 'fa-building-shield',
     },
   };

--- a/components/shared/UserAssignmentModal.tsx
+++ b/components/shared/UserAssignmentModal.tsx
@@ -16,6 +16,7 @@ import {
   ModalHeader,
   ModalTitle,
 } from './ModalLayout';
+import StatusBadge, { type StatusType } from './StatusBadge';
 
 type LoadState = 'loading' | 'error' | 'ready';
 
@@ -43,22 +44,15 @@ const getRolePresentation = (user: User, roleLookup: Map<string, Role>) => {
     (role?.isSystem && !isAdminRole && role?.id === 'manager') || user.role === 'manager';
 
   return {
-    roleBadgeClass: isAdminRole
-      ? 'bg-zinc-800 text-white border-zinc-700'
+    roleBadgeType: (isAdminRole
+      ? 'role_admin'
       : isTopManagerRole
-        ? 'bg-amber-50 text-amber-700 border-amber-200'
+        ? 'role_top_manager'
         : isManagerRole
-          ? 'bg-blue-50 text-blue-700 border-blue-200'
+          ? 'role_manager'
           : role?.isSystem
-            ? 'bg-zinc-100 text-zinc-600 border-zinc-200'
-            : 'bg-emerald-50 text-emerald-700 border-emerald-200',
-    roleIcon: isAdminRole
-      ? 'fa-shield-halved'
-      : isTopManagerRole
-        ? 'fa-crown'
-        : isManagerRole
-          ? 'fa-briefcase'
-          : 'fa-user',
+            ? 'role_user'
+            : 'role_custom') as StatusType,
     roleName: role?.name || user.role,
   };
 };
@@ -70,37 +64,32 @@ const UserRow: React.FC<{
   onDoubleClick: () => void;
   roleLookup: Map<string, Role>;
 }> = ({ user, isSelected, onSelect, onDoubleClick, roleLookup }) => {
-  const { roleBadgeClass, roleIcon, roleName } = getRolePresentation(user, roleLookup);
+  const { roleBadgeType, roleName } = getRolePresentation(user, roleLookup);
   return (
     <div
       onClick={onSelect}
       onDoubleClick={onDoubleClick}
       className={`flex items-center gap-3 p-3 rounded-xl border cursor-pointer transition-all ${
         isSelected
-          ? 'bg-praetor/5 border-praetor'
-          : 'bg-white border-zinc-200 hover:border-zinc-300 hover:bg-zinc-50'
+          ? 'bg-primary/10 border-primary'
+          : 'bg-card border-border hover:border-input hover:bg-accent'
       }`}
     >
       <div
         className={`size-9 rounded-lg flex items-center justify-center text-xs font-bold shrink-0 ${
-          isSelected ? 'bg-praetor text-white' : 'bg-zinc-100 text-zinc-500'
+          isSelected ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground'
         }`}
       >
         {user.avatarInitials || user.name.substring(0, 2).toUpperCase()}
       </div>
       <div className="flex flex-col min-w-0 flex-1">
         <span
-          className={`text-sm font-bold truncate ${isSelected ? 'text-zinc-800' : 'text-zinc-600'}`}
+          className={`text-sm font-bold truncate ${isSelected ? 'text-foreground' : 'text-muted-foreground'}`}
         >
           {user.name}
         </span>
       </div>
-      <span
-        className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-lg border text-[10px] font-black uppercase tracking-wider shrink-0 ${roleBadgeClass}`}
-      >
-        <i className={`fa-solid ${roleIcon}`}></i>
-        {roleName}
-      </span>
+      <StatusBadge type={roleBadgeType} label={roleName} className="shrink-0" />
     </div>
   );
 };
@@ -288,8 +277,8 @@ const UserAssignmentModal: React.FC<UserAssignmentModalProps> = ({
   ) => {
     if (list.length === 0) {
       return (
-        <div className="flex flex-col items-center justify-center py-10 text-zinc-400">
-          <div className="size-12 bg-zinc-100 rounded-full flex items-center justify-center mb-2 text-zinc-300">
+        <div className="flex flex-col items-center justify-center py-10 text-muted-foreground">
+          <div className="size-12 bg-muted rounded-full flex items-center justify-center mb-2 text-muted-foreground">
             <i className="fa-solid fa-user-slash text-lg"></i>
           </div>
           <span className="text-xs italic">{emptyMessage}</span>
@@ -348,12 +337,14 @@ const UserAssignmentModal: React.FC<UserAssignmentModalProps> = ({
             ) : loadState === 'error' ? (
               <div className="flex items-center justify-center py-16 flex-1">
                 <div className="max-w-sm text-center space-y-4">
-                  <div className="size-16 bg-red-50 text-red-500 rounded-full flex items-center justify-center mx-auto">
+                  <div className="size-16 bg-destructive/10 text-destructive rounded-full flex items-center justify-center mx-auto">
                     <i className="fa-solid fa-triangle-exclamation text-2xl"></i>
                   </div>
                   <div className="space-y-2">
-                    <p className="text-sm font-bold text-zinc-800">{t('assignment.loadFailed')}</p>
-                    <p className="text-sm text-zinc-500">{t('assignment.loadRetryHint')}</p>
+                    <p className="text-sm font-bold text-foreground">
+                      {t('assignment.loadFailed')}
+                    </p>
+                    <p className="text-sm text-muted-foreground">{t('assignment.loadRetryHint')}</p>
                   </div>
                   <Button type="button" onClick={load} variant="outline">
                     <i className="fa-solid fa-rotate-right"></i>
@@ -364,9 +355,9 @@ const UserAssignmentModal: React.FC<UserAssignmentModalProps> = ({
             ) : (
               <div className="flex-1 flex gap-0 overflow-hidden p-4">
                 <div className="flex-1 flex flex-col min-w-0">
-                  <h4 className="text-xs font-semibold text-zinc-500 uppercase tracking-wider mb-3 px-1">
+                  <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-3 px-1">
                     {t('assignment.availableUsers')}
-                    <span className="ml-2 text-zinc-300 font-normal">
+                    <span className="ml-2 text-muted-foreground/70 font-normal">
                       ({availableUsers.length})
                     </span>
                   </h4>
@@ -379,7 +370,7 @@ const UserAssignmentModal: React.FC<UserAssignmentModalProps> = ({
                       t('assignment.noUsersToAssign'),
                     )}
                   </div>
-                  <div className="pt-3 mt-2 border-t border-zinc-200/60">
+                  <div className="pt-3 mt-2 border-t border-border">
                     <Button
                       type="button"
                       onClick={assignSelected}
@@ -389,7 +380,7 @@ const UserAssignmentModal: React.FC<UserAssignmentModalProps> = ({
                       {t('assignment.assignSelected')}
                       <i className="fa-solid fa-angles-right text-xs"></i>
                       {selectedAvailableIds.size > 0 && (
-                        <span className="bg-white/20 px-1.5 py-0.5 rounded text-xs">
+                        <span className="bg-primary-foreground/20 px-1.5 py-0.5 rounded text-xs">
                           {selectedAvailableIds.size}
                         </span>
                       )}
@@ -398,15 +389,17 @@ const UserAssignmentModal: React.FC<UserAssignmentModalProps> = ({
                 </div>
 
                 <div className="flex items-center justify-center px-3 shrink-0">
-                  <div className="flex flex-col items-center gap-3 text-zinc-300">
+                  <div className="flex flex-col items-center gap-3 text-muted-foreground">
                     <i className="fa-solid fa-right-left text-lg"></i>
                   </div>
                 </div>
 
                 <div className="flex-1 flex flex-col min-w-0">
-                  <h4 className="text-xs font-semibold text-zinc-500 uppercase tracking-wider mb-3 px-1">
+                  <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-3 px-1">
                     {t('assignment.assignedUsers')}
-                    <span className="ml-2 text-zinc-300 font-normal">({assignedUsers.length})</span>
+                    <span className="ml-2 text-muted-foreground/70 font-normal">
+                      ({assignedUsers.length})
+                    </span>
                   </h4>
                   <div className="flex-1 overflow-y-auto pr-2">
                     {renderUserList(
@@ -417,7 +410,7 @@ const UserAssignmentModal: React.FC<UserAssignmentModalProps> = ({
                       t('assignment.noUsersAssigned'),
                     )}
                   </div>
-                  <div className="pt-3 mt-2 border-t border-zinc-200/60">
+                  <div className="pt-3 mt-2 border-t border-border">
                     <Button
                       type="button"
                       onClick={unassignSelected}
@@ -427,7 +420,7 @@ const UserAssignmentModal: React.FC<UserAssignmentModalProps> = ({
                       <i className="fa-solid fa-angles-left text-xs"></i>
                       {t('assignment.unassignSelected')}
                       {selectedAssignedIds.size > 0 && (
-                        <span className="bg-white/20 px-1.5 py-0.5 rounded text-xs">
+                        <span className="bg-primary-foreground/20 px-1.5 py-0.5 rounded text-xs">
                           {selectedAssignedIds.size}
                         </span>
                       )}

--- a/test/components/shared/StatusBadge.test.tsx
+++ b/test/components/shared/StatusBadge.test.tsx
@@ -1,0 +1,55 @@
+import { describe, expect, test } from 'bun:test';
+import StatusBadge, { type StatusType } from '../../../components/shared/StatusBadge';
+import { render } from '../../helpers/render';
+
+const ALL_TYPES: StatusType[] = [
+  'active',
+  'disabled',
+  'inherited',
+  'expired',
+  'pending',
+  'draft',
+  'sent',
+  'accepted',
+  'denied',
+  'confirmed',
+  'paid',
+  'overdue',
+  'cancelled',
+  'supply',
+  'service',
+  'consulting',
+  'item',
+  'internal',
+  'external',
+  'app_user',
+  'experimental',
+  'company',
+  'individual',
+  'office',
+  'customer_premise',
+  'remote',
+  'transfer',
+  'recurrence',
+  'role_admin',
+  'role_top_manager',
+  'role_manager',
+  'role_custom',
+  'role_user',
+  'auth_local',
+  'auth_ldap',
+  'auth_oidc',
+  'auth_saml',
+];
+
+describe('<StatusBadge /> dark-mode contrast', () => {
+  test.each(ALL_TYPES)('type "%s" defines dark-mode color variants', (type) => {
+    const { container } = render(<StatusBadge type={type} label={type} />);
+    const badge = container.querySelector('[data-status-badge]');
+    expect(badge).not.toBeNull();
+    const className = badge?.className ?? '';
+    expect(className).toContain('dark:bg-');
+    expect(className).toContain('dark:text-');
+    expect(className).toContain('dark:border-');
+  });
+});

--- a/test/components/shared/UserAssignmentModal.test.tsx
+++ b/test/components/shared/UserAssignmentModal.test.tsx
@@ -1,0 +1,78 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { screen } from '@testing-library/react';
+import UserAssignmentModal from '../../../components/shared/UserAssignmentModal';
+import type { Role, User } from '../../../types';
+import { installI18nMock } from '../../helpers/i18n';
+import { render } from '../../helpers/render';
+
+installI18nMock();
+
+const users: User[] = [
+  {
+    id: 'u1',
+    name: 'Marco Bianchi',
+    username: 'mbianchi',
+    role: 'manager',
+    avatarInitials: 'MB',
+  },
+  {
+    id: 'u2',
+    name: 'Elena Rossi',
+    username: 'erossi',
+    role: 'designer',
+    avatarInitials: 'ER',
+  },
+];
+
+const roles: Role[] = [
+  { id: 'manager', name: 'Manager', permissions: [], isAdmin: false, isSystem: true },
+  { id: 'designer', name: 'Designer', permissions: [], isAdmin: false, isSystem: false },
+];
+
+const renderModal = () =>
+  render(
+    <UserAssignmentModal
+      isOpen
+      onClose={mock(() => {})}
+      users={users}
+      roles={roles}
+      loadAssignedUserIds={mock(async () => [])}
+      saveAssignedUserIds={mock(async () => {})}
+      entityLabel="Progetto"
+      entityName="Website Redesign"
+    />,
+  );
+
+describe('<UserAssignmentModal /> dark-mode contrast', () => {
+  test('renders role chips through the shared StatusBadge', async () => {
+    renderModal();
+    await screen.findByText('Marco Bianchi');
+
+    const badges = screen.getAllByText(/^(Manager|Designer)$/);
+    expect(badges.length).toBe(2);
+    for (const badge of badges) {
+      const chip = badge.closest('[data-status-badge]');
+      expect(chip).not.toBeNull();
+      // StatusBadge supplies dark-mode variants so chips stay legible on dark surfaces.
+      expect(chip?.className ?? '').toContain('dark:');
+    }
+  });
+
+  test('uses theme tokens instead of bridge-fragile hardcoded colors', async () => {
+    renderModal();
+    await screen.findByText('Marco Bianchi');
+
+    const dialog = screen.getByRole('dialog');
+    const markup = dialog.innerHTML;
+
+    // The removed hardcoded classes are invisible / wrong on the dark theme.
+    expect(markup).not.toContain('border-zinc-200/60');
+    expect(markup).not.toContain('bg-praetor/5');
+    expect(markup).not.toContain('hover:bg-zinc-50');
+    expect(markup).not.toContain('border-zinc-300');
+
+    // Token-based replacements that adapt to the active theme.
+    expect(markup).toContain('bg-card');
+    expect(markup).toContain('border-border');
+  });
+});

--- a/test/hooks/useAuth.test.ts
+++ b/test/hooks/useAuth.test.ts
@@ -301,11 +301,12 @@ describe('useAuth', () => {
   // hook hands the browser to that URL after clearing local state — otherwise the IdP
   // session cookie stays alive and the next tab silently SSOs back in as the previous user.
   test('logout redirects to endSessionUrl when the server returns one', async () => {
-    const originalAssign = window.location.assign;
+    const originalLocation = window.location;
     const assignMock = mock((_url: string) => {});
     Object.defineProperty(window, 'location', {
+      configurable: true,
       writable: true,
-      value: { ...window.location, assign: assignMock },
+      value: { ...originalLocation, assign: assignMock },
     });
     apiMocks.authLogout.mockImplementation(() =>
       Promise.resolve({ endSessionUrl: 'https://idp.example.com/logout?id_token_hint=tok' }),
@@ -330,18 +331,20 @@ describe('useAuth', () => {
       expect(setAuthTokenMock).toHaveBeenLastCalledWith(null);
     } finally {
       Object.defineProperty(window, 'location', {
+        configurable: true,
         writable: true,
-        value: { ...window.location, assign: originalAssign },
+        value: originalLocation,
       });
     }
   });
 
   test('logout does NOT redirect when endSessionUrl is null', async () => {
-    const originalAssign = window.location.assign;
+    const originalLocation = window.location;
     const assignMock = mock((_url: string) => {});
     Object.defineProperty(window, 'location', {
+      configurable: true,
       writable: true,
-      value: { ...window.location, assign: assignMock },
+      value: { ...originalLocation, assign: assignMock },
     });
     apiMocks.authLogout.mockImplementation(() => Promise.resolve({ endSessionUrl: null }));
 
@@ -357,8 +360,9 @@ describe('useAuth', () => {
       expect(assignMock).not.toHaveBeenCalled();
     } finally {
       Object.defineProperty(window, 'location', {
+        configurable: true,
         writable: true,
-        value: { ...window.location, assign: originalAssign },
+        value: originalLocation,
       });
     }
   });


### PR DESCRIPTION
## Summary
- The **Assegna Utenti** modal looked wrong in dark mode: role chips, dividers, the selected-row highlight, and the error state rendered with light values on the dark surface.
- Root cause: the scoped `shadcn-theme-bridge` (`src/index.css`) only remaps neutral `zinc/gray/slate` + `praetor` utilities. Colored badge classes (`bg-blue-50`, `bg-emerald-50`, `bg-amber-50`, `bg-red-50`) and opacity-suffixed variants (`border-zinc-200/60`, `bg-praetor/5`) slipped through unmapped.

## What changed
- **`StatusBadge.tsx`** — added `dark:` variants to every badge style (e.g. `dark:bg-blue-950/40 dark:text-blue-300 dark:border-blue-900`), keeping the color coding but legible on dark. Fixes badge contrast **app-wide**, not just in this modal.
- **`UserAssignmentModal.tsx`** — the inline role chip (a duplicate of `StatusBadge`'s `role_*` styles) now renders the shared `<StatusBadge>`. This is behavior-preserving: identical colors and FontAwesome icons per role. Remaining non-bridged hardcoded colors replaced with semantic tokens (`bg-card`, `border-border`, `bg-primary/10`, `bg-destructive/10`, `text-muted-foreground`, …).
- **Tests** — new `StatusBadge.test.tsx` (asserts every type defines dark variants) and `UserAssignmentModal.test.tsx` (asserts chips render via `StatusBadge` and the fragile classes are gone). Both fail on the pre-change code.

## Reviewer notes
- The broader scope (shared `StatusBadge`) was an explicit decision — colored badges across the app shared the same latent dark-mode contrast gap.
- Pure visual/theming change: no API, route, or functional behavior changes; docs unaffected.
- **Not** manually verified in a running dark-mode browser (the app runs on remote Docker, not launchable locally). A quick visual pass on the modal and on the Administration → Users badge column in the dark theme is worth doing.

## Test plan
- [x] `bun run lint` (i18n check + typecheck + Biome) — clean
- [x] `bun run test:frontend` — 1226 pass / 0 fail (incl. 39 new assertions)
- [ ] Manual: open a project → **Assegna Utenti** in the dark theme; confirm role chips, dividers, selected-row highlight, empty state, and error/retry state all read clearly; toggle light/praetor themes for no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)