### PR TITLE
ui(404): migrate NotFound page to shadcn primitives and theme tokens

### DIFF
--- a/components/NotFound.tsx
+++ b/components/NotFound.tsx
@@ -1,5 +1,16 @@
+import { Compass, House } from 'lucide-react';
 import type React from 'react';
 import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from '@/components/ui/empty';
 
 export interface NotFoundProps {
   onReturn: () => void;
@@ -9,32 +20,31 @@ const NotFound: React.FC<NotFoundProps> = ({ onReturn }) => {
   const { t } = useTranslation('common');
 
   return (
-    <div className="min-h-[70vh] flex flex-col items-center justify-center text-center px-4 animate-in fade-in zoom-in duration-500">
-      <div className="relative mb-8">
-        <div className="text-9xl font-black text-zinc-100 select-none">404</div>
-        <div className="absolute inset-0 flex items-center justify-center">
-          <i className="fa-solid fa-compass-slash text-6xl text-praetor animate-bounce"></i>
-        </div>
+    <Empty className="min-h-[70vh] border-none animate-in fade-in zoom-in duration-500">
+      <div className="relative flex select-none items-center justify-center">
+        <span className="text-[8rem] font-black leading-none tracking-tighter text-muted-foreground/20 sm:text-[10rem]">
+          404
+        </span>
+        <EmptyMedia
+          variant="icon"
+          className="absolute size-16 rounded-2xl bg-primary/10 text-primary"
+        >
+          <Compass aria-hidden="true" className="size-8 animate-bounce" />
+        </EmptyMedia>
       </div>
 
-      <h2 className="text-3xl font-semibold text-zinc-800 mb-4">{t('notFound.title')}</h2>
-      <p className="text-zinc-500 max-w-md mb-8 leading-relaxed">{t('notFound.message')}</p>
+      <EmptyHeader>
+        <EmptyTitle className="text-2xl">{t('notFound.title')}</EmptyTitle>
+        <EmptyDescription>{t('notFound.message')}</EmptyDescription>
+      </EmptyHeader>
 
-      <button
-        type="button"
-        onClick={onReturn}
-        className="px-8 py-3 bg-praetor text-white font-bold rounded-xl shadow-lg shadow-zinc-200 hover:bg-zinc-700 hover:-translate-y-0.5 transition-all flex items-center gap-2 group"
-      >
-        <i className="fa-solid fa-house-chimney text-sm transition-transform group-hover:scale-110"></i>
-        {t('notFound.return')}
-      </button>
-
-      <div className="mt-12 grid grid-cols-3 gap-4 w-full max-w-lg opacity-30 select-none">
-        <div className="h-1 bg-zinc-200 rounded-full"></div>
-        <div className="h-1 bg-praetor rounded-full opacity-50"></div>
-        <div className="h-1 bg-zinc-200 rounded-full"></div>
-      </div>
-    </div>
+      <EmptyContent>
+        <Button size="lg" onClick={onReturn}>
+          <House aria-hidden="true" />
+          {t('notFound.return')}
+        </Button>
+      </EmptyContent>
+    </Empty>
   );
 };
 

--- a/components/NotFound.tsx
+++ b/components/NotFound.tsx
@@ -34,7 +34,9 @@ const NotFound: React.FC<NotFoundProps> = ({ onReturn }) => {
       </div>
 
       <EmptyHeader>
-        <EmptyTitle className="text-2xl">{t('notFound.title')}</EmptyTitle>
+        <EmptyTitle role="heading" aria-level={2} className="text-2xl">
+          {t('notFound.title')}
+        </EmptyTitle>
         <EmptyDescription>{t('notFound.message')}</EmptyDescription>
       </EmptyHeader>
 

--- a/test/components/NotFound.test.tsx
+++ b/test/components/NotFound.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { fireEvent, screen } from '@testing-library/react';
+import { installI18nMock } from '../helpers/i18n';
+import { render } from '../helpers/render';
+
+installI18nMock();
+
+const NotFound = (await import('../../components/NotFound')).default;
+
+describe('<NotFound />', () => {
+  test('renders the localized title, message and return action', () => {
+    render(<NotFound onReturn={() => {}} />);
+
+    expect(screen.getByText('404')).toBeInTheDocument();
+    expect(screen.getByText('notFound.title')).toBeInTheDocument();
+    expect(screen.getByText('notFound.message')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'notFound.return' })).toBeInTheDocument();
+  });
+
+  test('invokes onReturn when the home button is clicked', () => {
+    const onReturn = mock(() => {});
+    render(<NotFound onReturn={onReturn} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'notFound.return' }));
+
+    expect(onReturn).toHaveBeenCalledTimes(1);
+  });
+
+  test('uses shadcn theme tokens instead of hardcoded colors', () => {
+    render(<NotFound onReturn={() => {}} />);
+
+    // The big 404 marker is themed via muted-foreground, not a fixed zinc shade.
+    const marker = screen.getByText('404');
+    expect(marker.className).toContain('text-muted-foreground/20');
+    expect(marker.className).not.toContain('zinc');
+
+    // The return action is a shadcn Button (primary token), not a bespoke control.
+    const button = screen.getByRole('button', { name: 'notFound.return' });
+    expect(button.className).toContain('bg-primary');
+    expect(button.className).not.toContain('praetor');
+  });
+});

--- a/test/components/NotFound.test.tsx
+++ b/test/components/NotFound.test.tsx
@@ -17,6 +17,14 @@ describe('<NotFound />', () => {
     expect(screen.getByRole('button', { name: 'notFound.return' })).toBeInTheDocument();
   });
 
+  test('exposes the title as a level-2 heading for screen readers', () => {
+    render(<NotFound onReturn={() => {}} />);
+
+    // EmptyTitle renders a <div>, so it must carry explicit heading semantics
+    // to preserve the navigable <h2> the legacy page provided.
+    expect(screen.getByRole('heading', { level: 2, name: 'notFound.title' })).toBeInTheDocument();
+  });
+
   test('invokes onReturn when the home button is clicked', () => {
     const onReturn = mock(() => {});
     render(<NotFound onReturn={onReturn} />);


### PR DESCRIPTION
## What

Migrates the app's **404 / Not Found page** (`components/NotFound.tsx`) from hand-rolled markup with hardcoded `zinc`/`praetor` Tailwind colors to shadcn primitives and semantic theme tokens, matching the rest of the recently-migrated UI.

## Why

The old page used fixed `zinc`/`praetor` utility classes that only rendered correctly in dark mode via the legacy `shadcn-theme-bridge` fallbacks in `index.css`. It now uses semantic tokens directly, so it respects every theme (light / dark / praetor / zebra) without depending on the bridge.

## Changes

- Rebuilt the layout with the shadcn `Empty` family (`Empty`, `EmptyHeader`, `EmptyMedia`, `EmptyTitle`, `EmptyDescription`, `EmptyContent`) — the same pattern used in `RolesView`.
- Big **404** is now a themed watermark (`text-muted-foreground/20`) with a primary-tinted `EmptyMedia` icon badge overlaid.
- Title / message use `EmptyTitle` + `EmptyDescription`; the "Return to Home" action is the shadcn `<Button size="lg">` (`bg-primary`), replacing the custom pill button.
- Swapped FontAwesome icons for lucide `Compass` / `House`, both marked `aria-hidden="true"` as decorative (consistent with `RolesView`).
- Dropped the decorative zinc/praetor bar grid (not a shadcn idiom).
- i18n keys (`notFound.title` / `message` / `return`) and the `onReturn` behavior are unchanged.

## Tests

Added `test/components/NotFound.test.tsx` (mirrors the `ErrorBoundary` test):
- renders title / message / return button,
- verifies `onReturn` fires on click,
- asserts semantic tokens are used (`text-muted-foreground/20`, `bg-primary`) with no `zinc` / `praetor` leftovers.

`bun test test/components/NotFound.test.tsx` → 3 pass · existing `test/App.notfound.test.ts` → 2 pass · Biome clean · `tsc` reports no errors.

No docs update needed — visual-only migration, no behavior / API / routing change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
