### PR TITLE
fix(demo-seed): drop removed projects.color column from seed.sql

### DIFF
--- a/server/db/seed.sql
+++ b/server/db/seed.sql
@@ -28,10 +28,10 @@ ON CONFLICT (id) DO NOTHING;
 
 -- start_date/end_date bracket the demo time entries logged against each project
 -- (see the first time_entries block below) so every entry falls inside its project window.
-INSERT INTO projects (id, name, client_id, color, description, start_date, end_date) VALUES
-    ('p1', 'Website Redesign', 'c1', '#3b82f6', 'Complete overhaul of the main marketing site.', (CURRENT_DATE - INTERVAL '30 days')::date, (CURRENT_DATE + INTERVAL '30 days')::date),
-    ('p2', 'Mobile App', 'c1', '#10b981', 'Native iOS and Android application development.', (CURRENT_DATE - INTERVAL '28 days')::date, (CURRENT_DATE + INTERVAL '28 days')::date),
-    ('p3', 'Internal Research', 'c2', '#8b5cf6', 'Ongoing research into new market trends.', (CURRENT_DATE - INTERVAL '25 days')::date, (CURRENT_DATE + INTERVAL '25 days')::date)
+INSERT INTO projects (id, name, client_id, description, start_date, end_date) VALUES
+    ('p1', 'Website Redesign', 'c1', 'Complete overhaul of the main marketing site.', (CURRENT_DATE - INTERVAL '30 days')::date, (CURRENT_DATE + INTERVAL '30 days')::date),
+    ('p2', 'Mobile App', 'c1', 'Native iOS and Android application development.', (CURRENT_DATE - INTERVAL '28 days')::date, (CURRENT_DATE + INTERVAL '28 days')::date),
+    ('p3', 'Internal Research', 'c2', 'Ongoing research into new market trends.', (CURRENT_DATE - INTERVAL '25 days')::date, (CURRENT_DATE + INTERVAL '25 days')::date)
 ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO tasks (id, name, project_id, description) VALUES
@@ -968,7 +968,6 @@ INSERT INTO projects (
     id,
     name,
     client_id,
-    color,
     description,
     is_disabled,
     created_at,
@@ -982,7 +981,6 @@ INSERT INTO projects (
         'dm_proj_01',
         'DM-CLI-001_DM-SVC-AUDIT_' || TO_CHAR(CURRENT_DATE, 'YYYY'),
         'dm_cli_01',
-        '#0f766e',
         'Assessment track for operations',
         FALSE,
         CURRENT_TIMESTAMP - INTERVAL '18 days',
@@ -996,7 +994,6 @@ INSERT INTO projects (
         'dm_proj_02',
         'DM-CLI-001_DM-SVC-DEPLOY_' || TO_CHAR(CURRENT_DATE, 'YYYY'),
         'dm_cli_01',
-        '#1d4ed8',
         'Deployment wave for phase one',
         FALSE,
         CURRENT_TIMESTAMP - INTERVAL '18 days',
@@ -1009,7 +1006,6 @@ INSERT INTO projects (
 ON CONFLICT (id) DO UPDATE SET
     name = EXCLUDED.name,
     client_id = EXCLUDED.client_id,
-    color = EXCLUDED.color,
     description = EXCLUDED.description,
     is_disabled = EXCLUDED.is_disabled,
     created_at = EXCLUDED.created_at,

--- a/server/test/db/seedSchemaColumns.test.ts
+++ b/server/test/db/seedSchemaColumns.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { getTableColumns } from 'drizzle-orm';
+import { projects } from '../../db/schema/projects.ts';
+
+// Drift guard between server/db/seed.sql and the projects schema. The demo seed refresh
+// (db/demoSeed.ts) applies seed.sql verbatim at startup, so any column the seed names that no
+// longer exists on the projects table aborts the whole refresh and the server boot. PR #742
+// dropped projects.color and updated demoSeed.ts but not seed.sql, crashing startup with
+// `column "color" of relation "projects" does not exist`. This test ties every projects column
+// referenced in seed.sql back to the live Drizzle schema so the two cannot silently drift again.
+
+const SERVER_ROOT = join(import.meta.dirname, '..', '..');
+const SEED_SQL = readFileSync(join(SERVER_ROOT, 'db', 'seed.sql'), 'utf-8');
+
+const schemaColumns = new Set(
+  Object.values(getTableColumns(projects)).map((column) => column.name),
+);
+
+// Each `INSERT INTO projects ( ... ) ... ;` statement in seed.sql (the compatibility defaults and
+// the dm_* demo dataset). A projects column list has no quotes or nested parens, and these
+// statements carry no `;` inside their literals, so slicing to the next `;` bounds the block.
+const projectInsertBlocks = Array.from(
+  SEED_SQL.matchAll(/INSERT\s+INTO\s+projects\s*\(/gi),
+  (match) => {
+    const start = match.index ?? 0;
+    const semicolon = SEED_SQL.indexOf(';', start);
+    return SEED_SQL.slice(start, semicolon === -1 ? undefined : semicolon);
+  },
+);
+
+// Column names from the `(...)` list immediately after `INSERT INTO projects`.
+const columnListOf = (block: string) => {
+  const open = block.indexOf('(');
+  const close = block.indexOf(')', open);
+  return block
+    .slice(open + 1, close)
+    .split(',')
+    .map((column) => column.trim())
+    .filter((column) => column.length > 0);
+};
+
+// Target columns of an `ON CONFLICT ... DO UPDATE SET col = EXCLUDED.col` clause.
+const upsertTargetsOf = (block: string) =>
+  Array.from(block.matchAll(/(\w+)\s*=\s*EXCLUDED\./g), (match) => match[1]);
+
+describe('seed.sql projects inserts stay in sync with the projects schema', () => {
+  test('parses both projects INSERT statements', () => {
+    expect(projectInsertBlocks.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test('every referenced column exists on the projects table', () => {
+    const referenced = projectInsertBlocks.flatMap((block) => [
+      ...columnListOf(block),
+      ...upsertTargetsOf(block),
+    ]);
+    const unknown = [...new Set(referenced)].filter((column) => !schemaColumns.has(column));
+    expect(unknown).toEqual([]);
+  });
+});

--- a/server/test/db/seedSchemaColumns.test.ts
+++ b/server/test/db/seedSchemaColumns.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { getTableColumns } from 'drizzle-orm';
 import { projects } from '../../db/schema/projects.ts';
+import { parseInsertValuesBlocks } from './seedSqlParsing.ts';
 
 // Drift guard between server/db/seed.sql and the projects schema. The demo seed refresh
 // (db/demoSeed.ts) applies seed.sql verbatim at startup, so any column the seed names that no
@@ -18,44 +19,22 @@ const schemaColumns = new Set(
   Object.values(getTableColumns(projects)).map((column) => column.name),
 );
 
-// Each `INSERT INTO projects ( ... ) ... ;` statement in seed.sql (the compatibility defaults and
-// the dm_* demo dataset). A projects column list has no quotes or nested parens, and these
-// statements carry no `;` inside their literals, so slicing to the next `;` bounds the block.
-const projectInsertBlocks = Array.from(
-  SEED_SQL.matchAll(/INSERT\s+INTO\s+projects\s*\(/gi),
-  (match) => {
-    const start = match.index ?? 0;
-    const semicolon = SEED_SQL.indexOf(';', start);
-    return SEED_SQL.slice(start, semicolon === -1 ? undefined : semicolon);
-  },
-);
-
-// Column names from the `(...)` list immediately after `INSERT INTO projects`.
-const columnListOf = (block: string) => {
-  const open = block.indexOf('(');
-  const close = block.indexOf(')', open);
-  return block
-    .slice(open + 1, close)
-    .split(',')
-    .map((column) => column.trim())
-    .filter((column) => column.length > 0);
-};
-
-// Target columns of an `ON CONFLICT ... DO UPDATE SET col = EXCLUDED.col` clause.
-const upsertTargetsOf = (block: string) =>
-  Array.from(block.matchAll(/(\w+)\s*=\s*EXCLUDED\./g), (match) => match[1]);
+// parseInsertValuesBlocks keys each parsed row by its column name, so the union of keys across
+// every `INSERT INTO projects (...)` block (the compatibility defaults and the dm_* demo
+// dataset) is exactly the set of projects columns the seed references. The ON CONFLICT
+// `col = EXCLUDED.col` targets need no separate check: EXCLUDED.col is only valid when col is
+// already in the insert column list, which this set covers.
+const seededRows = parseInsertValuesBlocks(SEED_SQL, 'projects');
+const referencedColumns = new Set(seededRows.flatMap((row) => Object.keys(row)));
 
 describe('seed.sql projects inserts stay in sync with the projects schema', () => {
-  test('parses both projects INSERT statements', () => {
-    expect(projectInsertBlocks.length).toBeGreaterThanOrEqual(2);
+  test('parses the projects INSERT rows from seed.sql', () => {
+    // Guards against a vacuous pass if the seed format changes and parsing yields nothing.
+    expect(seededRows.length).toBeGreaterThanOrEqual(2);
   });
 
   test('every referenced column exists on the projects table', () => {
-    const referenced = projectInsertBlocks.flatMap((block) => [
-      ...columnListOf(block),
-      ...upsertTargetsOf(block),
-    ]);
-    const unknown = [...new Set(referenced)].filter((column) => !schemaColumns.has(column));
+    const unknown = [...referencedColumns].filter((column) => !schemaColumns.has(column));
     expect(unknown).toEqual([]);
   });
 });


### PR DESCRIPTION
## What

Removes the `color` column from both `INSERT INTO projects` blocks in `server/db/seed.sql` (the `p1/p2/p3` compatibility defaults and the `dm_proj_01/02` demo dataset) — the column names, the hex values, and the `color = EXCLUDED.color` upsert target. Adds a regression test that guards against this class of drift.

## Why

PR #742 ("Remove project color feature", #742) dropped the `projects.color` column (migration `0068_remove_project_color.sql`) and updated `demoSeed.ts`, but missed `server/db/seed.sql`. The demo-seed refresh applies that file verbatim at startup, so the `dm_proj` insert crashed with:

```
column "color" of relation "projects" does not exist
```

This failed at statement index 18 and cascaded into FK failures on `tasks`, `user_projects`, and `user_tasks`, aborting server boot whenever `DEMO_SEEDING=true`.

## How

- **`server/db/seed.sql`** — drop every `color` reference so the seed matches the current schema (net: 4 insertions / 8 deletions).
- **`server/test/db/seedSchemaColumns.test.ts`** — a DB-free guard that parses the `projects` inserts via the shared `parseInsertValuesBlocks` helper and asserts every referenced column exists on the live Drizzle `projects` schema. It catches future seed/schema drift generically (not just `color`).

## Verification

- New test passes; confirmed **red on the pre-fix seed** (`unknown = ["color"]`) and green on the fix.
- Full server `test/db/` suite: **190 pass / 0 fail** (existing `seedProjectCoherence`/`seedTaskReferences` still parse the edited seed correctly).
- `tsc` clean (server `-p tsconfig.json` and root `--noEmit`); Biome clean.

## Reviewer notes

- No migration needed — the schema/migration already dropped `color` (#742); this only realigns the seed data.
- No docs changes — demo-seed data fix with no API or user-facing behavior change.
- `seed.sql` has mixed CRLF/LF line endings in the repo; the edit was made byte-preserving so the diff is exactly the 4/8 content change with no line-ending noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
