### PR TITLE
ui(hr): use native shadcn Button for competence-center manage members (#719)

### DIFF
--- a/components/WorkUnitsView.tsx
+++ b/components/WorkUnitsView.tsx
@@ -425,13 +425,9 @@ const WorkUnitsView: React.FC<WorkUnitsViewProps> = ({
                   </div>
                 </div>
                 {canManageMembers && (
-                  <button
-                    type="button"
-                    onClick={() => openAssignments(unit)}
-                    className="text-xs font-bold text-praetor hover:text-zinc-700 bg-zinc-100 hover:bg-zinc-200 px-3 py-1.5 rounded-lg transition-colors"
-                  >
+                  <Button type="button" onClick={() => openAssignments(unit)}>
                     {t('hr:competenceCenters.manageMembers')}
-                  </button>
+                  </Button>
                 )}
               </div>
             </div>

--- a/test/components/hr/WorkUnitsView.assignmentModal.test.tsx
+++ b/test/components/hr/WorkUnitsView.assignmentModal.test.tsx
@@ -54,6 +54,28 @@ const PERMISSIONS = [
 ];
 
 describe('<WorkUnitsView /> member assignments', () => {
+  test('renders the manage-members action as a native shadcn primary button', () => {
+    render(
+      <WorkUnitsView
+        workUnits={[UNIT]}
+        users={USERS}
+        permissions={PERMISSIONS}
+        onAddWorkUnit={mock(() => Promise.resolve()) as unknown as never}
+        onUpdateWorkUnit={mock(() => Promise.resolve()) as unknown as never}
+        onDeleteWorkUnit={mock(() => Promise.resolve()) as unknown as never}
+        refreshWorkUnits={mock(() => Promise.resolve()) as unknown as never}
+      />,
+    );
+
+    const trigger = screen.getByRole('button', {
+      name: 'hr:competenceCenters.manageMembers',
+    });
+    // Native shadcn Button carries these data attributes; the old bespoke
+    // <button> did not, so this fails on the pre-fix markup.
+    expect(trigger).toHaveAttribute('data-slot', 'button');
+    expect(trigger).toHaveAttribute('data-variant', 'default');
+  });
+
   test('uses the shared user assignment modal for competence-center members', async () => {
     const refresh = mock(() => Promise.resolve());
 


### PR DESCRIPTION
## Summary

Fixes #719. On each Competence Center card, the **Gestisci Membri** action was a bespoke `<button>` styled as a tertiary link (`text-xs`, muted zinc colors), so it read more like a link than the card's primary action and was easy to overlook. This swaps it for the native shadcn `Button`.

## What changed

`components/WorkUnitsView.tsx` — replaced the hand-rolled button with `<Button>` (already imported in the file):

```diff
-                  <button
-                    type="button"
-                    onClick={() => openAssignments(unit)}
-                    className="text-xs font-bold text-praetor hover:text-zinc-700 bg-zinc-100 hover:bg-zinc-200 px-3 py-1.5 rounded-lg transition-colors"
-                  >
-                    {t('hr:competenceCenters.manageMembers')}
-                  </button>
+                  <Button type="button" onClick={() => openAssignments(unit)}>
+                    {t('hr:competenceCenters.manageMembers')}
+                  </Button>
```

This addresses each point in the issue:
- **Height/padding** — default `Button` size is `h-9 px-4 py-2` (~36px) vs the old ~28px, matching the visual weight of the adjacent avatar/labels.
- **Reads as a primary action** — the default variant is solid `bg-primary`, which maps to the praetor brand color (`--color-praetor: var(--color-primary)`), instead of a faint link.
- **Placement / breathing room** — kept bottom-right via the existing `justify-between` row; the card's `p-6` padding keeps it clear of the border.

Using the theme-token-based `Button` rather than hardcoded zinc/praetor classes also means the action now respects the selected theme, including dark mode (per the CLAUDE.md UI guidance).

## Testing

- Added a regression test in `test/components/hr/WorkUnitsView.assignmentModal.test.tsx` asserting the trigger renders as a native shadcn `Button` (`data-slot="button"`, `data-variant="default"`) — fails on the old plain `<button>`, passes on the fix.
- Frontend lint + typecheck clean; both `WorkUnitsView` test files pass.

## Notes for reviewer

- Visual-only change to an existing action — no behavior, API, or routing change. No docs reference this button, so documentation is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)