### PR TITLE
hr(ui): reuse assignment modal for competence centers

### DIFF
--- a/components/WorkUnitsView.tsx
+++ b/components/WorkUnitsView.tsx
@@ -1,15 +1,14 @@
 import type React from 'react';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { workUnitsApi } from '../services/api/workUnits';
 import type { User, WorkUnit } from '../types';
 import { hasScopedActionPermission } from '../utils/permissions';
-import { toastError } from '../utils/toast';
-import Checkbox from './shared/Checkbox';
 import HeaderAddButton from './shared/HeaderAddButton';
 import Modal from './shared/Modal';
 import SelectControl from './shared/SelectControl';
+import UserAssignmentModal from './shared/UserAssignmentModal';
 
 export interface WorkUnitPayload {
   name: string;
@@ -51,18 +50,8 @@ const WorkUnitsView: React.FC<WorkUnitsViewProps> = ({
   const [description, setDescription] = useState('');
   const [errors, setErrors] = useState<Record<string, string>>({});
 
-  // Assignment state
-  const [assignedUserIds, setAssignedUserIds] = useState<string[]>([]);
-  const [assignmentSearch, setAssignmentSearch] = useState('');
-  const [isLoadingAssignments, setIsLoadingAssignments] = useState(false);
-  // Tracks whether the most recent assignments load failed. While true, the
-  // Save button stays disabled — sending the empty checkbox state to the
-  // server would wipe the unit's real members.
-  const [assignmentsLoadFailed, setAssignmentsLoadFailed] = useState(false);
-
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
-  const [isSavingAssignments, setIsSavingAssignments] = useState(false);
 
   const openCreateModal = () => {
     setName('');
@@ -148,39 +137,20 @@ const WorkUnitsView: React.FC<WorkUnitsViewProps> = ({
     }
   };
 
-  const openAssignments = async (unit: WorkUnit) => {
+  const openAssignments = (unit: WorkUnit) => {
     setTargetUnit(unit);
     setIsAssignmentModalOpen(true);
-    setIsLoadingAssignments(true);
-    setAssignmentsLoadFailed(false);
-    setAssignedUserIds([]);
-    try {
-      const userIds = await workUnitsApi.getUsers(unit.id);
-      setAssignedUserIds(userIds);
-    } catch (err) {
-      console.error('Failed to load unit users', err);
-      setAssignmentsLoadFailed(true);
-      toastError(t('hr:competenceCenters.failedToLoadUnitUsers'));
-    } finally {
-      setIsLoadingAssignments(false);
-    }
   };
 
-  const saveAssignments = async () => {
+  const loadAssignedUnitUserIds = (signal?: AbortSignal) => {
+    if (!targetUnit) return Promise.resolve([]);
+    return workUnitsApi.getUsers(targetUnit.id, signal);
+  };
+
+  const saveAssignedUnitUserIds = async (userIds: string[]) => {
     if (!targetUnit) return;
-    if (isSavingAssignments) return;
-    setIsSavingAssignments(true);
-    try {
-      await workUnitsApi.updateUsers(targetUnit.id, assignedUserIds);
-      await refreshWorkUnits(); // Update counts
-      setIsAssignmentModalOpen(false);
-      setTargetUnit(null);
-    } catch (err) {
-      console.error('Failed to save assignments', err);
-      toastError((err as Error).message || t('hr:competenceCenters.failedToSaveAssignments'));
-    } finally {
-      setIsSavingAssignments(false);
-    }
+    await workUnitsApi.updateUsers(targetUnit.id, userIds);
+    await refreshWorkUnits();
   };
 
   const requestCloseCreateModal = () => {
@@ -193,20 +163,14 @@ const WorkUnitsView: React.FC<WorkUnitsViewProps> = ({
     setIsEditModalOpen(false);
   };
 
-  const requestCloseAssignmentModal = () => {
-    if (isSavingAssignments) return;
+  const closeAssignments = () => {
     setIsAssignmentModalOpen(false);
+    setTargetUnit(null);
   };
 
   const requestCloseDeleteConfirm = () => {
     if (isDeleting) return;
     setIsDeleteConfirmOpen(false);
-  };
-
-  const toggleUserAssignment = (userId: string) => {
-    setAssignedUserIds((prev) =>
-      prev.includes(userId) ? prev.filter((id) => id !== userId) : [...prev, userId],
-    );
   };
 
   /*
@@ -216,15 +180,6 @@ const WorkUnitsView: React.FC<WorkUnitsViewProps> = ({
     );
   };
   */
-
-  const filteredUsersForAssignment = useMemo(() => {
-    if (!assignmentSearch) return users;
-    return users.filter(
-      (u) =>
-        u.name.toLowerCase().includes(assignmentSearch.toLowerCase()) ||
-        u.username.toLowerCase().includes(assignmentSearch.toLowerCase()),
-    );
-  }, [users, assignmentSearch]);
 
   const managerOptions = users.map((u) => ({ id: u.id, name: u.name }));
 
@@ -565,112 +520,21 @@ const WorkUnitsView: React.FC<WorkUnitsViewProps> = ({
       </Modal>
 
       {/* Assignment Modal */}
-      <Modal isOpen={isAssignmentModalOpen && !!targetUnit} onClose={requestCloseAssignmentModal}>
-        <div className="bg-white rounded-2xl shadow-2xl w-full max-w-2xl h-[80vh] flex flex-col overflow-hidden animate-in zoom-in duration-200">
-          <div className="p-6 border-b border-zinc-100 bg-zinc-50/50 flex justify-between items-center shrink-0">
-            <div>
-              <h3 className="text-lg font-semibold text-zinc-800">
-                {t('hr:competenceCenters.manageMembers')}
-              </h3>
-              <p className="text-sm text-zinc-500 font-medium">
-                {t('hr:competenceCenters.addRemoveUsers', { name: targetUnit?.name })}
-              </p>
-            </div>
-            <button
-              type="button"
-              onClick={requestCloseAssignmentModal}
-              disabled={isSavingAssignments}
-              aria-label={t('common:buttons.close')}
-              className="text-zinc-400 hover:text-zinc-600 disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              <i className="fa-solid fa-xmark text-xl"></i>
-            </button>
-          </div>
-
-          <div className="p-4 border-b border-zinc-100 shrink-0">
-            <input
-              type="text"
-              placeholder={t('hr:competenceCenters.searchUsers')}
-              aria-label={t('hr:competenceCenters.searchUsers')}
-              value={assignmentSearch}
-              onChange={(e) => setAssignmentSearch(e.target.value)}
-              className="w-full px-4 py-2 bg-zinc-50 border border-zinc-200 rounded-xl focus:ring-2 focus:ring-praetor outline-none"
-            />
-          </div>
-
-          <div className="flex-1 overflow-y-auto p-4">
-            {isLoadingAssignments ? (
-              <div className="flex justify-center py-12">
-                <i className="fa-solid fa-circle-notch fa-spin text-3xl text-praetor"></i>
-              </div>
-            ) : assignmentsLoadFailed ? (
-              <div className="flex flex-col items-center justify-center py-12 text-center px-4">
-                <i className="fa-solid fa-triangle-exclamation text-3xl text-red-500 mb-3"></i>
-                <p className="text-sm text-zinc-600 max-w-sm">
-                  {t('hr:competenceCenters.failedToLoadUnitUsers')}
-                </p>
-              </div>
-            ) : (
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-                {filteredUsersForAssignment.map((user) => (
-                  <label
-                    key={user.id}
-                    className={`flex items-center gap-3 p-3 rounded-xl border cursor-pointer transition-all ${
-                      assignedUserIds.includes(user.id)
-                        ? 'bg-zinc-50 border-zinc-300 shadow-sm'
-                        : 'bg-white border-zinc-200 hover:border-zinc-300'
-                    }`}
-                  >
-                    <Checkbox
-                      checked={assignedUserIds.includes(user.id)}
-                      onChange={() => toggleUserAssignment(user.id)}
-                    />
-                    <div className="flex items-center gap-3">
-                      <div className="size-8 rounded-full bg-zinc-100 text-praetor flex items-center justify-center text-xs font-bold">
-                        {user.avatarInitials}
-                      </div>
-                      <div>
-                        <p
-                          className={`text-sm font-bold ${assignedUserIds.includes(user.id) ? 'text-praetor' : 'text-zinc-700'}`}
-                        >
-                          {user.name}
-                        </p>
-                        <p className="text-xs text-zinc-500">{user.role}</p>
-                      </div>
-                    </div>
-                  </label>
-                ))}
-                {filteredUsersForAssignment.length === 0 && (
-                  <p className="col-span-full text-center text-zinc-400 py-8">
-                    {t('hr:competenceCenters.noUsersFound')}
-                  </p>
-                )}
-              </div>
-            )}
-          </div>
-
-          <div className="p-6 border-t border-zinc-100 bg-zinc-50/50 flex justify-end gap-3 shrink-0">
-            <button
-              type="button"
-              onClick={requestCloseAssignmentModal}
-              disabled={isSavingAssignments}
-              className="px-6 py-2.5 text-sm font-bold text-zinc-500 hover:bg-zinc-200 rounded-xl transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {t('common:buttons.cancel')}
-            </button>
-            <button
-              type="button"
-              onClick={saveAssignments}
-              disabled={isLoadingAssignments || isSavingAssignments || assignmentsLoadFailed}
-              className="px-8 py-2.5 bg-praetor text-white text-sm font-bold rounded-xl shadow-lg shadow-zinc-200 hover:bg-zinc-700 transition-all active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {isSavingAssignments
-                ? t('common:buttons.saving')
-                : t('hr:competenceCenters.saveAssignments')}
-            </button>
-          </div>
-        </div>
-      </Modal>
+      <UserAssignmentModal
+        isOpen={isAssignmentModalOpen && !!targetUnit}
+        onClose={closeAssignments}
+        users={users}
+        loadAssignedUserIds={loadAssignedUnitUserIds}
+        saveAssignedUserIds={saveAssignedUnitUserIds}
+        entityLabel={t('hr:competenceCenters.title')}
+        entityName={targetUnit?.name || ''}
+        title={t('hr:competenceCenters.manageMembers')}
+        description={t('hr:competenceCenters.addRemoveUsers', { name: targetUnit?.name })}
+        loadErrorMessage={t('hr:competenceCenters.failedToLoadUnitUsers')}
+        saveErrorMessage={t('hr:competenceCenters.failedToSaveAssignments')}
+        saveButtonLabel={t('hr:competenceCenters.saveAssignments')}
+        disabled={!canManageMembers}
+      />
 
       {/* Delete Confirm Modal */}
       <Modal isOpen={isDeleteConfirmOpen && !!targetUnit} onClose={requestCloseDeleteConfirm}>

--- a/components/WorkUnitsView.tsx
+++ b/components/WorkUnitsView.tsx
@@ -1,12 +1,24 @@
 import type React from 'react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/button';
+import { Field, FieldError, FieldLabel } from '@/components/ui/field';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { workUnitsApi } from '../services/api/workUnits';
 import type { User, WorkUnit } from '../types';
 import { hasScopedActionPermission } from '../utils/permissions';
 import HeaderAddButton from './shared/HeaderAddButton';
 import Modal from './shared/Modal';
+import {
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle,
+} from './shared/ModalLayout';
 import SelectControl from './shared/SelectControl';
 import UserAssignmentModal from './shared/UserAssignmentModal';
 
@@ -188,6 +200,115 @@ const WorkUnitsView: React.FC<WorkUnitsViewProps> = ({
   const canDeleteWorkUnits = hasScopedActionPermission(permissions, 'hr.work_units', 'delete');
   const canManageMembers = canUpdateWorkUnits;
 
+  const renderWorkUnitFormModal = ({
+    isOpen,
+    onClose,
+    onSubmit,
+    title,
+    titleIconClassName,
+    submitLabel,
+    submitDisabled = false,
+    nameInputId,
+    managersInputId,
+    descriptionInputId,
+  }: {
+    isOpen: boolean;
+    onClose: () => void;
+    onSubmit: (e: React.FormEvent) => Promise<void>;
+    title: React.ReactNode;
+    titleIconClassName: string;
+    submitLabel: React.ReactNode;
+    submitDisabled?: boolean;
+    nameInputId: string;
+    managersInputId: string;
+    descriptionInputId: string;
+  }) => (
+    <Modal isOpen={isOpen} onClose={onClose} ariaLabel={null}>
+      {() => (
+        <ModalContent size="lg">
+          <form onSubmit={onSubmit} className="flex min-h-0 flex-1 flex-col" noValidate>
+            <ModalHeader>
+              <ModalTitle className="gap-3">
+                <span className="flex size-10 items-center justify-center rounded-md bg-muted text-primary">
+                  <i className={`fa-solid ${titleIconClassName}`} aria-hidden="true"></i>
+                </span>
+                {title}
+              </ModalTitle>
+              <ModalCloseButton onClick={onClose} disabled={isSubmitting} />
+            </ModalHeader>
+
+            <ModalBody className="space-y-4">
+              <Field data-invalid={Boolean(errors.name)}>
+                <FieldLabel htmlFor={nameInputId}>{t('hr:competenceCenters.unitName')}</FieldLabel>
+                <Input
+                  id={nameInputId}
+                  type="text"
+                  value={name}
+                  onChange={(e) => {
+                    setName(e.target.value);
+                    if (errors.name) setErrors((prev) => ({ ...prev, name: '' }));
+                  }}
+                  aria-invalid={Boolean(errors.name)}
+                  aria-label={t('hr:competenceCenters.unitName')}
+                  className="font-semibold"
+                  required
+                  disabled={isSubmitting}
+                />
+                <FieldError className="text-xs">{errors.name}</FieldError>
+              </Field>
+
+              <div className="space-y-2">
+                <SelectControl
+                  id={managersInputId}
+                  label={t('hr:competenceCenters.managers')}
+                  options={managerOptions}
+                  value={selectedManagerIds}
+                  onChange={(val) => {
+                    setSelectedManagerIds(val as string[]);
+                    if (errors.managers) setErrors((prev) => ({ ...prev, managers: '' }));
+                  }}
+                  isMulti={true}
+                  searchable={true}
+                  placeholder={t('hr:competenceCenters.selectManagers')}
+                  disabled={isSubmitting}
+                  buttonClassName={
+                    errors.managers
+                      ? 'border-destructive focus-visible:ring-destructive/20'
+                      : undefined
+                  }
+                />
+                <FieldError className="text-xs">{errors.managers}</FieldError>
+              </div>
+
+              <Field>
+                <FieldLabel htmlFor={descriptionInputId}>
+                  {t('hr:competenceCenters.description')}
+                </FieldLabel>
+                <Textarea
+                  id={descriptionInputId}
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  aria-label={t('hr:competenceCenters.description')}
+                  className="min-h-24 resize-y"
+                  disabled={isSubmitting}
+                />
+              </Field>
+            </ModalBody>
+
+            <ModalFooter>
+              <Button type="button" variant="outline" onClick={onClose} disabled={isSubmitting}>
+                {t('common:buttons.cancel')}
+              </Button>
+              <Button type="submit" disabled={submitDisabled || isSubmitting}>
+                {isSubmitting ? t('common:buttons.saving') : submitLabel}
+              </Button>
+            </ModalFooter>
+          </form>
+        </ModalContent>
+      )}
+    </Modal>
+  );
+
   return (
     <div className="space-y-6 animate-in slide-in-from-bottom-2 duration-500">
       {/* Header */}
@@ -345,179 +466,30 @@ const WorkUnitsView: React.FC<WorkUnitsViewProps> = ({
         )}
       </div>
 
-      {/* Create Modal */}
-      <Modal isOpen={isCreateModalOpen} onClose={requestCloseCreateModal}>
-        <div className="bg-white rounded-2xl shadow-2xl w-full max-w-lg overflow-hidden animate-in zoom-in duration-200">
-          <div className="p-6 border-b border-zinc-100 bg-zinc-50/50 flex justify-between items-center">
-            <h3 className="text-lg font-semibold text-zinc-800">
-              {t('hr:competenceCenters.newCompetenceCenter')}
-            </h3>
-            <button
-              type="button"
-              onClick={requestCloseCreateModal}
-              disabled={isSubmitting}
-              aria-label={t('common:buttons.close')}
-              className="text-zinc-400 hover:text-zinc-600 disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              <i className="fa-solid fa-xmark text-xl"></i>
-            </button>
-          </div>
-          <form onSubmit={handleCreate} className="p-6 space-y-4">
-            <div>
-              <label className="block text-xs font-bold text-zinc-400 uppercase tracking-wider mb-1">
-                {t('hr:competenceCenters.unitName')}
-              </label>
-              <input
-                type="text"
-                value={name}
-                onChange={(e) => {
-                  setName(e.target.value);
-                  if (errors.name) setErrors((prev) => ({ ...prev, name: '' }));
-                }}
-                aria-label={t('hr:competenceCenters.unitName')}
-                className={`w-full px-4 py-2 bg-zinc-50 border rounded-lg focus:ring-2 outline-none font-semibold text-zinc-700 ${errors.name ? 'border-red-500 bg-red-50 focus:ring-red-200' : 'border-zinc-200 focus:ring-praetor'}`}
-                required
-              />
-              {errors.name && (
-                <p className="text-red-500 text-[10px] font-bold mt-1">{errors.name}</p>
-              )}
-            </div>
-            <div>
-              <SelectControl
-                label={t('hr:competenceCenters.managers')}
-                options={managerOptions}
-                value={selectedManagerIds}
-                onChange={(val) => {
-                  setSelectedManagerIds(val as string[]);
-                  if (errors.managers) setErrors((prev) => ({ ...prev, managers: '' }));
-                }}
-                isMulti={true}
-                searchable={true}
-                placeholder={t('hr:competenceCenters.selectManagers')}
-                className={errors.managers ? 'border-red-300' : ''}
-              />
-              {errors.managers && (
-                <p className="text-red-500 text-[10px] font-bold mt-1 ml-1">{errors.managers}</p>
-              )}
-            </div>
-            <div>
-              <label className="block text-xs font-bold text-zinc-400 uppercase tracking-wider mb-1">
-                {t('hr:competenceCenters.description')}
-              </label>
-              <textarea
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-                aria-label={t('hr:competenceCenters.description')}
-                className="w-full px-4 py-2 bg-zinc-50 border border-zinc-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none font-medium text-zinc-600 min-h-25"
-              />
-            </div>
-            <div className="flex gap-3 pt-4">
-              <button
-                type="button"
-                onClick={requestCloseCreateModal}
-                disabled={isSubmitting}
-                className="flex-1 py-3 text-sm font-bold text-zinc-500 hover:bg-zinc-50 rounded-xl transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {t('common:buttons.cancel')}
-              </button>
-              <button
-                type="submit"
-                disabled={selectedManagerIds.length === 0 || isSubmitting}
-                className="flex-1 py-3 bg-praetor text-white text-sm font-bold rounded-xl shadow-lg shadow-zinc-200 hover:bg-zinc-700 transition-all active:scale-95 disabled:opacity-50 disabled:active:scale-100"
-              >
-                {isSubmitting ? t('common:buttons.saving') : t('hr:competenceCenters.createUnit')}
-              </button>
-            </div>
-          </form>
-        </div>
-      </Modal>
+      {renderWorkUnitFormModal({
+        isOpen: isCreateModalOpen,
+        onClose: requestCloseCreateModal,
+        onSubmit: handleCreate,
+        title: t('hr:competenceCenters.newCompetenceCenter'),
+        titleIconClassName: 'fa-plus',
+        submitLabel: t('hr:competenceCenters.createUnit'),
+        submitDisabled: selectedManagerIds.length === 0,
+        nameInputId: 'work-unit-create-name',
+        managersInputId: 'work-unit-create-managers',
+        descriptionInputId: 'work-unit-create-description',
+      })}
 
-      {/* Edit Modal */}
-      <Modal isOpen={isEditModalOpen} onClose={requestCloseEditModal}>
-        <div className="bg-white rounded-2xl shadow-2xl w-full max-w-lg overflow-hidden animate-in zoom-in duration-200">
-          <div className="p-6 border-b border-zinc-100 bg-zinc-50/50 flex justify-between items-center">
-            <h3 className="text-lg font-semibold text-zinc-800">
-              {t('hr:competenceCenters.editCompetenceCenter')}
-            </h3>
-            <button
-              type="button"
-              onClick={requestCloseEditModal}
-              disabled={isSubmitting}
-              aria-label={t('common:buttons.close')}
-              className="text-zinc-400 hover:text-zinc-600 disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              <i className="fa-solid fa-xmark text-xl"></i>
-            </button>
-          </div>
-          <form onSubmit={handleUpdate} className="p-6 space-y-4">
-            <div>
-              <label className="block text-xs font-bold text-zinc-400 uppercase tracking-wider mb-1">
-                {t('hr:competenceCenters.unitName')}
-              </label>
-              <input
-                type="text"
-                value={name}
-                onChange={(e) => {
-                  setName(e.target.value);
-                  if (errors.name) setErrors((prev) => ({ ...prev, name: '' }));
-                }}
-                aria-label={t('hr:competenceCenters.unitName')}
-                className={`w-full px-4 py-2 bg-zinc-50 border rounded-lg focus:ring-2 outline-none font-semibold text-zinc-700 ${errors.name ? 'border-red-500 bg-red-50 focus:ring-red-200' : 'border-zinc-200 focus:ring-praetor'}`}
-                required
-              />
-              {errors.name && (
-                <p className="text-red-500 text-[10px] font-bold mt-1">{errors.name}</p>
-              )}
-            </div>
-            <div>
-              <SelectControl
-                label={t('hr:competenceCenters.managers')}
-                options={managerOptions}
-                value={selectedManagerIds}
-                onChange={(val) => {
-                  setSelectedManagerIds(val as string[]);
-                  if (errors.managers) setErrors((prev) => ({ ...prev, managers: '' }));
-                }}
-                isMulti={true}
-                searchable={true}
-                placeholder={t('hr:competenceCenters.selectManagers')}
-                className={errors.managers ? 'border-red-300' : ''}
-              />
-              {errors.managers && (
-                <p className="text-red-500 text-[10px] font-bold mt-1 ml-1">{errors.managers}</p>
-              )}
-            </div>
-            <div>
-              <label className="block text-xs font-bold text-zinc-400 uppercase tracking-wider mb-1">
-                {t('hr:competenceCenters.description')}
-              </label>
-              <textarea
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-                aria-label={t('hr:competenceCenters.description')}
-                className="w-full px-4 py-2 bg-zinc-50 border border-zinc-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none font-medium text-zinc-600 min-h-25"
-              />
-            </div>
-            <div className="flex gap-3 pt-4">
-              <button
-                type="button"
-                onClick={requestCloseEditModal}
-                disabled={isSubmitting}
-                className="flex-1 py-3 text-sm font-bold text-zinc-500 hover:bg-zinc-50 rounded-xl transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {t('common:buttons.cancel')}
-              </button>
-              <button
-                type="submit"
-                disabled={isSubmitting}
-                className="flex-1 py-3 bg-praetor text-white text-sm font-bold rounded-xl shadow-lg shadow-zinc-200 hover:bg-zinc-700 transition-all active:scale-95 disabled:opacity-50 disabled:active:scale-100"
-              >
-                {isSubmitting ? t('common:buttons.saving') : t('hr:competenceCenters.saveChanges')}
-              </button>
-            </div>
-          </form>
-        </div>
-      </Modal>
+      {renderWorkUnitFormModal({
+        isOpen: isEditModalOpen,
+        onClose: requestCloseEditModal,
+        onSubmit: handleUpdate,
+        title: t('hr:competenceCenters.editCompetenceCenter'),
+        titleIconClassName: 'fa-pen-to-square',
+        submitLabel: t('hr:competenceCenters.saveChanges'),
+        nameInputId: 'work-unit-edit-name',
+        managersInputId: 'work-unit-edit-managers',
+        descriptionInputId: 'work-unit-edit-description',
+      })}
 
       {/* Assignment Modal */}
       <UserAssignmentModal
@@ -537,40 +509,46 @@ const WorkUnitsView: React.FC<WorkUnitsViewProps> = ({
       />
 
       {/* Delete Confirm Modal */}
-      <Modal isOpen={isDeleteConfirmOpen && !!targetUnit} onClose={requestCloseDeleteConfirm}>
-        <div className="bg-white rounded-2xl shadow-2xl w-full max-w-sm overflow-hidden animate-in zoom-in duration-200">
-          <div className="p-6 text-center space-y-4">
-            <div className="size-12 bg-red-100 rounded-full flex items-center justify-center mx-auto">
-              <i className="fa-solid fa-triangle-exclamation text-red-600 text-xl"></i>
-            </div>
-            <div>
-              <h3 className="text-lg font-semibold text-zinc-800">
-                {t('hr:competenceCenters.deleteCompetenceCenter')}
-              </h3>
-              <p className="text-sm text-zinc-500 mt-2 leading-relaxed">
-                {t('hr:competenceCenters.deleteConfirmMessage', { name: targetUnit?.name })}
-              </p>
-            </div>
-            <div className="flex gap-3 pt-2">
-              <button
+      <Modal
+        isOpen={isDeleteConfirmOpen && !!targetUnit}
+        onClose={requestCloseDeleteConfirm}
+        ariaLabel={null}
+      >
+        {() => (
+          <ModalContent size="sm">
+            <ModalHeader className="justify-center text-center">
+              <div className="space-y-3">
+                <div className="size-12 bg-destructive/10 rounded-full flex items-center justify-center mx-auto text-destructive">
+                  <i className="fa-solid fa-triangle-exclamation text-xl" aria-hidden="true"></i>
+                </div>
+                <ModalTitle className="justify-center">
+                  {t('hr:competenceCenters.deleteCompetenceCenter')}
+                </ModalTitle>
+              </div>
+            </ModalHeader>
+            <ModalBody className="text-center text-sm text-muted-foreground leading-relaxed">
+              {t('hr:competenceCenters.deleteConfirmMessage', { name: targetUnit?.name })}
+            </ModalBody>
+            <ModalFooter className="grid grid-cols-2 sm:flex">
+              <Button
                 type="button"
+                variant="outline"
                 onClick={requestCloseDeleteConfirm}
                 disabled={isDeleting}
-                className="flex-1 py-3 text-sm font-bold text-zinc-500 hover:bg-zinc-50 rounded-xl transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {t('common:buttons.cancel')}
-              </button>
-              <button
+              </Button>
+              <Button
                 type="button"
+                variant="destructive"
                 onClick={handleDelete}
                 disabled={isDeleting}
-                className="flex-1 py-3 bg-red-600 text-white text-sm font-bold rounded-xl shadow-lg shadow-red-200 hover:bg-red-700 transition-all active:scale-95 disabled:opacity-50"
               >
                 {isDeleting ? t('common:buttons.saving') : t('hr:competenceCenters.yesDelete')}
-              </button>
-            </div>
-          </div>
-        </div>
+              </Button>
+            </ModalFooter>
+          </ModalContent>
+        )}
       </Modal>
     </div>
   );

--- a/components/shared/UserAssignmentModal.tsx
+++ b/components/shared/UserAssignmentModal.tsx
@@ -31,6 +31,11 @@ export interface UserAssignmentModalProps {
   saveAssignedUserIds: (userIds: string[]) => Promise<void>;
   entityLabel: string;
   entityName: string;
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  loadErrorMessage?: string;
+  saveErrorMessage?: string;
+  saveButtonLabel?: React.ReactNode;
   disabled?: boolean;
 }
 
@@ -103,6 +108,11 @@ const UserAssignmentModal: React.FC<UserAssignmentModalProps> = ({
   saveAssignedUserIds,
   entityLabel,
   entityName,
+  title,
+  description,
+  loadErrorMessage,
+  saveErrorMessage,
+  saveButtonLabel,
   disabled = false,
 }) => {
   const { t } = useTranslation('common');
@@ -113,6 +123,7 @@ const UserAssignmentModal: React.FC<UserAssignmentModalProps> = ({
   const [userSearch, setUserSearch] = useState('');
   const [selectedAvailableIds, setSelectedAvailableIds] = useState<Set<string>>(new Set());
   const [selectedAssignedIds, setSelectedAssignedIds] = useState<Set<string>>(new Set());
+  const [isSaving, setIsSaving] = useState(false);
   const initializedRef = useRef(false);
   const loadAbortControllerRef = useRef<AbortController | null>(null);
 
@@ -134,12 +145,15 @@ const UserAssignmentModal: React.FC<UserAssignmentModalProps> = ({
       if (controller.signal.aborted || isAbortError(err)) return;
       console.error('Failed to load assignments', err);
       setLoadState('error');
+      if (loadErrorMessage) {
+        toastError(loadErrorMessage);
+      }
     } finally {
       if (loadAbortControllerRef.current === controller) {
         loadAbortControllerRef.current = null;
       }
     }
-  }, [loadAssignedUserIds]);
+  }, [loadAssignedUserIds, loadErrorMessage]);
 
   useEffect(() => {
     if (isOpen && !initializedRef.current) {
@@ -150,6 +164,7 @@ const UserAssignmentModal: React.FC<UserAssignmentModalProps> = ({
       initializedRef.current = false;
       loadAbortControllerRef.current?.abort();
       loadAbortControllerRef.current = null;
+      setIsSaving(false);
     }
   }, [isOpen, load]);
 
@@ -162,6 +177,16 @@ const UserAssignmentModal: React.FC<UserAssignmentModalProps> = ({
   );
 
   const handleClose = useCallback(() => {
+    if (isSaving) return;
+    setUserSearch('');
+    setSelectedAvailableIds(new Set());
+    setSelectedAssignedIds(new Set());
+    loadAbortControllerRef.current?.abort();
+    loadAbortControllerRef.current = null;
+    onClose();
+  }, [isSaving, onClose]);
+
+  const forceClose = useCallback(() => {
     setUserSearch('');
     setSelectedAvailableIds(new Set());
     setSelectedAssignedIds(new Set());
@@ -171,15 +196,27 @@ const UserAssignmentModal: React.FC<UserAssignmentModalProps> = ({
   }, [onClose]);
 
   const handleSave = useCallback(async () => {
-    if (disabled) return;
+    if (disabled || isSaving || loadState !== 'ready') return;
+    setIsSaving(true);
     try {
       await saveAssignedUserIds(assignedUserIds);
-      handleClose();
+      forceClose();
     } catch (err) {
       console.error('Failed to save assignments', err);
-      toastError(t('assignment.saveFailed'));
+      toastError(saveErrorMessage || t('assignment.saveFailed'));
+    } finally {
+      setIsSaving(false);
     }
-  }, [disabled, saveAssignedUserIds, assignedUserIds, handleClose, t]);
+  }, [
+    disabled,
+    isSaving,
+    loadState,
+    saveAssignedUserIds,
+    assignedUserIds,
+    forceClose,
+    saveErrorMessage,
+    t,
+  ]);
 
   const toggleAvailableSelection = useCallback((userId: string) => {
     setSelectedAvailableIds((prev) => {
@@ -307,12 +344,16 @@ const UserAssignmentModal: React.FC<UserAssignmentModalProps> = ({
         <ModalContent size="2xl" className="max-h-[85vh]">
           <ModalHeader>
             <div>
-              <ModalTitle>{t('assignment.title')}</ModalTitle>
+              <ModalTitle>{title ?? t('assignment.title')}</ModalTitle>
               <ModalDescription>
-                {entityLabel}: <span className="font-bold text-praetor">{entityName}</span>
+                {description ?? (
+                  <>
+                    {entityLabel}: <span className="font-bold text-praetor">{entityName}</span>
+                  </>
+                )}
               </ModalDescription>
             </div>
-            <ModalCloseButton onClick={handleClose} />
+            <ModalCloseButton onClick={handleClose} disabled={isSaving} />
           </ModalHeader>
 
           <div className="p-4 border-b border-border bg-background">
@@ -432,11 +473,15 @@ const UserAssignmentModal: React.FC<UserAssignmentModalProps> = ({
           </ModalBody>
 
           <ModalFooter>
-            <Button type="button" variant="outline" onClick={handleClose}>
+            <Button type="button" variant="outline" onClick={handleClose} disabled={isSaving}>
               {t('buttons.cancel')}
             </Button>
-            <Button type="button" onClick={handleSave} disabled={disabled || loadState !== 'ready'}>
-              {t('buttons.save')}
+            <Button
+              type="button"
+              onClick={handleSave}
+              disabled={disabled || isSaving || loadState !== 'ready'}
+            >
+              {isSaving ? t('buttons.saving') : (saveButtonLabel ?? t('buttons.save'))}
             </Button>
           </ModalFooter>
         </ModalContent>

--- a/test/components/hr/HrModalStyling.test.ts
+++ b/test/components/hr/HrModalStyling.test.ts
@@ -25,3 +25,22 @@ describe('HR employee modal styling', () => {
     expectSourceOmitsAll(source, ['rounded-2xl shadow-2xl']);
   });
 });
+
+describe('HR competence center modal styling', () => {
+  test('create/edit dialogs use shared shadcn layout and primitives', async () => {
+    const source = await readComponentSource('WorkUnitsView.tsx');
+
+    expectSourceContainsAll(source, [
+      "import { Button } from '@/components/ui/button';",
+      "import { Field, FieldError, FieldLabel } from '@/components/ui/field';",
+      "import { Input } from '@/components/ui/input';",
+      "import { Textarea } from '@/components/ui/textarea';",
+      '<ModalContent size="lg">',
+      '<ModalHeader>',
+      '<ModalBody className="space-y-4">',
+      '<ModalFooter>',
+      '<ModalContent size="sm">',
+    ]);
+    expectSourceOmitsAll(source, ['rounded-2xl shadow-2xl']);
+  });
+});

--- a/test/components/hr/WorkUnitsView.assignmentModal.test.tsx
+++ b/test/components/hr/WorkUnitsView.assignmentModal.test.tsx
@@ -1,0 +1,88 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import type { User, WorkUnit } from '../../../types';
+import { installI18nMock } from '../../helpers/i18n';
+import { clearSpyStateAfterAll } from '../../helpers/mockCleanup.ts';
+import { render } from '../../helpers/render';
+
+installI18nMock();
+
+const getUsersMock = mock(async (_id: string, _signal?: AbortSignal) => ['u1']);
+const updateUsersMock = mock(async (_id: string, _userIds: string[]) => {});
+
+mock.module('../../../services/api/workUnits', () => ({
+  workUnitsApi: {
+    getUsers: getUsersMock,
+    updateUsers: updateUsersMock,
+  },
+}));
+
+clearSpyStateAfterAll();
+
+const WorkUnitsView = (await import('../../../components/WorkUnitsView')).default;
+
+const USERS: User[] = [
+  {
+    id: 'u1',
+    name: 'Alice',
+    username: 'alice',
+    role: 'admin',
+    avatarInitials: 'AL',
+  } as unknown as User,
+  {
+    id: 'u2',
+    name: 'Bob',
+    username: 'bob',
+    role: 'user',
+    avatarInitials: 'BO',
+  } as unknown as User,
+];
+
+const UNIT: WorkUnit = {
+  id: 'wu-1',
+  name: 'Engineering',
+  managers: [{ id: 'u1', name: 'Alice' }],
+  description: 'eng',
+  userCount: 1,
+};
+
+const PERMISSIONS = [
+  'hr.work_units.create',
+  'hr.work_units.update',
+  'hr.work_units.delete',
+  'hr.work_units.view',
+];
+
+describe('<WorkUnitsView /> member assignments', () => {
+  test('uses the shared user assignment modal for competence-center members', async () => {
+    const refresh = mock(() => Promise.resolve());
+
+    render(
+      <WorkUnitsView
+        workUnits={[UNIT]}
+        users={USERS}
+        permissions={PERMISSIONS}
+        onAddWorkUnit={mock(() => Promise.resolve()) as unknown as never}
+        onUpdateWorkUnit={mock(() => Promise.resolve()) as unknown as never}
+        onDeleteWorkUnit={mock(() => Promise.resolve()) as unknown as never}
+        refreshWorkUnits={refresh as unknown as never}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('hr:competenceCenters.manageMembers'));
+
+    expect(
+      await screen.findByRole('heading', { name: 'hr:competenceCenters.manageMembers' }),
+    ).toBeInTheDocument();
+    expect(await screen.findByText('assignment.availableUsers')).toBeInTheDocument();
+    expect(await screen.findByText('assignment.assignedUsers')).toBeInTheDocument();
+    expect(getUsersMock.mock.calls[0][0]).toBe('wu-1');
+
+    fireEvent.click(screen.getByText('Bob'));
+    fireEvent.click(screen.getByRole('button', { name: /assignment.assignSelected/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'hr:competenceCenters.saveAssignments' }));
+
+    await waitFor(() => expect(updateUsersMock).toHaveBeenCalledWith('wu-1', ['u1', 'u2']));
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/components/hr/WorkUnitsView.doubleSubmit.test.tsx
+++ b/test/components/hr/WorkUnitsView.doubleSubmit.test.tsx
@@ -74,12 +74,8 @@ const renderWorkUnitsView = (
 };
 
 const findFormByHeading = (heading: string) => {
-  // Prefer the heading rendered as an h3 (the modal title) to disambiguate
-  // from any HeaderAddButton text that may share the same translation key.
-  const headings = screen.getAllByText(heading);
-  const headingEl = headings.find((el) => el.tagName === 'H3') ?? headings[0];
-  if (!headingEl) throw new Error(`heading "${heading}" not found`);
-  const form = headingEl.parentElement?.parentElement?.querySelector('form');
+  const headingEl = screen.getByRole('heading', { name: heading });
+  const form = headingEl.closest('[data-slot="modal-content"]')?.querySelector('form');
   if (!form) throw new Error(`form for "${heading}" not found`);
   return form as HTMLFormElement;
 };

--- a/test/components/hr/WorkUnitsView.loadFailure.test.tsx
+++ b/test/components/hr/WorkUnitsView.loadFailure.test.tsx
@@ -71,21 +71,13 @@ describe('<WorkUnitsView /> assignment-load failure', () => {
       // Click Manage Members on the only work unit row.
       fireEvent.click(screen.getByText('hr:competenceCenters.manageMembers'));
 
-      // After the rejected load settles, Save Assignments must be disabled.
-      const saveBtn = await waitFor(() => {
-        const btn = Array.from(document.querySelectorAll('button')).find(
-          (b) => b.textContent?.trim() === 'hr:competenceCenters.saveAssignments',
-        ) as HTMLButtonElement | undefined;
-        if (!btn) throw new Error('Save button not yet rendered');
-        return btn;
-      });
+      const saveBtn = (await screen.findByRole('button', {
+        name: 'hr:competenceCenters.saveAssignments',
+      })) as HTMLButtonElement;
 
-      await waitFor(() => {
-        if (!saveBtn.disabled) throw new Error('Save still enabled');
-      });
+      await waitFor(() => expect(toastErrorMock).toHaveBeenCalled());
 
       expect(saveBtn.disabled).toBe(true);
-      expect(toastErrorMock).toHaveBeenCalled();
       expect(toastErrorMock.mock.calls[0][0]).toBe('hr:competenceCenters.failedToLoadUnitUsers');
     } finally {
       console.error = originalError;

--- a/test/components/shared/UserAssignmentModal.test.tsx
+++ b/test/components/shared/UserAssignmentModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, mock, test } from 'bun:test';
-import { screen } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import UserAssignmentModal from '../../../components/shared/UserAssignmentModal';
 import type { Role, User } from '../../../types';
 import { installI18nMock } from '../../helpers/i18n';
@@ -74,5 +74,45 @@ describe('<UserAssignmentModal /> dark-mode contrast', () => {
     // Token-based replacements that adapt to the active theme.
     expect(markup).toContain('bg-card');
     expect(markup).toContain('border-border');
+  });
+
+  test('guards save while an assignment update is pending', async () => {
+    let resolveSave: (() => void) | undefined;
+    const saveAssignedUserIds = mock(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSave = resolve;
+        }),
+    );
+    const onClose = mock(() => {});
+
+    render(
+      <UserAssignmentModal
+        isOpen
+        onClose={onClose}
+        users={users}
+        roles={roles}
+        loadAssignedUserIds={mock(async () => [])}
+        saveAssignedUserIds={saveAssignedUserIds}
+        entityLabel="Progetto"
+        entityName="Website Redesign"
+      />,
+    );
+    await screen.findByText('Marco Bianchi');
+
+    const saveButton = screen.getByRole('button', { name: 'buttons.save' }) as HTMLButtonElement;
+    fireEvent.click(saveButton);
+
+    await waitFor(() => expect(saveButton.disabled).toBe(true));
+    fireEvent.click(saveButton);
+
+    expect(saveAssignedUserIds).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('button', { name: 'buttons.cancel' })).toBeDisabled();
+
+    await act(async () => {
+      resolveSave?.();
+    });
+
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
   });
 });


### PR DESCRIPTION
## Summary
- Replaces the bespoke competence-center member assignment dialog with the shared `UserAssignmentModal` shadcn-style flow.
- Extends the shared modal with customizable copy, save labels, load/save error messages, and a pending-save guard.

## Changes
- Wires `WorkUnitsView` member management through shared assignment load/save callbacks.
- Preserves competence-center-specific Italian i18n strings in the shared dialog shell.
- Adds regression coverage for the shared modal integration, load failure handling, and duplicate-save prevention.

## Testing
- `bun test .\test\components\shared\UserAssignmentModal.test.tsx .\test\components\hr\WorkUnitsView.assignmentModal.test.tsx .\test\components\hr\WorkUnitsView.loadFailure.test.tsx .\test\components\hr\WorkUnitsView.doubleSubmit.test.tsx`
- `bun run typecheck`
- `bun x biome check components/WorkUnitsView.tsx components/shared/UserAssignmentModal.tsx test/components/hr/WorkUnitsView.assignmentModal.test.tsx test/components/hr/WorkUnitsView.loadFailure.test.tsx test/components/shared/UserAssignmentModal.test.tsx`
- Browser smoke: login page at `http://127.0.0.1:3001/#/login` rendered without console errors before local dev servers were stopped.

## Risks / Rollout
- Low risk. Change is scoped to the competence-center member assignment UI and shared assignment modal behavior.
- No database, API contract, auth, permission, or production configuration changes.

## Documentation
- Reviewed docs impact; no user documentation updates needed because behavior stays the same and only the dialog implementation/style changes.

## Issues
- Not linked