### PR TITLE
Replace native date inputs with the audit-log calendar picker

### DIFF
--- a/components/HR/EmployeeHrFields.tsx
+++ b/components/HR/EmployeeHrFields.tsx
@@ -10,6 +10,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
+import DateField from '../shared/DateField';
 import {
   CONTRACT_TYPE_OPTIONS,
   EMPLOYMENT_STATUS_OPTIONS,
@@ -204,11 +205,10 @@ const EmployeeHrFields: React.FC<EmployeeHrFieldsProps> = ({
 
           <Field>
             <FieldLabel htmlFor={`${prefix}-hire-date`}>{t('employeeProfile.hireDate')}</FieldLabel>
-            <Input
+            <DateField
               id={`${prefix}-hire-date`}
-              type="date"
               value={formData.hireDate}
-              onChange={(e) => setField('hireDate', e.target.value)}
+              onChange={(value) => setField('hireDate', value)}
             />
           </Field>
 
@@ -216,11 +216,10 @@ const EmployeeHrFields: React.FC<EmployeeHrFieldsProps> = ({
             <FieldLabel htmlFor={`${prefix}-termination-date`}>
               {t('employeeProfile.terminationDate')}
             </FieldLabel>
-            <Input
+            <DateField
               id={`${prefix}-termination-date`}
-              type="date"
               value={formData.terminationDate}
-              onChange={(e) => setField('terminationDate', e.target.value)}
+              onChange={(value) => setField('terminationDate', value)}
               aria-invalid={Boolean(errors.terminationDate)}
             />
             <FieldError className="text-xs">{errors.terminationDate}</FieldError>

--- a/components/accounting/ClientsInvoicesView.tsx
+++ b/components/accounting/ClientsInvoicesView.tsx
@@ -10,6 +10,7 @@ import type { Client, Invoice, InvoiceItem, Product } from '../../types';
 import { addDaysToDateOnly, formatDateOnlyForLocale, getLocalDateString } from '../../utils/date';
 import { calcProductSalePrice } from '../../utils/numbers';
 import CostSummaryPanel from '../shared/CostSummaryPanel';
+import DateField from '../shared/DateField';
 import DeleteConfirmModal from '../shared/DeleteConfirmModal';
 import HeaderAddButton from '../shared/HeaderAddButton';
 import Modal from '../shared/Modal';
@@ -628,14 +629,11 @@ const ClientsInvoicesView: React.FC<ClientsInvoicesViewProps> = ({
                     <FieldLabel htmlFor="client-invoice-issue-date">
                       {t('accounting:clientsInvoices.issueDate')}
                     </FieldLabel>
-                    <Input
+                    <DateField
                       id="client-invoice-issue-date"
-                      type="date"
                       required
                       value={formData.issueDate}
-                      onChange={(event) =>
-                        setFormData((prev) => ({ ...prev, issueDate: event.target.value }))
-                      }
+                      onChange={(value) => setFormData((prev) => ({ ...prev, issueDate: value }))}
                       aria-invalid={Boolean(errors.issueDate)}
                     />
                     <FieldError className="text-xs">{errors.issueDate}</FieldError>
@@ -644,14 +642,11 @@ const ClientsInvoicesView: React.FC<ClientsInvoicesViewProps> = ({
                     <FieldLabel htmlFor="client-invoice-due-date">
                       {t('accounting:clientsInvoices.dueDate')}
                     </FieldLabel>
-                    <Input
+                    <DateField
                       id="client-invoice-due-date"
-                      type="date"
                       required
                       value={formData.dueDate}
-                      onChange={(event) =>
-                        setFormData((prev) => ({ ...prev, dueDate: event.target.value }))
-                      }
+                      onChange={(value) => setFormData((prev) => ({ ...prev, dueDate: value }))}
                       aria-invalid={Boolean(errors.dueDate)}
                     />
                     <FieldError className="text-xs">{errors.dueDate}</FieldError>

--- a/components/accounting/SupplierInvoicesView.tsx
+++ b/components/accounting/SupplierInvoicesView.tsx
@@ -14,6 +14,7 @@ import {
   normalizeDateOnlyString,
 } from '../../utils/date';
 import CostSummaryPanel from '../shared/CostSummaryPanel';
+import DateField from '../shared/DateField';
 import DeleteConfirmModal from '../shared/DeleteConfirmModal';
 import Modal from '../shared/Modal';
 import {
@@ -474,13 +475,12 @@ const SupplierInvoicesView: React.FC<SupplierInvoicesViewProps> = ({
                     <FieldLabel htmlFor="supplier-invoice-issue-date">
                       {t('accounting:supplierInvoices.issueDate')}
                     </FieldLabel>
-                    <Input
+                    <DateField
                       id="supplier-invoice-issue-date"
-                      type="date"
                       required
                       value={formData.issueDate || ''}
-                      onChange={(event) =>
-                        dispatch({ type: 'patchForm', patch: { issueDate: event.target.value } })
+                      onChange={(value) =>
+                        dispatch({ type: 'patchForm', patch: { issueDate: value } })
                       }
                     />
                   </Field>
@@ -488,13 +488,12 @@ const SupplierInvoicesView: React.FC<SupplierInvoicesViewProps> = ({
                     <FieldLabel htmlFor="supplier-invoice-due-date">
                       {t('accounting:supplierInvoices.dueDate')}
                     </FieldLabel>
-                    <Input
+                    <DateField
                       id="supplier-invoice-due-date"
-                      type="date"
                       required
                       value={formData.dueDate || ''}
-                      onChange={(event) =>
-                        dispatch({ type: 'patchForm', patch: { dueDate: event.target.value } })
+                      onChange={(value) =>
+                        dispatch({ type: 'patchForm', patch: { dueDate: value } })
                       }
                     />
                   </Field>

--- a/components/projects/ProjectDetailView.tsx
+++ b/components/projects/ProjectDetailView.tsx
@@ -55,6 +55,7 @@ import type {
 import { formatInsertDate } from '../../utils/date';
 import { calculatePricingTotals } from '../../utils/numbers';
 import { hasPermission, hasScopedActionPermission } from '../../utils/permissions';
+import DateField from '../shared/DateField';
 import DeleteConfirmModal from '../shared/DeleteConfirmModal';
 import SelectControl from '../shared/SelectControl';
 import StatusBadge from '../shared/StatusBadge';
@@ -1030,14 +1031,13 @@ const ProjectDetailView: React.FC<ProjectDetailViewProps> = ({
               <FieldLabel htmlFor="detail-start-date">
                 {t('projects:projects.startDate')} {project.startDate && <RequiredMark />}
               </FieldLabel>
-              <Input
+              <DateField
                 id="detail-start-date"
-                type="date"
                 value={startDate}
                 disabled={!canUpdateProjects}
                 aria-invalid={Boolean(errors.startDate || errors.dateRange)}
-                onChange={(e) => {
-                  setStartDate(e.target.value);
+                onChange={(value) => {
+                  setStartDate(value);
                   if (errors.startDate || errors.dateRange) {
                     setErrors((prev) => ({ ...prev, startDate: '', dateRange: '' }));
                   }
@@ -1049,14 +1049,13 @@ const ProjectDetailView: React.FC<ProjectDetailViewProps> = ({
               <FieldLabel htmlFor="detail-end-date">
                 {t('projects:projects.endDate')} {project.endDate && <RequiredMark />}
               </FieldLabel>
-              <Input
+              <DateField
                 id="detail-end-date"
-                type="date"
                 value={endDate}
                 disabled={!canUpdateProjects}
                 aria-invalid={Boolean(errors.endDate || errors.dateRange)}
-                onChange={(e) => {
-                  setEndDate(e.target.value);
+                onChange={(value) => {
+                  setEndDate(value);
                   if (errors.endDate || errors.dateRange) {
                     setErrors((prev) => ({ ...prev, endDate: '', dateRange: '' }));
                   }

--- a/components/projects/ProjectsView.tsx
+++ b/components/projects/ProjectsView.tsx
@@ -22,6 +22,7 @@ import type {
 import { formatInsertDate } from '../../utils/date';
 import { calculatePricingTotals } from '../../utils/numbers';
 import { buildPermission, hasPermission, hasScopedActionPermission } from '../../utils/permissions';
+import DateField from '../shared/DateField';
 import DeleteConfirmModal from '../shared/DeleteConfirmModal';
 import HeaderAddButton from '../shared/HeaderAddButton';
 import Modal from '../shared/Modal';
@@ -771,14 +772,13 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
                       <FieldLabel htmlFor="project-start-date">
                         {t('projects:projects.startDate')} <RequiredMark />
                       </FieldLabel>
-                      <Input
+                      <DateField
                         id="project-start-date"
-                        type="date"
                         required
                         value={startDate}
                         aria-invalid={Boolean(errors.startDate || errors.dateRange)}
-                        onChange={(e) => {
-                          setStartDate(e.target.value);
+                        onChange={(value) => {
+                          setStartDate(value);
                           if (errors.startDate || errors.dateRange) {
                             setErrors((prev) => ({ ...prev, startDate: '', dateRange: '' }));
                           }
@@ -790,14 +790,13 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
                       <FieldLabel htmlFor="project-end-date">
                         {t('projects:projects.endDate')} <RequiredMark />
                       </FieldLabel>
-                      <Input
+                      <DateField
                         id="project-end-date"
-                        type="date"
                         required
                         value={endDate}
                         aria-invalid={Boolean(errors.endDate || errors.dateRange)}
-                        onChange={(e) => {
-                          setEndDate(e.target.value);
+                        onChange={(value) => {
+                          setEndDate(value);
                           if (errors.endDate || errors.dateRange) {
                             setErrors((prev) => ({ ...prev, endDate: '', dateRange: '' }));
                           }

--- a/components/sales/ClientOffersView.tsx
+++ b/components/sales/ClientOffersView.tsx
@@ -39,6 +39,7 @@ import { getPaymentTermsOptions } from '../../utils/options';
 import { makeCostUpdater, makeMolUpdater } from '../../utils/pricingHandlers';
 import { toastError } from '../../utils/toast';
 import CostSummaryPanel from '../shared/CostSummaryPanel';
+import DateField from '../shared/DateField';
 import DeleteConfirmModal from '../shared/DeleteConfirmModal';
 import FieldTooltip from '../shared/FieldTooltip';
 import HeaderAddButton from '../shared/HeaderAddButton';
@@ -1132,14 +1133,13 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                           defaultValue: 'Expiration date',
                         })}
                       </FieldLabel>
-                      <Input
+                      <DateField
                         id="client-offer-expiration-date"
-                        type="date"
                         required
                         value={formData.expirationDate || ''}
                         disabled={isReadOnly}
-                        onChange={(event) =>
-                          setFormData((prev) => ({ ...prev, expirationDate: event.target.value }))
+                        onChange={(value) =>
+                          setFormData((prev) => ({ ...prev, expirationDate: value }))
                         }
                       />
                     </Field>

--- a/components/sales/ClientQuotesView.tsx
+++ b/components/sales/ClientQuotesView.tsx
@@ -40,6 +40,7 @@ import { getPaymentTermsOptions } from '../../utils/options';
 import { makeCostUpdater, makeMolUpdater } from '../../utils/pricingHandlers';
 import { toastError } from '../../utils/toast';
 import CostSummaryPanel from '../shared/CostSummaryPanel';
+import DateField from '../shared/DateField';
 import DeleteConfirmModal from '../shared/DeleteConfirmModal';
 import FieldTooltip from '../shared/FieldTooltip';
 import HeaderAddButton from '../shared/HeaderAddButton';
@@ -1443,13 +1444,12 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                       <FieldLabel htmlFor="client-quote-expiration-date">
                         {t('sales:clientQuotes.expirationDateLabel')}
                       </FieldLabel>
-                      <Input
+                      <DateField
                         id="client-quote-expiration-date"
-                        type="date"
                         required
                         value={formData.expirationDate}
-                        onChange={(e) =>
-                          setFormData((prev) => ({ ...prev, expirationDate: e.target.value }))
+                        onChange={(value) =>
+                          setFormData((prev) => ({ ...prev, expirationDate: value }))
                         }
                         disabled={isReadOnly}
                       />

--- a/components/sales/SupplierQuotesView.tsx
+++ b/components/sales/SupplierQuotesView.tsx
@@ -27,6 +27,7 @@ import { convertUnitPrice, parseNumberInputValue } from '../../utils/numbers';
 import { getPaymentTermsOptions } from '../../utils/options';
 import { toastError } from '../../utils/toast';
 import CostSummaryPanel from '../shared/CostSummaryPanel';
+import DateField from '../shared/DateField';
 import DeleteConfirmModal from '../shared/DeleteConfirmModal';
 import FieldTooltip from '../shared/FieldTooltip';
 import HeaderAddButton from '../shared/HeaderAddButton';
@@ -890,13 +891,12 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
                           defaultValue: 'Expiration Date',
                         })}
                       </FieldLabel>
-                      <Input
+                      <DateField
                         id="supplier-quote-expiration-date"
-                        type="date"
                         value={formData.expirationDate || ''}
                         disabled={isReadOnly}
-                        onChange={(event) =>
-                          setFormData((prev) => ({ ...prev, expirationDate: event.target.value }))
+                        onChange={(value) =>
+                          setFormData((prev) => ({ ...prev, expirationDate: value }))
                         }
                       />
                     </Field>

--- a/components/shared/DateField.tsx
+++ b/components/shared/DateField.tsx
@@ -1,0 +1,132 @@
+import { CalendarDays } from 'lucide-react';
+import type React from 'react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/button';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { cn } from '@/lib/utils';
+import { formatDateOnlyForLocale, normalizeDateOnlyString } from '../../utils/date';
+import Calendar from './Calendar';
+
+export interface DateFieldProps {
+  /** Selected date as a `YYYY-MM-DD` string (empty/undefined/null when unset). */
+  value: string | null | undefined;
+  /** Called with the newly selected date as a `YYYY-MM-DD` string ('' when cleared). */
+  onChange: (value: string) => void;
+  id?: string;
+  name?: string;
+  disabled?: boolean;
+  /** When true, the clear affordance is hidden (the field must always hold a date). */
+  required?: boolean;
+  placeholder?: string;
+  /** Extra classes for the trigger control. */
+  className?: string;
+  'aria-invalid'?: boolean;
+  'aria-label'?: string;
+  'aria-describedby'?: string;
+  startOfWeek?: 'Monday' | 'Sunday';
+  treatSaturdayAsHoliday?: boolean;
+}
+
+/**
+ * Date-only picker built on the shared {@link Calendar} (the same calendar used by the
+ * audit-log time filters), minus the time input and apply row. Drop-in replacement for a
+ * native `<input type="date">`: it speaks `YYYY-MM-DD` strings in and out. Selecting a day
+ * commits immediately and closes the popover.
+ */
+const DateField: React.FC<DateFieldProps> = ({
+  value,
+  onChange,
+  id,
+  name,
+  disabled = false,
+  required = false,
+  placeholder,
+  className = '',
+  'aria-invalid': ariaInvalid,
+  'aria-label': ariaLabel,
+  'aria-describedby': ariaDescribedBy,
+  startOfWeek = 'Monday',
+  treatSaturdayAsHoliday = false,
+}) => {
+  const { t, i18n } = useTranslation('common');
+  const [isOpen, setIsOpen] = useState(false);
+
+  const normalized = value ? normalizeDateOnlyString(value) : '';
+  const displayValue = normalized
+    ? formatDateOnlyForLocale(normalized, i18n.language, {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+      })
+    : '';
+
+  const handleDateSelect = (dateStr: string) => {
+    onChange(dateStr);
+    setIsOpen(false);
+  };
+
+  const handleClear = () => {
+    onChange('');
+    setIsOpen(false);
+  };
+
+  const canClear = !required && !disabled && Boolean(normalized);
+
+  return (
+    <Popover open={isOpen} onOpenChange={disabled ? undefined : setIsOpen}>
+      <PopoverTrigger asChild>
+        <button
+          id={id}
+          name={name}
+          type="button"
+          disabled={disabled}
+          aria-invalid={ariaInvalid}
+          aria-label={ariaLabel}
+          aria-describedby={ariaDescribedBy}
+          className={cn(
+            'flex h-9 w-full min-w-0 items-center gap-2 rounded-md border border-input bg-transparent px-3 py-1 text-left text-base shadow-xs outline-none transition-[color,box-shadow] md:text-sm dark:bg-input/30',
+            'focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50',
+            'aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40',
+            'disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
+            className,
+          )}
+        >
+          <CalendarDays className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+          <span
+            className={cn(
+              'flex-1 truncate',
+              displayValue ? 'text-foreground' : 'text-muted-foreground',
+            )}
+          >
+            {displayValue || placeholder || t('labels.selectDate', { defaultValue: 'Select date' })}
+          </span>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-72 space-y-2.5 p-3">
+        <Calendar
+          selectedDate={normalized || undefined}
+          onDateSelect={handleDateSelect}
+          allowWeekendSelection
+          startOfWeek={startOfWeek}
+          treatSaturdayAsHoliday={treatSaturdayAsHoliday}
+          size="compact"
+          bare
+        />
+        {canClear && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={handleClear}
+            className="w-full rounded-lg bg-transparent text-foreground dark:bg-transparent"
+          >
+            {t('buttons.clear')}
+          </Button>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+export default DateField;

--- a/components/shared/DateField.tsx
+++ b/components/shared/DateField.tsx
@@ -3,6 +3,7 @@ import type React from 'react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
+import { inputBaseClassName } from '@/components/ui/inputStyles';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { cn } from '@/lib/utils';
 import { formatDateOnlyForLocale, normalizeDateOnlyString } from '../../utils/date';
@@ -14,9 +15,8 @@ export interface DateFieldProps {
   /** Called with the newly selected date as a `YYYY-MM-DD` string ('' when cleared). */
   onChange: (value: string) => void;
   id?: string;
-  name?: string;
   disabled?: boolean;
-  /** When true, the clear affordance is hidden (the field must always hold a date). */
+  /** When true, the clear affordance is hidden so the field can't be emptied once set. */
   required?: boolean;
   placeholder?: string;
   /** Extra classes for the trigger control. */
@@ -38,7 +38,6 @@ const DateField: React.FC<DateFieldProps> = ({
   value,
   onChange,
   id,
-  name,
   disabled = false,
   required = false,
   placeholder,
@@ -78,19 +77,12 @@ const DateField: React.FC<DateFieldProps> = ({
       <PopoverTrigger asChild>
         <button
           id={id}
-          name={name}
           type="button"
           disabled={disabled}
           aria-invalid={ariaInvalid}
           aria-label={ariaLabel}
           aria-describedby={ariaDescribedBy}
-          className={cn(
-            'flex h-9 w-full min-w-0 items-center gap-2 rounded-md border border-input bg-transparent px-3 py-1 text-left text-base shadow-xs outline-none transition-[color,box-shadow] md:text-sm dark:bg-input/30',
-            'focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50',
-            'aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40',
-            'disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
-            className,
-          )}
+          className={cn(inputBaseClassName, 'flex items-center gap-2 text-left', className)}
         >
           <CalendarDays className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
           <span
@@ -99,7 +91,7 @@ const DateField: React.FC<DateFieldProps> = ({
               displayValue ? 'text-foreground' : 'text-muted-foreground',
             )}
           >
-            {displayValue || placeholder || t('labels.selectDate', { defaultValue: 'Select date' })}
+            {displayValue || placeholder || t('labels.selectDate')}
           </span>
         </button>
       </PopoverTrigger>

--- a/components/timesheet/DailyView.tsx
+++ b/components/timesheet/DailyView.tsx
@@ -243,7 +243,7 @@ const DailyRepeatControls: React.FC<{
             </span>
             <DateField
               value={recurrenceEndDate}
-              onChange={(value) => onRecurrenceEndDateChange(value)}
+              onChange={onRecurrenceEndDateChange}
               aria-invalid={!!recurrenceEndDateError}
               className="text-xs font-medium shrink-0 w-auto"
             />

--- a/components/timesheet/DailyView.tsx
+++ b/components/timesheet/DailyView.tsx
@@ -11,6 +11,7 @@ import TaskFormModal, {
   type TaskFormDetails,
 } from '../projects/TaskFormModal';
 import CustomRepeatModal from '../shared/CustomRepeatModal';
+import DateField from '../shared/DateField';
 import SelectControl from '../shared/SelectControl';
 import { Button } from '../ui/button';
 import { Field, FieldLabel } from '../ui/field';
@@ -240,10 +241,9 @@ const DailyRepeatControls: React.FC<{
             <span className="text-[10px] font-bold text-muted-foreground uppercase tracking-wider whitespace-nowrap">
               {t('entry.until')}
             </span>
-            <Input
-              type="date"
+            <DateField
               value={recurrenceEndDate}
-              onChange={(event) => onRecurrenceEndDateChange(event.target.value)}
+              onChange={(value) => onRecurrenceEndDateChange(value)}
               aria-invalid={!!recurrenceEndDateError}
               className="text-xs font-medium shrink-0 w-auto"
             />

--- a/components/timesheet/RecurringTaskEditModal.tsx
+++ b/components/timesheet/RecurringTaskEditModal.tsx
@@ -3,11 +3,11 @@ import { useReducer } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { Field, FieldError, FieldGroup, FieldLabel } from '@/components/ui/field';
-import { Input } from '@/components/ui/input';
 import type { ProjectTask } from '../../types';
 import { getLocalDateString } from '../../utils/date';
 import { formatRecurrencePattern } from '../../utils/recurrence';
 import CustomRepeatModal from '../shared/CustomRepeatModal';
+import DateField from '../shared/DateField';
 import Modal from '../shared/Modal';
 import {
   ModalBody,
@@ -167,21 +167,19 @@ const RecurringTaskEditModal: React.FC<RecurringTaskEditModalProps> = ({
               <FieldGroup className="grid grid-cols-2 gap-4">
                 <Field>
                   <FieldLabel htmlFor="recurring-start-date">{t('recurring.startDate')}</FieldLabel>
-                  <Input
+                  <DateField
                     id="recurring-start-date"
-                    type="date"
                     value={startDate}
-                    onChange={(e) => dispatch({ type: 'setStartDate', startDate: e.target.value })}
+                    onChange={(value) => dispatch({ type: 'setStartDate', startDate: value })}
                   />
                 </Field>
                 <Field data-invalid={Boolean(dateError)}>
                   <FieldLabel htmlFor="recurring-end-date">{t('recurring.endDate')}</FieldLabel>
-                  <Input
+                  <DateField
                     id="recurring-end-date"
-                    type="date"
                     value={endDate}
                     aria-invalid={Boolean(dateError)}
-                    onChange={(e) => dispatch({ type: 'setEndDate', endDate: e.target.value })}
+                    onChange={(value) => dispatch({ type: 'setEndDate', endDate: value })}
                   />
                 </Field>
               </FieldGroup>

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,6 +1,7 @@
 import type * as React from 'react';
 
 import { cn } from '@/lib/utils';
+import { inputBaseClassName } from './inputStyles';
 
 function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
   return (
@@ -8,9 +9,8 @@ function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
       type={type}
       data-slot="input"
       className={cn(
-        'h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:bg-input/30',
-        'focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50',
-        'aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40',
+        inputBaseClassName,
+        'selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground',
         className,
       )}
       {...props}

--- a/components/ui/inputStyles.ts
+++ b/components/ui/inputStyles.ts
@@ -1,0 +1,9 @@
+/**
+ * Shared appearance + interaction-state classes for input-shaped controls: base sizing,
+ * border, background, focus ring, and the disabled / aria-invalid treatments. Reused by
+ * the `Input` component and by input-like Popover triggers (e.g. the date picker) so they
+ * can't drift apart. Excludes `<input>`-only utilities (selection / file / placeholder)
+ * that non-input triggers don't need.
+ */
+export const inputBaseClassName =
+  'h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:bg-input/30 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40';

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -89,7 +89,8 @@
     "clearFilters": "Clear filters",
     "searchPlaceholder": "Search...",
     "rowsPerPage": "Rows per page",
-    "actions": "Actions"
+    "actions": "Actions",
+    "selectDate": "Select date"
   },
   "validation": {
     "required": "This field is required",

--- a/locales/it/common.json
+++ b/locales/it/common.json
@@ -89,7 +89,8 @@
     "clearFilters": "Cancella filtri",
     "searchPlaceholder": "Cerca...",
     "rowsPerPage": "Righe per pagina",
-    "actions": "Azioni"
+    "actions": "Azioni",
+    "selectDate": "Seleziona data"
   },
   "validation": {
     "required": "Questo campo è obbligatorio",

--- a/test/components/shared/DateField.test.tsx
+++ b/test/components/shared/DateField.test.tsx
@@ -1,0 +1,70 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { installI18nMock } from '../../helpers/i18n';
+import { render } from '../../helpers/render';
+
+installI18nMock();
+
+const DateField = (await import('../../../components/shared/DateField')).default;
+
+describe('<DateField />', () => {
+  test('shows the placeholder label when no value is set', () => {
+    render(<DateField value="" onChange={() => {}} />);
+    // identity i18n mock returns the translation key verbatim
+    expect(screen.getByText('labels.selectDate')).toBeInTheDocument();
+  });
+
+  test('renders the selected date formatted for the locale', () => {
+    render(<DateField value="2024-03-15" onChange={() => {}} />);
+    const trigger = screen.getByRole('button');
+    // en locale → 2-digit month/day, numeric year
+    expect(trigger.textContent).toContain('03/15/2024');
+  });
+
+  test('selecting a day commits a YYYY-MM-DD string', async () => {
+    const onChange = mock((_v: string) => {});
+    const user = userEvent.setup();
+    render(<DateField value="2024-03-10" onChange={onChange} />);
+
+    await user.click(screen.getByRole('button'));
+    const day20 = await screen.findByText('20');
+    await user.click(day20);
+
+    expect(onChange).toHaveBeenCalledWith('2024-03-20');
+  });
+
+  test('optional fields expose a clear action that emits an empty string', async () => {
+    const onChange = mock((_v: string) => {});
+    const user = userEvent.setup();
+    render(<DateField value="2024-03-10" onChange={onChange} />);
+
+    await user.click(screen.getByRole('button'));
+    const clear = await screen.findByText('buttons.clear');
+    await user.click(clear);
+
+    expect(onChange).toHaveBeenCalledWith('');
+  });
+
+  test('required fields do not render a clear action', async () => {
+    const user = userEvent.setup();
+    render(<DateField value="2024-03-10" required onChange={() => {}} />);
+
+    await user.click(screen.getByRole('button'));
+    // Wait for the calendar to mount before asserting the clear button is absent.
+    await screen.findByText('20');
+    expect(screen.queryByText('buttons.clear')).not.toBeInTheDocument();
+  });
+
+  test('disabled field keeps the calendar closed', () => {
+    render(<DateField value="2024-03-10" disabled onChange={() => {}} />);
+    const trigger = screen.getByRole('button');
+    expect(trigger).toBeDisabled();
+    expect(screen.queryByText('20')).not.toBeInTheDocument();
+  });
+
+  test('reflects an aria-invalid state on the trigger', () => {
+    render(<DateField value="" onChange={() => {}} aria-invalid />);
+    expect(screen.getByRole('button')).toHaveAttribute('aria-invalid', 'true');
+  });
+});


### PR DESCRIPTION
@
## What

Replaces every native `<input type="date">` in the app with a shared **`DateField`** picker built on the same styled `Calendar` used by the audit-log time filters — but **without the hour input and apply/submit row**.

New component: [`components/shared/DateField.tsx`](https://github.com/xBounceIT/praetor/blob/claude/crazy-noyce-17bc08/components/shared/DateField.tsx)
- Drop-in replacement for a native date input: speaks `YYYY-MM-DD` strings in and out.
- Renders the shared `Calendar` (month/year dropdowns, *Oggi*/today, weekend·holiday markings, festivo/goal legend) inside a shadcn `Popover`.
- Commits on day-select and closes; exposes a *Cancella*/Clear action for optional fields (suppressed when `required`).
- Excludes the time field + apply (↑) row that the audit-log `DatePickerButton` adds.

Call sites converted (10 inputs across 10 files):
- **Accounting:** client invoices (issue/due), supplier invoices (issue/due)
- **Sales:** client quotes, client offers, supplier quotes (expiration)
- **Projects:** create & detail forms (start/end)
- **HR:** employee hire/termination dates
- **Timesheet:** recurring-task start/end, daily recurrence end

## Why

The app mixed OS-native date pickers (inconsistent look per browser/OS, light-on-dark theming issues) with the polished custom calendar used in audit-log filters. This unifies date selection on the themed calendar everywhere, matching the audit-log experience.

## How

- Each call site swapped `<Input type="date" onChange={(e)=>…e.target.value}>` for `<DateField onChange={(value)=>…value}>`, preserving `id`, `disabled`, `aria-invalid`, and validation. Native `required` was not load-bearing (these modals validate in JS or pre-fill defaults), so it now maps to "not clearable".
- Added a `labels.selectDate` placeholder key to the `en`/`it` `common` locales.

## Cleanup pass (second commit)

A `/code-review`-style cleanup followed:
- Extracted the duplicated shadcn `Input` class string into a shared `inputBaseClassName` ([`components/ui/inputStyles.ts`](https://github.com/xBounceIT/praetor/blob/claude/crazy-noyce-17bc08/components/ui/inputStyles.ts)), reused by both `Input` and the `DateField` trigger so they can no longer drift (kept in a styles-only module so `ui/input.tsx` still exports only its component → Fast Refresh intact).
- Removed a dead `name` prop, a redundant i18n `defaultValue`, and a pass-through arrow wrapper; clarified the `required` JSDoc.

## Reviewer notes

- `DateField` is intentionally kept separate from `DatePickerButton` (the audit-log date+time picker): different value types (`string` vs `Date`) and commit semantics (commit-on-select vs apply row). Merging them behind a flag would be worse altitude.
- Date-only selection means no free-text typing / `min`/`max`; none of the converted fields used those.

## Testing

- New unit tests: [`test/components/shared/DateField.test.tsx`](https://github.com/xBounceIT/praetor/blob/claude/crazy-noyce-17bc08/test/components/shared/DateField.test.tsx) (7 tests: placeholder, locale formatting, day-select emits `YYYY-MM-DD`, clear for optional, no-clear when required, disabled, aria-invalid).
- Full frontend suite: **1594 pass / 0 fail**.
- Lint clean (i18n keys + `tsc` + Biome, 0 warnings). React Doctor steady at **66/100** (no regression).
- Docs reviewed: no docs reference the date-input widget; selection behavior/data shape unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@