### PR TITLE
fix(ui): searchable select dropdown fits content and scrolls with the wheel inside dialogs

### DIFF
--- a/components/shared/SelectControl.tsx
+++ b/components/shared/SelectControl.tsx
@@ -1,6 +1,6 @@
 import { CheckIcon, ChevronsUpDownIcon, XIcon } from 'lucide-react';
 import type React from 'react';
-import { useMemo, useReducer } from 'react';
+import { useMemo, useReducer, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Button } from '@/components/ui/button';
@@ -58,6 +58,18 @@ const toSelectValue = (value: string) => (value === '' ? EMPTY_VALUE_SENTINEL : 
 const fromSelectValue = (value: string) => (value === EMPTY_VALUE_SENTINEL ? '' : value);
 
 const baseTriggerClassName = 'w-full min-w-0 justify-between text-left text-sm font-normal';
+
+/**
+ * When the combobox lives inside a modal dialog, Radix's scroll-lock
+ * (`react-remove-scroll`) only whitelists the dialog's own content subtree.
+ * This popover is portaled to `document.body` — outside that subtree — so the
+ * scroll-lock swallows wheel events over the option list (dragging the scrollbar
+ * still works, since that's a pointer interaction). Promoting the popover to
+ * `modal` gives it its own scroll-lock that whitelists the list, restoring wheel
+ * scrolling. Page-level selects stay non-modal so they never lock page scroll.
+ */
+const isInsideModalDialog = (element: HTMLElement | null) =>
+  Boolean(element?.closest('[data-slot="dialog-content"],[data-slot="sheet-content"]'));
 
 const getSingleSelectedOption = (options: Option[], value: string | string[]) => {
   if (Array.isArray(value)) return undefined;
@@ -211,6 +223,8 @@ const SearchableSelectControl = ({
     searchTerm: '',
   });
   const { open, searchTerm } = state;
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const [modal, setModal] = useState(false);
   const selectedOption = getSingleSelectedOption(options, value);
   const selectedValueSet = useMemo(() => new Set(Array.isArray(value) ? value : []), [value]);
   const selectedOptions = useMemo(
@@ -267,12 +281,19 @@ const SearchableSelectControl = ({
       <SelectLabel id={id} label={label} />
       <Popover
         open={open}
+        modal={modal}
         onOpenChange={
-          disabled ? undefined : (nextOpen) => dispatch({ type: 'setOpen', open: nextOpen })
+          disabled
+            ? undefined
+            : (nextOpen) => {
+                if (nextOpen) setModal(isInsideModalDialog(triggerRef.current));
+                dispatch({ type: 'setOpen', open: nextOpen });
+              }
         }
       >
         <PopoverTrigger asChild>
           <Button
+            ref={triggerRef}
             type="button"
             id={id}
             variant="outline"

--- a/components/shared/SelectControl.tsx
+++ b/components/shared/SelectControl.tsx
@@ -313,7 +313,7 @@ const SearchableSelectControl = ({
           </Button>
         </PopoverTrigger>
         <PopoverContent
-          className="w-[var(--radix-popover-trigger-width)] min-w-[12rem] p-0"
+          className="w-fit min-w-[max(12rem,var(--radix-popover-trigger-width))] max-w-[var(--radix-popover-content-available-width)] p-0"
           align="start"
         >
           <Command shouldFilter={false}>

--- a/test/components/SelectControl.test.tsx
+++ b/test/components/SelectControl.test.tsx
@@ -126,6 +126,26 @@ describe('<SelectControl />', () => {
     expect(popoverContent?.className).toContain('z-[90]');
   });
 
+  test('searchable popover content sizes to fit its options instead of clipping to the trigger width', () => {
+    render(<SelectControl options={options} value="" onChange={() => {}} searchable />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    const popoverContent = document.querySelector('[data-slot="popover-content"]');
+    // Grows to fit the widest option (no truncated supplier names)...
+    expect(popoverContent?.className).toContain('w-fit');
+    // ...but never narrower than the trigger...
+    expect(popoverContent?.className).toContain(
+      'min-w-[max(12rem,var(--radix-popover-trigger-width))]',
+    );
+    // ...and never wider than the available viewport space (stays on screen).
+    expect(popoverContent?.className).toContain(
+      'max-w-[var(--radix-popover-content-available-width)]',
+    );
+    // The old behaviour hard-pinned the panel to the trigger width, clipping content.
+    expect(popoverContent?.className).not.toContain('w-[var(--radix-popover-trigger-width)]');
+  });
+
   test('multi combobox toggles selected values and renders chips', () => {
     const onChange = mock((_value: string | string[]) => {});
     const { rerender } = render(

--- a/test/components/SelectControl.test.tsx
+++ b/test/components/SelectControl.test.tsx
@@ -146,6 +146,31 @@ describe('<SelectControl />', () => {
     expect(popoverContent?.className).not.toContain('w-[var(--radix-popover-trigger-width)]');
   });
 
+  test('searchable combobox stays non-modal on a plain page so it never locks page scroll', () => {
+    render(<SelectControl options={options} value="" onChange={() => {}} searchable />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    // A non-modal popover leaves the rest of the page interactive.
+    expect(document.body.style.pointerEvents).not.toBe('none');
+  });
+
+  test('searchable combobox becomes modal inside a dialog so the option list scrolls with the wheel', () => {
+    // Inside a modal dialog, Radix's scroll-lock whitelists only the dialog's own
+    // subtree, so wheel events over this portaled popover are swallowed. Promoting
+    // it to modal gives it its own scroll-lock; Radix signals modality by disabling
+    // outside pointer events.
+    render(
+      <div data-slot="dialog-content">
+        <SelectControl options={options} value="" onChange={() => {}} searchable />
+      </div>,
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(document.body.style.pointerEvents).toBe('none');
+  });
+
   test('multi combobox toggles selected values and renders chips', () => {
     const onChange = mock((_value: string | string[]) => {});
     const { rerender } = render(


### PR DESCRIPTION
Two related fixes to the shared searchable `SelectControl` (the cmdk combobox used for the sales line-item supplier-quote / product selects, and ~25 other call sites).

## 1. Dropdown sizes to fit content

The panel was hard-pinned to the trigger width (`w-[var(--radix-popover-trigger-width)]`), so in narrow grid columns long option names ("SecureEdge Syste…") were truncated.

```diff
- className="w-[var(--radix-popover-trigger-width)] min-w-[12rem] p-0"
+ className="w-fit min-w-[max(12rem,var(--radix-popover-trigger-width))] max-w-[var(--radix-popover-content-available-width)] p-0"
```

`w-fit` shrink-wraps to the widest option, floored at the trigger width and capped at the available viewport width (stays on screen). The plain (non-searchable) variant already fits content via Radix Select''s `item-aligned` positioning, so it''s untouched.

## 2. Wheel scroll works inside dialogs

Inside a modal (Radix `Dialog` / `Sheet`), the option list scrolled by dragging the scrollbar but not with the mouse wheel. The dialog''s scroll-lock (`react-remove-scroll`) only whitelists the dialog''s own subtree; the popover is portaled to `document.body` — outside it — so wheel events over the list were swallowed (scrollbar drag is a pointer event, so it survived).

Fix: promote the popover to `modal` **only when it lives inside a dialog/sheet** (detected via the trigger''s nearest `[data-slot="dialog-content"]` / `[data-slot="sheet-content"]`). A modal popover establishes its own scroll-lock that whitelists the list. Page-level selects stay non-modal so they never lock page scroll.

## Why at the shared-component level

Both fixes land in `components/shared/SelectControl.tsx`, so every searchable select across the app benefits — not just the sales views.

## Notes for reviewers

- The Radix `PopoverContent` is portaled to `document.body`, so a panel wider than its grid column/modal floats above and is viewport-bounded (not clipped) — standard combobox behaviour and the intended fix.
- The modal-scroll fix mirrors the canonical Radix "combobox inside a Dialog" pattern; verified against the actual `react-remove-scroll` / Radix Popover source (the modal popover''s `RemoveScroll` wraps the content directly, so wheel-over-list is whitelisted; no `node_modules` patch needed).
- The closed trigger still truncates (fixed-width column) and keeps its hover tooltip — out of scope.

## Testing

`test/components/SelectControl.test.tsx` — added guards for: fit-content sizing (no longer pins to trigger width), modal-inside-dialog (its own scroll-lock), and non-modal-on-page (no page scroll-lock regression). 18 tests pass.

Biome clean · `tsc --noEmit` exit 0 · React Doctor 66 → 66 (no regression). Docs deemed unchanged (internal CSS/behaviour fix, no API change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)