### PR TITLE
test(useAuth): fix window.location pollution that broke the Login test suite in CI

### DIFF
--- a/test/hooks/useAuth.test.ts
+++ b/test/hooks/useAuth.test.ts
@@ -50,6 +50,28 @@ clearSpyStateAfterAll();
 
 const { useAuth } = await import('../../hooks/useAuth');
 
+// Stub only window.location.assign in place, returning a restore fn. Do NOT replace
+// window.location wholesale (e.g. `{ ...window.location, assign }`): happy-dom exposes
+// href/pathname/etc. as prototype getters with no own-enumerable properties, so the spread
+// collapses to `{}`, stripping `href` and making `new URL(window.location.href)` throw in
+// suites that run later in the same process. The global guard in test/setup.ts enforces this.
+const stubLocationAssign = (impl: (url: string) => void): (() => void) => {
+  const originalDescriptor = Object.getOwnPropertyDescriptor(window.location, 'assign');
+  Object.defineProperty(window.location, 'assign', {
+    configurable: true,
+    writable: true,
+    value: impl,
+  });
+  return () => {
+    if (originalDescriptor) {
+      Object.defineProperty(window.location, 'assign', originalDescriptor);
+    } else {
+      // `assign` is inherited from Location.prototype with no own property; drop our shadow.
+      delete (window.location as { assign?: unknown }).assign;
+    }
+  };
+};
+
 describe('useAuth', () => {
   beforeEach(() => {
     tokenStore.token = null;
@@ -301,12 +323,8 @@ describe('useAuth', () => {
   // hook hands the browser to that URL after clearing local state — otherwise the IdP
   // session cookie stays alive and the next tab silently SSOs back in as the previous user.
   test('logout redirects to endSessionUrl when the server returns one', async () => {
-    const originalAssign = window.location.assign;
     const assignMock = mock((_url: string) => {});
-    Object.defineProperty(window, 'location', {
-      writable: true,
-      value: { ...window.location, assign: assignMock },
-    });
+    const restoreAssign = stubLocationAssign(assignMock);
     apiMocks.authLogout.mockImplementation(() =>
       Promise.resolve({ endSessionUrl: 'https://idp.example.com/logout?id_token_hint=tok' }),
     );
@@ -329,20 +347,13 @@ describe('useAuth', () => {
       expect(result.current.currentUser).toBeNull();
       expect(setAuthTokenMock).toHaveBeenLastCalledWith(null);
     } finally {
-      Object.defineProperty(window, 'location', {
-        writable: true,
-        value: { ...window.location, assign: originalAssign },
-      });
+      restoreAssign();
     }
   });
 
   test('logout does NOT redirect when endSessionUrl is null', async () => {
-    const originalAssign = window.location.assign;
     const assignMock = mock((_url: string) => {});
-    Object.defineProperty(window, 'location', {
-      writable: true,
-      value: { ...window.location, assign: assignMock },
-    });
+    const restoreAssign = stubLocationAssign(assignMock);
     apiMocks.authLogout.mockImplementation(() => Promise.resolve({ endSessionUrl: null }));
 
     try {
@@ -356,10 +367,7 @@ describe('useAuth', () => {
 
       expect(assignMock).not.toHaveBeenCalled();
     } finally {
-      Object.defineProperty(window, 'location', {
-        writable: true,
-        value: { ...window.location, assign: originalAssign },
-      });
+      restoreAssign();
     }
   });
 

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -8,3 +8,19 @@ expect.extend(matchers as any);
 afterEach(() => {
   cleanup();
 });
+
+// Guardrail against a footgun that previously broke CI cross-file: a test must never replace
+// window.location wholesale (e.g. `{ ...window.location, assign }`). happy-dom exposes
+// href/pathname/etc. as prototype getters with no own-enumerable properties, so such a spread
+// strips `href` and makes `new URL(window.location.href)` throw in unrelated suites that run
+// later in the same process. Stub individual location methods in place instead. This fires
+// after every test, so it pins the regression even when the offending test lives elsewhere.
+afterEach(() => {
+  if (typeof window.location.href !== 'string') {
+    throw new Error(
+      'window.location.href is no longer a string — a test replaced window.location instead of ' +
+        'stubbing a property in place. Override the specific method via ' +
+        'Object.defineProperty(window.location, <method>, ...) and restore it afterward.',
+    );
+  }
+});


### PR DESCRIPTION
## Problem

The frontend **Tests** CI job intermittently failed with `new URL(window.location.href)` throwing **Invalid URL** in `components/Login.tsx` — surfaced on the login-restyle PR. It wasn't a bug in the login page; it was global-state pollution from another test.

`test/hooks/useAuth.test.ts` replaced `window.location` wholesale to stub `assign`:

```ts
Object.defineProperty(window, 'location', {
  writable: true,
  value: { ...window.location, assign: assignMock },
});
```

happy-dom exposes `href`/`pathname`/etc. as **prototype getters with no own-enumerable properties**, so `{ ...window.location }` collapses to `{}` — stripping `href`. Worse, the `finally` "restore" spread the already-emptied object, leaving `window.location.href === undefined` for the rest of the Bun process. Any test rendering a component that reads `window.location.href` afterward (the `<Login />` suite) then threw, and `happyDOM.setURL()` could not heal a `defineProperty`-replaced location.

`main` passed only by luck of alphabetical file ordering (`Login` runs before `useAuth`); branches that shifted ordering detonated the landmine.

## Fix

- **`test/hooks/useAuth.test.ts`** — replace the wholesale replacement with `stubLocationAssign`, which overrides **only** `window.location.assign` in place (descriptor capture + restore-or-delete, matching the existing idiom in `test/utils/clipboard.test.ts`). The real happy-dom `Location` — and its `href` getter — stays intact.
- **`test/setup.ts`** — add a global `afterEach` guard that fails any test leaving `window.location.href` a non-string. This pins the regression **cross-file** (the original victim lived in a different test file) and fails on the old code directly. Server tests don't inherit this preload (`server/bunfig.toml` stops the lookup), so `bun run test:server` is unaffected.

## Verification

- Full frontend suite: **1187 pass / 0 fail** (111 files); `useAuth`: 22 pass.
- The global guard **fails on the old spread-replace pattern** (verified with a throwaway repro) and produces **no false positives** across the suite.
- `bunx biome check` clean; `bun run typecheck` exit 0.

## Notes for reviewers

- No functional/API/UI/routing change — test infrastructure only, so documentation is unchanged.
- The guard is intentionally a `typeof href === 'string'` check: it precisely targets the "location replaced by a plain object" footgun without coupling to URL specifics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)