### PR TITLE
Add required-field markers (red asterisks) across all forms

### DIFF
--- a/components/CRM/ClientsView.tsx
+++ b/components/CRM/ClientsView.tsx
@@ -2,7 +2,7 @@ import type React from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
-import { Field, FieldError, FieldLabel } from '@/components/ui/field';
+import { Field, FieldError, FieldLabel, RequiredMark } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -1144,7 +1144,7 @@ const ClientsView: React.FC<ClientsViewProps> = ({
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   <div className="space-y-1.5">
                     <label className="text-xs font-bold text-zinc-500 ml-1">
-                      {t('crm:clients.clientCode')} <span className="text-red-500">*</span>
+                      {t('crm:clients.clientCode')} <RequiredMark />
                     </label>
                     <Input
                       type="text"
@@ -1164,7 +1164,7 @@ const ClientsView: React.FC<ClientsViewProps> = ({
                   </div>
                   <div className="space-y-1.5">
                     <label className="text-xs font-bold text-zinc-500 ml-1">
-                      {t('crm:clients.name')} <span className="text-red-500">*</span>
+                      {t('crm:clients.name')} <RequiredMark />
                     </label>
                     <Input
                       type="text"
@@ -1347,7 +1347,7 @@ const ClientsView: React.FC<ClientsViewProps> = ({
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-4 p-4 bg-zinc-50 rounded-xl border border-zinc-200">
                           <div className="space-y-1.5">
                             <label className="text-xs font-bold text-zinc-500 ml-1">
-                              {t('crm:clients.fullName')} <span className="text-red-500">*</span>
+                              {t('crm:clients.fullName')} <RequiredMark />
                             </label>
                             <Input
                               type="text"
@@ -1444,7 +1444,7 @@ const ClientsView: React.FC<ClientsViewProps> = ({
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   <div className="space-y-1.5">
                     <label className="text-xs font-bold text-zinc-500 ml-1">
-                      {t('crm:clients.fiscalCode')} <span className="text-red-500">*</span>
+                      {t('crm:clients.fiscalCode')} <RequiredMark />
                     </label>
                     <Input
                       type="text"

--- a/components/CRM/SuppliersView.tsx
+++ b/components/CRM/SuppliersView.tsx
@@ -482,7 +482,9 @@ const SuppliersView: React.FC<SuppliersViewProps> = ({
                 </h4>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   <Field data-invalid={Boolean(errors.supplierCode)}>
-                    <FieldLabel htmlFor="supplier-code">{t('crm:suppliers.code')}</FieldLabel>
+                    <FieldLabel htmlFor="supplier-code">
+                      {t('crm:suppliers.code')} <span className="text-red-500">*</span>
+                    </FieldLabel>
                     <Input
                       id="supplier-code"
                       type="text"
@@ -497,7 +499,9 @@ const SuppliersView: React.FC<SuppliersViewProps> = ({
                     <FieldError className="text-xs">{errors.supplierCode}</FieldError>
                   </Field>
                   <Field data-invalid={Boolean(errors.name)}>
-                    <FieldLabel htmlFor="supplier-name">{t('crm:suppliers.name')}</FieldLabel>
+                    <FieldLabel htmlFor="supplier-name">
+                      {t('crm:suppliers.name')} <span className="text-red-500">*</span>
+                    </FieldLabel>
                     <Input
                       id="supplier-name"
                       type="text"
@@ -584,7 +588,7 @@ const SuppliersView: React.FC<SuppliersViewProps> = ({
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   <Field data-invalid={Boolean(errors.vatNumber)}>
                     <FieldLabel htmlFor="supplier-vat-number">
-                      {t('crm:suppliers.vatNumber')}
+                      {t('crm:suppliers.vatNumber')} <span className="text-red-500">*</span>
                     </FieldLabel>
                     <Input
                       id="supplier-vat-number"

--- a/components/CRM/SuppliersView.tsx
+++ b/components/CRM/SuppliersView.tsx
@@ -482,8 +482,8 @@ const SuppliersView: React.FC<SuppliersViewProps> = ({
                 </h4>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   <Field data-invalid={Boolean(errors.supplierCode)}>
-                    <FieldLabel htmlFor="supplier-code">
-                      {t('crm:suppliers.code')} <span className="text-red-500">*</span>
+                    <FieldLabel htmlFor="supplier-code" required>
+                      {t('crm:suppliers.code')}
                     </FieldLabel>
                     <Input
                       id="supplier-code"
@@ -499,8 +499,8 @@ const SuppliersView: React.FC<SuppliersViewProps> = ({
                     <FieldError className="text-xs">{errors.supplierCode}</FieldError>
                   </Field>
                   <Field data-invalid={Boolean(errors.name)}>
-                    <FieldLabel htmlFor="supplier-name">
-                      {t('crm:suppliers.name')} <span className="text-red-500">*</span>
+                    <FieldLabel htmlFor="supplier-name" required>
+                      {t('crm:suppliers.name')}
                     </FieldLabel>
                     <Input
                       id="supplier-name"
@@ -587,8 +587,8 @@ const SuppliersView: React.FC<SuppliersViewProps> = ({
                 </h4>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   <Field data-invalid={Boolean(errors.vatNumber)}>
-                    <FieldLabel htmlFor="supplier-vat-number">
-                      {t('crm:suppliers.vatNumber')} <span className="text-red-500">*</span>
+                    <FieldLabel htmlFor="supplier-vat-number" required={!editingSupplier}>
+                      {t('crm:suppliers.vatNumber')}
                     </FieldLabel>
                     <Input
                       id="supplier-vat-number"

--- a/components/HR/EmployeeHrFields.tsx
+++ b/components/HR/EmployeeHrFields.tsx
@@ -102,8 +102,8 @@ const EmployeeHrFields: React.FC<EmployeeHrFieldsProps> = ({
         </h3>
         <div className="grid gap-4 md:grid-cols-3">
           <Field data-invalid={Boolean(errors.name)}>
-            <FieldLabel htmlFor={`${prefix}-name`}>
-              {t(`${section}.name`)} <span className="text-red-500">*</span>
+            <FieldLabel htmlFor={`${prefix}-name`} required>
+              {t(`${section}.name`)}
             </FieldLabel>
             <Input
               id={`${prefix}-name`}

--- a/components/HR/EmployeeHrFields.tsx
+++ b/components/HR/EmployeeHrFields.tsx
@@ -102,7 +102,9 @@ const EmployeeHrFields: React.FC<EmployeeHrFieldsProps> = ({
         </h3>
         <div className="grid gap-4 md:grid-cols-3">
           <Field data-invalid={Boolean(errors.name)}>
-            <FieldLabel htmlFor={`${prefix}-name`}>{t(`${section}.name`)} *</FieldLabel>
+            <FieldLabel htmlFor={`${prefix}-name`}>
+              {t(`${section}.name`)} <span className="text-red-500">*</span>
+            </FieldLabel>
             <Input
               id={`${prefix}-name`}
               type="text"

--- a/components/Login.tsx
+++ b/components/Login.tsx
@@ -408,7 +408,7 @@ const Login: React.FC<LoginProps> = ({
                   render={({ field, fieldState }) => (
                     <Field data-invalid={fieldState.invalid}>
                       <FieldLabel className="text-xs font-bold uppercase tracking-wider text-muted-foreground">
-                        {t('common:labels.username')}
+                        {t('common:labels.username')} <span className="text-red-500">*</span>
                       </FieldLabel>
                       <Input
                         {...field}
@@ -429,7 +429,7 @@ const Login: React.FC<LoginProps> = ({
                   render={({ field, fieldState }) => (
                     <Field data-invalid={fieldState.invalid}>
                       <FieldLabel className="text-xs font-bold uppercase tracking-wider text-muted-foreground">
-                        {t('common:labels.password')}
+                        {t('common:labels.password')} <span className="text-red-500">*</span>
                       </FieldLabel>
                       <div className="relative">
                         <Input

--- a/components/Login.tsx
+++ b/components/Login.tsx
@@ -407,8 +407,11 @@ const Login: React.FC<LoginProps> = ({
                   name="username"
                   render={({ field, fieldState }) => (
                     <Field data-invalid={fieldState.invalid}>
-                      <FieldLabel className="text-xs font-bold uppercase tracking-wider text-muted-foreground">
-                        {t('common:labels.username')} <span className="text-red-500">*</span>
+                      <FieldLabel
+                        className="text-xs font-bold uppercase tracking-wider text-muted-foreground"
+                        required
+                      >
+                        {t('common:labels.username')}
                       </FieldLabel>
                       <Input
                         {...field}
@@ -428,8 +431,11 @@ const Login: React.FC<LoginProps> = ({
                   name="password"
                   render={({ field, fieldState }) => (
                     <Field data-invalid={fieldState.invalid}>
-                      <FieldLabel className="text-xs font-bold uppercase tracking-wider text-muted-foreground">
-                        {t('common:labels.password')} <span className="text-red-500">*</span>
+                      <FieldLabel
+                        className="text-xs font-bold uppercase tracking-wider text-muted-foreground"
+                        required
+                      >
+                        {t('common:labels.password')}
                       </FieldLabel>
                       <div className="relative">
                         <Input

--- a/components/UserSettings.tsx
+++ b/components/UserSettings.tsx
@@ -837,7 +837,9 @@ const UserSettings: React.FC<UserSettingsProps> = ({
               )}
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                 <Field>
-                  <FieldLabel htmlFor="profile-full-name">{t('userProfile.fullName')}</FieldLabel>
+                  <FieldLabel htmlFor="profile-full-name">
+                    {t('userProfile.fullName')} <span className="text-red-500">*</span>
+                  </FieldLabel>
                   <Input
                     id="profile-full-name"
                     type="text"
@@ -850,7 +852,9 @@ const UserSettings: React.FC<UserSettingsProps> = ({
                   />
                 </Field>
                 <Field>
-                  <FieldLabel htmlFor="profile-email">{t('userProfile.email')}</FieldLabel>
+                  <FieldLabel htmlFor="profile-email">
+                    {t('userProfile.email')} <span className="text-red-500">*</span>
+                  </FieldLabel>
                   <Input
                     id="profile-email"
                     type="email"
@@ -1025,7 +1029,7 @@ const UserSettings: React.FC<UserSettingsProps> = ({
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                     <Field>
                       <FieldLabel htmlFor="security-current-password">
-                        {t('password.currentPassword')}
+                        {t('password.currentPassword')} <span className="text-red-500">*</span>
                       </FieldLabel>
                       <Input
                         id="security-current-password"
@@ -1038,7 +1042,7 @@ const UserSettings: React.FC<UserSettingsProps> = ({
                     </Field>
                     <Field className="md:col-start-1">
                       <FieldLabel htmlFor="security-new-password">
-                        {t('password.newPassword')}
+                        {t('password.newPassword')} <span className="text-red-500">*</span>
                       </FieldLabel>
                       <Input
                         id="security-new-password"
@@ -1051,7 +1055,7 @@ const UserSettings: React.FC<UserSettingsProps> = ({
                     </Field>
                     <Field>
                       <FieldLabel htmlFor="security-confirm-password">
-                        {t('password.confirmNewPassword')}
+                        {t('password.confirmNewPassword')} <span className="text-red-500">*</span>
                       </FieldLabel>
                       <Input
                         id="security-confirm-password"
@@ -1240,7 +1244,8 @@ const UserSettings: React.FC<UserSettingsProps> = ({
                                   {isLocalAuth && (
                                     <Field>
                                       <FieldLabel htmlFor="totp-disable-password">
-                                        {t('twoFactor.disablePasswordLabel')}
+                                        {t('twoFactor.disablePasswordLabel')}{' '}
+                                        <span className="text-red-500">*</span>
                                       </FieldLabel>
                                       <Input
                                         id="totp-disable-password"
@@ -1257,7 +1262,8 @@ const UserSettings: React.FC<UserSettingsProps> = ({
                                   )}
                                   <Field>
                                     <FieldLabel htmlFor="totp-disable-code">
-                                      {t('twoFactor.disableCodeLabel')}
+                                      {t('twoFactor.disableCodeLabel')}{' '}
+                                      <span className="text-red-500">*</span>
                                     </FieldLabel>
                                     <Input
                                       id="totp-disable-code"
@@ -1489,7 +1495,8 @@ const UserSettings: React.FC<UserSettingsProps> = ({
                               <div className="space-y-4 py-4">
                                 <Field>
                                   <FieldLabel htmlFor="totp-setup-password">
-                                    {t('twoFactor.reauthPasswordLabel')}
+                                    {t('twoFactor.reauthPasswordLabel')}{' '}
+                                    <span className="text-red-500">*</span>
                                   </FieldLabel>
                                   <Input
                                     id="totp-setup-password"
@@ -1676,7 +1683,9 @@ const UserSettings: React.FC<UserSettingsProps> = ({
               className="grid grid-cols-1 gap-3 md:grid-cols-[1fr_minmax(10rem,auto)_auto]"
             >
               <Field>
-                <FieldLabel htmlFor="mcp-token-name">{t('mcp.nameLabel')}</FieldLabel>
+                <FieldLabel htmlFor="mcp-token-name">
+                  {t('mcp.nameLabel')} <span className="text-red-500">*</span>
+                </FieldLabel>
                 <Input
                   id="mcp-token-name"
                   type="text"

--- a/components/UserSettings.tsx
+++ b/components/UserSettings.tsx
@@ -837,8 +837,8 @@ const UserSettings: React.FC<UserSettingsProps> = ({
               )}
               <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                 <Field>
-                  <FieldLabel htmlFor="profile-full-name">
-                    {t('userProfile.fullName')} <span className="text-red-500">*</span>
+                  <FieldLabel htmlFor="profile-full-name" required={isLocalAuth}>
+                    {t('userProfile.fullName')}
                   </FieldLabel>
                   <Input
                     id="profile-full-name"
@@ -852,8 +852,8 @@ const UserSettings: React.FC<UserSettingsProps> = ({
                   />
                 </Field>
                 <Field>
-                  <FieldLabel htmlFor="profile-email">
-                    {t('userProfile.email')} <span className="text-red-500">*</span>
+                  <FieldLabel htmlFor="profile-email" required={isLocalAuth}>
+                    {t('userProfile.email')}
                   </FieldLabel>
                   <Input
                     id="profile-email"
@@ -1028,8 +1028,8 @@ const UserSettings: React.FC<UserSettingsProps> = ({
 
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                     <Field>
-                      <FieldLabel htmlFor="security-current-password">
-                        {t('password.currentPassword')} <span className="text-red-500">*</span>
+                      <FieldLabel htmlFor="security-current-password" required>
+                        {t('password.currentPassword')}
                       </FieldLabel>
                       <Input
                         id="security-current-password"
@@ -1041,8 +1041,8 @@ const UserSettings: React.FC<UserSettingsProps> = ({
                       />
                     </Field>
                     <Field className="md:col-start-1">
-                      <FieldLabel htmlFor="security-new-password">
-                        {t('password.newPassword')} <span className="text-red-500">*</span>
+                      <FieldLabel htmlFor="security-new-password" required>
+                        {t('password.newPassword')}
                       </FieldLabel>
                       <Input
                         id="security-new-password"
@@ -1054,8 +1054,8 @@ const UserSettings: React.FC<UserSettingsProps> = ({
                       />
                     </Field>
                     <Field>
-                      <FieldLabel htmlFor="security-confirm-password">
-                        {t('password.confirmNewPassword')} <span className="text-red-500">*</span>
+                      <FieldLabel htmlFor="security-confirm-password" required>
+                        {t('password.confirmNewPassword')}
                       </FieldLabel>
                       <Input
                         id="security-confirm-password"
@@ -1243,9 +1243,8 @@ const UserSettings: React.FC<UserSettingsProps> = ({
                                   )}
                                   {isLocalAuth && (
                                     <Field>
-                                      <FieldLabel htmlFor="totp-disable-password">
-                                        {t('twoFactor.disablePasswordLabel')}{' '}
-                                        <span className="text-red-500">*</span>
+                                      <FieldLabel htmlFor="totp-disable-password" required>
+                                        {t('twoFactor.disablePasswordLabel')}
                                       </FieldLabel>
                                       <Input
                                         id="totp-disable-password"
@@ -1261,9 +1260,8 @@ const UserSettings: React.FC<UserSettingsProps> = ({
                                     </Field>
                                   )}
                                   <Field>
-                                    <FieldLabel htmlFor="totp-disable-code">
-                                      {t('twoFactor.disableCodeLabel')}{' '}
-                                      <span className="text-red-500">*</span>
+                                    <FieldLabel htmlFor="totp-disable-code" required>
+                                      {t('twoFactor.disableCodeLabel')}
                                     </FieldLabel>
                                     <Input
                                       id="totp-disable-code"
@@ -1494,9 +1492,8 @@ const UserSettings: React.FC<UserSettingsProps> = ({
                               </DialogHeader>
                               <div className="space-y-4 py-4">
                                 <Field>
-                                  <FieldLabel htmlFor="totp-setup-password">
-                                    {t('twoFactor.reauthPasswordLabel')}{' '}
-                                    <span className="text-red-500">*</span>
+                                  <FieldLabel htmlFor="totp-setup-password" required>
+                                    {t('twoFactor.reauthPasswordLabel')}
                                   </FieldLabel>
                                   <Input
                                     id="totp-setup-password"
@@ -1683,8 +1680,8 @@ const UserSettings: React.FC<UserSettingsProps> = ({
               className="grid grid-cols-1 gap-3 md:grid-cols-[1fr_minmax(10rem,auto)_auto]"
             >
               <Field>
-                <FieldLabel htmlFor="mcp-token-name">
-                  {t('mcp.nameLabel')} <span className="text-red-500">*</span>
+                <FieldLabel htmlFor="mcp-token-name" required>
+                  {t('mcp.nameLabel')}
                 </FieldLabel>
                 <Input
                   id="mcp-token-name"

--- a/components/WorkUnitsView.tsx
+++ b/components/WorkUnitsView.tsx
@@ -134,7 +134,9 @@ const WorkUnitFormModal = ({
 
           <ModalBody className="space-y-4">
             <Field data-invalid={Boolean(errors.name)}>
-              <FieldLabel htmlFor={nameInputId}>{t('hr:competenceCenters.unitName')}</FieldLabel>
+              <FieldLabel htmlFor={nameInputId}>
+                {t('hr:competenceCenters.unitName')} <span className="text-red-500">*</span>
+              </FieldLabel>
               <Input
                 id={nameInputId}
                 type="text"
@@ -155,7 +157,11 @@ const WorkUnitFormModal = ({
             <div className="space-y-2">
               <SelectControl
                 id={managersInputId}
-                label={t('hr:competenceCenters.managers')}
+                label={
+                  <>
+                    {t('hr:competenceCenters.managers')} <span className="text-red-500">*</span>
+                  </>
+                }
                 options={managerOptions}
                 value={selectedManagerIds}
                 onChange={(val) => {

--- a/components/WorkUnitsView.tsx
+++ b/components/WorkUnitsView.tsx
@@ -79,6 +79,7 @@ interface WorkUnitFormModalProps {
   titleIconClassName: string;
   submitLabel: React.ReactNode;
   submitDisabled?: boolean;
+  managersRequired?: boolean;
   nameInputId: string;
   managersInputId: string;
   descriptionInputId: string;
@@ -103,6 +104,7 @@ const WorkUnitFormModal = ({
   titleIconClassName,
   submitLabel,
   submitDisabled = false,
+  managersRequired = false,
   nameInputId,
   managersInputId,
   descriptionInputId,
@@ -134,8 +136,8 @@ const WorkUnitFormModal = ({
 
           <ModalBody className="space-y-4">
             <Field data-invalid={Boolean(errors.name)}>
-              <FieldLabel htmlFor={nameInputId}>
-                {t('hr:competenceCenters.unitName')} <span className="text-red-500">*</span>
+              <FieldLabel htmlFor={nameInputId} required>
+                {t('hr:competenceCenters.unitName')}
               </FieldLabel>
               <Input
                 id={nameInputId}
@@ -157,11 +159,8 @@ const WorkUnitFormModal = ({
             <div className="space-y-2">
               <SelectControl
                 id={managersInputId}
-                label={
-                  <>
-                    {t('hr:competenceCenters.managers')} <span className="text-red-500">*</span>
-                  </>
-                }
+                label={t('hr:competenceCenters.managers')}
+                required={managersRequired}
                 options={managerOptions}
                 value={selectedManagerIds}
                 onChange={(val) => {
@@ -633,6 +632,7 @@ const WorkUnitsView: React.FC<WorkUnitsViewProps> = ({
         titleIconClassName="fa-plus"
         submitLabel={t('hr:competenceCenters.createUnit')}
         submitDisabled={selectedManagerIds.length === 0}
+        managersRequired
         nameInputId="work-unit-create-name"
         managersInputId="work-unit-create-managers"
         descriptionInputId="work-unit-create-description"

--- a/components/accounting/ClientsInvoicesView.tsx
+++ b/components/accounting/ClientsInvoicesView.tsx
@@ -658,7 +658,12 @@ const ClientsInvoicesView: React.FC<ClientsInvoicesViewProps> = ({
                       }))}
                       value={formData.clientId || ''}
                       onChange={(value) => handleClientChange(value as string)}
-                      label={t('accounting:clientsInvoices.client')}
+                      label={
+                        <>
+                          {t('accounting:clientsInvoices.client')}{' '}
+                          <span className="text-red-500">*</span>
+                        </>
+                      }
                       placeholder={t('accounting:clientsInvoices.allClients')}
                       searchable={true}
                       buttonClassName={errors.clientId ? 'h-9 border-destructive' : 'h-9'}
@@ -667,7 +672,8 @@ const ClientsInvoicesView: React.FC<ClientsInvoicesViewProps> = ({
                   </Field>
                   <Field data-invalid={Boolean(errors.id)}>
                     <FieldLabel htmlFor="client-invoice-number">
-                      {t('accounting:clientsInvoices.invoiceNumber')}
+                      {t('accounting:clientsInvoices.invoiceNumber')}{' '}
+                      <span className="text-red-500">*</span>
                     </FieldLabel>
                     <Input
                       id="client-invoice-number"
@@ -685,7 +691,8 @@ const ClientsInvoicesView: React.FC<ClientsInvoicesViewProps> = ({
                   </Field>
                   <Field data-invalid={Boolean(errors.issueDate)}>
                     <FieldLabel htmlFor="client-invoice-issue-date">
-                      {t('accounting:clientsInvoices.issueDate')}
+                      {t('accounting:clientsInvoices.issueDate')}{' '}
+                      <span className="text-red-500">*</span>
                     </FieldLabel>
                     <DateField
                       id="client-invoice-issue-date"
@@ -698,7 +705,8 @@ const ClientsInvoicesView: React.FC<ClientsInvoicesViewProps> = ({
                   </Field>
                   <Field data-invalid={Boolean(errors.dueDate)}>
                     <FieldLabel htmlFor="client-invoice-due-date">
-                      {t('accounting:clientsInvoices.dueDate')}
+                      {t('accounting:clientsInvoices.dueDate')}{' '}
+                      <span className="text-red-500">*</span>
                     </FieldLabel>
                     <DateField
                       id="client-invoice-due-date"
@@ -817,7 +825,8 @@ const ClientsInvoicesView: React.FC<ClientsInvoicesViewProps> = ({
                             </div>
                             <div className="space-y-1 lg:col-span-2">
                               <FieldLabel className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground lg:hidden">
-                                {t('common:labels.quantity')}
+                                {t('common:labels.quantity')}{' '}
+                                <span className="text-red-500">*</span>
                               </FieldLabel>
                               <div className="flex items-center justify-center gap-1">
                                 <ValidatedNumberInput
@@ -880,7 +889,7 @@ const ClientsInvoicesView: React.FC<ClientsInvoicesViewProps> = ({
                             </div>
                             <div className="space-y-1 lg:col-span-2">
                               <FieldLabel className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground lg:hidden">
-                                {t('common:labels.price')}
+                                {t('common:labels.price')} <span className="text-red-500">*</span>
                               </FieldLabel>
                               <div className="flex items-center gap-1">
                                 <ValidatedNumberInput
@@ -982,7 +991,7 @@ const ClientsInvoicesView: React.FC<ClientsInvoicesViewProps> = ({
                             htmlFor={`client-invoice-item-description-${index}`}
                             className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground"
                           >
-                            {t('common:labels.description')}
+                            {t('common:labels.description')} <span className="text-red-500">*</span>
                           </FieldLabel>
                           <Input
                             id={`client-invoice-item-description-${index}`}

--- a/components/accounting/ClientsInvoicesView.tsx
+++ b/components/accounting/ClientsInvoicesView.tsx
@@ -658,12 +658,8 @@ const ClientsInvoicesView: React.FC<ClientsInvoicesViewProps> = ({
                       }))}
                       value={formData.clientId || ''}
                       onChange={(value) => handleClientChange(value as string)}
-                      label={
-                        <>
-                          {t('accounting:clientsInvoices.client')}{' '}
-                          <span className="text-red-500">*</span>
-                        </>
-                      }
+                      label={t('accounting:clientsInvoices.client')}
+                      required
                       placeholder={t('accounting:clientsInvoices.allClients')}
                       searchable={true}
                       buttonClassName={errors.clientId ? 'h-9 border-destructive' : 'h-9'}
@@ -671,9 +667,8 @@ const ClientsInvoicesView: React.FC<ClientsInvoicesViewProps> = ({
                     <FieldError className="text-xs">{errors.clientId}</FieldError>
                   </Field>
                   <Field data-invalid={Boolean(errors.id)}>
-                    <FieldLabel htmlFor="client-invoice-number">
-                      {t('accounting:clientsInvoices.invoiceNumber')}{' '}
-                      <span className="text-red-500">*</span>
+                    <FieldLabel htmlFor="client-invoice-number" required>
+                      {t('accounting:clientsInvoices.invoiceNumber')}
                     </FieldLabel>
                     <Input
                       id="client-invoice-number"
@@ -690,9 +685,8 @@ const ClientsInvoicesView: React.FC<ClientsInvoicesViewProps> = ({
                     <FieldError className="text-xs">{errors.id}</FieldError>
                   </Field>
                   <Field data-invalid={Boolean(errors.issueDate)}>
-                    <FieldLabel htmlFor="client-invoice-issue-date">
-                      {t('accounting:clientsInvoices.issueDate')}{' '}
-                      <span className="text-red-500">*</span>
+                    <FieldLabel htmlFor="client-invoice-issue-date" required>
+                      {t('accounting:clientsInvoices.issueDate')}
                     </FieldLabel>
                     <DateField
                       id="client-invoice-issue-date"
@@ -704,9 +698,8 @@ const ClientsInvoicesView: React.FC<ClientsInvoicesViewProps> = ({
                     <FieldError className="text-xs">{errors.issueDate}</FieldError>
                   </Field>
                   <Field data-invalid={Boolean(errors.dueDate)}>
-                    <FieldLabel htmlFor="client-invoice-due-date">
-                      {t('accounting:clientsInvoices.dueDate')}{' '}
-                      <span className="text-red-500">*</span>
+                    <FieldLabel htmlFor="client-invoice-due-date" required>
+                      {t('accounting:clientsInvoices.dueDate')}
                     </FieldLabel>
                     <DateField
                       id="client-invoice-due-date"
@@ -824,9 +817,11 @@ const ClientsInvoicesView: React.FC<ClientsInvoicesViewProps> = ({
                               </div>
                             </div>
                             <div className="space-y-1 lg:col-span-2">
-                              <FieldLabel className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground lg:hidden">
-                                {t('common:labels.quantity')}{' '}
-                                <span className="text-red-500">*</span>
+                              <FieldLabel
+                                className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground lg:hidden"
+                                required
+                              >
+                                {t('common:labels.quantity')}
                               </FieldLabel>
                               <div className="flex items-center justify-center gap-1">
                                 <ValidatedNumberInput
@@ -888,8 +883,11 @@ const ClientsInvoicesView: React.FC<ClientsInvoicesViewProps> = ({
                               </div>
                             </div>
                             <div className="space-y-1 lg:col-span-2">
-                              <FieldLabel className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground lg:hidden">
-                                {t('common:labels.price')} <span className="text-red-500">*</span>
+                              <FieldLabel
+                                className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground lg:hidden"
+                                required
+                              >
+                                {t('common:labels.price')}
                               </FieldLabel>
                               <div className="flex items-center gap-1">
                                 <ValidatedNumberInput
@@ -990,8 +988,9 @@ const ClientsInvoicesView: React.FC<ClientsInvoicesViewProps> = ({
                           <FieldLabel
                             htmlFor={`client-invoice-item-description-${index}`}
                             className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground"
+                            required
                           >
-                            {t('common:labels.description')} <span className="text-red-500">*</span>
+                            {t('common:labels.description')}
                           </FieldLabel>
                           <Input
                             id={`client-invoice-item-description-${index}`}

--- a/components/accounting/ClientsOrdersView.tsx
+++ b/components/accounting/ClientsOrdersView.tsx
@@ -970,7 +970,12 @@ const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
                         options={activeClients.map((c) => ({ id: c.id, name: c.name }))}
                         value={formData.clientId || ''}
                         onChange={(val) => handleClientChange(val as string)}
-                        label={t('accounting:clientsOrders.client')}
+                        label={
+                          <>
+                            {t('accounting:clientsOrders.client')}{' '}
+                            <span className="text-red-500">*</span>
+                          </>
+                        }
                         placeholder={t('sales:clientQuotes.selectAClient')}
                         searchable={true}
                         disabled={isReadOnly}

--- a/components/accounting/ClientsOrdersView.tsx
+++ b/components/accounting/ClientsOrdersView.tsx
@@ -970,12 +970,8 @@ const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
                         options={activeClients.map((c) => ({ id: c.id, name: c.name }))}
                         value={formData.clientId || ''}
                         onChange={(val) => handleClientChange(val as string)}
-                        label={
-                          <>
-                            {t('accounting:clientsOrders.client')}{' '}
-                            <span className="text-red-500">*</span>
-                          </>
-                        }
+                        label={t('accounting:clientsOrders.client')}
+                        required
                         placeholder={t('sales:clientQuotes.selectAClient')}
                         searchable={true}
                         disabled={isReadOnly}

--- a/components/accounting/SupplierInvoicesView.tsx
+++ b/components/accounting/SupplierInvoicesView.tsx
@@ -456,9 +456,8 @@ const SupplierInvoicesView: React.FC<SupplierInvoicesViewProps> = ({
                     />
                   </Field>
                   <Field>
-                    <FieldLabel htmlFor="supplier-invoice-number">
-                      {t('accounting:supplierInvoices.invoiceNumber')}{' '}
-                      <span className="text-red-500">*</span>
+                    <FieldLabel htmlFor="supplier-invoice-number" required>
+                      {t('accounting:supplierInvoices.invoiceNumber')}
                     </FieldLabel>
                     <Input
                       id="supplier-invoice-number"
@@ -473,9 +472,8 @@ const SupplierInvoicesView: React.FC<SupplierInvoicesViewProps> = ({
                     />
                   </Field>
                   <Field>
-                    <FieldLabel htmlFor="supplier-invoice-issue-date">
-                      {t('accounting:supplierInvoices.issueDate')}{' '}
-                      <span className="text-red-500">*</span>
+                    <FieldLabel htmlFor="supplier-invoice-issue-date" required>
+                      {t('accounting:supplierInvoices.issueDate')}
                     </FieldLabel>
                     <DateField
                       id="supplier-invoice-issue-date"
@@ -487,9 +485,8 @@ const SupplierInvoicesView: React.FC<SupplierInvoicesViewProps> = ({
                     />
                   </Field>
                   <Field>
-                    <FieldLabel htmlFor="supplier-invoice-due-date">
-                      {t('accounting:supplierInvoices.dueDate')}{' '}
-                      <span className="text-red-500">*</span>
+                    <FieldLabel htmlFor="supplier-invoice-due-date" required>
+                      {t('accounting:supplierInvoices.dueDate')}
                     </FieldLabel>
                     <DateField
                       id="supplier-invoice-due-date"

--- a/components/accounting/SupplierInvoicesView.tsx
+++ b/components/accounting/SupplierInvoicesView.tsx
@@ -457,7 +457,8 @@ const SupplierInvoicesView: React.FC<SupplierInvoicesViewProps> = ({
                   </Field>
                   <Field>
                     <FieldLabel htmlFor="supplier-invoice-number">
-                      {t('accounting:supplierInvoices.invoiceNumber')}
+                      {t('accounting:supplierInvoices.invoiceNumber')}{' '}
+                      <span className="text-red-500">*</span>
                     </FieldLabel>
                     <Input
                       id="supplier-invoice-number"
@@ -473,7 +474,8 @@ const SupplierInvoicesView: React.FC<SupplierInvoicesViewProps> = ({
                   </Field>
                   <Field>
                     <FieldLabel htmlFor="supplier-invoice-issue-date">
-                      {t('accounting:supplierInvoices.issueDate')}
+                      {t('accounting:supplierInvoices.issueDate')}{' '}
+                      <span className="text-red-500">*</span>
                     </FieldLabel>
                     <DateField
                       id="supplier-invoice-issue-date"
@@ -486,7 +488,8 @@ const SupplierInvoicesView: React.FC<SupplierInvoicesViewProps> = ({
                   </Field>
                   <Field>
                     <FieldLabel htmlFor="supplier-invoice-due-date">
-                      {t('accounting:supplierInvoices.dueDate')}
+                      {t('accounting:supplierInvoices.dueDate')}{' '}
+                      <span className="text-red-500">*</span>
                     </FieldLabel>
                     <DateField
                       id="supplier-invoice-due-date"

--- a/components/administration/AuthSettings.tsx
+++ b/components/administration/AuthSettings.tsx
@@ -746,7 +746,7 @@ const AuthSettings: React.FC<AuthSettingsProps> = ({
                     value={draft.issuerUrl || ''}
                     error={errors[`${prefix}issuerUrl`]}
                     monospace
-                    required
+                    required={!!draft.enabled}
                     onChange={(issuerUrl) => updateProviderDraft(protocol, { issuerUrl })}
                   />
                   <Field
@@ -754,7 +754,7 @@ const AuthSettings: React.FC<AuthSettingsProps> = ({
                     value={draft.clientId || ''}
                     error={errors[`${prefix}clientId`]}
                     monospace
-                    required
+                    required={!!draft.enabled}
                     onChange={(clientId) => updateProviderDraft(protocol, { clientId })}
                   />
                   <SecretField
@@ -922,7 +922,7 @@ const AuthSettings: React.FC<AuthSettingsProps> = ({
                 value={draft.usernameAttribute || ''}
                 error={errors[`${prefix}usernameAttribute`]}
                 monospace
-                required={protocol === 'oidc'}
+                required={protocol === 'oidc' && !!draft.enabled}
                 onChange={(usernameAttribute) =>
                   updateProviderDraft(protocol, { usernameAttribute })
                 }
@@ -1183,7 +1183,7 @@ const AuthSettings: React.FC<AuthSettingsProps> = ({
                   value={ldapForm.serverUrl}
                   error={errors.serverUrl}
                   monospace
-                  required
+                  required={ldapForm.enabled}
                   onChange={(serverUrl) => setLdapForm((prev) => ({ ...prev, serverUrl }))}
                 />
                 <Field
@@ -1191,7 +1191,7 @@ const AuthSettings: React.FC<AuthSettingsProps> = ({
                   value={ldapForm.baseDn}
                   error={errors.baseDn}
                   monospace
-                  required
+                  required={ldapForm.enabled}
                   onChange={(baseDn) => setLdapForm((prev) => ({ ...prev, baseDn }))}
                 />
                 <Field
@@ -1199,7 +1199,7 @@ const AuthSettings: React.FC<AuthSettingsProps> = ({
                   value={ldapForm.userFilter}
                   error={errors.userFilter}
                   monospace
-                  required
+                  required={ldapForm.enabled}
                   onChange={(userFilter) => setLdapForm((prev) => ({ ...prev, userFilter }))}
                 />
                 <Field
@@ -1228,7 +1228,7 @@ const AuthSettings: React.FC<AuthSettingsProps> = ({
                   value={ldapForm.groupBaseDn}
                   error={errors.groupBaseDn}
                   monospace
-                  required
+                  required={ldapForm.enabled}
                   onChange={(groupBaseDn) => setLdapForm((prev) => ({ ...prev, groupBaseDn }))}
                 />
                 <Field
@@ -1236,7 +1236,7 @@ const AuthSettings: React.FC<AuthSettingsProps> = ({
                   value={ldapForm.groupFilter}
                   error={errors.groupFilter}
                   monospace
-                  required
+                  required={ldapForm.enabled}
                   onChange={(groupFilter) => setLdapForm((prev) => ({ ...prev, groupFilter }))}
                 />
               </CardContent>
@@ -1645,14 +1645,8 @@ const Field: React.FC<FieldProps> = ({
   const id = useId();
   return (
     <UIField>
-      <FieldLabel htmlFor={id}>
+      <FieldLabel htmlFor={id} required={required}>
         {label}
-        {required && (
-          <>
-            {' '}
-            <span className="text-red-500">*</span>
-          </>
-        )}
       </FieldLabel>
       <Input
         id={id}

--- a/components/administration/AuthSettings.tsx
+++ b/components/administration/AuthSettings.tsx
@@ -725,6 +725,7 @@ const AuthSettings: React.FC<AuthSettingsProps> = ({
                 label={t('admin.sso.name', 'Name')}
                 value={draft.name || ''}
                 error={errors[`${prefix}name`]}
+                required
                 onChange={(name) => updateProviderDraft(protocol, { name })}
               />
               <Field
@@ -732,6 +733,7 @@ const AuthSettings: React.FC<AuthSettingsProps> = ({
                 value={draft.slug || ''}
                 error={errors[`${prefix}slug`]}
                 monospace
+                required
                 onChange={(slug) => updateProviderDraft(protocol, { slug: slug.toLowerCase() })}
               />
             </div>
@@ -744,6 +746,7 @@ const AuthSettings: React.FC<AuthSettingsProps> = ({
                     value={draft.issuerUrl || ''}
                     error={errors[`${prefix}issuerUrl`]}
                     monospace
+                    required
                     onChange={(issuerUrl) => updateProviderDraft(protocol, { issuerUrl })}
                   />
                   <Field
@@ -751,6 +754,7 @@ const AuthSettings: React.FC<AuthSettingsProps> = ({
                     value={draft.clientId || ''}
                     error={errors[`${prefix}clientId`]}
                     monospace
+                    required
                     onChange={(clientId) => updateProviderDraft(protocol, { clientId })}
                   />
                   <SecretField
@@ -918,6 +922,7 @@ const AuthSettings: React.FC<AuthSettingsProps> = ({
                 value={draft.usernameAttribute || ''}
                 error={errors[`${prefix}usernameAttribute`]}
                 monospace
+                required={protocol === 'oidc'}
                 onChange={(usernameAttribute) =>
                   updateProviderDraft(protocol, { usernameAttribute })
                 }
@@ -1178,6 +1183,7 @@ const AuthSettings: React.FC<AuthSettingsProps> = ({
                   value={ldapForm.serverUrl}
                   error={errors.serverUrl}
                   monospace
+                  required
                   onChange={(serverUrl) => setLdapForm((prev) => ({ ...prev, serverUrl }))}
                 />
                 <Field
@@ -1185,6 +1191,7 @@ const AuthSettings: React.FC<AuthSettingsProps> = ({
                   value={ldapForm.baseDn}
                   error={errors.baseDn}
                   monospace
+                  required
                   onChange={(baseDn) => setLdapForm((prev) => ({ ...prev, baseDn }))}
                 />
                 <Field
@@ -1192,6 +1199,7 @@ const AuthSettings: React.FC<AuthSettingsProps> = ({
                   value={ldapForm.userFilter}
                   error={errors.userFilter}
                   monospace
+                  required
                   onChange={(userFilter) => setLdapForm((prev) => ({ ...prev, userFilter }))}
                 />
                 <Field
@@ -1220,6 +1228,7 @@ const AuthSettings: React.FC<AuthSettingsProps> = ({
                   value={ldapForm.groupBaseDn}
                   error={errors.groupBaseDn}
                   monospace
+                  required
                   onChange={(groupBaseDn) => setLdapForm((prev) => ({ ...prev, groupBaseDn }))}
                 />
                 <Field
@@ -1227,6 +1236,7 @@ const AuthSettings: React.FC<AuthSettingsProps> = ({
                   value={ldapForm.groupFilter}
                   error={errors.groupFilter}
                   monospace
+                  required
                   onChange={(groupFilter) => setLdapForm((prev) => ({ ...prev, groupFilter }))}
                 />
               </CardContent>
@@ -1489,6 +1499,7 @@ const AuthSettings: React.FC<AuthSettingsProps> = ({
                   label={t('admin.ldap.testUsername')}
                   value={testUsername}
                   error={testErrors.testUsername}
+                  required
                   onChange={(value) => {
                     setTestUsername(value);
                     if (testErrors.testUsername)
@@ -1500,6 +1511,7 @@ const AuthSettings: React.FC<AuthSettingsProps> = ({
                   value={testPassword}
                   type="password"
                   error={testErrors.testPassword}
+                  required
                   onChange={(value) => {
                     setTestPassword(value);
                     if (testErrors.testPassword)
@@ -1618,6 +1630,7 @@ type FieldProps = {
   error?: string;
   type?: string;
   monospace?: boolean;
+  required?: boolean;
 };
 
 const Field: React.FC<FieldProps> = ({
@@ -1627,11 +1640,20 @@ const Field: React.FC<FieldProps> = ({
   error,
   type = 'text',
   monospace,
+  required,
 }) => {
   const id = useId();
   return (
     <UIField>
-      <FieldLabel htmlFor={id}>{label}</FieldLabel>
+      <FieldLabel htmlFor={id}>
+        {label}
+        {required && (
+          <>
+            {' '}
+            <span className="text-red-500">*</span>
+          </>
+        )}
+      </FieldLabel>
       <Input
         id={id}
         type={type}

--- a/components/administration/EmailSettings.tsx
+++ b/components/administration/EmailSettings.tsx
@@ -331,7 +331,9 @@ const EmailSettings: React.FC<EmailSettingsProps> = ({ config, onSave, onTestEma
           >
             <div className="grid grid-cols-1 gap-6 md:grid-cols-4">
               <Field className="md:col-span-2">
-                <FieldLabel htmlFor="email-smtp-host">{t('email.host', 'SMTP Host')}</FieldLabel>
+                <FieldLabel htmlFor="email-smtp-host">
+                  {t('email.host', 'SMTP Host')} <span className="text-red-500">*</span>
+                </FieldLabel>
                 <Input
                   id="email-smtp-host"
                   type="text"
@@ -348,7 +350,9 @@ const EmailSettings: React.FC<EmailSettingsProps> = ({ config, onSave, onTestEma
               </Field>
 
               <Field>
-                <FieldLabel htmlFor="email-smtp-port">{t('email.port', 'Port')}</FieldLabel>
+                <FieldLabel htmlFor="email-smtp-port">
+                  {t('email.port', 'Port')} <span className="text-red-500">*</span>
+                </FieldLabel>
                 <Input
                   id="email-smtp-port"
                   type="number"
@@ -458,7 +462,7 @@ const EmailSettings: React.FC<EmailSettingsProps> = ({ config, onSave, onTestEma
             <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
               <Field>
                 <FieldLabel htmlFor="email-from-email">
-                  {t('email.fromEmail', 'From Email')}
+                  {t('email.fromEmail', 'From Email')} <span className="text-red-500">*</span>
                 </FieldLabel>
                 <Input
                   id="email-from-email"
@@ -538,7 +542,8 @@ const EmailSettings: React.FC<EmailSettingsProps> = ({ config, onSave, onTestEma
             <form onSubmit={handleTest} className="space-y-4">
               <Field>
                 <FieldLabel htmlFor="email-test-recipient">
-                  {t('email.recipientEmail', 'Recipient Email')}
+                  {t('email.recipientEmail', 'Recipient Email')}{' '}
+                  <span className="text-red-500">*</span>
                 </FieldLabel>
                 <Input
                   id="email-test-recipient"

--- a/components/administration/EmailSettings.tsx
+++ b/components/administration/EmailSettings.tsx
@@ -331,8 +331,8 @@ const EmailSettings: React.FC<EmailSettingsProps> = ({ config, onSave, onTestEma
           >
             <div className="grid grid-cols-1 gap-6 md:grid-cols-4">
               <Field className="md:col-span-2">
-                <FieldLabel htmlFor="email-smtp-host">
-                  {t('email.host', 'SMTP Host')} <span className="text-red-500">*</span>
+                <FieldLabel htmlFor="email-smtp-host" required>
+                  {t('email.host', 'SMTP Host')}
                 </FieldLabel>
                 <Input
                   id="email-smtp-host"
@@ -350,8 +350,8 @@ const EmailSettings: React.FC<EmailSettingsProps> = ({ config, onSave, onTestEma
               </Field>
 
               <Field>
-                <FieldLabel htmlFor="email-smtp-port">
-                  {t('email.port', 'Port')} <span className="text-red-500">*</span>
+                <FieldLabel htmlFor="email-smtp-port" required>
+                  {t('email.port', 'Port')}
                 </FieldLabel>
                 <Input
                   id="email-smtp-port"
@@ -461,8 +461,8 @@ const EmailSettings: React.FC<EmailSettingsProps> = ({ config, onSave, onTestEma
 
             <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
               <Field>
-                <FieldLabel htmlFor="email-from-email">
-                  {t('email.fromEmail', 'From Email')} <span className="text-red-500">*</span>
+                <FieldLabel htmlFor="email-from-email" required>
+                  {t('email.fromEmail', 'From Email')}
                 </FieldLabel>
                 <Input
                   id="email-from-email"
@@ -541,9 +541,8 @@ const EmailSettings: React.FC<EmailSettingsProps> = ({ config, onSave, onTestEma
           <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
             <form onSubmit={handleTest} className="space-y-4">
               <Field>
-                <FieldLabel htmlFor="email-test-recipient">
-                  {t('email.recipientEmail', 'Recipient Email')}{' '}
-                  <span className="text-red-500">*</span>
+                <FieldLabel htmlFor="email-test-recipient" required>
+                  {t('email.recipientEmail', 'Recipient Email')}
                 </FieldLabel>
                 <Input
                   id="email-test-recipient"

--- a/components/administration/GeneralSettings.tsx
+++ b/components/administration/GeneralSettings.tsx
@@ -742,7 +742,8 @@ const GeneralSettings: React.FC<GeneralSettingsProps> = ({
                     <FieldLabel htmlFor="general-ai-api-key">
                       {aiProvider === 'gemini'
                         ? t('general.geminiApiKey')
-                        : t('general.openrouterApiKey')}
+                        : t('general.openrouterApiKey')}{' '}
+                      <span className="text-red-500">*</span>
                     </FieldLabel>
                     <Input
                       id="general-ai-api-key"
@@ -789,7 +790,9 @@ const GeneralSettings: React.FC<GeneralSettingsProps> = ({
                   </Field>
 
                   <Field data-invalid={isModelMissing() || isModelNotFound ? 'true' : undefined}>
-                    <FieldLabel htmlFor="general-ai-model">{t('general.modelIdLabel')}</FieldLabel>
+                    <FieldLabel htmlFor="general-ai-model">
+                      {t('general.modelIdLabel')} <span className="text-red-500">*</span>
+                    </FieldLabel>
                     <div className="flex flex-col gap-2 sm:flex-row">
                       <Input
                         id="general-ai-model"

--- a/components/administration/GeneralSettings.tsx
+++ b/components/administration/GeneralSettings.tsx
@@ -739,11 +739,10 @@ const GeneralSettings: React.FC<GeneralSettingsProps> = ({
                   </Field>
 
                   <Field data-invalid={isApiKeyMissing() ? 'true' : undefined}>
-                    <FieldLabel htmlFor="general-ai-api-key">
+                    <FieldLabel htmlFor="general-ai-api-key" required>
                       {aiProvider === 'gemini'
                         ? t('general.geminiApiKey')
-                        : t('general.openrouterApiKey')}{' '}
-                      <span className="text-red-500">*</span>
+                        : t('general.openrouterApiKey')}
                     </FieldLabel>
                     <Input
                       id="general-ai-api-key"
@@ -790,8 +789,8 @@ const GeneralSettings: React.FC<GeneralSettingsProps> = ({
                   </Field>
 
                   <Field data-invalid={isModelMissing() || isModelNotFound ? 'true' : undefined}>
-                    <FieldLabel htmlFor="general-ai-model">
-                      {t('general.modelIdLabel')} <span className="text-red-500">*</span>
+                    <FieldLabel htmlFor="general-ai-model" required>
+                      {t('general.modelIdLabel')}
                     </FieldLabel>
                     <div className="flex flex-col gap-2 sm:flex-row">
                       <Input

--- a/components/administration/RolesView.tsx
+++ b/components/administration/RolesView.tsx
@@ -563,7 +563,9 @@ const RoleCreateModal: React.FC<
             </ModalHeader>
             <ModalBody className="flex-1 space-y-6">
               <Field>
-                <FieldLabel htmlFor="role-create-name">{t('common:labels.name')}</FieldLabel>
+                <FieldLabel htmlFor="role-create-name">
+                  {t('common:labels.name')} <span className="text-red-500">*</span>
+                </FieldLabel>
                 <Input
                   id="role-create-name"
                   value={roleName}
@@ -630,7 +632,9 @@ const RoleRenameModal: React.FC<{
             </ModalHeader>
             <ModalBody className="space-y-4">
               <Field>
-                <FieldLabel htmlFor="role-rename-name">{t('common:labels.name')}</FieldLabel>
+                <FieldLabel htmlFor="role-rename-name">
+                  {t('common:labels.name')} <span className="text-red-500">*</span>
+                </FieldLabel>
                 <Input
                   id="role-rename-name"
                   value={roleName}

--- a/components/administration/RolesView.tsx
+++ b/components/administration/RolesView.tsx
@@ -563,8 +563,8 @@ const RoleCreateModal: React.FC<
             </ModalHeader>
             <ModalBody className="flex-1 space-y-6">
               <Field>
-                <FieldLabel htmlFor="role-create-name">
-                  {t('common:labels.name')} <span className="text-red-500">*</span>
+                <FieldLabel htmlFor="role-create-name" required>
+                  {t('common:labels.name')}
                 </FieldLabel>
                 <Input
                   id="role-create-name"
@@ -632,8 +632,8 @@ const RoleRenameModal: React.FC<{
             </ModalHeader>
             <ModalBody className="space-y-4">
               <Field>
-                <FieldLabel htmlFor="role-rename-name">
-                  {t('common:labels.name')} <span className="text-red-500">*</span>
+                <FieldLabel htmlFor="role-rename-name" required>
+                  {t('common:labels.name')}
                 </FieldLabel>
                 <Input
                   id="role-rename-name"

--- a/components/administration/UserManagement.tsx
+++ b/components/administration/UserManagement.tsx
@@ -1280,7 +1280,7 @@ const UserManagement: React.FC<UserManagementProps> = ({
               <div className="grid grid-cols-2 gap-3">
                 <div>
                   <label className="block text-xs font-bold text-zinc-400 uppercase tracking-wider mb-1">
-                    {t('hr:workforce.name')}
+                    {t('hr:workforce.name')} <span className="text-red-500">*</span>
                   </label>
                   <input
                     type="text"

--- a/components/administration/UserManagement.tsx
+++ b/components/administration/UserManagement.tsx
@@ -10,6 +10,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { RequiredMark } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
@@ -1280,7 +1281,7 @@ const UserManagement: React.FC<UserManagementProps> = ({
               <div className="grid grid-cols-2 gap-3">
                 <div>
                   <label className="block text-xs font-bold text-zinc-400 uppercase tracking-wider mb-1">
-                    {t('hr:workforce.name')} <span className="text-red-500">*</span>
+                    {t('hr:workforce.name')} {!editIdentityReadOnly && <RequiredMark />}
                   </label>
                   <input
                     type="text"

--- a/components/catalog/InternalListingView.tsx
+++ b/components/catalog/InternalListingView.tsx
@@ -2,7 +2,7 @@ import type React from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
-import { FieldLabel } from '@/components/ui/field';
+import { FieldLabel, RequiredMark } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -1265,9 +1265,7 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
                 </h4>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   <div className="space-y-1.5">
-                    <FieldLabel>
-                      {t('crm:internalListing.productName')} <span className="text-red-500">*</span>
-                    </FieldLabel>
+                    <FieldLabel required>{t('crm:internalListing.productName')}</FieldLabel>
                     <Input
                       type="text"
                       value={formData.name}
@@ -1284,9 +1282,7 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
                   </div>
 
                   <div className="space-y-1.5">
-                    <FieldLabel>
-                      {t('crm:internalListing.productCode')} <span className="text-red-500">*</span>
-                    </FieldLabel>
+                    <FieldLabel required>{t('crm:internalListing.productCode')}</FieldLabel>
                     <Input
                       type="text"
                       value={formData.productCode}
@@ -1322,9 +1318,7 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
 
                   <div className="space-y-1.5">
                     <div className="flex min-h-6 items-center justify-between gap-2">
-                      <FieldLabel>
-                        {t('crm:internalListing.type')} <span className="text-red-500">*</span>
-                      </FieldLabel>
+                      <FieldLabel required>{t('crm:internalListing.type')}</FieldLabel>
                       <Button
                         type="button"
                         variant="ghost"
@@ -1427,7 +1421,7 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   <div className="space-y-1.5">
                     <FieldLabel>
-                      {t('crm:internalListing.cost')} <span className="text-red-500">*</span>
+                      {t('crm:internalListing.cost')} <RequiredMark />
                       <span className="text-zinc-400 font-semibold">
                         /
                         {formData.costUnit === 'hours'
@@ -1449,9 +1443,7 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
                   </div>
 
                   <div className="space-y-1.5">
-                    <FieldLabel>
-                      {t('crm:internalListing.mol')} <span className="text-red-500">*</span>
-                    </FieldLabel>
+                    <FieldLabel required>{t('crm:internalListing.mol')}</FieldLabel>
                     <div className="flex gap-2">
                       <ValidatedNumberInput
                         value={formData.molPercentage ?? ''}

--- a/components/catalog/InternalListingView.tsx
+++ b/components/catalog/InternalListingView.tsx
@@ -1265,7 +1265,9 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
                 </h4>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   <div className="space-y-1.5">
-                    <FieldLabel>{t('crm:internalListing.productName')}</FieldLabel>
+                    <FieldLabel>
+                      {t('crm:internalListing.productName')} <span className="text-red-500">*</span>
+                    </FieldLabel>
                     <Input
                       type="text"
                       value={formData.name}
@@ -1282,7 +1284,9 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
                   </div>
 
                   <div className="space-y-1.5">
-                    <FieldLabel>{t('crm:internalListing.productCode')}</FieldLabel>
+                    <FieldLabel>
+                      {t('crm:internalListing.productCode')} <span className="text-red-500">*</span>
+                    </FieldLabel>
                     <Input
                       type="text"
                       value={formData.productCode}
@@ -1318,7 +1322,9 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
 
                   <div className="space-y-1.5">
                     <div className="flex min-h-6 items-center justify-between gap-2">
-                      <FieldLabel>{t('crm:internalListing.type')}</FieldLabel>
+                      <FieldLabel>
+                        {t('crm:internalListing.type')} <span className="text-red-500">*</span>
+                      </FieldLabel>
                       <Button
                         type="button"
                         variant="ghost"
@@ -1421,7 +1427,7 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   <div className="space-y-1.5">
                     <FieldLabel>
-                      {t('crm:internalListing.cost')}
+                      {t('crm:internalListing.cost')} <span className="text-red-500">*</span>
                       <span className="text-zinc-400 font-semibold">
                         /
                         {formData.costUnit === 'hours'
@@ -1443,7 +1449,9 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
                   </div>
 
                   <div className="space-y-1.5">
-                    <FieldLabel>{t('crm:internalListing.mol')}</FieldLabel>
+                    <FieldLabel>
+                      {t('crm:internalListing.mol')} <span className="text-red-500">*</span>
+                    </FieldLabel>
                     <div className="flex gap-2">
                       <ValidatedNumberInput
                         value={formData.molPercentage ?? ''}

--- a/components/projects/ProjectDetailView.tsx
+++ b/components/projects/ProjectDetailView.tsx
@@ -31,7 +31,7 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from '@/components/ui/empty';
-import { Field, FieldError, FieldLabel } from '@/components/ui/field';
+import { Field, FieldError, FieldLabel, RequiredMark } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
 import { Separator } from '@/components/ui/separator';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -105,12 +105,6 @@ const formatOrderId = (id: string) => `#${id.replace('co-', '')}`;
 
 const toStoredBillingType = (value: BillingType | undefined): StoredBillingType =>
   value === 'retainer' ? 'retainer' : 'time_and_materials';
-
-const RequiredMark = () => (
-  <span className="text-destructive" aria-hidden="true">
-    *
-  </span>
-);
 
 const billingTypeOptions = [
   { id: 'time_and_materials', name: 'projects:projects.billingTypes.timeAndMaterials' },

--- a/components/projects/ProjectRuleFormModal.tsx
+++ b/components/projects/ProjectRuleFormModal.tsx
@@ -338,7 +338,7 @@ const ProjectRuleFormModalSession: React.FC<ProjectRuleFormModalSessionProps> = 
         <form className="space-y-5" onSubmit={handleSubmit}>
           <Field data-invalid={!!errors.name}>
             <FieldLabel htmlFor="project-rule-name">
-              {t('projects:detail.rules.form.name')}
+              {t('projects:detail.rules.form.name')} <span className="text-red-500">*</span>
             </FieldLabel>
             <Input
               id="project-rule-name"
@@ -447,7 +447,8 @@ const ProjectRuleFormModalSession: React.FC<ProjectRuleFormModalSessionProps> = 
                     >
                       <Field data-invalid={!!fieldError}>
                         <FieldLabel className="md:sr-only" htmlFor={`project-rule-field-${index}`}>
-                          {t('projects:detail.rules.form.field')}
+                          {t('projects:detail.rules.form.field')}{' '}
+                          <span className="text-red-500">*</span>
                         </FieldLabel>
                         <Select
                           value={condition.field}
@@ -479,7 +480,8 @@ const ProjectRuleFormModalSession: React.FC<ProjectRuleFormModalSessionProps> = 
                           className="md:sr-only"
                           htmlFor={`project-rule-operator-${index}`}
                         >
-                          {t('projects:detail.rules.form.operator')}
+                          {t('projects:detail.rules.form.operator')}{' '}
+                          <span className="text-red-500">*</span>
                         </FieldLabel>
                         <Select
                           value={condition.operator}
@@ -541,7 +543,8 @@ const ProjectRuleFormModalSession: React.FC<ProjectRuleFormModalSessionProps> = 
                             valueType === 'field'
                               ? 'projects:detail.rules.form.targetField'
                               : 'projects:detail.rules.form.value',
-                          )}
+                          )}{' '}
+                          <span className="text-red-500">*</span>
                         </FieldLabel>
                         {valueType === 'field' ? (
                           <Select

--- a/components/projects/ProjectRuleFormModal.tsx
+++ b/components/projects/ProjectRuleFormModal.tsx
@@ -337,8 +337,8 @@ const ProjectRuleFormModalSession: React.FC<ProjectRuleFormModalSessionProps> = 
 
         <form className="space-y-5" onSubmit={handleSubmit}>
           <Field data-invalid={!!errors.name}>
-            <FieldLabel htmlFor="project-rule-name">
-              {t('projects:detail.rules.form.name')} <span className="text-red-500">*</span>
+            <FieldLabel htmlFor="project-rule-name" required>
+              {t('projects:detail.rules.form.name')}
             </FieldLabel>
             <Input
               id="project-rule-name"
@@ -446,9 +446,12 @@ const ProjectRuleFormModalSession: React.FC<ProjectRuleFormModalSessionProps> = 
                       className={`${CONDITION_GRID_CLASSNAME} p-3`}
                     >
                       <Field data-invalid={!!fieldError}>
-                        <FieldLabel className="md:sr-only" htmlFor={`project-rule-field-${index}`}>
-                          {t('projects:detail.rules.form.field')}{' '}
-                          <span className="text-red-500">*</span>
+                        <FieldLabel
+                          className="md:sr-only"
+                          htmlFor={`project-rule-field-${index}`}
+                          required
+                        >
+                          {t('projects:detail.rules.form.field')}
                         </FieldLabel>
                         <Select
                           value={condition.field}
@@ -479,9 +482,9 @@ const ProjectRuleFormModalSession: React.FC<ProjectRuleFormModalSessionProps> = 
                         <FieldLabel
                           className="md:sr-only"
                           htmlFor={`project-rule-operator-${index}`}
+                          required
                         >
-                          {t('projects:detail.rules.form.operator')}{' '}
-                          <span className="text-red-500">*</span>
+                          {t('projects:detail.rules.form.operator')}
                         </FieldLabel>
                         <Select
                           value={condition.operator}
@@ -538,13 +541,16 @@ const ProjectRuleFormModalSession: React.FC<ProjectRuleFormModalSessionProps> = 
                       </Field>
 
                       <Field data-invalid={!!valueError}>
-                        <FieldLabel className="md:sr-only" htmlFor={`project-rule-value-${index}`}>
+                        <FieldLabel
+                          className="md:sr-only"
+                          htmlFor={`project-rule-value-${index}`}
+                          required
+                        >
                           {t(
                             valueType === 'field'
                               ? 'projects:detail.rules.form.targetField'
                               : 'projects:detail.rules.form.value',
-                          )}{' '}
-                          <span className="text-red-500">*</span>
+                          )}
                         </FieldLabel>
                         {valueType === 'field' ? (
                           <Select

--- a/components/projects/ProjectsView.tsx
+++ b/components/projects/ProjectsView.tsx
@@ -2,7 +2,7 @@ import type React from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
-import { Field, FieldError, FieldLabel } from '@/components/ui/field';
+import { Field, FieldError, FieldLabel, RequiredMark } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -76,13 +76,6 @@ const billingFrequencyOptions = [
 
 const toStoredBillingType = (value: BillingType | undefined): StoredBillingType =>
   value === 'retainer' ? 'retainer' : 'time_and_materials';
-
-// `aria-hidden` — screen readers get the requirement signal from the input's `required` attr.
-const RequiredMark = () => (
-  <span className="text-destructive" aria-hidden="true">
-    *
-  </span>
-);
 
 type RevenueSource = 'activities' | 'order' | 'manual';
 type RevenueLike = { revenue?: number | string | null };

--- a/components/projects/TaskFormModal.tsx
+++ b/components/projects/TaskFormModal.tsx
@@ -445,11 +445,8 @@ const TaskFormModalSession: React.FC<TaskFormModalSessionProps> = ({
                       billing: isEditing ? undefined : deriveBillingFromProject(nextProject),
                     });
                   }}
-                  label={
-                    <>
-                      {t('tasks.project')} <span className="text-red-500">*</span>
-                    </>
-                  }
+                  label={t('tasks.project')}
+                  required
                   placeholder={t('common:labels.selectOption')}
                   searchable={true}
                   disabled={projectLocked}
@@ -457,8 +454,8 @@ const TaskFormModalSession: React.FC<TaskFormModalSessionProps> = ({
                 />
 
                 <Field>
-                  <FieldLabel htmlFor="task-name">
-                    {t('tasks.name')} <span className="text-red-500">*</span>
+                  <FieldLabel htmlFor="task-name" required>
+                    {t('tasks.name')}
                   </FieldLabel>
                   <Input
                     id="task-name"

--- a/components/projects/TaskFormModal.tsx
+++ b/components/projects/TaskFormModal.tsx
@@ -445,7 +445,11 @@ const TaskFormModalSession: React.FC<TaskFormModalSessionProps> = ({
                       billing: isEditing ? undefined : deriveBillingFromProject(nextProject),
                     });
                   }}
-                  label={t('tasks.project')}
+                  label={
+                    <>
+                      {t('tasks.project')} <span className="text-red-500">*</span>
+                    </>
+                  }
                   placeholder={t('common:labels.selectOption')}
                   searchable={true}
                   disabled={projectLocked}
@@ -453,7 +457,9 @@ const TaskFormModalSession: React.FC<TaskFormModalSessionProps> = ({
                 />
 
                 <Field>
-                  <FieldLabel htmlFor="task-name">{t('tasks.name')}</FieldLabel>
+                  <FieldLabel htmlFor="task-name">
+                    {t('tasks.name')} <span className="text-red-500">*</span>
+                  </FieldLabel>
                   <Input
                     id="task-name"
                     type="text"

--- a/components/sales/ClientOffersView.tsx
+++ b/components/sales/ClientOffersView.tsx
@@ -1148,21 +1148,16 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                         })}
                         searchable={true}
                         disabled={isReadOnly || isClientLocked}
-                        label={
-                          <>
-                            {t('sales:clientOffers.client', { defaultValue: 'Client' })}{' '}
-                            <span className="text-red-500">*</span>
-                          </>
-                        }
+                        label={t('sales:clientOffers.client', { defaultValue: 'Client' })}
+                        required
                         buttonClassName="h-9"
                         className={errors.clientId ? 'border-red-300' : ''}
                       />
                       <FieldError className="text-xs">{errors.clientId}</FieldError>
                     </Field>
                     <Field data-invalid={Boolean(errors.id)}>
-                      <FieldLabel htmlFor="client-offer-code">
-                        {t('sales:clientOffers.offerCode', { defaultValue: 'Offer code' })}{' '}
-                        <span className="text-red-500">*</span>
+                      <FieldLabel htmlFor="client-offer-code" required>
+                        {t('sales:clientOffers.offerCode', { defaultValue: 'Offer code' })}
                       </FieldLabel>
                       <Input
                         id="client-offer-code"
@@ -1198,11 +1193,10 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                       />
                     </Field>
                     <Field>
-                      <FieldLabel htmlFor="client-offer-expiration-date">
+                      <FieldLabel htmlFor="client-offer-expiration-date" required>
                         {t('sales:clientOffers.expirationDate', {
                           defaultValue: 'Expiration date',
-                        })}{' '}
-                        <span className="text-red-500">*</span>
+                        })}
                       </FieldLabel>
                       <DateField
                         id="client-offer-expiration-date"

--- a/components/sales/ClientOffersView.tsx
+++ b/components/sales/ClientOffersView.tsx
@@ -1148,7 +1148,12 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                         })}
                         searchable={true}
                         disabled={isReadOnly || isClientLocked}
-                        label={t('sales:clientOffers.client', { defaultValue: 'Client' })}
+                        label={
+                          <>
+                            {t('sales:clientOffers.client', { defaultValue: 'Client' })}{' '}
+                            <span className="text-red-500">*</span>
+                          </>
+                        }
                         buttonClassName="h-9"
                         className={errors.clientId ? 'border-red-300' : ''}
                       />
@@ -1156,7 +1161,8 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                     </Field>
                     <Field data-invalid={Boolean(errors.id)}>
                       <FieldLabel htmlFor="client-offer-code">
-                        {t('sales:clientOffers.offerCode', { defaultValue: 'Offer code' })}
+                        {t('sales:clientOffers.offerCode', { defaultValue: 'Offer code' })}{' '}
+                        <span className="text-red-500">*</span>
                       </FieldLabel>
                       <Input
                         id="client-offer-code"
@@ -1195,7 +1201,8 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                       <FieldLabel htmlFor="client-offer-expiration-date">
                         {t('sales:clientOffers.expirationDate', {
                           defaultValue: 'Expiration date',
-                        })}
+                        })}{' '}
+                        <span className="text-red-500">*</span>
                       </FieldLabel>
                       <DateField
                         id="client-offer-expiration-date"

--- a/components/sales/ClientQuotesView.tsx
+++ b/components/sales/ClientQuotesView.tsx
@@ -1461,7 +1461,11 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                         placeholder={t('sales:clientQuotes.selectAClient')}
                         searchable={true}
                         disabled={isReadOnly}
-                        label={t('sales:clientQuotes.client')}
+                        label={
+                          <>
+                            {t('sales:clientQuotes.client')} <span className="text-red-500">*</span>
+                          </>
+                        }
                         buttonClassName="h-9"
                         className={errors.clientId ? 'border-red-300' : ''}
                       />
@@ -1469,7 +1473,8 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                     </Field>
                     <Field data-invalid={Boolean(errors.id)}>
                       <FieldLabel htmlFor="client-quote-code">
-                        {t('sales:clientQuotes.quoteCode', { defaultValue: 'Quote Code' })}
+                        {t('sales:clientQuotes.quoteCode', { defaultValue: 'Quote Code' })}{' '}
+                        <span className="text-red-500">*</span>
                       </FieldLabel>
                       <Input
                         id="client-quote-code"
@@ -1511,7 +1516,8 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                     </Field>
                     <Field>
                       <FieldLabel htmlFor="client-quote-expiration-date">
-                        {t('sales:clientQuotes.expirationDateLabel')}
+                        {t('sales:clientQuotes.expirationDateLabel')}{' '}
+                        <span className="text-red-500">*</span>
                       </FieldLabel>
                       <DateField
                         id="client-quote-expiration-date"

--- a/components/sales/ClientQuotesView.tsx
+++ b/components/sales/ClientQuotesView.tsx
@@ -1461,20 +1461,16 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                         placeholder={t('sales:clientQuotes.selectAClient')}
                         searchable={true}
                         disabled={isReadOnly}
-                        label={
-                          <>
-                            {t('sales:clientQuotes.client')} <span className="text-red-500">*</span>
-                          </>
-                        }
+                        label={t('sales:clientQuotes.client')}
+                        required
                         buttonClassName="h-9"
                         className={errors.clientId ? 'border-red-300' : ''}
                       />
                       <FieldError className="text-xs">{errors.clientId}</FieldError>
                     </Field>
                     <Field data-invalid={Boolean(errors.id)}>
-                      <FieldLabel htmlFor="client-quote-code">
-                        {t('sales:clientQuotes.quoteCode', { defaultValue: 'Quote Code' })}{' '}
-                        <span className="text-red-500">*</span>
+                      <FieldLabel htmlFor="client-quote-code" required>
+                        {t('sales:clientQuotes.quoteCode', { defaultValue: 'Quote Code' })}
                       </FieldLabel>
                       <Input
                         id="client-quote-code"
@@ -1515,9 +1511,8 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                       />
                     </Field>
                     <Field>
-                      <FieldLabel htmlFor="client-quote-expiration-date">
-                        {t('sales:clientQuotes.expirationDateLabel')}{' '}
-                        <span className="text-red-500">*</span>
+                      <FieldLabel htmlFor="client-quote-expiration-date" required>
+                        {t('sales:clientQuotes.expirationDateLabel')}
                       </FieldLabel>
                       <DateField
                         id="client-quote-expiration-date"

--- a/components/sales/SupplierQuotesView.tsx
+++ b/components/sales/SupplierQuotesView.tsx
@@ -938,7 +938,12 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
                         })}
                         searchable={true}
                         disabled={isReadOnly}
-                        label={t('sales:supplierQuotes.supplier', { defaultValue: 'Supplier' })}
+                        label={
+                          <>
+                            {t('sales:supplierQuotes.supplier', { defaultValue: 'Supplier' })}{' '}
+                            <span className="text-red-500">*</span>
+                          </>
+                        }
                         buttonClassName="h-9"
                         className={errors.supplierId ? 'border-red-300' : ''}
                       />
@@ -961,7 +966,8 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
                     </Field>
                     <Field data-invalid={Boolean(errors.id)}>
                       <FieldLabel htmlFor="supplier-quote-code">
-                        {t('sales:supplierQuotes.quoteCode', { defaultValue: 'Quote Code' })}
+                        {t('sales:supplierQuotes.quoteCode', { defaultValue: 'Quote Code' })}{' '}
+                        <span className="text-red-500">*</span>
                       </FieldLabel>
                       <Input
                         id="supplier-quote-code"

--- a/components/sales/SupplierQuotesView.tsx
+++ b/components/sales/SupplierQuotesView.tsx
@@ -938,12 +938,8 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
                         })}
                         searchable={true}
                         disabled={isReadOnly}
-                        label={
-                          <>
-                            {t('sales:supplierQuotes.supplier', { defaultValue: 'Supplier' })}{' '}
-                            <span className="text-red-500">*</span>
-                          </>
-                        }
+                        label={t('sales:supplierQuotes.supplier', { defaultValue: 'Supplier' })}
+                        required
                         buttonClassName="h-9"
                         className={errors.supplierId ? 'border-red-300' : ''}
                       />
@@ -965,9 +961,8 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
                       />
                     </Field>
                     <Field data-invalid={Boolean(errors.id)}>
-                      <FieldLabel htmlFor="supplier-quote-code">
-                        {t('sales:supplierQuotes.quoteCode', { defaultValue: 'Quote Code' })}{' '}
-                        <span className="text-red-500">*</span>
+                      <FieldLabel htmlFor="supplier-quote-code" required>
+                        {t('sales:supplierQuotes.quoteCode', { defaultValue: 'Quote Code' })}
                       </FieldLabel>
                       <Input
                         id="supplier-quote-code"

--- a/components/shared/CustomViewModal.tsx
+++ b/components/shared/CustomViewModal.tsx
@@ -89,7 +89,9 @@ const CustomViewModal: React.FC<CustomViewModalProps> = ({
 
           <ModalBody className="space-y-4">
             <Field>
-              <FieldLabel htmlFor="custom-view-name">{t('table.viewName')}</FieldLabel>
+              <FieldLabel htmlFor="custom-view-name">
+                {t('table.viewName')} <span className="text-red-500">*</span>
+              </FieldLabel>
               <Input
                 id="custom-view-name"
                 type="text"

--- a/components/shared/CustomViewModal.tsx
+++ b/components/shared/CustomViewModal.tsx
@@ -89,8 +89,8 @@ const CustomViewModal: React.FC<CustomViewModalProps> = ({
 
           <ModalBody className="space-y-4">
             <Field>
-              <FieldLabel htmlFor="custom-view-name">
-                {t('table.viewName')} <span className="text-red-500">*</span>
+              <FieldLabel htmlFor="custom-view-name" required>
+                {t('table.viewName')}
               </FieldLabel>
               <Input
                 id="custom-view-name"

--- a/components/shared/SelectControl.tsx
+++ b/components/shared/SelectControl.tsx
@@ -37,6 +37,7 @@ export interface SelectControlProps {
   value: string | string[];
   onChange: (value: string | string[]) => void;
   label?: React.ReactNode;
+  required?: boolean;
   placeholder?: string;
   className?: string;
   disabled?: boolean;
@@ -94,9 +95,21 @@ const getMultiButtonLabel = ({
   return `${selectedOptions.length} ${t('select.selected').toLowerCase()}`;
 };
 
-const SelectLabel = ({ id, label }: { id?: string; label?: React.ReactNode }) => {
+const SelectLabel = ({
+  id,
+  label,
+  required,
+}: {
+  id?: string;
+  label?: React.ReactNode;
+  required?: boolean;
+}) => {
   if (!label) return null;
-  return <FieldLabel htmlFor={id}>{label}</FieldLabel>;
+  return (
+    <FieldLabel htmlFor={id} required={required}>
+      {label}
+    </FieldLabel>
+  );
 };
 
 const TriggerLabel = ({ isPlaceholder, label }: { isPlaceholder: boolean; label: string }) => {
@@ -155,6 +168,7 @@ const PlainSelectControl = ({
   displayValueIsPlaceholder,
   id,
   label,
+  required,
   onChange,
   options,
   placeholder,
@@ -169,7 +183,7 @@ const PlainSelectControl = ({
 
   return (
     <Field className={cn('relative min-w-0', className)}>
-      <SelectLabel id={id} label={label} />
+      <SelectLabel id={id} label={label} required={required} />
       <Select
         disabled={disabled}
         value={selectValue}
@@ -212,6 +226,7 @@ const SearchableSelectControl = ({
   id,
   isMulti = false,
   label,
+  required,
   onChange,
   options,
   placeholder,
@@ -278,7 +293,7 @@ const SearchableSelectControl = ({
 
   return (
     <Field className={cn('relative min-w-0', className)}>
-      <SelectLabel id={id} label={label} />
+      <SelectLabel id={id} label={label} required={required} />
       <Popover
         open={open}
         modal={modal}

--- a/components/timesheet/DailyView.tsx
+++ b/components/timesheet/DailyView.tsx
@@ -15,7 +15,7 @@ import CustomRepeatModal from '../shared/CustomRepeatModal';
 import DateField from '../shared/DateField';
 import SelectControl from '../shared/SelectControl';
 import { Button } from '../ui/button';
-import { Field, FieldLabel } from '../ui/field';
+import { Field, FieldLabel, RequiredMark } from '../ui/field';
 import { Input } from '../ui/input';
 import { Separator } from '../ui/separator';
 import EntryCatalogSelector from './EntryCatalogSelector';
@@ -407,7 +407,7 @@ const DailyView: React.FC<DailyViewProps> = ({
     () => (
       <Field className="min-w-0">
         <FieldLabel htmlFor="daily-entry-hours">
-          {t('entry.hours')} <span className="text-destructive">*</span>
+          {t('entry.hours')} <RequiredMark />
         </FieldLabel>
         <Input
           id="daily-entry-hours"

--- a/components/timesheet/EntryCatalogSelector.tsx
+++ b/components/timesheet/EntryCatalogSelector.tsx
@@ -75,11 +75,8 @@ const EntryCatalogSelector: React.FC<EntryCatalogSelectorProps> = ({
     <div className={gridClass}>
       <div className="min-w-0">
         <SelectControl
-          label={
-            <>
-              {t('entry.client')} <span className="text-red-500">*</span>
-            </>
-          }
+          label={t('entry.client')}
+          required
           options={clientOptions}
           value={selectedClientId}
           onChange={(val) => onClientChange(val as string)}
@@ -93,11 +90,8 @@ const EntryCatalogSelector: React.FC<EntryCatalogSelectorProps> = ({
 
       <div className="min-w-0">
         <SelectControl
-          label={
-            <>
-              {t('entry.project')} <span className="text-red-500">*</span>
-            </>
-          }
+          label={t('entry.project')}
+          required
           options={projectOptions}
           value={selectedProjectId}
           onChange={(val) => onProjectChange(val as string)}
@@ -114,11 +108,8 @@ const EntryCatalogSelector: React.FC<EntryCatalogSelectorProps> = ({
 
       <div className="min-w-0">
         <SelectControl
-          label={
-            <>
-              {t('entry.task')} <span className="text-red-500">*</span>
-            </>
-          }
+          label={t('entry.task')}
+          required
           options={taskOptions}
           value={selectedTaskId}
           onChange={(val) => onTaskChange(val as string)}

--- a/components/timesheet/EntryCatalogSelector.tsx
+++ b/components/timesheet/EntryCatalogSelector.tsx
@@ -75,7 +75,11 @@ const EntryCatalogSelector: React.FC<EntryCatalogSelectorProps> = ({
     <div className={gridClass}>
       <div className="min-w-0">
         <SelectControl
-          label={t('entry.client')}
+          label={
+            <>
+              {t('entry.client')} <span className="text-red-500">*</span>
+            </>
+          }
           options={clientOptions}
           value={selectedClientId}
           onChange={(val) => onClientChange(val as string)}
@@ -89,7 +93,11 @@ const EntryCatalogSelector: React.FC<EntryCatalogSelectorProps> = ({
 
       <div className="min-w-0">
         <SelectControl
-          label={t('entry.project')}
+          label={
+            <>
+              {t('entry.project')} <span className="text-red-500">*</span>
+            </>
+          }
           options={projectOptions}
           value={selectedProjectId}
           onChange={(val) => onProjectChange(val as string)}
@@ -106,7 +114,11 @@ const EntryCatalogSelector: React.FC<EntryCatalogSelectorProps> = ({
 
       <div className="min-w-0">
         <SelectControl
-          label={t('entry.task')}
+          label={
+            <>
+              {t('entry.task')} <span className="text-red-500">*</span>
+            </>
+          }
           options={taskOptions}
           value={selectedTaskId}
           onChange={(val) => onTaskChange(val as string)}

--- a/components/timesheet/EntryEditDialog.tsx
+++ b/components/timesheet/EntryEditDialog.tsx
@@ -3,7 +3,7 @@ import type React from 'react';
 import { useReducer } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
-import { Field, FieldLabel } from '@/components/ui/field';
+import { Field, FieldLabel, RequiredMark } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
 import { cn } from '@/lib/utils';
 import type { Client, Project, ProjectTask, TimeEntry } from '../../types';
@@ -279,7 +279,7 @@ const EntryEditDialogContent: React.FC<ContentProps> = ({
               </Field>
               <Field className="min-w-0">
                 <FieldLabel htmlFor="entry-edit-hours">
-                  {t('entry.hours')} <span className="text-destructive">*</span>
+                  {t('entry.hours')} <RequiredMark />
                 </FieldLabel>
                 <Input
                   id="entry-edit-hours"

--- a/components/timesheet/RecurringTaskEditModal.tsx
+++ b/components/timesheet/RecurringTaskEditModal.tsx
@@ -148,11 +148,8 @@ const RecurringTaskEditModal: React.FC<RecurringTaskEditModalProps> = ({
               <Field>
                 <SelectControl
                   id="recurring-pattern"
-                  label={
-                    <>
-                      {t('recurring.pattern')} <span className="text-red-500">*</span>
-                    </>
-                  }
+                  label={t('recurring.pattern')}
+                  required
                   options={[
                     { id: 'daily', name: t('entry.recurrencePatterns.daily') },
                     { id: 'weekly', name: t('entry.recurrencePatterns.weekly') },
@@ -170,8 +167,8 @@ const RecurringTaskEditModal: React.FC<RecurringTaskEditModalProps> = ({
 
               <FieldGroup className="grid grid-cols-2 gap-4">
                 <Field>
-                  <FieldLabel htmlFor="recurring-start-date">
-                    {t('recurring.startDate')} <span className="text-red-500">*</span>
+                  <FieldLabel htmlFor="recurring-start-date" required>
+                    {t('recurring.startDate')}
                   </FieldLabel>
                   <DateField
                     id="recurring-start-date"

--- a/components/timesheet/RecurringTaskEditModal.tsx
+++ b/components/timesheet/RecurringTaskEditModal.tsx
@@ -148,7 +148,11 @@ const RecurringTaskEditModal: React.FC<RecurringTaskEditModalProps> = ({
               <Field>
                 <SelectControl
                   id="recurring-pattern"
-                  label={t('recurring.pattern')}
+                  label={
+                    <>
+                      {t('recurring.pattern')} <span className="text-red-500">*</span>
+                    </>
+                  }
                   options={[
                     { id: 'daily', name: t('entry.recurrencePatterns.daily') },
                     { id: 'weekly', name: t('entry.recurrencePatterns.weekly') },
@@ -166,7 +170,9 @@ const RecurringTaskEditModal: React.FC<RecurringTaskEditModalProps> = ({
 
               <FieldGroup className="grid grid-cols-2 gap-4">
                 <Field>
-                  <FieldLabel htmlFor="recurring-start-date">{t('recurring.startDate')}</FieldLabel>
+                  <FieldLabel htmlFor="recurring-start-date">
+                    {t('recurring.startDate')} <span className="text-red-500">*</span>
+                  </FieldLabel>
                   <DateField
                     id="recurring-start-date"
                     value={startDate}

--- a/components/ui/field.tsx
+++ b/components/ui/field.tsx
@@ -23,12 +23,23 @@ function FieldGroup({ className, ...props }: React.ComponentProps<'div'>) {
   );
 }
 
+function RequiredMark() {
+  return (
+    <span className="text-destructive" aria-hidden="true">
+      *
+    </span>
+  );
+}
+
 function FieldLabel({
   className,
   asChild = false,
+  required = false,
+  children,
   ...props
 }: React.ComponentProps<typeof LabelPrimitive.Root> & {
   asChild?: boolean;
+  required?: boolean;
 }) {
   const Comp = asChild ? Slot.Root : LabelPrimitive.Root;
 
@@ -41,7 +52,15 @@ function FieldLabel({
         className,
       )}
       {...props}
-    />
+    >
+      {children}
+      {required && !asChild && (
+        <>
+          {' '}
+          <RequiredMark />
+        </>
+      )}
+    </Comp>
   );
 }
 
@@ -147,4 +166,5 @@ export {
   FieldSeparator,
   FieldSet,
   FieldTitle,
+  RequiredMark,
 };

--- a/docs-site/src/content/docs/en/faq.md
+++ b/docs-site/src/content/docs/en/faq.md
@@ -11,7 +11,7 @@ Module visibility depends on role permissions and some global settings. Ask an a
 
 ## I cannot save a document
 
-Check required fields, numeric values, and dates. In commercial documents, also verify that rows, quantities, prices, and records are complete.
+Check required fields, numeric values, and dates. In forms, required fields are marked with a red asterisk (*) next to the label. In commercial documents, also verify that rows, quantities, prices, and records are complete.
 
 ## Totals are not what I expected
 

--- a/docs-site/src/content/docs/faq.md
+++ b/docs-site/src/content/docs/faq.md
@@ -11,7 +11,7 @@ La visibilità dei moduli dipende dai permessi del ruolo e da alcune impostazion
 
 ## Non riesco a salvare un documento
 
-Controlla i campi obbligatori, i valori numerici e le date. Nei documenti commerciali verifica anche che righe, quantità, prezzi e anagrafica siano completi.
+Controlla i campi obbligatori, i valori numerici e le date. Nei moduli, i campi obbligatori sono contrassegnati da un asterisco rosso (*) accanto all'etichetta. Nei documenti commerciali verifica anche che righe, quantità, prezzi e anagrafica siano completi.
 
 ## I totali non sono quelli attesi
 

--- a/test/components/UserSettings.test.tsx
+++ b/test/components/UserSettings.test.tsx
@@ -299,13 +299,13 @@ describe('<UserSettings /> Security tab', () => {
     fireEvent.click(screen.getByText('security.title'));
 
     const samePassword = 'same-pw-1234';
-    fireEvent.change(screen.getByLabelText('password.currentPassword'), {
+    fireEvent.change(screen.getByLabelText('password.currentPassword', { exact: false }), {
       target: { value: samePassword },
     });
-    fireEvent.change(screen.getByLabelText('password.newPassword'), {
+    fireEvent.change(screen.getByLabelText('password.newPassword', { exact: false }), {
       target: { value: samePassword },
     });
-    fireEvent.change(screen.getByLabelText('password.confirmNewPassword'), {
+    fireEvent.change(screen.getByLabelText('password.confirmNewPassword', { exact: false }), {
       target: { value: samePassword },
     });
 
@@ -646,9 +646,15 @@ describe('<UserSettings /> non-local auth', () => {
 
     expect(await screen.findByText('password.lockedBanner')).toBeInTheDocument();
 
-    expect(screen.queryByLabelText('password.currentPassword')).not.toBeInTheDocument();
-    expect(screen.queryByLabelText('password.newPassword')).not.toBeInTheDocument();
-    expect(screen.queryByLabelText('password.confirmNewPassword')).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText('password.currentPassword', { exact: false }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText('password.newPassword', { exact: false }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText('password.confirmNewPassword', { exact: false }),
+    ).not.toBeInTheDocument();
 
     await waitFor(() => expect(onGetPersonalAccessToken).toHaveBeenCalled());
     expect(screen.getByText('security.personalAccessToken.title')).toBeInTheDocument();

--- a/test/components/administration/AuthSettings.test.tsx
+++ b/test/components/administration/AuthSettings.test.tsx
@@ -140,7 +140,7 @@ const fillMinimalOidcProvider = () => {
 
   const getInputByLabel = (labelText: string) => {
     const label = [...form.querySelectorAll('label')].find(
-      (element) => element.textContent === labelText,
+      (element) => element.textContent?.replace(/\s*\*$/, '') === labelText,
     );
     const input = label?.parentElement?.querySelector('input');
     if (!input) throw new Error(`Input for "${labelText}" not found`);
@@ -423,7 +423,7 @@ describe('<AuthSettings />', () => {
     fireEvent.click(screen.getByRole('button', { name: 'admin.tabs.saml' }));
     const form = screen.getByText('admin.sso.newProvider').closest('form') as HTMLFormElement;
     const slugLabel = [...form.querySelectorAll('label')].find(
-      (el) => el.textContent === 'admin.sso.slug',
+      (el) => el.textContent?.replace(/\s*\*$/, '') === 'admin.sso.slug',
     );
     const slugInput = slugLabel?.parentElement?.querySelector('input') as HTMLInputElement;
     fireEvent.change(slugInput, { target: { value: 'okta' } });
@@ -463,7 +463,7 @@ describe('<AuthSettings />', () => {
     // And the retry produces a usable URL.
     const form = screen.getByText('admin.sso.newProvider').closest('form') as HTMLFormElement;
     const slugLabel = [...form.querySelectorAll('label')].find(
-      (el) => el.textContent === 'admin.sso.slug',
+      (el) => el.textContent?.replace(/\s*\*$/, '') === 'admin.sso.slug',
     );
     const slugInput = slugLabel?.parentElement?.querySelector('input') as HTMLInputElement;
     fireEvent.change(slugInput, { target: { value: 'okta' } });
@@ -495,7 +495,7 @@ describe('<AuthSettings />', () => {
     // Wait for the error UI so we know the first attempt resolved into the 'error' state.
     const form = screen.getByText('admin.sso.newProvider').closest('form') as HTMLFormElement;
     const slugLabel = [...form.querySelectorAll('label')].find(
-      (el) => el.textContent === 'admin.sso.slug',
+      (el) => el.textContent?.replace(/\s*\*$/, '') === 'admin.sso.slug',
     );
     const slugInput = slugLabel?.parentElement?.querySelector('input') as HTMLInputElement;
     fireEvent.change(slugInput, { target: { value: 'okta' } });
@@ -534,7 +534,7 @@ describe('<AuthSettings />', () => {
     fireEvent.click(screen.getByRole('button', { name: 'admin.tabs.saml' }));
     const form = screen.getByText('admin.sso.newProvider').closest('form') as HTMLFormElement;
     const slugLabel = [...form.querySelectorAll('label')].find(
-      (el) => el.textContent === 'admin.sso.slug',
+      (el) => el.textContent?.replace(/\s*\*$/, '') === 'admin.sso.slug',
     );
     const slugInput = slugLabel?.parentElement?.querySelector('input') as HTMLInputElement;
     fireEvent.change(slugInput, { target: { value: 'okta' } });

--- a/test/components/catalog/InternalListingModalStyling.test.ts
+++ b/test/components/catalog/InternalListingModalStyling.test.ts
@@ -11,7 +11,7 @@ describe('InternalListingView modal styling', () => {
 
     expectSourceContainsAll(source, [
       "import { Button } from '@/components/ui/button';",
-      "import { FieldLabel } from '@/components/ui/field';",
+      "import { FieldLabel, RequiredMark } from '@/components/ui/field';",
       "import { Input } from '@/components/ui/input';",
       "import { Textarea } from '@/components/ui/textarea';",
       '<ModalContent size="2xl" className="max-h-[90vh]">',

--- a/test/components/projects/TasksView.test.ts
+++ b/test/components/projects/TasksView.test.ts
@@ -21,7 +21,7 @@ describe('TasksView', () => {
       expect(source).toContain('<ModalFooter className="sm:justify-between">');
       expect(source).toContain('<div className="grid gap-4 md:grid-cols-2">');
       expect(source).toContain('<div className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">');
-      expect(source).toContain('<FieldLabel htmlFor="task-name">');
+      expect(source).toContain('<FieldLabel htmlFor="task-name" required>');
       expect(source).toContain('<FieldLabel htmlFor="task-description">');
       expect(source).toContain('<FieldLabel htmlFor="task-notes">');
       expect(source).toContain('<Input');


### PR DESCRIPTION
## What & why

Required form fields across the app had no visual indicator. This PR adds a **red asterisk** marker next to the label of every required field, app-wide, and lands it as proper shared infrastructure rather than duplicated markup.

## How it works

- New shared **`RequiredMark`** component in `components/ui/field.tsx` — uses the theme token `text-destructive` (respects the user's theme, per CLAUDE.md) and `aria-hidden="true"` (the asterisk is decorative; required-ness is conveyed to assistive tech via the input's own `required`/validation).
- A **`required` prop** on the shared `FieldLabel` and `SelectControl` primitives, so call sites write `<FieldLabel required>` / `<SelectControl required>` instead of hand-appending JSX.
- All ~50 required-field labels across CRM, sales, accounting, projects, administration, HR, timesheet, catalog, settings, and auth forms now use this mechanism.
- **Converged** pre-existing duplication onto the shared component: two local `RequiredMark` defs (ProjectsView/ProjectDetailView), ClientsView's literals, and the DailyView/EntryEditDialog bare spans.

"Required" was determined from each form's validation/submit logic and HTML `required` attributes — optional fields are intentionally left unmarked.

## Conditional-required correctness

Several fields are required only in certain states; the marker is gated on the actual condition rather than shown unconditionally:

- SuppliersView `vatNumber` → create-only (`!editingSupplier`)
- WorkUnitsView `managers` → create-only (new `managersRequired` prop)
- UserSettings `fullName`/`email` → local-auth only (`isLocalAuth`)
- AuthSettings OIDC `issuerUrl`/`clientId`/`usernameAttribute` → `draft.enabled`; LDAP server/base/user/group filters → `ldapForm.enabled`
- UserManagement edit `firstName` → hidden when the identity is provider-managed

## Testing

- `bun run lint` (i18n keys + typecheck + Biome): clean
- Frontend suite: **1587 pass / 0 fail** — updated a few label selectors to tolerate the marker (AuthSettings `textContent` lookups, UserSettings `getByLabelText`) and two source-string assertions (TaskFormModal `required` prop, InternalListing import)
- Server suite: 3346 pass / 0 fail (unchanged — no server code touched)
- React Doctor score: **66 → 66** (no regression)

## Docs

Noted the asterisk convention in the IT/EN FAQ ("I cannot save a document").

## Reviewer notes

- The marker renders as `<span class="text-destructive" aria-hidden> *</span>` — red in both light and dark themes.
- Two intentionally **unmarked** ambiguous spots: the Login TOTP backup-code field and the CustomViewModal columns group-legend (neither is a standard single required field). Easy to add if desired.
- Pre-existing non-asterisk `text-red-500` usages (invoice balance coloring, Login alert icon, validation-error text) were left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)