### PR TITLE
hr(feature): add ERP employee profile details

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ data volume.
 The compose setup defaults backend `TRUST_PROXY=1` for the bundled Caddy -> API hop.
 Set `DEMO_SEEDING=true` in `.env` when you want the stack to provision the canonical demo users and demo business data.
 That refresh flow is intended for demo and test stacks, owns the canonical demo namespace, and supports reused Docker volumes.
+The demo users include HR profile data such as employee codes, departments, contract status, work locations, emergency contacts, and sample internal/external employee records.
 
 To rerun the same refresh manually against an existing backend database:
 

--- a/components/HR/EmployeeHrFields.tsx
+++ b/components/HR/EmployeeHrFields.tsx
@@ -1,0 +1,297 @@
+import type React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Field, FieldError, FieldLabel } from '@/components/ui/field';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  CONTRACT_TYPE_OPTIONS,
+  EMPLOYMENT_STATUS_OPTIONS,
+  type EmployeeHrFormData,
+  type EmployeeSectionKey,
+  WORK_LOCATION_OPTIONS,
+} from './employeeHrProfile';
+
+const NONE_SELECT_VALUE = '__none__';
+
+type EmployeeHrFieldsProps = {
+  section: EmployeeSectionKey;
+  prefix: string;
+  formData: EmployeeHrFormData;
+  errors: Record<string, string>;
+  setFormData: React.Dispatch<React.SetStateAction<EmployeeHrFormData>>;
+  currency: string;
+  canViewCosts: boolean;
+  canUpdateCosts: boolean;
+  identityReadOnly: boolean;
+};
+
+type SelectFieldProps<T extends string> = {
+  id: string;
+  label: string;
+  value: T | '';
+  options: readonly T[];
+  optionPrefix: string;
+  onChange: (value: T | '') => void;
+};
+
+const EmployeeSelectField = <T extends string>({
+  id,
+  label,
+  value,
+  options,
+  optionPrefix,
+  onChange,
+}: SelectFieldProps<T>) => {
+  const { t } = useTranslation(['hr']);
+
+  return (
+    <Field>
+      <FieldLabel htmlFor={id}>{label}</FieldLabel>
+      <Select
+        value={value || NONE_SELECT_VALUE}
+        onValueChange={(nextValue) =>
+          onChange(nextValue === NONE_SELECT_VALUE ? '' : (nextValue as T))
+        }
+      >
+        <SelectTrigger id={id} className="w-full">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={NONE_SELECT_VALUE}>{t('employeeProfile.notSet')}</SelectItem>
+          {options.map((option) => (
+            <SelectItem key={option} value={option}>
+              {t(`${optionPrefix}.${option}`)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </Field>
+  );
+};
+
+const EmployeeHrFields: React.FC<EmployeeHrFieldsProps> = ({
+  section,
+  prefix,
+  formData,
+  errors,
+  setFormData,
+  currency,
+  canViewCosts,
+  canUpdateCosts,
+  identityReadOnly,
+}) => {
+  const { t } = useTranslation(['hr', 'common']);
+
+  const setField = <K extends keyof EmployeeHrFormData>(field: K, value: EmployeeHrFormData[K]) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+  };
+
+  return (
+    <div className="space-y-6">
+      <section className="space-y-3">
+        <h3 className="text-sm font-semibold text-foreground">
+          {t('employeeProfile.contactSection')}
+        </h3>
+        <div className="grid gap-4 md:grid-cols-3">
+          <Field data-invalid={Boolean(errors.name)}>
+            <FieldLabel htmlFor={`${prefix}-name`}>{t(`${section}.name`)} *</FieldLabel>
+            <Input
+              id={`${prefix}-name`}
+              type="text"
+              value={formData.name}
+              onChange={(e) => setField('name', e.target.value)}
+              aria-invalid={Boolean(errors.name)}
+              placeholder={t(`${section}.name`)}
+              disabled={identityReadOnly}
+            />
+            <FieldError className="text-xs">{errors.name}</FieldError>
+          </Field>
+
+          <Field data-invalid={Boolean(errors.email)}>
+            <FieldLabel htmlFor={`${prefix}-email`}>{t('employeeProfile.email')}</FieldLabel>
+            <Input
+              id={`${prefix}-email`}
+              type="email"
+              value={formData.email}
+              onChange={(e) => setField('email', e.target.value)}
+              aria-invalid={Boolean(errors.email)}
+              placeholder="name@example.com"
+              disabled={identityReadOnly}
+            />
+            <FieldError className="text-xs">{errors.email}</FieldError>
+          </Field>
+
+          <Field>
+            <FieldLabel htmlFor={`${prefix}-phone`}>{t('employeeProfile.phone')}</FieldLabel>
+            <Input
+              id={`${prefix}-phone`}
+              type="tel"
+              value={formData.phone}
+              onChange={(e) => setField('phone', e.target.value)}
+            />
+          </Field>
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <h3 className="text-sm font-semibold text-foreground">
+          {t('employeeProfile.employmentSection')}
+        </h3>
+        <div className="grid gap-4 md:grid-cols-3">
+          <Field>
+            <FieldLabel htmlFor={`${prefix}-job-title`}>{t('employeeProfile.jobTitle')}</FieldLabel>
+            <Input
+              id={`${prefix}-job-title`}
+              value={formData.jobTitle}
+              onChange={(e) => setField('jobTitle', e.target.value)}
+            />
+          </Field>
+
+          <Field>
+            <FieldLabel htmlFor={`${prefix}-department`}>
+              {t('employeeProfile.department')}
+            </FieldLabel>
+            <Input
+              id={`${prefix}-department`}
+              value={formData.department}
+              onChange={(e) => setField('department', e.target.value)}
+            />
+          </Field>
+
+          <Field>
+            <FieldLabel htmlFor={`${prefix}-employee-code`}>
+              {t('employeeProfile.employeeCode')}
+            </FieldLabel>
+            <Input
+              id={`${prefix}-employee-code`}
+              value={formData.employeeCode}
+              onChange={(e) => setField('employeeCode', e.target.value)}
+            />
+          </Field>
+
+          <Field>
+            <FieldLabel htmlFor={`${prefix}-hire-date`}>{t('employeeProfile.hireDate')}</FieldLabel>
+            <Input
+              id={`${prefix}-hire-date`}
+              type="date"
+              value={formData.hireDate}
+              onChange={(e) => setField('hireDate', e.target.value)}
+            />
+          </Field>
+
+          <Field data-invalid={Boolean(errors.terminationDate)}>
+            <FieldLabel htmlFor={`${prefix}-termination-date`}>
+              {t('employeeProfile.terminationDate')}
+            </FieldLabel>
+            <Input
+              id={`${prefix}-termination-date`}
+              type="date"
+              value={formData.terminationDate}
+              onChange={(e) => setField('terminationDate', e.target.value)}
+              aria-invalid={Boolean(errors.terminationDate)}
+            />
+            <FieldError className="text-xs">{errors.terminationDate}</FieldError>
+          </Field>
+
+          <EmployeeSelectField
+            id={`${prefix}-contract-type`}
+            label={t('employeeProfile.contractType')}
+            value={formData.contractType}
+            options={CONTRACT_TYPE_OPTIONS}
+            optionPrefix="employeeProfile.contractTypes"
+            onChange={(value) => setField('contractType', value)}
+          />
+
+          <EmployeeSelectField
+            id={`${prefix}-employment-status`}
+            label={t('employeeProfile.employmentStatus')}
+            value={formData.employmentStatus}
+            options={EMPLOYMENT_STATUS_OPTIONS}
+            optionPrefix="employeeProfile.employmentStatuses"
+            onChange={(value) => setField('employmentStatus', value)}
+          />
+
+          <EmployeeSelectField
+            id={`${prefix}-work-location`}
+            label={t('employeeProfile.workLocation')}
+            value={formData.workLocation}
+            options={WORK_LOCATION_OPTIONS}
+            optionPrefix="employeeProfile.workLocations"
+            onChange={(value) => setField('workLocation', value)}
+          />
+
+          {canViewCosts && (
+            <Field>
+              <FieldLabel htmlFor={`${prefix}-cost`}>{t(`${section}.costPerHour`)}</FieldLabel>
+              <div className="relative">
+                <span className="absolute left-3 top-1/2 -translate-y-1/2 text-sm font-medium text-muted-foreground">
+                  {currency}
+                </span>
+                <Input
+                  id={`${prefix}-cost`}
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  value={formData.costPerHour}
+                  onChange={(e) => setField('costPerHour', e.target.value)}
+                  className="pl-8"
+                  placeholder="0.00"
+                  disabled={!canUpdateCosts}
+                />
+              </div>
+            </Field>
+          )}
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <h3 className="text-sm font-semibold text-foreground">
+          {t('employeeProfile.emergencySection')}
+        </h3>
+        <div className="grid gap-4 md:grid-cols-2">
+          <Field>
+            <FieldLabel htmlFor={`${prefix}-emergency-name`}>
+              {t('employeeProfile.emergencyContactName')}
+            </FieldLabel>
+            <Input
+              id={`${prefix}-emergency-name`}
+              value={formData.emergencyContactName}
+              onChange={(e) => setField('emergencyContactName', e.target.value)}
+            />
+          </Field>
+
+          <Field>
+            <FieldLabel htmlFor={`${prefix}-emergency-phone`}>
+              {t('employeeProfile.emergencyContactPhone')}
+            </FieldLabel>
+            <Input
+              id={`${prefix}-emergency-phone`}
+              type="tel"
+              value={formData.emergencyContactPhone}
+              onChange={(e) => setField('emergencyContactPhone', e.target.value)}
+            />
+          </Field>
+        </div>
+
+        <Field>
+          <FieldLabel htmlFor={`${prefix}-notes`}>{t('employeeProfile.notes')}</FieldLabel>
+          <Textarea
+            id={`${prefix}-notes`}
+            value={formData.notes}
+            onChange={(e) => setField('notes', e.target.value)}
+            rows={3}
+          />
+        </Field>
+      </section>
+    </div>
+  );
+};
+
+export default EmployeeHrFields;

--- a/components/HR/ExternalEmployeesView.tsx
+++ b/components/HR/ExternalEmployeesView.tsx
@@ -2,8 +2,6 @@ import type React from 'react';
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
-import { Field, FieldError, FieldLabel } from '@/components/ui/field';
-import { Input } from '@/components/ui/input';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import type { Client, Project, ProjectTask, User } from '../../types';
 import { buildPermission, hasPermission, TOP_MANAGER_ROLE_ID } from '../../utils/permissions';
@@ -21,16 +19,24 @@ import {
 import StandardTable, { type Column } from '../shared/StandardTable';
 import StatusBadge from '../shared/StatusBadge';
 import EmployeeAssignmentsModal from './EmployeeAssignmentsModal';
+import EmployeeHrFields from './EmployeeHrFields';
+import {
+  buildEmployeeCreatePayload,
+  buildEmployeeHrPayload,
+  createEmployeeHrForm,
+  createEmptyEmployeeHrForm,
+  type EmployeeCreatePayload,
+  type EmployeeHrFormData,
+  getEmployeeHrStatusBadgeType,
+  validateEmployeeHrForm,
+} from './employeeHrProfile';
 
 export interface ExternalEmployeesViewProps {
   users: User[];
   clients: Client[];
   projects: Project[];
   tasks: ProjectTask[];
-  onAddEmployee: (
-    name: string,
-    costPerHour?: number,
-  ) => Promise<{ success: boolean; error?: string }>;
+  onAddEmployee: (employee: EmployeeCreatePayload) => Promise<{ success: boolean; error?: string }>;
   onUpdateEmployee: (id: string, updates: Partial<User>) => void;
   onDeleteEmployee: (id: string) => void;
   currency: string;
@@ -49,9 +55,9 @@ interface EmptyStateProps {
 
 const EmptyState: React.FC<EmptyStateProps> = ({ title, description }) => (
   <div className="p-8 text-center">
-    <i className="fa-solid fa-user-clock text-4xl mb-3 text-zinc-300"></i>
-    <p className="text-zinc-500 font-medium">{title}</p>
-    <p className="text-sm text-zinc-400 mt-1">{description}</p>
+    <i className="fa-solid fa-user-clock text-4xl mb-3 text-muted-foreground/50"></i>
+    <p className="text-muted-foreground font-medium">{title}</p>
+    <p className="text-sm text-muted-foreground mt-1">{description}</p>
   </div>
 );
 
@@ -76,6 +82,18 @@ const ExternalEmployeesView: React.FC<ExternalEmployeesViewProps> = ({
     permissions,
     buildPermission('hr.employee_assignments', 'update'),
   );
+  const notSetLabel = t('employeeProfile.notSet');
+  const formatOptionalText = (value: unknown): string => {
+    if (typeof value === 'string') return value.trim();
+    if (value === null || value === undefined) return '';
+    return String(value).trim();
+  };
+  const renderOptionalText = (value: unknown, className = 'text-muted-foreground') => {
+    const text = formatOptionalText(value);
+    return (
+      <span className={text ? className : 'text-muted-foreground'}>{text || notSetLabel}</span>
+    );
+  };
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingEmployee, setEditingEmployee] = useState<User | null>(null);
   const [managingEmployee, setManagingEmployee] = useState<User | null>(null);
@@ -95,18 +113,12 @@ const ExternalEmployeesView: React.FC<ExternalEmployeesViewProps> = ({
     });
   }, [users]);
 
-  const [formData, setFormData] = useState<{ name: string; costPerHour: string }>({
-    name: '',
-    costPerHour: '',
-  });
+  const [formData, setFormData] = useState<EmployeeHrFormData>(createEmptyEmployeeHrForm);
 
   const openAddModal = () => {
     if (!canCreateEmployees) return;
     setEditingEmployee(null);
-    setFormData({
-      name: '',
-      costPerHour: '',
-    });
+    setFormData(createEmptyEmployeeHrForm());
     setErrors({});
     setIsModalOpen(true);
   };
@@ -114,10 +126,7 @@ const ExternalEmployeesView: React.FC<ExternalEmployeesViewProps> = ({
   const openEditModal = (employee: User) => {
     if (!canUpdateEmployees) return;
     setEditingEmployee(employee);
-    setFormData({
-      name: employee.name || '',
-      costPerHour: employee.costPerHour?.toString() || '',
-    });
+    setFormData(createEmployeeHrForm(employee));
     setErrors({});
     setIsModalOpen(true);
   };
@@ -128,10 +137,13 @@ const ExternalEmployeesView: React.FC<ExternalEmployeesViewProps> = ({
     if (editingEmployee && !canUpdateEmployees) return;
     if (!editingEmployee && !canCreateEmployees) return;
 
-    const newErrors: Record<string, string> = {};
-    if (!formData.name?.trim()) {
-      newErrors.name = t('common:validation.required');
-    }
+    const identityReadOnly = Boolean(editingEmployee && editingEmployee.authMethod !== 'local');
+    const newErrors = validateEmployeeHrForm(formData, {
+      identityReadOnly,
+      requiredMessage: t('common:validation.required'),
+      invalidEmailMessage: t('common:validation.invalidEmail'),
+      dateRangeMessage: t('employeeProfile.dateRangeInvalid'),
+    });
 
     if (Object.keys(newErrors).length > 0) {
       setErrors(newErrors);
@@ -142,24 +154,17 @@ const ExternalEmployeesView: React.FC<ExternalEmployeesViewProps> = ({
 
     try {
       if (editingEmployee) {
-        const updates: Partial<User> = {
-          name: formData.name.trim(),
-        };
-
-        // Only submit costPerHour when the input was actually rendered. Without
-        // canViewCosts the GET response masked the field to 0, so including it
-        // here on an unrelated edit (e.g. name) would silently clobber the real
-        // DB value.
-        if (canViewCosts && canUpdateCosts) {
-          updates.costPerHour = formData.costPerHour ? parseFloat(formData.costPerHour) : 0;
-        }
-
+        const updates = buildEmployeeHrPayload(formData, {
+          includeIdentity: !identityReadOnly,
+          includeCost: canViewCosts && canUpdateCosts,
+        });
         onUpdateEmployee(editingEmployee.id, updates);
         setIsModalOpen(false);
       } else {
         const result = await onAddEmployee(
-          formData.name.trim(),
-          canUpdateCosts && formData.costPerHour ? parseFloat(formData.costPerHour) : undefined,
+          buildEmployeeCreatePayload(formData, {
+            includeCost: canViewCosts && canUpdateCosts,
+          }),
         );
         if (result.success) {
           setIsModalOpen(false);
@@ -195,12 +200,55 @@ const ExternalEmployeesView: React.FC<ExternalEmployeesViewProps> = ({
           <div className="size-9 rounded-full bg-amber-100 text-amber-700 flex items-center justify-center font-bold text-xs">
             {row.avatarInitials}
           </div>
-          <span className="font-semibold text-zinc-800">{row.name}</span>
+          <span className="font-semibold text-foreground">{row.name}</span>
         </div>
       ),
     },
     {
+      header: t('employeeProfile.employeeCode'),
+      accessorKey: 'employeeCode',
+      cell: ({ value }: { value: unknown }) =>
+        renderOptionalText(value, 'font-medium text-muted-foreground'),
+    },
+    {
+      header: t('employeeProfile.contact'),
+      id: 'contact',
+      accessorFn: (row) => [row.email, row.phone].filter(Boolean).join(' '),
+      cell: ({ row }) => {
+        const email = row.email?.trim();
+        const phone = row.phone?.trim();
+        return (
+          <div className="flex min-w-40 flex-col gap-0.5 text-sm">
+            {email && <span className="text-foreground">{email}</span>}
+            {phone && <span className="text-muted-foreground">{phone}</span>}
+            {!email && !phone && <span className="text-muted-foreground">{notSetLabel}</span>}
+          </div>
+        );
+      },
+    },
+    {
+      header: t('employeeProfile.jobTitle'),
+      id: 'roleTitle',
+      accessorFn: (row) => row.jobTitle || '',
+      cell: ({ row }) => (
+        <div className="flex min-w-36 flex-col gap-0.5 text-sm">
+          {renderOptionalText(row.jobTitle, 'font-medium text-foreground')}
+          {row.contractType && (
+            <span className="text-xs text-muted-foreground">
+              {t(`employeeProfile.contractTypes.${row.contractType}`)}
+            </span>
+          )}
+        </div>
+      ),
+    },
+    {
+      header: t('employeeProfile.department'),
+      accessorKey: 'department',
+      cell: ({ value }: { value: unknown }) => renderOptionalText(value),
+    },
+    {
       header: t('externalEmployees.type'),
+      id: 'employeeTypeLabel',
       accessorFn: () => 'external',
       cell: () => <StatusBadge type="external" label={t('externalEmployees.externalBadge')} />,
       disableSorting: true,
@@ -212,7 +260,7 @@ const ExternalEmployeesView: React.FC<ExternalEmployeesViewProps> = ({
             accessorKey: 'costPerHour' as keyof User,
             align: 'right' as const,
             cell: ({ value }: { value: unknown }) => (
-              <span className="font-medium text-zinc-600">
+              <span className="font-medium text-muted-foreground">
                 {currency}
                 {Number(value ?? 0).toFixed(2)}
               </span>
@@ -221,10 +269,23 @@ const ExternalEmployeesView: React.FC<ExternalEmployeesViewProps> = ({
         ]
       : []),
     {
-      header: t('externalEmployees.status'),
-      accessorFn: () => 'active',
-      cell: () => <StatusBadge type="active" label={t('externalEmployees.active')} />,
-      disableSorting: true,
+      header: t('employeeProfile.hrStatus'),
+      id: 'hrStatus',
+      accessorFn: (row) => row.employmentStatus || '',
+      filterFormat: (value) =>
+        value ? t(`employeeProfile.employmentStatuses.${String(value)}`) : notSetLabel,
+      cell: ({ row }) => {
+        const status = row.employmentStatus;
+        if (!status) {
+          return <span className="text-muted-foreground">{notSetLabel}</span>;
+        }
+        return (
+          <StatusBadge
+            type={getEmployeeHrStatusBadgeType(status)}
+            label={t(`employeeProfile.employmentStatuses.${status}`)}
+          />
+        );
+      },
     },
     {
       header: t('externalEmployees.actions'),
@@ -241,7 +302,7 @@ const ExternalEmployeesView: React.FC<ExternalEmployeesViewProps> = ({
                       type="button"
                       onClick={() => setManagingEmployee(row)}
                       aria-label={t('workforce.manageAssignments')}
-                      className="p-2 text-zinc-400 hover:text-praetor hover:bg-praetor/5 rounded-lg transition-colors"
+                      className="p-2 text-muted-foreground hover:text-primary hover:bg-primary/5 rounded-lg transition-colors"
                     >
                       <i className="fa-solid fa-link"></i>
                     </button>
@@ -258,7 +319,7 @@ const ExternalEmployeesView: React.FC<ExternalEmployeesViewProps> = ({
                     type="button"
                     onClick={() => openEditModal(row)}
                     aria-label={t('externalEmployees.editEmployee')}
-                    className="p-2 text-zinc-400 hover:text-praetor hover:bg-praetor/5 rounded-lg transition-colors"
+                    className="p-2 text-muted-foreground hover:text-primary hover:bg-primary/5 rounded-lg transition-colors"
                   >
                     <i className="fa-solid fa-pen-to-square"></i>
                   </button>
@@ -295,7 +356,7 @@ const ExternalEmployeesView: React.FC<ExternalEmployeesViewProps> = ({
     <div className="space-y-8 animate-in fade-in duration-500">
       {/* Add/Edit Modal */}
       <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)}>
-        <ModalContent size="md">
+        <ModalContent size="2xl">
           <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col" noValidate>
             <ModalHeader>
               <ModalTitle className="gap-3">
@@ -312,53 +373,26 @@ const ExternalEmployeesView: React.FC<ExternalEmployeesViewProps> = ({
               <ModalCloseButton onClick={() => setIsModalOpen(false)} />
             </ModalHeader>
 
-            <ModalBody className="space-y-4">
+            <ModalBody className="space-y-6">
               {errors.submit && (
                 <div className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
                   {errors.submit}
                 </div>
               )}
 
-              <Field data-invalid={Boolean(errors.name)}>
-                <FieldLabel htmlFor="external-employee-name">
-                  {t('externalEmployees.name')} *
-                </FieldLabel>
-                <Input
-                  id="external-employee-name"
-                  type="text"
-                  value={formData.name}
-                  onChange={(e) => setFormData((prev) => ({ ...prev, name: e.target.value }))}
-                  aria-invalid={Boolean(errors.name)}
-                  placeholder={t('externalEmployees.name')}
-                />
-                <FieldError className="text-xs">{errors.name}</FieldError>
-              </Field>
-
-              {canViewCosts && (
-                <Field>
-                  <FieldLabel htmlFor="external-employee-cost">
-                    {t('externalEmployees.costPerHour')}
-                  </FieldLabel>
-                  <div className="relative">
-                    <span className="absolute left-3 top-1/2 -translate-y-1/2 text-sm font-medium text-muted-foreground">
-                      {currency}
-                    </span>
-                    <Input
-                      id="external-employee-cost"
-                      type="number"
-                      step="0.01"
-                      min="0"
-                      value={formData.costPerHour}
-                      onChange={(e) =>
-                        setFormData((prev) => ({ ...prev, costPerHour: e.target.value }))
-                      }
-                      className="pl-8"
-                      placeholder="0.00"
-                      disabled={!canUpdateCosts}
-                    />
-                  </div>
-                </Field>
-              )}
+              <EmployeeHrFields
+                section="externalEmployees"
+                prefix="external-employee"
+                formData={formData}
+                errors={errors}
+                setFormData={setFormData}
+                currency={currency}
+                canViewCosts={canViewCosts}
+                canUpdateCosts={canUpdateCosts}
+                identityReadOnly={Boolean(
+                  editingEmployee && editingEmployee.authMethod !== 'local',
+                )}
+              />
             </ModalBody>
 
             <ModalFooter>
@@ -389,8 +423,8 @@ const ExternalEmployeesView: React.FC<ExternalEmployeesViewProps> = ({
       {/* Header */}
       <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
         <div>
-          <h2 className="text-2xl font-semibold text-zinc-800">{t('externalEmployees.title')}</h2>
-          <p className="text-zinc-500">{t('externalEmployees.subtitle')}</p>
+          <h2 className="text-2xl font-semibold text-foreground">{t('externalEmployees.title')}</h2>
+          <p className="text-muted-foreground">{t('externalEmployees.subtitle')}</p>
         </div>
         {canCreateEmployees && (
           <HeaderAddButton actionSize="tall" onClick={openAddModal}>

--- a/components/HR/InternalEmployeesView.tsx
+++ b/components/HR/InternalEmployeesView.tsx
@@ -2,8 +2,6 @@ import type React from 'react';
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
-import { Field, FieldError, FieldLabel } from '@/components/ui/field';
-import { Input } from '@/components/ui/input';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import type { Client, Project, ProjectTask, User } from '../../types';
 import { buildPermission, hasPermission, TOP_MANAGER_ROLE_ID } from '../../utils/permissions';
@@ -21,16 +19,24 @@ import {
 import StandardTable, { type Column } from '../shared/StandardTable';
 import StatusBadge from '../shared/StatusBadge';
 import EmployeeAssignmentsModal from './EmployeeAssignmentsModal';
+import EmployeeHrFields from './EmployeeHrFields';
+import {
+  buildEmployeeCreatePayload,
+  buildEmployeeHrPayload,
+  createEmployeeHrForm,
+  createEmptyEmployeeHrForm,
+  type EmployeeCreatePayload,
+  type EmployeeHrFormData,
+  getEmployeeHrStatusBadgeType,
+  validateEmployeeHrForm,
+} from './employeeHrProfile';
 
 export interface InternalEmployeesViewProps {
   users: User[];
   clients: Client[];
   projects: Project[];
   tasks: ProjectTask[];
-  onAddEmployee: (
-    name: string,
-    costPerHour?: number,
-  ) => Promise<{ success: boolean; error?: string }>;
+  onAddEmployee: (employee: EmployeeCreatePayload) => Promise<{ success: boolean; error?: string }>;
   onUpdateEmployee: (id: string, updates: Partial<User>) => void;
   onDeleteEmployee: (id: string) => void;
   currency: string;
@@ -49,9 +55,9 @@ interface EmptyStateProps {
 
 const EmptyState: React.FC<EmptyStateProps> = ({ title, description }) => (
   <div className="p-8 text-center">
-    <i className="fa-solid fa-users text-4xl mb-3 text-zinc-300"></i>
-    <p className="text-zinc-500 font-medium">{title}</p>
-    <p className="text-sm text-zinc-400 mt-1">{description}</p>
+    <i className="fa-solid fa-users text-4xl mb-3 text-muted-foreground/50"></i>
+    <p className="text-muted-foreground font-medium">{title}</p>
+    <p className="text-sm text-muted-foreground mt-1">{description}</p>
   </div>
 );
 
@@ -76,6 +82,18 @@ const InternalEmployeesView: React.FC<InternalEmployeesViewProps> = ({
     permissions,
     buildPermission('hr.employee_assignments', 'update'),
   );
+  const notSetLabel = t('employeeProfile.notSet');
+  const formatOptionalText = (value: unknown): string => {
+    if (typeof value === 'string') return value.trim();
+    if (value === null || value === undefined) return '';
+    return String(value).trim();
+  };
+  const renderOptionalText = (value: unknown, className = 'text-muted-foreground') => {
+    const text = formatOptionalText(value);
+    return (
+      <span className={text ? className : 'text-muted-foreground'}>{text || notSetLabel}</span>
+    );
+  };
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingEmployee, setEditingEmployee] = useState<User | null>(null);
   const [managingEmployee, setManagingEmployee] = useState<User | null>(null);
@@ -100,18 +118,12 @@ const InternalEmployeesView: React.FC<InternalEmployeesViewProps> = ({
     });
   }, [users]);
 
-  const [formData, setFormData] = useState<{ name: string; costPerHour: string }>({
-    name: '',
-    costPerHour: '',
-  });
+  const [formData, setFormData] = useState<EmployeeHrFormData>(createEmptyEmployeeHrForm);
 
   const openAddModal = () => {
     if (!canCreateEmployees) return;
     setEditingEmployee(null);
-    setFormData({
-      name: '',
-      costPerHour: '',
-    });
+    setFormData(createEmptyEmployeeHrForm());
     setErrors({});
     setIsModalOpen(true);
   };
@@ -119,10 +131,7 @@ const InternalEmployeesView: React.FC<InternalEmployeesViewProps> = ({
   const openEditModal = (employee: User) => {
     if (!canUpdateEmployees) return;
     setEditingEmployee(employee);
-    setFormData({
-      name: employee.name || '',
-      costPerHour: employee.costPerHour?.toString() || '',
-    });
+    setFormData(createEmployeeHrForm(employee));
     setErrors({});
     setIsModalOpen(true);
   };
@@ -133,10 +142,13 @@ const InternalEmployeesView: React.FC<InternalEmployeesViewProps> = ({
     if (editingEmployee && !canUpdateEmployees) return;
     if (!editingEmployee && !canCreateEmployees) return;
 
-    const newErrors: Record<string, string> = {};
-    if (!formData.name?.trim()) {
-      newErrors.name = t('common:validation.required');
-    }
+    const identityReadOnly = Boolean(editingEmployee && editingEmployee.authMethod !== 'local');
+    const newErrors = validateEmployeeHrForm(formData, {
+      identityReadOnly,
+      requiredMessage: t('common:validation.required'),
+      invalidEmailMessage: t('common:validation.invalidEmail'),
+      dateRangeMessage: t('employeeProfile.dateRangeInvalid'),
+    });
 
     if (Object.keys(newErrors).length > 0) {
       setErrors(newErrors);
@@ -147,24 +159,17 @@ const InternalEmployeesView: React.FC<InternalEmployeesViewProps> = ({
 
     try {
       if (editingEmployee) {
-        const updates: Partial<User> = {
-          name: formData.name.trim(),
-        };
-
-        // Only submit costPerHour when the input was actually rendered. Without
-        // canViewCosts the GET response masked the field to 0, so including it
-        // here on an unrelated edit (e.g. name) would silently clobber the real
-        // DB value.
-        if (canViewCosts && canUpdateCosts) {
-          updates.costPerHour = formData.costPerHour ? parseFloat(formData.costPerHour) : 0;
-        }
-
+        const updates = buildEmployeeHrPayload(formData, {
+          includeIdentity: !identityReadOnly,
+          includeCost: canViewCosts && canUpdateCosts,
+        });
         onUpdateEmployee(editingEmployee.id, updates);
         setIsModalOpen(false);
       } else {
         const result = await onAddEmployee(
-          formData.name.trim(),
-          canUpdateCosts && formData.costPerHour ? parseFloat(formData.costPerHour) : undefined,
+          buildEmployeeCreatePayload(formData, {
+            includeCost: canViewCosts && canUpdateCosts,
+          }),
         );
         if (result.success) {
           setIsModalOpen(false);
@@ -200,9 +205,42 @@ const InternalEmployeesView: React.FC<InternalEmployeesViewProps> = ({
           <div className="size-9 rounded-full bg-praetor/10 text-praetor flex items-center justify-center font-bold text-xs">
             {row.avatarInitials}
           </div>
-          <span className="font-semibold text-zinc-800">{row.name}</span>
+          <span className="font-semibold text-foreground">{row.name}</span>
         </div>
       ),
+    },
+    {
+      header: t('employeeProfile.employeeCode'),
+      accessorKey: 'employeeCode',
+      cell: ({ value }: { value: unknown }) =>
+        renderOptionalText(value, 'font-medium text-muted-foreground'),
+    },
+    {
+      header: t('employeeProfile.contact'),
+      id: 'contact',
+      accessorFn: (row) => [row.email, row.phone].filter(Boolean).join(' '),
+      cell: ({ row }) => {
+        const email = row.email?.trim();
+        const phone = row.phone?.trim();
+        return (
+          <div className="flex min-w-40 flex-col gap-0.5 text-sm">
+            {email && <span className="text-foreground">{email}</span>}
+            {phone && <span className="text-muted-foreground">{phone}</span>}
+            {!email && !phone && <span className="text-muted-foreground">{notSetLabel}</span>}
+          </div>
+        );
+      },
+    },
+    {
+      header: t('employeeProfile.jobTitle'),
+      id: 'roleTitle',
+      accessorFn: (row) => row.jobTitle || '',
+      cell: ({ row }) => renderOptionalText(row.jobTitle, 'font-medium text-foreground'),
+    },
+    {
+      header: t('employeeProfile.department'),
+      accessorKey: 'department',
+      cell: ({ value }: { value: unknown }) => renderOptionalText(value),
     },
     {
       header: t('internalEmployees.type'),
@@ -229,7 +267,7 @@ const InternalEmployeesView: React.FC<InternalEmployeesViewProps> = ({
             accessorKey: 'costPerHour' as keyof User,
             align: 'right' as const,
             cell: ({ value }: { value: unknown }) => (
-              <span className="font-medium text-zinc-600">
+              <span className="font-medium text-muted-foreground">
                 {currency}
                 {Number(value ?? 0).toFixed(2)}
               </span>
@@ -238,10 +276,23 @@ const InternalEmployeesView: React.FC<InternalEmployeesViewProps> = ({
         ]
       : []),
     {
-      header: t('internalEmployees.status'),
-      accessorFn: () => 'active',
-      cell: () => <StatusBadge type="active" label={t('internalEmployees.active')} />,
-      disableSorting: true,
+      header: t('employeeProfile.hrStatus'),
+      id: 'hrStatus',
+      accessorFn: (row) => row.employmentStatus || '',
+      filterFormat: (value) =>
+        value ? t(`employeeProfile.employmentStatuses.${String(value)}`) : notSetLabel,
+      cell: ({ row }) => {
+        const status = row.employmentStatus;
+        if (!status) {
+          return <span className="text-muted-foreground">{notSetLabel}</span>;
+        }
+        return (
+          <StatusBadge
+            type={getEmployeeHrStatusBadgeType(status)}
+            label={t(`employeeProfile.employmentStatuses.${status}`)}
+          />
+        );
+      },
     },
     {
       header: t('internalEmployees.actions'),
@@ -259,7 +310,7 @@ const InternalEmployeesView: React.FC<InternalEmployeesViewProps> = ({
                       type="button"
                       onClick={() => setManagingEmployee(row)}
                       aria-label={t('workforce.manageAssignments')}
-                      className="p-2 text-zinc-400 hover:text-praetor hover:bg-praetor/5 rounded-lg transition-colors"
+                      className="p-2 text-muted-foreground hover:text-primary hover:bg-primary/5 rounded-lg transition-colors"
                     >
                       <i className="fa-solid fa-link"></i>
                     </button>
@@ -276,7 +327,7 @@ const InternalEmployeesView: React.FC<InternalEmployeesViewProps> = ({
                     type="button"
                     onClick={() => openEditModal(row)}
                     aria-label={t('internalEmployees.editEmployee')}
-                    className="p-2 text-zinc-400 hover:text-praetor hover:bg-praetor/5 rounded-lg transition-colors"
+                    className="p-2 text-muted-foreground hover:text-primary hover:bg-primary/5 rounded-lg transition-colors"
                   >
                     <i className="fa-solid fa-pen-to-square"></i>
                   </button>
@@ -307,7 +358,7 @@ const InternalEmployeesView: React.FC<InternalEmployeesViewProps> = ({
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <span className="inline-flex">
-                      <span className="p-2 text-zinc-300 cursor-not-allowed">
+                      <span className="p-2 text-muted-foreground/50 cursor-not-allowed">
                         <i className="fa-solid fa-lock"></i>
                       </span>
                     </span>
@@ -326,7 +377,7 @@ const InternalEmployeesView: React.FC<InternalEmployeesViewProps> = ({
     <div className="space-y-8 animate-in fade-in duration-500">
       {/* Add/Edit Modal */}
       <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)}>
-        <ModalContent size="md">
+        <ModalContent size="2xl">
           <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col" noValidate>
             <ModalHeader>
               <ModalTitle className="gap-3">
@@ -343,53 +394,26 @@ const InternalEmployeesView: React.FC<InternalEmployeesViewProps> = ({
               <ModalCloseButton onClick={() => setIsModalOpen(false)} />
             </ModalHeader>
 
-            <ModalBody className="space-y-4">
+            <ModalBody className="space-y-6">
               {errors.submit && (
                 <div className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
                   {errors.submit}
                 </div>
               )}
 
-              <Field data-invalid={Boolean(errors.name)}>
-                <FieldLabel htmlFor="internal-employee-name">
-                  {t('internalEmployees.name')} *
-                </FieldLabel>
-                <Input
-                  id="internal-employee-name"
-                  type="text"
-                  value={formData.name}
-                  onChange={(e) => setFormData((prev) => ({ ...prev, name: e.target.value }))}
-                  aria-invalid={Boolean(errors.name)}
-                  placeholder={t('internalEmployees.name')}
-                />
-                <FieldError className="text-xs">{errors.name}</FieldError>
-              </Field>
-
-              {canViewCosts && (
-                <Field>
-                  <FieldLabel htmlFor="internal-employee-cost">
-                    {t('internalEmployees.costPerHour')}
-                  </FieldLabel>
-                  <div className="relative">
-                    <span className="absolute left-3 top-1/2 -translate-y-1/2 text-sm font-medium text-muted-foreground">
-                      {currency}
-                    </span>
-                    <Input
-                      id="internal-employee-cost"
-                      type="number"
-                      step="0.01"
-                      min="0"
-                      value={formData.costPerHour}
-                      onChange={(e) =>
-                        setFormData((prev) => ({ ...prev, costPerHour: e.target.value }))
-                      }
-                      className="pl-8"
-                      placeholder="0.00"
-                      disabled={!canUpdateCosts}
-                    />
-                  </div>
-                </Field>
-              )}
+              <EmployeeHrFields
+                section="internalEmployees"
+                prefix="internal-employee"
+                formData={formData}
+                errors={errors}
+                setFormData={setFormData}
+                currency={currency}
+                canViewCosts={canViewCosts}
+                canUpdateCosts={canUpdateCosts}
+                identityReadOnly={Boolean(
+                  editingEmployee && editingEmployee.authMethod !== 'local',
+                )}
+              />
             </ModalBody>
 
             <ModalFooter>
@@ -420,8 +444,8 @@ const InternalEmployeesView: React.FC<InternalEmployeesViewProps> = ({
       {/* Header */}
       <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
         <div>
-          <h2 className="text-2xl font-semibold text-zinc-800">{t('internalEmployees.title')}</h2>
-          <p className="text-zinc-500">{t('internalEmployees.subtitle')}</p>
+          <h2 className="text-2xl font-semibold text-foreground">{t('internalEmployees.title')}</h2>
+          <p className="text-muted-foreground">{t('internalEmployees.subtitle')}</p>
         </div>
         {canCreateEmployees && (
           <HeaderAddButton actionSize="tall" onClick={openAddModal}>

--- a/components/HR/employeeHrProfile.ts
+++ b/components/HR/employeeHrProfile.ts
@@ -1,0 +1,166 @@
+import type { User, UserContractType, UserEmploymentStatus, UserWorkLocation } from '../../types';
+import type { StatusType } from '../shared/StatusBadge';
+
+export type EmployeeHrFormData = {
+  name: string;
+  email: string;
+  phone: string;
+  jobTitle: string;
+  department: string;
+  employeeCode: string;
+  hireDate: string;
+  terminationDate: string;
+  contractType: UserContractType | '';
+  employmentStatus: UserEmploymentStatus | '';
+  workLocation: UserWorkLocation | '';
+  emergencyContactName: string;
+  emergencyContactPhone: string;
+  notes: string;
+  costPerHour: string;
+};
+
+export type EmployeeHrSubmitPayload = Partial<User> & { costPerHour?: number };
+export type EmployeeCreatePayload = EmployeeHrSubmitPayload & { name: string };
+
+export type EmployeeSectionKey = 'internalEmployees' | 'externalEmployees';
+
+export const CONTRACT_TYPE_OPTIONS: UserContractType[] = [
+  'permanent',
+  'fixed_term',
+  'contractor',
+  'internship',
+  'consultant',
+  'other',
+];
+
+export const EMPLOYMENT_STATUS_OPTIONS: UserEmploymentStatus[] = [
+  'active',
+  'onboarding',
+  'on_leave',
+  'terminated',
+];
+
+export const WORK_LOCATION_OPTIONS: UserWorkLocation[] = [
+  'office',
+  'remote',
+  'hybrid',
+  'customer_site',
+  'other',
+];
+
+export const createEmptyEmployeeHrForm = (): EmployeeHrFormData => ({
+  name: '',
+  email: '',
+  phone: '',
+  jobTitle: '',
+  department: '',
+  employeeCode: '',
+  hireDate: '',
+  terminationDate: '',
+  contractType: '',
+  employmentStatus: '',
+  workLocation: '',
+  emergencyContactName: '',
+  emergencyContactPhone: '',
+  notes: '',
+  costPerHour: '',
+});
+
+export const createEmployeeHrForm = (employee: User): EmployeeHrFormData => ({
+  name: employee.name || '',
+  email: employee.email || '',
+  phone: employee.phone || '',
+  jobTitle: employee.jobTitle || '',
+  department: employee.department || '',
+  employeeCode: employee.employeeCode || '',
+  hireDate: employee.hireDate || '',
+  terminationDate: employee.terminationDate || '',
+  contractType: employee.contractType || '',
+  employmentStatus: employee.employmentStatus || '',
+  workLocation: employee.workLocation || '',
+  emergencyContactName: employee.emergencyContactName || '',
+  emergencyContactPhone: employee.emergencyContactPhone || '',
+  notes: employee.notes || '',
+  costPerHour: employee.costPerHour?.toString() || '',
+});
+
+const nullableText = (value: string): string | null => {
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+};
+
+export const buildEmployeeHrPayload = (
+  formData: EmployeeHrFormData,
+  options: { includeIdentity: boolean; includeCost: boolean },
+): EmployeeHrSubmitPayload => {
+  const payload: EmployeeHrSubmitPayload = {
+    phone: nullableText(formData.phone),
+    jobTitle: nullableText(formData.jobTitle),
+    department: nullableText(formData.department),
+    employeeCode: nullableText(formData.employeeCode),
+    hireDate: formData.hireDate || null,
+    terminationDate: formData.terminationDate || null,
+    contractType: formData.contractType || null,
+    employmentStatus: formData.employmentStatus || null,
+    workLocation: formData.workLocation || null,
+    emergencyContactName: nullableText(formData.emergencyContactName),
+    emergencyContactPhone: nullableText(formData.emergencyContactPhone),
+    notes: nullableText(formData.notes),
+  };
+
+  if (options.includeIdentity) {
+    payload.name = formData.name.trim();
+    payload.email = formData.email.trim();
+  }
+
+  if (options.includeCost) {
+    payload.costPerHour = formData.costPerHour ? parseFloat(formData.costPerHour) : 0;
+  }
+
+  return payload;
+};
+
+export const buildEmployeeCreatePayload = (
+  formData: EmployeeHrFormData,
+  options: { includeCost: boolean },
+): EmployeeCreatePayload => ({
+  ...buildEmployeeHrPayload(formData, { includeIdentity: false, includeCost: options.includeCost }),
+  name: formData.name.trim(),
+  email: formData.email.trim(),
+});
+
+export const getEmployeeHrStatusBadgeType = (
+  status: UserEmploymentStatus | null | undefined,
+): StatusType => {
+  if (status === 'terminated') return 'disabled';
+  if (status === 'onboarding' || status === 'on_leave') return 'pending';
+  return 'active';
+};
+
+const isValidEmail = (value: string): boolean => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+
+export const validateEmployeeHrForm = (
+  formData: EmployeeHrFormData,
+  options: {
+    identityReadOnly: boolean;
+    requiredMessage: string;
+    invalidEmailMessage: string;
+    dateRangeMessage: string;
+  },
+): Record<string, string> => {
+  const errors: Record<string, string> = {};
+  if (!formData.name?.trim()) {
+    errors.name = options.requiredMessage;
+  }
+  if (!options.identityReadOnly && formData.email.trim() && !isValidEmail(formData.email.trim())) {
+    errors.email = options.invalidEmailMessage;
+  }
+  if (
+    formData.hireDate &&
+    formData.terminationDate &&
+    formData.hireDate > formData.terminationDate
+  ) {
+    errors.terminationDate = options.dateRangeMessage;
+  }
+  return errors;
+};

--- a/components/administration/UserManagement.tsx
+++ b/components/administration/UserManagement.tsx
@@ -45,6 +45,9 @@ import ValidatedNumberInput from '../shared/ValidatedNumberInput';
 const isSsoAuthMethod = (authMethod: UserAuthMethod): authMethod is 'oidc' | 'saml' =>
   authMethod === 'oidc' || authMethod === 'saml';
 
+const isProviderManagedIdentity = (user: Pick<User, 'authMethod'> | null | undefined) =>
+  (user?.authMethod || 'local') !== 'local';
+
 const sanitizeUsernamePart = (s: string) =>
   s
     .normalize('NFD')
@@ -561,14 +564,17 @@ const UserManagement: React.FC<UserManagementProps> = ({
 
   const saveEdit = async () => {
     if (editingUser) {
+      const identityReadOnly = isProviderManagedIdentity(editingUser);
       const newErrors: Record<string, string> = {};
       const originalHasSurname = !!splitFullName(editingUser.name).surname.trim();
-      if (!editFirstName.trim()) newErrors.firstName = t('common:validation.nameRequired');
-      if (originalHasSurname && !editSurname.trim()) {
-        newErrors.surname = t('common:validation.surnameRequired');
-      }
-      if (editEmail.trim() && !isValidEmail(editEmail)) {
-        newErrors.email = t('common:validation.invalidEmail');
+      if (!identityReadOnly) {
+        if (!editFirstName.trim()) newErrors.firstName = t('common:validation.nameRequired');
+        if (originalHasSurname && !editSurname.trim()) {
+          newErrors.surname = t('common:validation.surnameRequired');
+        }
+        if (editEmail.trim() && !isValidEmail(editEmail)) {
+          newErrors.email = t('common:validation.invalidEmail');
+        }
       }
 
       if (Object.keys(newErrors).length > 0) {
@@ -576,11 +582,22 @@ const UserManagement: React.FC<UserManagementProps> = ({
         return;
       }
 
-      const updates: Partial<User> = {
-        name: buildFullName(editFirstName, editSurname),
-        email: editEmail.trim(),
-        isDisabled: editIsDisabled,
-      };
+      const updates: Partial<User> = {};
+
+      if (!identityReadOnly) {
+        const name = buildFullName(editFirstName, editSurname);
+        const email = editEmail.trim();
+        if (name !== editingUser.name) {
+          updates.name = name;
+        }
+        if (email !== (editingUser.email || '')) {
+          updates.email = email;
+        }
+      }
+
+      if (editIsDisabled !== !!editingUser.isDisabled) {
+        updates.isDisabled = editIsDisabled;
+      }
 
       const isEditingSelf = editingUser.id === currentUserId;
       const canEditAssignedRoles = canUpdateUsers && !isEditingSelf && roles.length > 0;
@@ -623,10 +640,15 @@ const UserManagement: React.FC<UserManagementProps> = ({
       // caller; otherwise the value comes from the masked GET response (0) and
       // would silently overwrite the real DB cost on an unrelated edit.
       if (canViewCosts && canEditCostFor(editingUser.id)) {
-        updates.costPerHour = parseFloat(editCostPerHour) || 0;
+        const costPerHour = parseFloat(editCostPerHour) || 0;
+        if (costPerHour !== (editingUser.costPerHour || 0)) {
+          updates.costPerHour = costPerHour;
+        }
       }
 
-      onUpdateUser(editingUser?.id, updates);
+      if (Object.keys(updates).length > 0) {
+        onUpdateUser(editingUser.id, updates);
+      }
       closeEditModal();
     }
   };
@@ -635,6 +657,12 @@ const UserManagement: React.FC<UserManagementProps> = ({
   const isEditingSelf = editingUser?.id === currentUserId;
   const canEditRole = canUpdateUsers && !isEditingSelf;
   const canEditAssignedRoles = canUpdateUsers && !isEditingSelf && roles.length > 0;
+  const editIdentityReadOnly = isProviderManagedIdentity(editingUser);
+  const hasIdentityChanges =
+    !!editingUser &&
+    !editIdentityReadOnly &&
+    (buildFullName(editFirstName, editSurname) !== editingUser.name ||
+      editEmail.trim() !== (editingUser.email || ''));
   const hasAssignedRoleChanges =
     !!editingUser &&
     canEditAssignedRoles &&
@@ -642,8 +670,7 @@ const UserManagement: React.FC<UserManagementProps> = ({
       editPrimaryRoleId !== initialEditPrimaryRoleId);
   const hasEditChanges =
     !!editingUser &&
-    (buildFullName(editFirstName, editSurname) !== editingUser.name ||
-      editEmail.trim() !== (editingUser.email || '') ||
+    (hasIdentityChanges ||
       editIsDisabled !== !!editingUser.isDisabled ||
       (canViewCosts &&
         canEditCostFor(editingUser.id) &&
@@ -1163,6 +1190,14 @@ const UserManagement: React.FC<UserManagementProps> = ({
             </div>
 
             <div className="space-y-4">
+              {editIdentityReadOnly && editingUser && (
+                <p className="text-xs text-zinc-500">
+                  {t('hr:workforce.identityManagedByProvider', {
+                    provider: getAuthMethodLabel(editingUser),
+                  })}
+                </p>
+              )}
+
               <div className="grid grid-cols-2 gap-3">
                 <div>
                   <label className="block text-xs font-bold text-zinc-400 uppercase tracking-wider mb-1">
@@ -1178,9 +1213,11 @@ const UserManagement: React.FC<UserManagementProps> = ({
                       }
                     }}
                     aria-label={t('hr:workforce.name')}
+                    readOnly={editIdentityReadOnly}
+                    disabled={editIdentityReadOnly}
                     className={`w-full px-4 py-2 bg-zinc-50 border rounded-lg focus:ring-2 focus:ring-praetor outline-none text-sm font-semibold ${
                       editFormErrors.firstName ? 'border-red-400' : 'border-zinc-200'
-                    }`}
+                    } disabled:cursor-not-allowed disabled:opacity-70`}
                   />
                   {editFormErrors.firstName && (
                     <p className="text-xs text-red-500 mt-1">{editFormErrors.firstName}</p>
@@ -1200,9 +1237,11 @@ const UserManagement: React.FC<UserManagementProps> = ({
                       }
                     }}
                     aria-label={t('hr:workforce.surname')}
+                    readOnly={editIdentityReadOnly}
+                    disabled={editIdentityReadOnly}
                     className={`w-full px-4 py-2 bg-zinc-50 border rounded-lg focus:ring-2 focus:ring-praetor outline-none text-sm font-semibold ${
                       editFormErrors.surname ? 'border-red-400' : 'border-zinc-200'
-                    }`}
+                    } disabled:cursor-not-allowed disabled:opacity-70`}
                   />
                   {editFormErrors.surname && (
                     <p className="text-xs text-red-500 mt-1">{editFormErrors.surname}</p>
@@ -1225,9 +1264,11 @@ const UserManagement: React.FC<UserManagementProps> = ({
                   }}
                   placeholder="e.g. alice.smith@example.com"
                   aria-label={t('common:labels.email')}
+                  readOnly={editIdentityReadOnly}
+                  disabled={editIdentityReadOnly}
                   className={`w-full px-4 py-2 bg-zinc-50 border rounded-lg focus:ring-2 focus:ring-praetor outline-none text-sm font-semibold ${
                     editFormErrors.email ? 'border-red-400' : 'border-zinc-200'
-                  }`}
+                  } disabled:cursor-not-allowed disabled:opacity-70`}
                 />
                 {editFormErrors.email && (
                   <p className="text-xs text-red-500 mt-1">{editFormErrors.email}</p>

--- a/docs-site/src/content/docs/administration.md
+++ b/docs-site/src/content/docs/administration.md
@@ -2,12 +2,14 @@
 title: Amministrazione
 description: Gestione di utenti, ruoli, autenticazione, impostazioni, email e log.
 sidebar:
-  order: 6
+  order: 7
 ---
 
 ## Utenti e ruoli
 
 Gli amministratori gestiscono utenti, ruoli e permessi. Ogni ruolo dovrebbe concedere solo le funzioni necessarie al lavoro quotidiano.
+
+La pagina **Utenti** resta focalizzata sull'accesso applicativo: username, ruolo, permessi, metodo di autenticazione e stato account. I dati HR come telefono, email operativa, mansione, reparto, contratto, sede e contatti di emergenza si gestiscono dal modulo **HR**, non da Amministrazione.
 
 Le righe di permesso con ambito **All** concedono accesso trasversale a tutti i record della stessa area, ad esempio tutti i clienti, fornitori, progetti, task, consuntivi o Competence Center. L'azione **View** abilita la vista e la consultazione su tutti i record; quando selezionate, anche **Create**, **Update** e **Delete** sono permessi reali e consentono scritture su record non assegnati. I permessi senza **All** mantengono l'ambito assegnato all'utente.
 

--- a/docs-site/src/content/docs/ai-reporting.md
+++ b/docs-site/src/content/docs/ai-reporting.md
@@ -2,7 +2,7 @@
 title: AI reporting
 description: Come consultare report assistiti dall'intelligenza artificiale e interpretare le risposte.
 sidebar:
-  order: 5
+  order: 6
 ---
 
 ## Disponibilità

--- a/docs-site/src/content/docs/en/administration.md
+++ b/docs-site/src/content/docs/en/administration.md
@@ -2,12 +2,14 @@
 title: Administration
 description: Managing users, roles, authentication, settings, email, and logs.
 sidebar:
-  order: 6
+  order: 7
 ---
 
 ## Users and roles
 
 Administrators manage users, roles, and permissions. Each role should grant only the functions needed for daily work.
+
+The **Users** page stays focused on application access: username, role, permissions, authentication method, and account status. HR data such as phone, work email, job title, department, contract, location, and emergency contacts is managed in the **HR** module, not in Administration.
 
 Permission rows marked **All** grant cross-record access for the same area, such as all clients, suppliers, projects, tasks, time entries, or competence centers. **View** opens the matching view and allows reading every matching record; when selected, **Create**, **Update**, and **Delete** are real write permissions and can operate on records that are not assigned to the user. Non-**All** permissions keep the user's assigned-record scope.
 

--- a/docs-site/src/content/docs/en/ai-reporting.md
+++ b/docs-site/src/content/docs/en/ai-reporting.md
@@ -2,7 +2,7 @@
 title: AI reporting
 description: How to read AI-assisted reports and interpret answers.
 sidebar:
-  order: 5
+  order: 6
 ---
 
 ## Availability

--- a/docs-site/src/content/docs/en/faq.md
+++ b/docs-site/src/content/docs/en/faq.md
@@ -2,7 +2,7 @@
 title: FAQ and troubleshooting
 description: Quick answers to common issues while using Praetor.
 sidebar:
-  order: 7
+  order: 8
 ---
 
 ## I cannot see a module

--- a/docs-site/src/content/docs/en/getting-started.md
+++ b/docs-site/src/content/docs/en/getting-started.md
@@ -21,7 +21,7 @@ The sidebar groups the main modules. Available items depend on your role:
 - **Sales** for quotes and offers.
 - **Accounting** for orders and invoices.
 - **Projects** for tasks, customers, and progress.
-- **HR** for employees and competence centers.
+- **HR** for employee profiles, operational details, and competence centers.
 - **Reports** for analysis and AI reporting.
 - **Administration** for configuration and audit.
 

--- a/docs-site/src/content/docs/en/hr.md
+++ b/docs-site/src/content/docs/en/hr.md
@@ -1,0 +1,41 @@
+---
+title: HR and employees
+description: Managing HR profiles for internal employees, external employees, and application users.
+sidebar:
+  order: 4
+---
+
+## Employee records
+
+The **HR** module manages operational employee data separately from access controls. The **Internal Employees** and **External Employees** screens show the details HR needs for daily work: employee code, phone, email, job title, department, contract type, HR status, work location, hire or termination dates, emergency contact, and notes.
+
+Application users with Praetor access appear among internal employees when you have the right HR permissions. This lets HR maintain the operational profile for people who also use the application, while **Administration > Users** stays focused on roles, permissions, authentication method, account status, and other security controls.
+
+## Internal and external profiles
+
+Use **Internal Employees** for company personnel and application users. Use **External Employees** for contractors, consultants, suppliers, or other outside resources that need to be tracked in HR and project workflows but do not have an application account.
+
+The HR tables expose the fields needed for quick review: employee code, contact details, role or title, department, and HR status. Open a row to update the profile when you have the matching update permission.
+
+HR status describes the employee lifecycle (**Active**, **Onboarding**, **On leave**, **Terminated**) and does not disable application access. To block an application account, keep using the account status in **Administration > Users**.
+
+In demo environments, the data seed includes realistic HR profiles for application users, non-login internal employees, and external collaborators, so the HR screens immediately show complete examples of contract, location, status, and contact data.
+
+## Name, email, and company providers
+
+For local users, HR can update name and email directly from the employee profile. Email is saved through the same settings-backed path used by personal settings, so it stays consistent with the rest of the application.
+
+For users managed by LDAP, OIDC, or SAML, name and email are controlled by the company provider. Praetor shows those fields as read-only in HR screens and rejects manual server-side changes. On each login or synchronization, non-empty provider values refresh the user's name, avatar initials, and email; missing provider values do not erase existing local data.
+
+## Permissions
+
+HR detail visibility follows the employee type:
+
+- **Internal HR - View/Update** allows reading or changing HR details for internal employees and application users treated as internal employees.
+- **External HR - View/Update** allows reading or changing HR details for external employees.
+
+Without the matching HR permissions, HR fields are omitted from user API responses and are unavailable in the screens. Account administration controls remain governed by user administration permissions.
+
+## Competence centers
+
+Competence centers connect people, costs, and assignments. Keep HR profiles current before analyzing costs, availability, and team composition on projects.

--- a/docs-site/src/content/docs/en/index.md
+++ b/docs-site/src/content/docs/en/index.md
@@ -23,7 +23,8 @@ The guides are written for operators, managers, and administrators. Each section
 
 - **Get started**: sign-in, navigation, and personal settings.
 - **Time tracking**: daily tracker, weekly view, and recurring tasks.
-- **CRM and projects**: records, catalog, tasks, and competence centers.
+- **CRM and projects**: records, catalog, tasks, and assignments.
+- **HR**: employee profiles, operational details, competence centers, and HR permissions.
 - **Sales and accounting**: quotes, offers, orders, and invoices.
 - **AI reporting**: reading reports and using the assistant responsibly.
 - **Administration**: users, roles, authentication, email, settings, and logs.

--- a/docs-site/src/content/docs/en/sales-accounting.md
+++ b/docs-site/src/content/docs/en/sales-accounting.md
@@ -2,7 +2,7 @@
 title: Sales and accounting
 description: Workflows for quotes, offers, orders, customer invoices, and supplier documents.
 sidebar:
-  order: 4
+  order: 5
 ---
 
 ## Customer quotes and offers

--- a/docs-site/src/content/docs/faq.md
+++ b/docs-site/src/content/docs/faq.md
@@ -2,7 +2,7 @@
 title: FAQ e risoluzione problemi
 description: Risposte rapide ai problemi piu comuni durante l'uso di Praetor.
 sidebar:
-  order: 7
+  order: 8
 ---
 
 ## Non vedo un modulo

--- a/docs-site/src/content/docs/getting-started.md
+++ b/docs-site/src/content/docs/getting-started.md
@@ -21,7 +21,7 @@ La barra laterale raggruppa i moduli principali. Le voci disponibili dipendono d
 - **Vendite** per preventivi e offerte.
 - **Contabilità** per ordini e fatture.
 - **Progetti** per attività, clienti e avanzamento.
-- **HR** per dipendenti e Competence Center.
+- **HR** per profili dipendente, dati operativi e Competence Center.
 - **Report** per analisi e AI reporting.
 - **Amministrazione** per configurazioni e audit.
 

--- a/docs-site/src/content/docs/hr.md
+++ b/docs-site/src/content/docs/hr.md
@@ -1,0 +1,41 @@
+---
+title: HR e dipendenti
+description: Gestione dei profili HR di dipendenti interni, esterni e utenti applicativi.
+sidebar:
+  order: 4
+---
+
+## Anagrafica dipendenti
+
+Il modulo **HR** gestisce i dati operativi dei dipendenti separandoli dai controlli di accesso. Le schermate **Dipendenti Interni** e **Dipendenti Esterni** mostrano i dettagli utili alla gestione quotidiana: codice dipendente, telefono, email, mansione, reparto, tipo di contratto, stato HR, sede di lavoro, date di assunzione o cessazione, contatto di emergenza e note.
+
+Gli utenti applicativi con accesso a Praetor compaiono tra i dipendenti interni quando hai i permessi HR necessari. In questo modo HR può mantenere il profilo operativo anche per chi usa l'applicazione, mentre **Amministrazione > Utenti** resta dedicata a ruoli, permessi, metodo di autenticazione, stato account e altri controlli di sicurezza.
+
+## Profili interni ed esterni
+
+Usa **Dipendenti Interni** per personale aziendale e utenti applicativi. Usa **Dipendenti Esterni** per collaboratori, consulenti, fornitori o altre risorse esterne che devono essere tracciate nei processi HR e di progetto ma non hanno un account applicativo.
+
+Le tabelle HR espongono i dati principali per lavorare rapidamente: codice dipendente, contatti, ruolo o mansione, reparto e stato HR. Apri una riga per aggiornare il profilo quando hai il permesso di modifica corrispondente.
+
+I valori di stato HR descrivono il ciclo di vita della risorsa (**Attivo**, **Onboarding**, **In permesso/assenza**, **Cessato**) e non disabilitano l'accesso all'applicazione. Per bloccare un account applicativo continua a usare lo stato account in **Amministrazione > Utenti**.
+
+Negli ambienti demo, il seed dati include profili HR realistici per utenti applicativi, dipendenti interni senza account e collaboratori esterni, così le schermate HR mostrano subito esempi completi di contratto, sede, stato e contatti.
+
+## Nome, email e provider aziendali
+
+Per utenti locali, HR può aggiornare nome ed email direttamente dal profilo dipendente. L'email viene salvata tramite lo stesso percorso usato dalle impostazioni personali, quindi resta coerente con le altre funzioni dell'applicazione.
+
+Per utenti gestiti da LDAP, OIDC o SAML, nome ed email sono controllati dal provider aziendale. Praetor li mostra in sola lettura nelle schermate HR e rifiuta modifiche manuali inviate al server. A ogni login o sincronizzazione, valori non vuoti provenienti dal provider aggiornano nome, iniziali avatar ed email; valori mancanti non cancellano i dati locali esistenti.
+
+## Permessi
+
+La visibilità dei dettagli HR dipende dal tipo di dipendente:
+
+- **HR Interni - View/Update** consente di leggere o modificare i dettagli HR di dipendenti interni e utenti applicativi trattati come interni.
+- **HR Esterni - View/Update** consente di leggere o modificare i dettagli HR dei dipendenti esterni.
+
+Senza i permessi HR corretti, i campi HR non vengono restituiti dalle API utenti e non sono disponibili nelle schermate. I controlli amministrativi dell'account restano governati dai permessi di amministrazione utenti.
+
+## Competence Center
+
+I Competence Center collegano persone, costi e assegnazioni. Mantieni aggiornate le anagrafiche HR prima di analizzare costi, disponibilità e composizione dei team sui progetti.

--- a/docs-site/src/content/docs/index.md
+++ b/docs-site/src/content/docs/index.md
@@ -23,7 +23,8 @@ Le guide sono pensate per utenti operativi, manager e amministratori. Ogni sezio
 
 - **Primi passi**: accesso, navigazione e impostazioni personali.
 - **Time tracking**: tracker giornaliero, vista settimanale e attività ricorrenti.
-- **CRM e progetti**: anagrafiche, catalogo, attività e Competence Center.
+- **CRM e progetti**: anagrafiche, catalogo, attività e assegnazioni.
+- **HR**: profili dipendente, dati operativi, Competence Center e permessi HR.
 - **Vendite e contabilità**: preventivi, offerte, ordini e fatture.
 - **AI reporting**: consultazione dei report e uso responsabile dell'assistente.
 - **Amministrazione**: utenti, ruoli, autenticazione, email, impostazioni e log.

--- a/docs-site/src/content/docs/sales-accounting.md
+++ b/docs-site/src/content/docs/sales-accounting.md
@@ -2,7 +2,7 @@
 title: Vendite e contabilità
 description: Flussi per preventivi, offerte, ordini, fatture clienti e documenti fornitori.
 sidebar:
-  order: 4
+  order: 5
 ---
 
 ## Preventivi e offerte clienti

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1714,6 +1714,149 @@
                           "external"
                         ]
                       },
+                      "phone": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "jobTitle": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "department": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "employeeCode": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "hireDate": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "format": "date"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "terminationDate": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "format": "date"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "contractType": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "enum": [
+                              "permanent",
+                              "fixed_term",
+                              "contractor",
+                              "internship",
+                              "consultant",
+                              "other"
+                            ]
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "employmentStatus": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "enum": [
+                              "active",
+                              "onboarding",
+                              "on_leave",
+                              "terminated"
+                            ]
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "workLocation": {
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "enum": [
+                              "office",
+                              "remote",
+                              "hybrid",
+                              "customer_site",
+                              "other"
+                            ]
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "emergencyContactName": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "emergencyContactPhone": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
+                      "notes": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
+                      },
                       "authMethod": {
                         "type": "string",
                         "enum": [
@@ -1957,6 +2100,149 @@
                       "internal",
                       "external"
                     ]
+                  },
+                  "phone": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "jobTitle": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "department": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "employeeCode": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "hireDate": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "format": "date"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "terminationDate": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "format": "date"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "contractType": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "permanent",
+                          "fixed_term",
+                          "contractor",
+                          "internship",
+                          "consultant",
+                          "other"
+                        ]
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "employmentStatus": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "active",
+                          "onboarding",
+                          "on_leave",
+                          "terminated"
+                        ]
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "workLocation": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "office",
+                          "remote",
+                          "hybrid",
+                          "customer_site",
+                          "other"
+                        ]
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "emergencyContactName": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "emergencyContactPhone": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "notes": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   }
                 },
                 "required": [
@@ -2004,6 +2290,149 @@
                         "app_user",
                         "internal",
                         "external"
+                      ]
+                    },
+                    "phone": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "jobTitle": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "department": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "employeeCode": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "hireDate": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "format": "date"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "terminationDate": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "format": "date"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "contractType": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "permanent",
+                            "fixed_term",
+                            "contractor",
+                            "internship",
+                            "consultant",
+                            "other"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "employmentStatus": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "active",
+                            "onboarding",
+                            "on_leave",
+                            "terminated"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workLocation": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "office",
+                            "remote",
+                            "hybrid",
+                            "customer_site",
+                            "other"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "emergencyContactName": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "emergencyContactPhone": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "notes": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
                       ]
                     },
                     "authMethod": {
@@ -2365,6 +2794,149 @@
                   },
                   "email": {
                     "type": "string"
+                  },
+                  "phone": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "jobTitle": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "department": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "employeeCode": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "hireDate": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "format": "date"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "terminationDate": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "format": "date"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "contractType": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "permanent",
+                          "fixed_term",
+                          "contractor",
+                          "internship",
+                          "consultant",
+                          "other"
+                        ]
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "employmentStatus": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "active",
+                          "onboarding",
+                          "on_leave",
+                          "terminated"
+                        ]
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "workLocation": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "office",
+                          "remote",
+                          "hybrid",
+                          "customer_site",
+                          "other"
+                        ]
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "emergencyContactName": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "emergencyContactPhone": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "notes": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   }
                 }
               }
@@ -2419,6 +2991,149 @@
                         "app_user",
                         "internal",
                         "external"
+                      ]
+                    },
+                    "phone": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "jobTitle": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "department": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "employeeCode": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "hireDate": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "format": "date"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "terminationDate": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "format": "date"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "contractType": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "permanent",
+                            "fixed_term",
+                            "contractor",
+                            "internship",
+                            "consultant",
+                            "other"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "employmentStatus": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "active",
+                            "onboarding",
+                            "on_leave",
+                            "terminated"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workLocation": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "office",
+                            "remote",
+                            "hybrid",
+                            "customer_site",
+                            "other"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "emergencyContactName": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "emergencyContactPhone": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "notes": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
                       ]
                     },
                     "authMethod": {
@@ -2694,6 +3409,149 @@
                         "app_user",
                         "internal",
                         "external"
+                      ]
+                    },
+                    "phone": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "jobTitle": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "department": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "employeeCode": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "hireDate": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "format": "date"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "terminationDate": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "format": "date"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "contractType": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "permanent",
+                            "fixed_term",
+                            "contractor",
+                            "internship",
+                            "consultant",
+                            "other"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "employmentStatus": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "active",
+                            "onboarding",
+                            "on_leave",
+                            "terminated"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workLocation": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "office",
+                            "remote",
+                            "hybrid",
+                            "customer_site",
+                            "other"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "emergencyContactName": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "emergencyContactPhone": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "notes": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
                       ]
                     },
                     "authMethod": {
@@ -3735,6 +4593,1452 @@
                     "clients",
                     "projects",
                     "projectTasks"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/views/": {
+      "get": {
+        "summary": "List saved views (own + shared) for a scope",
+        "tags": [
+          "views"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "table",
+                "dashboard"
+              ]
+            },
+            "in": "query",
+            "name": "kind",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "scopeKey",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "ownerId": {
+                        "type": "string"
+                      },
+                      "ownerName": {
+                        "type": "string"
+                      },
+                      "kind": {
+                        "type": "string",
+                        "enum": [
+                          "table",
+                          "dashboard"
+                        ]
+                      },
+                      "scopeKey": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "config": {
+                        "type": "object",
+                        "additionalProperties": true
+                      },
+                      "access": {
+                        "type": "string",
+                        "enum": [
+                          "owner",
+                          "read",
+                          "write"
+                        ]
+                      },
+                      "createdAt": {
+                        "type": "number"
+                      },
+                      "updatedAt": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "ownerId",
+                      "ownerName",
+                      "kind",
+                      "scopeKey",
+                      "name",
+                      "config",
+                      "access",
+                      "createdAt",
+                      "updatedAt"
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a saved view",
+        "tags": [
+          "views"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "table",
+                      "dashboard"
+                    ]
+                  },
+                  "scopeKey": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "config": {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                },
+                "required": [
+                  "kind",
+                  "scopeKey",
+                  "name",
+                  "config"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "ownerId": {
+                      "type": "string"
+                    },
+                    "ownerName": {
+                      "type": "string"
+                    },
+                    "kind": {
+                      "type": "string",
+                      "enum": [
+                        "table",
+                        "dashboard"
+                      ]
+                    },
+                    "scopeKey": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "config": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "access": {
+                      "type": "string",
+                      "enum": [
+                        "owner",
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "createdAt": {
+                      "type": "number"
+                    },
+                    "updatedAt": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "ownerId",
+                    "ownerName",
+                    "kind",
+                    "scopeKey",
+                    "name",
+                    "config",
+                    "access",
+                    "createdAt",
+                    "updatedAt"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/views/directory": {
+      "get": {
+        "summary": "List users for the share picker",
+        "tags": [
+          "views"
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "username": {
+                        "type": "string"
+                      },
+                      "avatarInitials": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "name",
+                      "username",
+                      "avatarInitials"
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/views/{id}": {
+      "put": {
+        "summary": "Update a saved view",
+        "tags": [
+          "views"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "config": {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "ownerId": {
+                      "type": "string"
+                    },
+                    "ownerName": {
+                      "type": "string"
+                    },
+                    "kind": {
+                      "type": "string",
+                      "enum": [
+                        "table",
+                        "dashboard"
+                      ]
+                    },
+                    "scopeKey": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "config": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "access": {
+                      "type": "string",
+                      "enum": [
+                        "owner",
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "createdAt": {
+                      "type": "number"
+                    },
+                    "updatedAt": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "ownerId",
+                    "ownerName",
+                    "kind",
+                    "scopeKey",
+                    "name",
+                    "config",
+                    "access",
+                    "createdAt",
+                    "updatedAt"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete a saved view",
+        "tags": [
+          "views"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Default Response"
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/views/{id}/shares": {
+      "get": {
+        "summary": "List shares for a saved view",
+        "tags": [
+          "views"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "shares": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "userId": {
+                            "type": "string"
+                          },
+                          "permission": {
+                            "type": "string",
+                            "enum": [
+                              "read",
+                              "write"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "userId",
+                          "permission"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "shares"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "Replace shares for a saved view",
+        "tags": [
+          "views"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "shares": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "userId": {
+                          "type": "string"
+                        },
+                        "permission": {
+                          "type": "string",
+                          "enum": [
+                            "read",
+                            "write"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "userId",
+                        "permission"
+                      ]
+                    }
+                  }
+                },
+                "required": [
+                  "shares"
+                ]
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "shares": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "userId": {
+                            "type": "string"
+                          },
+                          "permission": {
+                            "type": "string",
+                            "enum": [
+                              "read",
+                              "write"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "userId",
+                          "permission"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "shares"
                   ]
                 }
               }
@@ -38994,6 +41298,7 @@
                 "reports_ai_message",
                 "reports_ai_session",
                 "role",
+                "saved_view",
                 "settings",
                 "sso_provider",
                 "supplier",

--- a/hooks/handlers/userHandlers.ts
+++ b/hooks/handlers/userHandlers.ts
@@ -14,6 +14,8 @@ export type UserHandlersDeps = {
   setViewingUserId: React.Dispatch<React.SetStateAction<string>>;
 };
 
+type EmployeeCreatePayload = Partial<User> & { name: string; costPerHour?: number };
+
 export const makeUserHandlers = (deps: UserHandlersDeps) => {
   const { currentUser, setUsers, setRoles, setWorkUnits, setViewingUserId } = deps;
 
@@ -98,12 +100,11 @@ export const makeUserHandlers = (deps: UserHandlersDeps) => {
   };
 
   const addEmployee = async (
-    name: string,
+    data: EmployeeCreatePayload,
     employeeType: 'internal' | 'external',
-    costPerHour?: number,
   ): Promise<{ success: boolean; error?: string }> => {
     try {
-      const employee = await api.employees.create({ name, employeeType, costPerHour });
+      const employee = await api.employees.create({ ...data, employeeType });
       setUsers((prev) => [...prev, employee]);
       return { success: true };
     } catch (err) {
@@ -115,11 +116,9 @@ export const makeUserHandlers = (deps: UserHandlersDeps) => {
     }
   };
 
-  const addInternalEmployee = (name: string, costPerHour?: number) =>
-    addEmployee(name, 'internal', costPerHour);
+  const addInternalEmployee = (data: EmployeeCreatePayload) => addEmployee(data, 'internal');
 
-  const addExternalEmployee = (name: string, costPerHour?: number) =>
-    addEmployee(name, 'external', costPerHour);
+  const addExternalEmployee = (data: EmployeeCreatePayload) => addEmployee(data, 'external');
 
   const updateEmployee = async (id: string, updates: Partial<User>) => {
     try {

--- a/locales/en/hr.json
+++ b/locales/en/hr.json
@@ -36,6 +36,7 @@
     "disabled": "Disabled",
     "name": "Name",
     "surname": "Surname",
+    "identityManagedByProvider": "Name, surname, and email are managed by {{provider}}.",
     "saveChanges": "Save Changes",
     "yesDelete": "Yes, Delete",
     "disableUser": "Disable User",
@@ -136,6 +137,50 @@
     "top_manager": "Top Manager",
     "manager": "Manager",
     "user": "User"
+  },
+  "employeeProfile": {
+    "contactSection": "Contact",
+    "employmentSection": "Employment",
+    "emergencySection": "Emergency and Notes",
+    "notSet": "Not set",
+    "email": "Email Address",
+    "phone": "Phone Number",
+    "jobTitle": "Job Title",
+    "department": "Department",
+    "employeeCode": "Employee Code",
+    "hireDate": "Hire Date",
+    "terminationDate": "Termination Date",
+    "contractType": "Contract Type",
+    "employmentStatus": "HR Status",
+    "workLocation": "Work Location",
+    "emergencyContactName": "Emergency Contact",
+    "emergencyContactPhone": "Emergency Phone",
+    "notes": "Notes",
+    "contact": "Contact",
+    "roleTitle": "Role / Title",
+    "hrStatus": "HR Status",
+    "dateRangeInvalid": "Termination date must be on or after hire date",
+    "contractTypes": {
+      "permanent": "Permanent",
+      "fixed_term": "Fixed-term",
+      "contractor": "Contractor",
+      "internship": "Internship",
+      "consultant": "Consultant",
+      "other": "Other"
+    },
+    "employmentStatuses": {
+      "active": "Active",
+      "onboarding": "Onboarding",
+      "on_leave": "On Leave",
+      "terminated": "Terminated"
+    },
+    "workLocations": {
+      "office": "Office",
+      "remote": "Remote",
+      "hybrid": "Hybrid",
+      "customer_site": "Customer Site",
+      "other": "Other"
+    }
   },
   "internalEmployees": {
     "title": "Internal Employees",

--- a/locales/it/hr.json
+++ b/locales/it/hr.json
@@ -36,6 +36,7 @@
     "disabled": "Disabilitato",
     "name": "Nome",
     "surname": "Cognome",
+    "identityManagedByProvider": "Nome, cognome ed email sono gestiti da {{provider}}.",
     "saveChanges": "Salva Modifiche",
     "yesDelete": "Sì, Elimina",
     "disableUser": "Disabilita Utente",
@@ -136,6 +137,50 @@
     "top_manager": "Top Manager",
     "manager": "Manager",
     "user": "Utente"
+  },
+  "employeeProfile": {
+    "contactSection": "Contatti",
+    "employmentSection": "Rapporto di lavoro",
+    "emergencySection": "Emergenza e note",
+    "notSet": "Non impostato",
+    "email": "Indirizzo email",
+    "phone": "Numero di telefono",
+    "jobTitle": "Mansione",
+    "department": "Dipartimento",
+    "employeeCode": "Codice dipendente",
+    "hireDate": "Data assunzione",
+    "terminationDate": "Data cessazione",
+    "contractType": "Tipo contratto",
+    "employmentStatus": "Stato HR",
+    "workLocation": "Sede di lavoro",
+    "emergencyContactName": "Contatto emergenza",
+    "emergencyContactPhone": "Telefono emergenza",
+    "notes": "Note",
+    "contact": "Contatto",
+    "roleTitle": "Ruolo / Mansione",
+    "hrStatus": "Stato HR",
+    "dateRangeInvalid": "La data di cessazione deve essere successiva o uguale alla data di assunzione",
+    "contractTypes": {
+      "permanent": "Tempo indeterminato",
+      "fixed_term": "Tempo determinato",
+      "contractor": "Appaltatore",
+      "internship": "Stage",
+      "consultant": "Consulente",
+      "other": "Altro"
+    },
+    "employmentStatuses": {
+      "active": "Attivo",
+      "onboarding": "In inserimento",
+      "on_leave": "Assente",
+      "terminated": "Cessato"
+    },
+    "workLocations": {
+      "office": "Ufficio",
+      "remote": "Remoto",
+      "hybrid": "Ibrido",
+      "customer_site": "Sede cliente",
+      "other": "Altro"
+    }
   },
   "internalEmployees": {
     "title": "Dipendenti Interni",

--- a/server/db/demoSeed.ts
+++ b/server/db/demoSeed.ts
@@ -180,6 +180,7 @@ const insertCompatibilityDefaults = async (client: PoolClient, counts: Record<st
 const insertDemoUsersAndSettings = async (client: PoolClient, counts: Record<string, number>) => {
   const userValues: unknown[] = [];
   const userTuples = DEMO_USERS.map((user) => {
+    const index = userValues.length + 1;
     userValues.push(
       user.id,
       user.name,
@@ -188,14 +189,46 @@ const insertDemoUsersAndSettings = async (client: PoolClient, counts: Record<str
       user.role,
       user.avatarInitials,
       user.costPerHour,
-      'app_user',
+      user.employeeType,
+      user.phone,
+      user.jobTitle,
+      user.department,
+      user.employeeCode,
+      user.hireDate,
+      user.terminationDate,
+      user.contractType,
+      user.employmentStatus,
+      user.workLocation,
+      user.emergencyContactName,
+      user.emergencyContactPhone,
+      user.notes,
     );
-    const index = userValues.length - 7;
-    return `($${index}, $${index + 1}, $${index + 2}, $${index + 3}, $${index + 4}, $${index + 5}, $${index + 6}, $${index + 7})`;
+    return `(${Array.from({ length: 20 }, (_, offset) => `$${index + offset}`).join(', ')})`;
   });
   const usersResult = await executeStatement(
     client,
-    `INSERT INTO users (id, name, username, password_hash, role, avatar_initials, cost_per_hour, employee_type)
+    `INSERT INTO users (
+       id,
+       name,
+       username,
+       password_hash,
+       role,
+       avatar_initials,
+       cost_per_hour,
+       employee_type,
+       phone,
+       job_title,
+       department,
+       employee_code,
+       hire_date,
+       termination_date,
+       contract_type,
+       employment_status,
+       work_location,
+       emergency_contact_name,
+       emergency_contact_phone,
+       notes
+     )
      VALUES ${userTuples.join(', ')}
      ON CONFLICT (id) DO UPDATE SET
        name = EXCLUDED.name,
@@ -205,6 +238,18 @@ const insertDemoUsersAndSettings = async (client: PoolClient, counts: Record<str
        avatar_initials = EXCLUDED.avatar_initials,
        cost_per_hour = EXCLUDED.cost_per_hour,
        employee_type = EXCLUDED.employee_type,
+       phone = EXCLUDED.phone,
+       job_title = EXCLUDED.job_title,
+       department = EXCLUDED.department,
+       employee_code = EXCLUDED.employee_code,
+       hire_date = EXCLUDED.hire_date,
+       termination_date = EXCLUDED.termination_date,
+       contract_type = EXCLUDED.contract_type,
+       employment_status = EXCLUDED.employment_status,
+       work_location = EXCLUDED.work_location,
+       emergency_contact_name = EXCLUDED.emergency_contact_name,
+       emergency_contact_phone = EXCLUDED.emergency_contact_phone,
+       notes = EXCLUDED.notes,
        is_disabled = FALSE`,
     userValues,
   );

--- a/server/db/demoSeedManifest.ts
+++ b/server/db/demoSeedManifest.ts
@@ -1,9 +1,37 @@
+import type { UserContractType, UserEmploymentStatus, UserWorkLocation } from './schema/users.ts';
+
 const rangeIds = (prefix: string, count: number, pad = 2) =>
   Array.from({ length: count }, (_, index) => `${prefix}${String(index + 1).padStart(pad, '0')}`);
 
 const currentYear = new Date().getFullYear();
 
 export const DEMO_PASSWORD_HASH = '$2a$12$z5H7VrzTpLImYWSH3xufKufCiGB0n9CSlNMOrRBRIxq.6mvuVS7uy';
+
+type DemoEmployeeType = 'app_user' | 'internal' | 'external';
+
+type DemoUser = {
+  id: string;
+  name: string;
+  username: string;
+  role: 'manager' | 'top_manager' | 'user';
+  avatarInitials: string;
+  fullName: string;
+  email: string;
+  costPerHour: number;
+  employeeType: DemoEmployeeType;
+  phone: string;
+  jobTitle: string;
+  department: string;
+  employeeCode: string;
+  hireDate: string;
+  terminationDate: string | null;
+  contractType: UserContractType;
+  employmentStatus: UserEmploymentStatus;
+  workLocation: UserWorkLocation;
+  emergencyContactName: string;
+  emergencyContactPhone: string;
+  notes: string;
+};
 
 export const DEMO_USERS = [
   {
@@ -15,6 +43,19 @@ export const DEMO_USERS = [
     fullName: 'Manager User',
     email: 'manager@example.com',
     costPerHour: 65.0,
+    employeeType: 'app_user',
+    phone: '+39 02 555 0101',
+    jobTitle: 'Delivery Manager',
+    department: 'Operations',
+    employeeCode: 'EMP-100',
+    hireDate: '2021-02-15',
+    terminationDate: null,
+    contractType: 'permanent',
+    employmentStatus: 'active',
+    workLocation: 'hybrid',
+    emergencyContactName: 'Laura Manager',
+    emergencyContactPhone: '+39 02 555 0901',
+    notes: 'Coordinates delivery teams and customer escalations.',
   },
   {
     id: 'u3',
@@ -25,6 +66,19 @@ export const DEMO_USERS = [
     fullName: 'Standard User',
     email: 'user@example.com',
     costPerHour: 45.0,
+    employeeType: 'app_user',
+    phone: '+39 02 555 0102',
+    jobTitle: 'Software Engineer',
+    department: 'Engineering',
+    employeeCode: 'EMP-101',
+    hireDate: '2023-05-08',
+    terminationDate: null,
+    contractType: 'permanent',
+    employmentStatus: 'active',
+    workLocation: 'remote',
+    emergencyContactName: 'Pat User',
+    emergencyContactPhone: '+39 02 555 0902',
+    notes: 'Focuses on product delivery and support automation.',
   },
   {
     id: 'u4',
@@ -35,6 +89,19 @@ export const DEMO_USERS = [
     fullName: 'Sales Manager',
     email: 'salesmanager@example.com',
     costPerHour: 60.0,
+    employeeType: 'app_user',
+    phone: '+39 02 555 0103',
+    jobTitle: 'Sales Manager',
+    department: 'Sales',
+    employeeCode: 'EMP-102',
+    hireDate: '2020-09-01',
+    terminationDate: null,
+    contractType: 'permanent',
+    employmentStatus: 'active',
+    workLocation: 'office',
+    emergencyContactName: 'Morgan Sales',
+    emergencyContactPhone: '+39 02 555 0903',
+    notes: 'Owns commercial pipeline and key account coordination.',
   },
   {
     id: 'u5',
@@ -45,6 +112,19 @@ export const DEMO_USERS = [
     fullName: 'Elena Rossi',
     email: 'erossi@example.com',
     costPerHour: 50.0,
+    employeeType: 'app_user',
+    phone: '+39 02 555 0104',
+    jobTitle: 'ERP Consultant',
+    department: 'Delivery',
+    employeeCode: 'EMP-103',
+    hireDate: '2022-03-14',
+    terminationDate: null,
+    contractType: 'permanent',
+    employmentStatus: 'active',
+    workLocation: 'customer_site',
+    emergencyContactName: 'Andrea Rossi',
+    emergencyContactPhone: '+39 02 555 0904',
+    notes: 'Assigned to implementation workshops and customer training.',
   },
   {
     id: 'u6',
@@ -55,6 +135,19 @@ export const DEMO_USERS = [
     fullName: 'Marco Bianchi',
     email: 'mbianchi@example.com',
     costPerHour: 40.0,
+    employeeType: 'app_user',
+    phone: '+39 02 555 0105',
+    jobTitle: 'Backend Engineer',
+    department: 'Engineering',
+    employeeCode: 'EMP-104',
+    hireDate: `${currentYear}-01-15`,
+    terminationDate: null,
+    contractType: 'fixed_term',
+    employmentStatus: 'onboarding',
+    workLocation: 'hybrid',
+    emergencyContactName: 'Sara Bianchi',
+    emergencyContactPhone: '+39 02 555 0905',
+    notes: 'Onboarding plan includes API ownership and release workflow training.',
   },
   {
     id: 'u7',
@@ -65,6 +158,19 @@ export const DEMO_USERS = [
     fullName: 'Sofia Conti',
     email: 'sconti@example.com',
     costPerHour: 55.0,
+    employeeType: 'app_user',
+    phone: '+39 02 555 0106',
+    jobTitle: 'Account Executive',
+    department: 'Sales',
+    employeeCode: 'EMP-105',
+    hireDate: '2021-11-22',
+    terminationDate: null,
+    contractType: 'permanent',
+    employmentStatus: 'on_leave',
+    workLocation: 'remote',
+    emergencyContactName: 'Luca Conti',
+    emergencyContactPhone: '+39 02 555 0906',
+    notes: 'Temporary leave; opportunities are delegated to the sales manager.',
   },
   {
     id: 'u8',
@@ -75,6 +181,19 @@ export const DEMO_USERS = [
     fullName: 'Luca Moretti',
     email: 'lmoretti@example.com',
     costPerHour: 35.0,
+    employeeType: 'app_user',
+    phone: '+39 02 555 0107',
+    jobTitle: 'Support Specialist',
+    department: 'Operations',
+    employeeCode: 'EMP-106',
+    hireDate: '2024-06-03',
+    terminationDate: null,
+    contractType: 'permanent',
+    employmentStatus: 'active',
+    workLocation: 'office',
+    emergencyContactName: 'Marta Moretti',
+    emergencyContactPhone: '+39 02 555 0907',
+    notes: 'Covers service desk triage and managed support retainers.',
   },
   {
     id: 'u9',
@@ -85,8 +204,90 @@ export const DEMO_USERS = [
     fullName: 'Top Manager',
     email: 'topmanager@example.com',
     costPerHour: 75.0,
+    employeeType: 'app_user',
+    phone: '+39 02 555 0108',
+    jobTitle: 'Managing Director',
+    department: 'Executive',
+    employeeCode: 'EMP-107',
+    hireDate: '2019-01-07',
+    terminationDate: null,
+    contractType: 'permanent',
+    employmentStatus: 'active',
+    workLocation: 'office',
+    emergencyContactName: 'Alex Director',
+    emergencyContactPhone: '+39 02 555 0908',
+    notes: 'Approves portfolio priorities and cross-unit staffing decisions.',
   },
-] as const;
+  {
+    id: 'u10',
+    name: 'Giulia Verdi',
+    username: 'gverdi.internal',
+    role: 'user',
+    avatarInitials: 'GV',
+    fullName: 'Giulia Verdi',
+    email: 'gverdi@example.com',
+    costPerHour: 48.0,
+    employeeType: 'internal',
+    phone: '+39 02 555 0109',
+    jobTitle: 'HR Generalist',
+    department: 'People Operations',
+    employeeCode: 'EMP-108',
+    hireDate: '2022-11-01',
+    terminationDate: null,
+    contractType: 'permanent',
+    employmentStatus: 'active',
+    workLocation: 'office',
+    emergencyContactName: 'Paolo Verdi',
+    emergencyContactPhone: '+39 02 555 0909',
+    notes: 'Maintains employee records and onboarding checklists.',
+  },
+  {
+    id: 'u11',
+    name: 'Paolo Ferri',
+    username: 'pferri.external',
+    role: 'user',
+    avatarInitials: 'PF',
+    fullName: 'Paolo Ferri',
+    email: 'pferri@example.com',
+    costPerHour: 70.0,
+    employeeType: 'external',
+    phone: '+39 02 555 0110',
+    jobTitle: 'Security Consultant',
+    department: 'External Delivery',
+    employeeCode: 'EXT-201',
+    hireDate: `${currentYear}-02-01`,
+    terminationDate: `${currentYear}-12-31`,
+    contractType: 'consultant',
+    employmentStatus: 'active',
+    workLocation: 'customer_site',
+    emergencyContactName: 'Irene Ferri',
+    emergencyContactPhone: '+39 02 555 0910',
+    notes: 'Fixed-term consulting engagement for customer security reviews.',
+  },
+  {
+    id: 'u12',
+    name: 'Nadia Costa',
+    username: 'ncosta.external',
+    role: 'user',
+    avatarInitials: 'NC',
+    fullName: 'Nadia Costa',
+    email: 'ncosta@example.com',
+    costPerHour: 62.0,
+    employeeType: 'external',
+    phone: '+39 02 555 0111',
+    jobTitle: 'Implementation Partner',
+    department: 'Partner Network',
+    employeeCode: 'EXT-202',
+    hireDate: `${currentYear}-05-15`,
+    terminationDate: null,
+    contractType: 'contractor',
+    employmentStatus: 'onboarding',
+    workLocation: 'remote',
+    emergencyContactName: 'Roberto Costa',
+    emergencyContactPhone: '+39 02 555 0911',
+    notes: 'Partner onboarding for remote implementation capacity.',
+  },
+] as const satisfies readonly DemoUser[];
 
 export const DEMO_USER_IDS = DEMO_USERS.map((user) => user.id);
 export const DEMO_USERNAMES = DEMO_USERS.map((user) => user.username);

--- a/server/db/migrations/0067_add_user_hr_details.sql
+++ b/server/db/migrations/0067_add_user_hr_details.sql
@@ -1,0 +1,17 @@
+ALTER TABLE "users" ADD COLUMN "phone" varchar(50);--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "job_title" varchar(150);--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "department" varchar(150);--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "employee_code" varchar(50);--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "hire_date" date;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "termination_date" date;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "contract_type" varchar(30);--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "employment_status" varchar(30);--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "work_location" varchar(30);--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "emergency_contact_name" varchar(255);--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "emergency_contact_phone" varchar(50);--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "notes" text;--> statement-breakpoint
+CREATE UNIQUE INDEX "idx_users_employee_code_unique" ON "users" USING btree ("employee_code");--> statement-breakpoint
+ALTER TABLE "users" ADD CONSTRAINT "users_contract_type_check" CHECK ("users"."contract_type" IS NULL OR "users"."contract_type" IN ('permanent', 'fixed_term', 'contractor', 'internship', 'consultant', 'other'));--> statement-breakpoint
+ALTER TABLE "users" ADD CONSTRAINT "users_employment_status_check" CHECK ("users"."employment_status" IS NULL OR "users"."employment_status" IN ('active', 'onboarding', 'on_leave', 'terminated'));--> statement-breakpoint
+ALTER TABLE "users" ADD CONSTRAINT "users_work_location_check" CHECK ("users"."work_location" IS NULL OR "users"."work_location" IN ('office', 'remote', 'hybrid', 'customer_site', 'other'));--> statement-breakpoint
+ALTER TABLE "users" ADD CONSTRAINT "users_hr_date_range_check" CHECK ("users"."hire_date" IS NULL OR "users"."termination_date" IS NULL OR "users"."hire_date" <= "users"."termination_date");

--- a/server/db/migrations/meta/0067_snapshot.json
+++ b/server/db/migrations/meta/0067_snapshot.json
@@ -1,0 +1,7205 @@
+{
+  "id": "e9194ce4-cc9a-43fa-a45b-a38d737903de",
+  "prevId": "f4746e8c-b20e-4928-9210-402b49c0ff79",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user.login'"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_audit_logs_created_at": {
+          "name": "idx_audit_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_user_id": {
+          "name": "idx_audit_logs_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_logs_action": {
+          "name": "idx_audit_logs_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.client_profile_options": {
+      "name": "client_profile_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_client_profile_options_category_value_unique": {
+          "name": "idx_client_profile_options_category_value_unique",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "LOWER(\"value\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_client_profile_options_category_sort": {
+          "name": "idx_client_profile_options_category_sort",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "value",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_client_profile_options_category": {
+          "name": "chk_client_profile_options_category",
+          "value": "\"client_profile_options\".\"category\" IN ('sector', 'numberOfEmployees', 'revenue', 'officeCountRange')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.clients": {
+      "name": "clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'company'"
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_code": {
+          "name": "client_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ateco_code": {
+          "name": "ateco_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sector": {
+          "name": "sector",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_of_employees": {
+          "name": "number_of_employees",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revenue": {
+          "name": "revenue",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fiscal_code": {
+          "name": "fiscal_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_code": {
+          "name": "tax_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "office_count_range": {
+          "name": "office_count_range",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "address_country": {
+          "name": "address_country",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_state": {
+          "name": "address_state",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_cap": {
+          "name": "address_cap",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_province": {
+          "name": "address_province",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_civic_number": {
+          "name": "address_civic_number",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line": {
+          "name": "address_line",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_clients_fiscal_code_unique": {
+          "name": "idx_clients_fiscal_code_unique",
+          "columns": [
+            {
+              "expression": "LOWER(\"fiscal_code\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"fiscal_code\" IS NOT NULL AND \"clients\".\"fiscal_code\" <> ''",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_clients_vat_number_unique": {
+          "name": "idx_clients_vat_number_unique",
+          "columns": [
+            {
+              "expression": "LOWER(\"vat_number\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"vat_number\" IS NOT NULL AND \"clients\".\"vat_number\" <> ''",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_clients_tax_code_unique": {
+          "name": "idx_clients_tax_code_unique",
+          "columns": [
+            {
+              "expression": "LOWER(\"tax_code\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"tax_code\" IS NOT NULL AND \"clients\".\"tax_code\" <> ''",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_clients_client_code_unique": {
+          "name": "idx_clients_client_code_unique",
+          "columns": [
+            {
+              "expression": "client_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"clients\".\"client_code\" IS NOT NULL AND \"clients\".\"client_code\" <> ''",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_clients": {
+      "name": "user_clients",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_source": {
+          "name": "assignment_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_clients_user_id_users_id_fk": {
+          "name": "user_clients_user_id_users_id_fk",
+          "tableFrom": "user_clients",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_clients_client_id_clients_id_fk": {
+          "name": "user_clients_client_id_clients_id_fk",
+          "tableFrom": "user_clients",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_clients_user_id_client_id_pk": {
+          "name": "user_clients_user_id_client_id_pk",
+          "columns": ["user_id", "client_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_clients_assignment_source_check": {
+          "name": "user_clients_assignment_source_check",
+          "value": "\"user_clients\".\"assignment_source\" IN ('manual', 'top_manager_auto', 'project_cascade')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.customer_offer_items": {
+      "name": "customer_offer_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "offer_id": {
+          "name": "offer_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_cost": {
+          "name": "product_cost",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_mol_percentage": {
+          "name": "product_mol_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "unit_type": {
+          "name": "unit_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'hours'"
+        },
+        "supplier_quote_id": {
+          "name": "supplier_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_item_id": {
+          "name": "supplier_quote_item_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_supplier_name": {
+          "name": "supplier_quote_supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_unit_price": {
+          "name": "supplier_quote_unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_customer_offer_items_offer_id": {
+          "name": "idx_customer_offer_items_offer_id",
+          "columns": [
+            {
+              "expression": "offer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_offer_items_offer_id_customer_offers_id_fk": {
+          "name": "customer_offer_items_offer_id_customer_offers_id_fk",
+          "tableFrom": "customer_offer_items",
+          "tableTo": "customer_offers",
+          "columnsFrom": ["offer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "customer_offer_items_product_id_products_id_fk": {
+          "name": "customer_offer_items_product_id_products_id_fk",
+          "tableFrom": "customer_offer_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_customer_offer_items_unit_type": {
+          "name": "chk_customer_offer_items_unit_type",
+          "value": "\"customer_offer_items\".\"unit_type\" IN ('hours', 'days', 'unit')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.customer_offers": {
+      "name": "customer_offers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_quote_id": {
+          "name": "linked_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "delivery_date": {
+          "name": "delivery_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_customer_offers_linked_quote_id": {
+          "name": "idx_customer_offers_linked_quote_id",
+          "columns": [
+            {
+              "expression": "linked_quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_offers_client_id": {
+          "name": "idx_customer_offers_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_offers_status": {
+          "name": "idx_customer_offers_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_customer_offers_created_at": {
+          "name": "idx_customer_offers_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "customer_offers_linked_quote_id_quotes_id_fk": {
+          "name": "customer_offers_linked_quote_id_quotes_id_fk",
+          "tableFrom": "customer_offers",
+          "tableTo": "quotes",
+          "columnsFrom": ["linked_quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "customer_offers_client_id_clients_id_fk": {
+          "name": "customer_offers_client_id_clients_id_fk",
+          "tableFrom": "customer_offers",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "customer_offers_status_check": {
+          "name": "customer_offers_status_check",
+          "value": "\"customer_offers\".\"status\" IN ('draft', 'sent', 'accepted', 'denied')"
+        },
+        "chk_customer_offers_discount_type": {
+          "name": "chk_customer_offers_discount_type",
+          "value": "\"customer_offers\".\"discount_type\" IN ('percentage', 'currency')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.email_config": {
+      "name": "email_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "smtp_host": {
+          "name": "smtp_host",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "smtp_port": {
+          "name": "smtp_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 587
+        },
+        "smtp_encryption": {
+          "name": "smtp_encryption",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'tls'"
+        },
+        "smtp_reject_unauthorized": {
+          "name": "smtp_reject_unauthorized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "smtp_user": {
+          "name": "smtp_user",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "smtp_password": {
+          "name": "smtp_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "from_email": {
+          "name": "from_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Praetor'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "email_config_id_check": {
+          "name": "email_config_id_check",
+          "value": "\"email_config\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.general_settings": {
+      "name": "general_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'€'"
+        },
+        "daily_limit": {
+          "name": "daily_limit",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'8.00'"
+        },
+        "start_of_week": {
+          "name": "start_of_week",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Monday'"
+        },
+        "treat_saturday_as_holiday": {
+          "name": "treat_saturday_as_holiday",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "enable_ai_reporting": {
+          "name": "enable_ai_reporting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "gemini_api_key": {
+          "name": "gemini_api_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_provider": {
+          "name": "ai_provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'gemini'"
+        },
+        "openrouter_api_key": {
+          "name": "openrouter_api_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gemini_model_id": {
+          "name": "gemini_model_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "openrouter_model_id": {
+          "name": "openrouter_model_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_weekend_selection": {
+          "name": "allow_weekend_selection",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "default_location": {
+          "name": "default_location",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'remote'"
+        },
+        "ril_company_name": {
+          "name": "ril_company_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "ril_default_start_time": {
+          "name": "ril_default_start_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'09:00'"
+        },
+        "ril_default_exit_time": {
+          "name": "ril_default_exit_time",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'18:00'"
+        },
+        "ril_lunch_break_minutes": {
+          "name": "ril_lunch_break_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 60
+        },
+        "ril_note_options": {
+          "name": "ril_note_options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[{\"value\":\"P\",\"label\":\"Ferie\"},{\"value\":\"P2\",\"label\":\"Permesso\"},{\"value\":\"M\",\"label\":\"Malattia\"},{\"value\":\"F\",\"label\":\"Festivita\"}]'::jsonb"
+        },
+        "ril_transfer_options": {
+          "name": "ril_transfer_options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[\"In sede\",\"Telelavoro\"]'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "general_settings_id_check": {
+          "name": "general_settings_id_check",
+          "value": "\"general_settings\".\"id\" = 1"
+        },
+        "general_settings_start_of_week_check": {
+          "name": "general_settings_start_of_week_check",
+          "value": "\"general_settings\".\"start_of_week\" IN ('Monday', 'Sunday')"
+        },
+        "general_settings_ai_provider_check": {
+          "name": "general_settings_ai_provider_check",
+          "value": "\"general_settings\".\"ai_provider\" IN ('gemini', 'openrouter')"
+        },
+        "general_settings_ril_default_start_time_check": {
+          "name": "general_settings_ril_default_start_time_check",
+          "value": "\"general_settings\".\"ril_default_start_time\" ~ '^([01][0-9]|2[0-3]):[0-5][0-9]$'"
+        },
+        "general_settings_ril_default_exit_time_check": {
+          "name": "general_settings_ril_default_exit_time_check",
+          "value": "\"general_settings\".\"ril_default_exit_time\" ~ '^([01][0-9]|2[0-3]):[0-5][0-9]$'"
+        },
+        "general_settings_ril_lunch_break_minutes_check": {
+          "name": "general_settings_ril_lunch_break_minutes_check",
+          "value": "\"general_settings\".\"ril_lunch_break_minutes\" >= 0 AND \"general_settings\".\"ril_lunch_break_minutes\" <= 240"
+        },
+        "general_settings_ril_note_options_array_check": {
+          "name": "general_settings_ril_note_options_array_check",
+          "value": "jsonb_typeof(\"general_settings\".\"ril_note_options\") = 'array'"
+        },
+        "general_settings_ril_transfer_options_array_check": {
+          "name": "general_settings_ril_transfer_options_array_check",
+          "value": "jsonb_typeof(\"general_settings\".\"ril_transfer_options\") = 'array'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invoice_items": {
+      "name": "invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_of_measure": {
+          "name": "unit_of_measure",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unit'"
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "tax_rate": {
+          "name": "tax_rate",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_invoice_items_invoice_id": {
+          "name": "idx_invoice_items_invoice_id",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoice_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "invoices",
+          "columnsFrom": ["invoice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "invoice_items_product_id_products_id_fk": {
+          "name": "invoice_items_product_id_products_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_sale_id": {
+          "name": "linked_sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_date": {
+          "name": "issue_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "tax_total": {
+          "name": "tax_total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "amount_paid": {
+          "name": "amount_paid",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_invoices_client_id": {
+          "name": "idx_invoices_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_status": {
+          "name": "idx_invoices_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_issue_date": {
+          "name": "idx_invoices_issue_date",
+          "columns": [
+            {
+              "expression": "issue_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_linked_sale_id_sales_id_fk": {
+          "name": "invoices_linked_sale_id_sales_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "sales",
+          "columnsFrom": ["linked_sale_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "invoices_client_id_clients_id_fk": {
+          "name": "invoices_client_id_clients_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invoices_status_check": {
+          "name": "invoices_status_check",
+          "value": "\"invoices\".\"status\" IN ('draft', 'sent', 'paid', 'overdue', 'cancelled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ldap_config": {
+      "name": "ldap_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "server_url": {
+          "name": "server_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ldap://ldap.example.com:389'"
+        },
+        "base_dn": {
+          "name": "base_dn",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'dc=example,dc=com'"
+        },
+        "bind_dn": {
+          "name": "bind_dn",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'cn=read-only-admin,dc=example,dc=com'"
+        },
+        "bind_password": {
+          "name": "bind_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "user_filter": {
+          "name": "user_filter",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'(uid={0})'"
+        },
+        "group_base_dn": {
+          "name": "group_base_dn",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ou=groups,dc=example,dc=com'"
+        },
+        "group_filter": {
+          "name": "group_filter",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'(member={0})'"
+        },
+        "role_mappings": {
+          "name": "role_mappings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "tls_ca_certificate": {
+          "name": "tls_ca_certificate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_provision_all": {
+          "name": "auto_provision_all",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "provision_on_login": {
+          "name": "provision_on_login",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ldap_config_id_check": {
+          "name": "ldap_config_id_check",
+          "value": "\"ldap_config\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mcp_tokens": {
+      "name": "mcp_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_version_at_issue": {
+          "name": "token_version_at_issue",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "idx_mcp_tokens_token_hash_unique": {
+          "name": "idx_mcp_tokens_token_hash_unique",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_tokens_user_id": {
+          "name": "idx_mcp_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_mcp_tokens_active_user": {
+          "name": "idx_mcp_tokens_active_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_tokens_user_id_users_id_fk": {
+          "name": "mcp_tokens_user_id_users_id_fk",
+          "tableFrom": "mcp_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_notifications_user_id": {
+          "name": "idx_notifications_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_user_unread": {
+          "name": "idx_notifications_user_unread",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notifications\".\"is_read\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.offer_versions": {
+      "name": "offer_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "offer_id": {
+          "name": "offer_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'update'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_offer_versions_offer_id_created_at": {
+          "name": "idx_offer_versions_offer_id_created_at",
+          "columns": [
+            {
+              "expression": "offer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "offer_versions_offer_id_customer_offers_id_fk": {
+          "name": "offer_versions_offer_id_customer_offers_id_fk",
+          "tableFrom": "offer_versions",
+          "tableTo": "customer_offers",
+          "columnsFrom": ["offer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "offer_versions_created_by_user_id_users_id_fk": {
+          "name": "offer_versions_created_by_user_id_users_id_fk",
+          "tableFrom": "offer_versions",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_offer_versions_reason": {
+          "name": "chk_offer_versions_reason",
+          "value": "\"offer_versions\".\"reason\" IN ('update', 'restore')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_versions": {
+      "name": "order_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'update'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_order_versions_order_id_created_at": {
+          "name": "idx_order_versions_order_id_created_at",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_versions_order_id_sales_id_fk": {
+          "name": "order_versions_order_id_sales_id_fk",
+          "tableFrom": "order_versions",
+          "tableTo": "sales",
+          "columnsFrom": ["order_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "order_versions_created_by_user_id_users_id_fk": {
+          "name": "order_versions_created_by_user_id_users_id_fk",
+          "tableFrom": "order_versions",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_order_versions_reason": {
+          "name": "chk_order_versions_reason",
+          "value": "\"order_versions\".\"reason\" IN ('update', 'restore')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.personal_access_tokens": {
+      "name": "personal_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_version_at_issue": {
+          "name": "token_version_at_issue",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "personal_access_tokens_user_id_users_id_fk": {
+          "name": "personal_access_tokens_user_id_users_id_fk",
+          "tableFrom": "personal_access_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "personal_access_tokens_user_id_unique": {
+          "name": "personal_access_tokens_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        },
+        "personal_access_tokens_token_hash_unique": {
+          "name": "personal_access_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.internal_product_categories": {
+      "name": "internal_product_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_unit": {
+          "name": "cost_unit",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unit'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_internal_product_categories_type": {
+          "name": "idx_internal_product_categories_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "internal_product_categories_name_type_key": {
+          "name": "internal_product_categories_name_type_key",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "internal_product_categories_cost_unit_check": {
+          "name": "internal_product_categories_cost_unit_check",
+          "value": "\"internal_product_categories\".\"cost_unit\" IN ('unit', 'hours')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.internal_product_subcategories": {
+      "name": "internal_product_subcategories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_internal_product_subcategories_category_id": {
+          "name": "idx_internal_product_subcategories_category_id",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "internal_product_subcategories_category_id_name_key": {
+          "name": "internal_product_subcategories_category_id_name_key",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "internal_product_subcategories_category_id_internal_product_categories_id_fk": {
+          "name": "internal_product_subcategories_category_id_internal_product_categories_id_fk",
+          "tableFrom": "internal_product_subcategories",
+          "tableTo": "internal_product_categories",
+          "columnsFrom": ["category_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_code": {
+          "name": "product_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "costo": {
+          "name": "costo",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "mol_percentage": {
+          "name": "mol_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "cost_unit": {
+          "name": "cost_unit",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unit'"
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'item'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subcategory": {
+          "name": "subcategory",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_products_name": {
+          "name": "idx_products_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_name_unique": {
+          "name": "idx_products_name_unique",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_product_code_unique": {
+          "name": "idx_products_product_code_unique",
+          "columns": [
+            {
+              "expression": "product_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_supplier_id": {
+          "name": "idx_products_supplier_id",
+          "columns": [
+            {
+              "expression": "supplier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_type": {
+          "name": "idx_products_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "products_supplier_id_suppliers_id_fk": {
+          "name": "products_supplier_id_suppliers_id_fk",
+          "tableFrom": "products",
+          "tableTo": "suppliers",
+          "columnsFrom": ["supplier_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.product_types": {
+      "name": "product_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_unit": {
+          "name": "cost_unit",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unit'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_product_types_name": {
+          "name": "idx_product_types_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "product_types_name_unique": {
+          "name": "product_types_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "product_types_cost_unit_check": {
+          "name": "product_types_cost_unit_check",
+          "value": "\"product_types\".\"cost_unit\" IN ('unit', 'hours')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_rules": {
+      "name": "project_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field": {
+          "name": "field",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operator": {
+          "name": "operator",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_logic": {
+          "name": "condition_logic",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'and'"
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'notify'"
+        },
+        "action_config": {
+          "name": "action_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"recipientUserIds\":[],\"recipientRoleIds\":[]}'::jsonb"
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "condition_met": {
+          "name": "condition_met",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_project_rules_project_id": {
+          "name": "idx_project_rules_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_rules_enabled": {
+          "name": "idx_project_rules_enabled",
+          "columns": [
+            {
+              "expression": "is_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_project_rules_condition_met": {
+          "name": "idx_project_rules_condition_met",
+          "columns": [
+            {
+              "expression": "condition_met",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_rules_project_id_projects_id_fk": {
+          "name": "project_rules_project_id_projects_id_fk",
+          "tableFrom": "project_rules",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_rules_created_by_users_id_fk": {
+          "name": "project_rules_created_by_users_id_fk",
+          "tableFrom": "project_rules",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#3b82f6'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "offer_id": {
+          "name": "offer_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revenue": {
+          "name": "revenue",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_type": {
+          "name": "billing_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'time_and_materials'"
+        },
+        "billing_frequency": {
+          "name": "billing_frequency",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'monthly'"
+        }
+      },
+      "indexes": {
+        "idx_projects_client_id": {
+          "name": "idx_projects_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_projects_color_unique": {
+          "name": "idx_projects_color_unique",
+          "columns": [
+            {
+              "expression": "color",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_client_id_clients_id_fk": {
+          "name": "projects_client_id_clients_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "projects_order_id_sales_id_fk": {
+          "name": "projects_order_id_sales_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "sales",
+          "columnsFrom": ["order_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "projects_offer_id_customer_offers_id_fk": {
+          "name": "projects_offer_id_customer_offers_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "customer_offers",
+          "columnsFrom": ["offer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "projects_billing_type_check": {
+          "name": "projects_billing_type_check",
+          "value": "\"projects\".\"billing_type\" IN ('retainer', 'time_and_materials')"
+        },
+        "projects_billing_frequency_check": {
+          "name": "projects_billing_frequency_check",
+          "value": "\"projects\".\"billing_frequency\" IN ('monthly', 'one_time')"
+        },
+        "projects_time_and_materials_monthly_check": {
+          "name": "projects_time_and_materials_monthly_check",
+          "value": "\"projects\".\"billing_type\" != 'time_and_materials' OR \"projects\".\"billing_frequency\" = 'monthly'"
+        },
+        "projects_date_range_check": {
+          "name": "projects_date_range_check",
+          "value": "\"projects\".\"start_date\" IS NULL OR \"projects\".\"end_date\" IS NULL OR \"projects\".\"start_date\" <= \"projects\".\"end_date\""
+        },
+        "projects_revenue_non_negative_check": {
+          "name": "projects_revenue_non_negative_check",
+          "value": "\"projects\".\"revenue\" IS NULL OR \"projects\".\"revenue\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_projects": {
+      "name": "user_projects",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_source": {
+          "name": "assignment_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_projects_user_id_users_id_fk": {
+          "name": "user_projects_user_id_users_id_fk",
+          "tableFrom": "user_projects",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_projects_project_id_projects_id_fk": {
+          "name": "user_projects_project_id_projects_id_fk",
+          "tableFrom": "user_projects",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_projects_user_id_project_id_pk": {
+          "name": "user_projects_user_id_project_id_pk",
+          "columns": ["user_id", "project_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_projects_assignment_source_check": {
+          "name": "user_projects_assignment_source_check",
+          "value": "\"user_projects\".\"assignment_source\" IN ('manual', 'top_manager_auto', 'project_cascade')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.quote_items": {
+      "name": "quote_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_cost": {
+          "name": "product_cost",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_mol_percentage": {
+          "name": "product_mol_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_id": {
+          "name": "supplier_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_item_id": {
+          "name": "supplier_quote_item_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_supplier_name": {
+          "name": "supplier_quote_supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_unit_price": {
+          "name": "supplier_quote_unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_type": {
+          "name": "unit_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'hours'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_quote_items_quote_id": {
+          "name": "idx_quote_items_quote_id",
+          "columns": [
+            {
+              "expression": "quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quote_items_quote_id_quotes_id_fk": {
+          "name": "quote_items_quote_id_quotes_id_fk",
+          "tableFrom": "quote_items",
+          "tableTo": "quotes",
+          "columnsFrom": ["quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "quote_items_product_id_products_id_fk": {
+          "name": "quote_items_product_id_products_id_fk",
+          "tableFrom": "quote_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_quote_items_unit_type": {
+          "name": "chk_quote_items_unit_type",
+          "value": "\"quote_items\".\"unit_type\" IN ('hours', 'days', 'unit')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.quotes": {
+      "name": "quotes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_quotes_client_id": {
+          "name": "idx_quotes_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quotes_status": {
+          "name": "idx_quotes_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_quotes_created_at": {
+          "name": "idx_quotes_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quotes_client_id_clients_id_fk": {
+          "name": "quotes_client_id_clients_id_fk",
+          "tableFrom": "quotes",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "quotes_status_check": {
+          "name": "quotes_status_check",
+          "value": "\"quotes\".\"status\" IN ('quoted', 'confirmed', 'draft', 'sent', 'accepted', 'denied')"
+        },
+        "chk_quotes_discount_type": {
+          "name": "chk_quotes_discount_type",
+          "value": "\"quotes\".\"discount_type\" IN ('percentage', 'currency')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.quote_versions": {
+      "name": "quote_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'update'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_quote_versions_quote_id_created_at": {
+          "name": "idx_quote_versions_quote_id_created_at",
+          "columns": [
+            {
+              "expression": "quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quote_versions_quote_id_quotes_id_fk": {
+          "name": "quote_versions_quote_id_quotes_id_fk",
+          "tableFrom": "quote_versions",
+          "tableTo": "quotes",
+          "columnsFrom": ["quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "quote_versions_created_by_user_id_users_id_fk": {
+          "name": "quote_versions_created_by_user_id_users_id_fk",
+          "tableFrom": "quote_versions",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_quote_versions_reason": {
+          "name": "chk_quote_versions_reason",
+          "value": "\"quote_versions\".\"reason\" IN ('update', 'restore')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.report_chat_messages": {
+      "name": "report_chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thought_content": {
+          "name": "thought_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_report_chat_messages_session_created": {
+          "name": "idx_report_chat_messages_session_created",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_chat_messages_session_id_report_chat_sessions_id_fk": {
+          "name": "report_chat_messages_session_id_report_chat_sessions_id_fk",
+          "tableFrom": "report_chat_messages",
+          "tableTo": "report_chat_sessions",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "report_chat_messages_role_check": {
+          "name": "report_chat_messages_role_check",
+          "value": "\"report_chat_messages\".\"role\" IN ('user', 'assistant')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.report_chat_sessions": {
+      "name": "report_chat_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'AI Reporting'"
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_report_chat_sessions_user_updated": {
+          "name": "idx_report_chat_sessions_user_updated",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_report_chat_sessions_user_archived": {
+          "name": "idx_report_chat_sessions_user_archived",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "report_chat_sessions_user_id_users_id_fk": {
+          "name": "report_chat_sessions_user_id_users_id_fk",
+          "tableFrom": "report_chat_sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_permissions": {
+      "name": "role_permissions",
+      "schema": "",
+      "columns": {
+        "role_id": {
+          "name": "role_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "role_permissions_role_id_roles_id_fk": {
+          "name": "role_permissions_role_id_roles_id_fk",
+          "tableFrom": "role_permissions",
+          "tableTo": "roles",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "role_permissions_role_id_permission_pk": {
+          "name": "role_permissions_role_id_permission_pk",
+          "columns": ["role_id", "permission"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roles": {
+      "name": "roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "roles_name_unique": {
+          "name": "roles_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_roles": {
+      "name": "user_roles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_roles_user_id_users_id_fk": {
+          "name": "user_roles_user_id_users_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_roles_role_id_roles_id_fk": {
+          "name": "user_roles_role_id_roles_id_fk",
+          "tableFrom": "user_roles",
+          "tableTo": "roles",
+          "columnsFrom": ["role_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_roles_user_id_role_id_pk": {
+          "name": "user_roles_user_id_role_id_pk",
+          "columns": ["user_id", "role_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sale_items": {
+      "name": "sale_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sale_id": {
+          "name": "sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_cost": {
+          "name": "product_cost",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "product_mol_percentage": {
+          "name": "product_mol_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "unit_type": {
+          "name": "unit_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'hours'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_id": {
+          "name": "supplier_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_item_id": {
+          "name": "supplier_quote_item_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_supplier_name": {
+          "name": "supplier_quote_supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_quote_unit_price": {
+          "name": "supplier_quote_unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_sale_id": {
+          "name": "supplier_sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_sale_item_id": {
+          "name": "supplier_sale_item_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_sale_supplier_name": {
+          "name": "supplier_sale_supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_sale_items_sale_id": {
+          "name": "idx_sale_items_sale_id",
+          "columns": [
+            {
+              "expression": "sale_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sale_items_supplier_sale_id": {
+          "name": "idx_sale_items_supplier_sale_id",
+          "columns": [
+            {
+              "expression": "supplier_sale_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sale_items_sale_id_sales_id_fk": {
+          "name": "sale_items_sale_id_sales_id_fk",
+          "tableFrom": "sale_items",
+          "tableTo": "sales",
+          "columnsFrom": ["sale_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "sale_items_product_id_products_id_fk": {
+          "name": "sale_items_product_id_products_id_fk",
+          "tableFrom": "sale_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_sale_items_unit_type": {
+          "name": "chk_sale_items_unit_type",
+          "value": "\"sale_items\".\"unit_type\" IN ('hours', 'days', 'unit')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sales": {
+      "name": "sales",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_quote_id": {
+          "name": "linked_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_offer_id": {
+          "name": "linked_offer_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_sales_client_id": {
+          "name": "idx_sales_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_status": {
+          "name": "idx_sales_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_linked_quote_id": {
+          "name": "idx_sales_linked_quote_id",
+          "columns": [
+            {
+              "expression": "linked_quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_linked_offer_id": {
+          "name": "idx_sales_linked_offer_id",
+          "columns": [
+            {
+              "expression": "linked_offer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_linked_offer_id_unique": {
+          "name": "idx_sales_linked_offer_id_unique",
+          "columns": [
+            {
+              "expression": "linked_offer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sales\".\"linked_offer_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sales_created_at": {
+          "name": "idx_sales_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sales_linked_quote_id_quotes_id_fk": {
+          "name": "sales_linked_quote_id_quotes_id_fk",
+          "tableFrom": "sales",
+          "tableTo": "quotes",
+          "columnsFrom": ["linked_quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "sales_linked_offer_id_customer_offers_id_fk": {
+          "name": "sales_linked_offer_id_customer_offers_id_fk",
+          "tableFrom": "sales",
+          "tableTo": "customer_offers",
+          "columnsFrom": ["linked_offer_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "sales_client_id_clients_id_fk": {
+          "name": "sales_client_id_clients_id_fk",
+          "tableFrom": "sales",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sales_status_check": {
+          "name": "sales_status_check",
+          "value": "\"sales\".\"status\" IN ('draft', 'confirmed', 'denied')"
+        },
+        "chk_sales_discount_type": {
+          "name": "chk_sales_discount_type",
+          "value": "\"sales\".\"discount_type\" IN ('percentage', 'currency')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.saved_view_shares": {
+      "name": "saved_view_shares",
+      "schema": "",
+      "columns": {
+        "view_id": {
+          "name": "view_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'read'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_saved_view_shares_user_id": {
+          "name": "idx_saved_view_shares_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_view_shares_view_id_saved_views_id_fk": {
+          "name": "saved_view_shares_view_id_saved_views_id_fk",
+          "tableFrom": "saved_view_shares",
+          "tableTo": "saved_views",
+          "columnsFrom": ["view_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "saved_view_shares_user_id_users_id_fk": {
+          "name": "saved_view_shares_user_id_users_id_fk",
+          "tableFrom": "saved_view_shares",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "saved_view_shares_view_id_user_id_pk": {
+          "name": "saved_view_shares_view_id_user_id_pk",
+          "columns": ["view_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "saved_view_shares_permission_check": {
+          "name": "saved_view_shares_permission_check",
+          "value": "\"saved_view_shares\".\"permission\" IN ('read', 'write')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.saved_views": {
+      "name": "saved_views",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_key": {
+          "name": "scope_key",
+          "type": "varchar(150)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_saved_views_owner_kind_scope": {
+          "name": "idx_saved_views_owner_kind_scope",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_saved_views_kind_scope": {
+          "name": "idx_saved_views_kind_scope",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "saved_views_owner_id_users_id_fk": {
+          "name": "saved_views_owner_id_users_id_fk",
+          "tableFrom": "saved_views",
+          "tableTo": "users",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "saved_views_kind_check": {
+          "name": "saved_views_kind_check",
+          "value": "\"saved_views\".\"kind\" IN ('table', 'dashboard')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "daily_goal": {
+          "name": "daily_goal",
+          "type": "numeric(4, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'8.00'"
+        },
+        "start_of_week": {
+          "name": "start_of_week",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Monday'"
+        },
+        "compact_view": {
+          "name": "compact_view",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "treat_saturday_as_holiday": {
+          "name": "treat_saturday_as_holiday",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "settings_user_id_users_id_fk": {
+          "name": "settings_user_id_users_id_fk",
+          "tableFrom": "settings",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "settings_user_id_unique": {
+          "name": "settings_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "settings_language_check": {
+          "name": "settings_language_check",
+          "value": "\"settings\".\"language\" IN ('en', 'it', 'auto')"
+        },
+        "settings_start_of_week_check": {
+          "name": "settings_start_of_week_check",
+          "value": "\"settings\".\"start_of_week\" IN ('Monday', 'Sunday')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.external_identities": {
+      "name": "external_identities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protocol": {
+          "name": "protocol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_external_identities_identity_unique": {
+          "name": "idx_external_identities_identity_unique",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "protocol",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_external_identities_user_id": {
+          "name": "idx_external_identities_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "external_identities_provider_id_sso_providers_id_fk": {
+          "name": "external_identities_provider_id_sso_providers_id_fk",
+          "tableFrom": "external_identities",
+          "tableTo": "sso_providers",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "external_identities_user_id_users_id_fk": {
+          "name": "external_identities_user_id_users_id_fk",
+          "tableFrom": "external_identities",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "external_identities_protocol_check": {
+          "name": "external_identities_protocol_check",
+          "value": "\"external_identities\".\"protocol\" IN ('oidc', 'saml')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sso_login_tickets": {
+      "name": "sso_login_tickets",
+      "schema": "",
+      "columns": {
+        "ticket": {
+          "name": "ticket",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_role": {
+          "name": "active_role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_sso_login_tickets_user_id": {
+          "name": "idx_sso_login_tickets_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sso_login_tickets_expires_at": {
+          "name": "idx_sso_login_tickets_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sso_login_tickets_user_id_users_id_fk": {
+          "name": "sso_login_tickets_user_id_users_id_fk",
+          "tableFrom": "sso_login_tickets",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sso_providers": {
+      "name": "sso_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "protocol": {
+          "name": "protocol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "issuer_url": {
+          "name": "issuer_url",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'openid profile email'"
+        },
+        "metadata_url": {
+          "name": "metadata_url",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "metadata_xml": {
+          "name": "metadata_xml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "entry_point": {
+          "name": "entry_point",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "idp_issuer": {
+          "name": "idp_issuer",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "idp_cert": {
+          "name": "idp_cert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "sp_issuer": {
+          "name": "sp_issuer",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "public_cert": {
+          "name": "public_cert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "username_attribute": {
+          "name": "username_attribute",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'preferred_username'"
+        },
+        "name_attribute": {
+          "name": "name_attribute",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'name'"
+        },
+        "email_attribute": {
+          "name": "email_attribute",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'email'"
+        },
+        "groups_attribute": {
+          "name": "groups_attribute",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'groups'"
+        },
+        "role_mappings": {
+          "name": "role_mappings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "end_session_enabled": {
+          "name": "end_session_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_sso_providers_slug_unique": {
+          "name": "idx_sso_providers_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sso_providers_protocol_enabled": {
+          "name": "idx_sso_providers_protocol_enabled",
+          "columns": [
+            {
+              "expression": "protocol",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sso_providers_protocol_check": {
+          "name": "sso_providers_protocol_check",
+          "value": "\"sso_providers\".\"protocol\" IN ('oidc', 'saml')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sso_states": {
+      "name": "sso_states",
+      "schema": "",
+      "columns": {
+        "state": {
+          "name": "state",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protocol": {
+          "name": "protocol",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "relay_state": {
+          "name": "relay_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_sso_states_expires_at": {
+          "name": "idx_sso_states_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sso_states_provider_id_sso_providers_id_fk": {
+          "name": "sso_states_provider_id_sso_providers_id_fk",
+          "tableFrom": "sso_states",
+          "tableTo": "sso_providers",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sso_states_protocol_check": {
+          "name": "sso_states_protocol_check",
+          "value": "\"sso_states\".\"protocol\" IN ('oidc', 'saml')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sso_user_sessions": {
+      "name": "sso_user_sessions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sso_user_sessions_user_id_users_id_fk": {
+          "name": "sso_user_sessions_user_id_users_id_fk",
+          "tableFrom": "sso_user_sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sso_user_sessions_provider_id_sso_providers_id_fk": {
+          "name": "sso_user_sessions_provider_id_sso_providers_id_fk",
+          "tableFrom": "sso_user_sessions",
+          "tableTo": "sso_providers",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_invoice_items": {
+      "name": "supplier_invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_invoice_items_invoice_id": {
+          "name": "idx_supplier_invoice_items_invoice_id",
+          "columns": [
+            {
+              "expression": "invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_invoice_items_invoice_id_supplier_invoices_id_fk": {
+          "name": "supplier_invoice_items_invoice_id_supplier_invoices_id_fk",
+          "tableFrom": "supplier_invoice_items",
+          "tableTo": "supplier_invoices",
+          "columnsFrom": ["invoice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "supplier_invoice_items_product_id_products_id_fk": {
+          "name": "supplier_invoice_items_product_id_products_id_fk",
+          "tableFrom": "supplier_invoice_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_invoices": {
+      "name": "supplier_invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_sale_id": {
+          "name": "linked_sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_name": {
+          "name": "supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_date": {
+          "name": "issue_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total": {
+          "name": "total",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "amount_paid": {
+          "name": "amount_paid",
+          "type": "numeric(12, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_invoices_supplier_id": {
+          "name": "idx_supplier_invoices_supplier_id",
+          "columns": [
+            {
+              "expression": "supplier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_invoices_status": {
+          "name": "idx_supplier_invoices_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_invoices_issue_date": {
+          "name": "idx_supplier_invoices_issue_date",
+          "columns": [
+            {
+              "expression": "issue_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_invoices_linked_sale_id": {
+          "name": "idx_supplier_invoices_linked_sale_id",
+          "columns": [
+            {
+              "expression": "linked_sale_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_invoices_linked_sale_id_unique": {
+          "name": "idx_supplier_invoices_linked_sale_id_unique",
+          "columns": [
+            {
+              "expression": "linked_sale_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"supplier_invoices\".\"linked_sale_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_invoices_linked_sale_id_supplier_sales_id_fk": {
+          "name": "supplier_invoices_linked_sale_id_supplier_sales_id_fk",
+          "tableFrom": "supplier_invoices",
+          "tableTo": "supplier_sales",
+          "columnsFrom": ["linked_sale_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "supplier_invoices_supplier_id_suppliers_id_fk": {
+          "name": "supplier_invoices_supplier_id_suppliers_id_fk",
+          "tableFrom": "supplier_invoices",
+          "tableTo": "suppliers",
+          "columnsFrom": ["supplier_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "supplier_invoices_status_check": {
+          "name": "supplier_invoices_status_check",
+          "value": "\"supplier_invoices\".\"status\" IN ('draft', 'sent', 'paid', 'overdue', 'cancelled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier_order_versions": {
+      "name": "supplier_order_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'update'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_order_versions_order_id_created_at": {
+          "name": "idx_supplier_order_versions_order_id_created_at",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_order_versions_order_id_supplier_sales_id_fk": {
+          "name": "supplier_order_versions_order_id_supplier_sales_id_fk",
+          "tableFrom": "supplier_order_versions",
+          "tableTo": "supplier_sales",
+          "columnsFrom": ["order_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "supplier_order_versions_created_by_user_id_users_id_fk": {
+          "name": "supplier_order_versions_created_by_user_id_users_id_fk",
+          "tableFrom": "supplier_order_versions",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_supplier_order_versions_reason": {
+          "name": "chk_supplier_order_versions_reason",
+          "value": "\"supplier_order_versions\".\"reason\" IN ('update', 'restore')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier_quote_attachments": {
+      "name": "supplier_quote_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stored_name": {
+          "name": "stored_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by_user_id": {
+          "name": "uploaded_by_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_quote_attachments_quote_id": {
+          "name": "idx_supplier_quote_attachments_quote_id",
+          "columns": [
+            {
+              "expression": "quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_quote_attachments_quote_id_supplier_quotes_id_fk": {
+          "name": "supplier_quote_attachments_quote_id_supplier_quotes_id_fk",
+          "tableFrom": "supplier_quote_attachments",
+          "tableTo": "supplier_quotes",
+          "columnsFrom": ["quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "supplier_quote_attachments_uploaded_by_user_id_users_id_fk": {
+          "name": "supplier_quote_attachments_uploaded_by_user_id_users_id_fk",
+          "tableFrom": "supplier_quote_attachments",
+          "tableTo": "users",
+          "columnsFrom": ["uploaded_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_quote_items": {
+      "name": "supplier_quote_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "unit_type": {
+          "name": "unit_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'hours'"
+        }
+      },
+      "indexes": {
+        "idx_supplier_quote_items_quote_id": {
+          "name": "idx_supplier_quote_items_quote_id",
+          "columns": [
+            {
+              "expression": "quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_quote_items_quote_id_supplier_quotes_id_fk": {
+          "name": "supplier_quote_items_quote_id_supplier_quotes_id_fk",
+          "tableFrom": "supplier_quote_items",
+          "tableTo": "supplier_quotes",
+          "columnsFrom": ["quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "supplier_quote_items_product_id_products_id_fk": {
+          "name": "supplier_quote_items_product_id_products_id_fk",
+          "tableFrom": "supplier_quote_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_supplier_quote_items_unit_type": {
+          "name": "chk_supplier_quote_items_unit_type",
+          "value": "\"supplier_quote_items\".\"unit_type\" IN ('hours', 'days', 'unit')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier_quotes": {
+      "name": "supplier_quotes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_name": {
+          "name": "supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_quotes_supplier_id": {
+          "name": "idx_supplier_quotes_supplier_id",
+          "columns": [
+            {
+              "expression": "supplier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_quotes_status": {
+          "name": "idx_supplier_quotes_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_quotes_created_at": {
+          "name": "idx_supplier_quotes_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_quotes_supplier_id_suppliers_id_fk": {
+          "name": "supplier_quotes_supplier_id_suppliers_id_fk",
+          "tableFrom": "supplier_quotes",
+          "tableTo": "suppliers",
+          "columnsFrom": ["supplier_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "supplier_quotes_status_check": {
+          "name": "supplier_quotes_status_check",
+          "value": "\"supplier_quotes\".\"status\" IN ('received', 'approved', 'rejected', 'draft', 'sent', 'accepted', 'denied')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier_quote_versions": {
+      "name": "supplier_quote_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'update'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_quote_versions_quote_id_created_at": {
+          "name": "idx_supplier_quote_versions_quote_id_created_at",
+          "columns": [
+            {
+              "expression": "quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_quote_versions_quote_id_supplier_quotes_id_fk": {
+          "name": "supplier_quote_versions_quote_id_supplier_quotes_id_fk",
+          "tableFrom": "supplier_quote_versions",
+          "tableTo": "supplier_quotes",
+          "columnsFrom": ["quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "supplier_quote_versions_created_by_user_id_users_id_fk": {
+          "name": "supplier_quote_versions_created_by_user_id_users_id_fk",
+          "tableFrom": "supplier_quote_versions",
+          "tableTo": "users",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_supplier_quote_versions_reason": {
+          "name": "chk_supplier_quote_versions_reason",
+          "value": "\"supplier_quote_versions\".\"reason\" IN ('update', 'restore')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.supplier_sale_items": {
+      "name": "supplier_sale_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sale_id": {
+          "name": "sale_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1'"
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_sale_items_sale_id": {
+          "name": "idx_supplier_sale_items_sale_id",
+          "columns": [
+            {
+              "expression": "sale_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_sale_items_sale_id_supplier_sales_id_fk": {
+          "name": "supplier_sale_items_sale_id_supplier_sales_id_fk",
+          "tableFrom": "supplier_sale_items",
+          "tableTo": "supplier_sales",
+          "columnsFrom": ["sale_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "supplier_sale_items_product_id_products_id_fk": {
+          "name": "supplier_sale_items_product_id_products_id_fk",
+          "tableFrom": "supplier_sale_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.supplier_sales": {
+      "name": "supplier_sales",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "linked_quote_id": {
+          "name": "linked_quote_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_id": {
+          "name": "supplier_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "supplier_name": {
+          "name": "supplier_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'immediate'"
+        },
+        "discount": {
+          "name": "discount",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "discount_type": {
+          "name": "discount_type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'percentage'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_supplier_sales_supplier_id": {
+          "name": "idx_supplier_sales_supplier_id",
+          "columns": [
+            {
+              "expression": "supplier_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_sales_status": {
+          "name": "idx_supplier_sales_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_supplier_sales_linked_quote_id": {
+          "name": "idx_supplier_sales_linked_quote_id",
+          "columns": [
+            {
+              "expression": "linked_quote_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "supplier_sales_linked_quote_id_supplier_quotes_id_fk": {
+          "name": "supplier_sales_linked_quote_id_supplier_quotes_id_fk",
+          "tableFrom": "supplier_sales",
+          "tableTo": "supplier_quotes",
+          "columnsFrom": ["linked_quote_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        },
+        "supplier_sales_supplier_id_suppliers_id_fk": {
+          "name": "supplier_sales_supplier_id_suppliers_id_fk",
+          "tableFrom": "supplier_sales",
+          "tableTo": "suppliers",
+          "columnsFrom": ["supplier_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "supplier_sales_status_check": {
+          "name": "supplier_sales_status_check",
+          "value": "\"supplier_sales\".\"status\" IN ('draft', 'sent')"
+        },
+        "chk_supplier_sales_discount_type": {
+          "name": "chk_supplier_sales_discount_type",
+          "value": "\"supplier_sales\".\"discount_type\" IN ('percentage', 'currency')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.suppliers": {
+      "name": "suppliers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "supplier_code": {
+          "name": "supplier_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vat_number": {
+          "name": "vat_number",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_code": {
+          "name": "tax_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_terms": {
+          "name": "payment_terms",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_suppliers_name": {
+          "name": "idx_suppliers_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "recurrence_pattern": {
+          "name": "recurrence_pattern",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_start": {
+          "name": "recurrence_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_end": {
+          "name": "recurrence_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_duration": {
+          "name": "recurrence_duration",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "expected_effort": {
+          "name": "expected_effort",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "revenue": {
+          "name": "revenue",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "billing_type": {
+          "name": "billing_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'time_and_materials'"
+        },
+        "billing_frequency": {
+          "name": "billing_frequency",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'monthly'"
+        },
+        "monthly_effort": {
+          "name": "monthly_effort",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        }
+      },
+      "indexes": {
+        "idx_tasks_project_id": {
+          "name": "idx_tasks_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasks_project_id_projects_id_fk": {
+          "name": "tasks_project_id_projects_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "tasks_billing_type_check": {
+          "name": "tasks_billing_type_check",
+          "value": "\"tasks\".\"billing_type\" IN ('retainer', 'time_and_materials')"
+        },
+        "tasks_billing_frequency_check": {
+          "name": "tasks_billing_frequency_check",
+          "value": "\"tasks\".\"billing_frequency\" IN ('monthly', 'one_time')"
+        },
+        "tasks_time_and_materials_monthly_check": {
+          "name": "tasks_time_and_materials_monthly_check",
+          "value": "\"tasks\".\"billing_type\" != 'time_and_materials' OR \"tasks\".\"billing_frequency\" = 'monthly'"
+        },
+        "tasks_recurrence_duration_max_check": {
+          "name": "tasks_recurrence_duration_max_check",
+          "value": "\"tasks\".\"recurrence_duration\" IS NULL OR (\"tasks\".\"recurrence_duration\" >= 0 AND \"tasks\".\"recurrence_duration\" <= 24)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_tasks": {
+      "name": "user_tasks",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_source": {
+          "name": "assignment_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_tasks_user_id_users_id_fk": {
+          "name": "user_tasks_user_id_users_id_fk",
+          "tableFrom": "user_tasks",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_tasks_task_id_tasks_id_fk": {
+          "name": "user_tasks_task_id_tasks_id_fk",
+          "tableFrom": "user_tasks",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_tasks_user_id_task_id_pk": {
+          "name": "user_tasks_user_id_task_id_pk",
+          "columns": ["user_id", "task_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_tasks_assignment_source_check": {
+          "name": "user_tasks_assignment_source_check",
+          "value": "\"user_tasks\".\"assignment_source\" IN ('manual', 'top_manager_auto', 'project_cascade')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.time_entries": {
+      "name": "time_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_name": {
+          "name": "client_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_name": {
+          "name": "project_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task": {
+          "name": "task",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "hourly_cost": {
+          "name": "hourly_cost",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "is_placeholder": {
+          "name": "is_placeholder",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'remote'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "idx_time_entries_user_id": {
+          "name": "idx_time_entries_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_time_entries_date": {
+          "name": "idx_time_entries_date",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_time_entries_client_id": {
+          "name": "idx_time_entries_client_id",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_time_entries_project_id": {
+          "name": "idx_time_entries_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_time_entries_task_id": {
+          "name": "idx_time_entries_task_id",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_time_entries_created_at_id": {
+          "name": "idx_time_entries_created_at_id",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_time_entries_user_id_created_at_id": {
+          "name": "idx_time_entries_user_id_created_at_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "time_entries_user_id_users_id_fk": {
+          "name": "time_entries_user_id_users_id_fk",
+          "tableFrom": "time_entries",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "time_entries_client_id_clients_id_fk": {
+          "name": "time_entries_client_id_clients_id_fk",
+          "tableFrom": "time_entries",
+          "tableTo": "clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "time_entries_project_id_projects_id_fk": {
+          "name": "time_entries_project_id_projects_id_fk",
+          "tableFrom": "time_entries",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "time_entries_task_id_tasks_id_fk": {
+          "name": "time_entries_task_id_tasks_id_fk",
+          "tableFrom": "time_entries",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "time_entries_location_check": {
+          "name": "time_entries_location_check",
+          "value": "\"time_entries\".\"location\" IN ('remote', 'office', 'customer_premise', 'transfer')"
+        },
+        "time_entries_duration_max_check": {
+          "name": "time_entries_duration_max_check",
+          "value": "\"time_entries\".\"duration\" >= 0 AND \"time_entries\".\"duration\" <= 24"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_initials": {
+          "name": "avatar_initials",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_per_hour": {
+          "name": "cost_per_hour",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "employee_type": {
+          "name": "employee_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'app_user'"
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'local'"
+        },
+        "auth_provider_id": {
+          "name": "auth_provider_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_version": {
+          "name": "session_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "token_version": {
+          "name": "token_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_title": {
+          "name": "job_title",
+          "type": "varchar(150)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "department": {
+          "name": "department",
+          "type": "varchar(150)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "employee_code": {
+          "name": "employee_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hire_date": {
+          "name": "hire_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "termination_date": {
+          "name": "termination_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contract_type": {
+          "name": "contract_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "employment_status": {
+          "name": "employment_status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "work_location": {
+          "name": "work_location",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact_name": {
+          "name": "emergency_contact_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emergency_contact_phone": {
+          "name": "emergency_contact_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_users_auth_provider_id": {
+          "name": "idx_users_auth_provider_id",
+          "columns": [
+            {
+              "expression": "auth_provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_employee_code_unique": {
+          "name": "idx_users_employee_code_unique",
+          "columns": [
+            {
+              "expression": "employee_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_role_roles_id_fk": {
+          "name": "users_role_roles_id_fk",
+          "tableFrom": "users",
+          "tableTo": "roles",
+          "columnsFrom": ["role"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "users_auth_provider_id_sso_providers_id_fk": {
+          "name": "users_auth_provider_id_sso_providers_id_fk",
+          "tableFrom": "users",
+          "tableTo": "sso_providers",
+          "columnsFrom": ["auth_provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": ["username"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_employee_type_check": {
+          "name": "users_employee_type_check",
+          "value": "\"users\".\"employee_type\" IN ('app_user', 'internal', 'external')"
+        },
+        "users_auth_method_check": {
+          "name": "users_auth_method_check",
+          "value": "\"users\".\"auth_method\" IN ('local', 'ldap', 'oidc', 'saml')"
+        },
+        "users_contract_type_check": {
+          "name": "users_contract_type_check",
+          "value": "\"users\".\"contract_type\" IS NULL OR \"users\".\"contract_type\" IN ('permanent', 'fixed_term', 'contractor', 'internship', 'consultant', 'other')"
+        },
+        "users_employment_status_check": {
+          "name": "users_employment_status_check",
+          "value": "\"users\".\"employment_status\" IS NULL OR \"users\".\"employment_status\" IN ('active', 'onboarding', 'on_leave', 'terminated')"
+        },
+        "users_work_location_check": {
+          "name": "users_work_location_check",
+          "value": "\"users\".\"work_location\" IS NULL OR \"users\".\"work_location\" IN ('office', 'remote', 'hybrid', 'customer_site', 'other')"
+        },
+        "users_hr_date_range_check": {
+          "name": "users_hr_date_range_check",
+          "value": "\"users\".\"hire_date\" IS NULL OR \"users\".\"termination_date\" IS NULL OR \"users\".\"hire_date\" <= \"users\".\"termination_date\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_work_units": {
+      "name": "user_work_units",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "work_unit_id": {
+          "name": "work_unit_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_work_units_user_id_users_id_fk": {
+          "name": "user_work_units_user_id_users_id_fk",
+          "tableFrom": "user_work_units",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_work_units_work_unit_id_work_units_id_fk": {
+          "name": "user_work_units_work_unit_id_work_units_id_fk",
+          "tableFrom": "user_work_units",
+          "tableTo": "work_units",
+          "columnsFrom": ["work_unit_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_work_units_user_id_work_unit_id_pk": {
+          "name": "user_work_units_user_id_work_unit_id_pk",
+          "columns": ["user_id", "work_unit_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.work_unit_managers": {
+      "name": "work_unit_managers",
+      "schema": "",
+      "columns": {
+        "work_unit_id": {
+          "name": "work_unit_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "work_unit_managers_work_unit_id_work_units_id_fk": {
+          "name": "work_unit_managers_work_unit_id_work_units_id_fk",
+          "tableFrom": "work_unit_managers",
+          "tableTo": "work_units",
+          "columnsFrom": ["work_unit_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "work_unit_managers_user_id_users_id_fk": {
+          "name": "work_unit_managers_user_id_users_id_fk",
+          "tableFrom": "work_unit_managers",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "work_unit_managers_work_unit_id_user_id_pk": {
+          "name": "work_unit_managers_work_unit_id_user_id_pk",
+          "columns": ["work_unit_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.work_units": {
+      "name": "work_units",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_disabled": {
+          "name": "is_disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -470,6 +470,13 @@
       "when": 1780339668437,
       "tag": "0066_add_saved_views_and_shares",
       "breakpoints": true
+    },
+    {
+      "idx": 67,
+      "version": "7",
+      "when": 1780341356660,
+      "tag": "0067_add_user_hr_details",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/schema/users.ts
+++ b/server/db/schema/users.ts
@@ -2,17 +2,29 @@ import { sql } from 'drizzle-orm';
 import {
   boolean,
   check,
+  date,
   index,
   integer,
   numeric,
   pgTable,
+  text,
   timestamp,
+  uniqueIndex,
   varchar,
 } from 'drizzle-orm/pg-core';
 import { roles } from './roles.ts';
 import { ssoProviders } from './ssoProviders.ts';
 
 export type UserAuthMethod = 'local' | 'ldap' | 'oidc' | 'saml';
+export type UserContractType =
+  | 'permanent'
+  | 'fixed_term'
+  | 'contractor'
+  | 'internship'
+  | 'consultant'
+  | 'other';
+export type UserEmploymentStatus = 'active' | 'onboarding' | 'on_leave' | 'terminated';
+export type UserWorkLocation = 'office' | 'remote' | 'hybrid' | 'customer_site' | 'other';
 
 export const users = pgTable(
   'users',
@@ -31,6 +43,18 @@ export const users = pgTable(
     employeeType: varchar('employee_type', { length: 20 })
       .$type<'app_user' | 'internal' | 'external'>()
       .default('app_user'),
+    phone: varchar('phone', { length: 50 }),
+    jobTitle: varchar('job_title', { length: 150 }),
+    department: varchar('department', { length: 150 }),
+    employeeCode: varchar('employee_code', { length: 50 }),
+    hireDate: date('hire_date', { mode: 'string' }),
+    terminationDate: date('termination_date', { mode: 'string' }),
+    contractType: varchar('contract_type', { length: 30 }).$type<UserContractType>(),
+    employmentStatus: varchar('employment_status', { length: 30 }).$type<UserEmploymentStatus>(),
+    workLocation: varchar('work_location', { length: 30 }).$type<UserWorkLocation>(),
+    emergencyContactName: varchar('emergency_contact_name', { length: 255 }),
+    emergencyContactPhone: varchar('emergency_contact_phone', { length: 50 }),
+    notes: text('notes'),
     authMethod: varchar('auth_method', { length: 20 }).$type<UserAuthMethod>().default('local'),
     authProviderId: varchar('auth_provider_id', { length: 50 }).references(() => ssoProviders.id, {
       onDelete: 'set null',
@@ -48,6 +72,23 @@ export const users = pgTable(
       sql`${table.employeeType} IN ('app_user', 'internal', 'external')`,
     ),
     check('users_auth_method_check', sql`${table.authMethod} IN ('local', 'ldap', 'oidc', 'saml')`),
+    check(
+      'users_contract_type_check',
+      sql`${table.contractType} IS NULL OR ${table.contractType} IN ('permanent', 'fixed_term', 'contractor', 'internship', 'consultant', 'other')`,
+    ),
+    check(
+      'users_employment_status_check',
+      sql`${table.employmentStatus} IS NULL OR ${table.employmentStatus} IN ('active', 'onboarding', 'on_leave', 'terminated')`,
+    ),
+    check(
+      'users_work_location_check',
+      sql`${table.workLocation} IS NULL OR ${table.workLocation} IN ('office', 'remote', 'hybrid', 'customer_site', 'other')`,
+    ),
+    check(
+      'users_hr_date_range_check',
+      sql`${table.hireDate} IS NULL OR ${table.terminationDate} IS NULL OR ${table.hireDate} <= ${table.terminationDate}`,
+    ),
+    uniqueIndex('idx_users_employee_code_unique').on(table.employeeCode),
     index('idx_users_auth_provider_id').on(table.authProviderId),
   ],
 );

--- a/server/repositories/usersRepo.ts
+++ b/server/repositories/usersRepo.ts
@@ -1,6 +1,11 @@
 import { eq, sql } from 'drizzle-orm';
 import { type DbExecutor, db, executeRows, runAtomically } from '../db/drizzle.ts';
-import type { UserAuthMethod } from '../db/schema/users.ts';
+import type {
+  UserAuthMethod,
+  UserContractType,
+  UserEmploymentStatus,
+  UserWorkLocation,
+} from '../db/schema/users.ts';
 import { users } from '../db/schema/users.ts';
 import { NotFoundError } from '../utils/http-errors.ts';
 import { parseDbNumber } from '../utils/parse.ts';
@@ -8,6 +13,24 @@ import { ADMIN_ROLE_ID, TOP_MANAGER_ROLE_ID } from '../utils/permissions.ts';
 
 export type EmployeeType = 'app_user' | 'internal' | 'external';
 export type AuthMethod = UserAuthMethod;
+export type ContractType = UserContractType;
+export type EmploymentStatus = UserEmploymentStatus;
+export type WorkLocation = UserWorkLocation;
+
+export type UserHrFields = {
+  phone?: string | null;
+  jobTitle?: string | null;
+  department?: string | null;
+  employeeCode?: string | null;
+  hireDate?: string | null;
+  terminationDate?: string | null;
+  contractType?: ContractType | null;
+  employmentStatus?: EmploymentStatus | null;
+  workLocation?: WorkLocation | null;
+  emergencyContactName?: string | null;
+  emergencyContactPhone?: string | null;
+  notes?: string | null;
+};
 
 export type AuthUser = {
   id: string;
@@ -191,6 +214,18 @@ export const updateNameByUsername = async (
   await exec.update(users).set({ name }).where(eq(users.username, username));
 };
 
+export const updateDirectoryProfile = async (
+  userId: string,
+  fields: { name?: string; avatarInitials?: string },
+  exec: DbExecutor = db,
+): Promise<void> => {
+  const set: Record<string, unknown> = {};
+  if (fields.name !== undefined) set.name = fields.name;
+  if (fields.avatarInitials !== undefined) set.avatarInitials = fields.avatarInitials;
+  if (Object.keys(set).length === 0) return;
+  await exec.update(users).set(set).where(eq(users.id, userId));
+};
+
 // For users that authenticate externally (e.g. LDAP) and must never log in locally. Satisfies
 // the `password_hash NOT NULL` column with a malformed bcrypt that no plaintext can match.
 export const LDAP_PLACEHOLDER_PASSWORD_HASH = '$2a$10$invalidpasswordhashforldapuser00000000000000';
@@ -234,6 +269,18 @@ export type UserListRow = {
   costPerHour: number;
   isDisabled: boolean;
   employeeType: EmployeeType;
+  phone?: string | null;
+  jobTitle?: string | null;
+  department?: string | null;
+  employeeCode?: string | null;
+  hireDate?: string | null;
+  terminationDate?: string | null;
+  contractType?: ContractType | null;
+  employmentStatus?: EmploymentStatus | null;
+  workLocation?: WorkLocation | null;
+  emergencyContactName?: string | null;
+  emergencyContactPhone?: string | null;
+  notes?: string | null;
   hasTopManagerRole: boolean;
   isAdminOnly: boolean;
   authMethod: AuthMethod;
@@ -247,6 +294,8 @@ export type UserCore = {
   username: string;
   role: string;
   employeeType: EmployeeType;
+  hireDate: string | null;
+  terminationDate: string | null;
   authMethod: AuthMethod;
   authProviderId: string | null;
 };
@@ -260,14 +309,14 @@ export type UpdatedUserRow = {
   costPerHour: number;
   isDisabled: boolean;
   employeeType: EmployeeType;
-};
+} & UserHrFields;
 
 export type UserUpdateFields = {
   name?: string;
   isDisabled?: boolean;
   costPerHour?: number | null;
   role?: string;
-};
+} & UserHrFields;
 
 export type UserAssignments = {
   clientIds: string[];
@@ -293,7 +342,7 @@ export type NewFullUser = {
   employeeType: EmployeeType;
   authMethod?: AuthMethod;
   authProviderId?: string | null;
-};
+} & UserHrFields;
 
 type UserListRowDb = {
   id: string;
@@ -305,6 +354,18 @@ type UserListRowDb = {
   costPerHour: string | number | null;
   isDisabled: boolean | null;
   employeeType: string | null;
+  phone: string | null;
+  jobTitle: string | null;
+  department: string | null;
+  employeeCode: string | null;
+  hireDate: string | null;
+  terminationDate: string | null;
+  contractType: string | null;
+  employmentStatus: string | null;
+  workLocation: string | null;
+  emergencyContactName: string | null;
+  emergencyContactPhone: string | null;
+  notes: string | null;
   hasTopManagerRole: boolean | null;
   isAdminOnly: boolean | null;
   authMethod: string | null;
@@ -322,6 +383,18 @@ const mapUserListRow = (row: UserListRowDb): UserListRow => ({
   costPerHour: parseDbNumber(row.costPerHour, 0),
   isDisabled: !!row.isDisabled,
   employeeType: (row.employeeType as EmployeeType | null) ?? 'app_user',
+  phone: row.phone ?? undefined,
+  jobTitle: row.jobTitle ?? undefined,
+  department: row.department ?? undefined,
+  employeeCode: row.employeeCode ?? undefined,
+  hireDate: row.hireDate ?? null,
+  terminationDate: row.terminationDate ?? null,
+  contractType: (row.contractType as ContractType | null) ?? null,
+  employmentStatus: (row.employmentStatus as EmploymentStatus | null) ?? null,
+  workLocation: (row.workLocation as WorkLocation | null) ?? null,
+  emergencyContactName: row.emergencyContactName ?? undefined,
+  emergencyContactPhone: row.emergencyContactPhone ?? undefined,
+  notes: row.notes ?? undefined,
   hasTopManagerRole: !!row.hasTopManagerRole,
   isAdminOnly: !!row.isAdminOnly,
   authMethod: (row.authMethod as AuthMethod | null) ?? 'local',
@@ -338,6 +411,18 @@ type UpdatedUserRowDb = {
   costPerHour: string | number | null;
   isDisabled: boolean | null;
   employeeType: string | null;
+  phone: string | null;
+  jobTitle: string | null;
+  department: string | null;
+  employeeCode: string | null;
+  hireDate: string | null;
+  terminationDate: string | null;
+  contractType: string | null;
+  employmentStatus: string | null;
+  workLocation: string | null;
+  emergencyContactName: string | null;
+  emergencyContactPhone: string | null;
+  notes: string | null;
 };
 
 const mapUpdatedUserRow = (row: UpdatedUserRowDb): UpdatedUserRow => ({
@@ -349,7 +434,53 @@ const mapUpdatedUserRow = (row: UpdatedUserRowDb): UpdatedUserRow => ({
   costPerHour: parseDbNumber(row.costPerHour, 0),
   isDisabled: !!row.isDisabled,
   employeeType: (row.employeeType as EmployeeType | null) ?? 'app_user',
+  phone: row.phone ?? null,
+  jobTitle: row.jobTitle ?? null,
+  department: row.department ?? null,
+  employeeCode: row.employeeCode ?? null,
+  hireDate: row.hireDate ?? null,
+  terminationDate: row.terminationDate ?? null,
+  contractType: (row.contractType as ContractType | null) ?? null,
+  employmentStatus: (row.employmentStatus as EmploymentStatus | null) ?? null,
+  workLocation: (row.workLocation as WorkLocation | null) ?? null,
+  emergencyContactName: row.emergencyContactName ?? null,
+  emergencyContactPhone: row.emergencyContactPhone ?? null,
+  notes: row.notes ?? null,
 });
+
+const setHrFields = (set: Record<string, unknown>, fields: UserHrFields): void => {
+  if (fields.phone !== undefined) set.phone = fields.phone;
+  if (fields.jobTitle !== undefined) set.jobTitle = fields.jobTitle;
+  if (fields.department !== undefined) set.department = fields.department;
+  if (fields.employeeCode !== undefined) set.employeeCode = fields.employeeCode;
+  if (fields.hireDate !== undefined) set.hireDate = fields.hireDate;
+  if (fields.terminationDate !== undefined) set.terminationDate = fields.terminationDate;
+  if (fields.contractType !== undefined) set.contractType = fields.contractType;
+  if (fields.employmentStatus !== undefined) set.employmentStatus = fields.employmentStatus;
+  if (fields.workLocation !== undefined) set.workLocation = fields.workLocation;
+  if (fields.emergencyContactName !== undefined) {
+    set.emergencyContactName = fields.emergencyContactName;
+  }
+  if (fields.emergencyContactPhone !== undefined) {
+    set.emergencyContactPhone = fields.emergencyContactPhone;
+  }
+  if (fields.notes !== undefined) set.notes = fields.notes;
+};
+
+const USER_HR_SELECT_COLUMNS = sql`
+            u.phone,
+            u.job_title AS "jobTitle",
+            u.department,
+            u.employee_code AS "employeeCode",
+            u.hire_date AS "hireDate",
+            u.termination_date AS "terminationDate",
+            u.contract_type AS "contractType",
+            u.employment_status AS "employmentStatus",
+            u.work_location AS "workLocation",
+            u.emergency_contact_name AS "emergencyContactName",
+            u.emergency_contact_phone AS "emergencyContactPhone",
+            u.notes,
+`;
 
 const USER_LIST_FLAG_COLUMNS = sql`
   EXISTS (
@@ -379,6 +510,7 @@ export const listAllForAdmin = async (exec: DbExecutor = db): Promise<UserListRo
             u.cost_per_hour AS "costPerHour",
             u.is_disabled AS "isDisabled",
             u.employee_type AS "employeeType",
+            ${USER_HR_SELECT_COLUMNS}
             u.auth_method AS "authMethod",
             u.auth_provider_id AS "authProviderId",
             sp.name AS "authProviderName",
@@ -398,7 +530,9 @@ export const listScopedForManager = async (
 ): Promise<UserListRow[]> => {
   const conditions = [sql`u.id = ${viewerId}`];
   if (options.canViewManagedUsers) conditions.push(sql`wum.user_id = ${viewerId}`);
-  if (options.canViewInternal) conditions.push(sql`u.employee_type = 'internal'`);
+  if (options.canViewInternal) {
+    conditions.push(sql`u.employee_type IN ('app_user', 'internal')`);
+  }
   if (options.canViewExternal) conditions.push(sql`u.employee_type = 'external'`);
 
   const whereClause = sql.join(conditions, sql` OR `);
@@ -430,6 +564,7 @@ export const listScopedForManager = async (
                      u.cost_per_hour AS "costPerHour",
                      u.is_disabled AS "isDisabled",
                      u.employee_type AS "employeeType",
+                     ${USER_HR_SELECT_COLUMNS}
                      u.auth_method AS "authMethod",
                      u.auth_provider_id AS "authProviderId",
                      sp.name AS "authProviderName",
@@ -458,6 +593,7 @@ export const findById = async (id: string, exec: DbExecutor = db): Promise<UserL
             u.cost_per_hour AS "costPerHour",
             u.is_disabled AS "isDisabled",
             u.employee_type AS "employeeType",
+            ${USER_HR_SELECT_COLUMNS}
             u.auth_method AS "authMethod",
             u.auth_provider_id AS "authProviderId",
             sp.name AS "authProviderName",
@@ -478,6 +614,8 @@ export const findCoreById = async (id: string, exec: DbExecutor = db): Promise<U
       username: users.username,
       role: users.role,
       employeeType: users.employeeType,
+      hireDate: users.hireDate,
+      terminationDate: users.terminationDate,
       authMethod: users.authMethod,
       authProviderId: users.authProviderId,
     })
@@ -490,6 +628,8 @@ export const findCoreById = async (id: string, exec: DbExecutor = db): Promise<U
     username: rows[0].username,
     role: rows[0].role,
     employeeType: (rows[0].employeeType as EmployeeType | null) ?? 'app_user',
+    hireDate: rows[0].hireDate ?? null,
+    terminationDate: rows[0].terminationDate ?? null,
     authMethod: rows[0].authMethod ?? 'local',
     authProviderId: rows[0].authProviderId ?? null,
   };
@@ -548,6 +688,18 @@ export const insertUser = async (user: NewFullUser, exec: DbExecutor = db): Prom
     costPerHour: String(user.costPerHour),
     isDisabled: user.isDisabled,
     employeeType: user.employeeType,
+    phone: user.phone ?? null,
+    jobTitle: user.jobTitle ?? null,
+    department: user.department ?? null,
+    employeeCode: user.employeeCode ?? null,
+    hireDate: user.hireDate ?? null,
+    terminationDate: user.terminationDate ?? null,
+    contractType: user.contractType ?? null,
+    employmentStatus: user.employmentStatus ?? null,
+    workLocation: user.workLocation ?? null,
+    emergencyContactName: user.emergencyContactName ?? null,
+    emergencyContactPhone: user.emergencyContactPhone ?? null,
+    notes: user.notes ?? null,
     authMethod: user.authMethod ?? 'local',
     authProviderId: user.authProviderId ?? null,
   });
@@ -580,6 +732,7 @@ export const updateUserDynamic = async (
     set.costPerHour = fields.costPerHour === null ? null : String(fields.costPerHour);
   }
   if (fields.role !== undefined) set.role = fields.role;
+  setHrFields(set, fields);
 
   if (Object.keys(set).length === 0) return null;
 
@@ -592,6 +745,18 @@ export const updateUserDynamic = async (
     costPerHour: users.costPerHour,
     isDisabled: users.isDisabled,
     employeeType: users.employeeType,
+    phone: users.phone,
+    jobTitle: users.jobTitle,
+    department: users.department,
+    employeeCode: users.employeeCode,
+    hireDate: users.hireDate,
+    terminationDate: users.terminationDate,
+    contractType: users.contractType,
+    employmentStatus: users.employmentStatus,
+    workLocation: users.workLocation,
+    emergencyContactName: users.emergencyContactName,
+    emergencyContactPhone: users.emergencyContactPhone,
+    notes: users.notes,
   });
   return rows[0] ? mapUpdatedUserRow(rows[0]) : null;
 };

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -1,5 +1,6 @@
 import bcrypt from 'bcryptjs';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { withDbTransaction } from '../db/drizzle.ts';
 import {
   authenticateToken,
   generateToken,
@@ -7,6 +8,7 @@ import {
   requireSessionAuth,
 } from '../middleware/auth.ts';
 import * as rolesRepo from '../repositories/rolesRepo.ts';
+import * as settingsRepo from '../repositories/settingsRepo.ts';
 import * as usersRepo from '../repositories/usersRepo.ts';
 import { standardRateLimitedErrorResponses } from '../schemas/common.ts';
 import {
@@ -15,6 +17,7 @@ import {
 } from '../services/external-auth.ts';
 import * as ssoService from '../services/sso.ts';
 import { logAudit } from '../utils/audit.ts';
+import { computeAvatarInitials } from '../utils/initials.ts';
 import { getRolePermissions } from '../utils/permissions.ts';
 import { LOGIN_RATE_LIMIT } from '../utils/rate-limit.ts';
 import { replyError } from '../utils/replyError.ts';
@@ -80,6 +83,29 @@ const LDAP_UNAVAILABLE_BODY = {
   error: 'Authentication service temporarily unavailable',
   errorCode: 'ldap_unavailable',
 } as const;
+
+const syncLdapLoginProfile = async (
+  userId: string,
+  profile: { name?: string; email?: string },
+): Promise<{ name?: string; avatarInitials?: string }> => {
+  const name = profile.name?.trim();
+  const email = profile.email?.trim();
+  if (!name && !email) return {};
+
+  const avatarInitials = name ? computeAvatarInitials(name) : undefined;
+  await withDbTransaction(async (tx) => {
+    if (name) {
+      await usersRepo.updateDirectoryProfile(userId, { name, avatarInitials }, tx);
+    }
+    await settingsRepo.upsertForUser(
+      userId,
+      { fullName: name || null, email: email || null, language: null },
+      tx,
+    );
+  });
+
+  return name ? { name, avatarInitials } : {};
+};
 
 export default async function (fastify: FastifyInstance, _opts: unknown) {
   // POST /login
@@ -159,6 +185,17 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           ldapAuthSuccess = ldapAuthResult.authenticated;
           ldapGroups = ldapAuthResult.groups;
           ldapRoleMappings = ldapAuthResult.roleMappings;
+          if (ldapAuthSuccess) {
+            const syncedProfile = await syncLdapLoginProfile(user.id, {
+              name: ldapAuthResult.displayName,
+              email: ldapAuthResult.email,
+            });
+            user = {
+              ...user,
+              name: syncedProfile.name ?? user.name,
+              avatarInitials: syncedProfile.avatarInitials ?? user.avatarInitials,
+            };
+          }
         } catch (err) {
           fastify.log.error({ err, username: usernameResult.value }, 'LDAP auth attempt failed');
           return reply.code(503).send(LDAP_UNAVAILABLE_BODY);

--- a/server/routes/users.ts
+++ b/server/routes/users.ts
@@ -37,8 +37,10 @@ import {
   badRequest,
   ensureArrayOfStrings,
   optionalArrayOfStrings,
+  optionalDateString,
   optionalEmail,
   optionalLocalizedNonNegativeNumber,
+  optionalNonEmptyString,
   requireNonEmptyString,
   validateEnum,
 } from '../utils/validation.ts';
@@ -49,6 +51,30 @@ const idParamSchema = {
     id: { type: 'string' },
   },
   required: ['id'],
+} as const;
+
+const CONTRACT_TYPES = [
+  'permanent',
+  'fixed_term',
+  'contractor',
+  'internship',
+  'consultant',
+  'other',
+] as const;
+const EMPLOYMENT_STATUSES = ['active', 'onboarding', 'on_leave', 'terminated'] as const;
+const WORK_LOCATIONS = ['office', 'remote', 'hybrid', 'customer_site', 'other'] as const;
+const nullableStringSchema = { anyOf: [{ type: 'string' }, { type: 'null' }] } as const;
+const nullableDateSchema = {
+  anyOf: [{ type: 'string', format: 'date' }, { type: 'null' }],
+} as const;
+const nullableContractTypeSchema = {
+  anyOf: [{ type: 'string', enum: CONTRACT_TYPES }, { type: 'null' }],
+} as const;
+const nullableEmploymentStatusSchema = {
+  anyOf: [{ type: 'string', enum: EMPLOYMENT_STATUSES }, { type: 'null' }],
+} as const;
+const nullableWorkLocationSchema = {
+  anyOf: [{ type: 'string', enum: WORK_LOCATIONS }, { type: 'null' }],
 } as const;
 
 const userSchema = {
@@ -63,6 +89,18 @@ const userSchema = {
     costPerHour: { type: 'number' },
     isDisabled: { type: 'boolean' },
     employeeType: { type: 'string', enum: ['app_user', 'internal', 'external'] },
+    phone: nullableStringSchema,
+    jobTitle: nullableStringSchema,
+    department: nullableStringSchema,
+    employeeCode: nullableStringSchema,
+    hireDate: nullableDateSchema,
+    terminationDate: nullableDateSchema,
+    contractType: nullableContractTypeSchema,
+    employmentStatus: nullableEmploymentStatusSchema,
+    workLocation: nullableWorkLocationSchema,
+    emergencyContactName: nullableStringSchema,
+    emergencyContactPhone: nullableStringSchema,
+    notes: nullableStringSchema,
     authMethod: { type: 'string', enum: ['local', 'ldap', 'oidc', 'saml'] },
     authProviderId: { anyOf: [{ type: 'string' }, { type: 'null' }] },
     authProviderName: { anyOf: [{ type: 'string' }, { type: 'null' }] },
@@ -97,6 +135,18 @@ const userCreateBodySchema = {
     email: { type: 'string' },
     costPerHour: { type: 'number' },
     employeeType: { type: 'string', enum: ['app_user', 'internal', 'external'] },
+    phone: nullableStringSchema,
+    jobTitle: nullableStringSchema,
+    department: nullableStringSchema,
+    employeeCode: nullableStringSchema,
+    hireDate: nullableDateSchema,
+    terminationDate: nullableDateSchema,
+    contractType: nullableContractTypeSchema,
+    employmentStatus: nullableEmploymentStatusSchema,
+    workLocation: nullableWorkLocationSchema,
+    emergencyContactName: nullableStringSchema,
+    emergencyContactPhone: nullableStringSchema,
+    notes: nullableStringSchema,
   },
   required: ['name'],
 } as const;
@@ -109,6 +159,18 @@ const userUpdateBodySchema = {
     costPerHour: { type: 'number' },
     role: { type: 'string' },
     email: { type: 'string' },
+    phone: nullableStringSchema,
+    jobTitle: nullableStringSchema,
+    department: nullableStringSchema,
+    employeeCode: nullableStringSchema,
+    hireDate: nullableDateSchema,
+    terminationDate: nullableDateSchema,
+    contractType: nullableContractTypeSchema,
+    employmentStatus: nullableEmploymentStatusSchema,
+    workLocation: nullableWorkLocationSchema,
+    emergencyContactName: nullableStringSchema,
+    emergencyContactPhone: nullableStringSchema,
+    notes: nullableStringSchema,
   },
 } as const;
 
@@ -274,15 +336,70 @@ const DELETE_PERM_BY_EMPLOYEE_TYPE: Record<usersRepo.EmployeeType, string> = {
   external: 'hr.external.delete',
 };
 
+const HR_UPDATE_PERM_BY_EMPLOYEE_TYPE: Record<usersRepo.EmployeeType, string> = {
+  app_user: 'hr.internal.update',
+  internal: 'hr.internal.update',
+  external: 'hr.external.update',
+};
+
+const HR_VIEW_PERM_BY_EMPLOYEE_TYPE: Record<usersRepo.EmployeeType, string> = {
+  app_user: 'hr.internal.view',
+  internal: 'hr.internal.view',
+  external: 'hr.external.view',
+};
+
+const HR_DETAIL_FIELDS = [
+  'phone',
+  'jobTitle',
+  'department',
+  'employeeCode',
+  'hireDate',
+  'terminationDate',
+  'contractType',
+  'employmentStatus',
+  'workLocation',
+  'emergencyContactName',
+  'emergencyContactPhone',
+  'notes',
+] as const;
+
+const canViewHrDetailsFor = (request: FastifyRequest, employeeType: usersRepo.EmployeeType) =>
+  hasPermission(request, HR_VIEW_PERM_BY_EMPLOYEE_TYPE[employeeType]);
+
+const canUpdateHrDetailsFor = (request: FastifyRequest, employeeType: usersRepo.EmployeeType) =>
+  hasPermission(request, HR_UPDATE_PERM_BY_EMPLOYEE_TYPE[employeeType]);
+
+const canViewEmailFor = (request: FastifyRequest, user: usersRepo.UserListRow) =>
+  canViewUserEmails(request) || canViewHrDetailsFor(request, user.employeeType);
+
 const maskUserResponse = (
   user: usersRepo.UserListRow,
   canViewCosts: boolean,
   canRevealUserEmails: boolean,
-) => ({
-  ...user,
-  email: canRevealUserEmails ? user.email : '',
-  costPerHour: canViewCosts ? user.costPerHour : 0,
-});
+  canRevealHrDetails: boolean,
+) => {
+  const response: Partial<usersRepo.UserListRow> = {
+    ...user,
+    email: canRevealUserEmails ? user.email : '',
+    costPerHour: canViewCosts ? user.costPerHour : 0,
+  };
+
+  if (!canRevealHrDetails) {
+    for (const field of HR_DETAIL_FIELDS) {
+      delete response[field];
+    }
+  }
+
+  return response;
+};
+
+const maskUserForRequest = (request: FastifyRequest, user: usersRepo.UserListRow) =>
+  maskUserResponse(
+    user,
+    canViewCostFor(request, user.id),
+    canViewEmailFor(request, user),
+    canViewHrDetailsFor(request, user.employeeType),
+  );
 
 // Cost visibility per row — the two scopes are strictly independent:
 //   - own row    → hr.costs.view       (personal-scope, read-only counterpart of hr.costs.update)
@@ -293,6 +410,125 @@ const canViewCostFor = (request: FastifyRequest, targetUserId: string | null | u
   if (!targetUserId) return false;
   if (targetUserId === request.user?.id) return hasPermission(request, 'hr.costs.view');
   return hasPermission(request, 'hr.costs_all.view');
+};
+
+const parseNullableHrEnum = <T extends string>(
+  value: unknown,
+  allowedValues: readonly T[],
+  fieldName: string,
+): { ok: true; value: T | null } | { ok: false; message: string } => {
+  if (value === null || value === '') return { ok: true, value: null };
+  const result = validateEnum(value, allowedValues, fieldName);
+  if (!result.ok) return result;
+  return { ok: true, value: result.value };
+};
+
+const parseHrDetails = (
+  body: Record<string, unknown>,
+): { ok: true; fields: usersRepo.UserHrFields } | { ok: false; message: string } => {
+  const fields: usersRepo.UserHrFields = {};
+  const stringFields = [
+    'phone',
+    'jobTitle',
+    'department',
+    'employeeCode',
+    'emergencyContactName',
+    'emergencyContactPhone',
+    'notes',
+  ] as const;
+
+  for (const field of stringFields) {
+    if (!Object.hasOwn(body, field)) continue;
+    const result = optionalNonEmptyString(body[field], field);
+    if (!result.ok) return { ok: false, message: result.message };
+    fields[field] = result.value;
+  }
+
+  if (Object.hasOwn(body, 'hireDate')) {
+    const result = optionalDateString(body.hireDate, 'hireDate');
+    if (!result.ok) return { ok: false, message: result.message };
+    fields.hireDate = result.value;
+  }
+
+  if (Object.hasOwn(body, 'terminationDate')) {
+    const result = optionalDateString(body.terminationDate, 'terminationDate');
+    if (!result.ok) return { ok: false, message: result.message };
+    fields.terminationDate = result.value;
+  }
+
+  if (
+    fields.hireDate !== undefined &&
+    fields.terminationDate !== undefined &&
+    fields.hireDate &&
+    fields.terminationDate &&
+    fields.hireDate > fields.terminationDate
+  ) {
+    return { ok: false, message: 'hireDate must be on or before terminationDate' };
+  }
+
+  if (Object.hasOwn(body, 'contractType')) {
+    const result = parseNullableHrEnum(body.contractType, CONTRACT_TYPES, 'contractType');
+    if (!result.ok) return { ok: false, message: result.message };
+    fields.contractType = result.value;
+  }
+
+  if (Object.hasOwn(body, 'employmentStatus')) {
+    const result = parseNullableHrEnum(
+      body.employmentStatus,
+      EMPLOYMENT_STATUSES,
+      'employmentStatus',
+    );
+    if (!result.ok) return { ok: false, message: result.message };
+    fields.employmentStatus = result.value;
+  }
+
+  if (Object.hasOwn(body, 'workLocation')) {
+    const result = parseNullableHrEnum(body.workLocation, WORK_LOCATIONS, 'workLocation');
+    if (!result.ok) return { ok: false, message: result.message };
+    fields.workLocation = result.value;
+  }
+
+  return { ok: true, fields };
+};
+
+const hasHrDetailPatch = (fields: usersRepo.UserHrFields) =>
+  HR_DETAIL_FIELDS.some((field) => fields[field] !== undefined);
+
+const getHrDateRangeError = (
+  fields: usersRepo.UserHrFields,
+  current?: Pick<usersRepo.UserCore, 'hireDate' | 'terminationDate'>,
+): string | null => {
+  const hireDate = fields.hireDate !== undefined ? fields.hireDate : (current?.hireDate ?? null);
+  const terminationDate =
+    fields.terminationDate !== undefined
+      ? fields.terminationDate
+      : (current?.terminationDate ?? null);
+
+  if (hireDate && terminationDate && hireDate > terminationDate) {
+    return 'hireDate must be on or before terminationDate';
+  }
+  return null;
+};
+
+const getUserUniqueViolationMessage = (err: unknown) => {
+  const violation = getUniqueViolation(err);
+  if (!violation) return null;
+  if (
+    violation.constraint === 'idx_users_employee_code_unique' ||
+    violation.detail?.includes('employee_code')
+  ) {
+    return 'Employee code already exists';
+  }
+  if (
+    violation.constraint === 'users_username_unique' ||
+    violation.constraint === 'users_username_key' ||
+    violation.constraint === 'idx_users_username_lower_unique' ||
+    violation.detail?.includes('(username)') ||
+    violation.detail?.includes('(lower(username))')
+  ) {
+    return 'Username already exists';
+  }
+  return null;
 };
 
 const ensureSubmittedAssignmentsInScope = async (
@@ -378,8 +614,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const canViewInternal = hasPermission(request, 'hr.internal.view');
       const canViewExternal = hasPermission(request, 'hr.external.view');
 
-      const canRevealUserEmails = canViewUserEmails(request);
-
       const users = canViewAllUsers(request)
         ? await usersRepo.listAllForAdmin()
         : await usersRepo.listScopedForManager(request.user.id, {
@@ -388,9 +622,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
             canViewExternal,
           });
 
-      return users.map((u) =>
-        maskUserResponse(u, canViewCostFor(request, u.id), canRevealUserEmails),
-      );
+      return users.map((u) => maskUserForRequest(request, u));
     },
   );
 
@@ -417,7 +649,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       },
     },
     async (request: FastifyRequest, reply: FastifyReply) => {
-      const { name, username, password, role, email, costPerHour, employeeType } = request.body as {
+      const body = request.body as Record<string, unknown>;
+      const { name, username, password, role, email, costPerHour, employeeType } = body as {
         name: string;
         username?: string;
         password?: string;
@@ -458,6 +691,15 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const costPerHourResult = optionalLocalizedNonNegativeNumber(costPerHour, 'costPerHour');
       if (!costPerHourResult.ok) return badRequest(reply, costPerHourResult.message);
       const canApplyCost = hasPermission(request, 'hr.costs_all.update');
+      const hrDetailsResult = parseHrDetails(body);
+      if (!hrDetailsResult.ok) return badRequest(reply, hrDetailsResult.message);
+      const canApplyHrDetails =
+        effectiveEmployeeType === 'app_user'
+          ? canUpdateHrDetailsFor(request, effectiveEmployeeType)
+          : true;
+      const hrDetails = canApplyHrDetails ? hrDetailsResult.fields : {};
+      const dateRangeError = getHrDateRangeError(hrDetailsResult.fields);
+      if (dateRangeError) return badRequest(reply, dateRangeError);
 
       let usernameValue: string;
       let passwordHash: string;
@@ -510,6 +752,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
               costPerHour: canApplyCost ? costPerHourResult.value || 0 : 0,
               isDisabled: false,
               employeeType: effectiveEmployeeType,
+              ...hrDetails,
             },
             tx,
           );
@@ -542,11 +785,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
             secondaryLabel: usernameValue,
           },
         });
-        return reply.code(201).send({
+        const createdUser: usersRepo.UserListRow = {
           id,
           name: nameResult.value,
           username: usernameValue,
-          email: canViewUserEmails(request) ? emailResult.value || '' : '',
+          email: emailResult.value || '',
           role: roleValue,
           avatarInitials,
           // Mirror maskUserResponse's view-based mask used by GET / and PUT:
@@ -561,16 +804,18 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
               : 0,
           isDisabled: false,
           employeeType: effectiveEmployeeType,
+          ...hrDetails,
           authMethod: 'local',
           authProviderId: null,
           authProviderName: null,
           hasTopManagerRole: roleValue === TOP_MANAGER_ROLE_ID,
           isAdminOnly: roleValue === ADMIN_ROLE_ID,
-        });
+        };
+
+        return reply.code(201).send(maskUserForRequest(request, createdUser));
       } catch (err) {
-        if (getUniqueViolation(err)) {
-          return badRequest(reply, 'Username already exists');
-        }
+        const uniqueMessage = getUserUniqueViolationMessage(err);
+        if (uniqueMessage) return badRequest(reply, uniqueMessage);
         throw err;
       }
     },
@@ -686,7 +931,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
     },
     async (request: FastifyRequest, reply: FastifyReply) => {
       const { id } = request.params as { id: string };
-      const { name, email, isDisabled, costPerHour, role } = request.body as {
+      const body = request.body as Record<string, unknown>;
+      const { name, email, isDisabled, costPerHour, role } = body as {
         name?: string;
         email?: string;
         isDisabled?: boolean;
@@ -727,6 +973,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         validatedEmail = emailResult.value;
       }
 
+      const hrDetailsResult = parseHrDetails(body);
+      if (!hrDetailsResult.ok) return badRequest(reply, hrDetailsResult.message);
+      const hrDetails = hrDetailsResult.fields;
+      const hasHrDetails = hasHrDetailPatch(hrDetails);
+
       const targetUser = await usersRepo.findCoreById(idResult.value);
       if (!targetUser) {
         return replyError(request, reply, {
@@ -742,6 +993,19 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const currentRole = targetUser.role;
       const currentName = targetUser.name;
       const currentUsername = targetUser.username;
+      const dateRangeError = getHrDateRangeError(hrDetails, targetUser);
+      if (dateRangeError) return badRequest(reply, dateRangeError);
+
+      if (targetUser.authMethod !== 'local' && (name !== undefined || email !== undefined)) {
+        return replyError(request, reply, {
+          statusCode: 409,
+          message: 'Name and email are managed by the external authentication provider',
+          action: 'user.update.conflict',
+          entityType: 'user',
+          entityId: idResult.value,
+          details: { secondaryLabel: `auth_method_${targetUser.authMethod}` },
+        });
+      }
 
       // Cost-only edit bypass: a role granted just a cost-edit permission
       // (personal `hr.costs.update` for self-edit, or all-scope
@@ -755,16 +1019,22 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         name === undefined &&
         email === undefined &&
         isDisabled === undefined &&
-        role === undefined;
+        role === undefined &&
+        !hasHrDetails;
       const hasCostEditGrant = isSelf
         ? hasPermission(request, 'hr.costs.update')
         : hasPermission(request, 'hr.costs_all.update');
       const isCostOnlyEdit = onlyEditingCost && hasCostEditGrant;
+      const hasStandardUpdatePermission = hasPermission(
+        request,
+        UPDATE_PERM_BY_EMPLOYEE_TYPE[targetEmployeeType],
+      );
+      const hasHrUpdatePermission = canUpdateHrDetailsFor(request, targetEmployeeType);
+      const hasIdentityFields = name !== undefined || email !== undefined;
+      const hasIdentityUpdatePermission = hasStandardUpdatePermission || hasHrUpdatePermission;
+      const hasAccountFields = isDisabled !== undefined || role !== undefined;
 
-      if (
-        !isCostOnlyEdit &&
-        !hasPermission(request, UPDATE_PERM_BY_EMPLOYEE_TYPE[targetEmployeeType])
-      ) {
+      if (!isCostOnlyEdit && hasAccountFields && !hasStandardUpdatePermission) {
         return replyError(request, reply, {
           statusCode: 403,
           message: 'Insufficient permissions',
@@ -775,13 +1045,45 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         });
       }
 
+      if (!isCostOnlyEdit && hasIdentityFields && !hasIdentityUpdatePermission) {
+        return replyError(request, reply, {
+          statusCode: 403,
+          message: 'Insufficient permissions',
+          action: 'user.update.denied',
+          entityType: 'user',
+          entityId: idResult.value,
+          details: { secondaryLabel: `employee_type_${targetEmployeeType}` },
+        });
+      }
+
+      if (!isCostOnlyEdit && hasHrDetails && !hasHrUpdatePermission) {
+        return replyError(request, reply, {
+          statusCode: 403,
+          message: 'Insufficient permissions',
+          action: 'user.update.denied',
+          entityType: 'user',
+          entityId: idResult.value,
+          details: { secondaryLabel: `employee_type_${targetEmployeeType}` },
+        });
+      }
+
+      if (hasHrDetails) {
+        Object.assign(fields, hrDetails);
+      }
+
       // Cost-only edits also skip the manager-scoping check: the all-scope
       // `hr.costs_all.update` grant is explicitly cross-user by design, so
       // gating it through canManageUser would make the permission half-useful
       // (works for internal/external employees, fails for app_users).
+      const appUserHrProfileEdit =
+        targetEmployeeType === 'app_user' &&
+        !hasAccountFields &&
+        (hasIdentityFields || hasHrDetails) &&
+        hasHrUpdatePermission;
       if (
         !isCostOnlyEdit &&
         targetEmployeeType === 'app_user' &&
+        !appUserHrProfileEdit &&
         !hasPermission(request, 'administration.user_management_all.view') &&
         idResult.value !== request.user?.id &&
         !(await usersRepo.canManageUser(idResult.value, request.user?.id ?? ''))
@@ -832,34 +1134,42 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       }
 
       const needsSettingsUpsert = fields.name !== undefined || validatedEmail !== undefined;
+      const settingsEmailPatch = email !== undefined ? (validatedEmail ?? '') : null;
 
       if (hasFieldUpdates || needsSettingsUpsert) {
         // Single transaction so users.name/email and the mirrored settings row commit (or
         // roll back) together. Previously the settings upsert ran after the users-update
         // transaction had already committed, so a failed upsert left users updated while
         // settings stayed stale, and findById's LEFT JOIN returned an inconsistent row.
-        const txResult = await withDbTransaction(async (tx) => {
-          if (hasFieldUpdates) {
-            const row = await usersRepo.updateUserDynamic(idResult.value, fields, tx);
-            if (!row) return { userExists: false };
-            if (roleValue !== null) {
-              await usersRepo.replaceUserRoles(idResult.value, [roleValue], tx);
-              await userAssignmentsRepo.syncTopManagerAssignmentsForUser(idResult.value, tx);
+        let txResult: { userExists: boolean };
+        try {
+          txResult = await withDbTransaction(async (tx) => {
+            if (hasFieldUpdates) {
+              const row = await usersRepo.updateUserDynamic(idResult.value, fields, tx);
+              if (!row) return { userExists: false };
+              if (roleValue !== null) {
+                await usersRepo.replaceUserRoles(idResult.value, [roleValue], tx);
+                await userAssignmentsRepo.syncTopManagerAssignmentsForUser(idResult.value, tx);
+              }
             }
-          }
-          if (needsSettingsUpsert) {
-            await settingsRepo.upsertForUser(
-              idResult.value,
-              {
-                fullName: fields.name ?? null,
-                email: validatedEmail ?? null,
-                language: null,
-              },
-              tx,
-            );
-          }
-          return { userExists: true };
-        });
+            if (needsSettingsUpsert) {
+              await settingsRepo.upsertForUser(
+                idResult.value,
+                {
+                  fullName: fields.name ?? null,
+                  email: settingsEmailPatch,
+                  language: null,
+                },
+                tx,
+              );
+            }
+            return { userExists: true };
+          });
+        } catch (err) {
+          const uniqueMessage = getUserUniqueViolationMessage(err);
+          if (uniqueMessage) return badRequest(reply, uniqueMessage);
+          throw err;
+        }
 
         if (!txResult.userExists) {
           return replyError(request, reply, {
@@ -873,15 +1183,27 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       }
 
       const changedFields = getAuditChangedFields({
-        name,
-        email,
-        isDisabled,
+        name: fields.name,
+        email: email !== undefined ? (validatedEmail ?? '') : undefined,
+        isDisabled: fields.isDisabled,
         // Mirror the write-side gate: `fields.costPerHour` is set only when the
         // caller had permission to apply it (self + personal/all scope, or other
         // user + all scope). Anything else was silently dropped above, so it must
         // not appear in the audit diff either.
         costPerHour: fields.costPerHour,
-        role,
+        role: fields.role,
+        phone: fields.phone,
+        jobTitle: fields.jobTitle,
+        department: fields.department,
+        employeeCode: fields.employeeCode,
+        hireDate: fields.hireDate,
+        terminationDate: fields.terminationDate,
+        contractType: fields.contractType,
+        employmentStatus: fields.employmentStatus,
+        workLocation: fields.workLocation,
+        emergencyContactName: fields.emergencyContactName,
+        emergencyContactPhone: fields.emergencyContactPhone,
+        notes: fields.notes,
       });
 
       let action = 'user.updated';
@@ -904,8 +1226,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         });
       }
 
-      const canRevealUserEmails = canViewUserEmails(request);
-
       await logAudit({
         request,
         action,
@@ -919,7 +1239,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           toValue: role !== undefined ? fullUser.role : undefined,
         },
       });
-      return maskUserResponse(fullUser, canViewCostFor(request, fullUser.id), canRevealUserEmails);
+      return maskUserForRequest(request, fullUser);
     },
   );
 
@@ -1098,11 +1418,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         },
       });
 
-      return maskUserResponse(
-        updated,
-        canViewCostFor(request, updated.id),
-        canViewUserEmails(request),
-      );
+      return maskUserForRequest(request, updated);
     },
   );
 

--- a/server/services/external-auth.ts
+++ b/server/services/external-auth.ts
@@ -150,6 +150,27 @@ const writeExternalRoleIdsTx = async (
 const writeExternalRoleIds = (userId: string, roleIds: string[]): Promise<void> =>
   withDbTransaction((tx) => writeExternalRoleIdsTx(userId, roleIds, tx));
 
+const syncExternalProfileTx = async (
+  userId: string,
+  input: Pick<ResolveExternalIdentityInput, 'name' | 'email'>,
+  tx: DbExecutor,
+): Promise<{ name?: string; avatarInitials?: string }> => {
+  const name = input.name?.trim();
+  const email = input.email?.trim();
+  if (!name && !email) return {};
+
+  const avatarInitials = name ? computeAvatarInitials(name) : undefined;
+  if (name) {
+    await usersRepo.updateDirectoryProfile(userId, { name, avatarInitials }, tx);
+  }
+  await settingsRepo.upsertForUser(
+    userId,
+    { fullName: name || null, email: email || null, language: null },
+    tx,
+  );
+  return name ? { name, avatarInitials } : {};
+};
+
 const applyExternalRoleIdsForUser = async (
   userId: string,
   roleIds: string[],
@@ -346,6 +367,15 @@ export const resolveExternalIdentity = async (
 
       if (user.isDisabled) {
         throw new ExternalAuthError('User is disabled', 'user_disabled');
+      }
+
+      if (!wasCreated) {
+        const syncedProfile = await syncExternalProfileTx(user.id, input, tx);
+        user = {
+          ...user,
+          name: syncedProfile.name ?? user.name,
+          avatarInitials: syncedProfile.avatarInitials ?? user.avatarInitials,
+        };
       }
 
       // Role mapping is bootstrap-only: it seeds user_roles when this request is the one

--- a/server/services/ldap.ts
+++ b/server/services/ldap.ts
@@ -1,6 +1,8 @@
 import fs from 'fs';
 import ldap from 'ldapjs';
+import { type DbExecutor, withDbTransaction } from '../db/drizzle.ts';
 import * as ldapRepo from '../repositories/ldapRepo.ts';
+import * as settingsRepo from '../repositories/settingsRepo.ts';
 import * as usersRepo from '../repositories/usersRepo.ts';
 import { computeAvatarInitials } from '../utils/initials.ts';
 import {
@@ -29,6 +31,7 @@ interface LdapEntry {
   sAMAccountName?: string | string[];
   cn?: string | string[];
   displayName?: string | string[];
+  mail?: string | string[];
   [key: string]: unknown;
 }
 
@@ -97,6 +100,7 @@ export type LdapAuthResult = {
   roleMappings: ExternalRoleMapping[];
   canonicalUsername?: string;
   displayName?: string;
+  email?: string;
 };
 
 export type LdapUserEntry = {
@@ -181,8 +185,39 @@ const deriveCanonicalUsername = (
   typedUsername: string,
 ): string => getFirstAttributeValue(attributes, 'uid', 'sAMAccountName') ?? typedUsername;
 
-const deriveDisplayName = (attributes: Record<string, unknown>, fallback: string): string =>
-  getFirstAttributeValue(attributes, 'cn', 'displayName') ?? fallback;
+const deriveDisplayName = (attributes: Record<string, unknown>): string | undefined =>
+  getFirstAttributeValue(attributes, 'cn', 'displayName');
+
+const deriveEmail = (attributes: Record<string, unknown>): string | undefined =>
+  getFirstAttributeValue(attributes, 'mail', 'email');
+
+const syncDirectoryProfileTx = async (
+  userId: string,
+  profile: { name?: string; email?: string },
+  tx: DbExecutor,
+): Promise<void> => {
+  const name = profile.name?.trim();
+  const email = profile.email?.trim();
+  if (!name && !email) return;
+
+  if (name) {
+    await usersRepo.updateDirectoryProfile(
+      userId,
+      { name, avatarInitials: computeAvatarInitials(name) },
+      tx,
+    );
+  }
+  await settingsRepo.upsertForUser(
+    userId,
+    { fullName: name || null, email: email || null, language: null },
+    tx,
+  );
+};
+
+const syncDirectoryProfile = (
+  userId: string,
+  profile: { name?: string; email?: string },
+): Promise<void> => withDbTransaction((tx) => syncDirectoryProfileTx(userId, profile, tx));
 
 const isUniqueViolationError = (err: unknown): boolean => {
   if (!err || typeof err !== 'object') return false;
@@ -348,7 +383,8 @@ class LDAPService {
         matchedRoleIds: mapExternalGroupsToMatchedRoleIds(groups, roleMappings),
         roleMappings,
         canonicalUsername,
-        displayName: deriveDisplayName(userEntry.attributes, canonicalUsername),
+        displayName: deriveDisplayName(userEntry.attributes),
+        email: deriveEmail(userEntry.attributes),
       };
     } finally {
       if (client) {
@@ -406,6 +442,10 @@ class LDAPService {
           result.groups,
         );
       }
+      await syncDirectoryProfile(existingByCanonical.id, {
+        name: result.displayName,
+        email: result.email,
+      });
       return {
         authenticated: true,
         userId: existingByCanonical.id,
@@ -464,6 +504,10 @@ class LDAPService {
           // is acceptable; the bootstrap-only invariant only forbids re-applying mapping
           // for users that already existed BEFORE this provisioning request started.
           await applyExternalRolesForUserIfMatched(racedUser.id, result.groups, roleMappings);
+          await syncDirectoryProfile(racedUser.id, {
+            name: result.displayName,
+            email: result.email,
+          });
           return {
             authenticated: true,
             userId: racedUser.id,
@@ -480,6 +524,11 @@ class LDAPService {
       throw err;
     }
 
+    await settingsRepo.upsertForUser(id, {
+      fullName: name,
+      email: result.email?.trim() || '',
+      language: null,
+    });
     await applyExternalRolesForUser(id, result.groups, roleMappings);
     return { authenticated: true, userId: id, created: true, canonicalUsername };
   }
@@ -549,7 +598,7 @@ class LDAPService {
     const searchOptions = {
       scope: 'sub',
       filter: buildUserLookupFilter(config.userFilter, username),
-      attributes: ['uid', 'sAMAccountName', 'cn', 'displayName'],
+      attributes: ['uid', 'sAMAccountName', 'cn', 'displayName', 'mail'],
       sizeLimit: 1,
     };
 
@@ -738,7 +787,9 @@ class LDAPService {
         }
 
         const username = normalizeExternalUsername(candidate);
-        const name = getFirstAttributeValue(entry, 'cn', 'displayName') ?? username;
+        const directoryName = getFirstAttributeValue(entry, 'cn', 'displayName');
+        const name = directoryName ?? username;
+        const email = getFirstAttributeValue(entry, 'mail', 'email');
 
         const existing = await usersRepo.findLoginUserByNormalizedUsername(username);
 
@@ -772,13 +823,13 @@ class LDAPService {
               'LDAP sync skipped role-mapping diagnostic for user: group search failed',
             );
             // Still refresh the display name — that bit doesn't depend on group state.
-            await usersRepo.updateNameByUsername(existing.username, name);
+            await syncDirectoryProfile(existing.id, { name: directoryName, email });
             syncedCount++;
             continue;
           }
-          // Update by the row's stored username so a pre-migration mixed-case row still
-          // matches via LOWER() instead of a raw-bytes WHERE that wouldn't.
-          await usersRepo.updateNameByUsername(existing.username, name);
+          // Refresh by id so pre-migration mixed-case usernames and provider email claims
+          // both land on the already matched row.
+          await syncDirectoryProfile(existing.id, { name: directoryName, email });
           // Role mapping is bootstrap-only: sync refreshes display data but never rewrites
           // an existing user's roles from LDAP groups. Still warn when the user's groups
           // stop yielding any known role (no match or matched role was deleted), so admins
@@ -821,6 +872,11 @@ class LDAPService {
             avatarInitials: computeAvatarInitials(name),
             authMethod: 'ldap',
             authProviderId: null,
+          });
+          await settingsRepo.upsertForUser(id, {
+            fullName: name,
+            email: email?.trim() || '',
+            language: null,
           });
           await applyExternalRolesForUser(id, groups, roleMappings);
           createdCount++;

--- a/server/test/db/demoSeed.test.ts
+++ b/server/test/db/demoSeed.test.ts
@@ -1,5 +1,17 @@
 import { describe, expect, test } from 'bun:test';
 import { selectDemoUserCleanupIds } from '../../db/demoSeed.ts';
+import { DEMO_USERS } from '../../db/demoSeedManifest.ts';
+
+const CONTRACT_TYPES = new Set([
+  'permanent',
+  'fixed_term',
+  'contractor',
+  'internship',
+  'consultant',
+  'other',
+]);
+const EMPLOYMENT_STATUSES = new Set(['active', 'onboarding', 'on_leave', 'terminated']);
+const WORK_LOCATIONS = new Set(['office', 'remote', 'hybrid', 'customer_site', 'other']);
 
 describe('selectDemoUserCleanupIds', () => {
   test('preserves canonical demo users so cascading user data survives demo reseed', () => {
@@ -9,5 +21,33 @@ describe('selectDemoUserCleanupIds', () => {
       dependentUserIds: ['u2', 'u3', 'legacy-manager'],
       userIdsToDelete: ['legacy-manager'],
     });
+  });
+});
+
+describe('DEMO_USERS HR profiles', () => {
+  test('seeded users cover HR screens with complete operational profile data', () => {
+    const employeeTypes = new Set(DEMO_USERS.map((user) => user.employeeType));
+    expect(employeeTypes).toEqual(new Set(['app_user', 'internal', 'external']));
+
+    const employeeCodes = DEMO_USERS.map((user) => user.employeeCode);
+    expect(new Set(employeeCodes).size).toBe(employeeCodes.length);
+
+    for (const user of DEMO_USERS) {
+      expect(user.phone).toMatch(/^\+39 /);
+      expect(user.jobTitle.trim()).not.toBe('');
+      expect(user.department.trim()).not.toBe('');
+      expect(user.employeeCode).toMatch(/^(EMP|EXT)-\d{3}$/);
+      expect(user.hireDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(CONTRACT_TYPES.has(user.contractType)).toBe(true);
+      expect(EMPLOYMENT_STATUSES.has(user.employmentStatus)).toBe(true);
+      expect(WORK_LOCATIONS.has(user.workLocation)).toBe(true);
+      expect(user.emergencyContactName.trim()).not.toBe('');
+      expect(user.emergencyContactPhone).toMatch(/^\+39 /);
+      expect(user.notes.trim()).not.toBe('');
+      if (user.terminationDate !== null) {
+        expect(user.terminationDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+        expect(user.hireDate <= user.terminationDate).toBe(true);
+      }
+    }
   });
 });

--- a/server/test/integration/ldap-sync.integration.test.ts
+++ b/server/test/integration/ldap-sync.integration.test.ts
@@ -1,6 +1,9 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as realDrizzle from '../../db/drizzle.ts';
 import * as realLdapRepo from '../../repositories/ldapRepo.ts';
+import * as realSettingsRepo from '../../repositories/settingsRepo.ts';
 import * as realUsersRepo from '../../repositories/usersRepo.ts';
+import { makeWithDbTransactionMock } from '../helpers/withDbTransactionMock.ts';
 import { buildTestConfig, SHOULD_SKIP } from './helpers/ldapTestEnv.ts';
 
 type LdapServiceShape = {
@@ -15,12 +18,17 @@ type LdapServiceShape = {
 
 describe.skipIf(SHOULD_SKIP)('LDAP integration: syncUsers()', () => {
   const ldapRepoSnap = { ...realLdapRepo };
+  const drizzleSnap = { ...realDrizzle };
+  const settingsRepoSnap = { ...realSettingsRepo };
   const usersRepoSnap = { ...realUsersRepo };
 
   const ldapRepoGetMock = mock();
   const findLoginUserByNormalizedUsernameMock = mock();
   const updateNameByUsernameMock = mock();
+  const updateDirectoryProfileMock = mock();
+  const settingsUpsertForUserMock = mock();
   const createUserMock = mock();
+  const { withDbTransactionMock, resetWithDbTransactionMock } = makeWithDbTransactionMock();
 
   let ldapService: LdapServiceShape;
 
@@ -29,24 +37,38 @@ describe.skipIf(SHOULD_SKIP)('LDAP integration: syncUsers()', () => {
       ...ldapRepoSnap,
       get: ldapRepoGetMock,
     }));
+    mock.module('../../db/drizzle.ts', () => ({
+      ...drizzleSnap,
+      withDbTransaction: withDbTransactionMock,
+    }));
+    mock.module('../../repositories/settingsRepo.ts', () => ({
+      ...settingsRepoSnap,
+      upsertForUser: settingsUpsertForUserMock,
+    }));
     mock.module('../../repositories/usersRepo.ts', () => ({
       ...usersRepoSnap,
       findLoginUserByNormalizedUsername: findLoginUserByNormalizedUsernameMock,
       updateNameByUsername: updateNameByUsernameMock,
+      updateDirectoryProfile: updateDirectoryProfileMock,
       createUser: createUserMock,
     }));
     ldapService = (await import('../../services/ldap.ts')).default as unknown as LdapServiceShape;
   });
 
   afterAll(() => {
+    mock.module('../../db/drizzle.ts', () => drizzleSnap);
     mock.module('../../repositories/ldapRepo.ts', () => ldapRepoSnap);
+    mock.module('../../repositories/settingsRepo.ts', () => settingsRepoSnap);
     mock.module('../../repositories/usersRepo.ts', () => usersRepoSnap);
   });
 
   beforeEach(() => {
     ldapRepoGetMock.mockReset();
+    resetWithDbTransactionMock();
     findLoginUserByNormalizedUsernameMock.mockReset();
     updateNameByUsernameMock.mockReset();
+    updateDirectoryProfileMock.mockReset();
+    settingsUpsertForUserMock.mockReset();
     createUserMock.mockReset();
 
     ldapRepoGetMock.mockResolvedValue(buildTestConfig({ autoProvisionAll: true }));
@@ -59,7 +81,7 @@ describe.skipIf(SHOULD_SKIP)('LDAP integration: syncUsers()', () => {
 
     expect(result).toEqual({ synced: 0, created: 2 });
     expect(createUserMock).toHaveBeenCalledTimes(2);
-    expect(updateNameByUsernameMock).not.toHaveBeenCalled();
+    expect(updateDirectoryProfileMock).not.toHaveBeenCalled();
 
     const usernames = createUserMock.mock.calls
       .map((args) => (args[0] as { username: string }).username)
@@ -79,7 +101,7 @@ describe.skipIf(SHOULD_SKIP)('LDAP integration: syncUsers()', () => {
     }
   });
 
-  test('existing user: calls updateNameByUsername instead of createUser', async () => {
+  test('existing user: refreshes provider profile instead of createUser', async () => {
     findLoginUserByNormalizedUsernameMock.mockImplementation(async (username: string) =>
       username === 'alice' ? { id: 'u1', username, name: 'Old Name' } : null,
     );
@@ -87,8 +109,12 @@ describe.skipIf(SHOULD_SKIP)('LDAP integration: syncUsers()', () => {
     const result = await ldapService.syncUsers();
 
     expect(result).toEqual({ synced: 1, created: 1 });
-    expect(updateNameByUsernameMock).toHaveBeenCalledTimes(1);
-    expect(updateNameByUsernameMock).toHaveBeenCalledWith('alice', 'Alice Example');
+    expect(updateDirectoryProfileMock).toHaveBeenCalledTimes(1);
+    expect(updateDirectoryProfileMock).toHaveBeenCalledWith(
+      'u1',
+      { name: 'Alice Example', avatarInitials: 'AE' },
+      expect.anything(),
+    );
     expect(createUserMock).toHaveBeenCalledTimes(1);
     expect((createUserMock.mock.calls[0][0] as { username: string }).username).toBe('bob');
   });
@@ -121,8 +147,12 @@ describe.skipIf(SHOULD_SKIP)('LDAP integration: syncUsers()', () => {
     const result = await ldapService.syncUsers();
 
     expect(result).toEqual({ synced: 1, created: 0 });
-    expect(updateNameByUsernameMock).toHaveBeenCalledTimes(1);
-    expect(updateNameByUsernameMock).toHaveBeenCalledWith('alice', 'Alice Example');
+    expect(updateDirectoryProfileMock).toHaveBeenCalledTimes(1);
+    expect(updateDirectoryProfileMock).toHaveBeenCalledWith(
+      'u1',
+      { name: 'Alice Example', avatarInitials: 'AE' },
+      expect.anything(),
+    );
     expect(createUserMock).not.toHaveBeenCalled();
   });
 
@@ -134,7 +164,7 @@ describe.skipIf(SHOULD_SKIP)('LDAP integration: syncUsers()', () => {
 
     expect(result.skipped).toBe(true);
     expect(createUserMock).not.toHaveBeenCalled();
-    expect(updateNameByUsernameMock).not.toHaveBeenCalled();
+    expect(updateDirectoryProfileMock).not.toHaveBeenCalled();
   });
 
   test('returned counts match mock invocations exactly', async () => {
@@ -146,7 +176,7 @@ describe.skipIf(SHOULD_SKIP)('LDAP integration: syncUsers()', () => {
 
     const result = await ldapService.syncUsers();
 
-    expect(result.synced).toBe(updateNameByUsernameMock.mock.calls.length);
+    expect(result.synced).toBe(updateDirectoryProfileMock.mock.calls.length);
     expect(result.created).toBe(createUserMock.mock.calls.length);
     expect((result.synced ?? 0) + (result.created ?? 0)).toBe(2);
   });

--- a/server/test/repositories/usersRepo.test.ts
+++ b/server/test/repositories/usersRepo.test.ts
@@ -216,6 +216,18 @@ const sampleListRow = {
   costPerHour: '42.5',
   isDisabled: false,
   employeeType: 'app_user',
+  phone: '+39 02 1234',
+  jobTitle: 'Consultant',
+  department: 'Delivery',
+  employeeCode: 'EMP-001',
+  hireDate: '2024-01-15',
+  terminationDate: null,
+  contractType: 'permanent',
+  employmentStatus: 'active',
+  workLocation: 'hybrid',
+  emergencyContactName: 'Maria',
+  emergencyContactPhone: '+39 02 5678',
+  notes: 'Prefers morning shifts',
   hasTopManagerRole: false,
   isAdminOnly: false,
   authMethod: 'local',
@@ -239,6 +251,18 @@ describe('listAllForAdmin', () => {
         costPerHour: 42.5,
         isDisabled: false,
         employeeType: 'app_user',
+        phone: '+39 02 1234',
+        jobTitle: 'Consultant',
+        department: 'Delivery',
+        employeeCode: 'EMP-001',
+        hireDate: '2024-01-15',
+        terminationDate: null,
+        contractType: 'permanent',
+        employmentStatus: 'active',
+        workLocation: 'hybrid',
+        emergencyContactName: 'Maria',
+        emergencyContactPhone: '+39 02 5678',
+        notes: 'Prefers morning shifts',
         hasTopManagerRole: false,
         isAdminOnly: false,
         authMethod: 'local',
@@ -270,7 +294,7 @@ describe('listScopedForManager', () => {
     const sql = exec.calls[0].sql;
     expect(sql).toContain('u.id =');
     expect(sql).toContain('wum.user_id =');
-    expect(sql).toContain("u.employee_type = 'internal'");
+    expect(sql).toContain("u.employee_type IN ('app_user', 'internal')");
     expect(sql).not.toContain("u.employee_type = 'external'");
     expect(exec.calls[0].params).toContain('viewer-1');
   });
@@ -318,8 +342,12 @@ describe('findById', () => {
 
 describe('findCoreById', () => {
   test('returns the mapped core user when the row exists', async () => {
-    // Projection: id, name, username, role, employeeType, authMethod, authProviderId
-    exec.enqueue({ rows: [['user-1', 'Alice', 'alice', 'manager', 'internal', 'local', null]] });
+    // Projection: id, name, username, role, employeeType, hireDate, terminationDate, authMethod, authProviderId
+    exec.enqueue({
+      rows: [
+        ['user-1', 'Alice', 'alice', 'manager', 'internal', '2024-01-15', null, 'local', null],
+      ],
+    });
     const result = await usersRepo.findCoreById('user-1', testDb);
     expect(result).toEqual({
       id: 'user-1',
@@ -327,6 +355,8 @@ describe('findCoreById', () => {
       username: 'alice',
       role: 'manager',
       employeeType: 'internal',
+      hireDate: '2024-01-15',
+      terminationDate: null,
       authMethod: 'local',
       authProviderId: null,
     });
@@ -334,7 +364,7 @@ describe('findCoreById', () => {
   });
 
   test('defaults employeeType to app_user when null', async () => {
-    exec.enqueue({ rows: [['user-1', 'Alice', 'alice', 'manager', null, null, null]] });
+    exec.enqueue({ rows: [['user-1', 'Alice', 'alice', 'manager', null, null, null, null, null]] });
     const result = await usersRepo.findCoreById('user-1', testDb);
     expect(result?.employeeType).toBe('app_user');
   });
@@ -357,7 +387,7 @@ describe('existsByUsername', () => {
 });
 
 describe('insertUser', () => {
-  test('passes all 9 columns', async () => {
+  test('passes account and HR columns', async () => {
     exec.enqueue({ rows: [], rowCount: 1 });
     await usersRepo.insertUser(
       {
@@ -370,6 +400,18 @@ describe('insertUser', () => {
         costPerHour: 42,
         isDisabled: false,
         employeeType: 'internal',
+        phone: '+39 02 1234',
+        jobTitle: 'Consultant',
+        department: 'Delivery',
+        employeeCode: 'EMP-001',
+        hireDate: '2024-01-15',
+        terminationDate: null,
+        contractType: 'permanent',
+        employmentStatus: 'active',
+        workLocation: 'hybrid',
+        emergencyContactName: 'Maria',
+        emergencyContactPhone: '+39 02 5678',
+        notes: 'Prefers morning shifts',
       },
       testDb,
     );
@@ -383,6 +425,17 @@ describe('insertUser', () => {
     expect(exec.calls[0].params).toContain('42');
     expect(exec.calls[0].params).toContain(false);
     expect(exec.calls[0].params).toContain('internal');
+    expect(exec.calls[0].params).toContain('+39 02 1234');
+    expect(exec.calls[0].params).toContain('Consultant');
+    expect(exec.calls[0].params).toContain('Delivery');
+    expect(exec.calls[0].params).toContain('EMP-001');
+    expect(exec.calls[0].params).toContain('2024-01-15');
+    expect(exec.calls[0].params).toContain('permanent');
+    expect(exec.calls[0].params).toContain('active');
+    expect(exec.calls[0].params).toContain('hybrid');
+    expect(exec.calls[0].params).toContain('Maria');
+    expect(exec.calls[0].params).toContain('+39 02 5678');
+    expect(exec.calls[0].params).toContain('Prefers morning shifts');
   });
 });
 
@@ -415,7 +468,30 @@ describe('updateUserDynamic', () => {
     // RETURNING projection: id, name, username, role, avatarInitials, costPerHour, isDisabled,
     // employeeType
     exec.enqueue({
-      rows: [['user-1', 'Alice', 'alice', 'user', 'AL', '50', true, 'app_user']],
+      rows: [
+        [
+          'user-1',
+          'Alice',
+          'alice',
+          'user',
+          'AL',
+          '50',
+          true,
+          'app_user',
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+        ],
+      ],
       rowCount: 1,
     });
     await usersRepo.updateUserDynamic(
@@ -445,11 +521,102 @@ describe('updateUserDynamic', () => {
 
   test('parses cost_per_hour from string into number on the returned row', async () => {
     exec.enqueue({
-      rows: [['user-1', 'Alice', 'alice', 'user', 'AL', '17.25', false, 'app_user']],
+      rows: [
+        [
+          'user-1',
+          'Alice',
+          'alice',
+          'user',
+          'AL',
+          '17.25',
+          false,
+          'app_user',
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+        ],
+      ],
       rowCount: 1,
     });
     const result = await usersRepo.updateUserDynamic('user-1', { name: 'Alice' }, testDb);
     expect(result?.costPerHour).toBe(17.25);
+  });
+
+  test('updates and maps HR profile fields', async () => {
+    exec.enqueue({
+      rows: [
+        [
+          'user-1',
+          'Alice',
+          'alice',
+          'user',
+          'AL',
+          '17.25',
+          false,
+          'app_user',
+          '+39 02 1234',
+          'Consultant',
+          'Delivery',
+          'EMP-001',
+          '2024-01-15',
+          null,
+          'permanent',
+          'active',
+          'hybrid',
+          'Maria',
+          '+39 02 5678',
+          'Prefers morning shifts',
+        ],
+      ],
+      rowCount: 1,
+    });
+
+    const result = await usersRepo.updateUserDynamic(
+      'user-1',
+      {
+        phone: '+39 02 1234',
+        jobTitle: 'Consultant',
+        department: 'Delivery',
+        employeeCode: 'EMP-001',
+        hireDate: '2024-01-15',
+        contractType: 'permanent',
+        employmentStatus: 'active',
+        workLocation: 'hybrid',
+        emergencyContactName: 'Maria',
+        emergencyContactPhone: '+39 02 5678',
+        notes: 'Prefers morning shifts',
+      },
+      testDb,
+    );
+
+    const sql = exec.calls[0].sql.toLowerCase();
+    expect(sql).toContain('"phone"');
+    expect(sql).toContain('"job_title"');
+    expect(sql).toContain('"employee_code"');
+    expect(result).toEqual(
+      expect.objectContaining({
+        phone: '+39 02 1234',
+        jobTitle: 'Consultant',
+        department: 'Delivery',
+        employeeCode: 'EMP-001',
+        hireDate: '2024-01-15',
+        contractType: 'permanent',
+        employmentStatus: 'active',
+        workLocation: 'hybrid',
+        emergencyContactName: 'Maria',
+        emergencyContactPhone: '+39 02 5678',
+        notes: 'Prefers morning shifts',
+      }),
+    );
   });
 });
 

--- a/server/test/routes/auth.test.ts
+++ b/server/test/routes/auth.test.ts
@@ -1,8 +1,10 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
 import * as realBcrypt from 'bcryptjs';
 import type { FastifyInstance, FastifyPluginAsync } from 'fastify';
+import * as realDrizzle from '../../db/drizzle.ts';
 import * as realPersonalAccessTokensRepo from '../../repositories/personalAccessTokensRepo.ts';
 import * as realRolesRepo from '../../repositories/rolesRepo.ts';
+import * as realSettingsRepo from '../../repositories/settingsRepo.ts';
 import * as realUsersRepo from '../../repositories/usersRepo.ts';
 import * as realExternalAuth from '../../services/external-auth.ts';
 import * as realLdapService from '../../services/ldap.ts';
@@ -16,6 +18,7 @@ import {
 } from '../helpers/authMiddlewareMock.ts';
 import { buildRouteTestApp } from '../helpers/buildRouteTestApp.ts';
 import { decodeForAssertion, signToken } from '../helpers/jwt.ts';
+import { makeWithDbTransactionMock } from '../helpers/withDbTransactionMock.ts';
 
 // hashPersonalAccessToken (HMAC-keyed) requires ENCRYPTION_KEY at call time.
 process.env.ENCRYPTION_KEY = process.env.ENCRYPTION_KEY || 'test-encryption-key-32-bytes-long!!';
@@ -23,7 +26,9 @@ process.env.ENCRYPTION_KEY = process.env.ENCRYPTION_KEY || 'test-encryption-key-
 // Snapshot real exports so afterAll can restore them. Snapshot must run BEFORE mock.module
 // fires (i.e., before beforeAll executes) - see comment in middleware/auth.test.ts.
 const usersRepoSnap = { ...realUsersRepo };
+const drizzleSnap = { ...realDrizzle };
 const rolesRepoSnap = { ...realRolesRepo };
+const settingsRepoSnap = { ...realSettingsRepo };
 const permissionsSnap = { ...realPermissions };
 const personalAccessTokensRepoSnap = { ...realPersonalAccessTokensRepo };
 const auditSnap = { ...realAudit };
@@ -43,9 +48,12 @@ const markPersonalAccessTokenUsedMock = mock();
 // Auth route deps
 const findLoginUserByNormalizedUsernameMock = mock();
 const findLoginUserByIdMock = mock();
+const updateDirectoryProfileMock = mock();
 const bumpSessionVersionMock = mock();
 const listAvailableRolesForUserMock = mock();
 const logAuditMock = mock(async () => undefined);
+const settingsUpsertForUserMock = mock();
+const { withDbTransactionMock, resetWithDbTransactionMock } = makeWithDbTransactionMock();
 
 // External: bcryptjs.compare and the LDAP service (dynamically imported by /login)
 const bcryptCompareMock = mock();
@@ -64,7 +72,16 @@ beforeAll(async () => {
     findAuthUserById: findAuthUserByIdMock,
     findLoginUserByNormalizedUsername: findLoginUserByNormalizedUsernameMock,
     findLoginUserById: findLoginUserByIdMock,
+    updateDirectoryProfile: updateDirectoryProfileMock,
     bumpSessionVersion: bumpSessionVersionMock,
+  }));
+  mock.module('../../db/drizzle.ts', () => ({
+    ...drizzleSnap,
+    withDbTransaction: withDbTransactionMock,
+  }));
+  mock.module('../../repositories/settingsRepo.ts', () => ({
+    ...settingsRepoSnap,
+    upsertForUser: settingsUpsertForUserMock,
   }));
   mock.module('../../repositories/rolesRepo.ts', () => ({
     ...rolesRepoSnap,
@@ -109,7 +126,9 @@ beforeAll(async () => {
 
 afterAll(() => {
   restoreAuthMiddlewareMock();
+  mock.module('../../db/drizzle.ts', () => drizzleSnap);
   mock.module('../../repositories/usersRepo.ts', () => usersRepoSnap);
+  mock.module('../../repositories/settingsRepo.ts', () => settingsRepoSnap);
   mock.module('../../repositories/rolesRepo.ts', () => rolesRepoSnap);
   mock.module('../../utils/permissions.ts', () => permissionsSnap);
   mock.module('../../repositories/personalAccessTokensRepo.ts', () => personalAccessTokensRepoSnap);
@@ -153,9 +172,12 @@ const allMocks = [
   markPersonalAccessTokenUsedMock,
   findLoginUserByNormalizedUsernameMock,
   findLoginUserByIdMock,
+  updateDirectoryProfileMock,
   bumpSessionVersionMock,
   listAvailableRolesForUserMock,
   logAuditMock,
+  settingsUpsertForUserMock,
+  withDbTransactionMock,
   bcryptCompareMock,
   ldapAuthenticateMock,
   ldapAuthenticateWithProfileMock,
@@ -168,6 +190,7 @@ let testApp: FastifyInstance;
 
 beforeEach(async () => {
   for (const m of allMocks) m.mockReset();
+  resetWithDbTransactionMock();
 
   // Defaults: happy auth path for /me and /switch-role
   findAuthUserByIdMock.mockResolvedValue(HAPPY_USER);
@@ -298,6 +321,44 @@ describe('POST /api/auth/login', () => {
     expect(bcryptCompareMock).not.toHaveBeenCalled();
     const body = JSON.parse(res.body);
     expect(body.user.role).toBe('manager');
+  });
+
+  test('200: LDAP success refreshes provider-managed name and email', async () => {
+    findLoginUserByNormalizedUsernameMock.mockResolvedValue({
+      ...LOGIN_USER,
+      authMethod: 'ldap',
+      name: 'Old Name',
+      avatarInitials: 'ON',
+    });
+    ldapAuthenticateWithProfileMock.mockResolvedValue({
+      authenticated: true,
+      groups: [],
+      matchedRoleIds: [],
+      roleMappings: [],
+      displayName: 'Alice Provider',
+      email: 'alice.provider@example.com',
+    });
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/auth/login',
+      payload: { username: 'alice', password: 'secret' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(updateDirectoryProfileMock).toHaveBeenCalledWith(
+      'u1',
+      { name: 'Alice Provider', avatarInitials: 'AP' },
+      expect.anything(),
+    );
+    expect(settingsUpsertForUserMock).toHaveBeenCalledWith(
+      'u1',
+      { fullName: 'Alice Provider', email: 'alice.provider@example.com', language: null },
+      expect.anything(),
+    );
+    const body = JSON.parse(res.body);
+    expect(body.user.name).toBe('Alice Provider');
+    expect(body.user.avatarInitials).toBe('AP');
   });
 
   test('200: LDAP login sends the untrimmed password to the directory bind (#697)', async () => {

--- a/server/test/routes/users.test.ts
+++ b/server/test/routes/users.test.ts
@@ -19,6 +19,7 @@ import {
   restoreAuthMiddlewareMock,
 } from '../helpers/authMiddlewareMock.ts';
 import { buildRouteTestApp } from '../helpers/buildRouteTestApp.ts';
+import { makeDbError } from '../helpers/dbErrors.ts';
 import { signToken } from '../helpers/jwt.ts';
 import { TX_SENTINEL } from '../helpers/txSentinel.ts';
 import { makeWithDbTransactionMock } from '../helpers/withDbTransactionMock.ts';
@@ -280,6 +281,18 @@ const SAMPLE_USER_ROW = {
   costPerHour: 50,
   isDisabled: false,
   employeeType: 'app_user' as const,
+  phone: '+39 02 1234',
+  jobTitle: 'Consultant',
+  department: 'Delivery',
+  employeeCode: 'EMP-001',
+  hireDate: '2024-01-15',
+  terminationDate: null,
+  contractType: 'permanent' as const,
+  employmentStatus: 'active' as const,
+  workLocation: 'hybrid' as const,
+  emergencyContactName: 'Maria',
+  emergencyContactPhone: '+39 02 5678',
+  notes: 'Prefers morning shifts',
   authMethod: 'local' as const,
   authProviderId: null,
   authProviderName: null,
@@ -293,6 +306,8 @@ const SAMPLE_USER_CORE = {
   username: 'target',
   role: 'user',
   employeeType: 'app_user' as const,
+  hireDate: '2024-01-15',
+  terminationDate: null,
   authMethod: 'local' as const,
   authProviderId: null,
 };
@@ -472,6 +487,47 @@ describe('GET /api/users', () => {
     expect(body[0].email).toBe('');
   });
 
+  test('200 HR internal view reveals matching HR fields and email', async () => {
+    findAuthUserByIdMock.mockResolvedValue(MANAGER_USER);
+    getRolePermissionsMock.mockResolvedValue(['hr.internal.view']);
+    listScopedForManagerMock.mockResolvedValue([SAMPLE_USER_ROW]);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/users',
+      headers: managerAuth(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body[0]).toEqual(
+      expect.objectContaining({
+        email: 'target@example.com',
+        phone: '+39 02 1234',
+        employeeCode: 'EMP-001',
+        employmentStatus: 'active',
+      }),
+    );
+  });
+
+  test('200 non-HR viewer omits HR detail fields', async () => {
+    findAuthUserByIdMock.mockResolvedValue(REGULAR_USER);
+    getRolePermissionsMock.mockResolvedValue(USER_ONLY_PERMS);
+    listScopedForManagerMock.mockResolvedValue([SAMPLE_USER_ROW]);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/users',
+      headers: userAuth(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body[0]).not.toHaveProperty('phone');
+    expect(body[0]).not.toHaveProperty('employeeCode');
+    expect(body[0]).not.toHaveProperty('employmentStatus');
+  });
+
   test('200 with ONLY hr.costs.view → caller sees own cost, other rows masked to 0', async () => {
     // Personal-scope hr.costs.view is the read-only counterpart of
     // hr.costs.update: it grants visibility of the caller's *own* costPerHour
@@ -596,6 +652,79 @@ describe('POST /api/users', () => {
     expect(rolesFindByIdMock).not.toHaveBeenCalled();
   });
 
+  test('201 creates internal employee with HR profile fields', async () => {
+    getRolePermissionsMock.mockResolvedValue([
+      'hr.internal.create',
+      'hr.internal.update',
+      'hr.internal.view',
+      'hr.costs_all.view',
+      'hr.costs_all.update',
+    ]);
+    insertUserMock.mockResolvedValue(undefined);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/users',
+      headers: adminAuth(),
+      payload: {
+        name: 'Internal Bob',
+        employeeType: 'internal',
+        email: 'bob@example.com',
+        phone: '+39 02 1234',
+        jobTitle: 'Consultant',
+        department: 'Delivery',
+        employeeCode: 'EMP-123',
+        hireDate: '2024-01-15',
+        contractType: 'permanent',
+        employmentStatus: 'onboarding',
+        workLocation: 'hybrid',
+        emergencyContactName: 'Maria',
+        emergencyContactPhone: '+39 02 5678',
+        notes: 'Starts next week',
+        costPerHour: 70,
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    const [insertedRow] = insertUserMock.mock.calls[0] as [Record<string, unknown>];
+    expect(insertedRow).toEqual(
+      expect.objectContaining({
+        employeeType: 'internal',
+        phone: '+39 02 1234',
+        jobTitle: 'Consultant',
+        department: 'Delivery',
+        employeeCode: 'EMP-123',
+        hireDate: '2024-01-15',
+        contractType: 'permanent',
+        employmentStatus: 'onboarding',
+        workLocation: 'hybrid',
+        costPerHour: 70,
+      }),
+    );
+    expect(JSON.parse(res.body)).toEqual(
+      expect.objectContaining({
+        email: 'bob@example.com',
+        employeeCode: 'EMP-123',
+        employmentStatus: 'onboarding',
+      }),
+    );
+  });
+
+  test('400 maps duplicate employee code on create', async () => {
+    getRolePermissionsMock.mockResolvedValue(['hr.internal.create', 'hr.internal.update']);
+    insertUserMock.mockRejectedValue(makeDbError('23505', 'idx_users_employee_code_unique'));
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/users',
+      headers: adminAuth(),
+      payload: { name: 'Internal Bob', employeeType: 'internal', employeeCode: 'EMP-123' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toBe('Employee code already exists');
+  });
+
   test('201 top-manager triggers syncTopManagerAssignmentsForUser', async () => {
     rolesFindByIdMock.mockResolvedValue({
       id: 'top_manager',
@@ -687,6 +816,34 @@ describe('POST /api/users', () => {
     });
     // Caught by Fastify's schema enum
     expect(res.statusCode).toBe(400);
+  });
+
+  test('400 invalid HR enum', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/users',
+      headers: adminAuth(),
+      payload: { name: 'X', employeeType: 'internal', contractType: 'invalid' },
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('400 invalid HR date range', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/users',
+      headers: adminAuth(),
+      payload: {
+        name: 'X',
+        employeeType: 'internal',
+        hireDate: '2024-02-01',
+        terminationDate: '2024-01-01',
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toBe('hireDate must be on or before terminationDate');
   });
 
   test('403 without create permission for app_user', async () => {
@@ -868,6 +1025,200 @@ describe('PUT /api/users/:id', () => {
       TX_SENTINEL,
     );
     expect(logAuditMock).toHaveBeenCalledWith(expect.objectContaining({ action: 'user.updated' }));
+  });
+
+  test('200 HR internal update edits app-user profile fields and email without manager scope', async () => {
+    findAuthUserByIdMock.mockResolvedValue(MANAGER_USER);
+    getRolePermissionsMock.mockResolvedValue(['hr.internal.update', 'hr.internal.view']);
+    findCoreByIdMock.mockResolvedValue(SAMPLE_USER_CORE);
+    canManageUserMock.mockResolvedValue(false);
+    updateUserDynamicMock.mockResolvedValue({
+      ...SAMPLE_USER_CORE,
+      phone: '+39 02 1234',
+      jobTitle: 'Consultant',
+      department: 'Delivery',
+      employeeCode: 'EMP-123',
+      hireDate: '2024-01-15',
+      contractType: 'permanent',
+      employmentStatus: 'active',
+      workLocation: 'hybrid',
+      avatarInitials: 'T',
+      costPerHour: 50,
+      isDisabled: false,
+    });
+    findByIdMock.mockResolvedValue({
+      ...SAMPLE_USER_ROW,
+      email: 'target.hr@example.com',
+      phone: '+39 02 1234',
+      employeeCode: 'EMP-123',
+      employmentStatus: 'active',
+    });
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/users/u-target',
+      headers: managerAuth(),
+      payload: {
+        email: 'target.hr@example.com',
+        phone: '+39 02 1234',
+        jobTitle: 'Consultant',
+        department: 'Delivery',
+        employeeCode: 'EMP-123',
+        hireDate: '2024-01-15',
+        contractType: 'permanent',
+        employmentStatus: 'active',
+        workLocation: 'hybrid',
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(canManageUserMock).not.toHaveBeenCalled();
+    expect(updateUserDynamicMock).toHaveBeenCalledWith(
+      'u-target',
+      expect.objectContaining({
+        phone: '+39 02 1234',
+        jobTitle: 'Consultant',
+        department: 'Delivery',
+        employeeCode: 'EMP-123',
+        hireDate: '2024-01-15',
+        contractType: 'permanent',
+        employmentStatus: 'active',
+        workLocation: 'hybrid',
+      }),
+      TX_SENTINEL,
+    );
+    expect(settingsUpsertForUserMock).toHaveBeenCalledWith(
+      'u-target',
+      expect.objectContaining({ email: 'target.hr@example.com' }),
+      TX_SENTINEL,
+    );
+    expect(JSON.parse(res.body)).toEqual(
+      expect.objectContaining({ email: 'target.hr@example.com', employeeCode: 'EMP-123' }),
+    );
+  });
+
+  test('403 standard user-management update cannot edit HR details without HR update permission', async () => {
+    getRolePermissionsMock.mockResolvedValue([
+      'administration.user_management.view',
+      'administration.user_management.update',
+      'administration.user_management_all.view',
+    ]);
+    findCoreByIdMock.mockResolvedValue(SAMPLE_USER_CORE);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/users/u-target',
+      headers: adminAuth(),
+      payload: { phone: '+39 02 9999' },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(updateUserDynamicMock).not.toHaveBeenCalled();
+    expect(settingsUpsertForUserMock).not.toHaveBeenCalled();
+  });
+
+  test('409 rejects manual name or email changes for external-auth users', async () => {
+    findCoreByIdMock.mockResolvedValue({
+      ...SAMPLE_USER_CORE,
+      authMethod: 'oidc',
+      authProviderId: 'sso-1',
+    });
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/users/u-target',
+      headers: adminAuth(),
+      payload: { email: 'manual@example.com' },
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(updateUserDynamicMock).not.toHaveBeenCalled();
+    expect(settingsUpsertForUserMock).not.toHaveBeenCalled();
+  });
+
+  test('200 external-auth user account update succeeds when synced identity is omitted', async () => {
+    findCoreByIdMock.mockResolvedValue({
+      ...SAMPLE_USER_CORE,
+      authMethod: 'ldap',
+    });
+    updateUserDynamicMock.mockResolvedValue({
+      ...SAMPLE_USER_CORE,
+      authMethod: 'ldap',
+      avatarInitials: 'T',
+      costPerHour: 50,
+      isDisabled: true,
+    });
+    findByIdMock.mockResolvedValue({
+      ...SAMPLE_USER_ROW,
+      authMethod: 'ldap',
+      isDisabled: true,
+    });
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/users/u-target',
+      headers: adminAuth(),
+      payload: { isDisabled: true },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(updateUserDynamicMock).toHaveBeenCalledWith(
+      'u-target',
+      expect.objectContaining({ isDisabled: true }),
+      TX_SENTINEL,
+    );
+    const [, fields] = updateUserDynamicMock.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+      unknown,
+    ];
+    expect(fields).not.toHaveProperty('name');
+    expect(settingsUpsertForUserMock).not.toHaveBeenCalled();
+  });
+
+  test('400 rejects invalid HR update enum and date range', async () => {
+    let res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/users/u-target',
+      headers: adminAuth(),
+      payload: { employmentStatus: 'invalid' },
+    });
+    expect(res.statusCode).toBe(400);
+
+    res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/users/u-target',
+      headers: adminAuth(),
+      payload: { hireDate: '2024-02-01', terminationDate: '2024-01-01' },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('400 rejects HR date patches that conflict with the stored range', async () => {
+    findCoreByIdMock.mockResolvedValue({
+      ...SAMPLE_USER_CORE,
+      hireDate: '2024-01-15',
+      terminationDate: '2024-02-15',
+    });
+
+    let res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/users/u-target',
+      headers: adminAuth(),
+      payload: { hireDate: '2024-03-01' },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toBe('hireDate must be on or before terminationDate');
+
+    res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/users/u-target',
+      headers: adminAuth(),
+      payload: { terminationDate: '2024-01-01' },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error).toBe('hireDate must be on or before terminationDate');
+    expect(updateUserDynamicMock).not.toHaveBeenCalled();
   });
 
   test('200 isDisabled=true → user.disabled audit action', async () => {
@@ -1085,6 +1436,27 @@ describe('PUT /api/users/:id', () => {
       TX_SENTINEL,
     );
     // No dynamic field update needed → updateUserDynamic not called
+    expect(updateUserDynamicMock).not.toHaveBeenCalled();
+  });
+
+  test('200 blank email explicitly clears the settings-backed email', async () => {
+    findCoreByIdMock.mockResolvedValue(SAMPLE_USER_CORE);
+    findByIdMock.mockResolvedValue({ ...SAMPLE_USER_ROW, email: '' });
+    settingsUpsertForUserMock.mockResolvedValue({});
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/users/u-target',
+      headers: adminAuth(),
+      payload: { email: '' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(settingsUpsertForUserMock).toHaveBeenCalledWith(
+      'u-target',
+      expect.objectContaining({ email: '' }),
+      TX_SENTINEL,
+    );
     expect(updateUserDynamicMock).not.toHaveBeenCalled();
   });
 

--- a/server/test/services/external-auth.resolve.test.ts
+++ b/server/test/services/external-auth.resolve.test.ts
@@ -25,6 +25,7 @@ const syncTopManagerAssignmentsForUserMock = mock();
 const findLoginUserByIdMock = mock();
 const findLoginUserByNormalizedUsernameMock = mock();
 const insertUserMock = mock();
+const updateDirectoryProfileMock = mock();
 const replaceUserRolesMock = mock();
 const setPrimaryRoleMock = mock();
 
@@ -58,6 +59,7 @@ beforeAll(async () => {
     findLoginUserById: findLoginUserByIdMock,
     findLoginUserByNormalizedUsername: findLoginUserByNormalizedUsernameMock,
     insertUser: insertUserMock,
+    updateDirectoryProfile: updateDirectoryProfileMock,
     replaceUserRoles: replaceUserRolesMock,
     setPrimaryRole: setPrimaryRoleMock,
   }));
@@ -86,6 +88,7 @@ beforeEach(() => {
     findLoginUserByIdMock,
     findLoginUserByNormalizedUsernameMock,
     insertUserMock,
+    updateDirectoryProfileMock,
     replaceUserRolesMock,
     setPrimaryRoleMock,
   ]) {
@@ -125,6 +128,63 @@ const matchingSsoUser = {
 };
 
 describe('resolveExternalIdentity auth method enforcement', () => {
+  test('refreshes provider-managed name and email for existing bound users', async () => {
+    findByIdentityMock.mockResolvedValue({
+      id: 'eid-1',
+      providerId: 'sso-1',
+      protocol: 'oidc',
+      issuer: input.issuer,
+      subject: input.subject,
+      userId: 'u1',
+    });
+    findLoginUserByIdMock.mockResolvedValue({
+      ...matchingSsoUser,
+      name: 'Old Name',
+      avatarInitials: 'ON',
+    });
+
+    const result = await resolveExternalIdentity({
+      ...input,
+      name: 'Alice Provider',
+      email: 'alice.provider@example.com',
+    });
+
+    expect(updateDirectoryProfileMock).toHaveBeenCalledWith(
+      'u1',
+      { name: 'Alice Provider', avatarInitials: 'AP' },
+      expect.anything(),
+    );
+    expect(upsertForUserMock).toHaveBeenCalledWith(
+      'u1',
+      { fullName: 'Alice Provider', email: 'alice.provider@example.com', language: null },
+      expect.anything(),
+    );
+    expect(result.name).toBe('Alice Provider');
+    expect(result.avatarInitials).toBe('AP');
+  });
+
+  test('does not clear existing profile values when provider omits name and email', async () => {
+    findByIdentityMock.mockResolvedValue({
+      id: 'eid-1',
+      providerId: 'sso-1',
+      protocol: 'oidc',
+      issuer: input.issuer,
+      subject: input.subject,
+      userId: 'u1',
+    });
+    findLoginUserByIdMock.mockResolvedValue(matchingSsoUser);
+
+    const result = await resolveExternalIdentity({
+      ...input,
+      name: undefined,
+      email: undefined,
+    });
+
+    expect(updateDirectoryProfileMock).not.toHaveBeenCalled();
+    expect(upsertForUserMock).not.toHaveBeenCalled();
+    expect(result.name).toBe('Alice');
+  });
+
   test('binds existing username only when method and provider match', async () => {
     findByIdentityMock.mockResolvedValueOnce(null).mockResolvedValueOnce({
       id: 'eid-1',
@@ -166,7 +226,11 @@ describe('resolveExternalIdentity auth method enforcement', () => {
     expect(result.wasCreated).toBe(false);
     expect(result.wasBound).toBe(true);
     expect(insertUserMock).toHaveBeenCalledTimes(1);
-    expect(upsertForUserMock).not.toHaveBeenCalled();
+    expect(upsertForUserMock).toHaveBeenCalledWith(
+      'u1',
+      expect.objectContaining({ fullName: 'Alice', email: 'alice@example.com' }),
+      expect.anything(),
+    );
     expect(insertIdentityMock).toHaveBeenCalledTimes(1);
   });
 

--- a/server/test/services/ldap.test.ts
+++ b/server/test/services/ldap.test.ts
@@ -10,17 +10,22 @@ import {
   test,
 } from 'bun:test';
 import realLdap from 'ldapjs';
+import * as realDrizzle from '../../db/drizzle.ts';
 import * as realLdapRepo from '../../repositories/ldapRepo.ts';
+import * as realSettingsRepo from '../../repositories/settingsRepo.ts';
 import * as realUsersRepo from '../../repositories/usersRepo.ts';
 import * as realExternalAuth from '../../services/external-auth.ts';
 import ldapService from '../../services/ldap.ts';
 import * as realInitials from '../../utils/initials.ts';
 import * as realLogger from '../../utils/logger.ts';
 import * as realOrderIds from '../../utils/order-ids.ts';
+import { makeWithDbTransactionMock } from '../helpers/withDbTransactionMock.ts';
 
 // Snapshot real exports BEFORE the beforeAll fires (mock.module inside beforeAll is not hoisted).
 const ldapjsSnapshot = realLdap;
+const drizzleSnapshot = { ...realDrizzle };
 const ldapRepoSnapshot = { ...realLdapRepo };
+const settingsRepoSnapshot = { ...realSettingsRepo };
 const usersRepoSnapshot = { ...realUsersRepo };
 const externalAuthSnapshot = { ...realExternalAuth };
 const initialsSnapshot = { ...realInitials };
@@ -30,11 +35,14 @@ const orderIdsSnapshot = { ...realOrderIds };
 const ldapRepoGetMock = mock();
 const findLoginUserByNormalizedUsernameMock = mock();
 const updateNameByUsernameMock = mock();
+const updateDirectoryProfileMock = mock();
+const settingsUpsertForUserMock = mock();
 const createUserMock = mock();
 const applyExternalRolesForUserMock = mock();
 const applyExternalRolesForUserIfMatchedMock = mock();
 const externalGroupsYieldNoKnownRoleMock = mock();
 const filterExistingRoleIdsMock = mock();
+const { withDbTransactionMock, resetWithDbTransactionMock } = makeWithDbTransactionMock();
 
 // ─── ldapjs harness ───────────────────────────────────────────────────────────
 type SearchResponse = {
@@ -142,10 +150,19 @@ beforeAll(() => {
     ...ldapRepoSnapshot,
     get: ldapRepoGetMock,
   }));
+  mock.module('../../db/drizzle.ts', () => ({
+    ...drizzleSnapshot,
+    withDbTransaction: withDbTransactionMock,
+  }));
+  mock.module('../../repositories/settingsRepo.ts', () => ({
+    ...settingsRepoSnapshot,
+    upsertForUser: settingsUpsertForUserMock,
+  }));
   mock.module('../../repositories/usersRepo.ts', () => ({
     ...usersRepoSnapshot,
     findLoginUserByNormalizedUsername: findLoginUserByNormalizedUsernameMock,
     updateNameByUsername: updateNameByUsernameMock,
+    updateDirectoryProfile: updateDirectoryProfileMock,
     createUser: createUserMock,
   }));
   mock.module('../../services/external-auth.ts', () => ({
@@ -173,7 +190,9 @@ beforeAll(() => {
 
 afterAll(() => {
   mock.module('ldapjs', () => ({ default: ldapjsSnapshot }));
+  mock.module('../../db/drizzle.ts', () => drizzleSnapshot);
   mock.module('../../repositories/ldapRepo.ts', () => ldapRepoSnapshot);
+  mock.module('../../repositories/settingsRepo.ts', () => settingsRepoSnapshot);
   mock.module('../../repositories/usersRepo.ts', () => usersRepoSnapshot);
   mock.module('../../services/external-auth.ts', () => externalAuthSnapshot);
   mock.module('../../utils/initials.ts', () => initialsSnapshot);
@@ -226,8 +245,11 @@ beforeEach(() => {
   }
 
   ldapRepoGetMock.mockReset();
+  resetWithDbTransactionMock();
   findLoginUserByNormalizedUsernameMock.mockReset();
   updateNameByUsernameMock.mockReset();
+  updateDirectoryProfileMock.mockReset();
+  settingsUpsertForUserMock.mockReset();
   createUserMock.mockReset();
   applyExternalRolesForUserMock.mockReset();
   applyExternalRolesForUserIfMatchedMock.mockReset();
@@ -687,6 +709,33 @@ describe('authenticate', () => {
     ]);
   });
 
+  test('returns provider email from LDAP mail attributes without requiring it', async () => {
+    nextFixture = {
+      bindResponses: [null, null, null],
+      searchResponses: [
+        {
+          entries: [
+            {
+              objectName: 'uid=alice,dc=test,dc=com',
+              object: { uid: 'alice', cn: 'Alice Provider', mail: 'alice@example.com' },
+            },
+          ],
+          status: 0,
+        },
+        { entries: [], status: 0 },
+      ],
+    };
+
+    const result = await ldapService.authenticateWithProfile('alice', 'pw');
+
+    expect(result.authenticated).toBe(true);
+    expect(result.displayName).toBe('Alice Provider');
+    expect(result.email).toBe('alice@example.com');
+    expect(lastClientStats?.searchCalls[0]?.options).toEqual(
+      expect.objectContaining({ attributes: expect.arrayContaining(['mail']) }),
+    );
+  });
+
   test('rejects when any parallel group search fails (strict auth path, #637)', async () => {
     // Auth uses strict findUserGroups so a transient subtree failure surfaces as a 503
     // instead of returning [] and demoting new admins to the default role.
@@ -761,7 +810,13 @@ describe('findUserEntry (direct, with config preloaded)', () => {
     });
     await ldapService.findUserEntry(client as never, 'alice');
     const search = lastClientStats?.searchCalls[0];
-    expect(search?.options.attributes).toEqual(['uid', 'sAMAccountName', 'cn', 'displayName']);
+    expect(search?.options.attributes).toEqual([
+      'uid',
+      'sAMAccountName',
+      'cn',
+      'displayName',
+      'mail',
+    ]);
     expect(search?.options.sizeLimit).toBe(1);
   });
 
@@ -985,7 +1040,11 @@ describe('syncUsers', () => {
     const result = await ldapService.syncUsers();
     expect(findLoginUserByNormalizedUsernameMock).toHaveBeenCalledWith('jdoe');
     // Updates the existing row (matched by lower-cased lookup) rather than creating a new one.
-    expect(updateNameByUsernameMock).toHaveBeenCalledWith('jdoe', 'John Doe Updated');
+    expect(updateDirectoryProfileMock).toHaveBeenCalledWith(
+      'u-jdoe',
+      { name: 'John Doe Updated', avatarInitials: 'JO' },
+      expect.anything(),
+    );
     expect(createUserMock).not.toHaveBeenCalled();
     expect(result).toEqual({ synced: 1, created: 0 });
 
@@ -1019,7 +1078,7 @@ describe('syncUsers', () => {
     expect(created.name).toBe('Flat CN');
   });
 
-  test('updates existing user via updateNameByUsername instead of creating', async () => {
+  test('updates existing user profile instead of creating', async () => {
     nextFixture = {
       bindResponses: [null],
       searchResponses: [
@@ -1031,7 +1090,11 @@ describe('syncUsers', () => {
     };
     findLoginUserByNormalizedUsernameMock.mockResolvedValue(LDAP_LOGIN_USER);
     const result = await ldapService.syncUsers();
-    expect(updateNameByUsernameMock).toHaveBeenCalledWith('alice', 'Alice New');
+    expect(updateDirectoryProfileMock).toHaveBeenCalledWith(
+      LDAP_LOGIN_USER.id,
+      { name: 'Alice New', avatarInitials: 'AL' },
+      expect.anything(),
+    );
     expect(createUserMock).not.toHaveBeenCalled();
     expect(result).toEqual({ synced: 1, created: 0 });
   });
@@ -1080,7 +1143,11 @@ describe('syncUsers', () => {
     expect(result).toEqual({ synced: 1, created: 0 });
     // Display name still refreshed from the directory, but roles are NEVER rewritten
     // for an existing user — they're owned by the app post-provisioning.
-    expect(updateNameByUsernameMock).toHaveBeenCalledWith('daniel.dangeli', "Daniel D'Angeli");
+    expect(updateDirectoryProfileMock).toHaveBeenCalledWith(
+      LDAP_LOGIN_USER.id,
+      { name: "Daniel D'Angeli", avatarInitials: 'DA' },
+      expect.anything(),
+    );
     expect(applyExternalRolesForUserMock).not.toHaveBeenCalled();
   });
 
@@ -1102,7 +1169,11 @@ describe('syncUsers', () => {
       username === 'alice' ? LDAP_LOGIN_USER : null,
     );
     const result = await ldapService.syncUsers();
-    expect(updateNameByUsernameMock).toHaveBeenCalledWith('alice', 'Alice New');
+    expect(updateDirectoryProfileMock).toHaveBeenCalledWith(
+      LDAP_LOGIN_USER.id,
+      { name: 'Alice New', avatarInitials: 'AL' },
+      expect.anything(),
+    );
     expect(createUserMock).not.toHaveBeenCalled();
     expect(result).toEqual({ synced: 1, created: 0 });
   });
@@ -1125,7 +1196,7 @@ describe('syncUsers', () => {
 
     const result = await ldapService.syncUsers();
 
-    expect(updateNameByUsernameMock).not.toHaveBeenCalled();
+    expect(updateDirectoryProfileMock).not.toHaveBeenCalled();
     expect(applyExternalRolesForUserMock).not.toHaveBeenCalled();
     expect(createUserMock).not.toHaveBeenCalled();
     expect(result).toEqual({ synced: 0, created: 0 });
@@ -1148,7 +1219,7 @@ describe('syncUsers', () => {
 
     const result = await ldapService.syncUsers();
 
-    expect(updateNameByUsernameMock).not.toHaveBeenCalled();
+    expect(updateDirectoryProfileMock).not.toHaveBeenCalled();
     expect(applyExternalRolesForUserMock).not.toHaveBeenCalled();
     expect(createUserMock).not.toHaveBeenCalled();
     expect(result).toEqual({ synced: 0, created: 0 });
@@ -1221,7 +1292,7 @@ describe('syncUsers', () => {
     await expect(ldapService.syncUsers()).rejects.toThrow('search aborted by server');
     expect(lastClientStats?.unbindCalls).toBe(1);
     expect(createUserMock).not.toHaveBeenCalled();
-    expect(updateNameByUsernameMock).not.toHaveBeenCalled();
+    expect(updateDirectoryProfileMock).not.toHaveBeenCalled();
   });
 
   test('rejects when search end yields a non-zero status', async () => {
@@ -1648,6 +1719,63 @@ describe('authenticateAndProvision', () => {
     expect(applyExternalRolesForUserMock).not.toHaveBeenCalled();
   });
 
+  test('refreshes existing LDAP user name and email from provider claims', async () => {
+    nextFixture = {
+      bindResponses: [null, null],
+      searchResponses: [
+        {
+          entries: [
+            {
+              objectName: 'uid=alice,dc=test,dc=com',
+              object: { uid: 'alice', cn: 'Alice Provider', mail: 'alice@example.com' },
+            },
+          ],
+          status: 0,
+        },
+        { entries: [], status: 0 },
+      ],
+    };
+    findLoginUserByNormalizedUsernameMock.mockResolvedValue(LDAP_LOGIN_USER);
+
+    const result = await ldapService.authenticateAndProvision('alice', 'pw');
+
+    expect(result).toEqual({
+      authenticated: true,
+      userId: LDAP_LOGIN_USER.id,
+      created: false,
+      canonicalUsername: 'alice',
+    });
+    expect(updateDirectoryProfileMock).toHaveBeenCalledWith(
+      LDAP_LOGIN_USER.id,
+      { name: 'Alice Provider', avatarInitials: 'AL' },
+      expect.anything(),
+    );
+    expect(settingsUpsertForUserMock).toHaveBeenCalledWith(
+      LDAP_LOGIN_USER.id,
+      { fullName: 'Alice Provider', email: 'alice@example.com', language: null },
+      expect.anything(),
+    );
+  });
+
+  test('does not clear profile values when LDAP omits name and email', async () => {
+    nextFixture = {
+      bindResponses: [null, null],
+      searchResponses: [
+        {
+          entries: [{ objectName: 'uid=alice,dc=test,dc=com', object: { uid: 'alice' } }],
+          status: 0,
+        },
+        { entries: [], status: 0 },
+      ],
+    };
+    findLoginUserByNormalizedUsernameMock.mockResolvedValue(LDAP_LOGIN_USER);
+
+    await ldapService.authenticateAndProvision('alice', 'pw');
+
+    expect(updateDirectoryProfileMock).not.toHaveBeenCalled();
+    expect(settingsUpsertForUserMock).not.toHaveBeenCalled();
+  });
+
   test('existing-user login with no matching group preserves current role (regression #318)', async () => {
     nextFixture = {
       bindResponses: [null, null],
@@ -1885,6 +2013,29 @@ describe('authenticateAndProvision', () => {
     // genuinely map to a role.
     expect(applyExternalRolesForUserMock).not.toHaveBeenCalled();
     expect(applyExternalRolesForUserIfMatchedMock).toHaveBeenCalledWith(LDAP_LOGIN_USER.id, [], []);
+  });
+
+  test('race recovery does not overwrite provider-managed names when LDAP omits display name', async () => {
+    nextFixture = {
+      bindResponses: [null, null],
+      searchResponses: [
+        {
+          entries: [{ objectName: 'uid=alice,dc=test,dc=com', object: { uid: 'alice' } }],
+          status: 0,
+        },
+        { entries: [], status: 0 },
+      ],
+    };
+    findLoginUserByNormalizedUsernameMock
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(LDAP_LOGIN_USER);
+    const uniqueErr = Object.assign(new Error('duplicate key'), { code: '23505' });
+    createUserMock.mockRejectedValueOnce(uniqueErr);
+
+    await ldapService.authenticateAndProvision('alice', 'pw');
+
+    expect(updateDirectoryProfileMock).not.toHaveBeenCalled();
+    expect(settingsUpsertForUserMock).not.toHaveBeenCalled();
   });
 
   test('uses displayName when cn is absent', async () => {

--- a/services/api/employees.ts
+++ b/services/api/employees.ts
@@ -3,11 +3,13 @@ import { fetchApi } from './client';
 import { normalizeUser } from './normalizers';
 
 export const employeesApi = {
-  create: (data: {
-    name: string;
-    employeeType: EmployeeType;
-    costPerHour?: number;
-  }): Promise<User> =>
+  create: (
+    data: {
+      name: string;
+      employeeType: EmployeeType;
+      costPerHour?: number;
+    } & Partial<User>,
+  ): Promise<User> =>
     fetchApi<User>('/users', {
       method: 'POST',
       body: JSON.stringify(data),

--- a/services/api/normalizers.ts
+++ b/services/api/normalizers.ts
@@ -24,6 +24,9 @@ import type {
   TimeEntry,
   User,
   UserAuthMethod,
+  UserContractType,
+  UserEmploymentStatus,
+  UserWorkLocation,
 } from '../../types';
 import { normalizeDateOnlyString } from '../../utils/date';
 import {
@@ -127,6 +130,45 @@ const normalizeUserAuthMethod = (value: unknown): UserAuthMethod => {
   return 'local';
 };
 
+const normalizeUserContractType = (value: unknown): UserContractType | null => {
+  if (
+    value === 'permanent' ||
+    value === 'fixed_term' ||
+    value === 'contractor' ||
+    value === 'internship' ||
+    value === 'consultant' ||
+    value === 'other'
+  ) {
+    return value;
+  }
+  return null;
+};
+
+const normalizeUserEmploymentStatus = (value: unknown): UserEmploymentStatus | null => {
+  if (
+    value === 'active' ||
+    value === 'onboarding' ||
+    value === 'on_leave' ||
+    value === 'terminated'
+  ) {
+    return value;
+  }
+  return null;
+};
+
+const normalizeUserWorkLocation = (value: unknown): UserWorkLocation | null => {
+  if (
+    value === 'office' ||
+    value === 'remote' ||
+    value === 'hybrid' ||
+    value === 'customer_site' ||
+    value === 'other'
+  ) {
+    return value;
+  }
+  return null;
+};
+
 const normalizeAvailableRoles = (value: unknown): RoleSummary[] | undefined => {
   if (value === undefined) return undefined;
   if (!Array.isArray(value)) return [];
@@ -173,6 +215,13 @@ const normalizeOptionalString = (raw: unknown): string | undefined =>
 const normalizeNullableTrimmedString = (raw: unknown): string | null =>
   normalizeTrimmedString(raw) || null;
 
+const normalizeNullableDateOnlyString = (raw: unknown): string | null => {
+  const normalized = normalizeTrimmedString(raw);
+  if (!normalized) return null;
+  const dateOnly = normalizeDateOnlyString(normalized);
+  return /^\d{4}-\d{2}-\d{2}$/.test(dateOnly) ? dateOnly : null;
+};
+
 export const normalizeUser = (u: User): User => {
   // /auth/login and /auth/me only return id, name, username, role,
   // avatarInitials, permissions, availableRoles. Fabricating defaults for the
@@ -194,6 +243,18 @@ export const normalizeUser = (u: User): User => {
   assignIfPresent(raw, result, 'email', normalizeOptionalString);
   assignIfPresent(raw, result, 'costPerHour', normalizeCostPerHour);
   assignIfPresent(raw, result, 'employeeType', normalizeEmployeeType);
+  assignIfPresent(raw, result, 'phone', normalizeOptionalString);
+  assignIfPresent(raw, result, 'jobTitle', normalizeOptionalString);
+  assignIfPresent(raw, result, 'department', normalizeOptionalString);
+  assignIfPresent(raw, result, 'employeeCode', normalizeOptionalString);
+  assignIfPresent(raw, result, 'hireDate', normalizeNullableDateOnlyString);
+  assignIfPresent(raw, result, 'terminationDate', normalizeNullableDateOnlyString);
+  assignIfPresent(raw, result, 'contractType', normalizeUserContractType);
+  assignIfPresent(raw, result, 'employmentStatus', normalizeUserEmploymentStatus);
+  assignIfPresent(raw, result, 'workLocation', normalizeUserWorkLocation);
+  assignIfPresent(raw, result, 'emergencyContactName', normalizeOptionalString);
+  assignIfPresent(raw, result, 'emergencyContactPhone', normalizeOptionalString);
+  assignIfPresent(raw, result, 'notes', normalizeOptionalString);
   assignIfPresent(raw, result, 'authMethod', normalizeUserAuthMethod);
   assignIfPresent(raw, result, 'authProviderId', normalizeNullableTrimmedString);
   assignIfPresent(raw, result, 'authProviderName', normalizeNullableTrimmedString);

--- a/test/components/administration/UserManagement.test.tsx
+++ b/test/components/administration/UserManagement.test.tsx
@@ -211,6 +211,52 @@ describe('<UserManagement />', () => {
     expect(usersApiMock.getRoles).not.toHaveBeenCalled();
   });
 
+  test('locks synced identity fields for non-local users and omits them from account updates', async () => {
+    const ldapUser: User = {
+      id: 'u-ldap',
+      name: 'Lara LDAP',
+      role: 'user',
+      avatarInitials: 'LL',
+      username: 'lara.ldap',
+      email: 'lara.ldap@example.com',
+      employeeType: 'app_user',
+      authMethod: 'ldap',
+    };
+    const onUpdateUser = mock(() => {});
+    renderUserManagement({
+      users: [users[0], ldapUser],
+      onUpdateUser,
+    });
+
+    fireEvent.click(screen.getByText('Lara LDAP'));
+    await screen.findByText('hr:workforce.editUser');
+
+    const firstNameInput = screen.getByLabelText('hr:workforce.name') as HTMLInputElement;
+    const surnameInput = screen.getByLabelText('hr:workforce.surname') as HTMLInputElement;
+    const emailInput = screen.getByLabelText('common:labels.email') as HTMLInputElement;
+    expect(firstNameInput).toBeDisabled();
+    expect(surnameInput).toBeDisabled();
+    expect(emailInput).toBeDisabled();
+    expect(firstNameInput.value).toBe('Lara');
+    expect(surnameInput.value).toBe('LDAP');
+    expect(emailInput.value).toBe('lara.ldap@example.com');
+    expect(screen.getByText('hr:workforce.identityManagedByProvider')).toBeInTheDocument();
+
+    const saveButton = screen.getByRole('button', { name: 'hr:workforce.saveChanges' });
+    expect(saveButton).toBeDisabled();
+    const disabledToggle = document.body.querySelector<HTMLElement>('[role="switch"]');
+    if (!disabledToggle) throw new Error('Disabled switch not rendered');
+    fireEvent.click(disabledToggle);
+    await waitFor(() => expect(saveButton).not.toBeDisabled());
+
+    fireEvent.click(saveButton);
+
+    expect(onUpdateUser).toHaveBeenCalledWith('u-ldap', { isDisabled: true });
+    const [, updates] = onUpdateUser.mock.calls[0] as unknown as [string, Record<string, unknown>];
+    expect(updates).not.toHaveProperty('name');
+    expect(updates).not.toHaveProperty('email');
+  });
+
   const openAuthMethodDialog = async (
     rowName = 'Bob Brown',
     overrides: Partial<ComponentProps<typeof UserManagement>> = {},

--- a/test/components/hr/ExternalEmployeesView.rowClick.test.tsx
+++ b/test/components/hr/ExternalEmployeesView.rowClick.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, mock, test } from 'bun:test';
-import { fireEvent, screen } from '@testing-library/react';
+import { fireEvent, screen, within } from '@testing-library/react';
 import type { ComponentProps } from 'react';
 import type { User } from '../../../types';
 import { installI18nMock } from '../../helpers/i18n';
@@ -70,5 +70,37 @@ describe('<ExternalEmployeesView /> row click', () => {
     fireEvent.click(row);
 
     expect(screen.queryByDisplayValue('Mario Rossi')).not.toBeInTheDocument();
+  });
+
+  test('does not synthesize table values for unset HR profile fields', () => {
+    renderView({
+      users: [
+        {
+          ...employee,
+          email: undefined,
+          phone: null,
+          jobTitle: null,
+          department: null,
+          employeeCode: null,
+          employmentStatus: null,
+          contractType: 'contractor',
+        },
+      ],
+    });
+
+    const row = screen.getByText('Mario Rossi').closest('tr');
+    if (!row) throw new Error('employee row not found');
+
+    expect(
+      within(row).queryByText('employeeProfile.employmentStatuses.active'),
+    ).not.toBeInTheDocument();
+    expect(within(row).getAllByText('employeeProfile.notSet').length).toBeGreaterThanOrEqual(4);
+
+    fireEvent.click(row);
+
+    expect(screen.getByLabelText('employeeProfile.email')).toHaveValue('');
+    expect(screen.getByLabelText('employeeProfile.jobTitle')).toHaveValue('');
+    expect(screen.getByLabelText('employeeProfile.department')).toHaveValue('');
+    expect(screen.getByLabelText('employeeProfile.employeeCode')).toHaveValue('');
   });
 });

--- a/test/components/hr/HrModalStyling.test.ts
+++ b/test/components/hr/HrModalStyling.test.ts
@@ -14,15 +14,38 @@ describe('HR employee modal styling', () => {
 
     expectSourceContainsAll(source, [
       "import { Button } from '@/components/ui/button';",
-      "import { Field, FieldError, FieldLabel } from '@/components/ui/field';",
-      "import { Input } from '@/components/ui/input';",
-      '<ModalContent size="md"',
+      "import EmployeeHrFields from './EmployeeHrFields';",
+      "from './employeeHrProfile';",
+      '<ModalContent size="2xl"',
       '<ModalHeader>',
-      '<ModalBody className="space-y-4">',
+      '<ModalBody className="space-y-6">',
+      '<EmployeeHrFields',
       '<ModalFooter>',
       '<DeleteConfirmModal',
     ]);
     expectSourceOmitsAll(source, ['rounded-2xl shadow-2xl']);
+  });
+
+  test('shared HR profile fields use shadcn form primitives', async () => {
+    const source = await readComponentSource('HR/EmployeeHrFields.tsx');
+
+    expectSourceContainsAll(source, [
+      "import { Field, FieldError, FieldLabel } from '@/components/ui/field';",
+      "import { Input } from '@/components/ui/input';",
+      'import {',
+      'Select,',
+      "import { Textarea } from '@/components/ui/textarea';",
+    ]);
+    expectSourceOmitsAll(source, ['rounded-2xl shadow-2xl']);
+  });
+
+  test.each([
+    ['internal employees', 'HR/InternalEmployeesView.tsx'],
+    ['external employees', 'HR/ExternalEmployeesView.tsx'],
+  ])('%s table accessor columns use stable ids', async (_name, path) => {
+    const source = await readComponentSource(path);
+
+    expectSourceContainsAll(source, ["id: 'contact'", "id: 'roleTitle'", "id: 'hrStatus'"]);
   });
 });
 

--- a/test/components/hr/InternalEmployeesView.rowClick.test.tsx
+++ b/test/components/hr/InternalEmployeesView.rowClick.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, mock, test } from 'bun:test';
-import { fireEvent, screen } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import type { ComponentProps } from 'react';
 import type { User } from '../../../types';
 import { installI18nMock } from '../../helpers/i18n';
@@ -25,6 +25,12 @@ const employee: User = {
   username: 'mrossi',
   employeeType: 'internal',
   costPerHour: 25,
+  email: 'mario@example.com',
+  phone: '+39 02 1234',
+  jobTitle: 'Consultant',
+  department: 'Delivery',
+  employeeCode: 'EMP-001',
+  employmentStatus: 'active',
 };
 
 const renderView = (overrides: Partial<ComponentProps<typeof InternalEmployeesView>> = {}) => {
@@ -34,7 +40,7 @@ const renderView = (overrides: Partial<ComponentProps<typeof InternalEmployeesVi
     projects: [],
     tasks: [],
     onAddEmployee: mock(async () => ({ success: true })),
-    onUpdateEmployee: mock(() => {}),
+    onUpdateEmployee: mock<(id: string, updates: Partial<User>) => void>(() => {}),
     onDeleteEmployee: mock(() => {}),
     currency: '€',
     permissions: ['hr.internal.view', 'hr.internal.update'],
@@ -57,6 +63,9 @@ describe('<InternalEmployeesView /> row click', () => {
     fireEvent.click(row);
 
     expect(screen.getByDisplayValue('Mario Rossi')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('mario@example.com')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('+39 02 1234')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('EMP-001')).toBeInTheDocument();
   });
 
   test('row is not clickable without update permission', () => {
@@ -70,5 +79,103 @@ describe('<InternalEmployeesView /> row click', () => {
     fireEvent.click(row);
 
     expect(screen.queryByDisplayValue('Mario Rossi')).not.toBeInTheDocument();
+  });
+
+  test('does not synthesize table values for unset HR profile fields', () => {
+    renderView({
+      users: [
+        {
+          ...employee,
+          employeeType: 'app_user',
+          role: 'manager',
+          email: undefined,
+          phone: null,
+          jobTitle: null,
+          department: null,
+          employeeCode: null,
+          employmentStatus: null,
+        },
+      ],
+    });
+
+    const row = screen.getByText('Mario Rossi').closest('tr');
+    if (!row) throw new Error('employee row not found');
+
+    expect(within(row).queryByText('manager')).not.toBeInTheDocument();
+    expect(
+      within(row).queryByText('employeeProfile.employmentStatuses.active'),
+    ).not.toBeInTheDocument();
+    expect(within(row).getAllByText('employeeProfile.notSet').length).toBeGreaterThanOrEqual(4);
+
+    fireEvent.click(row);
+
+    expect(screen.getByLabelText('employeeProfile.email')).toHaveValue('');
+    expect(screen.getByLabelText('employeeProfile.jobTitle')).toHaveValue('');
+    expect(screen.getByLabelText('employeeProfile.department')).toHaveValue('');
+    expect(screen.getByLabelText('employeeProfile.employeeCode')).toHaveValue('');
+  });
+
+  test('submits HR profile fields when creating an internal employee', async () => {
+    const onAddEmployee = mock(async () => ({ success: true }));
+    renderView({
+      users: [],
+      onAddEmployee,
+      permissions: ['hr.internal.view', 'hr.internal.create', 'hr.internal.update'],
+    });
+
+    fireEvent.click(screen.getByText('internalEmployees.addEmployee'));
+    fireEvent.change(screen.getByLabelText('internalEmployees.name *'), {
+      target: { value: 'Luisa Bianchi' },
+    });
+    fireEvent.change(screen.getByLabelText('employeeProfile.email'), {
+      target: { value: 'luisa@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText('employeeProfile.phone'), {
+      target: { value: '+39 02 5555' },
+    });
+    fireEvent.change(screen.getByLabelText('employeeProfile.jobTitle'), {
+      target: { value: 'HR Specialist' },
+    });
+    fireEvent.change(screen.getByLabelText('employeeProfile.employeeCode'), {
+      target: { value: 'EMP-222' },
+    });
+
+    fireEvent.click(screen.getByText('internalEmployees.saveChanges'));
+
+    await waitFor(() => expect(onAddEmployee).toHaveBeenCalledTimes(1));
+    expect(onAddEmployee).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Luisa Bianchi',
+        email: 'luisa@example.com',
+        phone: '+39 02 5555',
+        jobTitle: 'HR Specialist',
+        employeeCode: 'EMP-222',
+      }),
+    );
+  });
+
+  test('keeps provider-managed name and email read-only on edit', async () => {
+    const onUpdateEmployee = mock<(id: string, updates: Partial<User>) => void>(() => {});
+    renderView({
+      users: [{ ...employee, employeeType: 'app_user', authMethod: 'ldap' }],
+      onUpdateEmployee,
+    });
+
+    const row = screen.getByText('Mario Rossi').closest('tr');
+    if (!row) throw new Error('employee row not found');
+    fireEvent.click(row);
+
+    expect(screen.getByLabelText('internalEmployees.name *')).toBeDisabled();
+    expect(screen.getByLabelText('employeeProfile.email')).toBeDisabled();
+    fireEvent.change(screen.getByLabelText('employeeProfile.phone'), {
+      target: { value: '+39 02 9999' },
+    });
+    fireEvent.click(screen.getByText('internalEmployees.saveChanges'));
+
+    await waitFor(() => expect(onUpdateEmployee).toHaveBeenCalledTimes(1));
+    const updates = onUpdateEmployee.mock.calls[0][1] as Partial<User>;
+    expect(updates).toEqual(expect.objectContaining({ phone: '+39 02 9999' }));
+    expect(updates).not.toHaveProperty('name');
+    expect(updates).not.toHaveProperty('email');
   });
 });

--- a/test/handlers/userHandlers.test.ts
+++ b/test/handlers/userHandlers.test.ts
@@ -309,7 +309,7 @@ describe('makeUserHandlers - employees', () => {
       Promise.resolve({ id: 'e-new', ...(data as object) }),
     );
     const ctx = buildHandlers();
-    const result = await ctx.handlers.addInternalEmployee('Bob', 75);
+    const result = await ctx.handlers.addInternalEmployee({ name: 'Bob', costPerHour: 75 });
     expect(result).toEqual({ success: true });
     expect(apiMocks.employeesCreate).toHaveBeenCalledWith({
       name: 'Bob',
@@ -324,11 +324,10 @@ describe('makeUserHandlers - employees', () => {
       Promise.resolve({ id: 'e-new', ...(data as object) }),
     );
     const ctx = buildHandlers();
-    await ctx.handlers.addExternalEmployee('Eve');
+    await ctx.handlers.addExternalEmployee({ name: 'Eve' });
     expect(apiMocks.employeesCreate).toHaveBeenCalledWith({
       name: 'Eve',
       employeeType: 'external',
-      costPerHour: undefined,
     });
   });
 
@@ -337,7 +336,7 @@ describe('makeUserHandlers - employees', () => {
     const ctx = buildHandlers();
     const restore = silenceConsole();
     try {
-      const result = await ctx.handlers.addInternalEmployee('Bob');
+      const result = await ctx.handlers.addInternalEmployee({ name: 'Bob' });
       expect(result).toEqual({ success: false, error: 'dup' });
     } finally {
       restore();
@@ -349,7 +348,7 @@ describe('makeUserHandlers - employees', () => {
     const ctx = buildHandlers();
     const restore = silenceConsole();
     try {
-      const result = await ctx.handlers.addInternalEmployee('Bob');
+      const result = await ctx.handlers.addInternalEmployee({ name: 'Bob' });
       expect(result).toEqual({ success: false, error: 'Failed to create employee' });
     } finally {
       restore();

--- a/test/services/normalizers.test.ts
+++ b/test/services/normalizers.test.ts
@@ -394,6 +394,18 @@ describe('normalizeUser', () => {
       hasTopManagerRole: true,
       isAdminOnly: false,
       employeeType: 'internal',
+      phone: '  +39 02 1234  ',
+      jobTitle: '  Consultant  ',
+      department: '  Delivery  ',
+      employeeCode: '  EMP-001  ',
+      hireDate: '2024-01-15T10:30:00Z',
+      terminationDate: '',
+      contractType: 'permanent',
+      employmentStatus: 'onboarding',
+      workLocation: 'hybrid',
+      emergencyContactName: '  Maria  ',
+      emergencyContactPhone: '  +39 02 5678  ',
+      notes: '  Starts next week  ',
       permissions: ['read', '  write  ', ''],
     });
     const result = normalizeUser(input);
@@ -407,6 +419,18 @@ describe('normalizeUser', () => {
     expect(result.hasTopManagerRole).toBe(true);
     expect(result.isAdminOnly).toBe(false);
     expect(result.employeeType).toBe('internal');
+    expect(result.phone).toBe('+39 02 1234');
+    expect(result.jobTitle).toBe('Consultant');
+    expect(result.department).toBe('Delivery');
+    expect(result.employeeCode).toBe('EMP-001');
+    expect(result.hireDate).toBe('2024-01-15');
+    expect(result.terminationDate).toBeNull();
+    expect(result.contractType).toBe('permanent');
+    expect(result.employmentStatus).toBe('onboarding');
+    expect(result.workLocation).toBe('hybrid');
+    expect(result.emergencyContactName).toBe('Maria');
+    expect(result.emergencyContactPhone).toBe('+39 02 5678');
+    expect(result.notes).toBe('Starts next week');
     expect(result.permissions).toEqual(['read', 'write']);
   });
 
@@ -427,6 +451,27 @@ describe('normalizeUser', () => {
     expect(result.hasTopManagerRole).toBeUndefined();
     expect(result.isAdminOnly).toBeUndefined();
     expect(result.employeeType).toBeUndefined();
+    expect(result.phone).toBeUndefined();
+    expect(result.employeeCode).toBeUndefined();
+    expect(result.employmentStatus).toBeUndefined();
+  });
+
+  test('normalizes invalid optional HR enums and dates to null', () => {
+    const input = make<User>(baseUser, {
+      hireDate: 'not-a-date',
+      terminationDate: null,
+      contractType: 'bad-contract',
+      employmentStatus: 'bad-status',
+      workLocation: 'bad-location',
+    });
+
+    const result = normalizeUser(input);
+
+    expect(result.hireDate).toBeNull();
+    expect(result.terminationDate).toBeNull();
+    expect(result.contractType).toBeNull();
+    expect(result.employmentStatus).toBeNull();
+    expect(result.workLocation).toBeNull();
   });
 
   test('returns 0 for non-finite costPerHour input', () => {

--- a/types.ts
+++ b/types.ts
@@ -57,6 +57,15 @@ export type KnownPermission = `${KnownPermissionResource}.${KnownPermissionActio
 export type Permission = KnownPermission | (string & {});
 export type EmployeeType = 'app_user' | 'internal' | 'external';
 export type UserAuthMethod = 'local' | 'ldap' | 'oidc' | 'saml';
+export type UserContractType =
+  | 'permanent'
+  | 'fixed_term'
+  | 'contractor'
+  | 'internship'
+  | 'consultant'
+  | 'other';
+export type UserEmploymentStatus = 'active' | 'onboarding' | 'on_leave' | 'terminated';
+export type UserWorkLocation = 'office' | 'remote' | 'hybrid' | 'customer_site' | 'other';
 export type DiscountType = 'percentage' | 'currency';
 export type TimeEntryLocation = 'office' | 'customer_premise' | 'remote' | 'transfer';
 export type StoredBillingType = 'retainer' | 'time_and_materials';
@@ -90,6 +99,18 @@ export interface User {
   costPerHour?: number;
   isDisabled?: boolean;
   employeeType?: EmployeeType;
+  phone?: string | null;
+  jobTitle?: string | null;
+  department?: string | null;
+  employeeCode?: string | null;
+  hireDate?: string | null;
+  terminationDate?: string | null;
+  contractType?: UserContractType | null;
+  employmentStatus?: UserEmploymentStatus | null;
+  workLocation?: UserWorkLocation | null;
+  emergencyContactName?: string | null;
+  emergencyContactPhone?: string | null;
+  notes?: string | null;
   authMethod?: UserAuthMethod;
   authProviderId?: string | null;
   authProviderName?: string | null;


### PR DESCRIPTION
## Summary
- Adds ERP-style HR profile fields to users and exposes them through `/api/users` with HR permission masking.
- Expands internal/external HR employee screens with contact, employment, emergency contact, and notes sections.
- Refreshes LDAP/SSO-managed name/email values from provider claims while keeping provider-managed identity fields read-only for manual edits.

## Changes
- Adds nullable user HR columns, enum/date constraints, and a nullable unique employee-code index in migration `0062_add_user_hr_details`.
- Extends users repository, route schemas, masking, create/update flows, and frontend normalizers/types for the HR profile fields.
- Allows HR internal permissions to update app-user HR profile data without account-administration controls.
- Updates HR documentation in Italian/English plus generated OpenAPI docs.

## Testing
- `bun run docs:api`
- `bun run lint`
- `cd server && bun run db:check`
- `bun run test`
- `bun run docs:user`
- Browser reload at `http://127.0.0.1:3000/#/login` showed no Vite overlay.

## Risks / Rollout
- Includes a database migration adding nullable `users` columns and a nullable unique employee-code index.
- Touches auth-provider profile synchronization and `/api/users` permission masking; regression tests cover HR masking, external-auth read-only rejection, date validation, LDAP/SSO refresh behavior, and email updates.

## Issues
Issue: Not linked