### PR TITLE
projects(feature): add project rules

### DIFF
--- a/components/projects/ProjectDetailView.tsx
+++ b/components/projects/ProjectDetailView.tsx
@@ -62,6 +62,7 @@ import UserAssignmentModal from '../shared/UserAssignmentModal';
 import DashboardControls from './DashboardControls';
 import DashboardGrid, { DashboardItem } from './DashboardGrid';
 import type { DashboardWidgetDef } from './dashboardLayout';
+import ProjectRules from './ProjectRules';
 import ProjectTasksTable from './ProjectTasksTable';
 import type { RecurringConfig } from './TaskFormModal';
 import { useDashboardLayout } from './useDashboardLayout';
@@ -1281,7 +1282,7 @@ const ProjectDetailView: React.FC<ProjectDetailViewProps> = ({
           </div>
         </div>
 
-        <ProjectRulesMockup className="xl:col-span-3" />
+        <ProjectRules projectId={project.id} permissions={permissions} className="xl:col-span-3" />
       </div>
 
       {/* Project tasks — full-width row so the table scales with many tasks */}
@@ -2383,56 +2384,6 @@ const ChartEmpty: React.FC<{ variant?: 'no-data' | 'forbidden' | 'failed' }> = (
         </EmptyDescription>
       </EmptyHeader>
     </Empty>
-  );
-};
-
-// Mockup — automatic controls for the project (budget alerts, deadline reminders,
-// stale-task pings). Rendered as a static, read-only preview so we can pin down the
-// shape with the user before wiring rule storage, evaluation, and notifications.
-const ProjectRulesMockup: React.FC<{ className?: string }> = ({ className }) => {
-  const { t } = useTranslation(['projects']);
-  const rules: Array<{ id: string; icon: string; enabled: boolean }> = [
-    { id: 'budgetThreshold', icon: 'fa-piggy-bank', enabled: true },
-    { id: 'deadlineApproaching', icon: 'fa-calendar-day', enabled: true },
-    { id: 'staleTask', icon: 'fa-hourglass-half', enabled: false },
-    { id: 'unassignedTask', icon: 'fa-user-slash', enabled: false },
-  ];
-  return (
-    <div className={`space-y-3 ${className ?? ''}`}>
-      <div className="space-y-1.5">
-        <div className="flex items-center gap-2">
-          <h2 className="text-base font-semibold leading-none">
-            {t('projects:detail.rules.title')}
-          </h2>
-          <span className="inline-flex items-center rounded-full border border-border bg-muted px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-            {t('projects:detail.rules.comingSoonBadge')}
-          </span>
-        </div>
-        <p className="text-sm text-muted-foreground">{t('projects:detail.rules.description')}</p>
-      </div>
-      <div className="rounded-lg border border-dashed border-border bg-background/40 p-1">
-        <ul className="divide-y divide-border">
-          {rules.map((rule) => (
-            <li key={rule.id} className="flex items-start justify-between gap-3 px-3 py-3">
-              <div className="flex items-start gap-3">
-                <div className="flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
-                  <i className={`fa-solid ${rule.icon}`} aria-hidden="true"></i>
-                </div>
-                <div className="space-y-0.5">
-                  <p className="text-sm font-medium text-foreground">
-                    {t(`projects:detail.rules.items.${rule.id}.name`)}
-                  </p>
-                  <p className="text-xs text-muted-foreground">
-                    {t(`projects:detail.rules.items.${rule.id}.description`)}
-                  </p>
-                </div>
-              </div>
-              <Toggle checked={rule.enabled} onChange={() => {}} disabled />
-            </li>
-          ))}
-        </ul>
-      </div>
-    </div>
   );
 };
 

--- a/components/projects/ProjectRuleFormModal.tsx
+++ b/components/projects/ProjectRuleFormModal.tsx
@@ -61,6 +61,9 @@ export interface ProjectRuleFormModalProps {
   onSubmit: (payload: ProjectRuleFormPayload) => Promise<void>;
 }
 
+const CONDITION_GRID_CLASSNAME =
+  'grid gap-3 md:grid-cols-[minmax(0,1fr)_10rem_10rem_minmax(10rem,14rem)_2.25rem]';
+
 const firstValueForField = (field: string) => {
   const definition = getProjectRuleFieldDefinition(field);
   if (definition?.kind === 'enum') return definition.enumValues?.[0] ?? '';
@@ -324,209 +327,238 @@ const ProjectRuleFormModal: React.FC<ProjectRuleFormModalProps> = ({
               </Button>
             </div>
 
-            {conditions.map((condition, index) => {
-              const fieldDefinition = getProjectRuleFieldDefinition(condition.field);
-              const operatorOptions =
-                fieldDefinition?.operators.map((id) => ({
-                  id,
-                  name: t(`projects:detail.rules.operators.${id}`),
-                })) ?? [];
-              const enumValueOptions =
-                fieldDefinition?.enumValues?.map((id) => ({
-                  id,
-                  name: t(enumValueLabelKey(condition.field, id)),
-                })) ?? [];
-              const valueType = condition.valueType ?? 'literal';
-              const valueFieldOptions = getAvailableProjectRuleValueFields(
-                condition.field,
-                permissions,
-              ).map((definition) => ({
-                id: definition.id,
-                name: t(`projects:detail.rules.fields.${definition.id}`),
-              }));
-              // Only offer "compare against another field" when a comparable peer field
-              // actually exists. Enum fields (e.g. billing_type, status) have no comparable
-              // peer, so showing that option would lead to an unresolvable validation error.
-              const valueTypeChoices: readonly ProjectRuleConditionValueType[] =
-                valueFieldOptions.length > 0
-                  ? (['literal', 'field'] as const)
-                  : (['literal'] as const);
-              const fieldError = errors[`field-${index}`];
-              const operatorError = errors[`operator-${index}`];
-              const valueError = errors[`value-${index}`];
-              return (
-                <div
-                  key={`${condition.field}-${index}`}
-                  className="grid gap-3 rounded-md border border-border p-3 md:grid-cols-[minmax(0,1fr)_10rem_10rem_minmax(10rem,14rem)_2.25rem]"
-                >
-                  <Field data-invalid={!!fieldError}>
-                    <FieldLabel htmlFor={`project-rule-field-${index}`}>
-                      {t('projects:detail.rules.form.field')}
-                    </FieldLabel>
-                    <Select
-                      value={condition.field}
-                      onValueChange={(nextField) => handleFieldChange(index, nextField)}
-                      disabled={submitting}
-                    >
-                      <SelectTrigger
-                        id={`project-rule-field-${index}`}
-                        className="w-full"
-                        aria-invalid={!!fieldError}
-                      >
-                        <SelectValue placeholder={t('projects:detail.rules.form.field')} />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectGroup>
-                          {fieldOptions.map((option) => (
-                            <SelectItem key={option.id} value={option.id}>
-                              {option.name}
-                            </SelectItem>
-                          ))}
-                        </SelectGroup>
-                      </SelectContent>
-                    </Select>
-                    <FieldError>{fieldError}</FieldError>
-                  </Field>
+            <div className="rounded-md border border-border">
+              <div
+                className={`${CONDITION_GRID_CLASSNAME} hidden border-b border-border px-3 py-2 text-sm font-medium text-muted-foreground md:grid`}
+              >
+                <span>{t('projects:detail.rules.form.field')}</span>
+                <span>{t('projects:detail.rules.form.operator')}</span>
+                <span>{t('projects:detail.rules.form.compareAgainst')}</span>
+                <span>
+                  {t('projects:detail.rules.form.value')} /{' '}
+                  {t('projects:detail.rules.form.targetField')}
+                </span>
+                <span className="sr-only">
+                  {t('projects:detail.rules.actions.removeCondition')}
+                </span>
+              </div>
 
-                  <Field data-invalid={!!operatorError}>
-                    <FieldLabel htmlFor={`project-rule-operator-${index}`}>
-                      {t('projects:detail.rules.form.operator')}
-                    </FieldLabel>
-                    <Select
-                      value={condition.operator}
-                      onValueChange={(operator) => updateCondition(index, { operator })}
-                      disabled={submitting}
+              <div className="divide-y divide-border">
+                {conditions.map((condition, index) => {
+                  const fieldDefinition = getProjectRuleFieldDefinition(condition.field);
+                  const operatorOptions =
+                    fieldDefinition?.operators.map((id) => ({
+                      id,
+                      name: t(`projects:detail.rules.operators.${id}`),
+                    })) ?? [];
+                  const enumValueOptions =
+                    fieldDefinition?.enumValues?.map((id) => ({
+                      id,
+                      name: t(enumValueLabelKey(condition.field, id)),
+                    })) ?? [];
+                  const valueType = condition.valueType ?? 'literal';
+                  const valueFieldOptions = getAvailableProjectRuleValueFields(
+                    condition.field,
+                    permissions,
+                  ).map((definition) => ({
+                    id: definition.id,
+                    name: t(`projects:detail.rules.fields.${definition.id}`),
+                  }));
+                  // Only offer "compare against another field" when a comparable peer field
+                  // actually exists. Enum fields (e.g. billing_type, status) have no comparable
+                  // peer, so showing that option would lead to an unresolvable validation error.
+                  const valueTypeChoices: readonly ProjectRuleConditionValueType[] =
+                    valueFieldOptions.length > 0
+                      ? (['literal', 'field'] as const)
+                      : (['literal'] as const);
+                  const fieldError = errors[`field-${index}`];
+                  const operatorError = errors[`operator-${index}`];
+                  const valueError = errors[`value-${index}`];
+                  return (
+                    <div
+                      key={`${condition.field}-${index}`}
+                      className={`${CONDITION_GRID_CLASSNAME} p-3`}
                     >
-                      <SelectTrigger
-                        id={`project-rule-operator-${index}`}
-                        className="w-full"
-                        aria-invalid={!!operatorError}
-                      >
-                        <SelectValue placeholder={t('projects:detail.rules.form.operator')} />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectGroup>
-                          {operatorOptions.map((option) => (
-                            <SelectItem key={option.id} value={option.id}>
-                              {option.name}
-                            </SelectItem>
-                          ))}
-                        </SelectGroup>
-                      </SelectContent>
-                    </Select>
-                    <FieldError>{operatorError}</FieldError>
-                  </Field>
-
-                  <Field>
-                    <FieldLabel htmlFor={`project-rule-value-type-${index}`}>
-                      {t('projects:detail.rules.form.compareAgainst')}
-                    </FieldLabel>
-                    <Select
-                      value={valueType}
-                      onValueChange={(next) =>
-                        handleValueTypeChange(index, next as ProjectRuleConditionValueType)
-                      }
-                      disabled={submitting}
-                    >
-                      <SelectTrigger id={`project-rule-value-type-${index}`} className="w-full">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectGroup>
-                          {valueTypeChoices.map((nextValueType) => (
-                            <SelectItem key={nextValueType} value={nextValueType}>
-                              {t(`projects:detail.rules.valueTypes.${nextValueType}`)}
-                            </SelectItem>
-                          ))}
-                        </SelectGroup>
-                      </SelectContent>
-                    </Select>
-                  </Field>
-
-                  <Field data-invalid={!!valueError}>
-                    <FieldLabel htmlFor={`project-rule-value-${index}`}>
-                      {t(
-                        valueType === 'field'
-                          ? 'projects:detail.rules.form.targetField'
-                          : 'projects:detail.rules.form.value',
-                      )}
-                    </FieldLabel>
-                    {valueType === 'field' ? (
-                      <Select
-                        value={condition.value}
-                        onValueChange={(value) => updateCondition(index, { value })}
-                        disabled={submitting || valueFieldOptions.length === 0}
-                      >
-                        <SelectTrigger
-                          id={`project-rule-value-${index}`}
-                          className="w-full"
-                          aria-invalid={!!valueError}
+                      <Field data-invalid={!!fieldError}>
+                        <FieldLabel className="md:sr-only" htmlFor={`project-rule-field-${index}`}>
+                          {t('projects:detail.rules.form.field')}
+                        </FieldLabel>
+                        <Select
+                          value={condition.field}
+                          onValueChange={(nextField) => handleFieldChange(index, nextField)}
+                          disabled={submitting}
                         >
-                          <SelectValue placeholder={t('projects:detail.rules.form.targetField')} />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectGroup>
-                            {valueFieldOptions.map((option) => (
-                              <SelectItem key={option.id} value={option.id}>
-                                {option.name}
-                              </SelectItem>
-                            ))}
-                          </SelectGroup>
-                        </SelectContent>
-                      </Select>
-                    ) : fieldDefinition?.kind === 'enum' ? (
-                      <Select
-                        value={condition.value}
-                        onValueChange={(value) => updateCondition(index, { value })}
-                        disabled={submitting}
-                      >
-                        <SelectTrigger
-                          id={`project-rule-value-${index}`}
-                          className="w-full"
-                          aria-invalid={!!valueError}
-                        >
-                          <SelectValue placeholder={t('projects:detail.rules.form.value')} />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectGroup>
-                            {enumValueOptions.map((option) => (
-                              <SelectItem key={option.id} value={option.id}>
-                                {option.name}
-                              </SelectItem>
-                            ))}
-                          </SelectGroup>
-                        </SelectContent>
-                      </Select>
-                    ) : (
-                      <Input
-                        id={`project-rule-value-${index}`}
-                        type="number"
-                        step="any"
-                        value={condition.value}
-                        onChange={(event) => updateCondition(index, { value: event.target.value })}
-                        disabled={submitting}
-                        aria-invalid={!!valueError}
-                        placeholder={t('projects:detail.rules.form.valuePlaceholder')}
-                      />
-                    )}
-                    <FieldError>{valueError}</FieldError>
-                  </Field>
+                          <SelectTrigger
+                            id={`project-rule-field-${index}`}
+                            className="w-full"
+                            aria-invalid={!!fieldError}
+                          >
+                            <SelectValue placeholder={t('projects:detail.rules.form.field')} />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectGroup>
+                              {fieldOptions.map((option) => (
+                                <SelectItem key={option.id} value={option.id}>
+                                  {option.name}
+                                </SelectItem>
+                              ))}
+                            </SelectGroup>
+                          </SelectContent>
+                        </Select>
+                        <FieldError>{fieldError}</FieldError>
+                      </Field>
 
-                  <div className="flex items-end justify-end">
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon-sm"
-                      onClick={() => removeCondition(index)}
-                      disabled={submitting || conditions.length === 1}
-                      aria-label={t('projects:detail.rules.actions.removeCondition')}
-                    >
-                      <Trash2Icon className="size-4" />
-                    </Button>
-                  </div>
-                </div>
-              );
-            })}
+                      <Field data-invalid={!!operatorError}>
+                        <FieldLabel
+                          className="md:sr-only"
+                          htmlFor={`project-rule-operator-${index}`}
+                        >
+                          {t('projects:detail.rules.form.operator')}
+                        </FieldLabel>
+                        <Select
+                          value={condition.operator}
+                          onValueChange={(operator) => updateCondition(index, { operator })}
+                          disabled={submitting}
+                        >
+                          <SelectTrigger
+                            id={`project-rule-operator-${index}`}
+                            className="w-full"
+                            aria-invalid={!!operatorError}
+                          >
+                            <SelectValue placeholder={t('projects:detail.rules.form.operator')} />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectGroup>
+                              {operatorOptions.map((option) => (
+                                <SelectItem key={option.id} value={option.id}>
+                                  {option.name}
+                                </SelectItem>
+                              ))}
+                            </SelectGroup>
+                          </SelectContent>
+                        </Select>
+                        <FieldError>{operatorError}</FieldError>
+                      </Field>
+
+                      <Field>
+                        <FieldLabel
+                          className="md:sr-only"
+                          htmlFor={`project-rule-value-type-${index}`}
+                        >
+                          {t('projects:detail.rules.form.compareAgainst')}
+                        </FieldLabel>
+                        <Select
+                          value={valueType}
+                          onValueChange={(next) =>
+                            handleValueTypeChange(index, next as ProjectRuleConditionValueType)
+                          }
+                          disabled={submitting}
+                        >
+                          <SelectTrigger id={`project-rule-value-type-${index}`} className="w-full">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectGroup>
+                              {valueTypeChoices.map((nextValueType) => (
+                                <SelectItem key={nextValueType} value={nextValueType}>
+                                  {t(`projects:detail.rules.valueTypes.${nextValueType}`)}
+                                </SelectItem>
+                              ))}
+                            </SelectGroup>
+                          </SelectContent>
+                        </Select>
+                      </Field>
+
+                      <Field data-invalid={!!valueError}>
+                        <FieldLabel className="md:sr-only" htmlFor={`project-rule-value-${index}`}>
+                          {t(
+                            valueType === 'field'
+                              ? 'projects:detail.rules.form.targetField'
+                              : 'projects:detail.rules.form.value',
+                          )}
+                        </FieldLabel>
+                        {valueType === 'field' ? (
+                          <Select
+                            value={condition.value}
+                            onValueChange={(value) => updateCondition(index, { value })}
+                            disabled={submitting || valueFieldOptions.length === 0}
+                          >
+                            <SelectTrigger
+                              id={`project-rule-value-${index}`}
+                              className="w-full"
+                              aria-invalid={!!valueError}
+                            >
+                              <SelectValue
+                                placeholder={t('projects:detail.rules.form.targetField')}
+                              />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectGroup>
+                                {valueFieldOptions.map((option) => (
+                                  <SelectItem key={option.id} value={option.id}>
+                                    {option.name}
+                                  </SelectItem>
+                                ))}
+                              </SelectGroup>
+                            </SelectContent>
+                          </Select>
+                        ) : fieldDefinition?.kind === 'enum' ? (
+                          <Select
+                            value={condition.value}
+                            onValueChange={(value) => updateCondition(index, { value })}
+                            disabled={submitting}
+                          >
+                            <SelectTrigger
+                              id={`project-rule-value-${index}`}
+                              className="w-full"
+                              aria-invalid={!!valueError}
+                            >
+                              <SelectValue placeholder={t('projects:detail.rules.form.value')} />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectGroup>
+                                {enumValueOptions.map((option) => (
+                                  <SelectItem key={option.id} value={option.id}>
+                                    {option.name}
+                                  </SelectItem>
+                                ))}
+                              </SelectGroup>
+                            </SelectContent>
+                          </Select>
+                        ) : (
+                          <Input
+                            id={`project-rule-value-${index}`}
+                            type="number"
+                            step="any"
+                            value={condition.value}
+                            onChange={(event) =>
+                              updateCondition(index, { value: event.target.value })
+                            }
+                            disabled={submitting}
+                            aria-invalid={!!valueError}
+                            placeholder={t('projects:detail.rules.form.valuePlaceholder')}
+                          />
+                        )}
+                        <FieldError>{valueError}</FieldError>
+                      </Field>
+
+                      <div className="flex items-end justify-end md:items-center">
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon-sm"
+                          onClick={() => removeCondition(index)}
+                          disabled={submitting || conditions.length === 1}
+                          aria-label={t('projects:detail.rules.actions.removeCondition')}
+                        >
+                          <Trash2Icon className="size-4" />
+                        </Button>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
             {errors.conditions && (
               <p className="text-sm font-medium text-destructive">{errors.conditions}</p>
             )}

--- a/components/projects/ProjectRuleFormModal.tsx
+++ b/components/projects/ProjectRuleFormModal.tsx
@@ -1,0 +1,592 @@
+import { PlusIcon, Trash2Icon } from 'lucide-react';
+import type React from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Field, FieldError, FieldLabel } from '@/components/ui/field';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import type {
+  ProjectRule,
+  ProjectRuleCondition,
+  ProjectRuleConditionLogic,
+  ProjectRuleConditionValueType,
+  ProjectRuleRecipientOptions,
+} from '../../types';
+import SelectControl from '../shared/SelectControl';
+import {
+  getAvailableProjectRuleFields,
+  getAvailableProjectRuleValueFields,
+  getProjectRuleFieldDefinition,
+  isValidProjectRuleConditionValue,
+} from './projectRuleRegistry';
+
+export type ProjectRuleFormPayload = {
+  name: string;
+  field: string;
+  operator: string;
+  value: string;
+  conditionLogic: ProjectRuleConditionLogic;
+  conditions: ProjectRuleCondition[];
+  actionType: 'notify';
+  actionConfig: {
+    recipientUserIds: string[];
+    recipientRoleIds: string[];
+  };
+  isEnabled: boolean;
+};
+
+export interface ProjectRuleFormModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  rule?: ProjectRule | null;
+  recipients: ProjectRuleRecipientOptions;
+  permissions: string[];
+  onSubmit: (payload: ProjectRuleFormPayload) => Promise<void>;
+}
+
+const firstValueForField = (field: string) => {
+  const definition = getProjectRuleFieldDefinition(field);
+  if (definition?.kind === 'enum') return definition.enumValues?.[0] ?? '';
+  return '';
+};
+
+const defaultConditionForField = (field: string): ProjectRuleCondition => {
+  const definition = getProjectRuleFieldDefinition(field);
+  return {
+    field,
+    operator: definition?.operators[0] ?? '',
+    value: firstValueForField(field),
+    valueType: 'literal',
+  };
+};
+
+const normalizeConditionForForm = (condition: ProjectRuleCondition): ProjectRuleCondition => ({
+  ...condition,
+  valueType: condition.valueType ?? 'literal',
+});
+
+const conditionsForRule = (
+  rule: ProjectRule | null | undefined,
+  fallbackField: string,
+): ProjectRuleCondition[] => {
+  if (rule?.conditions?.length) return rule.conditions.map(normalizeConditionForForm);
+  if (rule) {
+    return [
+      {
+        field: rule.field,
+        operator: rule.operator,
+        value: rule.value,
+        valueType: 'literal',
+      },
+    ];
+  }
+  return fallbackField ? [defaultConditionForField(fallbackField)] : [];
+};
+
+const enumValueLabelKey = (field: string, value: string) => {
+  if (field === 'billing_type') {
+    if (value === 'time_and_materials') return 'projects:projects.billingTypes.timeAndMaterials';
+    if (value === 'retainer') return 'projects:projects.billingTypes.retainer';
+  }
+  return `projects:detail.rules.values.${field}.${value}`;
+};
+
+const ProjectRuleFormModal: React.FC<ProjectRuleFormModalProps> = ({
+  open,
+  onOpenChange,
+  rule,
+  recipients,
+  permissions,
+  onSubmit,
+}) => {
+  const { t } = useTranslation(['projects', 'common']);
+  const availableFields = useMemo(() => getAvailableProjectRuleFields(permissions), [permissions]);
+  const initialField = rule?.field ?? availableFields[0]?.id ?? '';
+  const [name, setName] = useState(rule?.name ?? '');
+  const [conditionLogic, setConditionLogic] = useState<ProjectRuleConditionLogic>(
+    rule?.conditionLogic ?? 'and',
+  );
+  const [conditions, setConditions] = useState<ProjectRuleCondition[]>(
+    conditionsForRule(rule, initialField),
+  );
+  const [recipientUserIds, setRecipientUserIds] = useState<string[]>(
+    rule?.actionConfig.recipientUserIds ?? [],
+  );
+  const [recipientRoleIds, setRecipientRoleIds] = useState<string[]>(
+    rule?.actionConfig.recipientRoleIds ?? [],
+  );
+  const [isEnabled, setIsEnabled] = useState(rule?.isEnabled ?? true);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    const nextField = rule?.field ?? availableFields[0]?.id ?? '';
+    setName(rule?.name ?? '');
+    setConditionLogic(rule?.conditionLogic ?? 'and');
+    setConditions(conditionsForRule(rule, nextField));
+    setRecipientUserIds(rule?.actionConfig.recipientUserIds ?? []);
+    setRecipientRoleIds(rule?.actionConfig.recipientRoleIds ?? []);
+    setIsEnabled(rule?.isEnabled ?? true);
+    setErrors({});
+  }, [open, rule, availableFields]);
+
+  const fieldOptions = availableFields.map((definition) => ({
+    id: definition.id,
+    name: t(`projects:detail.rules.fields.${definition.id}`),
+  }));
+  const userOptions = recipients.users.map((user) => ({
+    id: user.id,
+    name: `${user.name} (${user.username})`,
+  }));
+  const roleOptions = recipients.roles.map((role) => ({ id: role.id, name: role.name }));
+
+  const updateCondition = (index: number, patch: Partial<ProjectRuleCondition>) => {
+    setConditions((current) =>
+      current.map((condition, conditionIndex) =>
+        conditionIndex === index ? { ...condition, ...patch } : condition,
+      ),
+    );
+  };
+
+  const firstValueFieldForField = (field: string) =>
+    getAvailableProjectRuleValueFields(field, permissions)[0]?.id ?? '';
+
+  const handleFieldChange = (index: number, nextField: string) => {
+    const currentValueType = conditions[index]?.valueType ?? 'literal';
+    const nextValueField = firstValueFieldForField(nextField);
+    const nextValueType: ProjectRuleConditionValueType =
+      currentValueType === 'field' && nextValueField ? 'field' : 'literal';
+    const nextDefinition = getProjectRuleFieldDefinition(nextField);
+    updateCondition(index, {
+      field: nextField,
+      operator: nextDefinition?.operators[0] ?? '',
+      valueType: nextValueType,
+      value: nextValueType === 'field' ? nextValueField : firstValueForField(nextField),
+    });
+  };
+
+  const handleValueTypeChange = (index: number, nextValueType: ProjectRuleConditionValueType) => {
+    const field = conditions[index]?.field ?? '';
+    updateCondition(index, {
+      valueType: nextValueType,
+      value: nextValueType === 'field' ? firstValueFieldForField(field) : firstValueForField(field),
+    });
+  };
+
+  const addCondition = () => {
+    const field = availableFields[0]?.id ?? '';
+    if (!field) return;
+    setConditions((current) => [...current, defaultConditionForField(field)]);
+  };
+
+  const removeCondition = (index: number) => {
+    setConditions((current) => current.filter((_, conditionIndex) => conditionIndex !== index));
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    const nextErrors: Record<string, string> = {};
+    const primary = conditions[0];
+    if (!name.trim()) nextErrors.name = t('projects:detail.rules.errors.nameRequired');
+    if (conditions.length === 0) {
+      nextErrors.conditions = t('projects:detail.rules.errors.conditionsRequired');
+    }
+    conditions.forEach((condition, index) => {
+      if (!condition.field)
+        nextErrors[`field-${index}`] = t('projects:detail.rules.errors.fieldRequired');
+      if (!condition.operator) {
+        nextErrors[`operator-${index}`] = t('projects:detail.rules.errors.operatorRequired');
+      }
+      if (
+        !isValidProjectRuleConditionValue({
+          field: condition.field,
+          value: condition.value,
+          valueType: condition.valueType ?? 'literal',
+          permissions,
+        })
+      ) {
+        nextErrors[`value-${index}`] = t('projects:detail.rules.errors.valueInvalid');
+      }
+    });
+    if (recipientUserIds.length + recipientRoleIds.length === 0) {
+      nextErrors.recipients = t('projects:detail.rules.errors.recipientsRequired');
+    }
+    setErrors(nextErrors);
+    if (Object.keys(nextErrors).length > 0) return;
+
+    setSubmitting(true);
+    try {
+      const normalizedConditions = conditions.map((condition) => ({
+        field: condition.field,
+        operator: condition.operator,
+        value: condition.value.trim(),
+        valueType: condition.valueType ?? 'literal',
+      }));
+      const firstCondition = normalizedConditions[0] ?? primary;
+      if (!firstCondition) return;
+      await onSubmit({
+        name: name.trim(),
+        field: firstCondition.field,
+        operator: firstCondition.operator,
+        value: firstCondition.value,
+        conditionLogic,
+        conditions: normalizedConditions,
+        actionType: 'notify',
+        actionConfig: { recipientUserIds, recipientRoleIds },
+        isEnabled,
+      });
+      onOpenChange(false);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={submitting ? undefined : onOpenChange}>
+      <DialogContent className="sm:max-w-4xl">
+        <DialogHeader>
+          <DialogTitle>
+            {rule
+              ? t('projects:detail.rules.form.editTitle')
+              : t('projects:detail.rules.form.createTitle')}
+          </DialogTitle>
+          <DialogDescription>{t('projects:detail.rules.form.description')}</DialogDescription>
+        </DialogHeader>
+
+        <form className="space-y-5" onSubmit={handleSubmit}>
+          <Field data-invalid={!!errors.name}>
+            <FieldLabel htmlFor="project-rule-name">
+              {t('projects:detail.rules.form.name')}
+            </FieldLabel>
+            <Input
+              id="project-rule-name"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              disabled={submitting}
+              aria-invalid={!!errors.name}
+              placeholder={t('projects:detail.rules.form.namePlaceholder')}
+            />
+            <FieldError>{errors.name}</FieldError>
+          </Field>
+
+          <div className="space-y-3">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+              <Field className="max-w-xs">
+                <FieldLabel htmlFor="project-rule-condition-logic">
+                  {t('projects:detail.rules.form.conditionLogic')}
+                </FieldLabel>
+                <Select
+                  value={conditionLogic}
+                  onValueChange={(next) => setConditionLogic(next as ProjectRuleConditionLogic)}
+                  disabled={submitting}
+                >
+                  <SelectTrigger id="project-rule-condition-logic" className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectGroup>
+                      {(['and', 'or'] as const).map((logic) => (
+                        <SelectItem key={logic} value={logic}>
+                          {t(`projects:detail.rules.conditionLogic.${logic}`)}
+                        </SelectItem>
+                      ))}
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
+              </Field>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={addCondition}
+                disabled={submitting || availableFields.length === 0}
+              >
+                <PlusIcon className="size-4" />
+                {t('projects:detail.rules.actions.addCondition')}
+              </Button>
+            </div>
+
+            {conditions.map((condition, index) => {
+              const fieldDefinition = getProjectRuleFieldDefinition(condition.field);
+              const operatorOptions =
+                fieldDefinition?.operators.map((id) => ({
+                  id,
+                  name: t(`projects:detail.rules.operators.${id}`),
+                })) ?? [];
+              const enumValueOptions =
+                fieldDefinition?.enumValues?.map((id) => ({
+                  id,
+                  name: t(enumValueLabelKey(condition.field, id)),
+                })) ?? [];
+              const valueType = condition.valueType ?? 'literal';
+              const valueFieldOptions = getAvailableProjectRuleValueFields(
+                condition.field,
+                permissions,
+              ).map((definition) => ({
+                id: definition.id,
+                name: t(`projects:detail.rules.fields.${definition.id}`),
+              }));
+              const fieldError = errors[`field-${index}`];
+              const operatorError = errors[`operator-${index}`];
+              const valueError = errors[`value-${index}`];
+              return (
+                <div
+                  key={`${condition.field}-${index}`}
+                  className="grid gap-3 rounded-md border border-border p-3 md:grid-cols-[minmax(0,1fr)_10rem_10rem_minmax(10rem,14rem)_2.25rem]"
+                >
+                  <Field data-invalid={!!fieldError}>
+                    <FieldLabel htmlFor={`project-rule-field-${index}`}>
+                      {t('projects:detail.rules.form.field')}
+                    </FieldLabel>
+                    <Select
+                      value={condition.field}
+                      onValueChange={(nextField) => handleFieldChange(index, nextField)}
+                      disabled={submitting}
+                    >
+                      <SelectTrigger
+                        id={`project-rule-field-${index}`}
+                        className="w-full"
+                        aria-invalid={!!fieldError}
+                      >
+                        <SelectValue placeholder={t('projects:detail.rules.form.field')} />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectGroup>
+                          {fieldOptions.map((option) => (
+                            <SelectItem key={option.id} value={option.id}>
+                              {option.name}
+                            </SelectItem>
+                          ))}
+                        </SelectGroup>
+                      </SelectContent>
+                    </Select>
+                    <FieldError>{fieldError}</FieldError>
+                  </Field>
+
+                  <Field data-invalid={!!operatorError}>
+                    <FieldLabel htmlFor={`project-rule-operator-${index}`}>
+                      {t('projects:detail.rules.form.operator')}
+                    </FieldLabel>
+                    <Select
+                      value={condition.operator}
+                      onValueChange={(operator) => updateCondition(index, { operator })}
+                      disabled={submitting}
+                    >
+                      <SelectTrigger
+                        id={`project-rule-operator-${index}`}
+                        className="w-full"
+                        aria-invalid={!!operatorError}
+                      >
+                        <SelectValue placeholder={t('projects:detail.rules.form.operator')} />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectGroup>
+                          {operatorOptions.map((option) => (
+                            <SelectItem key={option.id} value={option.id}>
+                              {option.name}
+                            </SelectItem>
+                          ))}
+                        </SelectGroup>
+                      </SelectContent>
+                    </Select>
+                    <FieldError>{operatorError}</FieldError>
+                  </Field>
+
+                  <Field>
+                    <FieldLabel htmlFor={`project-rule-value-type-${index}`}>
+                      {t('projects:detail.rules.form.compareAgainst')}
+                    </FieldLabel>
+                    <Select
+                      value={valueType}
+                      onValueChange={(next) =>
+                        handleValueTypeChange(index, next as ProjectRuleConditionValueType)
+                      }
+                      disabled={submitting}
+                    >
+                      <SelectTrigger id={`project-rule-value-type-${index}`} className="w-full">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectGroup>
+                          {(['literal', 'field'] as const).map((nextValueType) => (
+                            <SelectItem key={nextValueType} value={nextValueType}>
+                              {t(`projects:detail.rules.valueTypes.${nextValueType}`)}
+                            </SelectItem>
+                          ))}
+                        </SelectGroup>
+                      </SelectContent>
+                    </Select>
+                  </Field>
+
+                  <Field data-invalid={!!valueError}>
+                    <FieldLabel htmlFor={`project-rule-value-${index}`}>
+                      {t(
+                        valueType === 'field'
+                          ? 'projects:detail.rules.form.targetField'
+                          : 'projects:detail.rules.form.value',
+                      )}
+                    </FieldLabel>
+                    {valueType === 'field' ? (
+                      <Select
+                        value={condition.value}
+                        onValueChange={(value) => updateCondition(index, { value })}
+                        disabled={submitting || valueFieldOptions.length === 0}
+                      >
+                        <SelectTrigger
+                          id={`project-rule-value-${index}`}
+                          className="w-full"
+                          aria-invalid={!!valueError}
+                        >
+                          <SelectValue placeholder={t('projects:detail.rules.form.targetField')} />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectGroup>
+                            {valueFieldOptions.map((option) => (
+                              <SelectItem key={option.id} value={option.id}>
+                                {option.name}
+                              </SelectItem>
+                            ))}
+                          </SelectGroup>
+                        </SelectContent>
+                      </Select>
+                    ) : fieldDefinition?.kind === 'enum' ? (
+                      <Select
+                        value={condition.value}
+                        onValueChange={(value) => updateCondition(index, { value })}
+                        disabled={submitting}
+                      >
+                        <SelectTrigger
+                          id={`project-rule-value-${index}`}
+                          className="w-full"
+                          aria-invalid={!!valueError}
+                        >
+                          <SelectValue placeholder={t('projects:detail.rules.form.value')} />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectGroup>
+                            {enumValueOptions.map((option) => (
+                              <SelectItem key={option.id} value={option.id}>
+                                {option.name}
+                              </SelectItem>
+                            ))}
+                          </SelectGroup>
+                        </SelectContent>
+                      </Select>
+                    ) : (
+                      <Input
+                        id={`project-rule-value-${index}`}
+                        type="number"
+                        step="any"
+                        value={condition.value}
+                        onChange={(event) => updateCondition(index, { value: event.target.value })}
+                        disabled={submitting}
+                        aria-invalid={!!valueError}
+                        placeholder={t('projects:detail.rules.form.valuePlaceholder')}
+                      />
+                    )}
+                    <FieldError>{valueError}</FieldError>
+                  </Field>
+
+                  <div className="flex items-end justify-end">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon-sm"
+                      onClick={() => removeCondition(index)}
+                      disabled={submitting || conditions.length === 1}
+                      aria-label={t('projects:detail.rules.actions.removeCondition')}
+                    >
+                      <Trash2Icon className="size-4" />
+                    </Button>
+                  </div>
+                </div>
+              );
+            })}
+            {errors.conditions && (
+              <p className="text-sm font-medium text-destructive">{errors.conditions}</p>
+            )}
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <SelectControl
+              id="project-rule-users"
+              searchable
+              isMulti
+              disabled={submitting}
+              label={t('projects:detail.rules.form.users')}
+              placeholder={t('projects:detail.rules.form.usersPlaceholder')}
+              options={userOptions}
+              value={recipientUserIds}
+              onChange={(next) => setRecipientUserIds(Array.isArray(next) ? next : [])}
+            />
+            <SelectControl
+              id="project-rule-roles"
+              searchable
+              isMulti
+              disabled={submitting}
+              label={t('projects:detail.rules.form.roles')}
+              placeholder={t('projects:detail.rules.form.rolesPlaceholder')}
+              options={roleOptions}
+              value={recipientRoleIds}
+              onChange={(next) => setRecipientRoleIds(Array.isArray(next) ? next : [])}
+            />
+          </div>
+          {errors.recipients && (
+            <p className="text-sm font-medium text-destructive">{errors.recipients}</p>
+          )}
+
+          <Field className="flex-row items-center justify-between rounded-md border border-border p-3">
+            <div className="space-y-1">
+              <FieldLabel htmlFor="project-rule-enabled">
+                {t('projects:detail.rules.form.enabled')}
+              </FieldLabel>
+              <p className="text-sm text-muted-foreground">
+                {t('projects:detail.rules.form.enabledDescription')}
+              </p>
+            </div>
+            <Switch
+              id="project-rule-enabled"
+              checked={isEnabled}
+              onCheckedChange={setIsEnabled}
+              disabled={submitting}
+            />
+          </Field>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={submitting}
+            >
+              {t('common:buttons.cancel')}
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? t('common:buttons.saving') : t('common:buttons.save')}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default ProjectRuleFormModal;

--- a/components/projects/ProjectRuleFormModal.tsx
+++ b/components/projects/ProjectRuleFormModal.tsx
@@ -344,6 +344,13 @@ const ProjectRuleFormModal: React.FC<ProjectRuleFormModalProps> = ({
                 id: definition.id,
                 name: t(`projects:detail.rules.fields.${definition.id}`),
               }));
+              // Only offer "compare against another field" when a comparable peer field
+              // actually exists. Enum fields (e.g. billing_type, status) have no comparable
+              // peer, so showing that option would lead to an unresolvable validation error.
+              const valueTypeChoices: readonly ProjectRuleConditionValueType[] =
+                valueFieldOptions.length > 0
+                  ? (['literal', 'field'] as const)
+                  : (['literal'] as const);
               const fieldError = errors[`field-${index}`];
               const operatorError = errors[`operator-${index}`];
               const valueError = errors[`value-${index}`];
@@ -426,7 +433,7 @@ const ProjectRuleFormModal: React.FC<ProjectRuleFormModalProps> = ({
                       </SelectTrigger>
                       <SelectContent>
                         <SelectGroup>
-                          {(['literal', 'field'] as const).map((nextValueType) => (
+                          {valueTypeChoices.map((nextValueType) => (
                             <SelectItem key={nextValueType} value={nextValueType}>
                               {t(`projects:detail.rules.valueTypes.${nextValueType}`)}
                             </SelectItem>

--- a/components/projects/ProjectRuleFormModal.tsx
+++ b/components/projects/ProjectRuleFormModal.tsx
@@ -261,7 +261,7 @@ const ProjectRuleFormModal: React.FC<ProjectRuleFormModalProps> = ({
 
   return (
     <Dialog open={open} onOpenChange={submitting ? undefined : onOpenChange}>
-      <DialogContent className="sm:max-w-4xl">
+      <DialogContent className="max-h-[calc(100vh-2rem)] overflow-y-auto sm:max-w-4xl">
         <DialogHeader>
           <DialogTitle>
             {rule

--- a/components/projects/ProjectRules.tsx
+++ b/components/projects/ProjectRules.tsx
@@ -1,0 +1,384 @@
+import { BellRingIcon, PencilIcon, PlusIcon, RefreshCwIcon, Trash2Icon } from 'lucide-react';
+import type React from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Switch } from '@/components/ui/switch';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
+import { projectRulesApi } from '../../services/api/projectRules';
+import type { ProjectRule, ProjectRuleRecipientOptions } from '../../types';
+import { hasPermission } from '../../utils/permissions';
+import { toastError, toastSuccess } from '../../utils/toast';
+import ProjectRuleFormModal, { type ProjectRuleFormPayload } from './ProjectRuleFormModal';
+import { getProjectRuleFieldDefinition } from './projectRuleRegistry';
+
+export interface ProjectRulesProps {
+  projectId: string;
+  permissions: string[];
+  className?: string;
+}
+
+const emptyRecipients: ProjectRuleRecipientOptions = { users: [], roles: [] };
+
+const canModifyRuleField = (rule: ProjectRule, permissions: string[]) => {
+  const conditions =
+    rule.conditions?.length > 0
+      ? rule.conditions
+      : [
+          {
+            field: rule.field,
+            operator: rule.operator,
+            value: rule.value,
+            valueType: 'literal' as const,
+          },
+        ];
+  return conditions.every((condition) => {
+    const definition = getProjectRuleFieldDefinition(condition.field);
+    const valueDefinition =
+      condition.valueType === 'field' ? getProjectRuleFieldDefinition(condition.value) : null;
+    return (
+      (!definition?.requiresPermission || permissions.includes(definition.requiresPermission)) &&
+      (!valueDefinition?.requiresPermission ||
+        permissions.includes(valueDefinition.requiresPermission))
+    );
+  });
+};
+
+const enumValueLabelKey = (field: string, value: string) => {
+  if (field === 'billing_type') {
+    if (value === 'time_and_materials') return 'projects:projects.billingTypes.timeAndMaterials';
+    if (value === 'retainer') return 'projects:projects.billingTypes.retainer';
+  }
+  return `projects:detail.rules.values.${field}.${value}`;
+};
+
+const ProjectRules: React.FC<ProjectRulesProps> = ({ projectId, permissions, className }) => {
+  const { t } = useTranslation(['projects', 'common']);
+  const canView = hasPermission(permissions, 'projects.rules.view');
+  const canCreate = hasPermission(permissions, 'projects.rules.create');
+  const canUpdate = hasPermission(permissions, 'projects.rules.update');
+  const canDelete = hasPermission(permissions, 'projects.rules.delete');
+  const [rules, setRules] = useState<ProjectRule[]>([]);
+  const [recipients, setRecipients] = useState<ProjectRuleRecipientOptions>(emptyRecipients);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const [formRule, setFormRule] = useState<ProjectRule | null>(null);
+  const [formOpen, setFormOpen] = useState(false);
+  const [busyRuleId, setBusyRuleId] = useState<string | null>(null);
+  const [ruleToDelete, setRuleToDelete] = useState<ProjectRule | null>(null);
+
+  const loadRules = useCallback(
+    async (signal?: AbortSignal) => {
+      if (!canView) return;
+      setLoading(true);
+      setError(false);
+      try {
+        const [nextRules, nextRecipients] = await Promise.all([
+          projectRulesApi.list(projectId, signal),
+          projectRulesApi.getRecipients(projectId, signal),
+        ]);
+        if (signal?.aborted) return;
+        setRules(nextRules);
+        setRecipients(nextRecipients);
+      } catch (err) {
+        if (signal?.aborted) return;
+        console.error('Failed to load project rules', err);
+        setError(true);
+      } finally {
+        if (!signal?.aborted) setLoading(false);
+      }
+    },
+    [canView, projectId],
+  );
+
+  useEffect(() => {
+    if (!canView) return;
+    const controller = new AbortController();
+    void loadRules(controller.signal);
+    return () => controller.abort();
+  }, [canView, loadRules]);
+
+  const ruleSummary = useCallback(
+    (rule: ProjectRule) => {
+      const conditions =
+        rule.conditions?.length > 0
+          ? rule.conditions
+          : [
+              {
+                field: rule.field,
+                operator: rule.operator,
+                value: rule.value,
+                valueType: 'literal' as const,
+              },
+            ];
+      const joiner = ` ${t(`projects:detail.rules.joiners.${rule.conditionLogic ?? 'and'}`)} `;
+      return conditions
+        .map((condition) => {
+          const field = t(`projects:detail.rules.fields.${condition.field}`);
+          const operator = t(`projects:detail.rules.operators.${condition.operator}`);
+          const definition = getProjectRuleFieldDefinition(condition.field);
+          const value =
+            condition.valueType === 'field'
+              ? t(`projects:detail.rules.fields.${condition.value}`)
+              : definition?.kind === 'enum'
+                ? t(enumValueLabelKey(condition.field, condition.value))
+                : condition.value;
+          return `${field} ${operator} ${value}`;
+        })
+        .join(joiner);
+    },
+    [t],
+  );
+
+  const handleSubmit = async (payload: ProjectRuleFormPayload) => {
+    try {
+      if (formRule) {
+        const updated = await projectRulesApi.update(projectId, formRule.id, payload);
+        setRules((current) => current.map((rule) => (rule.id === updated.id ? updated : rule)));
+        toastSuccess(t('projects:detail.rules.toasts.updated'));
+      } else {
+        const created = await projectRulesApi.create(projectId, payload);
+        setRules((current) => [...current, created]);
+        toastSuccess(t('projects:detail.rules.toasts.created'));
+      }
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : t('projects:detail.rules.toasts.saveFailed');
+      toastError(message);
+      throw err;
+    }
+  };
+
+  const handleToggle = async (rule: ProjectRule, checked: boolean) => {
+    if (!canUpdate || !canModifyRuleField(rule, permissions)) return;
+    setBusyRuleId(rule.id);
+    try {
+      const updated = await projectRulesApi.update(projectId, rule.id, { isEnabled: checked });
+      setRules((current) => current.map((item) => (item.id === updated.id ? updated : item)));
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : t('projects:detail.rules.toasts.saveFailed');
+      toastError(message);
+    } finally {
+      setBusyRuleId(null);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!ruleToDelete || !canDelete) return;
+    setBusyRuleId(ruleToDelete.id);
+    try {
+      await projectRulesApi.delete(projectId, ruleToDelete.id);
+      setRules((current) => current.filter((rule) => rule.id !== ruleToDelete.id));
+      toastSuccess(t('projects:detail.rules.toasts.deleted'));
+      setRuleToDelete(null);
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : t('projects:detail.rules.toasts.deleteFailed');
+      toastError(message);
+    } finally {
+      setBusyRuleId(null);
+    }
+  };
+
+  const sortedRules = useMemo(
+    () => [...rules].sort((left, right) => left.name.localeCompare(right.name)),
+    [rules],
+  );
+  const deletingSelectedRule = busyRuleId === ruleToDelete?.id;
+
+  if (!canView) return null;
+
+  return (
+    <div className={cn('space-y-3', className)}>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-1.5">
+          <h2 className="text-base font-semibold leading-none">
+            {t('projects:detail.rules.title')}
+          </h2>
+          <p className="text-sm text-muted-foreground">{t('projects:detail.rules.description')}</p>
+        </div>
+        {canCreate && (
+          <Button
+            type="button"
+            size="sm"
+            onClick={() => {
+              setFormRule(null);
+              setFormOpen(true);
+            }}
+            disabled={loading || error}
+          >
+            <PlusIcon className="size-4" />
+            {t('projects:detail.rules.actions.add')}
+          </Button>
+        )}
+      </div>
+
+      <div className="rounded-lg border border-border bg-background">
+        {loading ? (
+          <div className="space-y-3 p-4">
+            <Skeleton className="h-14 w-full" />
+            <Skeleton className="h-14 w-full" />
+          </div>
+        ) : error ? (
+          <div className="flex flex-col items-center gap-3 px-4 py-8 text-center">
+            <p className="text-sm text-muted-foreground">
+              {t('projects:detail.rules.errors.loadFailed')}
+            </p>
+            <Button type="button" variant="outline" size="sm" onClick={() => void loadRules()}>
+              <RefreshCwIcon className="size-4" />
+              {t('common:buttons.refresh')}
+            </Button>
+          </div>
+        ) : sortedRules.length === 0 ? (
+          <div className="flex flex-col items-center gap-3 px-4 py-8 text-center">
+            <BellRingIcon className="size-8 text-muted-foreground" />
+            <div className="space-y-1">
+              <p className="text-sm font-medium">{t('projects:detail.rules.empty.title')}</p>
+              <p className="text-sm text-muted-foreground">
+                {t('projects:detail.rules.empty.description')}
+              </p>
+            </div>
+          </div>
+        ) : (
+          <ul className="divide-y divide-border">
+            {sortedRules.map((rule) => {
+              const canUpdateThis = canUpdate && canModifyRuleField(rule, permissions);
+              const disabledReason =
+                canUpdate && !canUpdateThis
+                  ? t('projects:detail.rules.costPermissionRequired')
+                  : undefined;
+              return (
+                <li
+                  key={rule.id}
+                  className="flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <div className="flex min-w-0 items-start gap-3">
+                    <div className="flex size-9 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+                      <BellRingIcon className="size-4" />
+                    </div>
+                    <div className="min-w-0 space-y-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <p className="truncate text-sm font-medium text-foreground">{rule.name}</p>
+                        {rule.conditionMet && (
+                          <span className="rounded-full border border-primary/30 bg-primary/10 px-2 py-0.5 text-[10px] font-medium uppercase text-primary">
+                            {t('projects:detail.rules.conditionMet')}
+                          </span>
+                        )}
+                      </div>
+                      <p className="text-sm text-muted-foreground">{ruleSummary(rule)}</p>
+                    </div>
+                  </div>
+                  <div className="flex items-center justify-end gap-2">
+                    <Tooltip disabled={!disabledReason}>
+                      <TooltipTrigger asChild>
+                        <span className="inline-flex">
+                          <Switch
+                            checked={rule.isEnabled}
+                            disabled={!canUpdateThis || busyRuleId === rule.id}
+                            onCheckedChange={(checked) => void handleToggle(rule, checked)}
+                            aria-label={t('projects:detail.rules.actions.toggle')}
+                          />
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent>{disabledReason}</TooltipContent>
+                    </Tooltip>
+                    {canUpdate && (
+                      <Tooltip disabled={!disabledReason}>
+                        <TooltipTrigger asChild>
+                          <span className="inline-flex">
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon-sm"
+                              disabled={!canUpdateThis || busyRuleId === rule.id}
+                              onClick={() => {
+                                setFormRule(rule);
+                                setFormOpen(true);
+                              }}
+                              aria-label={t('projects:detail.rules.actions.edit')}
+                            >
+                              <PencilIcon className="size-4" />
+                            </Button>
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          {disabledReason ?? t('projects:detail.rules.actions.edit')}
+                        </TooltipContent>
+                      </Tooltip>
+                    )}
+                    {canDelete && (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon-sm"
+                        disabled={busyRuleId === rule.id}
+                        onClick={() => setRuleToDelete(rule)}
+                        aria-label={t('projects:detail.rules.actions.delete')}
+                      >
+                        <Trash2Icon className="size-4 text-destructive" />
+                      </Button>
+                    )}
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
+      <ProjectRuleFormModal
+        open={formOpen}
+        onOpenChange={setFormOpen}
+        rule={formRule}
+        recipients={recipients}
+        permissions={permissions}
+        onSubmit={handleSubmit}
+      />
+
+      <Dialog
+        open={!!ruleToDelete}
+        onOpenChange={(open) => !open && !deletingSelectedRule && setRuleToDelete(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('projects:detail.rules.delete.title')}</DialogTitle>
+            <DialogDescription>
+              {t('projects:detail.rules.delete.description', { name: ruleToDelete?.name ?? '' })}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setRuleToDelete(null)}
+              disabled={deletingSelectedRule}
+            >
+              {t('common:buttons.cancel')}
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={() => void handleDelete()}
+              disabled={deletingSelectedRule}
+            >
+              {t('common:buttons.delete')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+};
+
+export default ProjectRules;

--- a/components/projects/projectRuleRegistry.ts
+++ b/components/projects/projectRuleRegistry.ts
@@ -1,0 +1,109 @@
+import type { Permission, ProjectRuleConditionValueType } from '../../types';
+
+export const PROJECT_RULE_NUMBER_OPERATORS = ['gt', 'gte', 'lt', 'lte', 'eq', 'neq'] as const;
+export const PROJECT_RULE_ENUM_OPERATORS = ['eq', 'neq'] as const;
+export const PROJECT_RULE_CONDITION_VALUE_TYPES = ['literal', 'field'] as const;
+
+export type ProjectRuleNumberOperator = (typeof PROJECT_RULE_NUMBER_OPERATORS)[number];
+export type ProjectRuleEnumOperator = (typeof PROJECT_RULE_ENUM_OPERATORS)[number];
+export type ProjectRuleOperator = ProjectRuleNumberOperator | ProjectRuleEnumOperator;
+export type ProjectRuleFieldKind = 'number' | 'enum';
+
+export type ProjectRuleFieldDefinition = {
+  id: string;
+  kind: ProjectRuleFieldKind;
+  operators: readonly ProjectRuleOperator[];
+  enumValues?: readonly string[];
+  requiresPermission?: Permission;
+};
+
+export const PROJECT_RULE_FIELD_DEFINITIONS: readonly ProjectRuleFieldDefinition[] = [
+  { id: 'revenue', kind: 'number', operators: PROJECT_RULE_NUMBER_OPERATORS },
+  {
+    id: 'cost_to_date',
+    kind: 'number',
+    operators: PROJECT_RULE_NUMBER_OPERATORS,
+    requiresPermission: 'reports.cost.view',
+  },
+  {
+    id: 'budget_used_pct',
+    kind: 'number',
+    operators: PROJECT_RULE_NUMBER_OPERATORS,
+    requiresPermission: 'reports.cost.view',
+  },
+  { id: 'hours_to_date', kind: 'number', operators: PROJECT_RULE_NUMBER_OPERATORS },
+  { id: 'days_until_deadline', kind: 'number', operators: PROJECT_RULE_NUMBER_OPERATORS },
+  {
+    id: 'billing_type',
+    kind: 'enum',
+    operators: PROJECT_RULE_ENUM_OPERATORS,
+    enumValues: ['time_and_materials', 'retainer'],
+  },
+  {
+    id: 'status',
+    kind: 'enum',
+    operators: PROJECT_RULE_ENUM_OPERATORS,
+    enumValues: ['active', 'disabled'],
+  },
+];
+
+export const getProjectRuleFieldDefinition = (field: string) =>
+  PROJECT_RULE_FIELD_DEFINITIONS.find((definition) => definition.id === field) ?? null;
+
+export const getAvailableProjectRuleFields = (permissions: readonly string[]) =>
+  PROJECT_RULE_FIELD_DEFINITIONS.filter(
+    (definition) =>
+      !definition.requiresPermission || permissions.includes(definition.requiresPermission),
+  );
+
+const enumValuesMatch = (
+  leftValues: readonly string[] | undefined,
+  rightValues: readonly string[] | undefined,
+) => {
+  if (!leftValues || !rightValues || leftValues.length !== rightValues.length) return false;
+  return leftValues.every((value, index) => value === rightValues[index]);
+};
+
+export const areProjectRuleFieldsComparable = (leftField: string, rightField: string) => {
+  const leftDefinition = getProjectRuleFieldDefinition(leftField);
+  const rightDefinition = getProjectRuleFieldDefinition(rightField);
+  if (!leftDefinition || !rightDefinition) return false;
+  if (leftDefinition.kind !== rightDefinition.kind) return false;
+  if (leftDefinition.kind === 'enum') {
+    return enumValuesMatch(leftDefinition.enumValues, rightDefinition.enumValues);
+  }
+  return true;
+};
+
+export const getAvailableProjectRuleValueFields = (field: string, permissions: readonly string[]) =>
+  getAvailableProjectRuleFields(permissions).filter(
+    (definition) => definition.id !== field && areProjectRuleFieldsComparable(field, definition.id),
+  );
+
+export const isValidProjectRuleValue = (field: string, value: string): boolean => {
+  const definition = getProjectRuleFieldDefinition(field);
+  if (!definition) return false;
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  if (definition.kind === 'number') return Number.isFinite(Number(trimmed));
+  return definition.enumValues?.includes(trimmed) ?? false;
+};
+
+export const isValidProjectRuleConditionValue = ({
+  field,
+  value,
+  valueType = 'literal',
+  permissions,
+}: {
+  field: string;
+  value: string;
+  valueType?: ProjectRuleConditionValueType;
+  permissions: readonly string[];
+}) => {
+  if (valueType === 'field') {
+    return getAvailableProjectRuleValueFields(field, permissions).some(
+      (definition) => definition.id === value,
+    );
+  }
+  return isValidProjectRuleValue(field, value);
+};

--- a/components/shared/NotificationBell.tsx
+++ b/components/shared/NotificationBell.tsx
@@ -12,8 +12,11 @@ export interface NotificationBellProps {
   onDelete: (id: string) => void;
 }
 
-const getNotificationIconClass = (type: string) =>
-  type === 'admin_password_warning' ? 'fa-triangle-exclamation' : 'fa-folder-tree';
+const getNotificationIconClass = (type: string) => {
+  if (type === 'admin_password_warning') return 'fa-triangle-exclamation';
+  if (type === 'project_rule_triggered') return 'fa-bell';
+  return 'fa-folder-tree';
+};
 
 const NotificationBell: React.FC<NotificationBellProps> = ({
   notifications,
@@ -92,6 +95,12 @@ const NotificationBell: React.FC<NotificationBellProps> = ({
       }
       return t('notifications.newProjects', '{{count}} new projects available', {
         count: projectCount,
+      });
+    }
+    if (notification.type === 'project_rule_triggered') {
+      return t('notifications.projectRuleTriggered', '{{rule}} triggered for {{project}}', {
+        rule: notification.data?.ruleName ?? notification.title,
+        project: notification.data?.projectName ?? '',
       });
     }
     // Fallback to the original title for unknown types
@@ -201,6 +210,10 @@ const NotificationBell: React.FC<NotificationBellProps> = ({
                         {notification.data?.clientName && (
                           <span> · {notification.data.clientName}</span>
                         )}
+                        {notification.type === 'project_rule_triggered' &&
+                          notification.data?.projectName && (
+                            <span> · {notification.data.projectName}</span>
+                          )}
                       </p>
 
                       {/* Expandable project list */}

--- a/components/shared/SelectControl.tsx
+++ b/components/shared/SelectControl.tsx
@@ -243,14 +243,18 @@ const SearchableSelectControl = ({
             variant="outline"
             disabled={disabled}
             aria-expanded={open}
-            className={cn(baseTriggerClassName, buttonClassName)}
+            className={cn(
+              baseTriggerClassName,
+              isMulti && 'h-auto min-h-9 items-start whitespace-normal py-1.5',
+              buttonClassName,
+            )}
           >
             {isMulti && selectedOptions.length > 0 && !displayValue ? (
               <span className="flex min-w-0 flex-1 flex-wrap gap-1.5">
                 {selectedOptions.map((option) => (
                   <span
                     key={option.id}
-                    className="inline-flex min-w-0 items-center gap-1.5 rounded border border-border bg-muted px-2 py-0.5 font-bold text-[10px] text-praetor uppercase tracking-wider"
+                    className="inline-flex max-w-full min-w-0 items-center gap-1.5 rounded border border-border bg-muted px-2 py-0.5 font-bold text-[10px] text-foreground uppercase tracking-wider"
                     onClick={(event) => event.stopPropagation()}
                   >
                     <span className="truncate">{option.name}</span>

--- a/docs-site/src/content/docs/crm-projects.md
+++ b/docs-site/src/content/docs/crm-projects.md
@@ -48,6 +48,10 @@ Praetor assegna automaticamente un colore univoco quando crei un progetto. Puoi 
 
 Quando un progetto termina, verifica che le attività siano coerenti e che non rimangano registrazioni pendenti.
 
+### Regole progetto
+
+La sezione **Regole del progetto** nella pagina di dettaglio permette di creare controlli automatici sul progetto. Una regola confronta uno o più campi del progetto (ricavo, ore consuntive, giorni alla scadenza, consuntivazione o stato; i campi di costo richiedono il permesso **Report costi**) con soglie, valori o altri campi compatibili e può combinare le condizioni con **AND** oppure **OR**. Quando la regola diventa vera, invia una notifica agli utenti assegnati selezionati o agli utenti che hanno uno dei ruoli scelti. La sezione è visibile e modificabile tramite il permesso **Regole Progetto** (`projects.rules`), assegnato per impostazione predefinita a Manager e Top Manager. Le notifiche sono inviate solo sul passaggio da condizione non verificata a verificata, quindi non vengono duplicate mentre la regola resta vera. Riabilitare una regola o modificarne la condizione la prepara a generare una nuova notifica al prossimo controllo pianificato.
+
 ### Assegnazione utenti
 
 Dal comando **Assegna Utenti** gestisci chi è assegnato a un progetto o a una sua attività. L'accesso a questa finestra è governato dal permesso **Assegnazioni Progetto**: l'azione **View** consente di aprire le assegnazioni di qualsiasi progetto o attività indipendentemente dalla propria appartenenza, mentre **Update** consente di modificarle. Manager e Top Manager dispongono di entrambe per impostazione predefinita, quindi possono gestire le assegnazioni anche quando non sono membri del progetto o dell'attività.

--- a/docs-site/src/content/docs/en/crm-projects.md
+++ b/docs-site/src/content/docs/en/crm-projects.md
@@ -48,6 +48,10 @@ Praetor assigns a unique color automatically when you create a project. You can 
 
 When a project ends, check that tasks are consistent and that no pending entries remain.
 
+### Project rules
+
+The **Project rules** section on the detail page lets you create automatic controls for a project. A rule compares one or more project fields (revenue, logged hours, days until deadline, billing, or status; cost fields require the **Cost reports** permission) against thresholds, values, or compatible fields and can combine conditions with **AND** or **OR**. When the rule becomes true, it sends a notification to selected assigned users or to users with selected roles. The section is shown and edited through the **Project Rules** permission (`projects.rules`), granted to Managers and Top Managers by default. Notifications fire only on the transition from not met to met, so they are not duplicated while the rule remains true. Re-enabling a rule or changing its condition prepares it to notify again on the next scheduled check.
+
 ### Assigning users
 
 The **Assign Users** command manages who is assigned to a project or one of its activities. Access to this dialog is governed by the **Project Assignments** permission: the **View** action lets a role open the assignments of any project or activity regardless of its own membership, while **Update** lets it edit them. Managers and Top Managers hold both by default, so they can manage assignments even when they are not members of the project or activity.

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -6198,6 +6198,16 @@
         "tags": [
           "projects"
         ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "userId",
+            "required": false
+          }
+        ],
         "responses": {
           "200": {
             "description": "Default Response",
@@ -7400,6 +7410,1400 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/projects/{projectId}/rules/recipients": {
+      "get": {
+        "summary": "List project rule recipient options",
+        "tags": [
+          "projects"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "projectId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "users": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "username": {
+                            "type": "string"
+                          },
+                          "avatarInitials": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name",
+                          "username",
+                          "avatarInitials"
+                        ]
+                      }
+                    },
+                    "roles": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "users",
+                    "roles"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/projects/{projectId}/rules": {
+      "get": {
+        "summary": "List project rules",
+        "tags": [
+          "projects"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "projectId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "projectId": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "field": {
+                        "type": "string"
+                      },
+                      "operator": {
+                        "type": "string"
+                      },
+                      "value": {
+                        "type": "string"
+                      },
+                      "conditionLogic": {
+                        "type": "string",
+                        "enum": [
+                          "and",
+                          "or"
+                        ]
+                      },
+                      "conditions": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "field": {
+                              "type": "string"
+                            },
+                            "operator": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            },
+                            "valueType": {
+                              "type": "string",
+                              "enum": [
+                                "literal",
+                                "field"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "field",
+                            "operator",
+                            "value"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "actionType": {
+                        "type": "string"
+                      },
+                      "actionConfig": {
+                        "type": "object",
+                        "properties": {
+                          "recipientUserIds": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "recipientRoleIds": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "recipientUserIds",
+                          "recipientRoleIds"
+                        ],
+                        "additionalProperties": false
+                      },
+                      "isEnabled": {
+                        "type": "boolean"
+                      },
+                      "conditionMet": {
+                        "type": "boolean"
+                      },
+                      "lastTriggeredAt": {
+                        "type": [
+                          "null",
+                          "number"
+                        ]
+                      },
+                      "createdBy": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      },
+                      "createdAt": {
+                        "type": "number"
+                      },
+                      "updatedAt": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "projectId",
+                      "name",
+                      "field",
+                      "operator",
+                      "value",
+                      "conditionLogic",
+                      "conditions",
+                      "actionType",
+                      "actionConfig",
+                      "isEnabled",
+                      "conditionMet",
+                      "lastTriggeredAt",
+                      "createdBy",
+                      "createdAt",
+                      "updatedAt"
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create project rule",
+        "tags": [
+          "projects"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "field": {
+                    "type": "string"
+                  },
+                  "operator": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  },
+                  "conditionLogic": {
+                    "type": "string",
+                    "enum": [
+                      "and",
+                      "or"
+                    ]
+                  },
+                  "conditions": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "field": {
+                          "type": "string"
+                        },
+                        "operator": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        },
+                        "valueType": {
+                          "type": "string",
+                          "enum": [
+                            "literal",
+                            "field"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "field",
+                        "operator",
+                        "value"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "actionType": {
+                    "type": "string"
+                  },
+                  "actionConfig": {
+                    "type": "object",
+                    "properties": {
+                      "recipientUserIds": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "recipientRoleIds": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "required": [
+                      "recipientUserIds",
+                      "recipientRoleIds"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "isEnabled": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "name",
+                  "actionConfig"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "projectId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "projectId": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    },
+                    "operator": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    },
+                    "conditionLogic": {
+                      "type": "string",
+                      "enum": [
+                        "and",
+                        "or"
+                      ]
+                    },
+                    "conditions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "field": {
+                            "type": "string"
+                          },
+                          "operator": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          },
+                          "valueType": {
+                            "type": "string",
+                            "enum": [
+                              "literal",
+                              "field"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "field",
+                          "operator",
+                          "value"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "actionType": {
+                      "type": "string"
+                    },
+                    "actionConfig": {
+                      "type": "object",
+                      "properties": {
+                        "recipientUserIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "recipientRoleIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "recipientUserIds",
+                        "recipientRoleIds"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "isEnabled": {
+                      "type": "boolean"
+                    },
+                    "conditionMet": {
+                      "type": "boolean"
+                    },
+                    "lastTriggeredAt": {
+                      "type": [
+                        "null",
+                        "number"
+                      ]
+                    },
+                    "createdBy": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "createdAt": {
+                      "type": "number"
+                    },
+                    "updatedAt": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "projectId",
+                    "name",
+                    "field",
+                    "operator",
+                    "value",
+                    "conditionLogic",
+                    "conditions",
+                    "actionType",
+                    "actionConfig",
+                    "isEnabled",
+                    "conditionMet",
+                    "lastTriggeredAt",
+                    "createdBy",
+                    "createdAt",
+                    "updatedAt"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/projects/{projectId}/rules/{ruleId}": {
+      "put": {
+        "summary": "Update project rule",
+        "tags": [
+          "projects"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "field": {
+                    "type": "string"
+                  },
+                  "operator": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  },
+                  "conditionLogic": {
+                    "type": "string",
+                    "enum": [
+                      "and",
+                      "or"
+                    ]
+                  },
+                  "conditions": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "field": {
+                          "type": "string"
+                        },
+                        "operator": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        },
+                        "valueType": {
+                          "type": "string",
+                          "enum": [
+                            "literal",
+                            "field"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "field",
+                        "operator",
+                        "value"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "actionType": {
+                    "type": "string"
+                  },
+                  "actionConfig": {
+                    "type": "object",
+                    "properties": {
+                      "recipientUserIds": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "recipientRoleIds": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "required": [
+                      "recipientUserIds",
+                      "recipientRoleIds"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "isEnabled": {
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "projectId",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "ruleId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "projectId": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "field": {
+                      "type": "string"
+                    },
+                    "operator": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    },
+                    "conditionLogic": {
+                      "type": "string",
+                      "enum": [
+                        "and",
+                        "or"
+                      ]
+                    },
+                    "conditions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "field": {
+                            "type": "string"
+                          },
+                          "operator": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          },
+                          "valueType": {
+                            "type": "string",
+                            "enum": [
+                              "literal",
+                              "field"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "field",
+                          "operator",
+                          "value"
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "actionType": {
+                      "type": "string"
+                    },
+                    "actionConfig": {
+                      "type": "object",
+                      "properties": {
+                        "recipientUserIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "recipientRoleIds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "recipientUserIds",
+                        "recipientRoleIds"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "isEnabled": {
+                      "type": "boolean"
+                    },
+                    "conditionMet": {
+                      "type": "boolean"
+                    },
+                    "lastTriggeredAt": {
+                      "type": [
+                        "null",
+                        "number"
+                      ]
+                    },
+                    "createdBy": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    "createdAt": {
+                      "type": "number"
+                    },
+                    "updatedAt": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "projectId",
+                    "name",
+                    "field",
+                    "operator",
+                    "value",
+                    "conditionLogic",
+                    "conditions",
+                    "actionType",
+                    "actionConfig",
+                    "isEnabled",
+                    "conditionMet",
+                    "lastTriggeredAt",
+                    "createdBy",
+                    "createdAt",
+                    "updatedAt"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete project rule",
+        "tags": [
+          "projects"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "projectId",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "ruleId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Default Response"
           },
           "400": {
             "description": "Default Response",
@@ -9248,6 +10652,17 @@
             },
             "in": "query",
             "name": "toDate",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "ril"
+              ]
+            },
+            "in": "query",
+            "name": "purpose",
             "required": false
           }
         ],
@@ -37574,6 +38989,7 @@
                 "product_subcategory",
                 "product_type",
                 "project",
+                "project_rule",
                 "reports_ai",
                 "reports_ai_message",
                 "reports_ai_session",

--- a/locales/en/administration.json
+++ b/locales/en/administration.json
@@ -49,6 +49,7 @@
       "manage_all": "Projects (All)",
       "tasks": "Tasks",
       "tasks_all": "Tasks (All)",
+      "rules": "Project Rules",
       "assignments": "Project Assignments"
     },
     "suppliers": {
@@ -152,6 +153,7 @@
         "ldap_config": "LDAP configuration",
         "product": "product",
         "project": "project",
+        "project_rule": "project rule",
         "role": "role",
         "settings": "settings",
         "supplier": "supplier",

--- a/locales/en/layout.json
+++ b/locales/en/layout.json
@@ -100,6 +100,7 @@
     "markAllAsRead": "Mark all as read",
     "newProjects": "{{count}} new projects available",
     "newProject": "1 new project available",
+    "projectRuleTriggered": "{{rule}} triggered for {{project}}",
     "justNow": "Just now",
     "minutesAgo": "{{count}} min ago",
     "hoursAgo": "{{count}}h ago",

--- a/locales/en/projects.json
+++ b/locales/en/projects.json
@@ -198,24 +198,98 @@
     "rules": {
       "title": "Project rules",
       "description": "Automatic controls that watch this project and notify you when something needs attention.",
-      "comingSoonBadge": "Coming soon",
-      "items": {
-        "budgetThreshold": {
-          "name": "Alert when budget exceeds threshold",
-          "description": "Notify project managers when logged cost crosses 80% of the project revenue."
+      "conditionMet": "Met",
+      "costPermissionRequired": "Cost-derived rule fields require cost report permission.",
+      "actions": {
+        "add": "Add rule",
+        "edit": "Edit rule",
+        "delete": "Delete rule",
+        "toggle": "Enable rule",
+        "addCondition": "Add condition",
+        "removeCondition": "Remove condition"
+      },
+      "empty": {
+        "title": "No rules configured",
+        "description": "Create a rule to notify users or roles when project metrics cross a threshold."
+      },
+      "delete": {
+        "title": "Delete project rule",
+        "description": "Delete \"{{name}}\"? This action cannot be undone."
+      },
+      "form": {
+        "createTitle": "Create project rule",
+        "editTitle": "Edit project rule",
+        "description": "Choose the condition to watch and who receives the notification.",
+        "name": "Rule name",
+        "namePlaceholder": "e.g. Budget above 80%",
+        "field": "Field",
+        "operator": "Operator",
+        "value": "Value",
+        "valuePlaceholder": "Threshold",
+        "compareAgainst": "Compare",
+        "targetField": "Other field",
+        "conditionLogic": "Combination",
+        "users": "Users",
+        "usersPlaceholder": "Select assigned users",
+        "roles": "Roles",
+        "rolesPlaceholder": "Select roles",
+        "enabled": "Enabled",
+        "enabledDescription": "Enabled rules are checked by the scheduled evaluator."
+      },
+      "conditionLogic": {
+        "and": "All conditions (AND)",
+        "or": "Any condition (OR)"
+      },
+      "joiners": {
+        "and": "AND",
+        "or": "OR"
+      },
+      "valueTypes": {
+        "literal": "Value",
+        "field": "Field"
+      },
+      "fields": {
+        "revenue": "Revenue",
+        "cost_to_date": "Cost to date",
+        "budget_used_pct": "Budget used %",
+        "hours_to_date": "Hours to date",
+        "days_until_deadline": "Days until deadline",
+        "billing_type": "Billing",
+        "status": "Status"
+      },
+      "operators": {
+        "gt": "Greater than",
+        "gte": "Greater than or equal to",
+        "lt": "Less than",
+        "lte": "Less than or equal to",
+        "eq": "Equal to",
+        "neq": "Not equal to"
+      },
+      "values": {
+        "billing_type": {
+          "time_and_materials": "Time and materials",
+          "retainer": "Retainer"
         },
-        "deadlineApproaching": {
-          "name": "Warn before the end date",
-          "description": "Surface a warning 7 days before the project end date if open tasks remain."
-        },
-        "staleTask": {
-          "name": "Flag stale tasks",
-          "description": "Highlight tasks with no time logged in the last 14 days."
-        },
-        "unassignedTask": {
-          "name": "Catch unassigned tasks",
-          "description": "Notify when a task is created without an assignee or with no expected effort."
+        "status": {
+          "active": "Active",
+          "disabled": "Disabled"
         }
+      },
+      "errors": {
+        "loadFailed": "Unable to load project rules.",
+        "nameRequired": "Rule name is required.",
+        "fieldRequired": "Field is required.",
+        "operatorRequired": "Operator is required.",
+        "valueInvalid": "Enter a valid value for the selected field.",
+        "conditionsRequired": "Add at least one condition.",
+        "recipientsRequired": "Select at least one user or role recipient."
+      },
+      "toasts": {
+        "created": "Project rule created.",
+        "updated": "Project rule updated.",
+        "deleted": "Project rule deleted.",
+        "saveFailed": "Unable to save project rule.",
+        "deleteFailed": "Unable to delete project rule."
       }
     }
   },

--- a/locales/it/administration.json
+++ b/locales/it/administration.json
@@ -49,6 +49,7 @@
       "manage_all": "Progetti (Tutti)",
       "tasks": "Attività",
       "tasks_all": "Attività (Tutte)",
+      "rules": "Regole Progetto",
       "assignments": "Assegnazioni Progetto"
     },
     "suppliers": {
@@ -152,6 +153,7 @@
         "ldap_config": "configurazione LDAP",
         "product": "prodotto",
         "project": "progetto",
+        "project_rule": "regola progetto",
         "role": "ruolo",
         "settings": "impostazioni",
         "supplier": "fornitore",

--- a/locales/it/layout.json
+++ b/locales/it/layout.json
@@ -100,6 +100,7 @@
     "markAllAsRead": "Segna tutte come lette",
     "newProjects": "{{count}} nuovi progetti disponibili",
     "newProject": "1 nuovo progetto disponibile",
+    "projectRuleTriggered": "{{rule}} attivata per {{project}}",
     "justNow": "Proprio ora",
     "minutesAgo": "{{count}} min fa",
     "hoursAgo": "{{count}}h fa",

--- a/locales/it/projects.json
+++ b/locales/it/projects.json
@@ -198,24 +198,98 @@
     "rules": {
       "title": "Regole del progetto",
       "description": "Controlli automatici che monitorano questo progetto e ti avvisano quando qualcosa richiede attenzione.",
-      "comingSoonBadge": "In arrivo",
-      "items": {
-        "budgetThreshold": {
-          "name": "Avviso al superamento della soglia di budget",
-          "description": "Notifica i project manager quando il costo registrato supera l'80% del ricavo del progetto."
+      "conditionMet": "Verificata",
+      "costPermissionRequired": "I campi derivati dai costi richiedono il permesso sui report costi.",
+      "actions": {
+        "add": "Aggiungi regola",
+        "edit": "Modifica regola",
+        "delete": "Elimina regola",
+        "toggle": "Abilita regola",
+        "addCondition": "Aggiungi condizione",
+        "removeCondition": "Rimuovi condizione"
+      },
+      "empty": {
+        "title": "Nessuna regola configurata",
+        "description": "Crea una regola per notificare utenti o ruoli quando le metriche del progetto superano una soglia."
+      },
+      "delete": {
+        "title": "Elimina regola progetto",
+        "description": "Eliminare \"{{name}}\"? Questa azione non può essere annullata."
+      },
+      "form": {
+        "createTitle": "Crea regola progetto",
+        "editTitle": "Modifica regola progetto",
+        "description": "Scegli la condizione da monitorare e chi riceve la notifica.",
+        "name": "Nome regola",
+        "namePlaceholder": "es. Budget oltre 80%",
+        "field": "Campo",
+        "operator": "Operatore",
+        "value": "Valore",
+        "valuePlaceholder": "Soglia",
+        "compareAgainst": "Confronta",
+        "targetField": "Altro campo",
+        "conditionLogic": "Combinazione",
+        "users": "Utenti",
+        "usersPlaceholder": "Seleziona utenti assegnati",
+        "roles": "Ruoli",
+        "rolesPlaceholder": "Seleziona ruoli",
+        "enabled": "Abilitata",
+        "enabledDescription": "Le regole abilitate vengono controllate dal valutatore pianificato."
+      },
+      "conditionLogic": {
+        "and": "Tutte le condizioni (AND)",
+        "or": "Almeno una condizione (OR)"
+      },
+      "joiners": {
+        "and": "AND",
+        "or": "OR"
+      },
+      "valueTypes": {
+        "literal": "Valore",
+        "field": "Campo"
+      },
+      "fields": {
+        "revenue": "Ricavo",
+        "cost_to_date": "Costo consuntivo",
+        "budget_used_pct": "Budget usato %",
+        "hours_to_date": "Ore consuntive",
+        "days_until_deadline": "Giorni alla scadenza",
+        "billing_type": "Consuntivazione",
+        "status": "Stato"
+      },
+      "operators": {
+        "gt": "Maggiore di",
+        "gte": "Maggiore o uguale a",
+        "lt": "Minore di",
+        "lte": "Minore o uguale a",
+        "eq": "Uguale a",
+        "neq": "Diverso da"
+      },
+      "values": {
+        "billing_type": {
+          "time_and_materials": "A misura",
+          "retainer": "Canone"
         },
-        "deadlineApproaching": {
-          "name": "Avviso prima della data di fine",
-          "description": "Mostra un avviso 7 giorni prima della data di fine progetto se ci sono attività aperte."
-        },
-        "staleTask": {
-          "name": "Segnala attività inattive",
-          "description": "Evidenzia le attività senza ore registrate negli ultimi 14 giorni."
-        },
-        "unassignedTask": {
-          "name": "Intercetta attività non assegnate",
-          "description": "Notifica quando un'attività viene creata senza un assegnatario o senza un impegno previsto."
+        "status": {
+          "active": "Attivo",
+          "disabled": "Disabilitato"
         }
+      },
+      "errors": {
+        "loadFailed": "Impossibile caricare le regole del progetto.",
+        "nameRequired": "Il nome della regola è obbligatorio.",
+        "fieldRequired": "Il campo è obbligatorio.",
+        "operatorRequired": "L'operatore è obbligatorio.",
+        "valueInvalid": "Inserisci un valore valido per il campo selezionato.",
+        "conditionsRequired": "Aggiungi almeno una condizione.",
+        "recipientsRequired": "Seleziona almeno un utente o un ruolo destinatario."
+      },
+      "toasts": {
+        "created": "Regola progetto creata.",
+        "updated": "Regola progetto aggiornata.",
+        "deleted": "Regola progetto eliminata.",
+        "saveFailed": "Impossibile salvare la regola progetto.",
+        "deleteFailed": "Impossibile eliminare la regola progetto."
       }
     }
   },

--- a/server/app.ts
+++ b/server/app.ts
@@ -19,6 +19,7 @@ import logsRoutes from './routes/logs.ts';
 import mcpRoutes from './routes/mcp.ts';
 import notificationsRoutes from './routes/notifications.ts';
 import productsRoutes from './routes/products.ts';
+import projectRulesRoutes from './routes/project-rules.ts';
 import projectsRoutes from './routes/projects.ts';
 import reportsRoutes from './routes/reports.ts';
 import rolesRoutes from './routes/roles.ts';
@@ -164,6 +165,7 @@ export const buildApp = async () => {
   await fastify.register(usersRoutes, { prefix: '/api/users' });
   await fastify.register(clientsRoutes, { prefix: '/api/clients' });
   await fastify.register(projectsRoutes, { prefix: '/api/projects' });
+  await fastify.register(projectRulesRoutes, { prefix: '/api/projects' });
   await fastify.register(tasksRoutes, { prefix: '/api/tasks' });
   await fastify.register(entriesRoutes, { prefix: '/api/entries' });
   await fastify.register(settingsRoutes, { prefix: '/api/settings' });

--- a/server/db/migrations/0063_add_project_rules.sql
+++ b/server/db/migrations/0063_add_project_rules.sql
@@ -1,0 +1,22 @@
+CREATE TABLE "project_rules" (
+	"id" varchar(50) PRIMARY KEY NOT NULL,
+	"project_id" varchar(50) NOT NULL,
+	"name" varchar(255) NOT NULL,
+	"field" varchar(50) NOT NULL,
+	"operator" varchar(30) NOT NULL,
+	"value" varchar(255) NOT NULL,
+	"action_type" varchar(30) DEFAULT 'notify' NOT NULL,
+	"action_config" jsonb DEFAULT '{"recipientUserIds":[],"recipientRoleIds":[]}'::jsonb NOT NULL,
+	"is_enabled" boolean DEFAULT true NOT NULL,
+	"condition_met" boolean DEFAULT false NOT NULL,
+	"last_triggered_at" timestamp,
+	"created_by" varchar(50),
+	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP,
+	"updated_at" timestamp DEFAULT CURRENT_TIMESTAMP
+);
+--> statement-breakpoint
+ALTER TABLE "project_rules" ADD CONSTRAINT "project_rules_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "project_rules" ADD CONSTRAINT "project_rules_created_by_users_id_fk" FOREIGN KEY ("created_by") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_project_rules_project_id" ON "project_rules" USING btree ("project_id");--> statement-breakpoint
+CREATE INDEX "idx_project_rules_enabled" ON "project_rules" USING btree ("is_enabled");--> statement-breakpoint
+CREATE INDEX "idx_project_rules_condition_met" ON "project_rules" USING btree ("condition_met");

--- a/server/db/migrations/0064_grant_projects_rules_permission.sql
+++ b/server/db/migrations/0064_grant_projects_rules_permission.sql
@@ -1,0 +1,16 @@
+-- Grant project-rule CRUD permissions to the shipped manager and top_manager roles.
+-- Idempotent and FK-safe for Drizzle-only fresh DBs where roles may not be seeded yet.
+INSERT INTO role_permissions (role_id, permission)
+SELECT r.id, p.permission
+FROM (VALUES
+    ('manager', 'projects.rules.view'),
+    ('manager', 'projects.rules.create'),
+    ('manager', 'projects.rules.update'),
+    ('manager', 'projects.rules.delete'),
+    ('top_manager', 'projects.rules.view'),
+    ('top_manager', 'projects.rules.create'),
+    ('top_manager', 'projects.rules.update'),
+    ('top_manager', 'projects.rules.delete')
+) AS p(role_id, permission)
+JOIN roles r ON r.id = p.role_id
+ON CONFLICT DO NOTHING;

--- a/server/db/migrations/0065_add_project_rule_condition_chains.sql
+++ b/server/db/migrations/0065_add_project_rule_condition_chains.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "project_rules" ADD COLUMN "condition_logic" varchar(10) DEFAULT 'and' NOT NULL;--> statement-breakpoint
+ALTER TABLE "project_rules" ADD COLUMN "conditions" jsonb DEFAULT '[]'::jsonb NOT NULL;

--- a/server/db/migrations/meta/0063_snapshot.json
+++ b/server/db/migrations/meta/0063_snapshot.json
@@ -1,0 +1,6877 @@
+{
+  "id": "617f3a74-277b-4a4b-8d91-1193c42f3ebe",
+  "prevId": "beee745b-3bf3-42ea-80b8-35d4c9637c4d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user.login'"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_audit_logs_created_at": {
+          "name": "idx_audit_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_user_id": {
+          "name": "idx_audit_logs_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_action": {
+          "name": "idx_audit_logs_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.client_profile_options": {
+      "name": "client_profile_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_client_profile_options_category_value_unique": {
+          "name": "idx_client_profile_options_category_value_unique",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "LOWER(\"value\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_client_profile_options_category_sort": {
+          "name": "idx_client_profile_options_category_sort",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_client_profile_options_category": {
+          "name": "chk_client_profile_options_category",
+          "value": "\"client_profile_options\".\"category\" IN ('sector', 'numberOfEmployees', 'revenue', 'officeCountRange')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'company'"
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_code": {
+          "name": "client_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ateco_code": {
+          "name": "ateco_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sector": {
+          "name": "sector",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_of_employees": {
+          "name": "number_of_employees",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revenue": {
+          "name": "revenue",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fiscal_code": {
+          "name": "fiscal_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_code": {
+          "name": "tax_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "office_count_range": {
+          "name": "office_count_range",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "address_country": {
+          "name": "address_country",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_state": {
+          "name": "address_state",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_cap": {
+          "name": "address_cap",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_province": {
+          "name": "address_province",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_civic_number": {
+          "name": "address_civic_number",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line": {
+          "name": "address_line",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_clients_fiscal_code_unique": {
+          "name": "idx_clients_fiscal_code_unique",
+          "columns": [
+            {
+              "expression": "LOWER(\"fiscal_code\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"fiscal_code\" IS NOT NULL AND \"clients\".\"fiscal_code\" <> ''",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_clients_vat_number_unique": {
+          "name": "idx_clients_vat_number_unique",
+          "columns": [
+            {
+              "expression": "LOWER(\"vat_number\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"vat_number\" IS NOT NULL AND \"clients\".\"vat_number\" <> ''",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_clients_tax_code_unique": {
+          "name": "idx_clients_tax_code_unique",
+          "columns": [
+            {
+              "expression": "LOWER(\"tax_code\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"tax_code\" IS NOT NULL AND \"clients\".\"tax_code\" <> ''",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_clients_client_code_unique": {
+          "name": "idx_clients_client_code_unique",
+          "columns": [
+            {
+              "expression": "client_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"client_code\" IS NOT NULL AND \"clients\".\"client_code\" <> ''",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_clients": {
+      "name": "user_clients",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_source": {
+          "name": "assignment_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_clients_user_id_users_id_fk": {
+          "name": "user_clients_user_id_users_id_fk",
+          "tableFrom": "user_clients",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_clients_client_id_clients_id_fk": {
+          "name": "user_clients_client_id_clients_id_fk",
+          "tableFrom": "user_clients",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_clients_user_id_client_id_pk": {
+          "name": "user_clients_user_id_client_id_pk",
+          "columns": ["user_id", "client_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_clients_assignment_source_check": {
+          "name": "user_clients_assignment_source_check",
+          "value": "\"user_clients\".\"assignment_source\" IN ('manual', 'top_manager_auto', 'project_cascade')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.customer_offer_items": {
+      "name": "customer_offer_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "offer_id": {
+          "name": "offer_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_cost": {
+          "name": "product_cost",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_mol_percentage": {
+          "name": "product_mol_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "unit_type": {
+          "name": "unit_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'hours'"
+        },
+        "supplier_quote_id": {
+          "name": "supplier_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_item_id": {
+          "name": "supplier_quote_item_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_supplier_name": {
+          "name": "supplier_quote_supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_unit_price": {
+          "name": "supplier_quote_unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_customer_offer_items_offer_id": {
+          "name": "idx_customer_offer_items_offer_id",
+          "columns": [
+            {
+              "expression": "offer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_offer_items_offer_id_customer_offers_id_fk": {
+          "name": "customer_offer_items_offer_id_customer_offers_id_fk",
+          "tableFrom": "customer_offer_items",
+          "tableTo": "customer_offers",
+          "columnsFrom": ["offer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "customer_offer_items_product_id_products_id_fk": {
+          "name": "customer_offer_items_product_id_products_id_fk",
+          "tableFrom": "customer_offer_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_customer_offer_items_unit_type": {
+          "name": "chk_customer_offer_items_unit_type",
+          "value": "\"customer_offer_items\".\"unit_type\" IN ('hours', 'days', 'unit')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.customer_offers": {
+      "name": "customer_offers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_quote_id": {
+          "name": "linked_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "delivery_date": {
+          "name": "delivery_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_customer_offers_linked_quote_id": {
+          "name": "idx_customer_offers_linked_quote_id",
+          "columns": [
+            {
+              "expression": "linked_quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_offers_client_id": {
+          "name": "idx_customer_offers_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_offers_status": {
+          "name": "idx_customer_offers_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_offers_created_at": {
+          "name": "idx_customer_offers_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_offers_linked_quote_id_quotes_id_fk": {
+          "name": "customer_offers_linked_quote_id_quotes_id_fk",
+          "tableFrom": "customer_offers",
+          "tableTo": "quotes",
+          "columnsFrom": ["linked_quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "customer_offers_client_id_clients_id_fk": {
+          "name": "customer_offers_client_id_clients_id_fk",
+          "tableFrom": "customer_offers",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "customer_offers_status_check": {
+          "name": "customer_offers_status_check",
+          "value": "\"customer_offers\".\"status\" IN ('draft', 'sent', 'accepted', 'denied')"
+        },
+        "chk_customer_offers_discount_type": {
+          "name": "chk_customer_offers_discount_type",
+          "value": "\"customer_offers\".\"discount_type\" IN ('percentage', 'currency')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.email_config": {
+      "name": "email_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "smtp_host": {
+          "name": "smtp_host",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "smtp_port": {
+          "name": "smtp_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 587
+        },
+        "smtp_encryption": {
+          "name": "smtp_encryption",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'tls'"
+        },
+        "smtp_reject_unauthorized": {
+          "name": "smtp_reject_unauthorized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "smtp_user": {
+          "name": "smtp_user",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "smtp_password": {
+          "name": "smtp_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "from_email": {
+          "name": "from_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Praetor'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "email_config_id_check": {
+          "name": "email_config_id_check",
+          "value": "\"email_config\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.general_settings": {
+      "name": "general_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'€'"
+        },
+        "daily_limit": {
+          "name": "daily_limit",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'8.00'"
+        },
+        "start_of_week": {
+          "name": "start_of_week",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Monday'"
+        },
+        "treat_saturday_as_holiday": {
+          "name": "treat_saturday_as_holiday",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "enable_ai_reporting": {
+          "name": "enable_ai_reporting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "gemini_api_key": {
+          "name": "gemini_api_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_provider": {
+          "name": "ai_provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'gemini'"
+        },
+        "openrouter_api_key": {
+          "name": "openrouter_api_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gemini_model_id": {
+          "name": "gemini_model_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "openrouter_model_id": {
+          "name": "openrouter_model_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_weekend_selection": {
+          "name": "allow_weekend_selection",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "default_location": {
+          "name": "default_location",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'remote'"
+        },
+        "ril_company_name": {
+          "name": "ril_company_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "ril_default_start_time": {
+          "name": "ril_default_start_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'09:00'"
+        },
+        "ril_default_exit_time": {
+          "name": "ril_default_exit_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'18:00'"
+        },
+        "ril_lunch_break_minutes": {
+          "name": "ril_lunch_break_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 60
+        },
+        "ril_note_options": {
+          "name": "ril_note_options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[{\"value\":\"P\",\"label\":\"Ferie\"},{\"value\":\"P2\",\"label\":\"Permesso\"},{\"value\":\"M\",\"label\":\"Malattia\"},{\"value\":\"F\",\"label\":\"Festivita\"}]'::jsonb"
+        },
+        "ril_transfer_options": {
+          "name": "ril_transfer_options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[\"In sede\",\"Telelavoro\"]'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "general_settings_id_check": {
+          "name": "general_settings_id_check",
+          "value": "\"general_settings\".\"id\" = 1"
+        },
+        "general_settings_start_of_week_check": {
+          "name": "general_settings_start_of_week_check",
+          "value": "\"general_settings\".\"start_of_week\" IN ('Monday', 'Sunday')"
+        },
+        "general_settings_ai_provider_check": {
+          "name": "general_settings_ai_provider_check",
+          "value": "\"general_settings\".\"ai_provider\" IN ('gemini', 'openrouter')"
+        },
+        "general_settings_ril_default_start_time_check": {
+          "name": "general_settings_ril_default_start_time_check",
+          "value": "\"general_settings\".\"ril_default_start_time\" ~ '^([01][0-9]|2[0-3]):[0-5][0-9]$'"
+        },
+        "general_settings_ril_default_exit_time_check": {
+          "name": "general_settings_ril_default_exit_time_check",
+          "value": "\"general_settings\".\"ril_default_exit_time\" ~ '^([01][0-9]|2[0-3]):[0-5][0-9]$'"
+        },
+        "general_settings_ril_lunch_break_minutes_check": {
+          "name": "general_settings_ril_lunch_break_minutes_check",
+          "value": "\"general_settings\".\"ril_lunch_break_minutes\" >= 0 AND \"general_settings\".\"ril_lunch_break_minutes\" <= 240"
+        },
+        "general_settings_ril_note_options_array_check": {
+          "name": "general_settings_ril_note_options_array_check",
+          "value": "jsonb_typeof(\"general_settings\".\"ril_note_options\") = 'array'"
+        },
+        "general_settings_ril_transfer_options_array_check": {
+          "name": "general_settings_ril_transfer_options_array_check",
+          "value": "jsonb_typeof(\"general_settings\".\"ril_transfer_options\") = 'array'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invoice_items": {
+      "name": "invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_of_measure": {
+          "name": "unit_of_measure",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unit'"
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "tax_rate": {
+          "name": "tax_rate",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_invoice_items_invoice_id": {
+          "name": "idx_invoice_items_invoice_id",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "invoices",
+          "columnsFrom": ["invoice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "invoice_items_product_id_products_id_fk": {
+          "name": "invoice_items_product_id_products_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_sale_id": {
+          "name": "linked_sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_date": {
+          "name": "issue_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "tax_total": {
+          "name": "tax_total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "amount_paid": {
+          "name": "amount_paid",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_invoices_client_id": {
+          "name": "idx_invoices_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_status": {
+          "name": "idx_invoices_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_issue_date": {
+          "name": "idx_invoices_issue_date",
+          "columns": [
+            {
+              "expression": "issue_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_linked_sale_id_sales_id_fk": {
+          "name": "invoices_linked_sale_id_sales_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "sales",
+          "columnsFrom": ["linked_sale_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "invoices_client_id_clients_id_fk": {
+          "name": "invoices_client_id_clients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invoices_status_check": {
+          "name": "invoices_status_check",
+          "value": "\"invoices\".\"status\" IN ('draft', 'sent', 'paid', 'overdue', 'cancelled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ldap_config": {
+      "name": "ldap_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "server_url": {
+          "name": "server_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ldap://ldap.example.com:389'"
+        },
+        "base_dn": {
+          "name": "base_dn",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'dc=example,dc=com'"
+        },
+        "bind_dn": {
+          "name": "bind_dn",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'cn=read-only-admin,dc=example,dc=com'"
+        },
+        "bind_password": {
+          "name": "bind_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "user_filter": {
+          "name": "user_filter",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'(uid={0})'"
+        },
+        "group_base_dn": {
+          "name": "group_base_dn",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ou=groups,dc=example,dc=com'"
+        },
+        "group_filter": {
+          "name": "group_filter",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'(member={0})'"
+        },
+        "role_mappings": {
+          "name": "role_mappings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "tls_ca_certificate": {
+          "name": "tls_ca_certificate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_provision_all": {
+          "name": "auto_provision_all",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "provision_on_login": {
+          "name": "provision_on_login",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ldap_config_id_check": {
+          "name": "ldap_config_id_check",
+          "value": "\"ldap_config\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mcp_tokens": {
+      "name": "mcp_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_version_at_issue": {
+          "name": "token_version_at_issue",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "idx_mcp_tokens_token_hash_unique": {
+          "name": "idx_mcp_tokens_token_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_tokens_user_id": {
+          "name": "idx_mcp_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_tokens_active_user": {
+          "name": "idx_mcp_tokens_active_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_tokens_user_id_users_id_fk": {
+          "name": "mcp_tokens_user_id_users_id_fk",
+          "tableFrom": "mcp_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_notifications_user_id": {
+          "name": "idx_notifications_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_user_unread": {
+          "name": "idx_notifications_user_unread",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notifications\".\"is_read\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.offer_versions": {
+      "name": "offer_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "offer_id": {
+          "name": "offer_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'update'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_offer_versions_offer_id_created_at": {
+          "name": "idx_offer_versions_offer_id_created_at",
+          "columns": [
+            {
+              "expression": "offer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "offer_versions_offer_id_customer_offers_id_fk": {
+          "name": "offer_versions_offer_id_customer_offers_id_fk",
+          "tableFrom": "offer_versions",
+          "tableTo": "customer_offers",
+          "columnsFrom": ["offer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "offer_versions_created_by_user_id_users_id_fk": {
+          "name": "offer_versions_created_by_user_id_users_id_fk",
+          "tableFrom": "offer_versions",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_offer_versions_reason": {
+          "name": "chk_offer_versions_reason",
+          "value": "\"offer_versions\".\"reason\" IN ('update', 'restore')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_versions": {
+      "name": "order_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'update'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_order_versions_order_id_created_at": {
+          "name": "idx_order_versions_order_id_created_at",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_versions_order_id_sales_id_fk": {
+          "name": "order_versions_order_id_sales_id_fk",
+          "tableFrom": "order_versions",
+          "tableTo": "sales",
+          "columnsFrom": ["order_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "order_versions_created_by_user_id_users_id_fk": {
+          "name": "order_versions_created_by_user_id_users_id_fk",
+          "tableFrom": "order_versions",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_order_versions_reason": {
+          "name": "chk_order_versions_reason",
+          "value": "\"order_versions\".\"reason\" IN ('update', 'restore')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.personal_access_tokens": {
+      "name": "personal_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_version_at_issue": {
+          "name": "token_version_at_issue",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "personal_access_tokens_user_id_users_id_fk": {
+          "name": "personal_access_tokens_user_id_users_id_fk",
+          "tableFrom": "personal_access_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "personal_access_tokens_user_id_unique": {
+          "name": "personal_access_tokens_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        },
+        "personal_access_tokens_token_hash_unique": {
+          "name": "personal_access_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.internal_product_categories": {
+      "name": "internal_product_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_unit": {
+          "name": "cost_unit",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unit'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_internal_product_categories_type": {
+          "name": "idx_internal_product_categories_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "internal_product_categories_name_type_key": {
+          "name": "internal_product_categories_name_type_key",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "internal_product_categories_cost_unit_check": {
+          "name": "internal_product_categories_cost_unit_check",
+          "value": "\"internal_product_categories\".\"cost_unit\" IN ('unit', 'hours')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.internal_product_subcategories": {
+      "name": "internal_product_subcategories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_internal_product_subcategories_category_id": {
+          "name": "idx_internal_product_subcategories_category_id",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "internal_product_subcategories_category_id_name_key": {
+          "name": "internal_product_subcategories_category_id_name_key",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "internal_product_subcategories_category_id_internal_product_categories_id_fk": {
+          "name": "internal_product_subcategories_category_id_internal_product_categories_id_fk",
+          "tableFrom": "internal_product_subcategories",
+          "tableTo": "internal_product_categories",
+          "columnsFrom": ["category_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_code": {
+          "name": "product_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "costo": {
+          "name": "costo",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "mol_percentage": {
+          "name": "mol_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "cost_unit": {
+          "name": "cost_unit",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unit'"
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'item'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subcategory": {
+          "name": "subcategory",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_products_name": {
+          "name": "idx_products_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_name_unique": {
+          "name": "idx_products_name_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_product_code_unique": {
+          "name": "idx_products_product_code_unique",
+          "columns": [
+            {
+              "expression": "product_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_supplier_id": {
+          "name": "idx_products_supplier_id",
+          "columns": [
+            {
+              "expression": "supplier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_type": {
+          "name": "idx_products_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "products_supplier_id_suppliers_id_fk": {
+          "name": "products_supplier_id_suppliers_id_fk",
+          "tableFrom": "products",
+          "tableTo": "suppliers",
+          "columnsFrom": ["supplier_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_types": {
+      "name": "product_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_unit": {
+          "name": "cost_unit",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unit'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_product_types_name": {
+          "name": "idx_product_types_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "product_types_name_unique": {
+          "name": "product_types_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "product_types_cost_unit_check": {
+          "name": "product_types_cost_unit_check",
+          "value": "\"product_types\".\"cost_unit\" IN ('unit', 'hours')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_rules": {
+      "name": "project_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field": {
+          "name": "field",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operator": {
+          "name": "operator",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'notify'"
+        },
+        "action_config": {
+          "name": "action_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"recipientUserIds\":[],\"recipientRoleIds\":[]}'::jsonb"
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "condition_met": {
+          "name": "condition_met",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_project_rules_project_id": {
+          "name": "idx_project_rules_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_rules_enabled": {
+          "name": "idx_project_rules_enabled",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_rules_condition_met": {
+          "name": "idx_project_rules_condition_met",
+          "columns": [
+            {
+              "expression": "condition_met",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_rules_project_id_projects_id_fk": {
+          "name": "project_rules_project_id_projects_id_fk",
+          "tableFrom": "project_rules",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_rules_created_by_users_id_fk": {
+          "name": "project_rules_created_by_users_id_fk",
+          "tableFrom": "project_rules",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#3b82f6'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "offer_id": {
+          "name": "offer_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revenue": {
+          "name": "revenue",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_type": {
+          "name": "billing_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'time_and_materials'"
+        },
+        "billing_frequency": {
+          "name": "billing_frequency",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'monthly'"
+        }
+      },
+      "indexes": {
+        "idx_projects_client_id": {
+          "name": "idx_projects_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_projects_color_unique": {
+          "name": "idx_projects_color_unique",
+          "columns": [
+            {
+              "expression": "color",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_client_id_clients_id_fk": {
+          "name": "projects_client_id_clients_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "projects_order_id_sales_id_fk": {
+          "name": "projects_order_id_sales_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "sales",
+          "columnsFrom": ["order_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "projects_offer_id_customer_offers_id_fk": {
+          "name": "projects_offer_id_customer_offers_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "customer_offers",
+          "columnsFrom": ["offer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "projects_billing_type_check": {
+          "name": "projects_billing_type_check",
+          "value": "\"projects\".\"billing_type\" IN ('retainer', 'time_and_materials')"
+        },
+        "projects_billing_frequency_check": {
+          "name": "projects_billing_frequency_check",
+          "value": "\"projects\".\"billing_frequency\" IN ('monthly', 'one_time')"
+        },
+        "projects_time_and_materials_monthly_check": {
+          "name": "projects_time_and_materials_monthly_check",
+          "value": "\"projects\".\"billing_type\" != 'time_and_materials' OR \"projects\".\"billing_frequency\" = 'monthly'"
+        },
+        "projects_date_range_check": {
+          "name": "projects_date_range_check",
+          "value": "\"projects\".\"start_date\" IS NULL OR \"projects\".\"end_date\" IS NULL OR \"projects\".\"start_date\" <= \"projects\".\"end_date\""
+        },
+        "projects_revenue_non_negative_check": {
+          "name": "projects_revenue_non_negative_check",
+          "value": "\"projects\".\"revenue\" IS NULL OR \"projects\".\"revenue\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_projects": {
+      "name": "user_projects",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_source": {
+          "name": "assignment_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_projects_user_id_users_id_fk": {
+          "name": "user_projects_user_id_users_id_fk",
+          "tableFrom": "user_projects",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_projects_project_id_projects_id_fk": {
+          "name": "user_projects_project_id_projects_id_fk",
+          "tableFrom": "user_projects",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_projects_user_id_project_id_pk": {
+          "name": "user_projects_user_id_project_id_pk",
+          "columns": ["user_id", "project_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_projects_assignment_source_check": {
+          "name": "user_projects_assignment_source_check",
+          "value": "\"user_projects\".\"assignment_source\" IN ('manual', 'top_manager_auto', 'project_cascade')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.quote_items": {
+      "name": "quote_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_cost": {
+          "name": "product_cost",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_mol_percentage": {
+          "name": "product_mol_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_id": {
+          "name": "supplier_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_item_id": {
+          "name": "supplier_quote_item_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_supplier_name": {
+          "name": "supplier_quote_supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_unit_price": {
+          "name": "supplier_quote_unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_type": {
+          "name": "unit_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'hours'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_quote_items_quote_id": {
+          "name": "idx_quote_items_quote_id",
+          "columns": [
+            {
+              "expression": "quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quote_items_quote_id_quotes_id_fk": {
+          "name": "quote_items_quote_id_quotes_id_fk",
+          "tableFrom": "quote_items",
+          "tableTo": "quotes",
+          "columnsFrom": ["quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "quote_items_product_id_products_id_fk": {
+          "name": "quote_items_product_id_products_id_fk",
+          "tableFrom": "quote_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_quote_items_unit_type": {
+          "name": "chk_quote_items_unit_type",
+          "value": "\"quote_items\".\"unit_type\" IN ('hours', 'days', 'unit')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.quotes": {
+      "name": "quotes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_quotes_client_id": {
+          "name": "idx_quotes_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quotes_status": {
+          "name": "idx_quotes_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quotes_created_at": {
+          "name": "idx_quotes_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quotes_client_id_clients_id_fk": {
+          "name": "quotes_client_id_clients_id_fk",
+          "tableFrom": "quotes",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "quotes_status_check": {
+          "name": "quotes_status_check",
+          "value": "\"quotes\".\"status\" IN ('quoted', 'confirmed', 'draft', 'sent', 'accepted', 'denied')"
+        },
+        "chk_quotes_discount_type": {
+          "name": "chk_quotes_discount_type",
+          "value": "\"quotes\".\"discount_type\" IN ('percentage', 'currency')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.quote_versions": {
+      "name": "quote_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'update'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_quote_versions_quote_id_created_at": {
+          "name": "idx_quote_versions_quote_id_created_at",
+          "columns": [
+            {
+              "expression": "quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quote_versions_quote_id_quotes_id_fk": {
+          "name": "quote_versions_quote_id_quotes_id_fk",
+          "tableFrom": "quote_versions",
+          "tableTo": "quotes",
+          "columnsFrom": ["quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "quote_versions_created_by_user_id_users_id_fk": {
+          "name": "quote_versions_created_by_user_id_users_id_fk",
+          "tableFrom": "quote_versions",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_quote_versions_reason": {
+          "name": "chk_quote_versions_reason",
+          "value": "\"quote_versions\".\"reason\" IN ('update', 'restore')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.report_chat_messages": {
+      "name": "report_chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thought_content": {
+          "name": "thought_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_report_chat_messages_session_created": {
+          "name": "idx_report_chat_messages_session_created",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_chat_messages_session_id_report_chat_sessions_id_fk": {
+          "name": "report_chat_messages_session_id_report_chat_sessions_id_fk",
+          "tableFrom": "report_chat_messages",
+          "tableTo": "report_chat_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "report_chat_messages_role_check": {
+          "name": "report_chat_messages_role_check",
+          "value": "\"report_chat_messages\".\"role\" IN ('user', 'assistant')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.report_chat_sessions": {
+      "name": "report_chat_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'AI Reporting'"
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_report_chat_sessions_user_updated": {
+          "name": "idx_report_chat_sessions_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_report_chat_sessions_user_archived": {
+          "name": "idx_report_chat_sessions_user_archived",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_chat_sessions_user_id_users_id_fk": {
+          "name": "report_chat_sessions_user_id_users_id_fk",
+          "tableFrom": "report_chat_sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_permissions": {
+      "name": "role_permissions",
+      "schema": "",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_permissions_role_id_roles_id_fk": {
+          "name": "role_permissions_role_id_roles_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "roles",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "role_permissions_role_id_permission_pk": {
+          "name": "role_permissions_role_id_permission_pk",
+          "columns": ["role_id", "permission"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roles": {
+      "name": "roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_roles": {
+      "name": "user_roles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_roles_user_id_users_id_fk": {
+          "name": "user_roles_user_id_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_role_id_roles_id_fk": {
+          "name": "user_roles_role_id_roles_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "roles",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_roles_user_id_role_id_pk": {
+          "name": "user_roles_user_id_role_id_pk",
+          "columns": ["user_id", "role_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sale_items": {
+      "name": "sale_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sale_id": {
+          "name": "sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_cost": {
+          "name": "product_cost",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_mol_percentage": {
+          "name": "product_mol_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "unit_type": {
+          "name": "unit_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'hours'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_id": {
+          "name": "supplier_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_item_id": {
+          "name": "supplier_quote_item_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_supplier_name": {
+          "name": "supplier_quote_supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_unit_price": {
+          "name": "supplier_quote_unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_sale_id": {
+          "name": "supplier_sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_sale_item_id": {
+          "name": "supplier_sale_item_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_sale_supplier_name": {
+          "name": "supplier_sale_supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_sale_items_sale_id": {
+          "name": "idx_sale_items_sale_id",
+          "columns": [
+            {
+              "expression": "sale_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sale_items_supplier_sale_id": {
+          "name": "idx_sale_items_supplier_sale_id",
+          "columns": [
+            {
+              "expression": "supplier_sale_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sale_items_sale_id_sales_id_fk": {
+          "name": "sale_items_sale_id_sales_id_fk",
+          "tableFrom": "sale_items",
+          "tableTo": "sales",
+          "columnsFrom": ["sale_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "sale_items_product_id_products_id_fk": {
+          "name": "sale_items_product_id_products_id_fk",
+          "tableFrom": "sale_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_sale_items_unit_type": {
+          "name": "chk_sale_items_unit_type",
+          "value": "\"sale_items\".\"unit_type\" IN ('hours', 'days', 'unit')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sales": {
+      "name": "sales",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_quote_id": {
+          "name": "linked_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_offer_id": {
+          "name": "linked_offer_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_sales_client_id": {
+          "name": "idx_sales_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_status": {
+          "name": "idx_sales_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_linked_quote_id": {
+          "name": "idx_sales_linked_quote_id",
+          "columns": [
+            {
+              "expression": "linked_quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_linked_offer_id": {
+          "name": "idx_sales_linked_offer_id",
+          "columns": [
+            {
+              "expression": "linked_offer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_linked_offer_id_unique": {
+          "name": "idx_sales_linked_offer_id_unique",
+          "columns": [
+            {
+              "expression": "linked_offer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sales\".\"linked_offer_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_created_at": {
+          "name": "idx_sales_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sales_linked_quote_id_quotes_id_fk": {
+          "name": "sales_linked_quote_id_quotes_id_fk",
+          "tableFrom": "sales",
+          "tableTo": "quotes",
+          "columnsFrom": ["linked_quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "sales_linked_offer_id_customer_offers_id_fk": {
+          "name": "sales_linked_offer_id_customer_offers_id_fk",
+          "tableFrom": "sales",
+          "tableTo": "customer_offers",
+          "columnsFrom": ["linked_offer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "sales_client_id_clients_id_fk": {
+          "name": "sales_client_id_clients_id_fk",
+          "tableFrom": "sales",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sales_status_check": {
+          "name": "sales_status_check",
+          "value": "\"sales\".\"status\" IN ('draft', 'confirmed', 'denied')"
+        },
+        "chk_sales_discount_type": {
+          "name": "chk_sales_discount_type",
+          "value": "\"sales\".\"discount_type\" IN ('percentage', 'currency')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "daily_goal": {
+          "name": "daily_goal",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'8.00'"
+        },
+        "start_of_week": {
+          "name": "start_of_week",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Monday'"
+        },
+        "compact_view": {
+          "name": "compact_view",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "treat_saturday_as_holiday": {
+          "name": "treat_saturday_as_holiday",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "settings_user_id_users_id_fk": {
+          "name": "settings_user_id_users_id_fk",
+          "tableFrom": "settings",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "settings_user_id_unique": {
+          "name": "settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "settings_language_check": {
+          "name": "settings_language_check",
+          "value": "\"settings\".\"language\" IN ('en', 'it', 'auto')"
+        },
+        "settings_start_of_week_check": {
+          "name": "settings_start_of_week_check",
+          "value": "\"settings\".\"start_of_week\" IN ('Monday', 'Sunday')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.external_identities": {
+      "name": "external_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protocol": {
+          "name": "protocol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_external_identities_identity_unique": {
+          "name": "idx_external_identities_identity_unique",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "protocol",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_external_identities_user_id": {
+          "name": "idx_external_identities_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "external_identities_provider_id_sso_providers_id_fk": {
+          "name": "external_identities_provider_id_sso_providers_id_fk",
+          "tableFrom": "external_identities",
+          "tableTo": "sso_providers",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "external_identities_user_id_users_id_fk": {
+          "name": "external_identities_user_id_users_id_fk",
+          "tableFrom": "external_identities",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "external_identities_protocol_check": {
+          "name": "external_identities_protocol_check",
+          "value": "\"external_identities\".\"protocol\" IN ('oidc', 'saml')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sso_login_tickets": {
+      "name": "sso_login_tickets",
+      "schema": "",
+      "columns": {
+        "ticket": {
+          "name": "ticket",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_role": {
+          "name": "active_role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_sso_login_tickets_user_id": {
+          "name": "idx_sso_login_tickets_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sso_login_tickets_expires_at": {
+          "name": "idx_sso_login_tickets_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sso_login_tickets_user_id_users_id_fk": {
+          "name": "sso_login_tickets_user_id_users_id_fk",
+          "tableFrom": "sso_login_tickets",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sso_providers": {
+      "name": "sso_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "protocol": {
+          "name": "protocol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "issuer_url": {
+          "name": "issuer_url",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'openid profile email'"
+        },
+        "metadata_url": {
+          "name": "metadata_url",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "metadata_xml": {
+          "name": "metadata_xml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "entry_point": {
+          "name": "entry_point",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "idp_issuer": {
+          "name": "idp_issuer",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "idp_cert": {
+          "name": "idp_cert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "sp_issuer": {
+          "name": "sp_issuer",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "public_cert": {
+          "name": "public_cert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "username_attribute": {
+          "name": "username_attribute",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'preferred_username'"
+        },
+        "name_attribute": {
+          "name": "name_attribute",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'name'"
+        },
+        "email_attribute": {
+          "name": "email_attribute",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'email'"
+        },
+        "groups_attribute": {
+          "name": "groups_attribute",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'groups'"
+        },
+        "role_mappings": {
+          "name": "role_mappings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "end_session_enabled": {
+          "name": "end_session_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_sso_providers_slug_unique": {
+          "name": "idx_sso_providers_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sso_providers_protocol_enabled": {
+          "name": "idx_sso_providers_protocol_enabled",
+          "columns": [
+            {
+              "expression": "protocol",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sso_providers_protocol_check": {
+          "name": "sso_providers_protocol_check",
+          "value": "\"sso_providers\".\"protocol\" IN ('oidc', 'saml')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sso_states": {
+      "name": "sso_states",
+      "schema": "",
+      "columns": {
+        "state": {
+          "name": "state",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protocol": {
+          "name": "protocol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "relay_state": {
+          "name": "relay_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_sso_states_expires_at": {
+          "name": "idx_sso_states_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sso_states_provider_id_sso_providers_id_fk": {
+          "name": "sso_states_provider_id_sso_providers_id_fk",
+          "tableFrom": "sso_states",
+          "tableTo": "sso_providers",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sso_states_protocol_check": {
+          "name": "sso_states_protocol_check",
+          "value": "\"sso_states\".\"protocol\" IN ('oidc', 'saml')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sso_user_sessions": {
+      "name": "sso_user_sessions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sso_user_sessions_user_id_users_id_fk": {
+          "name": "sso_user_sessions_user_id_users_id_fk",
+          "tableFrom": "sso_user_sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sso_user_sessions_provider_id_sso_providers_id_fk": {
+          "name": "sso_user_sessions_provider_id_sso_providers_id_fk",
+          "tableFrom": "sso_user_sessions",
+          "tableTo": "sso_providers",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_invoice_items": {
+      "name": "supplier_invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_invoice_items_invoice_id": {
+          "name": "idx_supplier_invoice_items_invoice_id",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_invoice_items_invoice_id_supplier_invoices_id_fk": {
+          "name": "supplier_invoice_items_invoice_id_supplier_invoices_id_fk",
+          "tableFrom": "supplier_invoice_items",
+          "tableTo": "supplier_invoices",
+          "columnsFrom": ["invoice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "supplier_invoice_items_product_id_products_id_fk": {
+          "name": "supplier_invoice_items_product_id_products_id_fk",
+          "tableFrom": "supplier_invoice_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_invoices": {
+      "name": "supplier_invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_sale_id": {
+          "name": "linked_sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_name": {
+          "name": "supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_date": {
+          "name": "issue_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "amount_paid": {
+          "name": "amount_paid",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_invoices_supplier_id": {
+          "name": "idx_supplier_invoices_supplier_id",
+          "columns": [
+            {
+              "expression": "supplier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_invoices_status": {
+          "name": "idx_supplier_invoices_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_invoices_issue_date": {
+          "name": "idx_supplier_invoices_issue_date",
+          "columns": [
+            {
+              "expression": "issue_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_invoices_linked_sale_id": {
+          "name": "idx_supplier_invoices_linked_sale_id",
+          "columns": [
+            {
+              "expression": "linked_sale_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_invoices_linked_sale_id_unique": {
+          "name": "idx_supplier_invoices_linked_sale_id_unique",
+          "columns": [
+            {
+              "expression": "linked_sale_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"supplier_invoices\".\"linked_sale_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_invoices_linked_sale_id_supplier_sales_id_fk": {
+          "name": "supplier_invoices_linked_sale_id_supplier_sales_id_fk",
+          "tableFrom": "supplier_invoices",
+          "tableTo": "supplier_sales",
+          "columnsFrom": ["linked_sale_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "supplier_invoices_supplier_id_suppliers_id_fk": {
+          "name": "supplier_invoices_supplier_id_suppliers_id_fk",
+          "tableFrom": "supplier_invoices",
+          "tableTo": "suppliers",
+          "columnsFrom": ["supplier_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "supplier_invoices_status_check": {
+          "name": "supplier_invoices_status_check",
+          "value": "\"supplier_invoices\".\"status\" IN ('draft', 'sent', 'paid', 'overdue', 'cancelled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier_order_versions": {
+      "name": "supplier_order_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'update'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_order_versions_order_id_created_at": {
+          "name": "idx_supplier_order_versions_order_id_created_at",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_order_versions_order_id_supplier_sales_id_fk": {
+          "name": "supplier_order_versions_order_id_supplier_sales_id_fk",
+          "tableFrom": "supplier_order_versions",
+          "tableTo": "supplier_sales",
+          "columnsFrom": ["order_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "supplier_order_versions_created_by_user_id_users_id_fk": {
+          "name": "supplier_order_versions_created_by_user_id_users_id_fk",
+          "tableFrom": "supplier_order_versions",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_supplier_order_versions_reason": {
+          "name": "chk_supplier_order_versions_reason",
+          "value": "\"supplier_order_versions\".\"reason\" IN ('update', 'restore')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier_quote_attachments": {
+      "name": "supplier_quote_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stored_name": {
+          "name": "stored_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by_user_id": {
+          "name": "uploaded_by_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_quote_attachments_quote_id": {
+          "name": "idx_supplier_quote_attachments_quote_id",
+          "columns": [
+            {
+              "expression": "quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_quote_attachments_quote_id_supplier_quotes_id_fk": {
+          "name": "supplier_quote_attachments_quote_id_supplier_quotes_id_fk",
+          "tableFrom": "supplier_quote_attachments",
+          "tableTo": "supplier_quotes",
+          "columnsFrom": ["quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "supplier_quote_attachments_uploaded_by_user_id_users_id_fk": {
+          "name": "supplier_quote_attachments_uploaded_by_user_id_users_id_fk",
+          "tableFrom": "supplier_quote_attachments",
+          "tableTo": "users",
+          "columnsFrom": ["uploaded_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_quote_items": {
+      "name": "supplier_quote_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "unit_type": {
+          "name": "unit_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'hours'"
+        }
+      },
+      "indexes": {
+        "idx_supplier_quote_items_quote_id": {
+          "name": "idx_supplier_quote_items_quote_id",
+          "columns": [
+            {
+              "expression": "quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_quote_items_quote_id_supplier_quotes_id_fk": {
+          "name": "supplier_quote_items_quote_id_supplier_quotes_id_fk",
+          "tableFrom": "supplier_quote_items",
+          "tableTo": "supplier_quotes",
+          "columnsFrom": ["quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "supplier_quote_items_product_id_products_id_fk": {
+          "name": "supplier_quote_items_product_id_products_id_fk",
+          "tableFrom": "supplier_quote_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_supplier_quote_items_unit_type": {
+          "name": "chk_supplier_quote_items_unit_type",
+          "value": "\"supplier_quote_items\".\"unit_type\" IN ('hours', 'days', 'unit')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier_quotes": {
+      "name": "supplier_quotes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_name": {
+          "name": "supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_quotes_supplier_id": {
+          "name": "idx_supplier_quotes_supplier_id",
+          "columns": [
+            {
+              "expression": "supplier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_quotes_status": {
+          "name": "idx_supplier_quotes_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_quotes_created_at": {
+          "name": "idx_supplier_quotes_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_quotes_supplier_id_suppliers_id_fk": {
+          "name": "supplier_quotes_supplier_id_suppliers_id_fk",
+          "tableFrom": "supplier_quotes",
+          "tableTo": "suppliers",
+          "columnsFrom": ["supplier_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "supplier_quotes_status_check": {
+          "name": "supplier_quotes_status_check",
+          "value": "\"supplier_quotes\".\"status\" IN ('received', 'approved', 'rejected', 'draft', 'sent', 'accepted', 'denied')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier_quote_versions": {
+      "name": "supplier_quote_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'update'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_quote_versions_quote_id_created_at": {
+          "name": "idx_supplier_quote_versions_quote_id_created_at",
+          "columns": [
+            {
+              "expression": "quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_quote_versions_quote_id_supplier_quotes_id_fk": {
+          "name": "supplier_quote_versions_quote_id_supplier_quotes_id_fk",
+          "tableFrom": "supplier_quote_versions",
+          "tableTo": "supplier_quotes",
+          "columnsFrom": ["quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "supplier_quote_versions_created_by_user_id_users_id_fk": {
+          "name": "supplier_quote_versions_created_by_user_id_users_id_fk",
+          "tableFrom": "supplier_quote_versions",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_supplier_quote_versions_reason": {
+          "name": "chk_supplier_quote_versions_reason",
+          "value": "\"supplier_quote_versions\".\"reason\" IN ('update', 'restore')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier_sale_items": {
+      "name": "supplier_sale_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sale_id": {
+          "name": "sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_sale_items_sale_id": {
+          "name": "idx_supplier_sale_items_sale_id",
+          "columns": [
+            {
+              "expression": "sale_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_sale_items_sale_id_supplier_sales_id_fk": {
+          "name": "supplier_sale_items_sale_id_supplier_sales_id_fk",
+          "tableFrom": "supplier_sale_items",
+          "tableTo": "supplier_sales",
+          "columnsFrom": ["sale_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "supplier_sale_items_product_id_products_id_fk": {
+          "name": "supplier_sale_items_product_id_products_id_fk",
+          "tableFrom": "supplier_sale_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_sales": {
+      "name": "supplier_sales",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_quote_id": {
+          "name": "linked_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_name": {
+          "name": "supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_sales_supplier_id": {
+          "name": "idx_supplier_sales_supplier_id",
+          "columns": [
+            {
+              "expression": "supplier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_sales_status": {
+          "name": "idx_supplier_sales_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_sales_linked_quote_id": {
+          "name": "idx_supplier_sales_linked_quote_id",
+          "columns": [
+            {
+              "expression": "linked_quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_sales_linked_quote_id_supplier_quotes_id_fk": {
+          "name": "supplier_sales_linked_quote_id_supplier_quotes_id_fk",
+          "tableFrom": "supplier_sales",
+          "tableTo": "supplier_quotes",
+          "columnsFrom": ["linked_quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "supplier_sales_supplier_id_suppliers_id_fk": {
+          "name": "supplier_sales_supplier_id_suppliers_id_fk",
+          "tableFrom": "supplier_sales",
+          "tableTo": "suppliers",
+          "columnsFrom": ["supplier_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "supplier_sales_status_check": {
+          "name": "supplier_sales_status_check",
+          "value": "\"supplier_sales\".\"status\" IN ('draft', 'sent')"
+        },
+        "chk_supplier_sales_discount_type": {
+          "name": "chk_supplier_sales_discount_type",
+          "value": "\"supplier_sales\".\"discount_type\" IN ('percentage', 'currency')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.suppliers": {
+      "name": "suppliers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "supplier_code": {
+          "name": "supplier_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_code": {
+          "name": "tax_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_suppliers_name": {
+          "name": "idx_suppliers_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "recurrence_pattern": {
+          "name": "recurrence_pattern",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_start": {
+          "name": "recurrence_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_end": {
+          "name": "recurrence_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_duration": {
+          "name": "recurrence_duration",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "expected_effort": {
+          "name": "expected_effort",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "revenue": {
+          "name": "revenue",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "billing_type": {
+          "name": "billing_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'time_and_materials'"
+        },
+        "billing_frequency": {
+          "name": "billing_frequency",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'monthly'"
+        },
+        "monthly_effort": {
+          "name": "monthly_effort",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        }
+      },
+      "indexes": {
+        "idx_tasks_project_id": {
+          "name": "idx_tasks_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasks_project_id_projects_id_fk": {
+          "name": "tasks_project_id_projects_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "tasks_billing_type_check": {
+          "name": "tasks_billing_type_check",
+          "value": "\"tasks\".\"billing_type\" IN ('retainer', 'time_and_materials')"
+        },
+        "tasks_billing_frequency_check": {
+          "name": "tasks_billing_frequency_check",
+          "value": "\"tasks\".\"billing_frequency\" IN ('monthly', 'one_time')"
+        },
+        "tasks_time_and_materials_monthly_check": {
+          "name": "tasks_time_and_materials_monthly_check",
+          "value": "\"tasks\".\"billing_type\" != 'time_and_materials' OR \"tasks\".\"billing_frequency\" = 'monthly'"
+        },
+        "tasks_recurrence_duration_max_check": {
+          "name": "tasks_recurrence_duration_max_check",
+          "value": "\"tasks\".\"recurrence_duration\" IS NULL OR (\"tasks\".\"recurrence_duration\" >= 0 AND \"tasks\".\"recurrence_duration\" <= 24)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_tasks": {
+      "name": "user_tasks",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_source": {
+          "name": "assignment_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_tasks_user_id_users_id_fk": {
+          "name": "user_tasks_user_id_users_id_fk",
+          "tableFrom": "user_tasks",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_tasks_task_id_tasks_id_fk": {
+          "name": "user_tasks_task_id_tasks_id_fk",
+          "tableFrom": "user_tasks",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_tasks_user_id_task_id_pk": {
+          "name": "user_tasks_user_id_task_id_pk",
+          "columns": ["user_id", "task_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_tasks_assignment_source_check": {
+          "name": "user_tasks_assignment_source_check",
+          "value": "\"user_tasks\".\"assignment_source\" IN ('manual', 'top_manager_auto', 'project_cascade')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.time_entries": {
+      "name": "time_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_name": {
+          "name": "project_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task": {
+          "name": "task",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "hourly_cost": {
+          "name": "hourly_cost",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "is_placeholder": {
+          "name": "is_placeholder",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'remote'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "idx_time_entries_user_id": {
+          "name": "idx_time_entries_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_time_entries_date": {
+          "name": "idx_time_entries_date",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_time_entries_client_id": {
+          "name": "idx_time_entries_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_time_entries_project_id": {
+          "name": "idx_time_entries_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_time_entries_task_id": {
+          "name": "idx_time_entries_task_id",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_time_entries_created_at_id": {
+          "name": "idx_time_entries_created_at_id",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_time_entries_user_id_created_at_id": {
+          "name": "idx_time_entries_user_id_created_at_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "time_entries_user_id_users_id_fk": {
+          "name": "time_entries_user_id_users_id_fk",
+          "tableFrom": "time_entries",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "time_entries_client_id_clients_id_fk": {
+          "name": "time_entries_client_id_clients_id_fk",
+          "tableFrom": "time_entries",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "time_entries_project_id_projects_id_fk": {
+          "name": "time_entries_project_id_projects_id_fk",
+          "tableFrom": "time_entries",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "time_entries_task_id_tasks_id_fk": {
+          "name": "time_entries_task_id_tasks_id_fk",
+          "tableFrom": "time_entries",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "time_entries_location_check": {
+          "name": "time_entries_location_check",
+          "value": "\"time_entries\".\"location\" IN ('remote', 'office', 'customer_premise', 'transfer')"
+        },
+        "time_entries_duration_max_check": {
+          "name": "time_entries_duration_max_check",
+          "value": "\"time_entries\".\"duration\" >= 0 AND \"time_entries\".\"duration\" <= 24"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_initials": {
+          "name": "avatar_initials",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_per_hour": {
+          "name": "cost_per_hour",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "employee_type": {
+          "name": "employee_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'app_user'"
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'local'"
+        },
+        "auth_provider_id": {
+          "name": "auth_provider_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_version": {
+          "name": "session_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "token_version": {
+          "name": "token_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "idx_users_auth_provider_id": {
+          "name": "idx_users_auth_provider_id",
+          "columns": [
+            {
+              "expression": "auth_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_role_roles_id_fk": {
+          "name": "users_role_roles_id_fk",
+          "tableFrom": "users",
+          "tableTo": "roles",
+          "columnsFrom": ["role"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "users_auth_provider_id_sso_providers_id_fk": {
+          "name": "users_auth_provider_id_sso_providers_id_fk",
+          "tableFrom": "users",
+          "tableTo": "sso_providers",
+          "columnsFrom": ["auth_provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": ["username"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_employee_type_check": {
+          "name": "users_employee_type_check",
+          "value": "\"users\".\"employee_type\" IN ('app_user', 'internal', 'external')"
+        },
+        "users_auth_method_check": {
+          "name": "users_auth_method_check",
+          "value": "\"users\".\"auth_method\" IN ('local', 'ldap', 'oidc', 'saml')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_work_units": {
+      "name": "user_work_units",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "work_unit_id": {
+          "name": "work_unit_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_work_units_user_id_users_id_fk": {
+          "name": "user_work_units_user_id_users_id_fk",
+          "tableFrom": "user_work_units",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_work_units_work_unit_id_work_units_id_fk": {
+          "name": "user_work_units_work_unit_id_work_units_id_fk",
+          "tableFrom": "user_work_units",
+          "tableTo": "work_units",
+          "columnsFrom": ["work_unit_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_work_units_user_id_work_unit_id_pk": {
+          "name": "user_work_units_user_id_work_unit_id_pk",
+          "columns": ["user_id", "work_unit_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.work_unit_managers": {
+      "name": "work_unit_managers",
+      "schema": "",
+      "columns": {
+        "work_unit_id": {
+          "name": "work_unit_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "work_unit_managers_work_unit_id_work_units_id_fk": {
+          "name": "work_unit_managers_work_unit_id_work_units_id_fk",
+          "tableFrom": "work_unit_managers",
+          "tableTo": "work_units",
+          "columnsFrom": ["work_unit_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "work_unit_managers_user_id_users_id_fk": {
+          "name": "work_unit_managers_user_id_users_id_fk",
+          "tableFrom": "work_unit_managers",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "work_unit_managers_work_unit_id_user_id_pk": {
+          "name": "work_unit_managers_work_unit_id_user_id_pk",
+          "columns": ["work_unit_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.work_units": {
+      "name": "work_units",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/db/migrations/meta/0064_snapshot.json
+++ b/server/db/migrations/meta/0064_snapshot.json
@@ -1,0 +1,6877 @@
+{
+  "id": "cf9f7bac-17fe-4a8d-a9c6-c9d03b30a94f",
+  "prevId": "617f3a74-277b-4a4b-8d91-1193c42f3ebe",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user.login'"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_audit_logs_created_at": {
+          "name": "idx_audit_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_audit_logs_user_id": {
+          "name": "idx_audit_logs_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_audit_logs_action": {
+          "name": "idx_audit_logs_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.client_profile_options": {
+      "name": "client_profile_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_client_profile_options_category_value_unique": {
+          "name": "idx_client_profile_options_category_value_unique",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "LOWER(\"value\")",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_client_profile_options_category_sort": {
+          "name": "idx_client_profile_options_category_sort",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_client_profile_options_category": {
+          "name": "chk_client_profile_options_category",
+          "value": "\"client_profile_options\".\"category\" IN ('sector', 'numberOfEmployees', 'revenue', 'officeCountRange')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'company'"
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_code": {
+          "name": "client_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ateco_code": {
+          "name": "ateco_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sector": {
+          "name": "sector",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_of_employees": {
+          "name": "number_of_employees",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revenue": {
+          "name": "revenue",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fiscal_code": {
+          "name": "fiscal_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_code": {
+          "name": "tax_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "office_count_range": {
+          "name": "office_count_range",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "address_country": {
+          "name": "address_country",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_state": {
+          "name": "address_state",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_cap": {
+          "name": "address_cap",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_province": {
+          "name": "address_province",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_civic_number": {
+          "name": "address_civic_number",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line": {
+          "name": "address_line",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_clients_fiscal_code_unique": {
+          "name": "idx_clients_fiscal_code_unique",
+          "columns": [
+            {
+              "expression": "LOWER(\"fiscal_code\")",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"clients\".\"fiscal_code\" IS NOT NULL AND \"clients\".\"fiscal_code\" <> ''",
+          "concurrently": false
+        },
+        "idx_clients_vat_number_unique": {
+          "name": "idx_clients_vat_number_unique",
+          "columns": [
+            {
+              "expression": "LOWER(\"vat_number\")",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"clients\".\"vat_number\" IS NOT NULL AND \"clients\".\"vat_number\" <> ''",
+          "concurrently": false
+        },
+        "idx_clients_tax_code_unique": {
+          "name": "idx_clients_tax_code_unique",
+          "columns": [
+            {
+              "expression": "LOWER(\"tax_code\")",
+              "isExpression": true,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"clients\".\"tax_code\" IS NOT NULL AND \"clients\".\"tax_code\" <> ''",
+          "concurrently": false
+        },
+        "idx_clients_client_code_unique": {
+          "name": "idx_clients_client_code_unique",
+          "columns": [
+            {
+              "expression": "client_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"clients\".\"client_code\" IS NOT NULL AND \"clients\".\"client_code\" <> ''",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_clients": {
+      "name": "user_clients",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_source": {
+          "name": "assignment_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_clients_user_id_users_id_fk": {
+          "name": "user_clients_user_id_users_id_fk",
+          "tableFrom": "user_clients",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "user_clients_client_id_clients_id_fk": {
+          "name": "user_clients_client_id_clients_id_fk",
+          "tableFrom": "user_clients",
+          "columnsFrom": ["client_id"],
+          "tableTo": "clients",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_clients_user_id_client_id_pk": {
+          "name": "user_clients_user_id_client_id_pk",
+          "columns": ["user_id", "client_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_clients_assignment_source_check": {
+          "name": "user_clients_assignment_source_check",
+          "value": "\"user_clients\".\"assignment_source\" IN ('manual', 'top_manager_auto', 'project_cascade')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.customer_offer_items": {
+      "name": "customer_offer_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "offer_id": {
+          "name": "offer_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_cost": {
+          "name": "product_cost",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_mol_percentage": {
+          "name": "product_mol_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "unit_type": {
+          "name": "unit_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'hours'"
+        },
+        "supplier_quote_id": {
+          "name": "supplier_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_item_id": {
+          "name": "supplier_quote_item_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_supplier_name": {
+          "name": "supplier_quote_supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_unit_price": {
+          "name": "supplier_quote_unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_customer_offer_items_offer_id": {
+          "name": "idx_customer_offer_items_offer_id",
+          "columns": [
+            {
+              "expression": "offer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "customer_offer_items_offer_id_customer_offers_id_fk": {
+          "name": "customer_offer_items_offer_id_customer_offers_id_fk",
+          "tableFrom": "customer_offer_items",
+          "columnsFrom": ["offer_id"],
+          "tableTo": "customer_offers",
+          "columnsTo": ["id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "customer_offer_items_product_id_products_id_fk": {
+          "name": "customer_offer_items_product_id_products_id_fk",
+          "tableFrom": "customer_offer_items",
+          "columnsFrom": ["product_id"],
+          "tableTo": "products",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_customer_offer_items_unit_type": {
+          "name": "chk_customer_offer_items_unit_type",
+          "value": "\"customer_offer_items\".\"unit_type\" IN ('hours', 'days', 'unit')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.customer_offers": {
+      "name": "customer_offers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_quote_id": {
+          "name": "linked_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "delivery_date": {
+          "name": "delivery_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_customer_offers_linked_quote_id": {
+          "name": "idx_customer_offers_linked_quote_id",
+          "columns": [
+            {
+              "expression": "linked_quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_customer_offers_client_id": {
+          "name": "idx_customer_offers_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_customer_offers_status": {
+          "name": "idx_customer_offers_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_customer_offers_created_at": {
+          "name": "idx_customer_offers_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "customer_offers_linked_quote_id_quotes_id_fk": {
+          "name": "customer_offers_linked_quote_id_quotes_id_fk",
+          "tableFrom": "customer_offers",
+          "columnsFrom": ["linked_quote_id"],
+          "tableTo": "quotes",
+          "columnsTo": ["id"],
+          "onUpdate": "cascade",
+          "onDelete": "restrict"
+        },
+        "customer_offers_client_id_clients_id_fk": {
+          "name": "customer_offers_client_id_clients_id_fk",
+          "tableFrom": "customer_offers",
+          "columnsFrom": ["client_id"],
+          "tableTo": "clients",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "customer_offers_status_check": {
+          "name": "customer_offers_status_check",
+          "value": "\"customer_offers\".\"status\" IN ('draft', 'sent', 'accepted', 'denied')"
+        },
+        "chk_customer_offers_discount_type": {
+          "name": "chk_customer_offers_discount_type",
+          "value": "\"customer_offers\".\"discount_type\" IN ('percentage', 'currency')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.email_config": {
+      "name": "email_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "smtp_host": {
+          "name": "smtp_host",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "smtp_port": {
+          "name": "smtp_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 587
+        },
+        "smtp_encryption": {
+          "name": "smtp_encryption",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'tls'"
+        },
+        "smtp_reject_unauthorized": {
+          "name": "smtp_reject_unauthorized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "smtp_user": {
+          "name": "smtp_user",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "smtp_password": {
+          "name": "smtp_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "from_email": {
+          "name": "from_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Praetor'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "email_config_id_check": {
+          "name": "email_config_id_check",
+          "value": "\"email_config\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.general_settings": {
+      "name": "general_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'€'"
+        },
+        "daily_limit": {
+          "name": "daily_limit",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'8.00'"
+        },
+        "start_of_week": {
+          "name": "start_of_week",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Monday'"
+        },
+        "treat_saturday_as_holiday": {
+          "name": "treat_saturday_as_holiday",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "enable_ai_reporting": {
+          "name": "enable_ai_reporting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "gemini_api_key": {
+          "name": "gemini_api_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_provider": {
+          "name": "ai_provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'gemini'"
+        },
+        "openrouter_api_key": {
+          "name": "openrouter_api_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gemini_model_id": {
+          "name": "gemini_model_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "openrouter_model_id": {
+          "name": "openrouter_model_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_weekend_selection": {
+          "name": "allow_weekend_selection",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "default_location": {
+          "name": "default_location",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'remote'"
+        },
+        "ril_company_name": {
+          "name": "ril_company_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "ril_default_start_time": {
+          "name": "ril_default_start_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'09:00'"
+        },
+        "ril_default_exit_time": {
+          "name": "ril_default_exit_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'18:00'"
+        },
+        "ril_lunch_break_minutes": {
+          "name": "ril_lunch_break_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 60
+        },
+        "ril_note_options": {
+          "name": "ril_note_options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[{\"value\":\"P\",\"label\":\"Ferie\"},{\"value\":\"P2\",\"label\":\"Permesso\"},{\"value\":\"M\",\"label\":\"Malattia\"},{\"value\":\"F\",\"label\":\"Festivita\"}]'::jsonb"
+        },
+        "ril_transfer_options": {
+          "name": "ril_transfer_options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[\"In sede\",\"Telelavoro\"]'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "general_settings_id_check": {
+          "name": "general_settings_id_check",
+          "value": "\"general_settings\".\"id\" = 1"
+        },
+        "general_settings_start_of_week_check": {
+          "name": "general_settings_start_of_week_check",
+          "value": "\"general_settings\".\"start_of_week\" IN ('Monday', 'Sunday')"
+        },
+        "general_settings_ai_provider_check": {
+          "name": "general_settings_ai_provider_check",
+          "value": "\"general_settings\".\"ai_provider\" IN ('gemini', 'openrouter')"
+        },
+        "general_settings_ril_default_start_time_check": {
+          "name": "general_settings_ril_default_start_time_check",
+          "value": "\"general_settings\".\"ril_default_start_time\" ~ '^([01][0-9]|2[0-3]):[0-5][0-9]$'"
+        },
+        "general_settings_ril_default_exit_time_check": {
+          "name": "general_settings_ril_default_exit_time_check",
+          "value": "\"general_settings\".\"ril_default_exit_time\" ~ '^([01][0-9]|2[0-3]):[0-5][0-9]$'"
+        },
+        "general_settings_ril_lunch_break_minutes_check": {
+          "name": "general_settings_ril_lunch_break_minutes_check",
+          "value": "\"general_settings\".\"ril_lunch_break_minutes\" >= 0 AND \"general_settings\".\"ril_lunch_break_minutes\" <= 240"
+        },
+        "general_settings_ril_note_options_array_check": {
+          "name": "general_settings_ril_note_options_array_check",
+          "value": "jsonb_typeof(\"general_settings\".\"ril_note_options\") = 'array'"
+        },
+        "general_settings_ril_transfer_options_array_check": {
+          "name": "general_settings_ril_transfer_options_array_check",
+          "value": "jsonb_typeof(\"general_settings\".\"ril_transfer_options\") = 'array'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invoice_items": {
+      "name": "invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_of_measure": {
+          "name": "unit_of_measure",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unit'"
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "tax_rate": {
+          "name": "tax_rate",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_invoice_items_invoice_id": {
+          "name": "idx_invoice_items_invoice_id",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "invoice_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_items",
+          "columnsFrom": ["invoice_id"],
+          "tableTo": "invoices",
+          "columnsTo": ["id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "invoice_items_product_id_products_id_fk": {
+          "name": "invoice_items_product_id_products_id_fk",
+          "tableFrom": "invoice_items",
+          "columnsFrom": ["product_id"],
+          "tableTo": "products",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_sale_id": {
+          "name": "linked_sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_date": {
+          "name": "issue_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "tax_total": {
+          "name": "tax_total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "amount_paid": {
+          "name": "amount_paid",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_invoices_client_id": {
+          "name": "idx_invoices_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_invoices_status": {
+          "name": "idx_invoices_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_invoices_issue_date": {
+          "name": "idx_invoices_issue_date",
+          "columns": [
+            {
+              "expression": "issue_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "invoices_linked_sale_id_sales_id_fk": {
+          "name": "invoices_linked_sale_id_sales_id_fk",
+          "tableFrom": "invoices",
+          "columnsFrom": ["linked_sale_id"],
+          "tableTo": "sales",
+          "columnsTo": ["id"],
+          "onUpdate": "cascade",
+          "onDelete": "set null"
+        },
+        "invoices_client_id_clients_id_fk": {
+          "name": "invoices_client_id_clients_id_fk",
+          "tableFrom": "invoices",
+          "columnsFrom": ["client_id"],
+          "tableTo": "clients",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invoices_status_check": {
+          "name": "invoices_status_check",
+          "value": "\"invoices\".\"status\" IN ('draft', 'sent', 'paid', 'overdue', 'cancelled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ldap_config": {
+      "name": "ldap_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "server_url": {
+          "name": "server_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ldap://ldap.example.com:389'"
+        },
+        "base_dn": {
+          "name": "base_dn",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'dc=example,dc=com'"
+        },
+        "bind_dn": {
+          "name": "bind_dn",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'cn=read-only-admin,dc=example,dc=com'"
+        },
+        "bind_password": {
+          "name": "bind_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "user_filter": {
+          "name": "user_filter",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'(uid={0})'"
+        },
+        "group_base_dn": {
+          "name": "group_base_dn",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ou=groups,dc=example,dc=com'"
+        },
+        "group_filter": {
+          "name": "group_filter",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'(member={0})'"
+        },
+        "role_mappings": {
+          "name": "role_mappings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "tls_ca_certificate": {
+          "name": "tls_ca_certificate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_provision_all": {
+          "name": "auto_provision_all",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "provision_on_login": {
+          "name": "provision_on_login",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ldap_config_id_check": {
+          "name": "ldap_config_id_check",
+          "value": "\"ldap_config\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mcp_tokens": {
+      "name": "mcp_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_version_at_issue": {
+          "name": "token_version_at_issue",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "idx_mcp_tokens_token_hash_unique": {
+          "name": "idx_mcp_tokens_token_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_mcp_tokens_user_id": {
+          "name": "idx_mcp_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_mcp_tokens_active_user": {
+          "name": "idx_mcp_tokens_active_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "mcp_tokens_user_id_users_id_fk": {
+          "name": "mcp_tokens_user_id_users_id_fk",
+          "tableFrom": "mcp_tokens",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_notifications_user_id": {
+          "name": "idx_notifications_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_notifications_user_unread": {
+          "name": "idx_notifications_user_unread",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "where": "\"notifications\".\"is_read\" = false",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.offer_versions": {
+      "name": "offer_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "offer_id": {
+          "name": "offer_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'update'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_offer_versions_offer_id_created_at": {
+          "name": "idx_offer_versions_offer_id_created_at",
+          "columns": [
+            {
+              "expression": "offer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "offer_versions_offer_id_customer_offers_id_fk": {
+          "name": "offer_versions_offer_id_customer_offers_id_fk",
+          "tableFrom": "offer_versions",
+          "columnsFrom": ["offer_id"],
+          "tableTo": "customer_offers",
+          "columnsTo": ["id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "offer_versions_created_by_user_id_users_id_fk": {
+          "name": "offer_versions_created_by_user_id_users_id_fk",
+          "tableFrom": "offer_versions",
+          "columnsFrom": ["created_by_user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_offer_versions_reason": {
+          "name": "chk_offer_versions_reason",
+          "value": "\"offer_versions\".\"reason\" IN ('update', 'restore')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_versions": {
+      "name": "order_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'update'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_order_versions_order_id_created_at": {
+          "name": "idx_order_versions_order_id_created_at",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "order_versions_order_id_sales_id_fk": {
+          "name": "order_versions_order_id_sales_id_fk",
+          "tableFrom": "order_versions",
+          "columnsFrom": ["order_id"],
+          "tableTo": "sales",
+          "columnsTo": ["id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "order_versions_created_by_user_id_users_id_fk": {
+          "name": "order_versions_created_by_user_id_users_id_fk",
+          "tableFrom": "order_versions",
+          "columnsFrom": ["created_by_user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_order_versions_reason": {
+          "name": "chk_order_versions_reason",
+          "value": "\"order_versions\".\"reason\" IN ('update', 'restore')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.personal_access_tokens": {
+      "name": "personal_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_version_at_issue": {
+          "name": "token_version_at_issue",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "personal_access_tokens_user_id_users_id_fk": {
+          "name": "personal_access_tokens_user_id_users_id_fk",
+          "tableFrom": "personal_access_tokens",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "personal_access_tokens_user_id_unique": {
+          "name": "personal_access_tokens_user_id_unique",
+          "columns": ["user_id"],
+          "nullsNotDistinct": false
+        },
+        "personal_access_tokens_token_hash_unique": {
+          "name": "personal_access_tokens_token_hash_unique",
+          "columns": ["token_hash"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.internal_product_categories": {
+      "name": "internal_product_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_unit": {
+          "name": "cost_unit",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unit'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_internal_product_categories_type": {
+          "name": "idx_internal_product_categories_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "internal_product_categories_name_type_key": {
+          "name": "internal_product_categories_name_type_key",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "internal_product_categories_cost_unit_check": {
+          "name": "internal_product_categories_cost_unit_check",
+          "value": "\"internal_product_categories\".\"cost_unit\" IN ('unit', 'hours')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.internal_product_subcategories": {
+      "name": "internal_product_subcategories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_internal_product_subcategories_category_id": {
+          "name": "idx_internal_product_subcategories_category_id",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "internal_product_subcategories_category_id_name_key": {
+          "name": "internal_product_subcategories_category_id_name_key",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "internal_product_subcategories_category_id_internal_product_categories_id_fk": {
+          "name": "internal_product_subcategories_category_id_internal_product_categories_id_fk",
+          "tableFrom": "internal_product_subcategories",
+          "columnsFrom": ["category_id"],
+          "tableTo": "internal_product_categories",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_code": {
+          "name": "product_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "costo": {
+          "name": "costo",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "mol_percentage": {
+          "name": "mol_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "cost_unit": {
+          "name": "cost_unit",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unit'"
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'item'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subcategory": {
+          "name": "subcategory",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_products_name": {
+          "name": "idx_products_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_products_name_unique": {
+          "name": "idx_products_name_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_products_product_code_unique": {
+          "name": "idx_products_product_code_unique",
+          "columns": [
+            {
+              "expression": "product_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_products_supplier_id": {
+          "name": "idx_products_supplier_id",
+          "columns": [
+            {
+              "expression": "supplier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_products_type": {
+          "name": "idx_products_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "products_supplier_id_suppliers_id_fk": {
+          "name": "products_supplier_id_suppliers_id_fk",
+          "tableFrom": "products",
+          "columnsFrom": ["supplier_id"],
+          "tableTo": "suppliers",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_types": {
+      "name": "product_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_unit": {
+          "name": "cost_unit",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unit'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_product_types_name": {
+          "name": "idx_product_types_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "product_types_name_unique": {
+          "name": "product_types_name_unique",
+          "columns": ["name"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "product_types_cost_unit_check": {
+          "name": "product_types_cost_unit_check",
+          "value": "\"product_types\".\"cost_unit\" IN ('unit', 'hours')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_rules": {
+      "name": "project_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field": {
+          "name": "field",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operator": {
+          "name": "operator",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'notify'"
+        },
+        "action_config": {
+          "name": "action_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"recipientUserIds\":[],\"recipientRoleIds\":[]}'::jsonb"
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "condition_met": {
+          "name": "condition_met",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_project_rules_project_id": {
+          "name": "idx_project_rules_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_project_rules_enabled": {
+          "name": "idx_project_rules_enabled",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_project_rules_condition_met": {
+          "name": "idx_project_rules_condition_met",
+          "columns": [
+            {
+              "expression": "condition_met",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "project_rules_project_id_projects_id_fk": {
+          "name": "project_rules_project_id_projects_id_fk",
+          "tableFrom": "project_rules",
+          "columnsFrom": ["project_id"],
+          "tableTo": "projects",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "project_rules_created_by_users_id_fk": {
+          "name": "project_rules_created_by_users_id_fk",
+          "tableFrom": "project_rules",
+          "columnsFrom": ["created_by"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#3b82f6'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "offer_id": {
+          "name": "offer_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revenue": {
+          "name": "revenue",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_type": {
+          "name": "billing_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'time_and_materials'"
+        },
+        "billing_frequency": {
+          "name": "billing_frequency",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'monthly'"
+        }
+      },
+      "indexes": {
+        "idx_projects_client_id": {
+          "name": "idx_projects_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_projects_color_unique": {
+          "name": "idx_projects_color_unique",
+          "columns": [
+            {
+              "expression": "color",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "projects_client_id_clients_id_fk": {
+          "name": "projects_client_id_clients_id_fk",
+          "tableFrom": "projects",
+          "columnsFrom": ["client_id"],
+          "tableTo": "clients",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "projects_order_id_sales_id_fk": {
+          "name": "projects_order_id_sales_id_fk",
+          "tableFrom": "projects",
+          "columnsFrom": ["order_id"],
+          "tableTo": "sales",
+          "columnsTo": ["id"],
+          "onUpdate": "cascade",
+          "onDelete": "set null"
+        },
+        "projects_offer_id_customer_offers_id_fk": {
+          "name": "projects_offer_id_customer_offers_id_fk",
+          "tableFrom": "projects",
+          "columnsFrom": ["offer_id"],
+          "tableTo": "customer_offers",
+          "columnsTo": ["id"],
+          "onUpdate": "cascade",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "projects_billing_type_check": {
+          "name": "projects_billing_type_check",
+          "value": "\"projects\".\"billing_type\" IN ('retainer', 'time_and_materials')"
+        },
+        "projects_billing_frequency_check": {
+          "name": "projects_billing_frequency_check",
+          "value": "\"projects\".\"billing_frequency\" IN ('monthly', 'one_time')"
+        },
+        "projects_time_and_materials_monthly_check": {
+          "name": "projects_time_and_materials_monthly_check",
+          "value": "\"projects\".\"billing_type\" != 'time_and_materials' OR \"projects\".\"billing_frequency\" = 'monthly'"
+        },
+        "projects_date_range_check": {
+          "name": "projects_date_range_check",
+          "value": "\"projects\".\"start_date\" IS NULL OR \"projects\".\"end_date\" IS NULL OR \"projects\".\"start_date\" <= \"projects\".\"end_date\""
+        },
+        "projects_revenue_non_negative_check": {
+          "name": "projects_revenue_non_negative_check",
+          "value": "\"projects\".\"revenue\" IS NULL OR \"projects\".\"revenue\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_projects": {
+      "name": "user_projects",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_source": {
+          "name": "assignment_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_projects_user_id_users_id_fk": {
+          "name": "user_projects_user_id_users_id_fk",
+          "tableFrom": "user_projects",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "user_projects_project_id_projects_id_fk": {
+          "name": "user_projects_project_id_projects_id_fk",
+          "tableFrom": "user_projects",
+          "columnsFrom": ["project_id"],
+          "tableTo": "projects",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_projects_user_id_project_id_pk": {
+          "name": "user_projects_user_id_project_id_pk",
+          "columns": ["user_id", "project_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_projects_assignment_source_check": {
+          "name": "user_projects_assignment_source_check",
+          "value": "\"user_projects\".\"assignment_source\" IN ('manual', 'top_manager_auto', 'project_cascade')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.quote_items": {
+      "name": "quote_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_cost": {
+          "name": "product_cost",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_mol_percentage": {
+          "name": "product_mol_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_id": {
+          "name": "supplier_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_item_id": {
+          "name": "supplier_quote_item_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_supplier_name": {
+          "name": "supplier_quote_supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_unit_price": {
+          "name": "supplier_quote_unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_type": {
+          "name": "unit_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'hours'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_quote_items_quote_id": {
+          "name": "idx_quote_items_quote_id",
+          "columns": [
+            {
+              "expression": "quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "quote_items_quote_id_quotes_id_fk": {
+          "name": "quote_items_quote_id_quotes_id_fk",
+          "tableFrom": "quote_items",
+          "columnsFrom": ["quote_id"],
+          "tableTo": "quotes",
+          "columnsTo": ["id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "quote_items_product_id_products_id_fk": {
+          "name": "quote_items_product_id_products_id_fk",
+          "tableFrom": "quote_items",
+          "columnsFrom": ["product_id"],
+          "tableTo": "products",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_quote_items_unit_type": {
+          "name": "chk_quote_items_unit_type",
+          "value": "\"quote_items\".\"unit_type\" IN ('hours', 'days', 'unit')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.quotes": {
+      "name": "quotes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_quotes_client_id": {
+          "name": "idx_quotes_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_quotes_status": {
+          "name": "idx_quotes_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_quotes_created_at": {
+          "name": "idx_quotes_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "quotes_client_id_clients_id_fk": {
+          "name": "quotes_client_id_clients_id_fk",
+          "tableFrom": "quotes",
+          "columnsFrom": ["client_id"],
+          "tableTo": "clients",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "quotes_status_check": {
+          "name": "quotes_status_check",
+          "value": "\"quotes\".\"status\" IN ('quoted', 'confirmed', 'draft', 'sent', 'accepted', 'denied')"
+        },
+        "chk_quotes_discount_type": {
+          "name": "chk_quotes_discount_type",
+          "value": "\"quotes\".\"discount_type\" IN ('percentage', 'currency')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.quote_versions": {
+      "name": "quote_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'update'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_quote_versions_quote_id_created_at": {
+          "name": "idx_quote_versions_quote_id_created_at",
+          "columns": [
+            {
+              "expression": "quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "quote_versions_quote_id_quotes_id_fk": {
+          "name": "quote_versions_quote_id_quotes_id_fk",
+          "tableFrom": "quote_versions",
+          "columnsFrom": ["quote_id"],
+          "tableTo": "quotes",
+          "columnsTo": ["id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "quote_versions_created_by_user_id_users_id_fk": {
+          "name": "quote_versions_created_by_user_id_users_id_fk",
+          "tableFrom": "quote_versions",
+          "columnsFrom": ["created_by_user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_quote_versions_reason": {
+          "name": "chk_quote_versions_reason",
+          "value": "\"quote_versions\".\"reason\" IN ('update', 'restore')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.report_chat_messages": {
+      "name": "report_chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thought_content": {
+          "name": "thought_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_report_chat_messages_session_created": {
+          "name": "idx_report_chat_messages_session_created",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "report_chat_messages_session_id_report_chat_sessions_id_fk": {
+          "name": "report_chat_messages_session_id_report_chat_sessions_id_fk",
+          "tableFrom": "report_chat_messages",
+          "columnsFrom": ["session_id"],
+          "tableTo": "report_chat_sessions",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "report_chat_messages_role_check": {
+          "name": "report_chat_messages_role_check",
+          "value": "\"report_chat_messages\".\"role\" IN ('user', 'assistant')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.report_chat_sessions": {
+      "name": "report_chat_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'AI Reporting'"
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_report_chat_sessions_user_updated": {
+          "name": "idx_report_chat_sessions_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_report_chat_sessions_user_archived": {
+          "name": "idx_report_chat_sessions_user_archived",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "report_chat_sessions_user_id_users_id_fk": {
+          "name": "report_chat_sessions_user_id_users_id_fk",
+          "tableFrom": "report_chat_sessions",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_permissions": {
+      "name": "role_permissions",
+      "schema": "",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_permissions_role_id_roles_id_fk": {
+          "name": "role_permissions_role_id_roles_id_fk",
+          "tableFrom": "role_permissions",
+          "columnsFrom": ["role_id"],
+          "tableTo": "roles",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "role_permissions_role_id_permission_pk": {
+          "name": "role_permissions_role_id_permission_pk",
+          "columns": ["role_id", "permission"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roles": {
+      "name": "roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "columns": ["name"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_roles": {
+      "name": "user_roles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_roles_user_id_users_id_fk": {
+          "name": "user_roles_user_id_users_id_fk",
+          "tableFrom": "user_roles",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "user_roles_role_id_roles_id_fk": {
+          "name": "user_roles_role_id_roles_id_fk",
+          "tableFrom": "user_roles",
+          "columnsFrom": ["role_id"],
+          "tableTo": "roles",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_roles_user_id_role_id_pk": {
+          "name": "user_roles_user_id_role_id_pk",
+          "columns": ["user_id", "role_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sale_items": {
+      "name": "sale_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sale_id": {
+          "name": "sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_cost": {
+          "name": "product_cost",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_mol_percentage": {
+          "name": "product_mol_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "unit_type": {
+          "name": "unit_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'hours'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_id": {
+          "name": "supplier_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_item_id": {
+          "name": "supplier_quote_item_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_supplier_name": {
+          "name": "supplier_quote_supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_unit_price": {
+          "name": "supplier_quote_unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_sale_id": {
+          "name": "supplier_sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_sale_item_id": {
+          "name": "supplier_sale_item_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_sale_supplier_name": {
+          "name": "supplier_sale_supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_sale_items_sale_id": {
+          "name": "idx_sale_items_sale_id",
+          "columns": [
+            {
+              "expression": "sale_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_sale_items_supplier_sale_id": {
+          "name": "idx_sale_items_supplier_sale_id",
+          "columns": [
+            {
+              "expression": "supplier_sale_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "sale_items_sale_id_sales_id_fk": {
+          "name": "sale_items_sale_id_sales_id_fk",
+          "tableFrom": "sale_items",
+          "columnsFrom": ["sale_id"],
+          "tableTo": "sales",
+          "columnsTo": ["id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "sale_items_product_id_products_id_fk": {
+          "name": "sale_items_product_id_products_id_fk",
+          "tableFrom": "sale_items",
+          "columnsFrom": ["product_id"],
+          "tableTo": "products",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_sale_items_unit_type": {
+          "name": "chk_sale_items_unit_type",
+          "value": "\"sale_items\".\"unit_type\" IN ('hours', 'days', 'unit')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sales": {
+      "name": "sales",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_quote_id": {
+          "name": "linked_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_offer_id": {
+          "name": "linked_offer_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_sales_client_id": {
+          "name": "idx_sales_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_sales_status": {
+          "name": "idx_sales_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_sales_linked_quote_id": {
+          "name": "idx_sales_linked_quote_id",
+          "columns": [
+            {
+              "expression": "linked_quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_sales_linked_offer_id": {
+          "name": "idx_sales_linked_offer_id",
+          "columns": [
+            {
+              "expression": "linked_offer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_sales_linked_offer_id_unique": {
+          "name": "idx_sales_linked_offer_id_unique",
+          "columns": [
+            {
+              "expression": "linked_offer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"sales\".\"linked_offer_id\" IS NOT NULL",
+          "concurrently": false
+        },
+        "idx_sales_created_at": {
+          "name": "idx_sales_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "sales_linked_quote_id_quotes_id_fk": {
+          "name": "sales_linked_quote_id_quotes_id_fk",
+          "tableFrom": "sales",
+          "columnsFrom": ["linked_quote_id"],
+          "tableTo": "quotes",
+          "columnsTo": ["id"],
+          "onUpdate": "cascade",
+          "onDelete": "set null"
+        },
+        "sales_linked_offer_id_customer_offers_id_fk": {
+          "name": "sales_linked_offer_id_customer_offers_id_fk",
+          "tableFrom": "sales",
+          "columnsFrom": ["linked_offer_id"],
+          "tableTo": "customer_offers",
+          "columnsTo": ["id"],
+          "onUpdate": "cascade",
+          "onDelete": "set null"
+        },
+        "sales_client_id_clients_id_fk": {
+          "name": "sales_client_id_clients_id_fk",
+          "tableFrom": "sales",
+          "columnsFrom": ["client_id"],
+          "tableTo": "clients",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sales_status_check": {
+          "name": "sales_status_check",
+          "value": "\"sales\".\"status\" IN ('draft', 'confirmed', 'denied')"
+        },
+        "chk_sales_discount_type": {
+          "name": "chk_sales_discount_type",
+          "value": "\"sales\".\"discount_type\" IN ('percentage', 'currency')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "daily_goal": {
+          "name": "daily_goal",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'8.00'"
+        },
+        "start_of_week": {
+          "name": "start_of_week",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Monday'"
+        },
+        "compact_view": {
+          "name": "compact_view",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "treat_saturday_as_holiday": {
+          "name": "treat_saturday_as_holiday",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "settings_user_id_users_id_fk": {
+          "name": "settings_user_id_users_id_fk",
+          "tableFrom": "settings",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "settings_user_id_unique": {
+          "name": "settings_user_id_unique",
+          "columns": ["user_id"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "settings_language_check": {
+          "name": "settings_language_check",
+          "value": "\"settings\".\"language\" IN ('en', 'it', 'auto')"
+        },
+        "settings_start_of_week_check": {
+          "name": "settings_start_of_week_check",
+          "value": "\"settings\".\"start_of_week\" IN ('Monday', 'Sunday')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.external_identities": {
+      "name": "external_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protocol": {
+          "name": "protocol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_external_identities_identity_unique": {
+          "name": "idx_external_identities_identity_unique",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "protocol",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_external_identities_user_id": {
+          "name": "idx_external_identities_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "external_identities_provider_id_sso_providers_id_fk": {
+          "name": "external_identities_provider_id_sso_providers_id_fk",
+          "tableFrom": "external_identities",
+          "columnsFrom": ["provider_id"],
+          "tableTo": "sso_providers",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "external_identities_user_id_users_id_fk": {
+          "name": "external_identities_user_id_users_id_fk",
+          "tableFrom": "external_identities",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "external_identities_protocol_check": {
+          "name": "external_identities_protocol_check",
+          "value": "\"external_identities\".\"protocol\" IN ('oidc', 'saml')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sso_login_tickets": {
+      "name": "sso_login_tickets",
+      "schema": "",
+      "columns": {
+        "ticket": {
+          "name": "ticket",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_role": {
+          "name": "active_role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_sso_login_tickets_user_id": {
+          "name": "idx_sso_login_tickets_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_sso_login_tickets_expires_at": {
+          "name": "idx_sso_login_tickets_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "sso_login_tickets_user_id_users_id_fk": {
+          "name": "sso_login_tickets_user_id_users_id_fk",
+          "tableFrom": "sso_login_tickets",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sso_providers": {
+      "name": "sso_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "protocol": {
+          "name": "protocol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "issuer_url": {
+          "name": "issuer_url",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'openid profile email'"
+        },
+        "metadata_url": {
+          "name": "metadata_url",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "metadata_xml": {
+          "name": "metadata_xml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "entry_point": {
+          "name": "entry_point",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "idp_issuer": {
+          "name": "idp_issuer",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "idp_cert": {
+          "name": "idp_cert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "sp_issuer": {
+          "name": "sp_issuer",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "public_cert": {
+          "name": "public_cert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "username_attribute": {
+          "name": "username_attribute",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'preferred_username'"
+        },
+        "name_attribute": {
+          "name": "name_attribute",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'name'"
+        },
+        "email_attribute": {
+          "name": "email_attribute",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'email'"
+        },
+        "groups_attribute": {
+          "name": "groups_attribute",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'groups'"
+        },
+        "role_mappings": {
+          "name": "role_mappings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "end_session_enabled": {
+          "name": "end_session_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_sso_providers_slug_unique": {
+          "name": "idx_sso_providers_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_sso_providers_protocol_enabled": {
+          "name": "idx_sso_providers_protocol_enabled",
+          "columns": [
+            {
+              "expression": "protocol",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sso_providers_protocol_check": {
+          "name": "sso_providers_protocol_check",
+          "value": "\"sso_providers\".\"protocol\" IN ('oidc', 'saml')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sso_states": {
+      "name": "sso_states",
+      "schema": "",
+      "columns": {
+        "state": {
+          "name": "state",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protocol": {
+          "name": "protocol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "relay_state": {
+          "name": "relay_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_sso_states_expires_at": {
+          "name": "idx_sso_states_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "sso_states_provider_id_sso_providers_id_fk": {
+          "name": "sso_states_provider_id_sso_providers_id_fk",
+          "tableFrom": "sso_states",
+          "columnsFrom": ["provider_id"],
+          "tableTo": "sso_providers",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sso_states_protocol_check": {
+          "name": "sso_states_protocol_check",
+          "value": "\"sso_states\".\"protocol\" IN ('oidc', 'saml')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sso_user_sessions": {
+      "name": "sso_user_sessions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sso_user_sessions_user_id_users_id_fk": {
+          "name": "sso_user_sessions_user_id_users_id_fk",
+          "tableFrom": "sso_user_sessions",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "sso_user_sessions_provider_id_sso_providers_id_fk": {
+          "name": "sso_user_sessions_provider_id_sso_providers_id_fk",
+          "tableFrom": "sso_user_sessions",
+          "columnsFrom": ["provider_id"],
+          "tableTo": "sso_providers",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_invoice_items": {
+      "name": "supplier_invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_invoice_items_invoice_id": {
+          "name": "idx_supplier_invoice_items_invoice_id",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "supplier_invoice_items_invoice_id_supplier_invoices_id_fk": {
+          "name": "supplier_invoice_items_invoice_id_supplier_invoices_id_fk",
+          "tableFrom": "supplier_invoice_items",
+          "columnsFrom": ["invoice_id"],
+          "tableTo": "supplier_invoices",
+          "columnsTo": ["id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "supplier_invoice_items_product_id_products_id_fk": {
+          "name": "supplier_invoice_items_product_id_products_id_fk",
+          "tableFrom": "supplier_invoice_items",
+          "columnsFrom": ["product_id"],
+          "tableTo": "products",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_invoices": {
+      "name": "supplier_invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_sale_id": {
+          "name": "linked_sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_name": {
+          "name": "supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_date": {
+          "name": "issue_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "amount_paid": {
+          "name": "amount_paid",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_invoices_supplier_id": {
+          "name": "idx_supplier_invoices_supplier_id",
+          "columns": [
+            {
+              "expression": "supplier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_supplier_invoices_status": {
+          "name": "idx_supplier_invoices_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_supplier_invoices_issue_date": {
+          "name": "idx_supplier_invoices_issue_date",
+          "columns": [
+            {
+              "expression": "issue_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_supplier_invoices_linked_sale_id": {
+          "name": "idx_supplier_invoices_linked_sale_id",
+          "columns": [
+            {
+              "expression": "linked_sale_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_supplier_invoices_linked_sale_id_unique": {
+          "name": "idx_supplier_invoices_linked_sale_id_unique",
+          "columns": [
+            {
+              "expression": "linked_sale_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "where": "\"supplier_invoices\".\"linked_sale_id\" IS NOT NULL",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "supplier_invoices_linked_sale_id_supplier_sales_id_fk": {
+          "name": "supplier_invoices_linked_sale_id_supplier_sales_id_fk",
+          "tableFrom": "supplier_invoices",
+          "columnsFrom": ["linked_sale_id"],
+          "tableTo": "supplier_sales",
+          "columnsTo": ["id"],
+          "onUpdate": "cascade",
+          "onDelete": "set null"
+        },
+        "supplier_invoices_supplier_id_suppliers_id_fk": {
+          "name": "supplier_invoices_supplier_id_suppliers_id_fk",
+          "tableFrom": "supplier_invoices",
+          "columnsFrom": ["supplier_id"],
+          "tableTo": "suppliers",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "supplier_invoices_status_check": {
+          "name": "supplier_invoices_status_check",
+          "value": "\"supplier_invoices\".\"status\" IN ('draft', 'sent', 'paid', 'overdue', 'cancelled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier_order_versions": {
+      "name": "supplier_order_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'update'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_order_versions_order_id_created_at": {
+          "name": "idx_supplier_order_versions_order_id_created_at",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "supplier_order_versions_order_id_supplier_sales_id_fk": {
+          "name": "supplier_order_versions_order_id_supplier_sales_id_fk",
+          "tableFrom": "supplier_order_versions",
+          "columnsFrom": ["order_id"],
+          "tableTo": "supplier_sales",
+          "columnsTo": ["id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "supplier_order_versions_created_by_user_id_users_id_fk": {
+          "name": "supplier_order_versions_created_by_user_id_users_id_fk",
+          "tableFrom": "supplier_order_versions",
+          "columnsFrom": ["created_by_user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_supplier_order_versions_reason": {
+          "name": "chk_supplier_order_versions_reason",
+          "value": "\"supplier_order_versions\".\"reason\" IN ('update', 'restore')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier_quote_attachments": {
+      "name": "supplier_quote_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stored_name": {
+          "name": "stored_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by_user_id": {
+          "name": "uploaded_by_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_quote_attachments_quote_id": {
+          "name": "idx_supplier_quote_attachments_quote_id",
+          "columns": [
+            {
+              "expression": "quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "supplier_quote_attachments_quote_id_supplier_quotes_id_fk": {
+          "name": "supplier_quote_attachments_quote_id_supplier_quotes_id_fk",
+          "tableFrom": "supplier_quote_attachments",
+          "columnsFrom": ["quote_id"],
+          "tableTo": "supplier_quotes",
+          "columnsTo": ["id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "supplier_quote_attachments_uploaded_by_user_id_users_id_fk": {
+          "name": "supplier_quote_attachments_uploaded_by_user_id_users_id_fk",
+          "tableFrom": "supplier_quote_attachments",
+          "columnsFrom": ["uploaded_by_user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_quote_items": {
+      "name": "supplier_quote_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "unit_type": {
+          "name": "unit_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'hours'"
+        }
+      },
+      "indexes": {
+        "idx_supplier_quote_items_quote_id": {
+          "name": "idx_supplier_quote_items_quote_id",
+          "columns": [
+            {
+              "expression": "quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "supplier_quote_items_quote_id_supplier_quotes_id_fk": {
+          "name": "supplier_quote_items_quote_id_supplier_quotes_id_fk",
+          "tableFrom": "supplier_quote_items",
+          "columnsFrom": ["quote_id"],
+          "tableTo": "supplier_quotes",
+          "columnsTo": ["id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "supplier_quote_items_product_id_products_id_fk": {
+          "name": "supplier_quote_items_product_id_products_id_fk",
+          "tableFrom": "supplier_quote_items",
+          "columnsFrom": ["product_id"],
+          "tableTo": "products",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_supplier_quote_items_unit_type": {
+          "name": "chk_supplier_quote_items_unit_type",
+          "value": "\"supplier_quote_items\".\"unit_type\" IN ('hours', 'days', 'unit')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier_quotes": {
+      "name": "supplier_quotes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_name": {
+          "name": "supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_quotes_supplier_id": {
+          "name": "idx_supplier_quotes_supplier_id",
+          "columns": [
+            {
+              "expression": "supplier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_supplier_quotes_status": {
+          "name": "idx_supplier_quotes_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_supplier_quotes_created_at": {
+          "name": "idx_supplier_quotes_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "supplier_quotes_supplier_id_suppliers_id_fk": {
+          "name": "supplier_quotes_supplier_id_suppliers_id_fk",
+          "tableFrom": "supplier_quotes",
+          "columnsFrom": ["supplier_id"],
+          "tableTo": "suppliers",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "supplier_quotes_status_check": {
+          "name": "supplier_quotes_status_check",
+          "value": "\"supplier_quotes\".\"status\" IN ('received', 'approved', 'rejected', 'draft', 'sent', 'accepted', 'denied')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier_quote_versions": {
+      "name": "supplier_quote_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'update'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_quote_versions_quote_id_created_at": {
+          "name": "idx_supplier_quote_versions_quote_id_created_at",
+          "columns": [
+            {
+              "expression": "quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "supplier_quote_versions_quote_id_supplier_quotes_id_fk": {
+          "name": "supplier_quote_versions_quote_id_supplier_quotes_id_fk",
+          "tableFrom": "supplier_quote_versions",
+          "columnsFrom": ["quote_id"],
+          "tableTo": "supplier_quotes",
+          "columnsTo": ["id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "supplier_quote_versions_created_by_user_id_users_id_fk": {
+          "name": "supplier_quote_versions_created_by_user_id_users_id_fk",
+          "tableFrom": "supplier_quote_versions",
+          "columnsFrom": ["created_by_user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_supplier_quote_versions_reason": {
+          "name": "chk_supplier_quote_versions_reason",
+          "value": "\"supplier_quote_versions\".\"reason\" IN ('update', 'restore')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier_sale_items": {
+      "name": "supplier_sale_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sale_id": {
+          "name": "sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_sale_items_sale_id": {
+          "name": "idx_supplier_sale_items_sale_id",
+          "columns": [
+            {
+              "expression": "sale_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "supplier_sale_items_sale_id_supplier_sales_id_fk": {
+          "name": "supplier_sale_items_sale_id_supplier_sales_id_fk",
+          "tableFrom": "supplier_sale_items",
+          "columnsFrom": ["sale_id"],
+          "tableTo": "supplier_sales",
+          "columnsTo": ["id"],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "supplier_sale_items_product_id_products_id_fk": {
+          "name": "supplier_sale_items_product_id_products_id_fk",
+          "tableFrom": "supplier_sale_items",
+          "columnsFrom": ["product_id"],
+          "tableTo": "products",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_sales": {
+      "name": "supplier_sales",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_quote_id": {
+          "name": "linked_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_name": {
+          "name": "supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_sales_supplier_id": {
+          "name": "idx_supplier_sales_supplier_id",
+          "columns": [
+            {
+              "expression": "supplier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_supplier_sales_status": {
+          "name": "idx_supplier_sales_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_supplier_sales_linked_quote_id": {
+          "name": "idx_supplier_sales_linked_quote_id",
+          "columns": [
+            {
+              "expression": "linked_quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "supplier_sales_linked_quote_id_supplier_quotes_id_fk": {
+          "name": "supplier_sales_linked_quote_id_supplier_quotes_id_fk",
+          "tableFrom": "supplier_sales",
+          "columnsFrom": ["linked_quote_id"],
+          "tableTo": "supplier_quotes",
+          "columnsTo": ["id"],
+          "onUpdate": "cascade",
+          "onDelete": "set null"
+        },
+        "supplier_sales_supplier_id_suppliers_id_fk": {
+          "name": "supplier_sales_supplier_id_suppliers_id_fk",
+          "tableFrom": "supplier_sales",
+          "columnsFrom": ["supplier_id"],
+          "tableTo": "suppliers",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "supplier_sales_status_check": {
+          "name": "supplier_sales_status_check",
+          "value": "\"supplier_sales\".\"status\" IN ('draft', 'sent')"
+        },
+        "chk_supplier_sales_discount_type": {
+          "name": "chk_supplier_sales_discount_type",
+          "value": "\"supplier_sales\".\"discount_type\" IN ('percentage', 'currency')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.suppliers": {
+      "name": "suppliers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "supplier_code": {
+          "name": "supplier_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_code": {
+          "name": "tax_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_suppliers_name": {
+          "name": "idx_suppliers_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "recurrence_pattern": {
+          "name": "recurrence_pattern",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_start": {
+          "name": "recurrence_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_end": {
+          "name": "recurrence_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_duration": {
+          "name": "recurrence_duration",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "expected_effort": {
+          "name": "expected_effort",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "revenue": {
+          "name": "revenue",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "billing_type": {
+          "name": "billing_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'time_and_materials'"
+        },
+        "billing_frequency": {
+          "name": "billing_frequency",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'monthly'"
+        },
+        "monthly_effort": {
+          "name": "monthly_effort",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        }
+      },
+      "indexes": {
+        "idx_tasks_project_id": {
+          "name": "idx_tasks_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "tasks_project_id_projects_id_fk": {
+          "name": "tasks_project_id_projects_id_fk",
+          "tableFrom": "tasks",
+          "columnsFrom": ["project_id"],
+          "tableTo": "projects",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "tasks_billing_type_check": {
+          "name": "tasks_billing_type_check",
+          "value": "\"tasks\".\"billing_type\" IN ('retainer', 'time_and_materials')"
+        },
+        "tasks_billing_frequency_check": {
+          "name": "tasks_billing_frequency_check",
+          "value": "\"tasks\".\"billing_frequency\" IN ('monthly', 'one_time')"
+        },
+        "tasks_time_and_materials_monthly_check": {
+          "name": "tasks_time_and_materials_monthly_check",
+          "value": "\"tasks\".\"billing_type\" != 'time_and_materials' OR \"tasks\".\"billing_frequency\" = 'monthly'"
+        },
+        "tasks_recurrence_duration_max_check": {
+          "name": "tasks_recurrence_duration_max_check",
+          "value": "\"tasks\".\"recurrence_duration\" IS NULL OR (\"tasks\".\"recurrence_duration\" >= 0 AND \"tasks\".\"recurrence_duration\" <= 24)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_tasks": {
+      "name": "user_tasks",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_source": {
+          "name": "assignment_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_tasks_user_id_users_id_fk": {
+          "name": "user_tasks_user_id_users_id_fk",
+          "tableFrom": "user_tasks",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "user_tasks_task_id_tasks_id_fk": {
+          "name": "user_tasks_task_id_tasks_id_fk",
+          "tableFrom": "user_tasks",
+          "columnsFrom": ["task_id"],
+          "tableTo": "tasks",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_tasks_user_id_task_id_pk": {
+          "name": "user_tasks_user_id_task_id_pk",
+          "columns": ["user_id", "task_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_tasks_assignment_source_check": {
+          "name": "user_tasks_assignment_source_check",
+          "value": "\"user_tasks\".\"assignment_source\" IN ('manual', 'top_manager_auto', 'project_cascade')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.time_entries": {
+      "name": "time_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_name": {
+          "name": "project_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task": {
+          "name": "task",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "hourly_cost": {
+          "name": "hourly_cost",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "is_placeholder": {
+          "name": "is_placeholder",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'remote'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "idx_time_entries_user_id": {
+          "name": "idx_time_entries_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_time_entries_date": {
+          "name": "idx_time_entries_date",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_time_entries_client_id": {
+          "name": "idx_time_entries_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_time_entries_project_id": {
+          "name": "idx_time_entries_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_time_entries_task_id": {
+          "name": "idx_time_entries_task_id",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_time_entries_created_at_id": {
+          "name": "idx_time_entries_created_at_id",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_time_entries_user_id_created_at_id": {
+          "name": "idx_time_entries_user_id_created_at_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "time_entries_user_id_users_id_fk": {
+          "name": "time_entries_user_id_users_id_fk",
+          "tableFrom": "time_entries",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "time_entries_client_id_clients_id_fk": {
+          "name": "time_entries_client_id_clients_id_fk",
+          "tableFrom": "time_entries",
+          "columnsFrom": ["client_id"],
+          "tableTo": "clients",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "time_entries_project_id_projects_id_fk": {
+          "name": "time_entries_project_id_projects_id_fk",
+          "tableFrom": "time_entries",
+          "columnsFrom": ["project_id"],
+          "tableTo": "projects",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "time_entries_task_id_tasks_id_fk": {
+          "name": "time_entries_task_id_tasks_id_fk",
+          "tableFrom": "time_entries",
+          "columnsFrom": ["task_id"],
+          "tableTo": "tasks",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "time_entries_location_check": {
+          "name": "time_entries_location_check",
+          "value": "\"time_entries\".\"location\" IN ('remote', 'office', 'customer_premise', 'transfer')"
+        },
+        "time_entries_duration_max_check": {
+          "name": "time_entries_duration_max_check",
+          "value": "\"time_entries\".\"duration\" >= 0 AND \"time_entries\".\"duration\" <= 24"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_initials": {
+          "name": "avatar_initials",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_per_hour": {
+          "name": "cost_per_hour",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "employee_type": {
+          "name": "employee_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'app_user'"
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'local'"
+        },
+        "auth_provider_id": {
+          "name": "auth_provider_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_version": {
+          "name": "session_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "token_version": {
+          "name": "token_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "idx_users_auth_provider_id": {
+          "name": "idx_users_auth_provider_id",
+          "columns": [
+            {
+              "expression": "auth_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "users_role_roles_id_fk": {
+          "name": "users_role_roles_id_fk",
+          "tableFrom": "users",
+          "columnsFrom": ["role"],
+          "tableTo": "roles",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        },
+        "users_auth_provider_id_sso_providers_id_fk": {
+          "name": "users_auth_provider_id_sso_providers_id_fk",
+          "tableFrom": "users",
+          "columnsFrom": ["auth_provider_id"],
+          "tableTo": "sso_providers",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": ["username"],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_employee_type_check": {
+          "name": "users_employee_type_check",
+          "value": "\"users\".\"employee_type\" IN ('app_user', 'internal', 'external')"
+        },
+        "users_auth_method_check": {
+          "name": "users_auth_method_check",
+          "value": "\"users\".\"auth_method\" IN ('local', 'ldap', 'oidc', 'saml')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_work_units": {
+      "name": "user_work_units",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "work_unit_id": {
+          "name": "work_unit_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_work_units_user_id_users_id_fk": {
+          "name": "user_work_units_user_id_users_id_fk",
+          "tableFrom": "user_work_units",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "user_work_units_work_unit_id_work_units_id_fk": {
+          "name": "user_work_units_work_unit_id_work_units_id_fk",
+          "tableFrom": "user_work_units",
+          "columnsFrom": ["work_unit_id"],
+          "tableTo": "work_units",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_work_units_user_id_work_unit_id_pk": {
+          "name": "user_work_units_user_id_work_unit_id_pk",
+          "columns": ["user_id", "work_unit_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.work_unit_managers": {
+      "name": "work_unit_managers",
+      "schema": "",
+      "columns": {
+        "work_unit_id": {
+          "name": "work_unit_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "work_unit_managers_work_unit_id_work_units_id_fk": {
+          "name": "work_unit_managers_work_unit_id_work_units_id_fk",
+          "tableFrom": "work_unit_managers",
+          "columnsFrom": ["work_unit_id"],
+          "tableTo": "work_units",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "work_unit_managers_user_id_users_id_fk": {
+          "name": "work_unit_managers_user_id_users_id_fk",
+          "tableFrom": "work_unit_managers",
+          "columnsFrom": ["user_id"],
+          "tableTo": "users",
+          "columnsTo": ["id"],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "work_unit_managers_work_unit_id_user_id_pk": {
+          "name": "work_unit_managers_work_unit_id_user_id_pk",
+          "columns": ["work_unit_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.work_units": {
+      "name": "work_units",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/db/migrations/meta/0065_snapshot.json
+++ b/server/db/migrations/meta/0065_snapshot.json
@@ -1,0 +1,6891 @@
+{
+  "id": "9bc227eb-08b8-44fa-b126-b522f6c4e5fd",
+  "prevId": "cf9f7bac-17fe-4a8d-a9c6-c9d03b30a94f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user.login'"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_audit_logs_created_at": {
+          "name": "idx_audit_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_user_id": {
+          "name": "idx_audit_logs_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_action": {
+          "name": "idx_audit_logs_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.client_profile_options": {
+      "name": "client_profile_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_client_profile_options_category_value_unique": {
+          "name": "idx_client_profile_options_category_value_unique",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "LOWER(\"value\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_client_profile_options_category_sort": {
+          "name": "idx_client_profile_options_category_sort",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_client_profile_options_category": {
+          "name": "chk_client_profile_options_category",
+          "value": "\"client_profile_options\".\"category\" IN ('sector', 'numberOfEmployees', 'revenue', 'officeCountRange')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'company'"
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_code": {
+          "name": "client_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ateco_code": {
+          "name": "ateco_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sector": {
+          "name": "sector",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_of_employees": {
+          "name": "number_of_employees",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revenue": {
+          "name": "revenue",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fiscal_code": {
+          "name": "fiscal_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_code": {
+          "name": "tax_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "office_count_range": {
+          "name": "office_count_range",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "address_country": {
+          "name": "address_country",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_state": {
+          "name": "address_state",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_cap": {
+          "name": "address_cap",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_province": {
+          "name": "address_province",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_civic_number": {
+          "name": "address_civic_number",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line": {
+          "name": "address_line",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_clients_fiscal_code_unique": {
+          "name": "idx_clients_fiscal_code_unique",
+          "columns": [
+            {
+              "expression": "LOWER(\"fiscal_code\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"fiscal_code\" IS NOT NULL AND \"clients\".\"fiscal_code\" <> ''",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_clients_vat_number_unique": {
+          "name": "idx_clients_vat_number_unique",
+          "columns": [
+            {
+              "expression": "LOWER(\"vat_number\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"vat_number\" IS NOT NULL AND \"clients\".\"vat_number\" <> ''",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_clients_tax_code_unique": {
+          "name": "idx_clients_tax_code_unique",
+          "columns": [
+            {
+              "expression": "LOWER(\"tax_code\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"tax_code\" IS NOT NULL AND \"clients\".\"tax_code\" <> ''",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_clients_client_code_unique": {
+          "name": "idx_clients_client_code_unique",
+          "columns": [
+            {
+              "expression": "client_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"client_code\" IS NOT NULL AND \"clients\".\"client_code\" <> ''",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_clients": {
+      "name": "user_clients",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_source": {
+          "name": "assignment_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_clients_user_id_users_id_fk": {
+          "name": "user_clients_user_id_users_id_fk",
+          "tableFrom": "user_clients",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_clients_client_id_clients_id_fk": {
+          "name": "user_clients_client_id_clients_id_fk",
+          "tableFrom": "user_clients",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_clients_user_id_client_id_pk": {
+          "name": "user_clients_user_id_client_id_pk",
+          "columns": ["user_id", "client_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_clients_assignment_source_check": {
+          "name": "user_clients_assignment_source_check",
+          "value": "\"user_clients\".\"assignment_source\" IN ('manual', 'top_manager_auto', 'project_cascade')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.customer_offer_items": {
+      "name": "customer_offer_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "offer_id": {
+          "name": "offer_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_cost": {
+          "name": "product_cost",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_mol_percentage": {
+          "name": "product_mol_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "unit_type": {
+          "name": "unit_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'hours'"
+        },
+        "supplier_quote_id": {
+          "name": "supplier_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_item_id": {
+          "name": "supplier_quote_item_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_supplier_name": {
+          "name": "supplier_quote_supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_unit_price": {
+          "name": "supplier_quote_unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_customer_offer_items_offer_id": {
+          "name": "idx_customer_offer_items_offer_id",
+          "columns": [
+            {
+              "expression": "offer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_offer_items_offer_id_customer_offers_id_fk": {
+          "name": "customer_offer_items_offer_id_customer_offers_id_fk",
+          "tableFrom": "customer_offer_items",
+          "tableTo": "customer_offers",
+          "columnsFrom": ["offer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "customer_offer_items_product_id_products_id_fk": {
+          "name": "customer_offer_items_product_id_products_id_fk",
+          "tableFrom": "customer_offer_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_customer_offer_items_unit_type": {
+          "name": "chk_customer_offer_items_unit_type",
+          "value": "\"customer_offer_items\".\"unit_type\" IN ('hours', 'days', 'unit')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.customer_offers": {
+      "name": "customer_offers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_quote_id": {
+          "name": "linked_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "delivery_date": {
+          "name": "delivery_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_customer_offers_linked_quote_id": {
+          "name": "idx_customer_offers_linked_quote_id",
+          "columns": [
+            {
+              "expression": "linked_quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_offers_client_id": {
+          "name": "idx_customer_offers_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_offers_status": {
+          "name": "idx_customer_offers_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_offers_created_at": {
+          "name": "idx_customer_offers_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_offers_linked_quote_id_quotes_id_fk": {
+          "name": "customer_offers_linked_quote_id_quotes_id_fk",
+          "tableFrom": "customer_offers",
+          "tableTo": "quotes",
+          "columnsFrom": ["linked_quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "customer_offers_client_id_clients_id_fk": {
+          "name": "customer_offers_client_id_clients_id_fk",
+          "tableFrom": "customer_offers",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "customer_offers_status_check": {
+          "name": "customer_offers_status_check",
+          "value": "\"customer_offers\".\"status\" IN ('draft', 'sent', 'accepted', 'denied')"
+        },
+        "chk_customer_offers_discount_type": {
+          "name": "chk_customer_offers_discount_type",
+          "value": "\"customer_offers\".\"discount_type\" IN ('percentage', 'currency')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.email_config": {
+      "name": "email_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "smtp_host": {
+          "name": "smtp_host",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "smtp_port": {
+          "name": "smtp_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 587
+        },
+        "smtp_encryption": {
+          "name": "smtp_encryption",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'tls'"
+        },
+        "smtp_reject_unauthorized": {
+          "name": "smtp_reject_unauthorized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "smtp_user": {
+          "name": "smtp_user",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "smtp_password": {
+          "name": "smtp_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "from_email": {
+          "name": "from_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Praetor'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "email_config_id_check": {
+          "name": "email_config_id_check",
+          "value": "\"email_config\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.general_settings": {
+      "name": "general_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'€'"
+        },
+        "daily_limit": {
+          "name": "daily_limit",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'8.00'"
+        },
+        "start_of_week": {
+          "name": "start_of_week",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Monday'"
+        },
+        "treat_saturday_as_holiday": {
+          "name": "treat_saturday_as_holiday",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "enable_ai_reporting": {
+          "name": "enable_ai_reporting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "gemini_api_key": {
+          "name": "gemini_api_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_provider": {
+          "name": "ai_provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'gemini'"
+        },
+        "openrouter_api_key": {
+          "name": "openrouter_api_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gemini_model_id": {
+          "name": "gemini_model_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "openrouter_model_id": {
+          "name": "openrouter_model_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_weekend_selection": {
+          "name": "allow_weekend_selection",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "default_location": {
+          "name": "default_location",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'remote'"
+        },
+        "ril_company_name": {
+          "name": "ril_company_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "ril_default_start_time": {
+          "name": "ril_default_start_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'09:00'"
+        },
+        "ril_default_exit_time": {
+          "name": "ril_default_exit_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'18:00'"
+        },
+        "ril_lunch_break_minutes": {
+          "name": "ril_lunch_break_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 60
+        },
+        "ril_note_options": {
+          "name": "ril_note_options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[{\"value\":\"P\",\"label\":\"Ferie\"},{\"value\":\"P2\",\"label\":\"Permesso\"},{\"value\":\"M\",\"label\":\"Malattia\"},{\"value\":\"F\",\"label\":\"Festivita\"}]'::jsonb"
+        },
+        "ril_transfer_options": {
+          "name": "ril_transfer_options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[\"In sede\",\"Telelavoro\"]'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "general_settings_id_check": {
+          "name": "general_settings_id_check",
+          "value": "\"general_settings\".\"id\" = 1"
+        },
+        "general_settings_start_of_week_check": {
+          "name": "general_settings_start_of_week_check",
+          "value": "\"general_settings\".\"start_of_week\" IN ('Monday', 'Sunday')"
+        },
+        "general_settings_ai_provider_check": {
+          "name": "general_settings_ai_provider_check",
+          "value": "\"general_settings\".\"ai_provider\" IN ('gemini', 'openrouter')"
+        },
+        "general_settings_ril_default_start_time_check": {
+          "name": "general_settings_ril_default_start_time_check",
+          "value": "\"general_settings\".\"ril_default_start_time\" ~ '^([01][0-9]|2[0-3]):[0-5][0-9]$'"
+        },
+        "general_settings_ril_default_exit_time_check": {
+          "name": "general_settings_ril_default_exit_time_check",
+          "value": "\"general_settings\".\"ril_default_exit_time\" ~ '^([01][0-9]|2[0-3]):[0-5][0-9]$'"
+        },
+        "general_settings_ril_lunch_break_minutes_check": {
+          "name": "general_settings_ril_lunch_break_minutes_check",
+          "value": "\"general_settings\".\"ril_lunch_break_minutes\" >= 0 AND \"general_settings\".\"ril_lunch_break_minutes\" <= 240"
+        },
+        "general_settings_ril_note_options_array_check": {
+          "name": "general_settings_ril_note_options_array_check",
+          "value": "jsonb_typeof(\"general_settings\".\"ril_note_options\") = 'array'"
+        },
+        "general_settings_ril_transfer_options_array_check": {
+          "name": "general_settings_ril_transfer_options_array_check",
+          "value": "jsonb_typeof(\"general_settings\".\"ril_transfer_options\") = 'array'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invoice_items": {
+      "name": "invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_of_measure": {
+          "name": "unit_of_measure",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unit'"
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "tax_rate": {
+          "name": "tax_rate",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_invoice_items_invoice_id": {
+          "name": "idx_invoice_items_invoice_id",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "invoices",
+          "columnsFrom": ["invoice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "invoice_items_product_id_products_id_fk": {
+          "name": "invoice_items_product_id_products_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_sale_id": {
+          "name": "linked_sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_date": {
+          "name": "issue_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "tax_total": {
+          "name": "tax_total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "amount_paid": {
+          "name": "amount_paid",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_invoices_client_id": {
+          "name": "idx_invoices_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_status": {
+          "name": "idx_invoices_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_issue_date": {
+          "name": "idx_invoices_issue_date",
+          "columns": [
+            {
+              "expression": "issue_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_linked_sale_id_sales_id_fk": {
+          "name": "invoices_linked_sale_id_sales_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "sales",
+          "columnsFrom": ["linked_sale_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "invoices_client_id_clients_id_fk": {
+          "name": "invoices_client_id_clients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invoices_status_check": {
+          "name": "invoices_status_check",
+          "value": "\"invoices\".\"status\" IN ('draft', 'sent', 'paid', 'overdue', 'cancelled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ldap_config": {
+      "name": "ldap_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "server_url": {
+          "name": "server_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ldap://ldap.example.com:389'"
+        },
+        "base_dn": {
+          "name": "base_dn",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'dc=example,dc=com'"
+        },
+        "bind_dn": {
+          "name": "bind_dn",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'cn=read-only-admin,dc=example,dc=com'"
+        },
+        "bind_password": {
+          "name": "bind_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "user_filter": {
+          "name": "user_filter",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'(uid={0})'"
+        },
+        "group_base_dn": {
+          "name": "group_base_dn",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ou=groups,dc=example,dc=com'"
+        },
+        "group_filter": {
+          "name": "group_filter",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'(member={0})'"
+        },
+        "role_mappings": {
+          "name": "role_mappings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "tls_ca_certificate": {
+          "name": "tls_ca_certificate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_provision_all": {
+          "name": "auto_provision_all",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "provision_on_login": {
+          "name": "provision_on_login",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ldap_config_id_check": {
+          "name": "ldap_config_id_check",
+          "value": "\"ldap_config\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mcp_tokens": {
+      "name": "mcp_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_version_at_issue": {
+          "name": "token_version_at_issue",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "idx_mcp_tokens_token_hash_unique": {
+          "name": "idx_mcp_tokens_token_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_tokens_user_id": {
+          "name": "idx_mcp_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_tokens_active_user": {
+          "name": "idx_mcp_tokens_active_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_tokens_user_id_users_id_fk": {
+          "name": "mcp_tokens_user_id_users_id_fk",
+          "tableFrom": "mcp_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_notifications_user_id": {
+          "name": "idx_notifications_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_user_unread": {
+          "name": "idx_notifications_user_unread",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notifications\".\"is_read\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.offer_versions": {
+      "name": "offer_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "offer_id": {
+          "name": "offer_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'update'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_offer_versions_offer_id_created_at": {
+          "name": "idx_offer_versions_offer_id_created_at",
+          "columns": [
+            {
+              "expression": "offer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "offer_versions_offer_id_customer_offers_id_fk": {
+          "name": "offer_versions_offer_id_customer_offers_id_fk",
+          "tableFrom": "offer_versions",
+          "tableTo": "customer_offers",
+          "columnsFrom": ["offer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "offer_versions_created_by_user_id_users_id_fk": {
+          "name": "offer_versions_created_by_user_id_users_id_fk",
+          "tableFrom": "offer_versions",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_offer_versions_reason": {
+          "name": "chk_offer_versions_reason",
+          "value": "\"offer_versions\".\"reason\" IN ('update', 'restore')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_versions": {
+      "name": "order_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'update'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_order_versions_order_id_created_at": {
+          "name": "idx_order_versions_order_id_created_at",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_versions_order_id_sales_id_fk": {
+          "name": "order_versions_order_id_sales_id_fk",
+          "tableFrom": "order_versions",
+          "tableTo": "sales",
+          "columnsFrom": ["order_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "order_versions_created_by_user_id_users_id_fk": {
+          "name": "order_versions_created_by_user_id_users_id_fk",
+          "tableFrom": "order_versions",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_order_versions_reason": {
+          "name": "chk_order_versions_reason",
+          "value": "\"order_versions\".\"reason\" IN ('update', 'restore')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.personal_access_tokens": {
+      "name": "personal_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_version_at_issue": {
+          "name": "token_version_at_issue",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "personal_access_tokens_user_id_users_id_fk": {
+          "name": "personal_access_tokens_user_id_users_id_fk",
+          "tableFrom": "personal_access_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "personal_access_tokens_user_id_unique": {
+          "name": "personal_access_tokens_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        },
+        "personal_access_tokens_token_hash_unique": {
+          "name": "personal_access_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.internal_product_categories": {
+      "name": "internal_product_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_unit": {
+          "name": "cost_unit",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unit'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_internal_product_categories_type": {
+          "name": "idx_internal_product_categories_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "internal_product_categories_name_type_key": {
+          "name": "internal_product_categories_name_type_key",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "internal_product_categories_cost_unit_check": {
+          "name": "internal_product_categories_cost_unit_check",
+          "value": "\"internal_product_categories\".\"cost_unit\" IN ('unit', 'hours')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.internal_product_subcategories": {
+      "name": "internal_product_subcategories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_internal_product_subcategories_category_id": {
+          "name": "idx_internal_product_subcategories_category_id",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "internal_product_subcategories_category_id_name_key": {
+          "name": "internal_product_subcategories_category_id_name_key",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "internal_product_subcategories_category_id_internal_product_categories_id_fk": {
+          "name": "internal_product_subcategories_category_id_internal_product_categories_id_fk",
+          "tableFrom": "internal_product_subcategories",
+          "tableTo": "internal_product_categories",
+          "columnsFrom": ["category_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_code": {
+          "name": "product_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "costo": {
+          "name": "costo",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "mol_percentage": {
+          "name": "mol_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "cost_unit": {
+          "name": "cost_unit",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unit'"
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'item'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subcategory": {
+          "name": "subcategory",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_products_name": {
+          "name": "idx_products_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_name_unique": {
+          "name": "idx_products_name_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_product_code_unique": {
+          "name": "idx_products_product_code_unique",
+          "columns": [
+            {
+              "expression": "product_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_supplier_id": {
+          "name": "idx_products_supplier_id",
+          "columns": [
+            {
+              "expression": "supplier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_type": {
+          "name": "idx_products_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "products_supplier_id_suppliers_id_fk": {
+          "name": "products_supplier_id_suppliers_id_fk",
+          "tableFrom": "products",
+          "tableTo": "suppliers",
+          "columnsFrom": ["supplier_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_types": {
+      "name": "product_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_unit": {
+          "name": "cost_unit",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unit'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_product_types_name": {
+          "name": "idx_product_types_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "product_types_name_unique": {
+          "name": "product_types_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "product_types_cost_unit_check": {
+          "name": "product_types_cost_unit_check",
+          "value": "\"product_types\".\"cost_unit\" IN ('unit', 'hours')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_rules": {
+      "name": "project_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field": {
+          "name": "field",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operator": {
+          "name": "operator",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_logic": {
+          "name": "condition_logic",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'and'"
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'notify'"
+        },
+        "action_config": {
+          "name": "action_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"recipientUserIds\":[],\"recipientRoleIds\":[]}'::jsonb"
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "condition_met": {
+          "name": "condition_met",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_project_rules_project_id": {
+          "name": "idx_project_rules_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_rules_enabled": {
+          "name": "idx_project_rules_enabled",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_rules_condition_met": {
+          "name": "idx_project_rules_condition_met",
+          "columns": [
+            {
+              "expression": "condition_met",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_rules_project_id_projects_id_fk": {
+          "name": "project_rules_project_id_projects_id_fk",
+          "tableFrom": "project_rules",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_rules_created_by_users_id_fk": {
+          "name": "project_rules_created_by_users_id_fk",
+          "tableFrom": "project_rules",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#3b82f6'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "offer_id": {
+          "name": "offer_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revenue": {
+          "name": "revenue",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_type": {
+          "name": "billing_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'time_and_materials'"
+        },
+        "billing_frequency": {
+          "name": "billing_frequency",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'monthly'"
+        }
+      },
+      "indexes": {
+        "idx_projects_client_id": {
+          "name": "idx_projects_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_projects_color_unique": {
+          "name": "idx_projects_color_unique",
+          "columns": [
+            {
+              "expression": "color",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_client_id_clients_id_fk": {
+          "name": "projects_client_id_clients_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "projects_order_id_sales_id_fk": {
+          "name": "projects_order_id_sales_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "sales",
+          "columnsFrom": ["order_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "projects_offer_id_customer_offers_id_fk": {
+          "name": "projects_offer_id_customer_offers_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "customer_offers",
+          "columnsFrom": ["offer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "projects_billing_type_check": {
+          "name": "projects_billing_type_check",
+          "value": "\"projects\".\"billing_type\" IN ('retainer', 'time_and_materials')"
+        },
+        "projects_billing_frequency_check": {
+          "name": "projects_billing_frequency_check",
+          "value": "\"projects\".\"billing_frequency\" IN ('monthly', 'one_time')"
+        },
+        "projects_time_and_materials_monthly_check": {
+          "name": "projects_time_and_materials_monthly_check",
+          "value": "\"projects\".\"billing_type\" != 'time_and_materials' OR \"projects\".\"billing_frequency\" = 'monthly'"
+        },
+        "projects_date_range_check": {
+          "name": "projects_date_range_check",
+          "value": "\"projects\".\"start_date\" IS NULL OR \"projects\".\"end_date\" IS NULL OR \"projects\".\"start_date\" <= \"projects\".\"end_date\""
+        },
+        "projects_revenue_non_negative_check": {
+          "name": "projects_revenue_non_negative_check",
+          "value": "\"projects\".\"revenue\" IS NULL OR \"projects\".\"revenue\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_projects": {
+      "name": "user_projects",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_source": {
+          "name": "assignment_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_projects_user_id_users_id_fk": {
+          "name": "user_projects_user_id_users_id_fk",
+          "tableFrom": "user_projects",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_projects_project_id_projects_id_fk": {
+          "name": "user_projects_project_id_projects_id_fk",
+          "tableFrom": "user_projects",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_projects_user_id_project_id_pk": {
+          "name": "user_projects_user_id_project_id_pk",
+          "columns": ["user_id", "project_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_projects_assignment_source_check": {
+          "name": "user_projects_assignment_source_check",
+          "value": "\"user_projects\".\"assignment_source\" IN ('manual', 'top_manager_auto', 'project_cascade')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.quote_items": {
+      "name": "quote_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_cost": {
+          "name": "product_cost",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_mol_percentage": {
+          "name": "product_mol_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_id": {
+          "name": "supplier_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_item_id": {
+          "name": "supplier_quote_item_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_supplier_name": {
+          "name": "supplier_quote_supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_unit_price": {
+          "name": "supplier_quote_unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_type": {
+          "name": "unit_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'hours'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_quote_items_quote_id": {
+          "name": "idx_quote_items_quote_id",
+          "columns": [
+            {
+              "expression": "quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quote_items_quote_id_quotes_id_fk": {
+          "name": "quote_items_quote_id_quotes_id_fk",
+          "tableFrom": "quote_items",
+          "tableTo": "quotes",
+          "columnsFrom": ["quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "quote_items_product_id_products_id_fk": {
+          "name": "quote_items_product_id_products_id_fk",
+          "tableFrom": "quote_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_quote_items_unit_type": {
+          "name": "chk_quote_items_unit_type",
+          "value": "\"quote_items\".\"unit_type\" IN ('hours', 'days', 'unit')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.quotes": {
+      "name": "quotes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_quotes_client_id": {
+          "name": "idx_quotes_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quotes_status": {
+          "name": "idx_quotes_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quotes_created_at": {
+          "name": "idx_quotes_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quotes_client_id_clients_id_fk": {
+          "name": "quotes_client_id_clients_id_fk",
+          "tableFrom": "quotes",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "quotes_status_check": {
+          "name": "quotes_status_check",
+          "value": "\"quotes\".\"status\" IN ('quoted', 'confirmed', 'draft', 'sent', 'accepted', 'denied')"
+        },
+        "chk_quotes_discount_type": {
+          "name": "chk_quotes_discount_type",
+          "value": "\"quotes\".\"discount_type\" IN ('percentage', 'currency')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.quote_versions": {
+      "name": "quote_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'update'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_quote_versions_quote_id_created_at": {
+          "name": "idx_quote_versions_quote_id_created_at",
+          "columns": [
+            {
+              "expression": "quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quote_versions_quote_id_quotes_id_fk": {
+          "name": "quote_versions_quote_id_quotes_id_fk",
+          "tableFrom": "quote_versions",
+          "tableTo": "quotes",
+          "columnsFrom": ["quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "quote_versions_created_by_user_id_users_id_fk": {
+          "name": "quote_versions_created_by_user_id_users_id_fk",
+          "tableFrom": "quote_versions",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_quote_versions_reason": {
+          "name": "chk_quote_versions_reason",
+          "value": "\"quote_versions\".\"reason\" IN ('update', 'restore')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.report_chat_messages": {
+      "name": "report_chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thought_content": {
+          "name": "thought_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_report_chat_messages_session_created": {
+          "name": "idx_report_chat_messages_session_created",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_chat_messages_session_id_report_chat_sessions_id_fk": {
+          "name": "report_chat_messages_session_id_report_chat_sessions_id_fk",
+          "tableFrom": "report_chat_messages",
+          "tableTo": "report_chat_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "report_chat_messages_role_check": {
+          "name": "report_chat_messages_role_check",
+          "value": "\"report_chat_messages\".\"role\" IN ('user', 'assistant')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.report_chat_sessions": {
+      "name": "report_chat_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'AI Reporting'"
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_report_chat_sessions_user_updated": {
+          "name": "idx_report_chat_sessions_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_report_chat_sessions_user_archived": {
+          "name": "idx_report_chat_sessions_user_archived",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_chat_sessions_user_id_users_id_fk": {
+          "name": "report_chat_sessions_user_id_users_id_fk",
+          "tableFrom": "report_chat_sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_permissions": {
+      "name": "role_permissions",
+      "schema": "",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_permissions_role_id_roles_id_fk": {
+          "name": "role_permissions_role_id_roles_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "roles",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "role_permissions_role_id_permission_pk": {
+          "name": "role_permissions_role_id_permission_pk",
+          "columns": ["role_id", "permission"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roles": {
+      "name": "roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_roles": {
+      "name": "user_roles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_roles_user_id_users_id_fk": {
+          "name": "user_roles_user_id_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_role_id_roles_id_fk": {
+          "name": "user_roles_role_id_roles_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "roles",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_roles_user_id_role_id_pk": {
+          "name": "user_roles_user_id_role_id_pk",
+          "columns": ["user_id", "role_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sale_items": {
+      "name": "sale_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sale_id": {
+          "name": "sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_cost": {
+          "name": "product_cost",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_mol_percentage": {
+          "name": "product_mol_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "unit_type": {
+          "name": "unit_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'hours'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_id": {
+          "name": "supplier_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_item_id": {
+          "name": "supplier_quote_item_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_supplier_name": {
+          "name": "supplier_quote_supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_unit_price": {
+          "name": "supplier_quote_unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_sale_id": {
+          "name": "supplier_sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_sale_item_id": {
+          "name": "supplier_sale_item_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_sale_supplier_name": {
+          "name": "supplier_sale_supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_sale_items_sale_id": {
+          "name": "idx_sale_items_sale_id",
+          "columns": [
+            {
+              "expression": "sale_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sale_items_supplier_sale_id": {
+          "name": "idx_sale_items_supplier_sale_id",
+          "columns": [
+            {
+              "expression": "supplier_sale_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sale_items_sale_id_sales_id_fk": {
+          "name": "sale_items_sale_id_sales_id_fk",
+          "tableFrom": "sale_items",
+          "tableTo": "sales",
+          "columnsFrom": ["sale_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "sale_items_product_id_products_id_fk": {
+          "name": "sale_items_product_id_products_id_fk",
+          "tableFrom": "sale_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_sale_items_unit_type": {
+          "name": "chk_sale_items_unit_type",
+          "value": "\"sale_items\".\"unit_type\" IN ('hours', 'days', 'unit')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sales": {
+      "name": "sales",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_quote_id": {
+          "name": "linked_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_offer_id": {
+          "name": "linked_offer_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_sales_client_id": {
+          "name": "idx_sales_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_status": {
+          "name": "idx_sales_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_linked_quote_id": {
+          "name": "idx_sales_linked_quote_id",
+          "columns": [
+            {
+              "expression": "linked_quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_linked_offer_id": {
+          "name": "idx_sales_linked_offer_id",
+          "columns": [
+            {
+              "expression": "linked_offer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_linked_offer_id_unique": {
+          "name": "idx_sales_linked_offer_id_unique",
+          "columns": [
+            {
+              "expression": "linked_offer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sales\".\"linked_offer_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_created_at": {
+          "name": "idx_sales_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sales_linked_quote_id_quotes_id_fk": {
+          "name": "sales_linked_quote_id_quotes_id_fk",
+          "tableFrom": "sales",
+          "tableTo": "quotes",
+          "columnsFrom": ["linked_quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "sales_linked_offer_id_customer_offers_id_fk": {
+          "name": "sales_linked_offer_id_customer_offers_id_fk",
+          "tableFrom": "sales",
+          "tableTo": "customer_offers",
+          "columnsFrom": ["linked_offer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "sales_client_id_clients_id_fk": {
+          "name": "sales_client_id_clients_id_fk",
+          "tableFrom": "sales",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sales_status_check": {
+          "name": "sales_status_check",
+          "value": "\"sales\".\"status\" IN ('draft', 'confirmed', 'denied')"
+        },
+        "chk_sales_discount_type": {
+          "name": "chk_sales_discount_type",
+          "value": "\"sales\".\"discount_type\" IN ('percentage', 'currency')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "daily_goal": {
+          "name": "daily_goal",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'8.00'"
+        },
+        "start_of_week": {
+          "name": "start_of_week",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Monday'"
+        },
+        "compact_view": {
+          "name": "compact_view",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "treat_saturday_as_holiday": {
+          "name": "treat_saturday_as_holiday",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "settings_user_id_users_id_fk": {
+          "name": "settings_user_id_users_id_fk",
+          "tableFrom": "settings",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "settings_user_id_unique": {
+          "name": "settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "settings_language_check": {
+          "name": "settings_language_check",
+          "value": "\"settings\".\"language\" IN ('en', 'it', 'auto')"
+        },
+        "settings_start_of_week_check": {
+          "name": "settings_start_of_week_check",
+          "value": "\"settings\".\"start_of_week\" IN ('Monday', 'Sunday')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.external_identities": {
+      "name": "external_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protocol": {
+          "name": "protocol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_external_identities_identity_unique": {
+          "name": "idx_external_identities_identity_unique",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "protocol",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_external_identities_user_id": {
+          "name": "idx_external_identities_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "external_identities_provider_id_sso_providers_id_fk": {
+          "name": "external_identities_provider_id_sso_providers_id_fk",
+          "tableFrom": "external_identities",
+          "tableTo": "sso_providers",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "external_identities_user_id_users_id_fk": {
+          "name": "external_identities_user_id_users_id_fk",
+          "tableFrom": "external_identities",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "external_identities_protocol_check": {
+          "name": "external_identities_protocol_check",
+          "value": "\"external_identities\".\"protocol\" IN ('oidc', 'saml')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sso_login_tickets": {
+      "name": "sso_login_tickets",
+      "schema": "",
+      "columns": {
+        "ticket": {
+          "name": "ticket",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_role": {
+          "name": "active_role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_sso_login_tickets_user_id": {
+          "name": "idx_sso_login_tickets_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sso_login_tickets_expires_at": {
+          "name": "idx_sso_login_tickets_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sso_login_tickets_user_id_users_id_fk": {
+          "name": "sso_login_tickets_user_id_users_id_fk",
+          "tableFrom": "sso_login_tickets",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sso_providers": {
+      "name": "sso_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "protocol": {
+          "name": "protocol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "issuer_url": {
+          "name": "issuer_url",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'openid profile email'"
+        },
+        "metadata_url": {
+          "name": "metadata_url",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "metadata_xml": {
+          "name": "metadata_xml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "entry_point": {
+          "name": "entry_point",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "idp_issuer": {
+          "name": "idp_issuer",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "idp_cert": {
+          "name": "idp_cert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "sp_issuer": {
+          "name": "sp_issuer",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "public_cert": {
+          "name": "public_cert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "username_attribute": {
+          "name": "username_attribute",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'preferred_username'"
+        },
+        "name_attribute": {
+          "name": "name_attribute",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'name'"
+        },
+        "email_attribute": {
+          "name": "email_attribute",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'email'"
+        },
+        "groups_attribute": {
+          "name": "groups_attribute",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'groups'"
+        },
+        "role_mappings": {
+          "name": "role_mappings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "end_session_enabled": {
+          "name": "end_session_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_sso_providers_slug_unique": {
+          "name": "idx_sso_providers_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sso_providers_protocol_enabled": {
+          "name": "idx_sso_providers_protocol_enabled",
+          "columns": [
+            {
+              "expression": "protocol",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sso_providers_protocol_check": {
+          "name": "sso_providers_protocol_check",
+          "value": "\"sso_providers\".\"protocol\" IN ('oidc', 'saml')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sso_states": {
+      "name": "sso_states",
+      "schema": "",
+      "columns": {
+        "state": {
+          "name": "state",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protocol": {
+          "name": "protocol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "relay_state": {
+          "name": "relay_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_sso_states_expires_at": {
+          "name": "idx_sso_states_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sso_states_provider_id_sso_providers_id_fk": {
+          "name": "sso_states_provider_id_sso_providers_id_fk",
+          "tableFrom": "sso_states",
+          "tableTo": "sso_providers",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sso_states_protocol_check": {
+          "name": "sso_states_protocol_check",
+          "value": "\"sso_states\".\"protocol\" IN ('oidc', 'saml')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sso_user_sessions": {
+      "name": "sso_user_sessions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sso_user_sessions_user_id_users_id_fk": {
+          "name": "sso_user_sessions_user_id_users_id_fk",
+          "tableFrom": "sso_user_sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sso_user_sessions_provider_id_sso_providers_id_fk": {
+          "name": "sso_user_sessions_provider_id_sso_providers_id_fk",
+          "tableFrom": "sso_user_sessions",
+          "tableTo": "sso_providers",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_invoice_items": {
+      "name": "supplier_invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_invoice_items_invoice_id": {
+          "name": "idx_supplier_invoice_items_invoice_id",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_invoice_items_invoice_id_supplier_invoices_id_fk": {
+          "name": "supplier_invoice_items_invoice_id_supplier_invoices_id_fk",
+          "tableFrom": "supplier_invoice_items",
+          "tableTo": "supplier_invoices",
+          "columnsFrom": ["invoice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "supplier_invoice_items_product_id_products_id_fk": {
+          "name": "supplier_invoice_items_product_id_products_id_fk",
+          "tableFrom": "supplier_invoice_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_invoices": {
+      "name": "supplier_invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_sale_id": {
+          "name": "linked_sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_name": {
+          "name": "supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_date": {
+          "name": "issue_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "amount_paid": {
+          "name": "amount_paid",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_invoices_supplier_id": {
+          "name": "idx_supplier_invoices_supplier_id",
+          "columns": [
+            {
+              "expression": "supplier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_invoices_status": {
+          "name": "idx_supplier_invoices_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_invoices_issue_date": {
+          "name": "idx_supplier_invoices_issue_date",
+          "columns": [
+            {
+              "expression": "issue_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_invoices_linked_sale_id": {
+          "name": "idx_supplier_invoices_linked_sale_id",
+          "columns": [
+            {
+              "expression": "linked_sale_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_invoices_linked_sale_id_unique": {
+          "name": "idx_supplier_invoices_linked_sale_id_unique",
+          "columns": [
+            {
+              "expression": "linked_sale_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"supplier_invoices\".\"linked_sale_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_invoices_linked_sale_id_supplier_sales_id_fk": {
+          "name": "supplier_invoices_linked_sale_id_supplier_sales_id_fk",
+          "tableFrom": "supplier_invoices",
+          "tableTo": "supplier_sales",
+          "columnsFrom": ["linked_sale_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "supplier_invoices_supplier_id_suppliers_id_fk": {
+          "name": "supplier_invoices_supplier_id_suppliers_id_fk",
+          "tableFrom": "supplier_invoices",
+          "tableTo": "suppliers",
+          "columnsFrom": ["supplier_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "supplier_invoices_status_check": {
+          "name": "supplier_invoices_status_check",
+          "value": "\"supplier_invoices\".\"status\" IN ('draft', 'sent', 'paid', 'overdue', 'cancelled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier_order_versions": {
+      "name": "supplier_order_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'update'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_order_versions_order_id_created_at": {
+          "name": "idx_supplier_order_versions_order_id_created_at",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_order_versions_order_id_supplier_sales_id_fk": {
+          "name": "supplier_order_versions_order_id_supplier_sales_id_fk",
+          "tableFrom": "supplier_order_versions",
+          "tableTo": "supplier_sales",
+          "columnsFrom": ["order_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "supplier_order_versions_created_by_user_id_users_id_fk": {
+          "name": "supplier_order_versions_created_by_user_id_users_id_fk",
+          "tableFrom": "supplier_order_versions",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_supplier_order_versions_reason": {
+          "name": "chk_supplier_order_versions_reason",
+          "value": "\"supplier_order_versions\".\"reason\" IN ('update', 'restore')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier_quote_attachments": {
+      "name": "supplier_quote_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stored_name": {
+          "name": "stored_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by_user_id": {
+          "name": "uploaded_by_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_quote_attachments_quote_id": {
+          "name": "idx_supplier_quote_attachments_quote_id",
+          "columns": [
+            {
+              "expression": "quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_quote_attachments_quote_id_supplier_quotes_id_fk": {
+          "name": "supplier_quote_attachments_quote_id_supplier_quotes_id_fk",
+          "tableFrom": "supplier_quote_attachments",
+          "tableTo": "supplier_quotes",
+          "columnsFrom": ["quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "supplier_quote_attachments_uploaded_by_user_id_users_id_fk": {
+          "name": "supplier_quote_attachments_uploaded_by_user_id_users_id_fk",
+          "tableFrom": "supplier_quote_attachments",
+          "tableTo": "users",
+          "columnsFrom": ["uploaded_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_quote_items": {
+      "name": "supplier_quote_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "unit_type": {
+          "name": "unit_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'hours'"
+        }
+      },
+      "indexes": {
+        "idx_supplier_quote_items_quote_id": {
+          "name": "idx_supplier_quote_items_quote_id",
+          "columns": [
+            {
+              "expression": "quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_quote_items_quote_id_supplier_quotes_id_fk": {
+          "name": "supplier_quote_items_quote_id_supplier_quotes_id_fk",
+          "tableFrom": "supplier_quote_items",
+          "tableTo": "supplier_quotes",
+          "columnsFrom": ["quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "supplier_quote_items_product_id_products_id_fk": {
+          "name": "supplier_quote_items_product_id_products_id_fk",
+          "tableFrom": "supplier_quote_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_supplier_quote_items_unit_type": {
+          "name": "chk_supplier_quote_items_unit_type",
+          "value": "\"supplier_quote_items\".\"unit_type\" IN ('hours', 'days', 'unit')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier_quotes": {
+      "name": "supplier_quotes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_name": {
+          "name": "supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_quotes_supplier_id": {
+          "name": "idx_supplier_quotes_supplier_id",
+          "columns": [
+            {
+              "expression": "supplier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_quotes_status": {
+          "name": "idx_supplier_quotes_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_quotes_created_at": {
+          "name": "idx_supplier_quotes_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_quotes_supplier_id_suppliers_id_fk": {
+          "name": "supplier_quotes_supplier_id_suppliers_id_fk",
+          "tableFrom": "supplier_quotes",
+          "tableTo": "suppliers",
+          "columnsFrom": ["supplier_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "supplier_quotes_status_check": {
+          "name": "supplier_quotes_status_check",
+          "value": "\"supplier_quotes\".\"status\" IN ('received', 'approved', 'rejected', 'draft', 'sent', 'accepted', 'denied')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier_quote_versions": {
+      "name": "supplier_quote_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'update'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_quote_versions_quote_id_created_at": {
+          "name": "idx_supplier_quote_versions_quote_id_created_at",
+          "columns": [
+            {
+              "expression": "quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_quote_versions_quote_id_supplier_quotes_id_fk": {
+          "name": "supplier_quote_versions_quote_id_supplier_quotes_id_fk",
+          "tableFrom": "supplier_quote_versions",
+          "tableTo": "supplier_quotes",
+          "columnsFrom": ["quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "supplier_quote_versions_created_by_user_id_users_id_fk": {
+          "name": "supplier_quote_versions_created_by_user_id_users_id_fk",
+          "tableFrom": "supplier_quote_versions",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_supplier_quote_versions_reason": {
+          "name": "chk_supplier_quote_versions_reason",
+          "value": "\"supplier_quote_versions\".\"reason\" IN ('update', 'restore')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier_sale_items": {
+      "name": "supplier_sale_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sale_id": {
+          "name": "sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_sale_items_sale_id": {
+          "name": "idx_supplier_sale_items_sale_id",
+          "columns": [
+            {
+              "expression": "sale_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_sale_items_sale_id_supplier_sales_id_fk": {
+          "name": "supplier_sale_items_sale_id_supplier_sales_id_fk",
+          "tableFrom": "supplier_sale_items",
+          "tableTo": "supplier_sales",
+          "columnsFrom": ["sale_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "supplier_sale_items_product_id_products_id_fk": {
+          "name": "supplier_sale_items_product_id_products_id_fk",
+          "tableFrom": "supplier_sale_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_sales": {
+      "name": "supplier_sales",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_quote_id": {
+          "name": "linked_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_name": {
+          "name": "supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_sales_supplier_id": {
+          "name": "idx_supplier_sales_supplier_id",
+          "columns": [
+            {
+              "expression": "supplier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_sales_status": {
+          "name": "idx_supplier_sales_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_sales_linked_quote_id": {
+          "name": "idx_supplier_sales_linked_quote_id",
+          "columns": [
+            {
+              "expression": "linked_quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_sales_linked_quote_id_supplier_quotes_id_fk": {
+          "name": "supplier_sales_linked_quote_id_supplier_quotes_id_fk",
+          "tableFrom": "supplier_sales",
+          "tableTo": "supplier_quotes",
+          "columnsFrom": ["linked_quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "supplier_sales_supplier_id_suppliers_id_fk": {
+          "name": "supplier_sales_supplier_id_suppliers_id_fk",
+          "tableFrom": "supplier_sales",
+          "tableTo": "suppliers",
+          "columnsFrom": ["supplier_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "supplier_sales_status_check": {
+          "name": "supplier_sales_status_check",
+          "value": "\"supplier_sales\".\"status\" IN ('draft', 'sent')"
+        },
+        "chk_supplier_sales_discount_type": {
+          "name": "chk_supplier_sales_discount_type",
+          "value": "\"supplier_sales\".\"discount_type\" IN ('percentage', 'currency')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.suppliers": {
+      "name": "suppliers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "supplier_code": {
+          "name": "supplier_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_code": {
+          "name": "tax_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_suppliers_name": {
+          "name": "idx_suppliers_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "recurrence_pattern": {
+          "name": "recurrence_pattern",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_start": {
+          "name": "recurrence_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_end": {
+          "name": "recurrence_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_duration": {
+          "name": "recurrence_duration",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "expected_effort": {
+          "name": "expected_effort",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "revenue": {
+          "name": "revenue",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "billing_type": {
+          "name": "billing_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'time_and_materials'"
+        },
+        "billing_frequency": {
+          "name": "billing_frequency",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'monthly'"
+        },
+        "monthly_effort": {
+          "name": "monthly_effort",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        }
+      },
+      "indexes": {
+        "idx_tasks_project_id": {
+          "name": "idx_tasks_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasks_project_id_projects_id_fk": {
+          "name": "tasks_project_id_projects_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "tasks_billing_type_check": {
+          "name": "tasks_billing_type_check",
+          "value": "\"tasks\".\"billing_type\" IN ('retainer', 'time_and_materials')"
+        },
+        "tasks_billing_frequency_check": {
+          "name": "tasks_billing_frequency_check",
+          "value": "\"tasks\".\"billing_frequency\" IN ('monthly', 'one_time')"
+        },
+        "tasks_time_and_materials_monthly_check": {
+          "name": "tasks_time_and_materials_monthly_check",
+          "value": "\"tasks\".\"billing_type\" != 'time_and_materials' OR \"tasks\".\"billing_frequency\" = 'monthly'"
+        },
+        "tasks_recurrence_duration_max_check": {
+          "name": "tasks_recurrence_duration_max_check",
+          "value": "\"tasks\".\"recurrence_duration\" IS NULL OR (\"tasks\".\"recurrence_duration\" >= 0 AND \"tasks\".\"recurrence_duration\" <= 24)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_tasks": {
+      "name": "user_tasks",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_source": {
+          "name": "assignment_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_tasks_user_id_users_id_fk": {
+          "name": "user_tasks_user_id_users_id_fk",
+          "tableFrom": "user_tasks",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_tasks_task_id_tasks_id_fk": {
+          "name": "user_tasks_task_id_tasks_id_fk",
+          "tableFrom": "user_tasks",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_tasks_user_id_task_id_pk": {
+          "name": "user_tasks_user_id_task_id_pk",
+          "columns": ["user_id", "task_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_tasks_assignment_source_check": {
+          "name": "user_tasks_assignment_source_check",
+          "value": "\"user_tasks\".\"assignment_source\" IN ('manual', 'top_manager_auto', 'project_cascade')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.time_entries": {
+      "name": "time_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_name": {
+          "name": "project_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task": {
+          "name": "task",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "hourly_cost": {
+          "name": "hourly_cost",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "is_placeholder": {
+          "name": "is_placeholder",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'remote'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "idx_time_entries_user_id": {
+          "name": "idx_time_entries_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_time_entries_date": {
+          "name": "idx_time_entries_date",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_time_entries_client_id": {
+          "name": "idx_time_entries_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_time_entries_project_id": {
+          "name": "idx_time_entries_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_time_entries_task_id": {
+          "name": "idx_time_entries_task_id",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_time_entries_created_at_id": {
+          "name": "idx_time_entries_created_at_id",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_time_entries_user_id_created_at_id": {
+          "name": "idx_time_entries_user_id_created_at_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "time_entries_user_id_users_id_fk": {
+          "name": "time_entries_user_id_users_id_fk",
+          "tableFrom": "time_entries",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "time_entries_client_id_clients_id_fk": {
+          "name": "time_entries_client_id_clients_id_fk",
+          "tableFrom": "time_entries",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "time_entries_project_id_projects_id_fk": {
+          "name": "time_entries_project_id_projects_id_fk",
+          "tableFrom": "time_entries",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "time_entries_task_id_tasks_id_fk": {
+          "name": "time_entries_task_id_tasks_id_fk",
+          "tableFrom": "time_entries",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "time_entries_location_check": {
+          "name": "time_entries_location_check",
+          "value": "\"time_entries\".\"location\" IN ('remote', 'office', 'customer_premise', 'transfer')"
+        },
+        "time_entries_duration_max_check": {
+          "name": "time_entries_duration_max_check",
+          "value": "\"time_entries\".\"duration\" >= 0 AND \"time_entries\".\"duration\" <= 24"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_initials": {
+          "name": "avatar_initials",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_per_hour": {
+          "name": "cost_per_hour",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "employee_type": {
+          "name": "employee_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'app_user'"
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'local'"
+        },
+        "auth_provider_id": {
+          "name": "auth_provider_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_version": {
+          "name": "session_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "token_version": {
+          "name": "token_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "idx_users_auth_provider_id": {
+          "name": "idx_users_auth_provider_id",
+          "columns": [
+            {
+              "expression": "auth_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_role_roles_id_fk": {
+          "name": "users_role_roles_id_fk",
+          "tableFrom": "users",
+          "tableTo": "roles",
+          "columnsFrom": ["role"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "users_auth_provider_id_sso_providers_id_fk": {
+          "name": "users_auth_provider_id_sso_providers_id_fk",
+          "tableFrom": "users",
+          "tableTo": "sso_providers",
+          "columnsFrom": ["auth_provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": ["username"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_employee_type_check": {
+          "name": "users_employee_type_check",
+          "value": "\"users\".\"employee_type\" IN ('app_user', 'internal', 'external')"
+        },
+        "users_auth_method_check": {
+          "name": "users_auth_method_check",
+          "value": "\"users\".\"auth_method\" IN ('local', 'ldap', 'oidc', 'saml')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_work_units": {
+      "name": "user_work_units",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "work_unit_id": {
+          "name": "work_unit_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_work_units_user_id_users_id_fk": {
+          "name": "user_work_units_user_id_users_id_fk",
+          "tableFrom": "user_work_units",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_work_units_work_unit_id_work_units_id_fk": {
+          "name": "user_work_units_work_unit_id_work_units_id_fk",
+          "tableFrom": "user_work_units",
+          "tableTo": "work_units",
+          "columnsFrom": ["work_unit_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_work_units_user_id_work_unit_id_pk": {
+          "name": "user_work_units_user_id_work_unit_id_pk",
+          "columns": ["user_id", "work_unit_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.work_unit_managers": {
+      "name": "work_unit_managers",
+      "schema": "",
+      "columns": {
+        "work_unit_id": {
+          "name": "work_unit_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "work_unit_managers_work_unit_id_work_units_id_fk": {
+          "name": "work_unit_managers_work_unit_id_work_units_id_fk",
+          "tableFrom": "work_unit_managers",
+          "tableTo": "work_units",
+          "columnsFrom": ["work_unit_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "work_unit_managers_user_id_users_id_fk": {
+          "name": "work_unit_managers_user_id_users_id_fk",
+          "tableFrom": "work_unit_managers",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "work_unit_managers_work_unit_id_user_id_pk": {
+          "name": "work_unit_managers_work_unit_id_user_id_pk",
+          "columns": ["work_unit_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.work_units": {
+      "name": "work_units",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -442,6 +442,27 @@
       "when": 1780318818676,
       "tag": "0062_grant_top_manager_work_units_all_rights",
       "breakpoints": true
+    },
+    {
+      "idx": 63,
+      "version": "7",
+      "when": 1780319171124,
+      "tag": "0063_add_project_rules",
+      "breakpoints": true
+    },
+    {
+      "idx": 64,
+      "version": "7",
+      "when": 1780319175389,
+      "tag": "0064_grant_projects_rules_permission",
+      "breakpoints": true
+    },
+    {
+      "idx": 65,
+      "version": "7",
+      "when": 1780323489128,
+      "tag": "0065_add_project_rule_condition_chains",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/readiness.ts
+++ b/server/db/readiness.ts
@@ -50,6 +50,7 @@ const schemaReadinessTables = [
   ['product_subcategories', schema.productSubcategories],
   ['products', schema.products],
   ['product_types', schema.productTypes],
+  ['project_rules', schema.projectRules],
   ['projects', schema.projects],
   ['quote_items', schema.quoteItems],
   ['quotes', schema.quotes],

--- a/server/db/schema/index.ts
+++ b/server/db/schema/index.ts
@@ -16,6 +16,7 @@ export * from './productCategories.ts';
 export * from './productSubcategories.ts';
 export * from './products.ts';
 export * from './productTypes.ts';
+export * from './projectRules.ts';
 export * from './projects.ts';
 export * from './quotes.ts';
 export * from './quoteVersions.ts';

--- a/server/db/schema/projectRules.ts
+++ b/server/db/schema/projectRules.ts
@@ -1,0 +1,56 @@
+import { sql } from 'drizzle-orm';
+import { boolean, index, jsonb, pgTable, timestamp, varchar } from 'drizzle-orm/pg-core';
+import { projects } from './projects.ts';
+import { users } from './users.ts';
+
+export type ProjectRuleActionConfig = {
+  recipientUserIds: string[];
+  recipientRoleIds: string[];
+};
+
+export type ProjectRuleCondition = {
+  field: string;
+  operator: string;
+  value: string;
+  valueType: ProjectRuleConditionValueType;
+};
+
+export type ProjectRuleConditionLogic = 'and' | 'or';
+export type ProjectRuleConditionValueType = 'literal' | 'field';
+
+export const projectRules = pgTable(
+  'project_rules',
+  {
+    id: varchar('id', { length: 50 }).primaryKey(),
+    projectId: varchar('project_id', { length: 50 })
+      .notNull()
+      .references(() => projects.id, { onDelete: 'cascade' }),
+    name: varchar('name', { length: 255 }).notNull(),
+    field: varchar('field', { length: 50 }).notNull(),
+    operator: varchar('operator', { length: 30 }).notNull(),
+    value: varchar('value', { length: 255 }).notNull(),
+    conditionLogic: varchar('condition_logic', { length: 10 }).notNull().default('and'),
+    conditions: jsonb('conditions')
+      .$type<ProjectRuleCondition[]>()
+      .notNull()
+      .default(sql`'[]'::jsonb`),
+    actionType: varchar('action_type', { length: 30 }).notNull().default('notify'),
+    actionConfig: jsonb('action_config')
+      .$type<ProjectRuleActionConfig>()
+      .notNull()
+      .default(sql`'{"recipientUserIds":[],"recipientRoleIds":[]}'::jsonb`),
+    isEnabled: boolean('is_enabled').notNull().default(true),
+    conditionMet: boolean('condition_met').notNull().default(false),
+    lastTriggeredAt: timestamp('last_triggered_at'),
+    createdBy: varchar('created_by', { length: 50 }).references(() => users.id, {
+      onDelete: 'set null',
+    }),
+    createdAt: timestamp('created_at').default(sql`CURRENT_TIMESTAMP`),
+    updatedAt: timestamp('updated_at').default(sql`CURRENT_TIMESTAMP`),
+  },
+  (table) => [
+    index('idx_project_rules_project_id').on(table.projectId),
+    index('idx_project_rules_enabled').on(table.isEnabled),
+    index('idx_project_rules_condition_met').on(table.conditionMet),
+  ],
+);

--- a/server/index.ts
+++ b/server/index.ts
@@ -7,6 +7,10 @@ import {
   type LdapSyncSchedulerHandle,
   startLdapSyncScheduler,
 } from './services/ldapSyncScheduler.ts';
+import {
+  type ProjectRulesSchedulerHandle,
+  startProjectRulesScheduler,
+} from './services/projectRulesScheduler.ts';
 import { performShutdown } from './shutdown.ts';
 import { createChildLogger, serializeError } from './utils/logger.ts';
 import {
@@ -39,9 +43,11 @@ const assertSecureRuntimeConfig = () => {
 };
 
 let ldapSyncScheduler: LdapSyncSchedulerHandle | null = null;
+let projectRulesScheduler: ProjectRulesSchedulerHandle | null = null;
 
 const shutdown = async (signal: string) => {
   ldapSyncScheduler?.stop();
+  projectRulesScheduler?.stop();
   const code = await performShutdown(fastify, signal, logger);
   process.exit(code);
 };
@@ -107,6 +113,8 @@ try {
   } catch (err) {
     logger.error({ err: serializeError(err) }, 'Failed to initialize LDAP sync task');
   }
+
+  projectRulesScheduler = startProjectRulesScheduler({ logger });
 } catch (err) {
   logger.error({ err: serializeError(err) }, 'Failed to start server');
   process.exit(1);

--- a/server/repositories/notificationsRepo.ts
+++ b/server/repositories/notificationsRepo.ts
@@ -1,6 +1,7 @@
 import { and, count, desc, eq, inArray, sql } from 'drizzle-orm';
 import { type DbExecutor, db } from '../db/drizzle.ts';
 import { notifications } from '../db/schema/notifications.ts';
+import { generatePrefixedId } from '../utils/order-ids.ts';
 
 // Matches the predicate of the partial index `idx_notifications_user_unread`
 // (`WHERE is_read = false`) so countUnreadForUser / markAllReadForUser can
@@ -17,6 +18,13 @@ export type Notification = {
   data: Record<string, unknown> | null;
   isRead: boolean;
   createdAt: number;
+};
+
+export type NewNotificationForUsers = {
+  type: string;
+  title: string;
+  message?: string | null;
+  data?: Record<string, unknown> | null;
 };
 
 // Sweep rows written under the pre-#612 global id; can be removed once no
@@ -99,6 +107,28 @@ export const deleteForUser = async (
     .delete(notifications)
     .where(and(eq(notifications.id, id), eq(notifications.userId, userId)));
   return (result.rowCount ?? 0) > 0;
+};
+
+export const createForUsers = async (
+  userIds: string[],
+  notification: NewNotificationForUsers,
+  exec: DbExecutor = db,
+): Promise<number> => {
+  const uniqueUserIds = Array.from(new Set(userIds.map((userId) => userId.trim()).filter(Boolean)));
+  if (uniqueUserIds.length === 0) return 0;
+
+  await exec.insert(notifications).values(
+    uniqueUserIds.map((userId) => ({
+      id: generatePrefixedId('n'),
+      userId,
+      type: notification.type,
+      title: notification.title,
+      message: notification.message ?? null,
+      data: notification.data ?? null,
+      isRead: false,
+    })),
+  );
+  return uniqueUserIds.length;
 };
 
 export const upsertAdminPasswordWarning = async (

--- a/server/repositories/projectMetricsRepo.ts
+++ b/server/repositories/projectMetricsRepo.ts
@@ -82,7 +82,13 @@ export const listForProjects = async (
   const rows = await executeRows<ProjectMetricsRow>(
     exec,
     sql`
-      WITH task_metrics AS (
+      WITH target_orders AS (
+        SELECT p.order_id AS id
+        FROM projects p
+        WHERE p.id = ANY(${sql.param(uniqueProjectIds)}::text[])
+          AND p.order_id IS NOT NULL
+      ),
+      task_metrics AS (
         SELECT
           t.project_id,
           COALESCE(SUM(COALESCE(t.revenue, 0)), 0) AS task_revenue
@@ -108,6 +114,7 @@ export const listForProjects = async (
             * (1 - COALESCE(si.discount, 0) / 100)
           ), 0) AS subtotal
         FROM sale_items si
+        WHERE si.sale_id IN (SELECT id FROM target_orders)
         GROUP BY si.sale_id
       ),
       order_totals AS (
@@ -126,6 +133,7 @@ export const listForProjects = async (
           ) AS order_total
         FROM sales s
         LEFT JOIN order_subtotals os ON os.sale_id = s.id
+        WHERE s.id IN (SELECT id FROM target_orders)
       )
       SELECT
         p.id AS "projectId",

--- a/server/repositories/projectMetricsRepo.ts
+++ b/server/repositories/projectMetricsRepo.ts
@@ -1,0 +1,190 @@
+import { sql } from 'drizzle-orm';
+import { type DbExecutor, db, executeRows } from '../db/drizzle.ts';
+import { type BillingType, DEFAULT_BILLING_TYPE } from '../utils/billing.ts';
+import { roundCurrency } from '../utils/invoice-math.ts';
+import { parseNullableDbNumber } from '../utils/parse.ts';
+import type { ProjectRuleField } from '../utils/projectRuleFields.ts';
+
+export type ProjectRuleMetricValue = string | number | null;
+
+export type ProjectRuleMetrics = {
+  projectId: string;
+  projectName: string;
+  revenue: number | null;
+  costToDate: number;
+  budgetUsedPct: number | null;
+  hoursToDate: number;
+  daysUntilDeadline: number | null;
+  billingType: BillingType;
+  status: 'active' | 'disabled';
+};
+
+type ProjectMetricsRow = {
+  projectId: string;
+  projectName: string;
+  projectIsDisabled: boolean | null;
+  clientIsDisabled: boolean | null;
+  endDate: string | null;
+  manualRevenue: string | number | null;
+  orderId: string | null;
+  taskRevenue: string | number | null;
+  orderTotal: string | number | null;
+  costToDate: string | number | null;
+  hoursToDate: string | number | null;
+  billingType: BillingType | null;
+};
+
+const MS_PER_DAY = 86_400_000;
+
+const diffCalendarDays = (endDate: string | null, now: Date): number | null => {
+  if (!endDate) return null;
+  const end = new Date(`${endDate}T00:00:00`);
+  if (Number.isNaN(end.getTime())) return null;
+  const today = new Date(now);
+  today.setHours(0, 0, 0, 0);
+  return Math.ceil((end.getTime() - today.getTime()) / MS_PER_DAY);
+};
+
+const resolveRevenue = (row: ProjectMetricsRow): number | null => {
+  const taskRevenue = parseNullableDbNumber(row.taskRevenue) ?? 0;
+  if (taskRevenue > 0) return roundCurrency(taskRevenue);
+
+  if (row.orderId) return roundCurrency(parseNullableDbNumber(row.orderTotal) ?? 0);
+
+  const manualRevenue = parseNullableDbNumber(row.manualRevenue);
+  return manualRevenue === null ? null : roundCurrency(manualRevenue);
+};
+
+const mapRow = (row: ProjectMetricsRow, now: Date): ProjectRuleMetrics => {
+  const revenue = resolveRevenue(row);
+  const costToDate = roundCurrency(parseNullableDbNumber(row.costToDate) ?? 0);
+  return {
+    projectId: row.projectId,
+    projectName: row.projectName,
+    revenue,
+    costToDate,
+    budgetUsedPct: revenue && revenue > 0 ? Math.round((costToDate / revenue) * 100) : null,
+    hoursToDate: parseNullableDbNumber(row.hoursToDate) ?? 0,
+    daysUntilDeadline: diffCalendarDays(row.endDate, now),
+    billingType: row.billingType ?? DEFAULT_BILLING_TYPE,
+    status: row.projectIsDisabled || row.clientIsDisabled ? 'disabled' : 'active',
+  };
+};
+
+export const listForProjects = async (
+  projectIds: string[],
+  now: Date,
+  exec: DbExecutor = db,
+): Promise<Map<string, ProjectRuleMetrics>> => {
+  const uniqueProjectIds = Array.from(new Set(projectIds));
+  if (uniqueProjectIds.length === 0) return new Map();
+
+  const rows = await executeRows<ProjectMetricsRow>(
+    exec,
+    sql`
+      WITH task_metrics AS (
+        SELECT
+          t.project_id,
+          COALESCE(SUM(COALESCE(t.revenue, 0)), 0) AS task_revenue
+        FROM tasks t
+        WHERE t.project_id = ANY(${sql.param(uniqueProjectIds)}::text[])
+        GROUP BY t.project_id
+      ),
+      entry_metrics AS (
+        SELECT
+          te.project_id,
+          COALESCE(SUM(ROUND((COALESCE(te.duration, 0) * COALESCE(te.hourly_cost, 0))::numeric, 2)), 0) AS cost_to_date,
+          COALESCE(SUM(COALESCE(te.duration, 0)), 0) AS hours_to_date
+        FROM time_entries te
+        WHERE te.project_id = ANY(${sql.param(uniqueProjectIds)}::text[])
+        GROUP BY te.project_id
+      ),
+      order_subtotals AS (
+        SELECT
+          si.sale_id,
+          COALESCE(SUM(
+            COALESCE(si.quantity, 0)
+            * COALESCE(si.unit_price, 0)
+            * (1 - COALESCE(si.discount, 0) / 100)
+          ), 0) AS subtotal
+        FROM sale_items si
+        GROUP BY si.sale_id
+      ),
+      order_totals AS (
+        SELECT
+          s.id,
+          ROUND(
+            (
+              COALESCE(os.subtotal, 0)
+              - CASE
+                  WHEN s.discount_type = 'currency'
+                    THEN LEAST(GREATEST(COALESCE(s.discount, 0), 0), COALESCE(os.subtotal, 0))
+                  ELSE COALESCE(os.subtotal, 0) * (COALESCE(s.discount, 0) / 100)
+                END
+            )::numeric,
+            2
+          ) AS order_total
+        FROM sales s
+        LEFT JOIN order_subtotals os ON os.sale_id = s.id
+      )
+      SELECT
+        p.id AS "projectId",
+        p.name AS "projectName",
+        p.is_disabled AS "projectIsDisabled",
+        c.is_disabled AS "clientIsDisabled",
+        p.end_date::text AS "endDate",
+        p.revenue AS "manualRevenue",
+        p.order_id AS "orderId",
+        tm.task_revenue AS "taskRevenue",
+        ot.order_total AS "orderTotal",
+        em.cost_to_date AS "costToDate",
+        em.hours_to_date AS "hoursToDate",
+        CASE
+          WHEN EXISTS (
+            SELECT 1 FROM tasks bt
+            WHERE bt.project_id = p.id
+              AND bt.billing_type <> p.billing_type
+          )
+          OR (
+            SELECT COUNT(DISTINCT bt2.billing_type)
+            FROM tasks bt2
+            WHERE bt2.project_id = p.id
+          ) > 1
+          THEN 'mixed'
+          ELSE p.billing_type
+        END AS "billingType"
+      FROM projects p
+      INNER JOIN clients c ON c.id = p.client_id
+      LEFT JOIN task_metrics tm ON tm.project_id = p.id
+      LEFT JOIN entry_metrics em ON em.project_id = p.id
+      LEFT JOIN order_totals ot ON ot.id = p.order_id
+      WHERE p.id = ANY(${sql.param(uniqueProjectIds)}::text[])
+    `,
+  );
+
+  return new Map(rows.map((row) => [row.projectId, mapRow(row, now)]));
+};
+
+export const metricValueForField = (
+  metrics: ProjectRuleMetrics,
+  field: ProjectRuleField | string,
+): ProjectRuleMetricValue => {
+  switch (field) {
+    case 'revenue':
+      return metrics.revenue;
+    case 'cost_to_date':
+      return metrics.costToDate;
+    case 'budget_used_pct':
+      return metrics.budgetUsedPct;
+    case 'hours_to_date':
+      return metrics.hoursToDate;
+    case 'days_until_deadline':
+      return metrics.daysUntilDeadline;
+    case 'billing_type':
+      return metrics.billingType;
+    case 'status':
+      return metrics.status;
+    default:
+      return null;
+  }
+};

--- a/server/repositories/projectRuleRecipientsRepo.ts
+++ b/server/repositories/projectRuleRecipientsRepo.ts
@@ -1,0 +1,148 @@
+import { sql } from 'drizzle-orm';
+import { type DbExecutor, db, executeRows } from '../db/drizzle.ts';
+import type { ProjectRuleActionConfig } from '../db/schema/projectRules.ts';
+
+export type ProjectRuleUserRecipientOption = {
+  id: string;
+  name: string;
+  username: string;
+  avatarInitials: string;
+};
+
+export type ProjectRuleRoleRecipientOption = {
+  id: string;
+  name: string;
+};
+
+export type ProjectRuleRecipientOptions = {
+  users: ProjectRuleUserRecipientOption[];
+  roles: ProjectRuleRoleRecipientOption[];
+};
+
+type UserRecipientRow = {
+  id: string;
+  name: string;
+  username: string;
+  avatarInitials: string | null;
+};
+
+type RoleRecipientRow = {
+  id: string;
+  name: string;
+};
+
+const uniqueStrings = (values: readonly string[]): string[] =>
+  Array.from(new Set(values.map((value) => value.trim()).filter(Boolean)));
+
+const mapUserRow = (row: UserRecipientRow): ProjectRuleUserRecipientOption => ({
+  id: row.id,
+  name: row.name,
+  username: row.username,
+  avatarInitials: row.avatarInitials ?? '',
+});
+
+export const listRecipientOptions = async (
+  projectId: string,
+  exec: DbExecutor = db,
+): Promise<ProjectRuleRecipientOptions> => {
+  const [userRows, roleRows] = await Promise.all([
+    executeRows<UserRecipientRow>(
+      exec,
+      sql`
+        SELECT u.id, u.name, u.username, u.avatar_initials AS "avatarInitials"
+        FROM users u
+        INNER JOIN user_projects up ON up.user_id = u.id
+        WHERE up.project_id = ${projectId}
+          AND COALESCE(u.is_disabled, false) = false
+        ORDER BY u.name
+      `,
+    ),
+    executeRows<RoleRecipientRow>(
+      exec,
+      sql`
+        SELECT r.id, r.name
+        FROM roles r
+        ORDER BY r.name
+      `,
+    ),
+  ]);
+
+  return {
+    users: userRows.map(mapUserRow),
+    roles: roleRows,
+  };
+};
+
+export const findInvalidRecipientIds = async (
+  projectId: string,
+  config: ProjectRuleActionConfig,
+  exec: DbExecutor = db,
+): Promise<{ userIds: string[]; roleIds: string[] }> => {
+  const userIds = uniqueStrings(config.recipientUserIds);
+  const roleIds = uniqueStrings(config.recipientRoleIds);
+  const [validUserRows, validRoleRows] = await Promise.all([
+    userIds.length === 0
+      ? Promise.resolve([])
+      : executeRows<{ id: string }>(
+          exec,
+          sql`
+            SELECT u.id
+            FROM users u
+            INNER JOIN user_projects up ON up.user_id = u.id
+            WHERE up.project_id = ${projectId}
+              AND u.id = ANY(${sql.param(userIds)}::text[])
+              AND COALESCE(u.is_disabled, false) = false
+          `,
+        ),
+    roleIds.length === 0
+      ? Promise.resolve([])
+      : executeRows<{ id: string }>(
+          exec,
+          sql`SELECT id FROM roles WHERE id = ANY(${sql.param(roleIds)}::text[])`,
+        ),
+  ]);
+
+  const validUserIds = new Set(validUserRows.map((row) => row.id));
+  const validRoleIds = new Set(validRoleRows.map((row) => row.id));
+  return {
+    userIds: userIds.filter((id) => !validUserIds.has(id)),
+    roleIds: roleIds.filter((id) => !validRoleIds.has(id)),
+  };
+};
+
+export const resolveRecipientUserIds = async (
+  projectId: string,
+  config: ProjectRuleActionConfig,
+  exec: DbExecutor = db,
+): Promise<string[]> => {
+  const recipientUserIds = uniqueStrings(config.recipientUserIds);
+  const recipientRoleIds = uniqueStrings(config.recipientRoleIds);
+  const rows = await executeRows<{ id: string }>(
+    exec,
+    sql`
+      SELECT DISTINCT u.id
+      FROM users u
+      LEFT JOIN user_projects up
+        ON up.user_id = u.id
+       AND up.project_id = ${projectId}
+      LEFT JOIN user_roles ur ON ur.user_id = u.id
+      WHERE COALESCE(u.is_disabled, false) = false
+        AND (
+          (
+            ${recipientUserIds.length > 0}
+            AND up.user_id IS NOT NULL
+            AND u.id = ANY(${sql.param(recipientUserIds)}::text[])
+          )
+          OR (
+            ${recipientRoleIds.length > 0}
+            AND (
+              u.role = ANY(${sql.param(recipientRoleIds)}::text[])
+              OR ur.role_id = ANY(${sql.param(recipientRoleIds)}::text[])
+            )
+          )
+        )
+      ORDER BY u.id
+    `,
+  );
+  return rows.map((row) => row.id);
+};

--- a/server/repositories/projectRulesRepo.ts
+++ b/server/repositories/projectRulesRepo.ts
@@ -1,0 +1,296 @@
+import { and, asc, eq } from 'drizzle-orm';
+import { type DbExecutor, db } from '../db/drizzle.ts';
+import {
+  type ProjectRuleActionConfig,
+  type ProjectRuleCondition,
+  type ProjectRuleConditionLogic,
+  type ProjectRuleConditionValueType,
+  projectRules,
+} from '../db/schema/projectRules.ts';
+
+export type { ProjectRuleCondition, ProjectRuleConditionLogic, ProjectRuleConditionValueType };
+
+export type ProjectRule = {
+  id: string;
+  projectId: string;
+  name: string;
+  field: string;
+  operator: string;
+  value: string;
+  conditionLogic: ProjectRuleConditionLogic;
+  conditions: ProjectRuleCondition[];
+  actionType: string;
+  actionConfig: ProjectRuleActionConfig;
+  isEnabled: boolean;
+  conditionMet: boolean;
+  lastTriggeredAt: number | null;
+  createdBy: string | null;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type NewProjectRule = {
+  id: string;
+  projectId: string;
+  name: string;
+  field: string;
+  operator: string;
+  value: string;
+  conditionLogic: ProjectRuleConditionLogic;
+  conditions: ProjectRuleCondition[];
+  actionType: string;
+  actionConfig: ProjectRuleActionConfig;
+  isEnabled: boolean;
+  createdBy: string;
+};
+
+export type ProjectRuleUpdate = Partial<
+  Pick<
+    ProjectRule,
+    | 'name'
+    | 'field'
+    | 'operator'
+    | 'value'
+    | 'conditionLogic'
+    | 'conditions'
+    | 'actionType'
+    | 'actionConfig'
+    | 'isEnabled'
+  >
+> & {
+  resetCondition?: boolean;
+};
+
+const EMPTY_ACTION_CONFIG: ProjectRuleActionConfig = {
+  recipientUserIds: [],
+  recipientRoleIds: [],
+};
+
+const normalizeRecipientIds = (values: unknown): string[] =>
+  Array.isArray(values)
+    ? Array.from(
+        new Set(
+          values
+            .filter((id): id is string => typeof id === 'string')
+            .map((id) => id.trim())
+            .filter(Boolean),
+        ),
+      )
+    : [];
+
+export const normalizeProjectRuleActionConfig = (
+  value: ProjectRuleActionConfig | null | undefined,
+): ProjectRuleActionConfig => ({
+  recipientUserIds: normalizeRecipientIds(value?.recipientUserIds),
+  recipientRoleIds: normalizeRecipientIds(value?.recipientRoleIds),
+});
+
+export const normalizeProjectRuleConditionLogic = (value: unknown): ProjectRuleConditionLogic =>
+  value === 'or' ? 'or' : 'and';
+
+export const normalizeProjectRuleConditionValueType = (
+  value: unknown,
+): ProjectRuleConditionValueType => (value === 'field' ? 'field' : 'literal');
+
+const normalizeCondition = (value: unknown): ProjectRuleCondition | null => {
+  if (!value || typeof value !== 'object') return null;
+  const raw = value as Record<string, unknown>;
+  const field = typeof raw.field === 'string' ? raw.field.trim() : '';
+  const operator = typeof raw.operator === 'string' ? raw.operator.trim() : '';
+  const conditionValue = typeof raw.value === 'string' ? raw.value.trim() : '';
+  if (!field || !operator || !conditionValue) return null;
+  return {
+    field,
+    operator,
+    value: conditionValue,
+    valueType: normalizeProjectRuleConditionValueType(raw.valueType),
+  };
+};
+
+export const normalizeProjectRuleConditions = (
+  value: unknown,
+  fallback?: ProjectRuleCondition,
+): ProjectRuleCondition[] => {
+  const normalized = Array.isArray(value)
+    ? value
+        .map(normalizeCondition)
+        .filter((condition): condition is ProjectRuleCondition => !!condition)
+    : [];
+  if (normalized.length > 0) return normalized;
+  return fallback ? [fallback] : [];
+};
+
+const primaryConditionFor = (rule: Pick<ProjectRule, 'field' | 'operator' | 'value'>) => ({
+  field: rule.field,
+  operator: rule.operator,
+  value: rule.value,
+  valueType: 'literal' as const,
+});
+
+const mapRow = (row: typeof projectRules.$inferSelect): ProjectRule => {
+  const fallback = primaryConditionFor(row);
+  const conditions = normalizeProjectRuleConditions(row.conditions, fallback);
+  const primary = conditions[0] ?? fallback;
+  return {
+    id: row.id,
+    projectId: row.projectId,
+    name: row.name,
+    field: primary.field,
+    operator: primary.operator,
+    value: primary.value,
+    conditionLogic: normalizeProjectRuleConditionLogic(row.conditionLogic),
+    conditions,
+    actionType: row.actionType,
+    actionConfig: normalizeProjectRuleActionConfig(row.actionConfig ?? EMPTY_ACTION_CONFIG),
+    isEnabled: row.isEnabled,
+    conditionMet: row.conditionMet,
+    lastTriggeredAt: row.lastTriggeredAt?.getTime() ?? null,
+    createdBy: row.createdBy,
+    createdAt: row.createdAt?.getTime() ?? 0,
+    updatedAt: row.updatedAt?.getTime() ?? 0,
+  };
+};
+
+export const listByProject = async (
+  projectId: string,
+  exec: DbExecutor = db,
+): Promise<ProjectRule[]> => {
+  const rows = await exec
+    .select()
+    .from(projectRules)
+    .where(eq(projectRules.projectId, projectId))
+    .orderBy(asc(projectRules.name), asc(projectRules.createdAt));
+  return rows.map(mapRow);
+};
+
+export const listEnabled = async (exec: DbExecutor = db): Promise<ProjectRule[]> => {
+  const rows = await exec
+    .select()
+    .from(projectRules)
+    .where(eq(projectRules.isEnabled, true))
+    .orderBy(asc(projectRules.projectId), asc(projectRules.createdAt));
+  return rows.map(mapRow);
+};
+
+export const findByProjectAndId = async (
+  projectId: string,
+  ruleId: string,
+  exec: DbExecutor = db,
+): Promise<ProjectRule | null> => {
+  const rows = await exec
+    .select()
+    .from(projectRules)
+    .where(and(eq(projectRules.projectId, projectId), eq(projectRules.id, ruleId)))
+    .limit(1);
+  return rows[0] ? mapRow(rows[0]) : null;
+};
+
+export const create = async (rule: NewProjectRule, exec: DbExecutor = db): Promise<ProjectRule> => {
+  const conditions = normalizeProjectRuleConditions(rule.conditions, primaryConditionFor(rule));
+  const primary = conditions[0] ?? primaryConditionFor(rule);
+  const rows = await exec
+    .insert(projectRules)
+    .values({
+      id: rule.id,
+      projectId: rule.projectId,
+      name: rule.name,
+      field: primary.field,
+      operator: primary.operator,
+      value: primary.value,
+      conditionLogic: normalizeProjectRuleConditionLogic(rule.conditionLogic),
+      conditions,
+      actionType: rule.actionType,
+      actionConfig: normalizeProjectRuleActionConfig(rule.actionConfig),
+      isEnabled: rule.isEnabled,
+      conditionMet: false,
+      lastTriggeredAt: null,
+      createdBy: rule.createdBy,
+    })
+    .returning();
+  return mapRow(rows[0]);
+};
+
+export const update = async (
+  projectId: string,
+  ruleId: string,
+  patch: ProjectRuleUpdate,
+  exec: DbExecutor = db,
+): Promise<ProjectRule | null> => {
+  const set: Record<string, unknown> = {
+    updatedAt: new Date(),
+  };
+
+  if (patch.name !== undefined) set.name = patch.name;
+  if (patch.conditionLogic !== undefined) {
+    set.conditionLogic = normalizeProjectRuleConditionLogic(patch.conditionLogic);
+  }
+  if (patch.conditions !== undefined) {
+    const conditions = normalizeProjectRuleConditions(patch.conditions);
+    const primary = conditions[0];
+    set.conditions = conditions;
+    if (primary) {
+      set.field = primary.field;
+      set.operator = primary.operator;
+      set.value = primary.value;
+    }
+  } else {
+    if (patch.field !== undefined) set.field = patch.field;
+    if (patch.operator !== undefined) set.operator = patch.operator;
+    if (patch.value !== undefined) set.value = patch.value;
+  }
+  if (patch.actionType !== undefined) set.actionType = patch.actionType;
+  if (patch.actionConfig !== undefined) {
+    set.actionConfig = normalizeProjectRuleActionConfig(patch.actionConfig);
+  }
+  if (patch.isEnabled !== undefined) set.isEnabled = patch.isEnabled;
+  if (patch.resetCondition) {
+    set.conditionMet = false;
+    set.lastTriggeredAt = null;
+  }
+
+  const rows = await exec
+    .update(projectRules)
+    .set(set)
+    .where(and(eq(projectRules.projectId, projectId), eq(projectRules.id, ruleId)))
+    .returning();
+  return rows[0] ? mapRow(rows[0]) : null;
+};
+
+export const deleteByProjectAndId = async (
+  projectId: string,
+  ruleId: string,
+  exec: DbExecutor = db,
+): Promise<boolean> => {
+  const result = await exec
+    .delete(projectRules)
+    .where(and(eq(projectRules.projectId, projectId), eq(projectRules.id, ruleId)));
+  return (result.rowCount ?? 0) > 0;
+};
+
+export const markConditionNotMet = async (
+  ruleId: string,
+  exec: DbExecutor = db,
+): Promise<boolean> => {
+  const result = await exec
+    .update(projectRules)
+    .set({ conditionMet: false, updatedAt: new Date() })
+    .where(and(eq(projectRules.id, ruleId), eq(projectRules.conditionMet, true)));
+  return (result.rowCount ?? 0) > 0;
+};
+
+export const markTriggeredOnRisingEdge = async (
+  ruleId: string,
+  now: Date,
+  exec: DbExecutor = db,
+): Promise<boolean> => {
+  const rows = await exec
+    .update(projectRules)
+    .set({
+      conditionMet: true,
+      lastTriggeredAt: now,
+      updatedAt: new Date(),
+    })
+    .where(and(eq(projectRules.id, ruleId), eq(projectRules.conditionMet, false)))
+    .returning({ id: projectRules.id });
+  return rows.length > 0;
+};

--- a/server/routes/project-rules.ts
+++ b/server/routes/project-rules.ts
@@ -1,0 +1,812 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import type { DbExecutor } from '../db/drizzle.ts';
+import { withDbTransaction } from '../db/drizzle.ts';
+import { authenticateToken, requirePermission } from '../middleware/auth.ts';
+import * as projectRuleRecipientsRepo from '../repositories/projectRuleRecipientsRepo.ts';
+import * as projectRulesRepo from '../repositories/projectRulesRepo.ts';
+import * as projectsRepo from '../repositories/projectsRepo.ts';
+import * as userAssignmentsRepo from '../repositories/userAssignmentsRepo.ts';
+import { standardErrorResponses } from '../schemas/common.ts';
+import { deriveToggleAction, getAuditChangedFields, logAudit } from '../utils/audit.ts';
+import { assertAuthenticated } from '../utils/auth-assert.ts';
+import { NotFoundError } from '../utils/http-errors.ts';
+import { generatePrefixedId } from '../utils/order-ids.ts';
+import { makeAccessChecker } from '../utils/permissions.ts';
+import {
+  getProjectRuleFieldDefinition,
+  isProjectRuleConditionValueType,
+  validateProjectRuleCondition,
+} from '../utils/projectRuleFields.ts';
+import { replyError } from '../utils/replyError.ts';
+import {
+  badRequest,
+  ensureArrayOfStrings,
+  parseBooleanField,
+  requireNonEmptyString,
+} from '../utils/validation.ts';
+
+const projectIdParamSchema = {
+  type: 'object',
+  properties: {
+    projectId: { type: 'string' },
+  },
+  required: ['projectId'],
+} as const;
+
+const projectRuleIdParamSchema = {
+  type: 'object',
+  properties: {
+    projectId: { type: 'string' },
+    ruleId: { type: 'string' },
+  },
+  required: ['projectId', 'ruleId'],
+} as const;
+
+const actionConfigSchema = {
+  type: 'object',
+  properties: {
+    recipientUserIds: { type: 'array', items: { type: 'string' } },
+    recipientRoleIds: { type: 'array', items: { type: 'string' } },
+  },
+  required: ['recipientUserIds', 'recipientRoleIds'],
+  additionalProperties: false,
+} as const;
+
+const projectRuleConditionSchema = {
+  type: 'object',
+  properties: {
+    field: { type: 'string' },
+    operator: { type: 'string' },
+    value: { type: 'string' },
+    valueType: { type: 'string', enum: ['literal', 'field'] },
+  },
+  required: ['field', 'operator', 'value'],
+  additionalProperties: false,
+} as const;
+
+const projectRuleSchema = {
+  type: 'object',
+  properties: {
+    id: { type: 'string' },
+    projectId: { type: 'string' },
+    name: { type: 'string' },
+    field: { type: 'string' },
+    operator: { type: 'string' },
+    value: { type: 'string' },
+    conditionLogic: { type: 'string', enum: ['and', 'or'] },
+    conditions: { type: 'array', items: projectRuleConditionSchema },
+    actionType: { type: 'string' },
+    actionConfig: actionConfigSchema,
+    isEnabled: { type: 'boolean' },
+    conditionMet: { type: 'boolean' },
+    lastTriggeredAt: { type: ['number', 'null'] },
+    createdBy: { type: ['string', 'null'] },
+    createdAt: { type: 'number' },
+    updatedAt: { type: 'number' },
+  },
+  required: [
+    'id',
+    'projectId',
+    'name',
+    'field',
+    'operator',
+    'value',
+    'conditionLogic',
+    'conditions',
+    'actionType',
+    'actionConfig',
+    'isEnabled',
+    'conditionMet',
+    'lastTriggeredAt',
+    'createdBy',
+    'createdAt',
+    'updatedAt',
+  ],
+} as const;
+
+const recipientOptionsSchema = {
+  type: 'object',
+  properties: {
+    users: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          name: { type: 'string' },
+          username: { type: 'string' },
+          avatarInitials: { type: 'string' },
+        },
+        required: ['id', 'name', 'username', 'avatarInitials'],
+      },
+    },
+    roles: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          name: { type: 'string' },
+        },
+        required: ['id', 'name'],
+      },
+    },
+  },
+  required: ['users', 'roles'],
+} as const;
+
+const projectRuleCreateBodySchema = {
+  type: 'object',
+  properties: {
+    name: { type: 'string' },
+    field: { type: 'string' },
+    operator: { type: 'string' },
+    value: { type: 'string' },
+    conditionLogic: { type: 'string', enum: ['and', 'or'] },
+    conditions: { type: 'array', items: projectRuleConditionSchema },
+    actionType: { type: 'string' },
+    actionConfig: actionConfigSchema,
+    isEnabled: { type: 'boolean' },
+  },
+  required: ['name', 'actionConfig'],
+  additionalProperties: false,
+} as const;
+
+const projectRuleUpdateBodySchema = {
+  type: 'object',
+  properties: projectRuleCreateBodySchema.properties,
+  additionalProperties: false,
+} as const;
+
+type ProjectRuleBody = Record<string, unknown>;
+
+class RecipientValidationError extends Error {}
+
+const canAccessProject = makeAccessChecker(
+  (userId, projectId) => userAssignmentsRepo.isProjectAssignedToUser(userId, projectId),
+  'projects.manage_all.view',
+);
+
+const parseActionConfig = (
+  value: unknown,
+):
+  | { ok: true; value: projectRulesRepo.ProjectRule['actionConfig'] }
+  | { ok: false; message: string } => {
+  const raw = value && typeof value === 'object' ? (value as Record<string, unknown>) : {};
+  const recipientUserIds = ensureArrayOfStrings(raw.recipientUserIds ?? [], 'recipientUserIds');
+  if (!recipientUserIds.ok) return { ok: false, message: recipientUserIds.message };
+  const recipientRoleIds = ensureArrayOfStrings(raw.recipientRoleIds ?? [], 'recipientRoleIds');
+  if (!recipientRoleIds.ok) return { ok: false, message: recipientRoleIds.message };
+
+  const normalized = projectRulesRepo.normalizeProjectRuleActionConfig({
+    recipientUserIds: recipientUserIds.value,
+    recipientRoleIds: recipientRoleIds.value,
+  });
+  if (normalized.recipientUserIds.length + normalized.recipientRoleIds.length === 0) {
+    return { ok: false, message: 'At least one recipient is required' };
+  }
+  return { ok: true, value: normalized };
+};
+
+const parseConditionLogic = (
+  value: unknown,
+):
+  | { ok: true; value: projectRulesRepo.ProjectRuleConditionLogic }
+  | { ok: false; message: string } => {
+  if (value === undefined) return { ok: true, value: 'and' };
+  const result = requireNonEmptyString(value, 'conditionLogic');
+  if (!result.ok) return { ok: false, message: result.message };
+  if (result.value !== 'and' && result.value !== 'or') {
+    return { ok: false, message: 'conditionLogic must be "and" or "or"' };
+  }
+  return { ok: true, value: result.value };
+};
+
+const parseCondition = (
+  value: unknown,
+  index: number,
+): { ok: true; value: projectRulesRepo.ProjectRuleCondition } | { ok: false; message: string } => {
+  if (!value || typeof value !== 'object') {
+    return { ok: false, message: `conditions[${index}] must be an object` };
+  }
+  const raw = value as ProjectRuleBody;
+  const field = requireNonEmptyString(raw.field, `conditions[${index}].field`);
+  if (!field.ok) return { ok: false, message: field.message };
+  const operator = requireNonEmptyString(raw.operator, `conditions[${index}].operator`);
+  if (!operator.ok) return { ok: false, message: operator.message };
+  const conditionValue = requireNonEmptyString(raw.value, `conditions[${index}].value`);
+  if (!conditionValue.ok) return { ok: false, message: conditionValue.message };
+  const valueTypeResult =
+    raw.valueType === undefined
+      ? ({ ok: true, value: 'literal' } as const)
+      : requireNonEmptyString(raw.valueType, `conditions[${index}].valueType`);
+  if (!valueTypeResult.ok) return { ok: false, message: valueTypeResult.message };
+  if (!isProjectRuleConditionValueType(valueTypeResult.value)) {
+    return { ok: false, message: `conditions[${index}].valueType must be literal or field` };
+  }
+  return {
+    ok: true,
+    value: {
+      field: field.value,
+      operator: operator.value,
+      value: conditionValue.value,
+      valueType: valueTypeResult.value,
+    },
+  };
+};
+
+const parseConditions = (
+  value: unknown,
+):
+  | { ok: true; value: projectRulesRepo.ProjectRuleCondition[] }
+  | { ok: false; message: string } => {
+  if (!Array.isArray(value)) return { ok: false, message: 'conditions must be an array' };
+  if (value.length === 0) return { ok: false, message: 'At least one condition is required' };
+  const conditions: projectRulesRepo.ProjectRuleCondition[] = [];
+  for (const [index, rawCondition] of value.entries()) {
+    const condition = parseCondition(rawCondition, index);
+    if (!condition.ok) return condition;
+    conditions.push(condition.value);
+  }
+  return { ok: true, value: conditions };
+};
+
+const parseLegacySingleCondition = (
+  body: ProjectRuleBody,
+): { ok: true; value: projectRulesRepo.ProjectRuleCondition } | { ok: false; message: string } => {
+  const field = requireNonEmptyString(body.field, 'field');
+  if (!field.ok) return { ok: false, message: field.message };
+  const operator = requireNonEmptyString(body.operator, 'operator');
+  if (!operator.ok) return { ok: false, message: operator.message };
+  const value = requireNonEmptyString(body.value, 'value');
+  if (!value.ok) return { ok: false, message: value.message };
+  return {
+    ok: true,
+    value: {
+      field: field.value,
+      operator: operator.value,
+      value: value.value,
+      valueType: 'literal',
+    },
+  };
+};
+
+const parseCreateBody = (
+  body: ProjectRuleBody,
+):
+  | { ok: true; value: Omit<projectRulesRepo.NewProjectRule, 'id' | 'projectId' | 'createdBy'> }
+  | { ok: false; message: string } => {
+  const name = requireNonEmptyString(body.name, 'name');
+  if (!name.ok) return { ok: false, message: name.message };
+  const conditions = Object.hasOwn(body, 'conditions')
+    ? parseConditions(body.conditions)
+    : (() => {
+        const condition = parseLegacySingleCondition(body);
+        return condition.ok ? { ok: true as const, value: [condition.value] } : condition;
+      })();
+  if (!conditions.ok) return { ok: false, message: conditions.message };
+  const conditionLogic = parseConditionLogic(body.conditionLogic);
+  if (!conditionLogic.ok) return conditionLogic;
+  const primary = conditions.value[0];
+  const actionType = body.actionType === undefined ? 'notify' : body.actionType;
+  const actionTypeResult = requireNonEmptyString(actionType, 'actionType');
+  if (!actionTypeResult.ok) return { ok: false, message: actionTypeResult.message };
+  if (actionTypeResult.value !== 'notify') {
+    return { ok: false, message: 'actionType must be notify' };
+  }
+  const actionConfig = parseActionConfig(body.actionConfig);
+  if (!actionConfig.ok) return actionConfig;
+  const isEnabled = parseBooleanField(body, 'isEnabled');
+  if (!isEnabled.ok) return { ok: false, message: isEnabled.message };
+
+  return {
+    ok: true,
+    value: {
+      name: name.value,
+      field: primary.field,
+      operator: primary.operator,
+      value: primary.value,
+      conditionLogic: conditionLogic.value,
+      conditions: conditions.value,
+      actionType: actionTypeResult.value,
+      actionConfig: actionConfig.value,
+      isEnabled: isEnabled.value ?? true,
+    },
+  };
+};
+
+const parseUpdateBody = (
+  body: ProjectRuleBody,
+): { ok: true; value: projectRulesRepo.ProjectRuleUpdate } | { ok: false; message: string } => {
+  const patch: projectRulesRepo.ProjectRuleUpdate = {};
+  if (Object.hasOwn(body, 'name')) {
+    const result = requireNonEmptyString(body.name, 'name');
+    if (!result.ok) return { ok: false, message: result.message };
+    patch.name = result.value;
+  }
+  if (Object.hasOwn(body, 'field')) {
+    const result = requireNonEmptyString(body.field, 'field');
+    if (!result.ok) return { ok: false, message: result.message };
+    patch.field = result.value;
+  }
+  if (Object.hasOwn(body, 'operator')) {
+    const result = requireNonEmptyString(body.operator, 'operator');
+    if (!result.ok) return { ok: false, message: result.message };
+    patch.operator = result.value;
+  }
+  if (Object.hasOwn(body, 'value')) {
+    const result = requireNonEmptyString(body.value, 'value');
+    if (!result.ok) return { ok: false, message: result.message };
+    patch.value = result.value;
+  }
+  if (Object.hasOwn(body, 'conditionLogic')) {
+    const result = parseConditionLogic(body.conditionLogic);
+    if (!result.ok) return { ok: false, message: result.message };
+    patch.conditionLogic = result.value;
+  }
+  if (Object.hasOwn(body, 'conditions')) {
+    const result = parseConditions(body.conditions);
+    if (!result.ok) return { ok: false, message: result.message };
+    patch.conditions = result.value;
+    const primary = result.value[0];
+    patch.field = primary.field;
+    patch.operator = primary.operator;
+    patch.value = primary.value;
+  }
+  if (Object.hasOwn(body, 'actionType')) {
+    const result = requireNonEmptyString(body.actionType, 'actionType');
+    if (!result.ok) return { ok: false, message: result.message };
+    if (result.value !== 'notify') return { ok: false, message: 'actionType must be notify' };
+    patch.actionType = result.value;
+  }
+  if (Object.hasOwn(body, 'actionConfig')) {
+    const result = parseActionConfig(body.actionConfig);
+    if (!result.ok) return result;
+    patch.actionConfig = result.value;
+  }
+  const isEnabled = parseBooleanField(body, 'isEnabled');
+  if (!isEnabled.ok) return { ok: false, message: isEnabled.message };
+  if (isEnabled.value !== undefined) patch.isEnabled = isEnabled.value;
+
+  if (Object.keys(patch).length === 0) {
+    return { ok: false, message: 'At least one rule field is required' };
+  }
+
+  return { ok: true, value: patch };
+};
+
+const validateFinalRule = async ({
+  projectId,
+  rule,
+  permissions,
+  exec,
+}: {
+  projectId: string;
+  rule: Pick<
+    projectRulesRepo.ProjectRule,
+    'conditions' | 'conditionLogic' | 'actionType' | 'actionConfig'
+  >;
+  permissions: readonly string[];
+  exec?: DbExecutor;
+}) => {
+  if (rule.actionType !== 'notify') {
+    throw new RecipientValidationError('actionType must be notify');
+  }
+
+  if (rule.conditionLogic !== 'and' && rule.conditionLogic !== 'or') {
+    throw new RecipientValidationError('conditionLogic must be "and" or "or"');
+  }
+  if (rule.conditions.length === 0) {
+    throw new RecipientValidationError('At least one condition is required');
+  }
+  for (const conditionInput of rule.conditions) {
+    const definition = getProjectRuleFieldDefinition(conditionInput.field);
+    const condition = validateProjectRuleCondition({
+      field: conditionInput.field,
+      operator: conditionInput.operator,
+      value: conditionInput.value,
+      valueType: conditionInput.valueType,
+      permissions,
+    });
+    if (!condition.ok) throw new RecipientValidationError(condition.message);
+    if (definition?.requiresPermission && !permissions.includes(definition.requiresPermission)) {
+      throw new RecipientValidationError(
+        `${conditionInput.field} requires ${definition.requiresPermission}`,
+      );
+    }
+  }
+
+  const invalidRecipients = await projectRuleRecipientsRepo.findInvalidRecipientIds(
+    projectId,
+    rule.actionConfig,
+    exec,
+  );
+  if (invalidRecipients.userIds.length > 0 || invalidRecipients.roleIds.length > 0) {
+    throw new RecipientValidationError('actionConfig contains invalid recipients');
+  }
+};
+
+const mergeRuleConditions = (
+  existing: projectRulesRepo.ProjectRule,
+  patch: projectRulesRepo.ProjectRuleUpdate,
+) => {
+  const existingConditions =
+    existing.conditions.length > 0
+      ? existing.conditions
+      : [
+          {
+            field: existing.field,
+            operator: existing.operator,
+            value: existing.value,
+            valueType: 'literal' as const,
+          },
+        ];
+  const conditionFieldsChanged =
+    patch.field !== undefined || patch.operator !== undefined || patch.value !== undefined;
+
+  if (patch.conditions !== undefined) {
+    return patch.conditions;
+  }
+
+  if (!conditionFieldsChanged) return existingConditions;
+
+  const first = {
+    field: patch.field ?? existingConditions[0].field,
+    operator: patch.operator ?? existingConditions[0].operator,
+    value: patch.value ?? existingConditions[0].value,
+    valueType: 'literal' as const,
+  };
+  return [first, ...existingConditions.slice(1)];
+};
+
+const ensureProjectAccess = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+  projectId: string,
+  action: string,
+) => {
+  if (await canAccessProject(request, projectId)) return true;
+  await replyError(request, reply, {
+    statusCode: 403,
+    message: 'Insufficient permissions',
+    action,
+    entityType: 'project',
+    entityId: projectId,
+    details: { secondaryLabel: 'project_access_denied' },
+  });
+  return false;
+};
+
+export default async function (fastify: FastifyInstance, _opts: unknown) {
+  fastify.get(
+    '/:projectId/rules/recipients',
+    {
+      onRequest: [authenticateToken, requirePermission('projects.rules.view')],
+      schema: {
+        tags: ['projects'],
+        summary: 'List project rule recipient options',
+        params: projectIdParamSchema,
+        response: {
+          200: recipientOptionsSchema,
+          ...standardErrorResponses,
+        },
+      },
+    },
+    async (request, reply) => {
+      const { projectId } = request.params as { projectId: string };
+      const id = requireNonEmptyString(projectId, 'projectId');
+      if (!id.ok) return badRequest(reply, id.message);
+      if (
+        !(await ensureProjectAccess(request, reply, id.value, 'project_rule.recipients.denied'))
+      ) {
+        return;
+      }
+      return projectRuleRecipientsRepo.listRecipientOptions(id.value);
+    },
+  );
+
+  fastify.get(
+    '/:projectId/rules',
+    {
+      onRequest: [authenticateToken, requirePermission('projects.rules.view')],
+      schema: {
+        tags: ['projects'],
+        summary: 'List project rules',
+        params: projectIdParamSchema,
+        response: {
+          200: { type: 'array', items: projectRuleSchema },
+          ...standardErrorResponses,
+        },
+      },
+    },
+    async (request, reply) => {
+      const { projectId } = request.params as { projectId: string };
+      const id = requireNonEmptyString(projectId, 'projectId');
+      if (!id.ok) return badRequest(reply, id.message);
+      if (!(await ensureProjectAccess(request, reply, id.value, 'project_rule.list.denied')))
+        return;
+      return projectRulesRepo.listByProject(id.value);
+    },
+  );
+
+  fastify.post(
+    '/:projectId/rules',
+    {
+      onRequest: [authenticateToken, requirePermission('projects.rules.create')],
+      schema: {
+        tags: ['projects'],
+        summary: 'Create project rule',
+        params: projectIdParamSchema,
+        body: projectRuleCreateBodySchema,
+        response: {
+          201: projectRuleSchema,
+          ...standardErrorResponses,
+        },
+      },
+    },
+    async (request, reply) => {
+      if (!assertAuthenticated(request, reply)) return;
+      const { projectId } = request.params as { projectId: string };
+      const id = requireNonEmptyString(projectId, 'projectId');
+      if (!id.ok) return badRequest(reply, id.message);
+      if (!(await ensureProjectAccess(request, reply, id.value, 'project_rule.create.denied'))) {
+        return;
+      }
+      const parsed = parseCreateBody(request.body as ProjectRuleBody);
+      if (!parsed.ok) return badRequest(reply, parsed.message);
+
+      const ruleId = generatePrefixedId('pr');
+      let created: projectRulesRepo.ProjectRule;
+      let projectName = '';
+      try {
+        created = await withDbTransaction(async (tx) => {
+          const project = await projectsRepo.findClientIdAndName(id.value, tx);
+          if (!project) throw new NotFoundError('Project');
+          await validateFinalRule({
+            projectId: id.value,
+            rule: parsed.value,
+            permissions: request.user.permissions ?? [],
+            exec: tx,
+          });
+          projectName = project.name;
+          return projectRulesRepo.create(
+            {
+              id: ruleId,
+              projectId: id.value,
+              createdBy: request.user.id,
+              ...parsed.value,
+            },
+            tx,
+          );
+        });
+      } catch (err) {
+        if (err instanceof NotFoundError) {
+          return replyError(request, reply, {
+            statusCode: 404,
+            message: err.message,
+            action: 'project_rule.create.not_found',
+            entityType: 'project',
+            entityId: id.value,
+          });
+        }
+        if (err instanceof RecipientValidationError) return badRequest(reply, err.message);
+        throw err;
+      }
+
+      await logAudit({
+        request,
+        action: 'project_rule.created',
+        entityType: 'project_rule',
+        entityId: created.id,
+        details: {
+          targetLabel: created.name,
+          secondaryLabel: projectName,
+          counts: {
+            recipientUsers: created.actionConfig.recipientUserIds.length,
+            recipientRoles: created.actionConfig.recipientRoleIds.length,
+          },
+        },
+      });
+      return reply.code(201).send(created);
+    },
+  );
+
+  fastify.put(
+    '/:projectId/rules/:ruleId',
+    {
+      onRequest: [authenticateToken, requirePermission('projects.rules.update')],
+      schema: {
+        tags: ['projects'],
+        summary: 'Update project rule',
+        params: projectRuleIdParamSchema,
+        body: projectRuleUpdateBodySchema,
+        response: {
+          200: projectRuleSchema,
+          ...standardErrorResponses,
+        },
+      },
+    },
+    async (request, reply) => {
+      const { projectId, ruleId } = request.params as { projectId: string; ruleId: string };
+      const projectIdResult = requireNonEmptyString(projectId, 'projectId');
+      if (!projectIdResult.ok) return badRequest(reply, projectIdResult.message);
+      const ruleIdResult = requireNonEmptyString(ruleId, 'ruleId');
+      if (!ruleIdResult.ok) return badRequest(reply, ruleIdResult.message);
+      if (
+        !(await ensureProjectAccess(
+          request,
+          reply,
+          projectIdResult.value,
+          'project_rule.update.denied',
+        ))
+      ) {
+        return;
+      }
+      const parsed = parseUpdateBody(request.body as ProjectRuleBody);
+      if (!parsed.ok) return badRequest(reply, parsed.message);
+
+      let updated: projectRulesRepo.ProjectRule;
+      let projectName = '';
+      try {
+        updated = await withDbTransaction(async (tx) => {
+          const [project, existing] = await Promise.all([
+            projectsRepo.findClientIdAndName(projectIdResult.value, tx),
+            projectRulesRepo.findByProjectAndId(projectIdResult.value, ruleIdResult.value, tx),
+          ]);
+          if (!project) throw new NotFoundError('Project');
+          if (!existing) throw new NotFoundError('Project rule');
+
+          const finalConditions = mergeRuleConditions(existing, parsed.value);
+          const primary = finalConditions[0];
+          const finalConditionLogic = parsed.value.conditionLogic ?? existing.conditionLogic;
+          const finalRule = {
+            ...existing,
+            ...parsed.value,
+            field: primary.field,
+            operator: primary.operator,
+            value: primary.value,
+            conditionLogic: finalConditionLogic,
+            conditions: finalConditions,
+            actionConfig: parsed.value.actionConfig ?? existing.actionConfig,
+          };
+          await validateFinalRule({
+            projectId: projectIdResult.value,
+            rule: finalRule,
+            permissions: request.user?.permissions ?? [],
+            exec: tx,
+          });
+
+          const conditionChanged =
+            parsed.value.field !== undefined ||
+            parsed.value.operator !== undefined ||
+            parsed.value.value !== undefined ||
+            parsed.value.conditions !== undefined ||
+            parsed.value.conditionLogic !== undefined;
+          const reEnabled = parsed.value.isEnabled === true && existing.isEnabled === false;
+          projectName = project.name;
+          const result = await projectRulesRepo.update(
+            projectIdResult.value,
+            ruleIdResult.value,
+            {
+              ...parsed.value,
+              field: primary.field,
+              operator: primary.operator,
+              value: primary.value,
+              conditionLogic: finalConditionLogic,
+              conditions: finalConditions,
+              resetCondition: conditionChanged || reEnabled,
+            },
+            tx,
+          );
+          if (!result) throw new NotFoundError('Project rule');
+          return result;
+        });
+      } catch (err) {
+        if (err instanceof NotFoundError) {
+          return replyError(request, reply, {
+            statusCode: 404,
+            message: err.message,
+            action: 'project_rule.update.not_found',
+            entityType: 'project_rule',
+            entityId: ruleIdResult.value,
+          });
+        }
+        if (err instanceof RecipientValidationError) return badRequest(reply, err.message);
+        throw err;
+      }
+
+      const changedFields = getAuditChangedFields(request.body as Record<string, unknown>);
+      await logAudit({
+        request,
+        action: deriveToggleAction(
+          changedFields,
+          'isEnabled',
+          'project_rule.updated',
+          'project_rule.enabled',
+          'project_rule.disabled',
+          (request.body as { isEnabled?: boolean }).isEnabled,
+        ),
+        entityType: 'project_rule',
+        entityId: updated.id,
+        details: {
+          targetLabel: updated.name,
+          secondaryLabel: projectName,
+          changedFields,
+        },
+      });
+      return updated;
+    },
+  );
+
+  fastify.delete(
+    '/:projectId/rules/:ruleId',
+    {
+      onRequest: [authenticateToken, requirePermission('projects.rules.delete')],
+      schema: {
+        tags: ['projects'],
+        summary: 'Delete project rule',
+        params: projectRuleIdParamSchema,
+        response: {
+          204: { type: 'null' },
+          ...standardErrorResponses,
+        },
+      },
+    },
+    async (request, reply) => {
+      const { projectId, ruleId } = request.params as { projectId: string; ruleId: string };
+      const projectIdResult = requireNonEmptyString(projectId, 'projectId');
+      if (!projectIdResult.ok) return badRequest(reply, projectIdResult.message);
+      const ruleIdResult = requireNonEmptyString(ruleId, 'ruleId');
+      if (!ruleIdResult.ok) return badRequest(reply, ruleIdResult.message);
+      if (
+        !(await ensureProjectAccess(
+          request,
+          reply,
+          projectIdResult.value,
+          'project_rule.delete.denied',
+        ))
+      ) {
+        return;
+      }
+
+      let deleted: projectRulesRepo.ProjectRule;
+      try {
+        deleted = await withDbTransaction(async (tx) => {
+          const existing = await projectRulesRepo.findByProjectAndId(
+            projectIdResult.value,
+            ruleIdResult.value,
+            tx,
+          );
+          if (!existing) throw new NotFoundError('Project rule');
+          const ok = await projectRulesRepo.deleteByProjectAndId(
+            projectIdResult.value,
+            ruleIdResult.value,
+            tx,
+          );
+          if (!ok) throw new NotFoundError('Project rule');
+          return existing;
+        });
+      } catch (err) {
+        if (err instanceof NotFoundError) {
+          return replyError(request, reply, {
+            statusCode: 404,
+            message: err.message,
+            action: 'project_rule.delete.not_found',
+            entityType: 'project_rule',
+            entityId: ruleIdResult.value,
+          });
+        }
+        throw err;
+      }
+
+      await logAudit({
+        request,
+        action: 'project_rule.deleted',
+        entityType: 'project_rule',
+        entityId: deleted.id,
+        details: { targetLabel: deleted.name, secondaryLabel: deleted.projectId },
+      });
+      return reply.code(204).send();
+    },
+  );
+}

--- a/server/services/projectRulesEvaluator.ts
+++ b/server/services/projectRulesEvaluator.ts
@@ -1,0 +1,135 @@
+import { type DbExecutor, db, runAtomically } from '../db/drizzle.ts';
+import * as notificationsRepo from '../repositories/notificationsRepo.ts';
+import * as projectMetricsRepo from '../repositories/projectMetricsRepo.ts';
+import * as projectRuleRecipientsRepo from '../repositories/projectRuleRecipientsRepo.ts';
+import * as projectRulesRepo from '../repositories/projectRulesRepo.ts';
+import { serializeError } from '../utils/logger.ts';
+import { evaluateProjectRuleCondition } from '../utils/projectRuleFields.ts';
+
+export const PROJECT_RULE_TRIGGERED_NOTIFICATION_TYPE = 'project_rule_triggered';
+
+export type ProjectRulesEvaluatorLogger = {
+  error: (obj: unknown, message?: string) => void;
+  warn?: (obj: unknown, message?: string) => void;
+  info?: (obj: unknown, message?: string) => void;
+};
+
+export type EvaluateProjectRulesOptions = {
+  now?: Date;
+  logger?: ProjectRulesEvaluatorLogger;
+  exec?: DbExecutor;
+};
+
+export type ProjectRulesEvaluationResult = {
+  evaluated: number;
+  triggered: number;
+  reset: number;
+  notified: number;
+};
+
+const buildNotification = (rule: projectRulesRepo.ProjectRule, projectName: string) => ({
+  type: PROJECT_RULE_TRIGGERED_NOTIFICATION_TYPE,
+  title: 'Project rule triggered',
+  message: `${rule.name} triggered for ${projectName}`,
+  data: {
+    projectId: rule.projectId,
+    projectName,
+    ruleId: rule.id,
+    ruleName: rule.name,
+  },
+});
+
+const evaluateRuleConditions = (
+  rule: projectRulesRepo.ProjectRule,
+  metrics: projectMetricsRepo.ProjectRuleMetrics,
+) => {
+  const conditions =
+    rule.conditions.length > 0
+      ? rule.conditions
+      : [
+          {
+            field: rule.field,
+            operator: rule.operator,
+            value: rule.value,
+            valueType: 'literal' as const,
+          },
+        ];
+  const evaluate = (condition: projectRulesRepo.ProjectRuleCondition) => {
+    const expectedActualValue =
+      condition.valueType === 'field'
+        ? projectMetricsRepo.metricValueForField(metrics, condition.value)
+        : undefined;
+    return evaluateProjectRuleCondition({
+      field: condition.field,
+      operator: condition.operator,
+      expectedValue: condition.value,
+      expectedValueType: condition.valueType,
+      actualValue: projectMetricsRepo.metricValueForField(metrics, condition.field),
+      expectedActualValue,
+    });
+  };
+
+  return rule.conditionLogic === 'or' ? conditions.some(evaluate) : conditions.every(evaluate);
+};
+
+export const evaluateProjectRulesOnce = async ({
+  now = new Date(),
+  logger,
+  exec = db,
+}: EvaluateProjectRulesOptions = {}): Promise<ProjectRulesEvaluationResult> => {
+  const rules = await projectRulesRepo.listEnabled(exec);
+  const metricsByProjectId = await projectMetricsRepo.listForProjects(
+    rules.map((rule) => rule.projectId),
+    now,
+    exec,
+  );
+
+  const result: ProjectRulesEvaluationResult = {
+    evaluated: 0,
+    triggered: 0,
+    reset: 0,
+    notified: 0,
+  };
+
+  for (const rule of rules) {
+    result.evaluated += 1;
+    try {
+      const metrics = metricsByProjectId.get(rule.projectId);
+      const conditionMet = metrics !== undefined && evaluateRuleConditions(rule, metrics);
+
+      if (!conditionMet) {
+        if (await projectRulesRepo.markConditionNotMet(rule.id, exec)) {
+          result.reset += 1;
+        }
+        continue;
+      }
+
+      if (!metrics) continue;
+
+      await runAtomically(exec, async (tx) => {
+        const acquired = await projectRulesRepo.markTriggeredOnRisingEdge(rule.id, now, tx);
+        if (!acquired) return;
+
+        const recipientUserIds = await projectRuleRecipientsRepo.resolveRecipientUserIds(
+          rule.projectId,
+          rule.actionConfig,
+          tx,
+        );
+        const notified = await notificationsRepo.createForUsers(
+          recipientUserIds,
+          buildNotification(rule, metrics.projectName),
+          tx,
+        );
+        result.triggered += 1;
+        result.notified += notified;
+      });
+    } catch (err) {
+      logger?.error(
+        { err: serializeError(err), ruleId: rule.id, projectId: rule.projectId },
+        'Project rule evaluation failed',
+      );
+    }
+  }
+
+  return result;
+};

--- a/server/services/projectRulesScheduler.ts
+++ b/server/services/projectRulesScheduler.ts
@@ -7,6 +7,8 @@ export const PROJECT_RULES_SCHEDULER_INTERVAL_MS = 15 * 60 * 1000;
 export interface ProjectRulesSchedulerOptions {
   logger: Logger;
   intervalMs?: number;
+  // Injectable for testing; defaults to the real evaluator.
+  evaluate?: typeof evaluateProjectRulesOnce;
 }
 
 export interface ProjectRulesSchedulerHandle {
@@ -16,6 +18,7 @@ export interface ProjectRulesSchedulerHandle {
 export const startProjectRulesScheduler = ({
   logger,
   intervalMs = PROJECT_RULES_SCHEDULER_INTERVAL_MS,
+  evaluate = evaluateProjectRulesOnce,
 }: ProjectRulesSchedulerOptions): ProjectRulesSchedulerHandle => {
   let stopped = false;
   let inFlight = false;
@@ -24,7 +27,7 @@ export const startProjectRulesScheduler = ({
     if (inFlight) return;
     inFlight = true;
     try {
-      await evaluateProjectRulesOnce({ logger });
+      await evaluate({ logger });
     } catch (err) {
       if (!stopped) {
         logger.error({ err: serializeError(err) }, 'Project rules scheduler error');

--- a/server/services/projectRulesScheduler.ts
+++ b/server/services/projectRulesScheduler.ts
@@ -1,0 +1,45 @@
+import type { Logger } from 'pino';
+import { serializeError } from '../utils/logger.ts';
+import { evaluateProjectRulesOnce } from './projectRulesEvaluator.ts';
+
+export const PROJECT_RULES_SCHEDULER_INTERVAL_MS = 15 * 60 * 1000;
+
+export interface ProjectRulesSchedulerOptions {
+  logger: Logger;
+  intervalMs?: number;
+}
+
+export interface ProjectRulesSchedulerHandle {
+  stop(): void;
+}
+
+export const startProjectRulesScheduler = ({
+  logger,
+  intervalMs = PROJECT_RULES_SCHEDULER_INTERVAL_MS,
+}: ProjectRulesSchedulerOptions): ProjectRulesSchedulerHandle => {
+  let stopped = false;
+  let inFlight = false;
+
+  const handle = setInterval(async () => {
+    if (inFlight) return;
+    inFlight = true;
+    try {
+      await evaluateProjectRulesOnce({ logger });
+    } catch (err) {
+      if (!stopped) {
+        logger.error({ err: serializeError(err) }, 'Project rules scheduler error');
+      }
+    } finally {
+      inFlight = false;
+    }
+  }, intervalMs);
+
+  handle.unref?.();
+
+  return {
+    stop() {
+      stopped = true;
+      clearInterval(handle);
+    },
+  };
+};

--- a/server/test/db/migration0063AddProjectRules.test.ts
+++ b/server/test/db/migration0063AddProjectRules.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'bun:test';
+import { readMigrationFile } from '../helpers/schemaFiles.ts';
+
+describe('migration 0063: add project_rules', () => {
+  const MIGRATION = readMigrationFile('0063_add_project_rules.sql');
+
+  test('creates the project_rules table with core condition/action columns', () => {
+    expect(MIGRATION).toContain('CREATE TABLE "project_rules"');
+    for (const column of [
+      '"project_id"',
+      '"field"',
+      '"operator"',
+      '"value"',
+      '"action_type"',
+      '"action_config"',
+      '"condition_met"',
+      '"last_triggered_at"',
+    ]) {
+      expect(MIGRATION).toContain(column);
+    }
+  });
+
+  test('uses non-null JSONB action config and project/user foreign keys', () => {
+    expect(MIGRATION).toContain(
+      `"action_config" jsonb DEFAULT '{"recipientUserIds":[],"recipientRoleIds":[]}'::jsonb NOT NULL`,
+    );
+    expect(MIGRATION).toContain('REFERENCES "public"."projects"("id") ON DELETE cascade');
+    expect(MIGRATION).toContain('REFERENCES "public"."users"("id") ON DELETE set null');
+  });
+});

--- a/server/test/db/migration0064GrantProjectRulesPermission.test.ts
+++ b/server/test/db/migration0064GrantProjectRulesPermission.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'bun:test';
+import { readMigrationFile } from '../helpers/schemaFiles.ts';
+
+describe('migration 0064: grants project rule permissions', () => {
+  const MIGRATION = readMigrationFile('0064_grant_projects_rules_permission.sql');
+
+  test('grants CRUD project rule permissions to manager and top_manager roles', () => {
+    for (const role of ['manager', 'top_manager']) {
+      for (const action of ['view', 'create', 'update', 'delete']) {
+        expect(MIGRATION).toContain(`('${role}', 'projects.rules.${action}')`);
+      }
+    }
+  });
+
+  test('uses INSERT...SELECT with role join and ON CONFLICT for fresh-db safety', () => {
+    expect(MIGRATION).toMatch(/INSERT INTO role_permissions \(role_id, permission\)/i);
+    expect(MIGRATION).toMatch(/JOIN roles r ON r\.id = p\.role_id/i);
+    expect(MIGRATION).toMatch(/ON CONFLICT DO NOTHING/i);
+  });
+});

--- a/server/test/db/migration0065AddProjectRuleConditionChains.test.ts
+++ b/server/test/db/migration0065AddProjectRuleConditionChains.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from 'bun:test';
+import { readMigrationFile } from '../helpers/schemaFiles.ts';
+
+describe('migration 0065: add project rule condition chains', () => {
+  const MIGRATION = readMigrationFile('0065_add_project_rule_condition_chains.sql');
+
+  test('adds condition logic and condition list columns', () => {
+    expect(MIGRATION).toContain('"condition_logic" varchar(10) DEFAULT \'and\' NOT NULL');
+    expect(MIGRATION).toContain('"conditions" jsonb DEFAULT \'[]\'::jsonb NOT NULL');
+  });
+});

--- a/server/test/db/readiness.test.ts
+++ b/server/test/db/readiness.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { sql } from 'drizzle-orm';
 import type { DbReadinessProbe } from '../../db/readiness.ts';
-import { verifyDbReadiness } from '../../db/readiness.ts';
+import { schemaReadinessProbes, verifyDbReadiness } from '../../db/readiness.ts';
 import { setupTestDb } from '../helpers/fakeExecutor.ts';
 
 const makeMigrationsDir = (count: number): string => {
@@ -20,6 +20,10 @@ const removeMigrationsDir = (dir: string) => {
 };
 
 describe('verifyDbReadiness', () => {
+  test('default schema probes include project_rules', () => {
+    expect(schemaReadinessProbes.some((probe) => probe.name === 'project_rules')).toBe(true);
+  });
+
   test('succeeds when migrations are complete and probes pass', async () => {
     const { exec, testDb } = setupTestDb();
     const probe: DbReadinessProbe = {

--- a/server/test/repositories/notificationsRepo.test.ts
+++ b/server/test/repositories/notificationsRepo.test.ts
@@ -119,6 +119,36 @@ describe('markAllReadForUser', () => {
   });
 });
 
+describe('createForUsers', () => {
+  test('deduplicates users and inserts unread notifications', async () => {
+    exec.enqueue({ rows: [], rowCount: 1 });
+
+    const result = await notificationsRepo.createForUsers(
+      ['u1', 'u1', 'u2'],
+      {
+        type: 'project_rule_triggered',
+        title: 'Project rule triggered',
+        message: 'Rule triggered',
+        data: { projectId: 'p1', projectName: 'Project', ruleId: 'pr1', ruleName: 'Rule' },
+      },
+      testDb,
+    );
+
+    expect(result).toBe(2);
+    expect(exec.calls[0].sql.toLowerCase()).toContain('insert into "notifications"');
+    expect(exec.calls[0].params).toContain('u1');
+    expect(exec.calls[0].params).toContain('u2');
+    expect(exec.calls[0].params).toContain('project_rule_triggered');
+    expect(exec.calls[0].params).toContain(false);
+  });
+
+  test('skips insert for empty user list', async () => {
+    const result = await notificationsRepo.createForUsers([], { type: 'x', title: 'x' }, testDb);
+    expect(result).toBe(0);
+    expect(exec.calls).toHaveLength(0);
+  });
+});
+
 const LEGACY_ADMIN_WARNING_ID = 'admin-default-password-warning';
 
 describe('admin password warning helpers', () => {

--- a/server/test/repositories/projectMetricsRepo.test.ts
+++ b/server/test/repositories/projectMetricsRepo.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import type { DbExecutor } from '../../db/drizzle.ts';
+import * as projectMetricsRepo from '../../repositories/projectMetricsRepo.ts';
+import { type FakeExecutor, setupTestDb } from '../helpers/fakeExecutor.ts';
+
+let exec: FakeExecutor;
+let testDb: DbExecutor;
+
+beforeEach(() => {
+  ({ exec, testDb } = setupTestDb());
+});
+
+const NOW = new Date('2026-05-31T12:00:00');
+
+describe('projectMetricsRepo.listForProjects', () => {
+  test('derives effective revenue, budget percent, effective billing type, and status', async () => {
+    exec.enqueue({
+      rows: [
+        {
+          projectId: 'p-task',
+          projectName: 'Task revenue project',
+          projectIsDisabled: false,
+          clientIsDisabled: false,
+          endDate: '2026-06-05',
+          manualRevenue: '1000',
+          orderId: 'co-1',
+          taskRevenue: '1200',
+          orderTotal: '900',
+          costToDate: '300',
+          hoursToDate: '12.5',
+          billingType: 'mixed',
+        },
+        {
+          projectId: 'p-manual-disabled',
+          projectName: 'Manual disabled project',
+          projectIsDisabled: false,
+          clientIsDisabled: true,
+          endDate: null,
+          manualRevenue: null,
+          orderId: null,
+          taskRevenue: '0',
+          orderTotal: null,
+          costToDate: '50',
+          hoursToDate: '2',
+          billingType: 'retainer',
+        },
+      ],
+    });
+
+    const result = await projectMetricsRepo.listForProjects(
+      ['p-task', 'p-manual-disabled'],
+      NOW,
+      testDb,
+    );
+
+    expect(result.get('p-task')).toEqual({
+      projectId: 'p-task',
+      projectName: 'Task revenue project',
+      revenue: 1200,
+      costToDate: 300,
+      budgetUsedPct: 25,
+      hoursToDate: 12.5,
+      daysUntilDeadline: 5,
+      billingType: 'mixed',
+      status: 'active',
+    });
+    expect(result.get('p-manual-disabled')).toEqual({
+      projectId: 'p-manual-disabled',
+      projectName: 'Manual disabled project',
+      revenue: null,
+      costToDate: 50,
+      budgetUsedPct: null,
+      hoursToDate: 2,
+      daysUntilDeadline: null,
+      billingType: 'retainer',
+      status: 'disabled',
+    });
+  });
+
+  test('uses linked order total when task revenue is zero and project has an order', async () => {
+    exec.enqueue({
+      rows: [
+        {
+          projectId: 'p-order',
+          projectName: 'Order project',
+          projectIsDisabled: false,
+          clientIsDisabled: false,
+          endDate: null,
+          manualRevenue: '500',
+          orderId: 'co-1',
+          taskRevenue: '0',
+          orderTotal: '800',
+          costToDate: '200',
+          hoursToDate: '1',
+          billingType: 'time_and_materials',
+        },
+      ],
+    });
+
+    const result = await projectMetricsRepo.listForProjects(['p-order'], NOW, testDb);
+
+    expect(result.get('p-order')?.revenue).toBe(800);
+    expect(result.get('p-order')?.budgetUsedPct).toBe(25);
+  });
+
+  test('query encodes the UI semantics for task revenue, linked order total, cost, and billing', async () => {
+    exec.enqueue({ rows: [] });
+    await projectMetricsRepo.listForProjects(['p1'], NOW, testDb);
+    const sql = exec.calls[0].sql.toLowerCase();
+    expect(sql).toContain('from tasks');
+    expect(sql).toContain('sale_items');
+    expect(sql).toContain('round((coalesce(te.duration');
+    expect(sql).toContain("then 'mixed'");
+    expect(sql).toContain('count(distinct bt2.billing_type)');
+  });
+});

--- a/server/test/repositories/projectRuleRecipientsRepo.test.ts
+++ b/server/test/repositories/projectRuleRecipientsRepo.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import type { DbExecutor } from '../../db/drizzle.ts';
+import * as recipientsRepo from '../../repositories/projectRuleRecipientsRepo.ts';
+import { type FakeExecutor, setupTestDb } from '../helpers/fakeExecutor.ts';
+
+let exec: FakeExecutor;
+let testDb: DbExecutor;
+
+beforeEach(() => {
+  ({ exec, testDb } = setupTestDb());
+});
+
+describe('projectRuleRecipientsRepo', () => {
+  test('lists enabled project-assigned users and role summaries', async () => {
+    exec.enqueue({
+      rows: [{ id: 'u1', name: 'Alice', username: 'alice', avatarInitials: 'AL' }],
+    });
+    exec.enqueue({ rows: [{ id: 'manager', name: 'Manager' }] });
+
+    const result = await recipientsRepo.listRecipientOptions('p1', testDb);
+
+    expect(result).toEqual({
+      users: [{ id: 'u1', name: 'Alice', username: 'alice', avatarInitials: 'AL' }],
+      roles: [{ id: 'manager', name: 'Manager' }],
+    });
+    expect(exec.calls[0].sql).toContain('INNER JOIN user_projects');
+    expect(exec.calls[0].sql).toContain('COALESCE(u.is_disabled, false) = false');
+  });
+
+  test('finds invalid explicit users and roles', async () => {
+    exec.enqueue({ rows: [{ id: 'u1' }] });
+    exec.enqueue({ rows: [{ id: 'manager' }] });
+
+    const result = await recipientsRepo.findInvalidRecipientIds(
+      'p1',
+      { recipientUserIds: ['u1', 'u2'], recipientRoleIds: ['manager', 'ghost'] },
+      testDb,
+    );
+
+    expect(result).toEqual({ userIds: ['u2'], roleIds: ['ghost'] });
+  });
+
+  test('resolves explicit project users plus primary and secondary role users', async () => {
+    exec.enqueue({ rows: [{ id: 'u1' }, { id: 'u2' }] });
+
+    const result = await recipientsRepo.resolveRecipientUserIds(
+      'p1',
+      { recipientUserIds: ['u1'], recipientRoleIds: ['manager'] },
+      testDb,
+    );
+
+    expect(result).toEqual(['u1', 'u2']);
+    expect(exec.calls[0].sql).toContain('LEFT JOIN user_roles');
+    expect(exec.calls[0].sql).toContain('u.role = ANY');
+    expect(exec.calls[0].sql).toContain('ur.role_id = ANY');
+  });
+});

--- a/server/test/repositories/projectRulesRepo.test.ts
+++ b/server/test/repositories/projectRulesRepo.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import type { DbExecutor } from '../../db/drizzle.ts';
+import * as projectRulesRepo from '../../repositories/projectRulesRepo.ts';
+import { type FakeExecutor, makeRow, setupTestDb } from '../helpers/fakeExecutor.ts';
+
+let exec: FakeExecutor;
+let testDb: DbExecutor;
+
+beforeEach(() => {
+  ({ exec, testDb } = setupTestDb());
+});
+
+const createdAt = new Date(1700000000000);
+const updatedAt = new Date(1700000100000);
+const lastTriggeredAt = new Date(1700000050000);
+
+const ruleRow = (overrides: Record<number, unknown> = {}) =>
+  makeRow(
+    [
+      'pr-1',
+      'p1',
+      'Budget warning',
+      'budget_used_pct',
+      'gte',
+      '80',
+      'and',
+      [{ field: 'budget_used_pct', operator: 'gte', value: '80', valueType: 'literal' }],
+      'notify',
+      { recipientUserIds: ['u1'], recipientRoleIds: ['manager'] },
+      true,
+      false,
+      lastTriggeredAt,
+      'u-admin',
+      createdAt,
+      updatedAt,
+    ],
+    overrides,
+  );
+
+describe('projectRulesRepo', () => {
+  test('listByProject maps rule rows to API shape', async () => {
+    exec.enqueue({ rows: [ruleRow()] });
+
+    const result = await projectRulesRepo.listByProject('p1', testDb);
+
+    expect(result).toEqual([
+      {
+        id: 'pr-1',
+        projectId: 'p1',
+        name: 'Budget warning',
+        field: 'budget_used_pct',
+        operator: 'gte',
+        value: '80',
+        conditionLogic: 'and',
+        conditions: [
+          { field: 'budget_used_pct', operator: 'gte', value: '80', valueType: 'literal' },
+        ],
+        actionType: 'notify',
+        actionConfig: { recipientUserIds: ['u1'], recipientRoleIds: ['manager'] },
+        isEnabled: true,
+        conditionMet: false,
+        lastTriggeredAt: 1700000050000,
+        createdBy: 'u-admin',
+        createdAt: 1700000000000,
+        updatedAt: 1700000100000,
+      },
+    ]);
+  });
+
+  test('create normalizes recipient config before insert', async () => {
+    exec.enqueue({ rows: [ruleRow()] });
+
+    await projectRulesRepo.create(
+      {
+        id: 'pr-1',
+        projectId: 'p1',
+        name: 'Budget warning',
+        field: 'budget_used_pct',
+        operator: 'gte',
+        value: '80',
+        conditionLogic: 'and',
+        conditions: [
+          { field: 'budget_used_pct', operator: 'gte', value: '80', valueType: 'literal' },
+          { field: 'status', operator: 'eq', value: 'active', valueType: 'literal' },
+        ],
+        actionType: 'notify',
+        actionConfig: {
+          recipientUserIds: [' u1 ', 'u1', ''],
+          recipientRoleIds: [' manager ', 'manager', ''],
+        },
+        isEnabled: true,
+        createdBy: 'u-admin',
+      },
+      testDb,
+    );
+
+    expect(exec.calls[0].params).toContain(
+      JSON.stringify({
+        recipientUserIds: ['u1'],
+        recipientRoleIds: ['manager'],
+      }),
+    );
+  });
+
+  test('update scopes by project and rule id, and can reset condition state', async () => {
+    exec.enqueue({ rows: [ruleRow({ 2: 'Updated warning', 11: false, 12: null })] });
+
+    const result = await projectRulesRepo.update(
+      'p1',
+      'pr-1',
+      {
+        name: 'Updated warning',
+        resetCondition: true,
+      },
+      testDb,
+    );
+
+    expect(result?.name).toBe('Updated warning');
+    expect(result?.conditionMet).toBe(false);
+    expect(result?.lastTriggeredAt).toBeNull();
+    expect(exec.calls[0].sql).toContain('"project_id" = $');
+    expect(exec.calls[0].sql).toContain('"id" = $');
+    expect(exec.calls[0].params).toContain('p1');
+    expect(exec.calls[0].params).toContain('pr-1');
+    expect(exec.calls[0].params).toContain(false);
+  });
+
+  test('deleteByProjectAndId deletes only the rule owned by the project', async () => {
+    exec.enqueue({ rows: [], rowCount: 1 });
+
+    const result = await projectRulesRepo.deleteByProjectAndId('p1', 'pr-1', testDb);
+
+    expect(result).toBe(true);
+    expect(exec.calls[0].sql).toContain('"project_id" = $');
+    expect(exec.calls[0].sql).toContain('"id" = $');
+    expect(exec.calls[0].params).toContain('p1');
+    expect(exec.calls[0].params).toContain('pr-1');
+  });
+
+  test('markTriggeredOnRisingEdge guards on condition_met=false', async () => {
+    exec.enqueue({ rows: [['pr-1']] });
+
+    const result = await projectRulesRepo.markTriggeredOnRisingEdge(
+      'pr-1',
+      new Date('2026-05-31T12:00:00'),
+      testDb,
+    );
+
+    expect(result).toBe(true);
+    expect(exec.calls[0].sql).toContain('"condition_met" = $');
+    expect(exec.calls[0].params).toContain(false);
+  });
+
+  test('markConditionNotMet only resets previously met rules', async () => {
+    exec.enqueue({ rows: [], rowCount: 1 });
+
+    const result = await projectRulesRepo.markConditionNotMet('pr-1', testDb);
+
+    expect(result).toBe(true);
+    expect(exec.calls[0].params).toContain(true);
+  });
+});

--- a/server/test/routes/project-rules.test.ts
+++ b/server/test/routes/project-rules.test.ts
@@ -349,6 +349,25 @@ describe('project rule routes', () => {
     expect(createRuleMock).not.toHaveBeenCalled();
   });
 
+  test('POST rejects an empty conditions array', async () => {
+    currentPermissions = ['projects.rules.create'];
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/projects/p1/rules',
+      headers: authHeaders(),
+      payload: {
+        name: 'No conditions',
+        conditions: [],
+        actionConfig: { recipientUserIds: ['u2'], recipientRoleIds: [] },
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toBe('At least one condition is required');
+    expect(createRuleMock).not.toHaveBeenCalled();
+  });
+
   test('POST rejects invalid recipients', async () => {
     currentPermissions = ['projects.rules.create'];
     findInvalidRecipientIdsMock.mockResolvedValue({ userIds: ['u-missing'], roleIds: [] });

--- a/server/test/routes/project-rules.test.ts
+++ b/server/test/routes/project-rules.test.ts
@@ -1,0 +1,483 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { FastifyInstance, FastifyPluginAsync } from 'fastify';
+import * as realDrizzle from '../../db/drizzle.ts';
+import * as realProjectRuleRecipientsRepo from '../../repositories/projectRuleRecipientsRepo.ts';
+import * as realProjectRulesRepo from '../../repositories/projectRulesRepo.ts';
+import * as realProjectsRepo from '../../repositories/projectsRepo.ts';
+import * as realRolesRepo from '../../repositories/rolesRepo.ts';
+import * as realUserAssignmentsRepo from '../../repositories/userAssignmentsRepo.ts';
+import * as realUsersRepo from '../../repositories/usersRepo.ts';
+import * as realAudit from '../../utils/audit.ts';
+import * as realPermissions from '../../utils/permissions.ts';
+import {
+  installAuthMiddlewareMock,
+  restoreAuthMiddlewareMock,
+} from '../helpers/authMiddlewareMock.ts';
+import { buildRouteTestApp } from '../helpers/buildRouteTestApp.ts';
+import { signToken } from '../helpers/jwt.ts';
+import { TX_SENTINEL } from '../helpers/txSentinel.ts';
+import { makeWithDbTransactionMock } from '../helpers/withDbTransactionMock.ts';
+
+const usersRepoSnap = { ...realUsersRepo };
+const rolesRepoSnap = { ...realRolesRepo };
+const permissionsSnap = { ...realPermissions };
+const projectRulesRepoSnap = { ...realProjectRulesRepo };
+const recipientsRepoSnap = { ...realProjectRuleRecipientsRepo };
+const projectsRepoSnap = { ...realProjectsRepo };
+const userAssignmentsRepoSnap = { ...realUserAssignmentsRepo };
+const auditSnap = { ...realAudit };
+const drizzleSnap = { ...realDrizzle };
+
+const findAuthUserByIdMock = mock();
+const userHasRoleMock = mock();
+const getRolePermissionsMock = mock();
+const listRulesMock = mock();
+const createRuleMock = mock();
+const updateRuleMock = mock();
+const findRuleMock = mock();
+const deleteRuleMock = mock();
+const listRecipientOptionsMock = mock();
+const findInvalidRecipientIdsMock = mock();
+const findProjectNameMock = mock();
+const isProjectAssignedToUserMock = mock();
+const logAuditMock = mock(async () => undefined);
+const { withDbTransactionMock, resetWithDbTransactionMock } = makeWithDbTransactionMock();
+
+let routePlugin: FastifyPluginAsync;
+let app: FastifyInstance;
+let currentPermissions: string[];
+
+const USER = {
+  id: 'u1',
+  name: 'Manager',
+  username: 'manager',
+  role: 'manager',
+  avatarInitials: 'MG',
+  isDisabled: false,
+  sessionVersion: 1,
+  tokenVersion: 1,
+};
+
+const authHeaders = () => ({ authorization: `Bearer ${signToken({ userId: USER.id })}` });
+
+const SAMPLE_RULE = {
+  id: 'pr-1',
+  projectId: 'p1',
+  name: 'Budget warning',
+  field: 'budget_used_pct',
+  operator: 'gte',
+  value: '80',
+  conditionLogic: 'and' as const,
+  conditions: [{ field: 'budget_used_pct', operator: 'gte', value: '80', valueType: 'literal' }],
+  actionType: 'notify',
+  actionConfig: { recipientUserIds: ['u2'], recipientRoleIds: ['manager'] },
+  isEnabled: true,
+  conditionMet: false,
+  lastTriggeredAt: null,
+  createdBy: 'u1',
+  createdAt: 1700000000000,
+  updatedAt: 1700000000000,
+};
+
+beforeAll(async () => {
+  installAuthMiddlewareMock();
+
+  mock.module('../../repositories/usersRepo.ts', () => ({
+    ...usersRepoSnap,
+    findAuthUserById: findAuthUserByIdMock,
+  }));
+  mock.module('../../repositories/rolesRepo.ts', () => ({
+    ...rolesRepoSnap,
+    userHasRole: userHasRoleMock,
+  }));
+  mock.module('../../utils/permissions.ts', () => ({
+    ...permissionsSnap,
+    getRolePermissions: getRolePermissionsMock,
+  }));
+  mock.module('../../repositories/projectRulesRepo.ts', () => ({
+    ...projectRulesRepoSnap,
+    listByProject: listRulesMock,
+    create: createRuleMock,
+    update: updateRuleMock,
+    findByProjectAndId: findRuleMock,
+    deleteByProjectAndId: deleteRuleMock,
+    normalizeProjectRuleActionConfig: projectRulesRepoSnap.normalizeProjectRuleActionConfig,
+  }));
+  mock.module('../../repositories/projectRuleRecipientsRepo.ts', () => ({
+    ...recipientsRepoSnap,
+    listRecipientOptions: listRecipientOptionsMock,
+    findInvalidRecipientIds: findInvalidRecipientIdsMock,
+  }));
+  mock.module('../../repositories/projectsRepo.ts', () => ({
+    ...projectsRepoSnap,
+    findClientIdAndName: findProjectNameMock,
+  }));
+  mock.module('../../repositories/userAssignmentsRepo.ts', () => ({
+    ...userAssignmentsRepoSnap,
+    isProjectAssignedToUser: isProjectAssignedToUserMock,
+  }));
+  mock.module('../../utils/audit.ts', () => ({
+    ...auditSnap,
+    logAudit: logAuditMock,
+  }));
+  mock.module('../../db/drizzle.ts', () => ({
+    ...drizzleSnap,
+    withDbTransaction: withDbTransactionMock,
+  }));
+
+  routePlugin = (await import('../../routes/project-rules.ts')).default;
+});
+
+afterAll(() => {
+  restoreAuthMiddlewareMock();
+  mock.module('../../repositories/usersRepo.ts', () => usersRepoSnap);
+  mock.module('../../repositories/rolesRepo.ts', () => rolesRepoSnap);
+  mock.module('../../utils/permissions.ts', () => permissionsSnap);
+  mock.module('../../repositories/projectRulesRepo.ts', () => projectRulesRepoSnap);
+  mock.module('../../repositories/projectRuleRecipientsRepo.ts', () => recipientsRepoSnap);
+  mock.module('../../repositories/projectsRepo.ts', () => projectsRepoSnap);
+  mock.module('../../repositories/userAssignmentsRepo.ts', () => userAssignmentsRepoSnap);
+  mock.module('../../utils/audit.ts', () => auditSnap);
+  mock.module('../../db/drizzle.ts', () => drizzleSnap);
+});
+
+beforeEach(async () => {
+  for (const fn of [
+    findAuthUserByIdMock,
+    userHasRoleMock,
+    getRolePermissionsMock,
+    listRulesMock,
+    createRuleMock,
+    updateRuleMock,
+    findRuleMock,
+    deleteRuleMock,
+    listRecipientOptionsMock,
+    findInvalidRecipientIdsMock,
+    findProjectNameMock,
+    isProjectAssignedToUserMock,
+    logAuditMock,
+    withDbTransactionMock,
+  ]) {
+    fn.mockReset();
+  }
+  resetWithDbTransactionMock();
+  currentPermissions = ['projects.rules.view'];
+  findAuthUserByIdMock.mockResolvedValue(USER);
+  userHasRoleMock.mockResolvedValue(true);
+  getRolePermissionsMock.mockImplementation(async () => currentPermissions);
+  isProjectAssignedToUserMock.mockResolvedValue(true);
+  findInvalidRecipientIdsMock.mockResolvedValue({ userIds: [], roleIds: [] });
+  findProjectNameMock.mockResolvedValue({ clientId: 'c1', name: 'Project' });
+  app = await buildRouteTestApp(routePlugin, '/api/projects');
+});
+
+afterEach(async () => {
+  await app.close();
+});
+
+describe('project rule routes', () => {
+  test('403 without projects.rules.view', async () => {
+    currentPermissions = [];
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/projects/p1/rules',
+      headers: authHeaders(),
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(listRulesMock).not.toHaveBeenCalled();
+  });
+
+  test('403 when the user lacks project assignment and manage_all.view', async () => {
+    currentPermissions = ['projects.rules.view'];
+    isProjectAssignedToUserMock.mockResolvedValue(false);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/projects/p1/rules',
+      headers: authHeaders(),
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(listRulesMock).not.toHaveBeenCalled();
+  });
+
+  test('GET recipients returns user and role options', async () => {
+    listRecipientOptionsMock.mockResolvedValue({
+      users: [{ id: 'u2', name: 'Alice', username: 'alice', avatarInitials: 'AL' }],
+      roles: [{ id: 'manager', name: 'Manager' }],
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/projects/p1/rules/recipients',
+      headers: authHeaders(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).users[0].id).toBe('u2');
+    expect(listRecipientOptionsMock).toHaveBeenCalledWith('p1');
+  });
+
+  test('POST rejects cost-derived fields without reports.cost.view', async () => {
+    currentPermissions = ['projects.rules.create'];
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/projects/p1/rules',
+      headers: authHeaders(),
+      payload: {
+        name: 'Budget',
+        field: 'budget_used_pct',
+        operator: 'gte',
+        value: '80',
+        actionConfig: { recipientUserIds: [], recipientRoleIds: ['manager'] },
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toContain('requires reports.cost.view');
+    expect(createRuleMock).not.toHaveBeenCalled();
+  });
+
+  test('POST rejects cost-derived target fields without reports.cost.view', async () => {
+    currentPermissions = ['projects.rules.create'];
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/projects/p1/rules',
+      headers: authHeaders(),
+      payload: {
+        name: 'Revenue vs cost',
+        conditions: [
+          { field: 'revenue', operator: 'gt', value: 'cost_to_date', valueType: 'field' },
+        ],
+        actionConfig: { recipientUserIds: ['u2'], recipientRoleIds: [] },
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toContain('cost_to_date requires reports.cost.view');
+    expect(createRuleMock).not.toHaveBeenCalled();
+  });
+
+  test('POST creates a rule and writes an audit log', async () => {
+    currentPermissions = ['projects.rules.create'];
+    const createdRule = {
+      ...SAMPLE_RULE,
+      field: 'revenue',
+      operator: 'gte',
+      value: '1000',
+      conditions: [
+        { field: 'revenue', operator: 'gte', value: '1000', valueType: 'literal' },
+        { field: 'revenue', operator: 'gt', value: 'hours_to_date', valueType: 'field' },
+      ],
+      actionConfig: { recipientUserIds: ['u2'], recipientRoleIds: [] },
+    };
+    createRuleMock.mockResolvedValue(createdRule);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/projects/p1/rules',
+      headers: authHeaders(),
+      payload: {
+        name: 'Revenue',
+        conditionLogic: 'and',
+        conditions: [
+          { field: 'revenue', operator: 'gte', value: '1000', valueType: 'literal' },
+          { field: 'revenue', operator: 'gt', value: 'hours_to_date', valueType: 'field' },
+        ],
+        actionConfig: { recipientUserIds: ['u2'], recipientRoleIds: [] },
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(JSON.parse(res.body)).toEqual(createdRule);
+    expect(createRuleMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: expect.stringMatching(/^pr-/),
+        projectId: 'p1',
+        createdBy: USER.id,
+        name: 'Revenue',
+        conditionLogic: 'and',
+        conditions: [
+          { field: 'revenue', operator: 'gte', value: '1000', valueType: 'literal' },
+          { field: 'revenue', operator: 'gt', value: 'hours_to_date', valueType: 'field' },
+        ],
+        actionType: 'notify',
+      }),
+      TX_SENTINEL,
+    );
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'project_rule.created', entityType: 'project_rule' }),
+    );
+  });
+
+  test('POST rejects unsupported fields and operators', async () => {
+    currentPermissions = ['projects.rules.create'];
+
+    const badField = await app.inject({
+      method: 'POST',
+      url: '/api/projects/p1/rules',
+      headers: authHeaders(),
+      payload: {
+        name: 'Bad field',
+        field: 'unknown_metric',
+        operator: 'gte',
+        value: '1000',
+        actionConfig: { recipientUserIds: ['u2'], recipientRoleIds: [] },
+      },
+    });
+    expect(badField.statusCode).toBe(400);
+    expect(JSON.parse(badField.body).error).toBe('field must be a supported project rule field');
+
+    const badOperator = await app.inject({
+      method: 'POST',
+      url: '/api/projects/p1/rules',
+      headers: authHeaders(),
+      payload: {
+        name: 'Bad operator',
+        field: 'status',
+        operator: 'gte',
+        value: 'active',
+        actionConfig: { recipientUserIds: ['u2'], recipientRoleIds: [] },
+      },
+    });
+    expect(badOperator.statusCode).toBe(400);
+    expect(JSON.parse(badOperator.body).error).toBe('operator is not valid for field');
+    expect(createRuleMock).not.toHaveBeenCalled();
+  });
+
+  test('POST rejects invalid recipients', async () => {
+    currentPermissions = ['projects.rules.create'];
+    findInvalidRecipientIdsMock.mockResolvedValue({ userIds: ['u-missing'], roleIds: [] });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/projects/p1/rules',
+      headers: authHeaders(),
+      payload: {
+        name: 'Revenue',
+        field: 'revenue',
+        operator: 'gte',
+        value: '1000',
+        actionConfig: { recipientUserIds: ['u-missing'], recipientRoleIds: [] },
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toBe('actionConfig contains invalid recipients');
+    expect(createRuleMock).not.toHaveBeenCalled();
+  });
+
+  test('PUT enforces rule ownership under the project', async () => {
+    currentPermissions = ['projects.rules.update'];
+    findRuleMock.mockResolvedValue(null);
+
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/projects/p1/rules/pr-missing',
+      headers: authHeaders(),
+      payload: { isEnabled: false },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(updateRuleMock).not.toHaveBeenCalled();
+  });
+
+  test('PUT rejects an empty update payload', async () => {
+    currentPermissions = ['projects.rules.update'];
+
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/projects/p1/rules/pr-1',
+      headers: authHeaders(),
+      payload: {},
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toBe('At least one rule field is required');
+    expect(findRuleMock).not.toHaveBeenCalled();
+    expect(updateRuleMock).not.toHaveBeenCalled();
+  });
+
+  test('PUT resets condition state when condition fields change', async () => {
+    currentPermissions = ['projects.rules.update'];
+    const existingRule = {
+      ...SAMPLE_RULE,
+      field: 'revenue',
+      value: '1000',
+      conditions: [{ field: 'revenue', operator: 'gte', value: '1000', valueType: 'literal' }],
+      conditionMet: true,
+    };
+    findRuleMock.mockResolvedValue(existingRule);
+    updateRuleMock.mockResolvedValue({
+      ...existingRule,
+      value: '2000',
+      conditions: [{ field: 'revenue', operator: 'gte', value: '2000', valueType: 'literal' }],
+      conditionMet: false,
+    });
+
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/projects/p1/rules/pr-1',
+      headers: authHeaders(),
+      payload: { value: '2000' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(updateRuleMock).toHaveBeenCalledWith(
+      'p1',
+      'pr-1',
+      expect.objectContaining({
+        value: '2000',
+        conditions: [{ field: 'revenue', operator: 'gte', value: '2000', valueType: 'literal' }],
+        resetCondition: true,
+      }),
+      TX_SENTINEL,
+    );
+  });
+
+  test('PUT resets condition state when a disabled rule is re-enabled', async () => {
+    currentPermissions = ['projects.rules.update', 'reports.cost.view'];
+    findRuleMock.mockResolvedValue({ ...SAMPLE_RULE, isEnabled: false, conditionMet: true });
+    updateRuleMock.mockResolvedValue({ ...SAMPLE_RULE, isEnabled: true, conditionMet: false });
+
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/projects/p1/rules/pr-1',
+      headers: authHeaders(),
+      payload: { isEnabled: true },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(updateRuleMock).toHaveBeenCalledWith(
+      'p1',
+      'pr-1',
+      expect.objectContaining({ isEnabled: true, resetCondition: true }),
+      TX_SENTINEL,
+    );
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'project_rule.enabled' }),
+    );
+  });
+
+  test('DELETE checks ownership and writes an audit log', async () => {
+    currentPermissions = ['projects.rules.delete'];
+    findRuleMock.mockResolvedValue(SAMPLE_RULE);
+    deleteRuleMock.mockResolvedValue(true);
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/api/projects/p1/rules/pr-1',
+      headers: authHeaders(),
+    });
+
+    expect(res.statusCode).toBe(204);
+    expect(deleteRuleMock).toHaveBeenCalledWith('p1', 'pr-1', TX_SENTINEL);
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'project_rule.deleted', entityType: 'project_rule' }),
+    );
+  });
+});

--- a/server/test/services/projectRulesEvaluator.test.ts
+++ b/server/test/services/projectRulesEvaluator.test.ts
@@ -1,0 +1,216 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as realDrizzle from '../../db/drizzle.ts';
+import * as realNotificationsRepo from '../../repositories/notificationsRepo.ts';
+import * as realProjectMetricsRepo from '../../repositories/projectMetricsRepo.ts';
+import * as realRecipientsRepo from '../../repositories/projectRuleRecipientsRepo.ts';
+import * as realProjectRulesRepo from '../../repositories/projectRulesRepo.ts';
+import { TX_SENTINEL } from '../helpers/txSentinel.ts';
+
+const drizzleSnap = { ...realDrizzle };
+const rulesRepoSnap = { ...realProjectRulesRepo };
+const metricsRepoSnap = { ...realProjectMetricsRepo };
+const recipientsRepoSnap = { ...realRecipientsRepo };
+const notificationsRepoSnap = { ...realNotificationsRepo };
+
+const listEnabledMock = mock();
+const listMetricsMock = mock();
+const markConditionNotMetMock = mock();
+const markTriggeredMock = mock();
+const resolveRecipientsMock = mock();
+const createForUsersMock = mock();
+const runAtomicallyMock = mock(async (_exec: unknown, cb: (tx: unknown) => unknown) =>
+  cb(TX_SENTINEL),
+);
+
+let evaluateProjectRulesOnce: typeof import('../../services/projectRulesEvaluator.ts').evaluateProjectRulesOnce;
+
+const RULE = {
+  id: 'pr-1',
+  projectId: 'p1',
+  name: 'Budget warning',
+  field: 'budget_used_pct',
+  operator: 'gte',
+  value: '80',
+  conditionLogic: 'and' as const,
+  conditions: [{ field: 'budget_used_pct', operator: 'gte', value: '80', valueType: 'literal' }],
+  actionType: 'notify',
+  actionConfig: { recipientUserIds: ['u1'], recipientRoleIds: ['manager'] },
+  isEnabled: true,
+  conditionMet: false,
+  lastTriggeredAt: null,
+  createdBy: 'u-admin',
+  createdAt: 1700000000000,
+  updatedAt: 1700000000000,
+};
+
+const METRICS = {
+  projectId: 'p1',
+  projectName: 'Project',
+  revenue: 1000,
+  costToDate: 900,
+  budgetUsedPct: 90,
+  hoursToDate: 10,
+  daysUntilDeadline: 5,
+  billingType: 'retainer' as const,
+  status: 'active' as const,
+};
+
+beforeAll(async () => {
+  mock.module('../../db/drizzle.ts', () => ({
+    ...drizzleSnap,
+    db: TX_SENTINEL,
+    runAtomically: runAtomicallyMock,
+  }));
+  mock.module('../../repositories/projectRulesRepo.ts', () => ({
+    ...rulesRepoSnap,
+    listEnabled: listEnabledMock,
+    markConditionNotMet: markConditionNotMetMock,
+    markTriggeredOnRisingEdge: markTriggeredMock,
+  }));
+  mock.module('../../repositories/projectMetricsRepo.ts', () => ({
+    ...metricsRepoSnap,
+    listForProjects: listMetricsMock,
+    metricValueForField: metricsRepoSnap.metricValueForField,
+  }));
+  mock.module('../../repositories/projectRuleRecipientsRepo.ts', () => ({
+    ...recipientsRepoSnap,
+    resolveRecipientUserIds: resolveRecipientsMock,
+  }));
+  mock.module('../../repositories/notificationsRepo.ts', () => ({
+    ...notificationsRepoSnap,
+    createForUsers: createForUsersMock,
+  }));
+
+  ({ evaluateProjectRulesOnce } = await import('../../services/projectRulesEvaluator.ts'));
+});
+
+afterAll(() => {
+  mock.module('../../db/drizzle.ts', () => drizzleSnap);
+  mock.module('../../repositories/projectRulesRepo.ts', () => rulesRepoSnap);
+  mock.module('../../repositories/projectMetricsRepo.ts', () => metricsRepoSnap);
+  mock.module('../../repositories/projectRuleRecipientsRepo.ts', () => recipientsRepoSnap);
+  mock.module('../../repositories/notificationsRepo.ts', () => notificationsRepoSnap);
+});
+
+beforeEach(() => {
+  for (const fn of [
+    listEnabledMock,
+    listMetricsMock,
+    markConditionNotMetMock,
+    markTriggeredMock,
+    resolveRecipientsMock,
+    createForUsersMock,
+    runAtomicallyMock,
+  ]) {
+    fn.mockReset();
+  }
+  runAtomicallyMock.mockImplementation(async (_exec, cb) => cb(TX_SENTINEL));
+  listEnabledMock.mockResolvedValue([RULE]);
+  listMetricsMock.mockResolvedValue(new Map([['p1', METRICS]]));
+  markConditionNotMetMock.mockResolvedValue(false);
+  markTriggeredMock.mockResolvedValue(true);
+  resolveRecipientsMock.mockResolvedValue(['u1', 'u2']);
+  createForUsersMock.mockResolvedValue(2);
+});
+
+describe('evaluateProjectRulesOnce', () => {
+  test('creates notifications only on the rising edge', async () => {
+    const now = new Date('2026-05-31T12:00:00');
+
+    const result = await evaluateProjectRulesOnce({ now, exec: TX_SENTINEL as never });
+
+    expect(result).toEqual({ evaluated: 1, triggered: 1, reset: 0, notified: 2 });
+    expect(markTriggeredMock).toHaveBeenCalledWith('pr-1', now, TX_SENTINEL);
+    expect(resolveRecipientsMock).toHaveBeenCalledWith('p1', RULE.actionConfig, TX_SENTINEL);
+    expect(createForUsersMock).toHaveBeenCalledWith(
+      ['u1', 'u2'],
+      expect.objectContaining({
+        type: 'project_rule_triggered',
+        data: {
+          projectId: 'p1',
+          projectName: 'Project',
+          ruleId: 'pr-1',
+          ruleName: 'Budget warning',
+        },
+      }),
+      TX_SENTINEL,
+    );
+  });
+
+  test('does not duplicate notifications while condition is still met', async () => {
+    markTriggeredMock.mockResolvedValue(false);
+
+    const result = await evaluateProjectRulesOnce({ exec: TX_SENTINEL as never });
+
+    expect(result.triggered).toBe(0);
+    expect(createForUsersMock).not.toHaveBeenCalled();
+  });
+
+  test('resets condition state when the condition becomes false', async () => {
+    listMetricsMock.mockResolvedValue(new Map([['p1', { ...METRICS, budgetUsedPct: 25 }]]));
+    markConditionNotMetMock.mockResolvedValue(true);
+
+    const result = await evaluateProjectRulesOnce({ exec: TX_SENTINEL as never });
+
+    expect(result).toEqual({ evaluated: 1, triggered: 0, reset: 1, notified: 0 });
+    expect(markConditionNotMetMock).toHaveBeenCalledWith('pr-1', TX_SENTINEL);
+    expect(markTriggeredMock).not.toHaveBeenCalled();
+  });
+
+  test('treats null metric values as not met', async () => {
+    listMetricsMock.mockResolvedValue(new Map([['p1', { ...METRICS, budgetUsedPct: null }]]));
+
+    await evaluateProjectRulesOnce({ exec: TX_SENTINEL as never });
+
+    expect(markConditionNotMetMock).toHaveBeenCalledWith('pr-1', TX_SENTINEL);
+    expect(createForUsersMock).not.toHaveBeenCalled();
+  });
+
+  test('supports AND and OR condition chains', async () => {
+    listEnabledMock.mockResolvedValue([
+      {
+        ...RULE,
+        id: 'pr-and',
+        conditionLogic: 'and',
+        conditions: [
+          { field: 'budget_used_pct', operator: 'gte', value: '80', valueType: 'literal' },
+          { field: 'status', operator: 'eq', value: 'active', valueType: 'literal' },
+        ],
+      },
+      {
+        ...RULE,
+        id: 'pr-or',
+        conditionLogic: 'or',
+        conditions: [
+          { field: 'budget_used_pct', operator: 'gte', value: '95', valueType: 'literal' },
+          { field: 'status', operator: 'eq', value: 'active', valueType: 'literal' },
+        ],
+      },
+    ]);
+
+    const result = await evaluateProjectRulesOnce({ exec: TX_SENTINEL as never });
+
+    expect(result.triggered).toBe(2);
+    expect(markTriggeredMock).toHaveBeenCalledWith('pr-and', expect.any(Date), TX_SENTINEL);
+    expect(markTriggeredMock).toHaveBeenCalledWith('pr-or', expect.any(Date), TX_SENTINEL);
+  });
+
+  test('supports comparing one field with another field', async () => {
+    listEnabledMock.mockResolvedValue([
+      {
+        ...RULE,
+        field: 'revenue',
+        operator: 'gt',
+        value: 'cost_to_date',
+        conditions: [
+          { field: 'revenue', operator: 'gt', value: 'cost_to_date', valueType: 'field' },
+        ],
+      },
+    ]);
+
+    const result = await evaluateProjectRulesOnce({ exec: TX_SENTINEL as never });
+
+    expect(result.triggered).toBe(1);
+    expect(markTriggeredMock).toHaveBeenCalledWith('pr-1', expect.any(Date), TX_SENTINEL);
+  });
+});

--- a/server/test/services/projectRulesScheduler.test.ts
+++ b/server/test/services/projectRulesScheduler.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, mock, test } from 'bun:test';
+import type { Logger } from 'pino';
+import type {
+  EvaluateProjectRulesOptions,
+  ProjectRulesEvaluationResult,
+} from '../../services/projectRulesEvaluator.ts';
+import { startProjectRulesScheduler } from '../../services/projectRulesScheduler.ts';
+
+const flushMicrotasks = () => new Promise((resolve) => setImmediate(resolve));
+
+const EMPTY_RESULT: ProjectRulesEvaluationResult = {
+  evaluated: 0,
+  triggered: 0,
+  reset: 0,
+  notified: 0,
+};
+
+const createLoggerStub = (): Logger => {
+  const stub = {
+    info: mock(),
+    error: mock(),
+    warn: mock(),
+    debug: mock(),
+    trace: mock(),
+    fatal: mock(),
+    child: () => stub,
+  };
+  return stub as unknown as Logger;
+};
+
+type Evaluate = (options?: EvaluateProjectRulesOptions) => Promise<ProjectRulesEvaluationResult>;
+
+describe('startProjectRulesScheduler', () => {
+  test('runs the evaluator on each interval tick', async () => {
+    const evaluate = mock<Evaluate>(async () => EMPTY_RESULT);
+    const logger = createLoggerStub();
+
+    const scheduler = startProjectRulesScheduler({ logger, intervalMs: 5, evaluate });
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    scheduler.stop();
+
+    expect(evaluate.mock.calls.length).toBeGreaterThan(0);
+    expect(evaluate.mock.calls[0][0]).toMatchObject({ logger });
+  });
+
+  test('stop() prevents future interval fires', async () => {
+    const evaluate = mock<Evaluate>(async () => EMPTY_RESULT);
+    const logger = createLoggerStub();
+
+    const scheduler = startProjectRulesScheduler({ logger, intervalMs: 5, evaluate });
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    const callsBeforeStop = evaluate.mock.calls.length;
+    expect(callsBeforeStop).toBeGreaterThan(0);
+
+    scheduler.stop();
+    const callsAtStop = evaluate.mock.calls.length;
+
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(evaluate.mock.calls.length).toBe(callsAtStop);
+  });
+
+  test('inFlight guard prevents overlapping evaluations', async () => {
+    let concurrent = 0;
+    let maxConcurrent = 0;
+    const evaluate = mock<Evaluate>(async () => {
+      concurrent++;
+      maxConcurrent = Math.max(maxConcurrent, concurrent);
+      await new Promise((resolve) => setTimeout(resolve, 15));
+      concurrent--;
+      return EMPTY_RESULT;
+    });
+    const logger = createLoggerStub();
+
+    const scheduler = startProjectRulesScheduler({ logger, intervalMs: 1, evaluate });
+
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    scheduler.stop();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(evaluate.mock.calls.length).toBeGreaterThan(0);
+    expect(maxConcurrent).toBe(1);
+  });
+
+  test('logs and continues when the evaluation throws while running', async () => {
+    const evaluate = mock<Evaluate>(async () => {
+      throw new Error('boom');
+    });
+    const logger = createLoggerStub();
+
+    const scheduler = startProjectRulesScheduler({ logger, intervalMs: 5, evaluate });
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    scheduler.stop();
+
+    const errorCalls = (logger.error as ReturnType<typeof mock>).mock.calls;
+    expect(errorCalls.length).toBeGreaterThan(0);
+    expect(errorCalls[0][0]).toMatchObject({ err: { name: 'Error', message: 'boom' } });
+  });
+
+  test('stop() suppresses errors from in-flight evaluations', async () => {
+    let releaseEvaluation!: () => void;
+    const blockingEvaluation = new Promise<void>((resolve) => {
+      releaseEvaluation = resolve;
+    });
+    const evaluate = mock<Evaluate>(async () => {
+      await blockingEvaluation;
+      throw new Error('pool has ended');
+    });
+    const logger = createLoggerStub();
+
+    const scheduler = startProjectRulesScheduler({ logger, intervalMs: 1, evaluate });
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    scheduler.stop();
+    releaseEvaluation();
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect((logger.error as ReturnType<typeof mock>).mock.calls.length).toBe(0);
+  });
+});

--- a/server/test/utils/permissions.test.ts
+++ b/server/test/utils/permissions.test.ts
@@ -46,6 +46,10 @@ describe('PERMISSION_DEFINITIONS / ALL_PERMISSIONS', () => {
     expect(ALL_PERMISSIONS).toContain('projects.manage_all.delete');
     expect(ALL_PERMISSIONS).toContain('projects.tasks_all.create');
     expect(ALL_PERMISSIONS).toContain('timesheets.ril.view');
+    expect(ALL_PERMISSIONS).toContain('projects.rules.view');
+    expect(ALL_PERMISSIONS).toContain('projects.rules.create');
+    expect(ALL_PERMISSIONS).toContain('projects.rules.update');
+    expect(ALL_PERMISSIONS).toContain('projects.rules.delete');
     expect(ALL_PERMISSIONS).toContain('timesheets.tracker_all.update');
     expect(ALL_PERMISSIONS).toContain('hr.work_units.delete');
     expect(ALL_PERMISSIONS).toContain('hr.work_units_all.delete');

--- a/server/test/utils/projectRuleFields.test.ts
+++ b/server/test/utils/projectRuleFields.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  evaluateProjectRuleCondition,
+  validateProjectRuleCondition,
+} from '../../utils/projectRuleFields.ts';
+
+describe('projectRuleFields', () => {
+  test('rejects cost-derived fields without reports.cost.view', () => {
+    expect(
+      validateProjectRuleCondition({
+        field: 'budget_used_pct',
+        operator: 'gte',
+        value: '80',
+        permissions: ['projects.rules.create'],
+      }),
+    ).toEqual({
+      ok: false,
+      message: 'budget_used_pct requires reports.cost.view',
+    });
+  });
+
+  test('validates numeric and enum operators against the selected field', () => {
+    expect(
+      validateProjectRuleCondition({
+        field: 'revenue',
+        operator: 'gte',
+        value: '1000',
+        permissions: [],
+      }),
+    ).toEqual({ ok: true });
+    expect(
+      validateProjectRuleCondition({
+        field: 'status',
+        operator: 'gt',
+        value: 'active',
+        permissions: [],
+      }),
+    ).toEqual({ ok: false, message: 'operator is not valid for field' });
+  });
+
+  test('validates field-to-field comparisons and target permissions', () => {
+    expect(
+      validateProjectRuleCondition({
+        field: 'revenue',
+        operator: 'neq',
+        value: 'cost_to_date',
+        valueType: 'field',
+        permissions: ['reports.cost.view'],
+      }),
+    ).toEqual({ ok: true });
+    expect(
+      validateProjectRuleCondition({
+        field: 'revenue',
+        operator: 'neq',
+        value: 'cost_to_date',
+        valueType: 'field',
+        permissions: [],
+      }),
+    ).toEqual({ ok: false, message: 'cost_to_date requires reports.cost.view' });
+    expect(
+      validateProjectRuleCondition({
+        field: 'revenue',
+        operator: 'eq',
+        value: 'revenue',
+        valueType: 'field',
+        permissions: [],
+      }),
+    ).toEqual({ ok: false, message: 'value field cannot be the same as field' });
+    expect(
+      validateProjectRuleCondition({
+        field: 'status',
+        operator: 'neq',
+        value: 'billing_type',
+        valueType: 'field',
+        permissions: [],
+      }),
+    ).toEqual({ ok: false, message: 'value field is not compatible with field' });
+  });
+
+  test('treats null or missing metric values as not met', () => {
+    expect(
+      evaluateProjectRuleCondition({
+        field: 'budget_used_pct',
+        operator: 'gte',
+        expectedValue: '80',
+        actualValue: null,
+      }),
+    ).toBe(false);
+  });
+
+  test('evaluates numeric and enum comparisons', () => {
+    expect(
+      evaluateProjectRuleCondition({
+        field: 'hours_to_date',
+        operator: 'gt',
+        expectedValue: '10',
+        actualValue: 12,
+      }),
+    ).toBe(true);
+    expect(
+      evaluateProjectRuleCondition({
+        field: 'billing_type',
+        operator: 'eq',
+        expectedValue: 'retainer',
+        actualValue: 'retainer',
+      }),
+    ).toBe(true);
+    expect(
+      evaluateProjectRuleCondition({
+        field: 'billing_type',
+        operator: 'eq',
+        expectedValue: 'retainer',
+        actualValue: 'mixed',
+      }),
+    ).toBe(false);
+    expect(
+      evaluateProjectRuleCondition({
+        field: 'billing_type',
+        operator: 'neq',
+        expectedValue: 'retainer',
+        actualValue: 'mixed',
+      }),
+    ).toBe(true);
+  });
+
+  test('evaluates comparisons against another metric field', () => {
+    expect(
+      evaluateProjectRuleCondition({
+        field: 'revenue',
+        operator: 'gt',
+        expectedValue: 'cost_to_date',
+        expectedValueType: 'field',
+        actualValue: 1000,
+        expectedActualValue: 900,
+      }),
+    ).toBe(true);
+    expect(
+      evaluateProjectRuleCondition({
+        field: 'revenue',
+        operator: 'neq',
+        expectedValue: 'cost_to_date',
+        expectedValueType: 'field',
+        actualValue: 1000,
+        expectedActualValue: null,
+      }),
+    ).toBe(false);
+  });
+
+  test('rejects derived mixed billing as a rule value', () => {
+    expect(
+      validateProjectRuleCondition({
+        field: 'billing_type',
+        operator: 'eq',
+        value: 'mixed',
+        permissions: [],
+      }),
+    ).toEqual({ ok: false, message: 'value is not valid for field' });
+    expect(
+      evaluateProjectRuleCondition({
+        field: 'billing_type',
+        operator: 'neq',
+        expectedValue: 'mixed',
+        actualValue: 'retainer',
+      }),
+    ).toBe(false);
+  });
+});

--- a/server/utils/audit.ts
+++ b/server/utils/audit.ts
@@ -25,6 +25,7 @@ export const AUDIT_ENTITY_TYPES = [
   'product_subcategory',
   'product_type',
   'project',
+  'project_rule',
   'reports_ai',
   'reports_ai_message',
   'reports_ai_session',

--- a/server/utils/permissions.ts
+++ b/server/utils/permissions.ts
@@ -53,6 +53,7 @@ export const PERMISSION_DEFINITIONS: PermissionDefinition[] = [
   { id: 'projects.manage_all', actions: CRUD, isScope: true },
   { id: 'projects.tasks', actions: CRUD },
   { id: 'projects.tasks_all', actions: CRUD, isScope: true },
+  { id: 'projects.rules', actions: CRUD },
   // `view` lets a role load any project/activity's assignment dialog regardless of
   // per-entity membership (role-agnostic); `update` additionally permits editing.
   { id: 'projects.assignments', actions: VIEW_UPDATE },

--- a/server/utils/projectRuleFields.ts
+++ b/server/utils/projectRuleFields.ts
@@ -1,0 +1,263 @@
+export const PROJECT_RULE_NUMBER_OPERATORS = ['gt', 'gte', 'lt', 'lte', 'eq', 'neq'] as const;
+export const PROJECT_RULE_ENUM_OPERATORS = ['eq', 'neq'] as const;
+export const PROJECT_RULE_CONDITION_VALUE_TYPES = ['literal', 'field'] as const;
+
+export type ProjectRuleNumberOperator = (typeof PROJECT_RULE_NUMBER_OPERATORS)[number];
+export type ProjectRuleEnumOperator = (typeof PROJECT_RULE_ENUM_OPERATORS)[number];
+export type ProjectRuleOperator = ProjectRuleNumberOperator | ProjectRuleEnumOperator;
+export type ProjectRuleConditionValueType = (typeof PROJECT_RULE_CONDITION_VALUE_TYPES)[number];
+
+export const PROJECT_RULE_FIELD_IDS = [
+  'revenue',
+  'cost_to_date',
+  'budget_used_pct',
+  'hours_to_date',
+  'days_until_deadline',
+  'billing_type',
+  'status',
+] as const;
+
+export type ProjectRuleField = (typeof PROJECT_RULE_FIELD_IDS)[number];
+export type ProjectRuleFieldKind = 'number' | 'enum';
+
+export type ProjectRuleFieldDefinition = {
+  id: ProjectRuleField;
+  kind: ProjectRuleFieldKind;
+  operators: readonly ProjectRuleOperator[];
+  enumValues?: readonly string[];
+  requiresPermission?: string;
+};
+
+export const PROJECT_RULE_FIELD_DEFINITIONS: readonly ProjectRuleFieldDefinition[] = [
+  { id: 'revenue', kind: 'number', operators: PROJECT_RULE_NUMBER_OPERATORS },
+  {
+    id: 'cost_to_date',
+    kind: 'number',
+    operators: PROJECT_RULE_NUMBER_OPERATORS,
+    requiresPermission: 'reports.cost.view',
+  },
+  {
+    id: 'budget_used_pct',
+    kind: 'number',
+    operators: PROJECT_RULE_NUMBER_OPERATORS,
+    requiresPermission: 'reports.cost.view',
+  },
+  { id: 'hours_to_date', kind: 'number', operators: PROJECT_RULE_NUMBER_OPERATORS },
+  { id: 'days_until_deadline', kind: 'number', operators: PROJECT_RULE_NUMBER_OPERATORS },
+  {
+    id: 'billing_type',
+    kind: 'enum',
+    operators: PROJECT_RULE_ENUM_OPERATORS,
+    enumValues: ['time_and_materials', 'retainer'],
+  },
+  {
+    id: 'status',
+    kind: 'enum',
+    operators: PROJECT_RULE_ENUM_OPERATORS,
+    enumValues: ['active', 'disabled'],
+  },
+];
+
+export const PROJECT_RULE_FIELDS = new Map(
+  PROJECT_RULE_FIELD_DEFINITIONS.map((definition) => [definition.id, definition]),
+);
+
+export const getProjectRuleFieldDefinition = (field: string): ProjectRuleFieldDefinition | null =>
+  PROJECT_RULE_FIELDS.get(field as ProjectRuleField) ?? null;
+
+export const isProjectRuleField = (field: string): field is ProjectRuleField =>
+  PROJECT_RULE_FIELDS.has(field as ProjectRuleField);
+
+export const isProjectRuleOperator = (operator: string): operator is ProjectRuleOperator =>
+  PROJECT_RULE_NUMBER_OPERATORS.includes(operator as ProjectRuleNumberOperator) ||
+  PROJECT_RULE_ENUM_OPERATORS.includes(operator as ProjectRuleEnumOperator);
+
+export const isProjectRuleConditionValueType = (
+  value: string,
+): value is ProjectRuleConditionValueType =>
+  PROJECT_RULE_CONDITION_VALUE_TYPES.includes(value as ProjectRuleConditionValueType);
+
+export const normalizeProjectRuleConditionValueType = (
+  value: unknown,
+): ProjectRuleConditionValueType => (value === 'field' ? 'field' : 'literal');
+
+const enumValuesMatch = (
+  leftValues: readonly string[] | undefined,
+  rightValues: readonly string[] | undefined,
+) => {
+  if (!leftValues || !rightValues || leftValues.length !== rightValues.length) return false;
+  return leftValues.every((value, index) => value === rightValues[index]);
+};
+
+const runtimeEnumValuesForField = (field: string, definition: ProjectRuleFieldDefinition) =>
+  field === 'billing_type' ? [...(definition.enumValues ?? []), 'mixed'] : definition.enumValues;
+
+export const areProjectRuleFieldsComparable = (leftField: string, rightField: string): boolean => {
+  const leftDefinition = getProjectRuleFieldDefinition(leftField);
+  const rightDefinition = getProjectRuleFieldDefinition(rightField);
+  if (!leftDefinition || !rightDefinition) return false;
+  if (leftDefinition.kind !== rightDefinition.kind) return false;
+  if (leftDefinition.kind === 'enum') {
+    return enumValuesMatch(leftDefinition.enumValues, rightDefinition.enumValues);
+  }
+  return true;
+};
+
+const normalizeNumericValue = (value: string): number | null => {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+export const validateProjectRuleCondition = ({
+  field,
+  operator,
+  value,
+  valueType = 'literal',
+  permissions,
+}: {
+  field: string;
+  operator: string;
+  value: string;
+  valueType?: ProjectRuleConditionValueType | string;
+  permissions?: readonly string[];
+}): { ok: true } | { ok: false; message: string } => {
+  const definition = getProjectRuleFieldDefinition(field);
+  if (!definition) return { ok: false, message: 'field must be a supported project rule field' };
+
+  if (definition.requiresPermission && !permissions?.includes(definition.requiresPermission)) {
+    return {
+      ok: false,
+      message: `${field} requires ${definition.requiresPermission}`,
+    };
+  }
+
+  if (!definition.operators.includes(operator as ProjectRuleOperator)) {
+    return { ok: false, message: 'operator is not valid for field' };
+  }
+
+  const trimmedValue = value.trim();
+  if (trimmedValue.length === 0) return { ok: false, message: 'value is required' };
+
+  const normalizedValueType = normalizeProjectRuleConditionValueType(valueType);
+  if (normalizedValueType === 'field') {
+    if (trimmedValue === field) {
+      return { ok: false, message: 'value field cannot be the same as field' };
+    }
+    const valueDefinition = getProjectRuleFieldDefinition(trimmedValue);
+    if (!valueDefinition) {
+      return { ok: false, message: 'value field must be a supported project rule field' };
+    }
+    if (
+      valueDefinition.requiresPermission &&
+      !permissions?.includes(valueDefinition.requiresPermission)
+    ) {
+      return {
+        ok: false,
+        message: `${trimmedValue} requires ${valueDefinition.requiresPermission}`,
+      };
+    }
+    if (!areProjectRuleFieldsComparable(field, trimmedValue)) {
+      return { ok: false, message: 'value field is not compatible with field' };
+    }
+    return { ok: true };
+  }
+
+  if (definition.kind === 'number') {
+    if (normalizeNumericValue(trimmedValue) === null) {
+      return { ok: false, message: 'value must be a valid number' };
+    }
+    return { ok: true };
+  }
+
+  if (!definition.enumValues?.includes(trimmedValue)) {
+    return { ok: false, message: 'value is not valid for field' };
+  }
+
+  return { ok: true };
+};
+
+export const evaluateProjectRuleCondition = ({
+  field,
+  operator,
+  expectedValue,
+  expectedValueType = 'literal',
+  actualValue,
+  expectedActualValue,
+}: {
+  field: string;
+  operator: string;
+  expectedValue: string;
+  expectedValueType?: ProjectRuleConditionValueType | string;
+  actualValue: string | number | null | undefined;
+  expectedActualValue?: string | number | null | undefined;
+}): boolean => {
+  if (actualValue === null || actualValue === undefined) return false;
+
+  const definition = getProjectRuleFieldDefinition(field);
+  if (!definition?.operators.includes(operator as ProjectRuleOperator)) {
+    return false;
+  }
+
+  if (definition.kind === 'number') {
+    const normalizedValueType = normalizeProjectRuleConditionValueType(expectedValueType);
+    if (normalizedValueType === 'field' && !areProjectRuleFieldsComparable(field, expectedValue)) {
+      return false;
+    }
+    const expected =
+      normalizedValueType === 'field'
+        ? typeof expectedActualValue === 'number'
+          ? expectedActualValue
+          : expectedActualValue === null || expectedActualValue === undefined
+            ? null
+            : normalizeNumericValue(String(expectedActualValue))
+        : normalizeNumericValue(expectedValue);
+    const actual =
+      typeof actualValue === 'number' ? actualValue : normalizeNumericValue(String(actualValue));
+    if (expected === null || actual === null) return false;
+
+    switch (operator) {
+      case 'gt':
+        return actual > expected;
+      case 'gte':
+        return actual >= expected;
+      case 'lt':
+        return actual < expected;
+      case 'lte':
+        return actual <= expected;
+      case 'eq':
+        return actual === expected;
+      case 'neq':
+        return actual !== expected;
+      default:
+        return false;
+    }
+  }
+
+  const actual = String(actualValue);
+  if (normalizeProjectRuleConditionValueType(expectedValueType) === 'field') {
+    if (!areProjectRuleFieldsComparable(field, expectedValue)) return false;
+    if (expectedActualValue === null || expectedActualValue === undefined) return false;
+    const expected = String(expectedActualValue);
+    const actualEnumValues = runtimeEnumValuesForField(field, definition);
+    const expectedDefinition = getProjectRuleFieldDefinition(expectedValue);
+    const expectedEnumValues = expectedDefinition
+      ? runtimeEnumValuesForField(expectedValue, expectedDefinition)
+      : undefined;
+    if (!actualEnumValues?.includes(actual) || !expectedEnumValues?.includes(expected)) {
+      return false;
+    }
+    if (operator === 'eq') return actual === expected;
+    if (operator === 'neq') return actual !== expected;
+    return false;
+  }
+
+  const actualEnumValues = runtimeEnumValuesForField(field, definition);
+  if (!definition.enumValues?.includes(expectedValue) || !actualEnumValues?.includes(actual)) {
+    return false;
+  }
+  if (operator === 'eq') return actual === expectedValue;
+  if (operator === 'neq') return actual !== expectedValue;
+  return false;
+};

--- a/services/api.ts
+++ b/services/api.ts
@@ -20,6 +20,7 @@ export { ldapApi } from './api/ldap';
 export { logsApi } from './api/logs';
 export { notificationsApi } from './api/notifications';
 export { productsApi } from './api/products';
+export { projectRulesApi } from './api/projectRules';
 export { projectsApi } from './api/projects';
 export { reportsApi } from './api/reports';
 export { rolesApi } from './api/roles';
@@ -50,6 +51,7 @@ import { ldapApi } from './api/ldap';
 import { logsApi } from './api/logs';
 import { notificationsApi } from './api/notifications';
 import { productsApi } from './api/products';
+import { projectRulesApi } from './api/projectRules';
 import { projectsApi } from './api/projects';
 import { reportsApi } from './api/reports';
 import { rolesApi } from './api/roles';
@@ -74,6 +76,7 @@ export default {
   tasks: tasksApi,
   entries: entriesApi,
   products: productsApi,
+  projectRules: projectRulesApi,
   quotes: clientQuotesApi,
   clientOffers: clientOffersApi,
   clientsOrders: clientsOrdersApi,

--- a/services/api/projectRules.ts
+++ b/services/api/projectRules.ts
@@ -1,0 +1,49 @@
+import type {
+  ProjectRule,
+  ProjectRuleCondition,
+  ProjectRuleConditionLogic,
+  ProjectRuleRecipientOptions,
+} from '../../types';
+import { fetchApi } from './client';
+
+export type ProjectRulePayload = {
+  name: string;
+  field: string;
+  operator: string;
+  value: string;
+  conditionLogic?: ProjectRuleConditionLogic;
+  conditions?: ProjectRuleCondition[];
+  actionType?: 'notify';
+  actionConfig: {
+    recipientUserIds: string[];
+    recipientRoleIds: string[];
+  };
+  isEnabled?: boolean;
+};
+
+export const projectRulesApi = {
+  list: (projectId: string, signal?: AbortSignal): Promise<ProjectRule[]> =>
+    fetchApi<ProjectRule[]>(`/projects/${projectId}/rules`, { signal }),
+
+  getRecipients: (projectId: string, signal?: AbortSignal): Promise<ProjectRuleRecipientOptions> =>
+    fetchApi<ProjectRuleRecipientOptions>(`/projects/${projectId}/rules/recipients`, { signal }),
+
+  create: (projectId: string, data: ProjectRulePayload): Promise<ProjectRule> =>
+    fetchApi<ProjectRule>(`/projects/${projectId}/rules`, {
+      method: 'POST',
+      body: JSON.stringify({ actionType: 'notify', ...data }),
+    }),
+
+  update: (
+    projectId: string,
+    ruleId: string,
+    data: Partial<ProjectRulePayload>,
+  ): Promise<ProjectRule> =>
+    fetchApi<ProjectRule>(`/projects/${projectId}/rules/${ruleId}`, {
+      method: 'PUT',
+      body: JSON.stringify(data),
+    }),
+
+  delete: (projectId: string, ruleId: string): Promise<void> =>
+    fetchApi<void>(`/projects/${projectId}/rules/${ruleId}`, { method: 'DELETE' }),
+};

--- a/test/components/NotificationBell.test.tsx
+++ b/test/components/NotificationBell.test.tsx
@@ -139,6 +139,32 @@ describe('<NotificationBell />', () => {
     expect(container.querySelector('i.fa-folder-tree')).toBeNull();
   });
 
+  test('project rule notifications use localized title and bell icon', () => {
+    const notification: Notification = {
+      id: 'n-rule',
+      userId: 'u1',
+      type: 'project_rule_triggered',
+      title: 'Project rule triggered',
+      isRead: false,
+      createdAt: NOW,
+      data: {
+        projectId: 'p1',
+        projectName: 'Project A',
+        ruleId: 'pr1',
+        ruleName: 'Budget warning',
+      },
+    };
+
+    const { container } = render(
+      <NotificationBell {...baseProps} notifications={[notification]} />,
+    );
+
+    openDropdown();
+
+    expect(screen.getByText('notifications.projectRuleTriggered')).toBeInTheDocument();
+    expect(container.querySelector('i.fa-bell')).not.toBeNull();
+  });
+
   test('clicking a single-project notification uses the singular translation key', () => {
     const single: Notification = {
       id: 'n3',

--- a/test/components/SelectControl.test.tsx
+++ b/test/components/SelectControl.test.tsx
@@ -99,6 +99,8 @@ describe('<SelectControl />', () => {
     );
 
     expect(screen.getByText('Apple')).toBeInTheDocument();
+    expect(screen.getByRole('button')).toHaveClass('h-auto', 'min-h-9', 'whitespace-normal');
+    expect(screen.getByText('Apple').parentElement).toHaveClass('text-foreground');
 
     fireEvent.click(screen.getByRole('button'));
     fireEvent.click(within(screen.getByRole('dialog')).getByText('Banana'));

--- a/test/components/projects/ProjectRuleFormModal.test.tsx
+++ b/test/components/projects/ProjectRuleFormModal.test.tsx
@@ -1,0 +1,114 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import type { ProjectRule, ProjectRuleRecipientOptions } from '../../../types';
+import { installI18nMock } from '../../helpers/i18n';
+import { render } from '../../helpers/render';
+
+installI18nMock();
+
+const ProjectRuleFormModal = (await import('../../../components/projects/ProjectRuleFormModal'))
+  .default;
+
+const recipients: ProjectRuleRecipientOptions = {
+  users: [{ id: 'u1', name: 'Alice', username: 'alice', avatarInitials: 'AL' }],
+  roles: [{ id: 'manager', name: 'Manager' }],
+};
+
+const rule: ProjectRule = {
+  id: 'rule-1',
+  projectId: 'project-1',
+  name: 'Revenue warning',
+  field: 'revenue',
+  operator: 'gt',
+  value: '1000',
+  conditionLogic: 'and',
+  conditions: [{ field: 'revenue', operator: 'gt', value: '1000', valueType: 'literal' }],
+  actionType: 'notify',
+  actionConfig: { recipientUserIds: ['u1'], recipientRoleIds: [] },
+  isEnabled: true,
+  conditionMet: false,
+  lastTriggeredAt: null,
+  createdBy: 'admin',
+  createdAt: 1700000000000,
+  updatedAt: 1700000000000,
+};
+
+describe('<ProjectRuleFormModal />', () => {
+  test('submits chained conditions with OR logic', async () => {
+    const onSubmit = mock(() => Promise.resolve());
+
+    render(
+      <ProjectRuleFormModal
+        open
+        onOpenChange={() => {}}
+        rule={rule}
+        recipients={recipients}
+        permissions={['projects.rules.update']}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    fireEvent.click(screen.getAllByRole('combobox')[0]);
+    fireEvent.click(
+      await screen.findByRole('option', {
+        name: 'projects:detail.rules.conditionLogic.or',
+      }),
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'projects:detail.rules.actions.addCondition' }),
+    );
+    fireEvent.change(screen.getAllByRole('spinbutton')[1], { target: { value: '2500' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'common:buttons.save' }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        field: 'revenue',
+        operator: 'gt',
+        value: '1000',
+        conditionLogic: 'or',
+        conditions: [
+          { field: 'revenue', operator: 'gt', value: '1000', valueType: 'literal' },
+          { field: 'revenue', operator: 'gt', value: '2500', valueType: 'literal' },
+        ],
+        actionType: 'notify',
+        actionConfig: { recipientUserIds: ['u1'], recipientRoleIds: [] },
+      }),
+    );
+  });
+
+  test('submits a condition that compares against another field', async () => {
+    const onSubmit = mock(() => Promise.resolve());
+
+    render(
+      <ProjectRuleFormModal
+        open
+        onOpenChange={() => {}}
+        rule={rule}
+        recipients={recipients}
+        permissions={['projects.rules.update']}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    fireEvent.click(screen.getAllByRole('combobox')[3]);
+    fireEvent.click(
+      await screen.findByRole('option', { name: 'projects:detail.rules.valueTypes.field' }),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'common:buttons.save' }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        field: 'revenue',
+        operator: 'gt',
+        value: 'hours_to_date',
+        conditions: [
+          { field: 'revenue', operator: 'gt', value: 'hours_to_date', valueType: 'field' },
+        ],
+      }),
+    );
+  });
+});

--- a/test/components/projects/ProjectRuleFormModal.test.tsx
+++ b/test/components/projects/ProjectRuleFormModal.test.tsx
@@ -1,13 +1,22 @@
 import { describe, expect, mock, test } from 'bun:test';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
+import type { FC } from 'react';
+import type { ProjectRuleFormModalProps } from '../../../components/projects/ProjectRuleFormModal';
 import type { ProjectRule, ProjectRuleRecipientOptions } from '../../../types';
 import { installI18nMock } from '../../helpers/i18n';
 import { render } from '../../helpers/render';
 
 installI18nMock();
 
-const ProjectRuleFormModal = (await import('../../../components/projects/ProjectRuleFormModal'))
-  .default;
+// ProjectRules.test.tsx replaces this module with a stub via `mock.module`. Bun's module
+// registry is shared process-wide and keyed by resolved path, so when that file loads first
+// this SUT would otherwise resolve to the stub — a failure that depends on test-file load
+// order (which differs between local and CI). A `?real` query suffix resolves to a fresh,
+// unmocked instance, so we always exercise the real component regardless of load order.
+// tsc cannot resolve a query-suffixed specifier, which is intentional here.
+// @ts-expect-error -- query-suffixed specifier is unresolvable to tsc by design (see note above)
+const realModalModule = await import('../../../components/projects/ProjectRuleFormModal.tsx?real');
+const ProjectRuleFormModal = realModalModule.default as FC<ProjectRuleFormModalProps>;
 
 const recipients: ProjectRuleRecipientOptions = {
   users: [{ id: 'u1', name: 'Alice', username: 'alice', avatarInitials: 'AL' }],

--- a/test/components/projects/ProjectRuleFormModal.test.tsx
+++ b/test/components/projects/ProjectRuleFormModal.test.tsx
@@ -43,6 +43,24 @@ const rule: ProjectRule = {
 };
 
 describe('<ProjectRuleFormModal />', () => {
+  test('keeps tall recipient selections inside a scrollable modal', () => {
+    render(
+      <ProjectRuleFormModal
+        open
+        onOpenChange={() => {}}
+        rule={rule}
+        recipients={recipients}
+        permissions={['projects.rules.update']}
+        onSubmit={() => Promise.resolve()}
+      />,
+    );
+
+    expect(document.querySelector('[data-slot="dialog-content"]')).toHaveClass(
+      'max-h-[calc(100vh-2rem)]',
+      'overflow-y-auto',
+    );
+  });
+
   test('submits chained conditions with OR logic', async () => {
     const onSubmit = mock(() => Promise.resolve());
 

--- a/test/components/projects/ProjectRuleFormModal.test.tsx
+++ b/test/components/projects/ProjectRuleFormModal.test.tsx
@@ -61,6 +61,31 @@ describe('<ProjectRuleFormModal />', () => {
     );
   });
 
+  test('renders chained conditions as compact rows in one grouped list', () => {
+    render(
+      <ProjectRuleFormModal
+        open
+        onOpenChange={() => {}}
+        rule={rule}
+        recipients={recipients}
+        permissions={['projects.rules.update']}
+        onSubmit={() => Promise.resolve()}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'projects:detail.rules.actions.addCondition' }),
+    );
+
+    const rowContainer = document.querySelector('.divide-y.divide-border');
+    expect(rowContainer?.children).toHaveLength(2);
+    expect(rowContainer?.parentElement).toHaveClass('rounded-md', 'border', 'border-border');
+    expect(rowContainer?.previousElementSibling).toHaveClass('hidden', 'md:grid');
+    for (const label of document.querySelectorAll('[for^="project-rule-field-"]')) {
+      expect(label).toHaveClass('md:sr-only');
+    }
+  });
+
   test('submits chained conditions with OR logic', async () => {
     const onSubmit = mock(() => Promise.resolve());
 

--- a/test/components/projects/ProjectRuleFormModal.test.tsx
+++ b/test/components/projects/ProjectRuleFormModal.test.tsx
@@ -120,4 +120,87 @@ describe('<ProjectRuleFormModal />', () => {
       }),
     );
   });
+
+  test('does not submit and shows an error when no recipients are selected', async () => {
+    const onSubmit = mock(() => Promise.resolve());
+
+    render(
+      <ProjectRuleFormModal
+        open
+        onOpenChange={() => {}}
+        rule={{ ...rule, actionConfig: { recipientUserIds: [], recipientRoleIds: [] } }}
+        recipients={recipients}
+        permissions={['projects.rules.update']}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'common:buttons.save' }));
+
+    expect(
+      await screen.findByText('projects:detail.rules.errors.recipientsRequired'),
+    ).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  test('does not submit and shows an error when a literal value is invalid', async () => {
+    const onSubmit = mock(() => Promise.resolve());
+
+    render(
+      <ProjectRuleFormModal
+        open
+        onOpenChange={() => {}}
+        rule={rule}
+        recipients={recipients}
+        permissions={['projects.rules.update']}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole('spinbutton'), { target: { value: '' } });
+    fireEvent.click(screen.getByRole('button', { name: 'common:buttons.save' }));
+
+    expect(
+      await screen.findByText('projects:detail.rules.errors.valueInvalid'),
+    ).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  test('hides the "compare against another field" option for enum fields without a peer', async () => {
+    const enumRule: ProjectRule = {
+      ...rule,
+      field: 'billing_type',
+      operator: 'eq',
+      value: 'time_and_materials',
+      conditions: [
+        {
+          field: 'billing_type',
+          operator: 'eq',
+          value: 'time_and_materials',
+          valueType: 'literal',
+        },
+      ],
+    };
+
+    render(
+      <ProjectRuleFormModal
+        open
+        onOpenChange={() => {}}
+        rule={enumRule}
+        recipients={recipients}
+        permissions={['projects.rules.update']}
+        onSubmit={mock(() => Promise.resolve())}
+      />,
+    );
+
+    // The "Compare against" select is the 4th combobox (after logic, field, operator).
+    fireEvent.click(screen.getAllByRole('combobox')[3]);
+
+    expect(
+      await screen.findByRole('option', { name: 'projects:detail.rules.valueTypes.literal' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('option', { name: 'projects:detail.rules.valueTypes.field' }),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/test/components/projects/ProjectRules.test.tsx
+++ b/test/components/projects/ProjectRules.test.tsx
@@ -1,0 +1,290 @@
+import { beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import type { ProjectRule, ProjectRuleRecipientOptions } from '../../../types';
+import { installI18nMock } from '../../helpers/i18n';
+import { clearSpyStateAfterAll } from '../../helpers/mockCleanup';
+import { render } from '../../helpers/render';
+
+installI18nMock();
+
+const listMock = mock();
+const recipientsMock = mock();
+const createMock = mock();
+const updateMock = mock();
+const deleteMock = mock();
+const toastSuccessMock = mock();
+const toastErrorMock = mock();
+
+mock.module('../../../services/api/projectRules', () => ({
+  projectRulesApi: {
+    list: listMock,
+    getRecipients: recipientsMock,
+    create: createMock,
+    update: updateMock,
+    delete: deleteMock,
+  },
+}));
+
+mock.module('../../../utils/toast', () => ({
+  toastSuccess: toastSuccessMock,
+  toastError: toastErrorMock,
+}));
+
+mock.module('../../../components/projects/ProjectRuleFormModal', () => ({
+  default: ({
+    open,
+    rule,
+    onSubmit,
+  }: {
+    open: boolean;
+    rule?: ProjectRule | null;
+    onSubmit: (payload: unknown) => Promise<void>;
+  }) =>
+    open ? (
+      <button
+        type="button"
+        onClick={() =>
+          void onSubmit({
+            name: rule ? 'Edited rule' : 'New rule',
+            field: 'revenue',
+            operator: 'gte',
+            value: '1000',
+            conditionLogic: 'and',
+            conditions: [
+              { field: 'revenue', operator: 'gte', value: '1000', valueType: 'literal' },
+            ],
+            actionType: 'notify',
+            actionConfig: { recipientUserIds: ['u1'], recipientRoleIds: [] },
+            isEnabled: true,
+          })
+        }
+      >
+        {rule ? 'submit-edit-rule' : 'submit-create-rule'}
+      </button>
+    ) : null,
+}));
+
+clearSpyStateAfterAll();
+
+const ProjectRules = (await import('../../../components/projects/ProjectRules')).default;
+
+const RULE: ProjectRule = {
+  id: 'pr-1',
+  projectId: 'p1',
+  name: 'Budget warning',
+  field: 'revenue',
+  operator: 'gte',
+  value: '1000',
+  conditionLogic: 'and',
+  conditions: [{ field: 'revenue', operator: 'gte', value: '1000', valueType: 'literal' }],
+  actionType: 'notify',
+  actionConfig: { recipientUserIds: ['u1'], recipientRoleIds: [] },
+  isEnabled: true,
+  conditionMet: false,
+  lastTriggeredAt: null,
+  createdBy: 'u-admin',
+  createdAt: 1700000000000,
+  updatedAt: 1700000000000,
+};
+
+const deferValue = <T,>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+};
+
+const renderProjectRules = (permissions: string[]) =>
+  render(<ProjectRules projectId="p1" permissions={permissions} />);
+
+beforeEach(() => {
+  for (const fn of [
+    listMock,
+    recipientsMock,
+    createMock,
+    updateMock,
+    deleteMock,
+    toastSuccessMock,
+    toastErrorMock,
+  ]) {
+    fn.mockReset();
+  }
+  listMock.mockResolvedValue([]);
+  recipientsMock.mockResolvedValue({
+    users: [{ id: 'u1', name: 'Alice', username: 'alice', avatarInitials: 'AL' }],
+    roles: [{ id: 'manager', name: 'Manager' }],
+  });
+  createMock.mockResolvedValue({ ...RULE, id: 'pr-created', name: 'New rule' });
+  updateMock.mockImplementation(
+    (_projectId: string, _ruleId: string, payload: Partial<ProjectRule>) =>
+      Promise.resolve({ ...RULE, ...payload }),
+  );
+  deleteMock.mockResolvedValue(undefined);
+});
+
+describe('<ProjectRules />', () => {
+  test('hides the section without projects.rules.view', () => {
+    renderProjectRules([]);
+
+    expect(screen.queryByText('projects:detail.rules.title')).not.toBeInTheDocument();
+    expect(listMock).not.toHaveBeenCalled();
+  });
+
+  test('renders empty state and hides add without create permission', async () => {
+    renderProjectRules(['projects.rules.view']);
+
+    expect(await screen.findByText('projects:detail.rules.empty.title')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'projects:detail.rules.actions.add' }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('shows loading state while rules and recipients are pending', async () => {
+    const pendingRules = deferValue<ProjectRule[]>();
+    const pendingRecipients = deferValue<ProjectRuleRecipientOptions>();
+    listMock.mockReturnValue(pendingRules.promise);
+    recipientsMock.mockReturnValue(pendingRecipients.promise);
+
+    renderProjectRules(['projects.rules.view', 'projects.rules.create']);
+
+    const addButton = screen.getByRole('button', {
+      name: 'projects:detail.rules.actions.add',
+    });
+    expect(addButton).toBeDisabled();
+    expect(screen.queryByText('projects:detail.rules.empty.title')).not.toBeInTheDocument();
+
+    pendingRules.resolve([]);
+    pendingRecipients.resolve({ users: [], roles: [] });
+
+    await waitFor(() => expect(addButton).not.toBeDisabled());
+  });
+
+  test('renders an error state and can retry loading rules', async () => {
+    const consoleError = spyOn(console, 'error').mockImplementation(() => {});
+    let loadCount = 0;
+    listMock.mockImplementation(() => {
+      loadCount += 1;
+      return loadCount === 1 ? Promise.reject(new Error('boom')) : Promise.resolve([]);
+    });
+    try {
+      renderProjectRules(['projects.rules.view']);
+
+      expect(
+        await screen.findByText('projects:detail.rules.errors.loadFailed'),
+      ).toBeInTheDocument();
+      fireEvent.click(screen.getByRole('button', { name: 'common:buttons.refresh' }));
+
+      expect(await screen.findByText('projects:detail.rules.empty.title')).toBeInTheDocument();
+      expect(listMock).toHaveBeenCalledTimes(2);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  test('creates a rule through the form modal callback', async () => {
+    renderProjectRules(['projects.rules.view', 'projects.rules.create']);
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'projects:detail.rules.actions.add' }),
+    );
+    fireEvent.click(screen.getByText('submit-create-rule'));
+
+    await waitFor(() => expect(createMock).toHaveBeenCalled());
+    expect(createMock).toHaveBeenCalledWith(
+      'p1',
+      expect.objectContaining({ name: 'New rule', actionType: 'notify' }),
+    );
+  });
+
+  test('hides edit and delete controls, and disables toggle without matching permissions', async () => {
+    listMock.mockResolvedValue([RULE]);
+    renderProjectRules(['projects.rules.view']);
+
+    expect(await screen.findByText('Budget warning')).toBeInTheDocument();
+    expect(
+      screen.getByRole('switch', { name: 'projects:detail.rules.actions.toggle' }),
+    ).toBeDisabled();
+    expect(
+      screen.queryByRole('button', { name: 'projects:detail.rules.actions.edit' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'projects:detail.rules.actions.delete' }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('edits and toggles an existing rule when update permission is present', async () => {
+    listMock.mockResolvedValue([RULE]);
+    renderProjectRules(['projects.rules.view', 'projects.rules.update']);
+
+    expect(await screen.findByText('Budget warning')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'projects:detail.rules.actions.edit' }));
+    fireEvent.click(screen.getByText('submit-edit-rule'));
+
+    await waitFor(() =>
+      expect(updateMock).toHaveBeenCalledWith(
+        'p1',
+        'pr-1',
+        expect.objectContaining({ name: 'Edited rule' }),
+      ),
+    );
+
+    fireEvent.click(screen.getByRole('switch', { name: 'projects:detail.rules.actions.toggle' }));
+    await waitFor(() =>
+      expect(updateMock).toHaveBeenCalledWith('p1', 'pr-1', { isEnabled: false }),
+    );
+  });
+
+  test('deletes a rule after confirmation', async () => {
+    listMock.mockResolvedValue([RULE]);
+    renderProjectRules(['projects.rules.view', 'projects.rules.delete']);
+
+    expect(await screen.findByText('Budget warning')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'projects:detail.rules.actions.delete' }));
+    fireEvent.click(screen.getByRole('button', { name: 'common:buttons.delete' }));
+
+    await waitFor(() => expect(deleteMock).toHaveBeenCalledWith('p1', 'pr-1'));
+  });
+
+  test('prevents duplicate delete submits while deletion is pending', async () => {
+    const pendingDelete = deferValue<void>();
+    listMock.mockResolvedValue([RULE]);
+    deleteMock.mockReturnValue(pendingDelete.promise);
+    renderProjectRules(['projects.rules.view', 'projects.rules.delete']);
+
+    expect(await screen.findByText('Budget warning')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'projects:detail.rules.actions.delete' }));
+    const confirmButton = screen.getByRole('button', { name: 'common:buttons.delete' });
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => expect(confirmButton).toBeDisabled());
+    fireEvent.click(confirmButton);
+    expect(deleteMock).toHaveBeenCalledTimes(1);
+
+    pendingDelete.resolve(undefined);
+    await waitFor(() =>
+      expect(toastSuccessMock).toHaveBeenCalledWith('projects:detail.rules.toasts.deleted'),
+    );
+  });
+
+  test('disables update controls for cost-derived rules without cost permission', async () => {
+    listMock.mockResolvedValue([
+      {
+        ...RULE,
+        field: 'budget_used_pct',
+        conditions: [
+          { field: 'budget_used_pct', operator: 'gte', value: '1000', valueType: 'literal' },
+        ],
+      },
+    ]);
+    renderProjectRules(['projects.rules.view', 'projects.rules.update']);
+
+    expect(await screen.findByText('Budget warning')).toBeInTheDocument();
+    expect(
+      screen.getByRole('switch', { name: 'projects:detail.rules.actions.toggle' }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole('button', { name: 'projects:detail.rules.actions.edit' }),
+    ).toBeDisabled();
+  });
+});

--- a/test/components/projects/projectRuleRegistry.test.ts
+++ b/test/components/projects/projectRuleRegistry.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  getAvailableProjectRuleFields,
+  getAvailableProjectRuleValueFields,
+  getProjectRuleFieldDefinition,
+  isValidProjectRuleConditionValue,
+  isValidProjectRuleValue,
+} from '../../../components/projects/projectRuleRegistry';
+
+describe('project rule registry', () => {
+  test('filters cost-derived fields without reports.cost.view', () => {
+    const fields = getAvailableProjectRuleFields(['projects.rules.create']).map(
+      (field) => field.id,
+    );
+    expect(fields).toContain('revenue');
+    expect(fields).not.toContain('cost_to_date');
+    expect(fields).not.toContain('budget_used_pct');
+  });
+
+  test('keeps cost-derived fields when reports.cost.view is present', () => {
+    const fields = getAvailableProjectRuleFields(['reports.cost.view']).map((field) => field.id);
+    expect(fields).toContain('cost_to_date');
+    expect(fields).toContain('budget_used_pct');
+  });
+
+  test('exposes enum operators and stored values for billing type', () => {
+    const definition = getProjectRuleFieldDefinition('billing_type');
+    expect(definition?.operators).toEqual(['eq', 'neq']);
+    expect(definition?.enumValues).toEqual(['time_and_materials', 'retainer']);
+    expect(definition?.enumValues).not.toContain('mixed');
+  });
+
+  test('validates number and enum values by field type', () => {
+    expect(isValidProjectRuleValue('revenue', '1000')).toBe(true);
+    expect(isValidProjectRuleValue('revenue', 'not-a-number')).toBe(false);
+    expect(isValidProjectRuleValue('status', 'active')).toBe(true);
+    expect(isValidProjectRuleValue('status', 'archived')).toBe(false);
+  });
+
+  test('exposes compatible target fields for field-to-field comparisons', () => {
+    expect(
+      getAvailableProjectRuleValueFields('revenue', ['reports.cost.view']).map((f) => f.id),
+    ).toContain('cost_to_date');
+    expect(getAvailableProjectRuleValueFields('revenue', []).map((f) => f.id)).not.toContain(
+      'cost_to_date',
+    );
+    expect(getAvailableProjectRuleValueFields('status', []).map((f) => f.id)).not.toContain(
+      'billing_type',
+    );
+  });
+
+  test('validates field comparison values through the registry', () => {
+    expect(
+      isValidProjectRuleConditionValue({
+        field: 'revenue',
+        value: 'hours_to_date',
+        valueType: 'field',
+        permissions: [],
+      }),
+    ).toBe(true);
+    expect(
+      isValidProjectRuleConditionValue({
+        field: 'status',
+        value: 'billing_type',
+        valueType: 'field',
+        permissions: [],
+      }),
+    ).toBe(false);
+  });
+});

--- a/test/utils/permissions.test.ts
+++ b/test/utils/permissions.test.ts
@@ -47,6 +47,10 @@ describe('PERMISSION_DEFINITIONS / ALL_PERMISSIONS', () => {
     expect(ALL_PERMISSIONS).toContain('crm.clients_all.create');
     expect(ALL_PERMISSIONS).toContain('projects.tasks_all.update');
     expect(ALL_PERMISSIONS).toContain('timesheets.ril.view');
+    expect(ALL_PERMISSIONS).toContain('projects.rules.view');
+    expect(ALL_PERMISSIONS).toContain('projects.rules.create');
+    expect(ALL_PERMISSIONS).toContain('projects.rules.update');
+    expect(ALL_PERMISSIONS).toContain('projects.rules.delete');
     expect(ALL_PERMISSIONS).toContain('timesheets.tracker_all.delete');
     expect(ALL_PERMISSIONS).toContain('hr.work_units.delete');
     expect(ALL_PERMISSIONS).toContain('hr.work_units_all.delete');

--- a/types.ts
+++ b/types.ts
@@ -30,6 +30,7 @@ export type KnownPermissionResource =
   | 'projects.manage_all'
   | 'projects.tasks'
   | 'projects.tasks_all'
+  | 'projects.rules'
   | 'projects.assignments'
   | 'hr.internal'
   | 'hr.external'
@@ -39,6 +40,7 @@ export type KnownPermissionResource =
   | 'hr.work_units'
   | 'hr.work_units_all'
   | 'reports.ai_reporting'
+  | 'reports.cost'
   | 'administration.authentication'
   | 'administration.general'
   | 'administration.user_management'
@@ -110,13 +112,17 @@ export interface UserSettings {
 export interface Notification {
   id: string;
   userId: string;
-  type: 'new_projects' | string;
+  type: 'new_projects' | 'project_rule_triggered' | string;
   title: string;
   message?: string;
   data?: {
     projectNames?: string[];
     orderId?: string;
     clientName?: string;
+    projectId?: string;
+    projectName?: string;
+    ruleId?: string;
+    ruleName?: string;
     [key: string]: unknown;
   };
   isRead: boolean;
@@ -222,6 +228,54 @@ export interface Project {
   revenue?: number | null;
   billingType?: BillingType;
   billingFrequency?: BillingFrequency;
+}
+
+export type ProjectRuleActionType = 'notify';
+
+export interface ProjectRuleActionConfig {
+  recipientUserIds: string[];
+  recipientRoleIds: string[];
+}
+
+export type ProjectRuleConditionLogic = 'and' | 'or';
+export type ProjectRuleConditionValueType = 'literal' | 'field';
+
+export interface ProjectRuleCondition {
+  field: string;
+  operator: string;
+  value: string;
+  valueType: ProjectRuleConditionValueType;
+}
+
+export interface ProjectRule {
+  id: string;
+  projectId: string;
+  name: string;
+  field: string;
+  operator: string;
+  value: string;
+  conditionLogic: ProjectRuleConditionLogic;
+  conditions: ProjectRuleCondition[];
+  actionType: ProjectRuleActionType;
+  actionConfig: ProjectRuleActionConfig;
+  isEnabled: boolean;
+  conditionMet: boolean;
+  lastTriggeredAt: number | null;
+  createdBy: string | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface ProjectRuleRecipientUser {
+  id: string;
+  name: string;
+  username: string;
+  avatarInitials: string;
+}
+
+export interface ProjectRuleRecipientOptions {
+  users: ProjectRuleRecipientUser[];
+  roles: RoleSummary[];
 }
 
 export interface ProjectTask {
@@ -907,6 +961,7 @@ export const AUDIT_ENTITY_TYPES = [
   'product_subcategory',
   'product_type',
   'project',
+  'project_rule',
   'reports_ai',
   'reports_ai_message',
   'reports_ai_session',

--- a/utils/permissions.ts
+++ b/utils/permissions.ts
@@ -56,6 +56,7 @@ export const PERMISSION_DEFINITIONS: PermissionDefinition[] = [
   { id: 'projects.manage_all', actions: CRUD, isScope: true, module: 'projects' },
   { id: 'projects.tasks', actions: CRUD, module: 'projects' },
   { id: 'projects.tasks_all', actions: CRUD, isScope: true, module: 'projects' },
+  { id: 'projects.rules', actions: CRUD, module: 'projects' },
   { id: 'projects.assignments', actions: VIEW_UPDATE, module: 'projects' },
 
   // HR


### PR DESCRIPTION
## Summary
- Adds project-scoped rules with CRUD APIs, persistent storage, permissions, and a scheduled evaluator.
- Replaces the project detail mockup with a registry-driven rules UI and notification recipient selection.
- Documents project rules and regenerates OpenAPI for the new endpoints.

## Changes
- Adds `project_rules` schema, Drizzle migrations, readiness coverage, and default Manager/Top Manager grants for `projects.rules.*`.
- Adds project rule repositories, metric aggregation, recipient resolution, bulk notification creation, routes under `/api/projects`, audit logging, and a 15-minute scheduler.
- Adds frontend rule types, API client, `ProjectRules` and `ProjectRuleFormModal`, i18n strings, and notification bell localization for `project_rule_triggered`.
- Adds backend and frontend tests for permissions, route validation, recipient handling, evaluator rising-edge behavior, registry filtering, and UI states.

## Testing
- `bun run test` - 1402 pass, 0 fail
- `bun run lint` - pass; existing `components/ui/chart.tsx` warnings remain
- `cd server && bun run build` - pass
- `bun run docs:api` - pass
- `bun run build` - pass
- `git diff --check` - pass

## Risks / Rollout
- Includes database migrations `0063_add_project_rules.sql`, `0064_grant_projects_rules_permission.sql`, and `0065_add_project_rule_condition_chains.sql`; deploy requires applying migrations before relying on the new APIs.
- The scheduler creates in-app notifications on rising-edge rule matches; notification volume depends on configured rules and recipient roles.
- Cost-derived rule fields remain gated by `reports.cost.view` on both frontend and backend validation.

## Issues
Issue: Not linked
