### PR TITLE
ui(login): fix unreadable input text in dark mode

### DIFF
--- a/components/Login.tsx
+++ b/components/Login.tsx
@@ -186,7 +186,7 @@ const Login: React.FC<LoginProps> = ({
         getShadcnThemeClassName(browserTheme),
       )}
     >
-      <div className="relative w-full max-w-md overflow-hidden rounded-xl border bg-card px-8 py-8 shadow-lg">
+      <div className="relative w-full max-w-md overflow-hidden rounded-xl border bg-card text-card-foreground px-8 py-8 shadow-lg">
         <div className="absolute inset-0 -top-px -left-px z-0" style={gridOverlayStyle} />
 
         <div className="relative isolate flex w-full flex-col items-center">

--- a/test/components/Login.test.tsx
+++ b/test/components/Login.test.tsx
@@ -394,6 +394,20 @@ describe('<Login />', () => {
       expect(logo.classList.contains('invert')).toBe(true);
     });
 
+    // Regression: the card paired `bg-card` with no foreground token, so input
+    // text fell back to the browser default (black) and was unreadable on the
+    // dark card. The `text-card-foreground` token must travel with `bg-card` so
+    // typed text adapts to the theme.
+    test('card carries the card-foreground token alongside bg-card', () => {
+      setPrefersDarkScheme(true);
+
+      const { container } = render(<Login onLogin={() => {}} />);
+      const card = container.querySelector('.bg-card');
+
+      expect(card).not.toBeNull();
+      expect(card?.classList.contains('text-card-foreground')).toBe(true);
+    });
+
     test('keeps the muted background and original logo colors in light mode', () => {
       setPrefersDarkScheme(false);
 


### PR DESCRIPTION
## What changed

The login card paired `bg-card` with no matching foreground token, so typed input text fell back to the browser default (black). On the light card it read fine, but against the dark card the text/password dots were near-black on a dark background and effectively unreadable.

Added `text-card-foreground` alongside `bg-card` (the shadcn-idiomatic pairing) on the login card so input text resolves to `--card-foreground` — near-white in dark mode, dark in light mode — and follows the active theme.

## Why

`bg-card` and `text-card-foreground` are meant to travel together. Without the foreground token there was no themed `color` in the cascade for the inputs to inherit, which is why dark mode regressed while light mode happened to stay legible.

## Reviewer notes

- One-line change in `components/Login.tsx` (line 189). Labels, placeholders, and the error banner already use explicit `text-muted-foreground` / `text-destructive` tokens, so they're unaffected.
- Added a regression test in `test/components/Login.test.tsx` asserting the card carries `text-card-foreground`. Verified it fails on the old code and passes with the fix.
- `bun test test/components/Login.test.tsx` → 22 pass. Frontend `tsc` and Biome on the changed files are clean.
- No docs update needed — visual color-token fix only, no functional/API/routing change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)