### PR TITLE
react-doctor cleanup: a11y, dead code, perf, useReducer (66 to 68)

### DIFF
--- a/components/CRM/ClientsView.tsx
+++ b/components/CRM/ClientsView.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useReducer } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { Field, FieldError, FieldLabel, RequiredMark } from '@/components/ui/field';
@@ -172,6 +172,204 @@ const hydrateContactsForEdit = (
   ];
 };
 
+interface ClientsViewState {
+  isModalOpen: boolean;
+  editingClient: Client | null;
+  errors: Record<string, string>;
+  formData: Partial<Client>;
+  contactsExpanded: boolean;
+  contactDraft: ClientContact | null;
+  editingContactIndex: number | null;
+  contactDraftError: string | null;
+  isDeleteConfirmOpen: boolean;
+  clientToDelete: Client | null;
+  profileOptions: ClientProfileOptionsByCategory;
+  isLoadingProfileOptions: boolean;
+  isManageProfileOptionModalOpen: boolean;
+  manageCategory: ClientProfileOptionCategory;
+  editingProfileOption: ClientProfileOption | null;
+  newProfileOptionValue: string;
+  profileOptionError: string | null;
+  isSavingProfileOption: boolean;
+}
+
+const INITIAL_CLIENTS_STATE: ClientsViewState = {
+  isModalOpen: false,
+  editingClient: null,
+  errors: {},
+  formData: INITIAL_FORM_DATA,
+  contactsExpanded: false,
+  contactDraft: null,
+  editingContactIndex: null,
+  contactDraftError: null,
+  isDeleteConfirmOpen: false,
+  clientToDelete: null,
+  profileOptions: EMPTY_PROFILE_OPTIONS,
+  isLoadingProfileOptions: false,
+  isManageProfileOptionModalOpen: false,
+  manageCategory: 'sector',
+  editingProfileOption: null,
+  newProfileOptionValue: '',
+  profileOptionError: null,
+  isSavingProfileOption: false,
+};
+
+type ClientsViewAction =
+  | { type: 'setErrors'; value: Record<string, string> }
+  | { type: 'patchErrors'; value: Record<string, string> }
+  | { type: 'setFormData'; value: Partial<Client> }
+  | { type: 'patchFormData'; value: Partial<Client> }
+  | { type: 'setContactsExpanded'; value: boolean }
+  | { type: 'toggleContactsExpanded' }
+  | { type: 'setContactDraft'; value: ClientContact | null }
+  | { type: 'patchContactDraft'; field: keyof ClientContact; value: string }
+  | { type: 'setEditingContactIndex'; value: number | null }
+  | { type: 'setContactDraftError'; value: string | null }
+  | { type: 'setProfileOptions'; value: ClientProfileOptionsByCategory }
+  | { type: 'setIsLoadingProfileOptions'; value: boolean }
+  | { type: 'setIsModalOpen'; value: boolean }
+  | { type: 'setIsManageProfileOptionModalOpen'; value: boolean }
+  | { type: 'setEditingProfileOption'; value: ClientProfileOption | null }
+  | { type: 'setNewProfileOptionValue'; value: string }
+  | { type: 'setProfileOptionError'; value: string | null }
+  | { type: 'setIsSavingProfileOption'; value: boolean }
+  | { type: 'openAddModal' }
+  | { type: 'openEditModal'; client: Client; formData: Partial<Client>; contactsExpanded: boolean }
+  | { type: 'closeModal' }
+  | { type: 'addContact'; clearContactsError: boolean }
+  | { type: 'editContact'; contact: ClientContact; index: number; clearContactsError: boolean }
+  | { type: 'cancelContactDraft' }
+  | { type: 'confirmDelete'; client: Client }
+  | { type: 'setIsDeleteConfirmOpen'; value: boolean }
+  | { type: 'closeDeleteConfirm' }
+  | { type: 'openManageProfileOptions'; category: ClientProfileOptionCategory };
+
+const clientsViewReducer = (
+  state: ClientsViewState,
+  action: ClientsViewAction,
+): ClientsViewState => {
+  switch (action.type) {
+    case 'setErrors':
+      return { ...state, errors: action.value };
+    case 'patchErrors':
+      return { ...state, errors: { ...state.errors, ...action.value } };
+    case 'setFormData':
+      return { ...state, formData: action.value };
+    case 'patchFormData':
+      return { ...state, formData: { ...state.formData, ...action.value } };
+    case 'setContactsExpanded':
+      return { ...state, contactsExpanded: action.value };
+    case 'toggleContactsExpanded':
+      return { ...state, contactsExpanded: !state.contactsExpanded };
+    case 'setContactDraft':
+      return { ...state, contactDraft: action.value };
+    case 'patchContactDraft':
+      return {
+        ...state,
+        contactDraft: {
+          ...(state.contactDraft ?? { ...EMPTY_CONTACT }),
+          [action.field]: action.value,
+        },
+      };
+    case 'setEditingContactIndex':
+      return { ...state, editingContactIndex: action.value };
+    case 'setContactDraftError':
+      return { ...state, contactDraftError: action.value };
+    case 'setProfileOptions':
+      return { ...state, profileOptions: action.value };
+    case 'setIsLoadingProfileOptions':
+      return { ...state, isLoadingProfileOptions: action.value };
+    case 'setIsModalOpen':
+      return { ...state, isModalOpen: action.value };
+    case 'setIsManageProfileOptionModalOpen':
+      return { ...state, isManageProfileOptionModalOpen: action.value };
+    case 'setEditingProfileOption':
+      return { ...state, editingProfileOption: action.value };
+    case 'setNewProfileOptionValue':
+      return { ...state, newProfileOptionValue: action.value };
+    case 'setProfileOptionError':
+      return { ...state, profileOptionError: action.value };
+    case 'setIsSavingProfileOption':
+      return { ...state, isSavingProfileOption: action.value };
+    case 'openAddModal':
+      return {
+        ...state,
+        editingClient: null,
+        formData: INITIAL_FORM_DATA,
+        contactsExpanded: false,
+        contactDraft: null,
+        editingContactIndex: null,
+        contactDraftError: null,
+        errors: {},
+        isModalOpen: true,
+      };
+    case 'openEditModal':
+      return {
+        ...state,
+        editingClient: action.client,
+        formData: action.formData,
+        contactsExpanded: action.contactsExpanded,
+        contactDraft: null,
+        editingContactIndex: null,
+        contactDraftError: null,
+        errors: {},
+        isModalOpen: true,
+      };
+    case 'closeModal':
+      return {
+        ...state,
+        isModalOpen: false,
+        errors: {},
+        contactsExpanded: false,
+        contactDraft: null,
+        editingContactIndex: null,
+        contactDraftError: null,
+      };
+    case 'addContact':
+      return {
+        ...state,
+        contactDraft: { ...EMPTY_CONTACT },
+        editingContactIndex: null,
+        contactDraftError: null,
+        errors: action.clearContactsError ? { ...state.errors, contacts: '' } : state.errors,
+        contactsExpanded: true,
+      };
+    case 'editContact':
+      return {
+        ...state,
+        contactDraft: { ...action.contact },
+        editingContactIndex: action.index,
+        contactDraftError: null,
+        errors: action.clearContactsError ? { ...state.errors, contacts: '' } : state.errors,
+        contactsExpanded: true,
+      };
+    case 'cancelContactDraft':
+      return {
+        ...state,
+        contactDraft: null,
+        editingContactIndex: null,
+        contactDraftError: null,
+      };
+    case 'confirmDelete':
+      return { ...state, clientToDelete: action.client, isDeleteConfirmOpen: true };
+    case 'setIsDeleteConfirmOpen':
+      return { ...state, isDeleteConfirmOpen: action.value };
+    case 'closeDeleteConfirm':
+      return { ...state, isDeleteConfirmOpen: false, clientToDelete: null };
+    case 'openManageProfileOptions':
+      return {
+        ...state,
+        manageCategory: action.category,
+        isManageProfileOptionModalOpen: true,
+        editingProfileOption: null,
+        newProfileOptionValue: '',
+        profileOptionError: null,
+      };
+    default:
+      return state;
+  }
+};
+
 const ClientsView: React.FC<ClientsViewProps> = ({
   clients,
   onAddClient,
@@ -189,40 +387,37 @@ const ClientsView: React.FC<ClientsViewProps> = ({
 
   const { language } = i18n;
 
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const [editingClient, setEditingClient] = useState<Client | null>(null);
-  const [errors, setErrors] = useState<Record<string, string>>({});
-  const [formData, setFormData] = useState<Partial<Client>>(INITIAL_FORM_DATA);
-  const [contactsExpanded, setContactsExpanded] = useState(false);
-  const [contactDraft, setContactDraft] = useState<ClientContact | null>(null);
-  const [editingContactIndex, setEditingContactIndex] = useState<number | null>(null);
-  const [contactDraftError, setContactDraftError] = useState<string | null>(null);
-
-  const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
-  const [clientToDelete, setClientToDelete] = useState<Client | null>(null);
-
-  const [profileOptions, setProfileOptions] =
-    useState<ClientProfileOptionsByCategory>(EMPTY_PROFILE_OPTIONS);
-  const [isLoadingProfileOptions, setIsLoadingProfileOptions] = useState(false);
-
-  const [isManageProfileOptionModalOpen, setIsManageProfileOptionModalOpen] = useState(false);
-  const [manageCategory, setManageCategory] = useState<ClientProfileOptionCategory>('sector');
-  const [editingProfileOption, setEditingProfileOption] = useState<ClientProfileOption | null>(
-    null,
-  );
-  const [newProfileOptionValue, setNewProfileOptionValue] = useState('');
-  const [profileOptionError, setProfileOptionError] = useState<string | null>(null);
-  const [isSavingProfileOption, setIsSavingProfileOption] = useState(false);
+  const [state, dispatch] = useReducer(clientsViewReducer, INITIAL_CLIENTS_STATE);
+  const {
+    isModalOpen,
+    editingClient,
+    errors,
+    formData,
+    contactsExpanded,
+    contactDraft,
+    editingContactIndex,
+    contactDraftError,
+    isDeleteConfirmOpen,
+    clientToDelete,
+    profileOptions,
+    isLoadingProfileOptions,
+    isManageProfileOptionModalOpen,
+    manageCategory,
+    editingProfileOption,
+    newProfileOptionValue,
+    profileOptionError,
+    isSavingProfileOption,
+  } = state;
 
   const loadProfileOptions = useCallback(async () => {
-    setIsLoadingProfileOptions(true);
+    dispatch({ type: 'setIsLoadingProfileOptions', value: true });
     try {
       const optionsByCategory = await api.clients.listAllProfileOptions();
-      setProfileOptions(optionsByCategory);
+      dispatch({ type: 'setProfileOptions', value: optionsByCategory });
     } catch (err) {
       console.error('Failed to load client profile options:', err);
     } finally {
-      setIsLoadingProfileOptions(false);
+      dispatch({ type: 'setIsLoadingProfileOptions', value: false });
     }
   }, []);
 
@@ -251,14 +446,7 @@ const ClientsView: React.FC<ClientsViewProps> = ({
 
   const openAddModal = () => {
     if (!canCreateClients) return;
-    setEditingClient(null);
-    setFormData(INITIAL_FORM_DATA);
-    setContactsExpanded(false);
-    setContactDraft(null);
-    setEditingContactIndex(null);
-    setContactDraftError(null);
-    setErrors({});
-    setIsModalOpen(true);
+    dispatch({ type: 'openAddModal' });
   };
 
   const openEditModal = useCallback(
@@ -267,61 +455,56 @@ const ClientsView: React.FC<ClientsViewProps> = ({
 
       const hydratedContacts = hydrateContactsForEdit(client, normalizeContacts(client.contacts));
       const primaryContact = hydratedContacts[0];
-      setEditingClient(client);
-      setFormData({
-        name: client.name || '',
-        type: client.type ?? 'company',
-        contacts: hydratedContacts,
-        contactName: client.contactName || primaryContact?.fullName || '',
-        clientCode: client.clientCode || '',
-        email: client.email || primaryContact?.email || '',
-        phone: client.phone || primaryContact?.phone || '',
-        address: client.address || '',
-        addressCountry: client.addressCountry || '',
-        addressState: client.addressState || '',
-        addressCap: client.addressCap || '',
-        addressProvince: client.addressProvince || '',
-        addressCivicNumber: client.addressCivicNumber || '',
-        addressLine: client.addressLine || client.address || '',
-        description: client.description || '',
-        atecoCode: client.atecoCode || '',
-        website: client.website || '',
-        sector: client.sector,
-        numberOfEmployees: client.numberOfEmployees,
-        revenue: client.revenue,
-        fiscalCode: getPrimaryTaxId(client),
-        officeCountRange: client.officeCountRange,
+      dispatch({
+        type: 'openEditModal',
+        client,
+        formData: {
+          name: client.name || '',
+          type: client.type ?? 'company',
+          contacts: hydratedContacts,
+          contactName: client.contactName || primaryContact?.fullName || '',
+          clientCode: client.clientCode || '',
+          email: client.email || primaryContact?.email || '',
+          phone: client.phone || primaryContact?.phone || '',
+          address: client.address || '',
+          addressCountry: client.addressCountry || '',
+          addressState: client.addressState || '',
+          addressCap: client.addressCap || '',
+          addressProvince: client.addressProvince || '',
+          addressCivicNumber: client.addressCivicNumber || '',
+          addressLine: client.addressLine || client.address || '',
+          description: client.description || '',
+          atecoCode: client.atecoCode || '',
+          website: client.website || '',
+          sector: client.sector,
+          numberOfEmployees: client.numberOfEmployees,
+          revenue: client.revenue,
+          fiscalCode: getPrimaryTaxId(client),
+          officeCountRange: client.officeCountRange,
+        },
+        contactsExpanded: hydratedContacts.length > 1,
       });
-      setContactsExpanded(hydratedContacts.length > 1);
-      setContactDraft(null);
-      setEditingContactIndex(null);
-      setContactDraftError(null);
-      setErrors({});
-      setIsModalOpen(true);
     },
     [canUpdateClients],
   );
 
-  const setContacts = useCallback((updater: (prev: ClientContact[]) => ClientContact[]) => {
-    setFormData((prev) => {
-      const current = normalizeContacts(prev.contacts);
-      return { ...prev, contacts: updater(current) };
-    });
-  }, []);
+  const setContacts = useCallback(
+    (updater: (prev: ClientContact[]) => ClientContact[]) => {
+      const current = normalizeContacts(formData.contacts);
+      dispatch({ type: 'patchFormData', value: { contacts: updater(current) } });
+    },
+    [formData.contacts],
+  );
 
   const addContact = useCallback(() => {
-    setContactDraft({ ...EMPTY_CONTACT });
-    setEditingContactIndex(null);
-    setContactDraftError(null);
-    if (errors.contacts) setErrors((prev) => ({ ...prev, contacts: '' }));
-    setContactsExpanded(true);
+    dispatch({ type: 'addContact', clearContactsError: Boolean(errors.contacts) });
   }, [errors.contacts]);
 
   const updateContactDraft = useCallback(
     (field: keyof ClientContact, value: string) => {
-      setContactDraft((prev) => ({ ...(prev ?? { ...EMPTY_CONTACT }), [field]: value }));
-      if (contactDraftError) setContactDraftError(null);
-      if (errors.contacts) setErrors((prev) => ({ ...prev, contacts: '' }));
+      dispatch({ type: 'patchContactDraft', field, value });
+      if (contactDraftError) dispatch({ type: 'setContactDraftError', value: null });
+      if (errors.contacts) dispatch({ type: 'patchErrors', value: { contacts: '' } });
     },
     [contactDraftError, errors.contacts],
   );
@@ -331,7 +514,7 @@ const ClientsView: React.FC<ClientsViewProps> = ({
 
     const normalizedDraft = normalizeContact(contactDraft);
     if (!normalizedDraft.fullName) {
-      setContactDraftError(t('common:validation.required'));
+      dispatch({ type: 'setContactDraftError', value: t('common:validation.required') });
       return;
     }
 
@@ -344,40 +527,39 @@ const ClientsView: React.FC<ClientsViewProps> = ({
       return [...prev, normalizedDraft];
     });
 
-    setContactDraft(null);
-    setEditingContactIndex(null);
-    setContactDraftError(null);
-    if (errors.contacts) setErrors((prev) => ({ ...prev, contacts: '' }));
+    dispatch({ type: 'setContactDraft', value: null });
+    dispatch({ type: 'setEditingContactIndex', value: null });
+    dispatch({ type: 'setContactDraftError', value: null });
+    if (errors.contacts) dispatch({ type: 'patchErrors', value: { contacts: '' } });
   }, [contactDraft, editingContactIndex, errors.contacts, setContacts, t]);
 
   const editContact = useCallback(
     (index: number) => {
       const target = normalizeContacts(formData.contacts)[index];
       if (!target) return;
-      setContactDraft({ ...target });
-      setEditingContactIndex(index);
-      setContactDraftError(null);
-      if (errors.contacts) setErrors((prev) => ({ ...prev, contacts: '' }));
-      setContactsExpanded(true);
+      dispatch({
+        type: 'editContact',
+        contact: target,
+        index,
+        clearContactsError: Boolean(errors.contacts),
+      });
     },
     [errors.contacts, formData.contacts],
   );
 
   const cancelContactDraft = useCallback(() => {
-    setContactDraft(null);
-    setEditingContactIndex(null);
-    setContactDraftError(null);
+    dispatch({ type: 'cancelContactDraft' });
   }, []);
 
   const removeContact = useCallback(
     (index: number) => {
       setContacts((prev) => prev.filter((_, currentIndex) => currentIndex !== index));
       if (editingContactIndex === index) {
-        setContactDraft(null);
-        setEditingContactIndex(null);
-        setContactDraftError(null);
+        dispatch({ type: 'setContactDraft', value: null });
+        dispatch({ type: 'setEditingContactIndex', value: null });
+        dispatch({ type: 'setContactDraftError', value: null });
       } else if (editingContactIndex !== null && editingContactIndex > index) {
-        setEditingContactIndex((prev) => (prev === null ? null : prev - 1));
+        dispatch({ type: 'setEditingContactIndex', value: editingContactIndex - 1 });
       }
     },
     [editingContactIndex, setContacts],
@@ -400,8 +582,8 @@ const ClientsView: React.FC<ClientsViewProps> = ({
 
     if (normalizedDraft && (editingContactIndex !== null || hasDraftValues)) {
       if (!normalizedDraft.fullName) {
-        setContactDraftError(t('common:validation.required'));
-        setContactsExpanded(true);
+        dispatch({ type: 'setContactDraftError', value: t('common:validation.required') });
+        dispatch({ type: 'setContactsExpanded', value: true });
         return;
       }
 
@@ -442,7 +624,7 @@ const ClientsView: React.FC<ClientsViewProps> = ({
     }
 
     if (Object.keys(newErrors).length > 0) {
-      setErrors(newErrors);
+      dispatch({ type: 'setErrors', value: newErrors });
       return;
     }
 
@@ -483,28 +665,30 @@ const ClientsView: React.FC<ClientsViewProps> = ({
       } else {
         await onAddClient(payload);
       }
-      setIsModalOpen(false);
+      dispatch({ type: 'setIsModalOpen', value: false });
     } catch (err) {
       const message = (err as Error).message;
       if (
         message.toLowerCase().includes('fiscal code') ||
         message.toLowerCase().includes('vat number')
       ) {
-        setErrors({ fiscalCode: message });
+        dispatch({ type: 'setErrors', value: { fiscalCode: message } });
       } else if (
         message.toLowerCase().includes('client id') ||
         message.toLowerCase().includes('client code')
       ) {
-        setErrors({ clientCode: t('common:validation.clientCodeUnique') });
+        dispatch({
+          type: 'setErrors',
+          value: { clientCode: t('common:validation.clientCodeUnique') },
+        });
       } else {
-        setErrors({ general: t('common:messages.errorOccurred') });
+        dispatch({ type: 'setErrors', value: { general: t('common:messages.errorOccurred') } });
       }
     }
   };
 
   const confirmDelete = useCallback((client: Client) => {
-    setClientToDelete(client);
-    setIsDeleteConfirmOpen(true);
+    dispatch({ type: 'confirmDelete', client });
   }, []);
 
   const handleDelete = async () => {
@@ -512,29 +696,19 @@ const ClientsView: React.FC<ClientsViewProps> = ({
     try {
       await onDeleteClient(clientToDelete.id);
     } finally {
-      setIsDeleteConfirmOpen(false);
-      setClientToDelete(null);
+      dispatch({ type: 'closeDeleteConfirm' });
     }
   };
 
   const handleModalClose = () => {
-    setIsModalOpen(false);
-    setErrors({});
-    setContactsExpanded(false);
-    setContactDraft(null);
-    setEditingContactIndex(null);
-    setContactDraftError(null);
+    dispatch({ type: 'closeModal' });
   };
 
   const canSubmit = editingClient ? canUpdateClients : canCreateClients;
 
   const openManageProfileOptions = (category: ClientProfileOptionCategory) => {
     if (!canUpdateClients) return;
-    setManageCategory(category);
-    setIsManageProfileOptionModalOpen(true);
-    setEditingProfileOption(null);
-    setNewProfileOptionValue('');
-    setProfileOptionError(null);
+    dispatch({ type: 'openManageProfileOptions', category });
   };
 
   const handleSaveProfileOption = async () => {
@@ -542,12 +716,12 @@ const ClientsView: React.FC<ClientsViewProps> = ({
 
     const trimmedValue = newProfileOptionValue.trim();
     if (!trimmedValue) {
-      setProfileOptionError(t('common:validation.required'));
+      dispatch({ type: 'setProfileOptionError', value: t('common:validation.required') });
       return;
     }
 
-    setIsSavingProfileOption(true);
-    setProfileOptionError(null);
+    dispatch({ type: 'setIsSavingProfileOption', value: true });
+    dispatch({ type: 'setProfileOptionError', value: null });
 
     try {
       if (editingProfileOption) {
@@ -556,21 +730,22 @@ const ClientsView: React.FC<ClientsViewProps> = ({
           sortOrder: editingProfileOption.sortOrder,
         });
         if (formData[manageCategory] === editingProfileOption.value) {
-          setFormData((prev) => ({ ...prev, [manageCategory]: trimmedValue }));
+          dispatch({ type: 'patchFormData', value: { [manageCategory]: trimmedValue } });
         }
       } else {
         await onCreateClientProfileOption(manageCategory, trimmedValue);
       }
 
       await loadProfileOptions();
-      setEditingProfileOption(null);
-      setNewProfileOptionValue('');
+      dispatch({ type: 'setEditingProfileOption', value: null });
+      dispatch({ type: 'setNewProfileOptionValue', value: '' });
     } catch (err) {
-      setProfileOptionError(
-        err instanceof Error ? err.message : t('common:messages.errorOccurred'),
-      );
+      dispatch({
+        type: 'setProfileOptionError',
+        value: err instanceof Error ? err.message : t('common:messages.errorOccurred'),
+      });
     } finally {
-      setIsSavingProfileOption(false);
+      dispatch({ type: 'setIsSavingProfileOption', value: false });
     }
   };
 
@@ -582,27 +757,28 @@ const ClientsView: React.FC<ClientsViewProps> = ({
       await loadProfileOptions();
 
       if (formData[option.category] === option.value) {
-        setFormData((prev) => ({ ...prev, [option.category]: null }));
+        dispatch({ type: 'patchFormData', value: { [option.category]: null } });
       }
     } catch (err) {
-      setProfileOptionError(
-        err instanceof Error ? err.message : t('common:messages.errorOccurred'),
-      );
+      dispatch({
+        type: 'setProfileOptionError',
+        value: err instanceof Error ? err.message : t('common:messages.errorOccurred'),
+      });
     }
   };
 
   const handleEditProfileOption = (option: ClientProfileOption) => {
     if (!canUpdateClients) return;
 
-    setEditingProfileOption(option);
-    setNewProfileOptionValue(option.value);
-    setProfileOptionError(null);
+    dispatch({ type: 'setEditingProfileOption', value: option });
+    dispatch({ type: 'setNewProfileOptionValue', value: option.value });
+    dispatch({ type: 'setProfileOptionError', value: null });
   };
 
   const handleCancelProfileOptionEdit = () => {
-    setEditingProfileOption(null);
-    setNewProfileOptionValue('');
-    setProfileOptionError(null);
+    dispatch({ type: 'setEditingProfileOption', value: null });
+    dispatch({ type: 'setNewProfileOptionValue', value: '' });
+    dispatch({ type: 'setProfileOptionError', value: null });
   };
 
   const contactColumns = useMemo<Column<ContactTableRow>[]>(
@@ -972,7 +1148,7 @@ const ClientsView: React.FC<ClientsViewProps> = ({
     <div className="space-y-8 animate-in fade-in duration-500">
       <Modal
         isOpen={isManageProfileOptionModalOpen}
-        onClose={() => setIsManageProfileOptionModalOpen(false)}
+        onClose={() => dispatch({ type: 'setIsManageProfileOptionModalOpen', value: false })}
         zIndex={70}
       >
         <ModalContent size="2xl">
@@ -983,7 +1159,9 @@ const ClientsView: React.FC<ClientsViewProps> = ({
               </span>
               {t('crm:clients.manageValuesTitle', { field: manageCategoryLabels[manageCategory] })}
             </ModalTitle>
-            <ModalCloseButton onClick={() => setIsManageProfileOptionModalOpen(false)} />
+            <ModalCloseButton
+              onClick={() => dispatch({ type: 'setIsManageProfileOptionModalOpen', value: false })}
+            />
           </ModalHeader>
 
           <ModalBody className="max-h-[60vh] space-y-4">
@@ -996,7 +1174,9 @@ const ClientsView: React.FC<ClientsViewProps> = ({
                   id="client-profile-option-value"
                   type="text"
                   value={newProfileOptionValue}
-                  onChange={(e) => setNewProfileOptionValue(e.target.value)}
+                  onChange={(e) =>
+                    dispatch({ type: 'setNewProfileOptionValue', value: e.target.value })
+                  }
                   placeholder={t('crm:clients.valuePlaceholder')}
                   onKeyDown={(e) => e.key === 'Enter' && void handleSaveProfileOption()}
                 />
@@ -1150,8 +1330,9 @@ const ClientsView: React.FC<ClientsViewProps> = ({
                       type="text"
                       value={formData.clientCode}
                       onChange={(e) => {
-                        setFormData((prev) => ({ ...prev, clientCode: e.target.value }));
-                        if (errors.clientCode) setErrors((prev) => ({ ...prev, clientCode: '' }));
+                        dispatch({ type: 'patchFormData', value: { clientCode: e.target.value } });
+                        if (errors.clientCode)
+                          dispatch({ type: 'patchErrors', value: { clientCode: '' } });
                       }}
                       placeholder={t('crm:clients.clientCodePlaceholder')}
                       className={`w-full text-sm px-4 py-2.5 bg-zinc-50 border rounded-xl focus:ring-2 focus:ring-praetor outline-none transition-all ${
@@ -1170,8 +1351,8 @@ const ClientsView: React.FC<ClientsViewProps> = ({
                       type="text"
                       value={formData.name}
                       onChange={(e) => {
-                        setFormData((prev) => ({ ...prev, name: e.target.value }));
-                        if (errors.name) setErrors((prev) => ({ ...prev, name: '' }));
+                        dispatch({ type: 'patchFormData', value: { name: e.target.value } });
+                        if (errors.name) dispatch({ type: 'patchErrors', value: { name: '' } });
                       }}
                       placeholder={t('crm:clients.namePlaceholder')}
                       className={`w-full text-sm px-4 py-2.5 bg-zinc-50 border rounded-xl focus:ring-2 focus:ring-praetor outline-none transition-all ${
@@ -1190,10 +1371,10 @@ const ClientsView: React.FC<ClientsViewProps> = ({
                       options={typeOptions}
                       value={formData.type || 'company'}
                       onChange={(val) =>
-                        setFormData((prev) => ({
-                          ...prev,
-                          type: (val as Client['type']) || 'company',
-                        }))
+                        dispatch({
+                          type: 'patchFormData',
+                          value: { type: (val as Client['type']) || 'company' },
+                        })
                       }
                       searchable={false}
                     />
@@ -1222,7 +1403,7 @@ const ClientsView: React.FC<ClientsViewProps> = ({
                       type="text"
                       value={formData.website ?? ''}
                       onChange={(e) =>
-                        setFormData((prev) => ({ ...prev, website: e.target.value }))
+                        dispatch({ type: 'patchFormData', value: { website: e.target.value } })
                       }
                       placeholder={t('crm:clients.websitePlaceholder')}
                       className="w-full text-sm px-4 py-2.5 bg-zinc-50 border border-zinc-200 rounded-xl focus:ring-2 focus:ring-praetor outline-none transition-all"
@@ -1236,7 +1417,10 @@ const ClientsView: React.FC<ClientsViewProps> = ({
                       type="text"
                       value={formData.addressCountry}
                       onChange={(e) =>
-                        setFormData((prev) => ({ ...prev, addressCountry: e.target.value }))
+                        dispatch({
+                          type: 'patchFormData',
+                          value: { addressCountry: e.target.value },
+                        })
                       }
                       placeholder={t('crm:clients.countryPlaceholder')}
                       className="w-full text-sm px-4 py-2.5 bg-zinc-50 border border-zinc-200 rounded-xl focus:ring-2 focus:ring-praetor outline-none transition-all"
@@ -1250,7 +1434,7 @@ const ClientsView: React.FC<ClientsViewProps> = ({
                       type="text"
                       value={formData.addressState}
                       onChange={(e) =>
-                        setFormData((prev) => ({ ...prev, addressState: e.target.value }))
+                        dispatch({ type: 'patchFormData', value: { addressState: e.target.value } })
                       }
                       placeholder={t('crm:clients.statePlaceholder')}
                       className="w-full text-sm px-4 py-2.5 bg-zinc-50 border border-zinc-200 rounded-xl focus:ring-2 focus:ring-praetor outline-none transition-all"
@@ -1264,7 +1448,7 @@ const ClientsView: React.FC<ClientsViewProps> = ({
                       type="text"
                       value={formData.addressCap}
                       onChange={(e) =>
-                        setFormData((prev) => ({ ...prev, addressCap: e.target.value }))
+                        dispatch({ type: 'patchFormData', value: { addressCap: e.target.value } })
                       }
                       placeholder={t('crm:clients.capPlaceholder')}
                       className="w-full text-sm px-4 py-2.5 bg-zinc-50 border border-zinc-200 rounded-xl focus:ring-2 focus:ring-praetor outline-none transition-all"
@@ -1278,7 +1462,10 @@ const ClientsView: React.FC<ClientsViewProps> = ({
                       type="text"
                       value={formData.addressProvince}
                       onChange={(e) =>
-                        setFormData((prev) => ({ ...prev, addressProvince: e.target.value }))
+                        dispatch({
+                          type: 'patchFormData',
+                          value: { addressProvince: e.target.value },
+                        })
                       }
                       placeholder={t('crm:clients.provincePlaceholder')}
                       className="w-full text-sm px-4 py-2.5 bg-zinc-50 border border-zinc-200 rounded-xl focus:ring-2 focus:ring-praetor outline-none transition-all"
@@ -1292,7 +1479,10 @@ const ClientsView: React.FC<ClientsViewProps> = ({
                       type="text"
                       value={formData.addressCivicNumber}
                       onChange={(e) =>
-                        setFormData((prev) => ({ ...prev, addressCivicNumber: e.target.value }))
+                        dispatch({
+                          type: 'patchFormData',
+                          value: { addressCivicNumber: e.target.value },
+                        })
                       }
                       placeholder={t('crm:clients.civicNumberPlaceholder')}
                       className="w-full text-sm px-4 py-2.5 bg-zinc-50 border border-zinc-200 rounded-xl focus:ring-2 focus:ring-praetor outline-none transition-all"
@@ -1306,7 +1496,7 @@ const ClientsView: React.FC<ClientsViewProps> = ({
                       type="text"
                       value={formData.addressLine}
                       onChange={(e) =>
-                        setFormData((prev) => ({ ...prev, addressLine: e.target.value }))
+                        dispatch({ type: 'patchFormData', value: { addressLine: e.target.value } })
                       }
                       placeholder={t('crm:clients.addressPlaceholder')}
                       className="w-full text-sm px-4 py-2.5 bg-zinc-50 border border-zinc-200 rounded-xl focus:ring-2 focus:ring-praetor outline-none transition-all"
@@ -1320,7 +1510,7 @@ const ClientsView: React.FC<ClientsViewProps> = ({
                       type="button"
                       variant="outline"
                       size="sm"
-                      onClick={() => setContactsExpanded((prev) => !prev)}
+                      onClick={() => dispatch({ type: 'toggleContactsExpanded' })}
                       className="gap-2 text-xs font-semibold uppercase tracking-wide"
                     >
                       <i
@@ -1450,8 +1640,9 @@ const ClientsView: React.FC<ClientsViewProps> = ({
                       type="text"
                       value={formData.fiscalCode}
                       onChange={(e) => {
-                        setFormData((prev) => ({ ...prev, fiscalCode: e.target.value }));
-                        if (errors.fiscalCode) setErrors((prev) => ({ ...prev, fiscalCode: '' }));
+                        dispatch({ type: 'patchFormData', value: { fiscalCode: e.target.value } });
+                        if (errors.fiscalCode)
+                          dispatch({ type: 'patchErrors', value: { fiscalCode: '' } });
                       }}
                       placeholder={t('crm:clients.fiscalCodePlaceholder')}
                       className={`w-full text-sm px-4 py-2.5 bg-zinc-50 border rounded-xl focus:ring-2 focus:ring-praetor outline-none transition-all ${
@@ -1470,7 +1661,7 @@ const ClientsView: React.FC<ClientsViewProps> = ({
                       type="text"
                       value={formData.atecoCode ?? ''}
                       onChange={(e) =>
-                        setFormData((prev) => ({ ...prev, atecoCode: e.target.value }))
+                        dispatch({ type: 'patchFormData', value: { atecoCode: e.target.value } })
                       }
                       placeholder={t('crm:clients.atecoCodePlaceholder')}
                       className="w-full text-sm px-4 py-2.5 bg-zinc-50 border border-zinc-200 rounded-xl focus:ring-2 focus:ring-praetor outline-none transition-all"
@@ -1506,10 +1697,10 @@ const ClientsView: React.FC<ClientsViewProps> = ({
                       options={sectorOptions}
                       value={formData.sector || ''}
                       onChange={(val) =>
-                        setFormData((prev) => ({
-                          ...prev,
-                          sector: (val as Client['sector']) || null,
-                        }))
+                        dispatch({
+                          type: 'patchFormData',
+                          value: { sector: (val as Client['sector']) || null },
+                        })
                       }
                       placeholder={t('common:form.selectOption')}
                       searchable={false}
@@ -1537,10 +1728,12 @@ const ClientsView: React.FC<ClientsViewProps> = ({
                       options={numberOfEmployeesOptions}
                       value={formData.numberOfEmployees || ''}
                       onChange={(val) =>
-                        setFormData((prev) => ({
-                          ...prev,
-                          numberOfEmployees: (val as Client['numberOfEmployees']) || null,
-                        }))
+                        dispatch({
+                          type: 'patchFormData',
+                          value: {
+                            numberOfEmployees: (val as Client['numberOfEmployees']) || null,
+                          },
+                        })
                       }
                       placeholder={t('common:form.selectOption')}
                       searchable={false}
@@ -1568,10 +1761,10 @@ const ClientsView: React.FC<ClientsViewProps> = ({
                       options={revenueOptions}
                       value={formData.revenue || ''}
                       onChange={(val) =>
-                        setFormData((prev) => ({
-                          ...prev,
-                          revenue: (val as Client['revenue']) || null,
-                        }))
+                        dispatch({
+                          type: 'patchFormData',
+                          value: { revenue: (val as Client['revenue']) || null },
+                        })
                       }
                       placeholder={t('common:form.selectOption')}
                       searchable={false}
@@ -1599,10 +1792,10 @@ const ClientsView: React.FC<ClientsViewProps> = ({
                       options={officeCountRangeOptions}
                       value={formData.officeCountRange || ''}
                       onChange={(val) =>
-                        setFormData((prev) => ({
-                          ...prev,
-                          officeCountRange: (val as Client['officeCountRange']) || null,
-                        }))
+                        dispatch({
+                          type: 'patchFormData',
+                          value: { officeCountRange: (val as Client['officeCountRange']) || null },
+                        })
                       }
                       placeholder={t('common:form.selectOption')}
                       searchable={false}
@@ -1617,7 +1810,7 @@ const ClientsView: React.FC<ClientsViewProps> = ({
                       rows={3}
                       value={formData.description ?? ''}
                       onChange={(e) =>
-                        setFormData((prev) => ({ ...prev, description: e.target.value }))
+                        dispatch({ type: 'patchFormData', value: { description: e.target.value } })
                       }
                       placeholder={t('crm:clients.description')}
                       className="w-full text-sm px-4 py-2.5 bg-zinc-50 border border-zinc-200 rounded-xl focus:ring-2 focus:ring-praetor outline-none transition-all resize-none"
@@ -1648,7 +1841,7 @@ const ClientsView: React.FC<ClientsViewProps> = ({
 
       <DeleteConfirmModal
         isOpen={isDeleteConfirmOpen}
-        onClose={() => setIsDeleteConfirmOpen(false)}
+        onClose={() => dispatch({ type: 'setIsDeleteConfirmOpen', value: false })}
         onConfirm={() => {
           void handleDelete();
         }}

--- a/components/Login.tsx
+++ b/components/Login.tsx
@@ -99,11 +99,13 @@ const Login: React.FC<LoginProps> = ({
   const usingCustomLogo = Boolean(logoUrl) && logoUrl !== failedLogoUrl;
   const resolvedLogoUrl = logoUrl && logoUrl !== failedLogoUrl ? logoUrl : '/praetor-logo.png';
 
-  // Second-factor flow state. `challengeToken`/`enrollToken` are short-lived
-  // server tokens returned by /auth/login that authorize the follow-up call.
+  // Second-factor flow state. `challengeToken`/`enrollToken` are short-lived server tokens returned
+  // by /auth/login that authorize the follow-up call. They are only ever read inside the verify/
+  // enroll handlers (never rendered) and are always set alongside a `setPhase(...)` transition that
+  // drives the re-render, so they live in refs rather than triggering a render of their own.
   const [phase, setPhase] = useState<LoginPhase>('credentials');
-  const [challengeToken, setChallengeToken] = useState('');
-  const [enrollToken, setEnrollToken] = useState('');
+  const challengeTokenRef = useRef('');
+  const enrollTokenRef = useRef('');
   const [totpCode, setTotpCode] = useState('');
   const [useBackupCode, setUseBackupCode] = useState(false);
   const [totpError, setTotpError] = useState('');
@@ -195,7 +197,7 @@ const Login: React.FC<LoginProps> = ({
       const result = await api.auth.login(username, password);
       // /auth/login may short-circuit into a second-factor branch (no token yet).
       if ('totpRequired' in result) {
-        setChallengeToken(result.challengeToken);
+        challengeTokenRef.current = result.challengeToken;
         setTotpCode('');
         setUseBackupCode(false);
         setTotpError('');
@@ -203,7 +205,7 @@ const Login: React.FC<LoginProps> = ({
         return;
       }
       if ('totpEnrollmentRequired' in result) {
-        setEnrollToken(result.enrollToken);
+        enrollTokenRef.current = result.enrollToken;
         pendingRef.current = null;
         setPhase('enroll');
         return;
@@ -225,8 +227,8 @@ const Login: React.FC<LoginProps> = ({
   // `bannerError` surfaces on the credentials form (e.g. an expired challenge).
   const resetToCredentials = (bannerError = '') => {
     setPhase('credentials');
-    setChallengeToken('');
-    setEnrollToken('');
+    challengeTokenRef.current = '';
+    enrollTokenRef.current = '';
     setTotpCode('');
     setUseBackupCode(false);
     setTotpError('');
@@ -240,7 +242,7 @@ const Login: React.FC<LoginProps> = ({
     setVerifyingTotp(true);
     setTotpError('');
     try {
-      const response = await api.auth.totpChallenge(challengeToken, code);
+      const response = await api.auth.totpChallenge(challengeTokenRef.current, code);
       onLogin(response.user, response.token);
     } catch (err) {
       // An expired/invalid challenge token can't be retried — send the user back
@@ -276,7 +278,7 @@ const Login: React.FC<LoginProps> = ({
   // Forced-enrollment confirm: capture the issued session token + user so the
   // wizard's onFinished can complete login after backup codes are shown.
   const handleEnrollConfirm = async (code: string) => {
-    const result = await api.auth.totpConfirm(code, enrollToken);
+    const result = await api.auth.totpConfirm(code, enrollTokenRef.current);
     if (result.token && result.user) {
       pendingRef.current = { token: result.token, user: result.user };
     }
@@ -616,7 +618,7 @@ const Login: React.FC<LoginProps> = ({
               </div>
 
               <TotpSetupWizard
-                onSetup={() => api.auth.totpSetup(enrollToken)}
+                onSetup={() => api.auth.totpSetup(enrollTokenRef.current)}
                 onConfirm={handleEnrollConfirm}
                 onFinished={handleEnrollFinished}
                 onCancel={() => resetToCredentials()}

--- a/components/TotpSetupWizard.tsx
+++ b/components/TotpSetupWizard.tsx
@@ -1,7 +1,7 @@
 import { REGEXP_ONLY_DIGITS } from 'input-otp';
 import { AlertCircle, Loader2, ShieldCheck } from 'lucide-react';
 import type * as React from 'react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useReducer, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Alert, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
@@ -34,6 +34,67 @@ type WizardStep = 'scan' | 'verify' | 'backup';
 
 const OTP_LENGTH = 6;
 
+// The wizard's setup/verify state is one cohesive flow (a step machine plus the in-flight/error
+// flags for each phase), so it lives in a single reducer rather than a fan of useState calls.
+interface WizardState {
+  step: WizardStep;
+  setupResult: TotpSetupResult | null;
+  isLoadingSetup: boolean;
+  setupError: string | null;
+  code: string;
+  isVerifying: boolean;
+  verifyError: string | null;
+}
+
+const INITIAL_WIZARD_STATE: WizardState = {
+  step: 'scan',
+  setupResult: null,
+  isLoadingSetup: false,
+  setupError: null,
+  code: '',
+  isVerifying: false,
+  verifyError: null,
+};
+
+type WizardAction =
+  | { type: 'setupStart' }
+  | { type: 'setupSuccess'; result: TotpSetupResult }
+  | { type: 'setupError'; message: string }
+  | { type: 'setupSettled' }
+  | { type: 'gotoVerify' }
+  | { type: 'setCode'; value: string }
+  | { type: 'verifyStart' }
+  | { type: 'verifySuccess' }
+  | { type: 'verifyError'; message: string }
+  | { type: 'verifySettled' };
+
+const wizardReducer = (state: WizardState, action: WizardAction): WizardState => {
+  switch (action.type) {
+    case 'setupStart':
+      return { ...state, isLoadingSetup: true, setupError: null };
+    case 'setupSuccess':
+      return { ...state, setupResult: action.result };
+    case 'setupError':
+      return { ...state, setupError: action.message };
+    case 'setupSettled':
+      return { ...state, isLoadingSetup: false };
+    case 'gotoVerify':
+      return { ...state, step: 'verify' };
+    case 'setCode':
+      return { ...state, code: action.value, verifyError: null };
+    case 'verifyStart':
+      return { ...state, isVerifying: true, verifyError: null };
+    case 'verifySuccess':
+      return { ...state, step: 'backup' };
+    case 'verifyError':
+      return { ...state, verifyError: action.message, code: '' };
+    case 'verifySettled':
+      return { ...state, isVerifying: false };
+    default:
+      return state;
+  }
+};
+
 const TotpSetupWizard: React.FC<TotpSetupWizardProps> = ({
   onSetup,
   onConfirm,
@@ -43,14 +104,8 @@ const TotpSetupWizard: React.FC<TotpSetupWizardProps> = ({
 }) => {
   const { t } = useTranslation('settings');
 
-  const [step, setStep] = useState<WizardStep>('scan');
-  const [setupResult, setSetupResult] = useState<TotpSetupResult | null>(null);
-  const [isLoadingSetup, setIsLoadingSetup] = useState(false);
-  const [setupError, setSetupError] = useState<string | null>(null);
-
-  const [code, setCode] = useState('');
-  const [isVerifying, setIsVerifying] = useState(false);
-  const [verifyError, setVerifyError] = useState<string | null>(null);
+  const [state, dispatch] = useReducer(wizardReducer, INITIAL_WIZARD_STATE);
+  const { step, setupResult, isLoadingSetup, setupError, code, isVerifying, verifyError } = state;
 
   const isMountedRef = useRef(true);
   // Set true on the first /setup attempt and NEVER reset — auto-run fires exactly once per mount,
@@ -70,19 +125,21 @@ const TotpSetupWizard: React.FC<TotpSetupWizardProps> = ({
   const runSetup = useCallback(async () => {
     if (setupStartedRef.current || setupResult) return;
     setupStartedRef.current = true;
-    setIsLoadingSetup(true);
-    setSetupError(null);
+    dispatch({ type: 'setupStart' });
     try {
       const result = await onSetup();
-      if (isMountedRef.current) setSetupResult(result);
+      if (isMountedRef.current) dispatch({ type: 'setupSuccess', result });
     } catch (err) {
       console.error('Failed to start two-factor setup:', err);
       if (isMountedRef.current) {
-        setSetupError((err as Error).message || t('twoFactor.invalidCode'));
+        dispatch({
+          type: 'setupError',
+          message: (err as Error).message || t('twoFactor.invalidCode'),
+        });
       }
     } finally {
       // Intentionally NOT resetting setupStartedRef — a failed setup must not auto-retry.
-      if (isMountedRef.current) setIsLoadingSetup(false);
+      if (isMountedRef.current) dispatch({ type: 'setupSettled' });
     }
   }, [onSetup, setupResult, t]);
 
@@ -95,31 +152,29 @@ const TotpSetupWizard: React.FC<TotpSetupWizardProps> = ({
     async (submittedCode: string) => {
       if (isVerifying) return;
       if (submittedCode.length !== OTP_LENGTH) return;
-      setIsVerifying(true);
-      setVerifyError(null);
+      dispatch({ type: 'verifyStart' });
       try {
         await onConfirm(submittedCode);
-        if (isMountedRef.current) setStep('backup');
+        if (isMountedRef.current) dispatch({ type: 'verifySuccess' });
       } catch (err) {
         console.error('Failed to verify two-factor code:', err);
         if (!isMountedRef.current) return;
         const isInvalidCode = err instanceof ApiError && err.errorCode === 'invalid_totp_code';
-        setVerifyError(
-          isInvalidCode
+        dispatch({
+          type: 'verifyError',
+          message: isInvalidCode
             ? t('twoFactor.invalidCode')
             : (err as Error).message || t('twoFactor.invalidCode'),
-        );
-        setCode('');
+        });
       } finally {
-        if (isMountedRef.current) setIsVerifying(false);
+        if (isMountedRef.current) dispatch({ type: 'verifySettled' });
       }
     },
     [isVerifying, onConfirm, t],
   );
 
   const handleCodeChange = (value: string) => {
-    setCode(value);
-    if (verifyError) setVerifyError(null);
+    dispatch({ type: 'setCode', value });
   };
 
   const backupCodes = setupResult?.backupCodes ?? [];
@@ -192,7 +247,7 @@ const TotpSetupWizard: React.FC<TotpSetupWizardProps> = ({
             )}
             <Button
               type="button"
-              onClick={() => setStep('verify')}
+              onClick={() => dispatch({ type: 'gotoVerify' })}
               disabled={!setupResult || isLoadingSetup}
             >
               {t('common:buttons.next', { defaultValue: 'Next' })}

--- a/components/UserSettings.tsx
+++ b/components/UserSettings.tsx
@@ -1140,10 +1140,9 @@ const UserSettings: React.FC<UserSettingsProps> = ({
                 </CardHeader>
                 <CardContent className="space-y-4 p-6">
                   {isIdpManagedTotp ? (
-                    <div
-                      role="status"
+                    <output
                       aria-live="polite"
-                      className="flex items-start gap-3 rounded-md border border-border bg-muted/40 p-4 text-sm text-muted-foreground"
+                      className="flex w-full items-start gap-3 rounded-md border border-border bg-muted/40 p-4 text-sm text-muted-foreground"
                     >
                       <Lock aria-hidden="true" className="mt-0.5 size-4 shrink-0" />
                       <div className="space-y-1">
@@ -1152,7 +1151,7 @@ const UserSettings: React.FC<UserSettingsProps> = ({
                         </p>
                         <p>{t('twoFactor.idpManagedDescription')}</p>
                       </div>
-                    </div>
+                    </output>
                   ) : isLoadingTotpStatus && !totpStatus ? (
                     <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
                       <Loader2 aria-hidden="true" className="size-4 animate-spin" />
@@ -1178,10 +1177,9 @@ const UserSettings: React.FC<UserSettingsProps> = ({
                       </Button>
                     </div>
                   ) : isFeatureDisabled ? (
-                    <div
-                      role="status"
+                    <output
                       aria-live="polite"
-                      className="flex items-start gap-3 rounded-md border border-border bg-muted/40 p-4 text-sm text-muted-foreground"
+                      className="flex w-full items-start gap-3 rounded-md border border-border bg-muted/40 p-4 text-sm text-muted-foreground"
                     >
                       <Lock aria-hidden="true" className="mt-0.5 size-4 shrink-0" />
                       <div className="space-y-1">
@@ -1195,7 +1193,7 @@ const UserSettings: React.FC<UserSettingsProps> = ({
                           )}
                         </p>
                       </div>
-                    </div>
+                    </output>
                   ) : isTotpEnabled ? (
                     <div className="space-y-4">
                       {isTotpRequired && (

--- a/components/administration/BrandingSettings.tsx
+++ b/components/administration/BrandingSettings.tsx
@@ -1,6 +1,6 @@
 import { ImageOff, Loader2, Save, Trash2, Upload } from 'lucide-react';
 import type React from 'react';
-import { useEffect, useRef, useState } from 'react';
+import { useReducer, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -22,32 +22,88 @@ export interface BrandingSettingsProps {
   animationClass?: string;
 }
 
+// The editable company-name field plus the three mutually-exclusive in-flight flags and the
+// failed-logo URL form one cohesive panel state, so they live in a single reducer.
+interface BrandingState {
+  companyName: string;
+  isSavingName: boolean;
+  isUploading: boolean;
+  isRemoving: boolean;
+  // Fall back to the ImageOff placeholder if the current logo fails to load (the server 404s a
+  // logo whose file is gone on disk). Tracking the failed URL (vs a boolean + reset effect) retries
+  // automatically when a new upload changes branding.logoUrl.
+  failedLogoUrl: string | null;
+}
+
+const initBrandingState = (companyName: string): BrandingState => ({
+  companyName,
+  isSavingName: false,
+  isUploading: false,
+  isRemoving: false,
+  failedLogoUrl: null,
+});
+
+type BrandingAction =
+  | { type: 'setCompanyName'; value: string }
+  | { type: 'savingStart' }
+  | { type: 'savingEnd' }
+  | { type: 'uploadStart' }
+  | { type: 'uploadEnd' }
+  | { type: 'removeStart' }
+  | { type: 'removeEnd' }
+  | { type: 'logoFailed'; url: string | null };
+
+const brandingReducer = (state: BrandingState, action: BrandingAction): BrandingState => {
+  switch (action.type) {
+    case 'setCompanyName':
+      return { ...state, companyName: action.value };
+    case 'savingStart':
+      return { ...state, isSavingName: true };
+    case 'savingEnd':
+      return { ...state, isSavingName: false };
+    case 'uploadStart':
+      return { ...state, isUploading: true };
+    case 'uploadEnd':
+      return { ...state, isUploading: false };
+    case 'removeStart':
+      return { ...state, isRemoving: true };
+    case 'removeEnd':
+      return { ...state, isRemoving: false };
+    case 'logoFailed':
+      return { ...state, failedLogoUrl: action.url };
+    default:
+      return state;
+  }
+};
+
 const BrandingSettings: React.FC<BrandingSettingsProps> = ({
   branding,
   onChange,
   animationClass,
 }) => {
   const { t } = useTranslation('settings');
-  const [companyName, setCompanyName] = useState(branding.companyName ?? '');
-  const [isSavingName, setIsSavingName] = useState(false);
-  const [isUploading, setIsUploading] = useState(false);
-  const [isRemoving, setIsRemoving] = useState(false);
-  // Fall back to the ImageOff placeholder if the current logo fails to load (the server 404s a
-  // logo whose file is gone on disk). Tracking the failed URL (vs a boolean + reset effect) retries
-  // automatically when a new upload changes branding.logoUrl.
-  const [failedLogoUrl, setFailedLogoUrl] = useState<string | null>(null);
+  const [state, dispatch] = useReducer(
+    brandingReducer,
+    branding.companyName ?? '',
+    initBrandingState,
+  );
+  const { companyName, isSavingName, isUploading, isRemoving, failedLogoUrl } = state;
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  // Keep the local field in sync when branding is (re)loaded or changed elsewhere.
-  useEffect(() => {
-    setCompanyName(branding.companyName ?? '');
-  }, [branding.companyName]);
+  // Keep the local field in sync when branding is (re)loaded or changed elsewhere. The last-synced
+  // prop is tracked in a ref (not state) so adjusting the field happens during render off the prop
+  // change itself — no post-render effect copying prop→state. See react.dev "you-might-not-need-an-effect".
+  const lastSyncedNameRef = useRef(branding.companyName ?? '');
+  if (lastSyncedNameRef.current !== (branding.companyName ?? '')) {
+    lastSyncedNameRef.current = branding.companyName ?? '';
+    dispatch({ type: 'setCompanyName', value: branding.companyName ?? '' });
+  }
 
   const nameChanged = companyName.trim() !== (branding.companyName ?? '');
   const busy = isSavingName || isUploading || isRemoving;
 
   const handleSaveName = async () => {
-    setIsSavingName(true);
+    dispatch({ type: 'savingStart' });
     try {
       const trimmed = companyName.trim();
       const updated = await api.branding.updateName(trimmed.length > 0 ? trimmed : null);
@@ -57,7 +113,7 @@ const BrandingSettings: React.FC<BrandingSettingsProps> = ({
       console.error('Failed to save company name:', err);
       toastError(t('branding.saveFailed'));
     } finally {
-      setIsSavingName(false);
+      dispatch({ type: 'savingEnd' });
     }
   };
 
@@ -84,7 +140,7 @@ const BrandingSettings: React.FC<BrandingSettingsProps> = ({
       toastError(validationError);
       return;
     }
-    setIsUploading(true);
+    dispatch({ type: 'uploadStart' });
     try {
       const updated = await api.branding.uploadLogo(file);
       onChange(updated);
@@ -93,12 +149,12 @@ const BrandingSettings: React.FC<BrandingSettingsProps> = ({
       console.error('Failed to upload logo:', err);
       toastError(t('branding.saveFailed'));
     } finally {
-      setIsUploading(false);
+      dispatch({ type: 'uploadEnd' });
     }
   };
 
   const handleRemoveLogo = async () => {
-    setIsRemoving(true);
+    dispatch({ type: 'removeStart' });
     try {
       const updated = await api.branding.deleteLogo();
       onChange(updated);
@@ -107,7 +163,7 @@ const BrandingSettings: React.FC<BrandingSettingsProps> = ({
       console.error('Failed to remove logo:', err);
       toastError(t('branding.saveFailed'));
     } finally {
-      setIsRemoving(false);
+      dispatch({ type: 'removeEnd' });
     }
   };
 
@@ -133,7 +189,7 @@ const BrandingSettings: React.FC<BrandingSettingsProps> = ({
               id="branding-company-name"
               value={companyName}
               maxLength={COMPANY_NAME_MAX_LENGTH}
-              onChange={(event) => setCompanyName(event.target.value)}
+              onChange={(event) => dispatch({ type: 'setCompanyName', value: event.target.value })}
               placeholder={t('branding.companyNamePlaceholder')}
             />
             <Button type="button" onClick={handleSaveName} disabled={busy || !nameChanged}>
@@ -157,7 +213,7 @@ const BrandingSettings: React.FC<BrandingSettingsProps> = ({
                   src={branding.logoUrl}
                   alt={t('branding.currentLogoAlt')}
                   className="size-full object-contain p-1"
-                  onError={() => setFailedLogoUrl(branding.logoUrl)}
+                  onError={() => dispatch({ type: 'logoFailed', url: branding.logoUrl })}
                 />
               ) : (
                 <ImageOff aria-hidden="true" className="size-6 text-muted-foreground" />
@@ -195,6 +251,7 @@ const BrandingSettings: React.FC<BrandingSettingsProps> = ({
           <input
             ref={fileInputRef}
             type="file"
+            aria-label={t('branding.uploadButton')}
             accept=".png,.jpg,.jpeg,.webp,.svg,image/png,image/jpeg,image/webp,image/svg+xml"
             className="hidden"
             onChange={handleFileSelected}

--- a/components/administration/GeneralSettings.tsx
+++ b/components/administration/GeneralSettings.tsx
@@ -11,7 +11,7 @@ import {
   TriangleAlert,
 } from 'lucide-react';
 import type React from 'react';
-import { useRef, useState } from 'react';
+import { useReducer, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -113,6 +113,85 @@ const areRilTransferOptionsEqual = (left: string[], right: unknown): boolean =>
   JSON.stringify(normalizeRilTransferOptions(left)) ===
   JSON.stringify(normalizeRilTransferOptions(right));
 
+interface GeneralSettingsState {
+  currency: string;
+  dailyLimit: number;
+  startOfWeek: IGeneralSettings['startOfWeek'];
+  treatSaturdayAsHoliday: boolean;
+  allowWeekendSelection: boolean;
+  defaultLocation: TimeEntryLocation;
+  rilCompanyName: string;
+  rilDefaultStartTime: string;
+  rilDefaultExitTime: string;
+  rilLunchBreakMinutes: number;
+  rilNoteOptions: EditableRilNoteOption[];
+  rilTransferOptions: EditableRilTransferOption[];
+  enableAiReporting: boolean;
+  geminiApiKey: string;
+  aiProvider: AiProvider;
+  openrouterApiKey: string;
+  geminiModelId: string;
+  openrouterModelId: string;
+  modelCheck: { state: ModelCheckState; message?: string };
+  activeTab: TabId;
+  tabDirection: 'left' | 'right';
+  isSaving: boolean;
+  isSaved: boolean;
+}
+
+const INITIAL_GENERAL_SETTINGS_STATE: GeneralSettingsState = {
+  currency: '',
+  dailyLimit: 8,
+  startOfWeek: 'Monday',
+  treatSaturdayAsHoliday: false,
+  allowWeekendSelection: true,
+  defaultLocation: 'remote',
+  rilCompanyName: '',
+  rilDefaultStartTime: DEFAULT_RIL_START_TIME,
+  rilDefaultExitTime: DEFAULT_RIL_EXIT_TIME,
+  rilLunchBreakMinutes: 60,
+  rilNoteOptions: toEditableRilNoteOptions(undefined),
+  rilTransferOptions: toEditableRilTransferOptions(undefined),
+  enableAiReporting: false,
+  geminiApiKey: '',
+  aiProvider: 'gemini',
+  openrouterApiKey: '',
+  geminiModelId: '',
+  openrouterModelId: '',
+  modelCheck: { state: 'idle' },
+  activeTab: 'localization',
+  tabDirection: 'right',
+  isSaving: false,
+  isSaved: false,
+};
+
+type GeneralSettingsAction =
+  | { type: 'merge'; patch: Partial<GeneralSettingsState> }
+  | {
+      type: 'setRilNoteOptions';
+      updater: (prev: EditableRilNoteOption[]) => EditableRilNoteOption[];
+    }
+  | {
+      type: 'setRilTransferOptions';
+      updater: (prev: EditableRilTransferOption[]) => EditableRilTransferOption[];
+    };
+
+const generalSettingsReducer = (
+  state: GeneralSettingsState,
+  action: GeneralSettingsAction,
+): GeneralSettingsState => {
+  switch (action.type) {
+    case 'merge':
+      return { ...state, ...action.patch };
+    case 'setRilNoteOptions':
+      return { ...state, rilNoteOptions: action.updater(state.rilNoteOptions) };
+    case 'setRilTransferOptions':
+      return { ...state, rilTransferOptions: action.updater(state.rilTransferOptions) };
+    default:
+      return state;
+  }
+};
+
 interface ToggleSettingRowProps {
   label: string;
   description: string;
@@ -148,43 +227,42 @@ const GeneralSettings: React.FC<GeneralSettingsProps> = ({
     { id: 'gemini', name: t('general.aiProviders.gemini') },
     { id: 'openrouter', name: t('general.aiProviders.openrouter') },
   ];
-  const [currency, setCurrency] = useState('');
-  const [dailyLimit, setDailyLimit] = useState(8);
-  const [startOfWeek, setStartOfWeek] = useState<IGeneralSettings['startOfWeek']>('Monday');
-  const [treatSaturdayAsHoliday, setTreatSaturdayAsHoliday] = useState(false);
-  const [allowWeekendSelection, setAllowWeekendSelection] = useState(true);
-  const [defaultLocation, setDefaultLocation] = useState<TimeEntryLocation>('remote');
-  const [rilCompanyName, setRilCompanyName] = useState('');
-  const [rilDefaultStartTime, setRilDefaultStartTime] = useState(DEFAULT_RIL_START_TIME);
-  const [rilDefaultExitTime, setRilDefaultExitTime] = useState(DEFAULT_RIL_EXIT_TIME);
-  const [rilLunchBreakMinutes, setRilLunchBreakMinutes] = useState(60);
-  const [rilNoteOptions, setRilNoteOptions] = useState<EditableRilNoteOption[]>(() =>
-    toEditableRilNoteOptions(undefined),
-  );
-  const [rilTransferOptions, setRilTransferOptions] = useState<EditableRilTransferOption[]>(() =>
-    toEditableRilTransferOptions(undefined),
-  );
-  const [enableAiReporting, setEnableAiReporting] = useState(false);
-  const [geminiApiKey, setGeminiApiKey] = useState('');
-  const [aiProvider, setAiProvider] = useState<AiProvider>('gemini');
-  const [openrouterApiKey, setOpenrouterApiKey] = useState('');
-  const [geminiModelId, setGeminiModelId] = useState('');
-  const [openrouterModelId, setOpenrouterModelId] = useState('');
-  const [modelCheck, setModelCheck] = useState<{ state: ModelCheckState; message?: string }>({
-    state: 'idle',
-  });
-  const [activeTab, setActiveTab] = useState<TabId>('localization');
-  const [tabDirection, setTabDirection] = useState<'left' | 'right'>('right');
-  const [isSaving, setIsSaving] = useState(false);
-  const [isSaved, setIsSaved] = useState(false);
+  const [state, dispatch] = useReducer(generalSettingsReducer, INITIAL_GENERAL_SETTINGS_STATE);
+  const {
+    currency,
+    dailyLimit,
+    startOfWeek,
+    treatSaturdayAsHoliday,
+    allowWeekendSelection,
+    defaultLocation,
+    rilCompanyName,
+    rilDefaultStartTime,
+    rilDefaultExitTime,
+    rilLunchBreakMinutes,
+    rilNoteOptions,
+    rilTransferOptions,
+    enableAiReporting,
+    geminiApiKey,
+    aiProvider,
+    openrouterApiKey,
+    geminiModelId,
+    openrouterModelId,
+    modelCheck,
+    activeTab,
+    tabDirection,
+    isSaving,
+    isSaved,
+  } = state;
   const loadedSettingsRef = useRef<IGeneralSettings | null>(null);
 
   const handleTabChange = (id: TabId) => {
     if (id === activeTab) return;
     const nextIndex = TABS.findIndex((tab) => tab.id === id);
     const currentIndex = TABS.findIndex((tab) => tab.id === activeTab);
-    setTabDirection(nextIndex > currentIndex ? 'right' : 'left');
-    setActiveTab(id);
+    dispatch({
+      type: 'merge',
+      patch: { tabDirection: nextIndex > currentIndex ? 'right' : 'left', activeTab: id },
+    });
   };
 
   const sectionAnimationClass =
@@ -194,38 +272,53 @@ const GeneralSettings: React.FC<GeneralSettingsProps> = ({
 
   if (loadedSettingsRef.current !== settings) {
     loadedSettingsRef.current = settings;
-    setCurrency(settings.currency);
-    setDailyLimit(settings.dailyLimit);
-    setStartOfWeek(settings.startOfWeek);
-    setTreatSaturdayAsHoliday(settings.treatSaturdayAsHoliday);
-    setAllowWeekendSelection(settings.allowWeekendSelection ?? true);
-    setDefaultLocation(settings.defaultLocation || 'remote');
-    setRilCompanyName(settings.rilCompanyName || '');
-    setRilDefaultStartTime(settings.rilDefaultStartTime || DEFAULT_RIL_START_TIME);
-    setRilDefaultExitTime(settings.rilDefaultExitTime || DEFAULT_RIL_EXIT_TIME);
-    setRilLunchBreakMinutes(settings.rilLunchBreakMinutes ?? 60);
-    setRilNoteOptions(toEditableRilNoteOptions(settings.rilNoteOptions));
-    setRilTransferOptions(toEditableRilTransferOptions(settings.rilTransferOptions));
-    setEnableAiReporting(settings.enableAiReporting);
-    setGeminiApiKey(settings.geminiApiKey || '');
-    setAiProvider(settings.aiProvider || 'gemini');
-    setOpenrouterApiKey(settings.openrouterApiKey || '');
-    setGeminiModelId(settings.geminiModelId || '');
-    setOpenrouterModelId(settings.openrouterModelId || '');
-    setModelCheck({ state: 'idle' });
+    dispatch({
+      type: 'merge',
+      patch: {
+        currency: settings.currency,
+        dailyLimit: settings.dailyLimit,
+        startOfWeek: settings.startOfWeek,
+        treatSaturdayAsHoliday: settings.treatSaturdayAsHoliday,
+        allowWeekendSelection: settings.allowWeekendSelection ?? true,
+        defaultLocation: settings.defaultLocation || 'remote',
+        rilCompanyName: settings.rilCompanyName || '',
+        rilDefaultStartTime: settings.rilDefaultStartTime || DEFAULT_RIL_START_TIME,
+        rilDefaultExitTime: settings.rilDefaultExitTime || DEFAULT_RIL_EXIT_TIME,
+        rilLunchBreakMinutes: settings.rilLunchBreakMinutes ?? 60,
+        rilNoteOptions: toEditableRilNoteOptions(settings.rilNoteOptions),
+        rilTransferOptions: toEditableRilTransferOptions(settings.rilTransferOptions),
+        enableAiReporting: settings.enableAiReporting,
+        geminiApiKey: settings.geminiApiKey || '',
+        aiProvider: settings.aiProvider || 'gemini',
+        openrouterApiKey: settings.openrouterApiKey || '',
+        geminiModelId: settings.geminiModelId || '',
+        openrouterModelId: settings.openrouterModelId || '',
+        modelCheck: { state: 'idle' },
+      },
+    });
   }
 
   const currentApiKey = aiProvider === 'gemini' ? geminiApiKey : openrouterApiKey;
   const currentModelId = aiProvider === 'gemini' ? geminiModelId : openrouterModelId;
 
   const handleApiKeyChange = (value: string) => {
-    (aiProvider === 'gemini' ? setGeminiApiKey : setOpenrouterApiKey)(value);
-    setModelCheck({ state: 'idle' });
+    dispatch({
+      type: 'merge',
+      patch: {
+        ...(aiProvider === 'gemini' ? { geminiApiKey: value } : { openrouterApiKey: value }),
+        modelCheck: { state: 'idle' },
+      },
+    });
   };
 
   const handleModelIdChange = (value: string) => {
-    (aiProvider === 'gemini' ? setGeminiModelId : setOpenrouterModelId)(value);
-    setModelCheck({ state: 'idle' });
+    dispatch({
+      type: 'merge',
+      patch: {
+        ...(aiProvider === 'gemini' ? { geminiModelId: value } : { openrouterModelId: value }),
+        modelCheck: { state: 'idle' },
+      },
+    });
   };
 
   const isAnyAiEnabled = enableAiReporting;
@@ -235,7 +328,7 @@ const GeneralSettings: React.FC<GeneralSettingsProps> = ({
 
   const handleCheckModel = async () => {
     if (!currentApiKey.trim() || !currentModelId.trim()) return;
-    setModelCheck({ state: 'checking' });
+    dispatch({ type: 'merge', patch: { modelCheck: { state: 'checking' } } });
     try {
       const res = await api.ai.validateModel({
         provider: aiProvider,
@@ -243,21 +336,30 @@ const GeneralSettings: React.FC<GeneralSettingsProps> = ({
         apiKey: currentApiKey,
       });
       if (res.ok) {
-        setModelCheck({ state: 'ok' });
+        dispatch({ type: 'merge', patch: { modelCheck: { state: 'ok' } } });
       } else if (res.code === 'NOT_FOUND') {
-        setModelCheck({ state: 'not_found', message: res.message || '' });
+        dispatch({
+          type: 'merge',
+          patch: { modelCheck: { state: 'not_found', message: res.message || '' } },
+        });
       } else {
-        setModelCheck({ state: 'error', message: res.message || '' });
+        dispatch({
+          type: 'merge',
+          patch: { modelCheck: { state: 'error', message: res.message || '' } },
+        });
       }
     } catch (err) {
-      setModelCheck({ state: 'error', message: (err as Error).message });
+      dispatch({
+        type: 'merge',
+        patch: { modelCheck: { state: 'error', message: (err as Error).message } },
+      });
     }
   };
 
   const handleSave = async (e: React.FormEvent) => {
     e.preventDefault();
     if (isApiKeyMissing() || isModelMissing() || isModelNotFound) return;
-    setIsSaving(true);
+    dispatch({ type: 'merge', patch: { isSaving: true } });
     try {
       await onUpdate({
         currency,
@@ -281,12 +383,12 @@ const GeneralSettings: React.FC<GeneralSettingsProps> = ({
         geminiModelId,
         openrouterModelId,
       });
-      setIsSaved(true);
-      setTimeout(() => setIsSaved(false), 3000);
+      dispatch({ type: 'merge', patch: { isSaved: true } });
+      setTimeout(() => dispatch({ type: 'merge', patch: { isSaved: false } }), 3000);
     } catch (err) {
       console.error('Failed to save general settings:', err);
     } finally {
-      setIsSaving(false);
+      dispatch({ type: 'merge', patch: { isSaving: false } });
     }
   };
 
@@ -321,43 +423,51 @@ const GeneralSettings: React.FC<GeneralSettingsProps> = ({
     (!hasChanges && !isSaved);
 
   const updateRilNoteOption = (index: number, field: keyof RilNoteOption, value: string) => {
-    setRilNoteOptions((prev) =>
-      prev.map((option, optionIndex) =>
-        optionIndex === index ? { ...option, [field]: value } : option,
-      ),
-    );
+    dispatch({
+      type: 'setRilNoteOptions',
+      updater: (prev) =>
+        prev.map((option, optionIndex) =>
+          optionIndex === index ? { ...option, [field]: value } : option,
+        ),
+    });
   };
 
   const addRilNoteOption = () => {
-    setRilNoteOptions((prev) => [
-      ...prev,
-      { value: '', label: '', draftId: createRilDraftId('note') },
-    ]);
+    dispatch({
+      type: 'setRilNoteOptions',
+      updater: (prev) => [...prev, { value: '', label: '', draftId: createRilDraftId('note') }],
+    });
   };
 
   const removeRilNoteOption = (index: number) => {
-    setRilNoteOptions((prev) =>
-      prev.length > 1 ? prev.filter((_, optionIndex) => optionIndex !== index) : prev,
-    );
+    dispatch({
+      type: 'setRilNoteOptions',
+      updater: (prev) =>
+        prev.length > 1 ? prev.filter((_, optionIndex) => optionIndex !== index) : prev,
+    });
   };
 
   const updateRilTransferOption = (index: number, value: string) => {
-    setRilTransferOptions((prev) =>
-      prev.map((option, optionIndex) => (optionIndex === index ? { ...option, value } : option)),
-    );
+    dispatch({
+      type: 'setRilTransferOptions',
+      updater: (prev) =>
+        prev.map((option, optionIndex) => (optionIndex === index ? { ...option, value } : option)),
+    });
   };
 
   const addRilTransferOption = () => {
-    setRilTransferOptions((prev) => [
-      ...prev,
-      { value: '', draftId: createRilDraftId('transfer') },
-    ]);
+    dispatch({
+      type: 'setRilTransferOptions',
+      updater: (prev) => [...prev, { value: '', draftId: createRilDraftId('transfer') }],
+    });
   };
 
   const removeRilTransferOption = (index: number) => {
-    setRilTransferOptions((prev) =>
-      prev.length > 1 ? prev.filter((_, optionIndex) => optionIndex !== index) : prev,
-    );
+    dispatch({
+      type: 'setRilTransferOptions',
+      updater: (prev) =>
+        prev.length > 1 ? prev.filter((_, optionIndex) => optionIndex !== index) : prev,
+    });
   };
 
   const {
@@ -424,7 +534,9 @@ const GeneralSettings: React.FC<GeneralSettingsProps> = ({
                   id="general-currency"
                   options={CURRENCY_OPTIONS}
                   value={currency}
-                  onChange={(val) => setCurrency(val as string)}
+                  onChange={(val) =>
+                    dispatch({ type: 'merge', patch: { currency: val as string } })
+                  }
                   searchable={true}
                   placeholder={t('general.currencyLabel')}
                 />
@@ -460,7 +572,10 @@ const GeneralSettings: React.FC<GeneralSettingsProps> = ({
                     value={dailyLimit}
                     onValueChange={(value) => {
                       const parsed = parseFloat(value);
-                      setDailyLimit(value === '' || Number.isNaN(parsed) ? 0 : parsed);
+                      dispatch({
+                        type: 'merge',
+                        patch: { dailyLimit: value === '' || Number.isNaN(parsed) ? 0 : parsed },
+                      });
                     }}
                   />
                   <FieldDescription>{t('general.dailyLimitDescription')}</FieldDescription>
@@ -477,7 +592,12 @@ const GeneralSettings: React.FC<GeneralSettingsProps> = ({
                       { id: 'Sunday', name: t('general.sunday') },
                     ]}
                     value={startOfWeek}
-                    onChange={(val) => setStartOfWeek(val as 'Monday' | 'Sunday')}
+                    onChange={(val) =>
+                      dispatch({
+                        type: 'merge',
+                        patch: { startOfWeek: val as 'Monday' | 'Sunday' },
+                      })
+                    }
                   />
                   <FieldDescription>{t('general.startOfWeekDescription')}</FieldDescription>
                 </Field>
@@ -495,7 +615,12 @@ const GeneralSettings: React.FC<GeneralSettingsProps> = ({
                       { id: 'transfer', name: t('general.locationTypes.transfer') },
                     ]}
                     value={defaultLocation}
-                    onChange={(val) => setDefaultLocation(val as TimeEntryLocation)}
+                    onChange={(val) =>
+                      dispatch({
+                        type: 'merge',
+                        patch: { defaultLocation: val as TimeEntryLocation },
+                      })
+                    }
                   />
                   <FieldDescription>{t('general.defaultLocationDescription')}</FieldDescription>
                 </Field>
@@ -505,14 +630,18 @@ const GeneralSettings: React.FC<GeneralSettingsProps> = ({
                 label={t('general.treatSaturdayAsHolidayLabel')}
                 description={t('general.treatSaturdayAsHolidayDescription')}
                 checked={treatSaturdayAsHoliday}
-                onChange={setTreatSaturdayAsHoliday}
+                onChange={(checked) =>
+                  dispatch({ type: 'merge', patch: { treatSaturdayAsHoliday: checked } })
+                }
               />
 
               <ToggleSettingRow
                 label={t('general.allowWeekendSelectionLabel')}
                 description={t('general.allowWeekendSelectionDescription')}
                 checked={allowWeekendSelection}
-                onChange={setAllowWeekendSelection}
+                onChange={(checked) =>
+                  dispatch({ type: 'merge', patch: { allowWeekendSelection: checked } })
+                }
               />
 
               <div className="space-y-4">
@@ -532,7 +661,9 @@ const GeneralSettings: React.FC<GeneralSettingsProps> = ({
                     <Input
                       id="general-ril-company-name"
                       value={rilCompanyName}
-                      onChange={(event) => setRilCompanyName(event.target.value)}
+                      onChange={(event) =>
+                        dispatch({ type: 'merge', patch: { rilCompanyName: event.target.value } })
+                      }
                     />
                     <FieldDescription>{t('general.rilCompanyNameDescription')}</FieldDescription>
                   </Field>
@@ -545,7 +676,12 @@ const GeneralSettings: React.FC<GeneralSettingsProps> = ({
                       id="general-ril-default-start-time"
                       type="time"
                       value={rilDefaultStartTime}
-                      onChange={(event) => setRilDefaultStartTime(event.target.value)}
+                      onChange={(event) =>
+                        dispatch({
+                          type: 'merge',
+                          patch: { rilDefaultStartTime: event.target.value },
+                        })
+                      }
                     />
                     <FieldDescription>
                       {t('general.rilDefaultStartTimeDescription')}
@@ -560,7 +696,12 @@ const GeneralSettings: React.FC<GeneralSettingsProps> = ({
                       id="general-ril-default-exit-time"
                       type="time"
                       value={rilDefaultExitTime}
-                      onChange={(event) => setRilDefaultExitTime(event.target.value)}
+                      onChange={(event) =>
+                        dispatch({
+                          type: 'merge',
+                          patch: { rilDefaultExitTime: event.target.value },
+                        })
+                      }
                     />
                     <FieldDescription>
                       {t('general.rilDefaultExitTimeDescription')}
@@ -579,7 +720,12 @@ const GeneralSettings: React.FC<GeneralSettingsProps> = ({
                       value={rilLunchBreakMinutes}
                       onValueChange={(value) => {
                         const parsed = parseInt(value, 10);
-                        setRilLunchBreakMinutes(value === '' || Number.isNaN(parsed) ? 0 : parsed);
+                        dispatch({
+                          type: 'merge',
+                          patch: {
+                            rilLunchBreakMinutes: value === '' || Number.isNaN(parsed) ? 0 : parsed,
+                          },
+                        });
                       }}
                     />
                     <FieldDescription>
@@ -716,7 +862,9 @@ const GeneralSettings: React.FC<GeneralSettingsProps> = ({
                 label={t('general.enableAiReportingLabel')}
                 description={t('general.enableAiReportingDescription')}
                 checked={enableAiReporting}
-                onChange={setEnableAiReporting}
+                onChange={(checked) =>
+                  dispatch({ type: 'merge', patch: { enableAiReporting: checked } })
+                }
                 contentClassName="max-w-md"
               />
 
@@ -730,10 +878,12 @@ const GeneralSettings: React.FC<GeneralSettingsProps> = ({
                       id="general-ai-provider"
                       options={AI_PROVIDER_OPTIONS}
                       value={aiProvider}
-                      onChange={(val) => {
-                        setAiProvider(val as AiProvider);
-                        setModelCheck({ state: 'idle' });
-                      }}
+                      onChange={(val) =>
+                        dispatch({
+                          type: 'merge',
+                          patch: { aiProvider: val as AiProvider, modelCheck: { state: 'idle' } },
+                        })
+                      }
                     />
                     <FieldDescription>{t('general.aiProviderDescription')}</FieldDescription>
                   </Field>

--- a/components/administration/UserManagement.tsx
+++ b/components/administration/UserManagement.tsx
@@ -1,5 +1,5 @@
 import { Eye, EyeOff, UserPlus } from 'lucide-react';
-import React, { useState } from 'react';
+import React, { useReducer } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import {
@@ -137,6 +137,146 @@ export interface UserManagementProps {
   currency: string;
 }
 
+interface AssignmentSelection {
+  clientIds: string[];
+  projectIds: string[];
+  taskIds: string[];
+}
+
+const EMPTY_ASSIGNMENTS: AssignmentSelection = {
+  clientIds: [],
+  projectIds: [],
+  taskIds: [],
+};
+
+interface UserManagementState {
+  // Create-user form
+  newFirstName: string;
+  newSurname: string;
+  newEmail: string;
+  newUsername: string;
+  newPassword: string;
+  newRole: string;
+  formErrors: Record<string, string>;
+  showNewPassword: boolean;
+  isCreateModalOpen: boolean;
+  // Assignment modal
+  managingUserId: string | null;
+  assignments: AssignmentSelection;
+  initialAssignments: AssignmentSelection;
+  clientSearch: string;
+  projectSearch: string;
+  taskSearch: string;
+  filterClientId: string;
+  filterProjectId: string;
+  isLoadingAssignments: boolean;
+  // Delete confirmation
+  isDeleteConfirmOpen: boolean;
+  userToDelete: User | null;
+  // Edit-user modal
+  editingUser: User | null;
+  editFirstName: string;
+  editSurname: string;
+  editEmail: string;
+  editRole: string;
+  editAssignedRoleIds: string[];
+  editPrimaryRoleId: string;
+  initialEditAssignedRoleIds: string[];
+  initialEditPrimaryRoleId: string;
+  isLoadingEditRoles: boolean;
+  editRolesError: string;
+  editFormErrors: Record<string, string>;
+  editCostPerHour: string;
+  editIsDisabled: boolean;
+  // Auth-method dialog
+  authMethodUser: User | null;
+  authMethodDraft: UserAuthMethod;
+  authProviderDraft: string;
+  authMethodError: string;
+  isSavingAuthMethod: boolean;
+  // TOTP reset dialog
+  totpResetUser: User | null;
+  totpResetError: string;
+  isResettingTotp: boolean;
+}
+
+const getInitialUserManagementState = (defaultRole: string): UserManagementState => ({
+  newFirstName: '',
+  newSurname: '',
+  newEmail: '',
+  newUsername: '',
+  newPassword: '',
+  newRole: defaultRole,
+  formErrors: {},
+  showNewPassword: false,
+  isCreateModalOpen: false,
+  managingUserId: null,
+  assignments: EMPTY_ASSIGNMENTS,
+  initialAssignments: EMPTY_ASSIGNMENTS,
+  clientSearch: '',
+  projectSearch: '',
+  taskSearch: '',
+  filterClientId: 'all',
+  filterProjectId: 'all',
+  isLoadingAssignments: false,
+  isDeleteConfirmOpen: false,
+  userToDelete: null,
+  editingUser: null,
+  editFirstName: '',
+  editSurname: '',
+  editEmail: '',
+  editRole: '',
+  editAssignedRoleIds: [],
+  editPrimaryRoleId: '',
+  initialEditAssignedRoleIds: [],
+  initialEditPrimaryRoleId: '',
+  isLoadingEditRoles: false,
+  editRolesError: '',
+  editFormErrors: {},
+  editCostPerHour: '0',
+  editIsDisabled: false,
+  authMethodUser: null,
+  authMethodDraft: 'local',
+  authProviderDraft: '',
+  authMethodError: '',
+  isSavingAuthMethod: false,
+  totpResetUser: null,
+  totpResetError: '',
+  isResettingTotp: false,
+});
+
+type UserManagementAction =
+  | { type: 'set'; values: Partial<UserManagementState> }
+  | { type: 'patchFormErrors'; value: Record<string, string> }
+  | { type: 'patchEditFormErrors'; value: Record<string, string> }
+  | { type: 'toggleEditAssignedRole'; roleId: string }
+  | { type: 'toggleAssignment'; assignments: AssignmentSelection };
+
+const userManagementReducer = (
+  state: UserManagementState,
+  action: UserManagementAction,
+): UserManagementState => {
+  switch (action.type) {
+    case 'set':
+      return { ...state, ...action.values };
+    case 'patchFormErrors':
+      return { ...state, formErrors: { ...state.formErrors, ...action.value } };
+    case 'patchEditFormErrors':
+      return { ...state, editFormErrors: { ...state.editFormErrors, ...action.value } };
+    case 'toggleEditAssignedRole':
+      return {
+        ...state,
+        editAssignedRoleIds: state.editAssignedRoleIds.includes(action.roleId)
+          ? state.editAssignedRoleIds.filter((id) => id !== action.roleId)
+          : [...state.editAssignedRoleIds, action.roleId],
+      };
+    case 'toggleAssignment':
+      return { ...state, assignments: action.assignments };
+    default:
+      return state;
+  }
+};
+
 const UserManagement: React.FC<UserManagementProps> = ({
   users,
   clients,
@@ -173,68 +313,54 @@ const UserManagement: React.FC<UserManagementProps> = ({
     return new Map(roles.map((role) => [role.id, role]));
   }, [roles]);
 
-  const [newFirstName, setNewFirstName] = useState('');
-  const [newSurname, setNewSurname] = useState('');
-  const [newEmail, setNewEmail] = useState('');
-  const [newUsername, setNewUsername] = useState('');
-  const [newPassword, setNewPassword] = useState('');
-  const [newRole, setNewRole] = useState<string>(roleOptions[0]?.id || '');
   const usernameManuallyEdited = React.useRef(false);
-  const [formErrors, setFormErrors] = useState<Record<string, string>>({});
-  const [showNewPassword, setShowNewPassword] = useState(false);
-
-  const [managingUserId, setManagingUserId] = useState<string | null>(null);
-  const [assignments, setAssignments] = useState<{
-    clientIds: string[];
-    projectIds: string[];
-    taskIds: string[];
-  }>({
-    clientIds: [],
-    projectIds: [],
-    taskIds: [],
-  });
-  const [initialAssignments, setInitialAssignments] = useState<{
-    clientIds: string[];
-    projectIds: string[];
-    taskIds: string[];
-  }>({
-    clientIds: [],
-    projectIds: [],
-    taskIds: [],
-  });
-  const [clientSearch, setClientSearch] = useState('');
-  const [projectSearch, setProjectSearch] = useState('');
-  const [taskSearch, setTaskSearch] = useState('');
-  const [filterClientId, setFilterClientId] = useState('all');
-  const [filterProjectId, setFilterProjectId] = useState('all');
-
-  const [isLoadingAssignments, setIsLoadingAssignments] = useState(false);
-  const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
-  const [userToDelete, setUserToDelete] = useState<User | null>(null);
-
-  const [editingUser, setEditingUser] = useState<User | null>(null);
-  const [editFirstName, setEditFirstName] = useState('');
-  const [editSurname, setEditSurname] = useState('');
-  const [editEmail, setEditEmail] = useState('');
-  const [editRole, setEditRole] = useState<string>('');
-  const [editAssignedRoleIds, setEditAssignedRoleIds] = useState<string[]>([]);
-  const [editPrimaryRoleId, setEditPrimaryRoleId] = useState<string>('');
-  const [initialEditAssignedRoleIds, setInitialEditAssignedRoleIds] = useState<string[]>([]);
-  const [initialEditPrimaryRoleId, setInitialEditPrimaryRoleId] = useState<string>('');
-  const [isLoadingEditRoles, setIsLoadingEditRoles] = useState(false);
-  const [editRolesError, setEditRolesError] = useState('');
-  const [editFormErrors, setEditFormErrors] = useState<Record<string, string>>({});
-  const [editCostPerHour, setEditCostPerHour] = useState<string>('0');
-  const [editIsDisabled, setEditIsDisabled] = useState(false);
-  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
-  const [authMethodUser, setAuthMethodUser] = useState<User | null>(null);
-  const [authMethodDraft, setAuthMethodDraft] = useState<UserAuthMethod>('local');
-  const [authProviderDraft, setAuthProviderDraft] = useState<string>('');
-  const [authMethodError, setAuthMethodError] = useState('');
-  const [isSavingAuthMethod, setIsSavingAuthMethod] = useState(false);
-  const [totpResetUser, setTotpResetUser] = useState<User | null>(null);
-  const [totpResetError, setTotpResetError] = useState('');
-  const [isResettingTotp, setIsResettingTotp] = useState(false);
+  const [state, dispatch] = useReducer(userManagementReducer, roleOptions[0]?.id || '', (role) =>
+    getInitialUserManagementState(role),
+  );
+  const {
+    newFirstName,
+    newSurname,
+    newEmail,
+    newUsername,
+    newPassword,
+    newRole,
+    formErrors,
+    showNewPassword,
+    isCreateModalOpen,
+    managingUserId,
+    assignments,
+    initialAssignments,
+    clientSearch,
+    projectSearch,
+    taskSearch,
+    filterClientId,
+    filterProjectId,
+    isLoadingAssignments,
+    isDeleteConfirmOpen,
+    userToDelete,
+    editingUser,
+    editFirstName,
+    editSurname,
+    editEmail,
+    editRole,
+    editAssignedRoleIds,
+    editPrimaryRoleId,
+    initialEditAssignedRoleIds,
+    initialEditPrimaryRoleId,
+    isLoadingEditRoles,
+    editRolesError,
+    editFormErrors,
+    editCostPerHour,
+    editIsDisabled,
+    authMethodUser,
+    authMethodDraft,
+    authProviderDraft,
+    authMethodError,
+    isSavingAuthMethod,
+    totpResetUser,
+    totpResetError,
+    isResettingTotp,
+  } = state;
 
   const canCreateUsers = hasPermission(
     permissions,
@@ -263,12 +389,12 @@ const UserManagement: React.FC<UserManagementProps> = ({
     canUpdateAllCosts || (canUpdateOwnCost && targetUserId === currentUserId);
   const canManageAssignments = canUpdateUsers;
   if (!newRole && roleOptions[0]?.id) {
-    setNewRole(roleOptions[0].id);
+    dispatch({ type: 'set', values: { newRole: roleOptions[0].id } });
   }
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    setFormErrors({});
+    dispatch({ type: 'set', values: { formErrors: {} } });
 
     const newErrors: Record<string, string> = {};
     if (!newFirstName?.trim()) newErrors.firstName = t('common:validation.nameRequired');
@@ -280,7 +406,7 @@ const UserManagement: React.FC<UserManagementProps> = ({
     if (!newPassword?.trim()) newErrors.password = t('common:validation.passwordRequired');
 
     if (Object.keys(newErrors).length > 0) {
-      setFormErrors(newErrors);
+      dispatch({ type: 'set', values: { formErrors: newErrors } });
       return;
     }
 
@@ -294,66 +420,91 @@ const UserManagement: React.FC<UserManagementProps> = ({
     );
     if (!result.success) {
       if (result.error?.includes('Username already exists')) {
-        setFormErrors({ username: t('common:validation.usernameAlreadyExists') || result.error });
+        dispatch({
+          type: 'set',
+          values: {
+            formErrors: { username: t('common:validation.usernameAlreadyExists') || result.error },
+          },
+        });
       } else if (result.error?.toLowerCase().includes('email')) {
-        setFormErrors({ email: t('common:validation.invalidEmail') || result.error });
+        dispatch({
+          type: 'set',
+          values: { formErrors: { email: t('common:validation.invalidEmail') || result.error } },
+        });
       } else {
-        setFormErrors({ general: result.error || t('common:messages.errorOccurred') });
+        dispatch({
+          type: 'set',
+          values: { formErrors: { general: result.error || t('common:messages.errorOccurred') } },
+        });
       }
       return;
     }
 
     resetCreateUserForm();
-    setIsCreateModalOpen(false);
+    dispatch({ type: 'set', values: { isCreateModalOpen: false } });
   };
 
   const resetCreateUserForm = () => {
-    setNewFirstName('');
-    setNewSurname('');
-    setNewEmail('');
-    setNewUsername('');
-    setNewPassword('');
-    setShowNewPassword(false);
-    setNewRole(roleOptions[0]?.id || '');
     usernameManuallyEdited.current = false;
-    setFormErrors({});
+    dispatch({
+      type: 'set',
+      values: {
+        newFirstName: '',
+        newSurname: '',
+        newEmail: '',
+        newUsername: '',
+        newPassword: '',
+        showNewPassword: false,
+        newRole: roleOptions[0]?.id || '',
+        formErrors: {},
+      },
+    });
   };
 
   const closeCreateModal = () => {
-    setIsCreateModalOpen(false);
+    dispatch({ type: 'set', values: { isCreateModalOpen: false } });
     resetCreateUserForm();
   };
 
   if (filterClientId !== 'all' && filterProjectId !== 'all') {
     const selectedProject = projects.find((project) => project.id === filterProjectId);
     if (!selectedProject || selectedProject.clientId !== filterClientId) {
-      setFilterProjectId('all');
+      dispatch({ type: 'set', values: { filterProjectId: 'all' } });
     }
   }
 
   const openAssignments = async (userId: string) => {
     if (!canManageAssignments) return;
-    setManagingUserId(userId);
-    setIsLoadingAssignments(true);
+    dispatch({ type: 'set', values: { managingUserId: userId, isLoadingAssignments: true } });
     try {
       const data = await usersApi.getAssignments(userId);
-      setAssignments(data);
-      setInitialAssignments(JSON.parse(JSON.stringify(data))); // Deep clone for comparison
+      dispatch({
+        type: 'set',
+        values: {
+          assignments: data,
+          initialAssignments: JSON.parse(JSON.stringify(data)), // Deep clone for comparison
+        },
+      });
     } catch (err) {
       console.error('Failed to load assignments', err);
     } finally {
-      setIsLoadingAssignments(false);
+      dispatch({ type: 'set', values: { isLoadingAssignments: false } });
     }
   };
 
   const closeAssignments = () => {
-    setManagingUserId(null);
-    setAssignments({ clientIds: [], projectIds: [], taskIds: [] });
-    setClientSearch('');
-    setProjectSearch('');
-    setTaskSearch('');
-    setFilterClientId('all');
-    setFilterProjectId('all');
+    dispatch({
+      type: 'set',
+      values: {
+        managingUserId: null,
+        assignments: { clientIds: [], projectIds: [], taskIds: [] },
+        clientSearch: '',
+        projectSearch: '',
+        taskSearch: '',
+        filterClientId: 'all',
+        filterProjectId: 'all',
+      },
+    });
   };
 
   const saveAssignments = async () => {
@@ -374,7 +525,7 @@ const UserManagement: React.FC<UserManagementProps> = ({
 
   const toggleAssignment = (type: 'client' | 'project' | 'task', id: string) => {
     if (!canManageAssignments) return;
-    setAssignments((prev) => {
+    const nextAssignments = ((prev: AssignmentSelection): AssignmentSelection => {
       const list =
         type === 'client' ? prev.clientIds : type === 'project' ? prev.projectIds : prev.taskIds;
       const isAdding = !list.includes(id);
@@ -467,141 +618,177 @@ const UserManagement: React.FC<UserManagementProps> = ({
         projectIds: newProjectIds,
         taskIds: newTaskIds,
       };
-    });
+    })(assignments);
+    dispatch({ type: 'toggleAssignment', assignments: nextAssignments });
   };
 
   const confirmDelete = (user: User) => {
-    setUserToDelete(user);
-    setIsDeleteConfirmOpen(true);
+    dispatch({ type: 'set', values: { userToDelete: user, isDeleteConfirmOpen: true } });
   };
 
   const cancelDelete = () => {
-    setIsDeleteConfirmOpen(false);
-    setUserToDelete(null);
+    dispatch({ type: 'set', values: { isDeleteConfirmOpen: false, userToDelete: null } });
   };
 
   const handleDelete = () => {
     if (userToDelete) {
       onDeleteUser(userToDelete.id);
-      setIsDeleteConfirmOpen(false);
-      setUserToDelete(null);
+      dispatch({ type: 'set', values: { isDeleteConfirmOpen: false, userToDelete: null } });
     }
   };
 
   const handleEdit = (user: User) => {
     const { firstName, surname } = splitFullName(user.name);
-    setEditingUser(user);
-    setEditFirstName(firstName);
-    setEditSurname(surname);
-    setEditEmail(user.email || '');
-    setEditRole(user.role);
-    setEditCostPerHour(user.costPerHour?.toString() || '0');
-    setEditIsDisabled(!!user.isDisabled);
-    setEditFormErrors({});
-
     // Multi-role edit state (admin-only in practice because roles are admin-scoped)
-    setEditRolesError('');
     if (user.id === currentUserId || roles.length === 0) {
       const fallback = [user.role];
-      setEditAssignedRoleIds(fallback);
-      setEditPrimaryRoleId(user.role);
-      setInitialEditAssignedRoleIds(fallback);
-      setInitialEditPrimaryRoleId(user.role);
+      dispatch({
+        type: 'set',
+        values: {
+          editingUser: user,
+          editFirstName: firstName,
+          editSurname: surname,
+          editEmail: user.email || '',
+          editRole: user.role,
+          editCostPerHour: user.costPerHour?.toString() || '0',
+          editIsDisabled: !!user.isDisabled,
+          editFormErrors: {},
+          editRolesError: '',
+          editAssignedRoleIds: fallback,
+          editPrimaryRoleId: user.role,
+          initialEditAssignedRoleIds: fallback,
+          initialEditPrimaryRoleId: user.role,
+        },
+      });
       return;
     }
 
-    setIsLoadingEditRoles(true);
+    dispatch({
+      type: 'set',
+      values: {
+        editingUser: user,
+        editFirstName: firstName,
+        editSurname: surname,
+        editEmail: user.email || '',
+        editRole: user.role,
+        editCostPerHour: user.costPerHour?.toString() || '0',
+        editIsDisabled: !!user.isDisabled,
+        editFormErrors: {},
+        editRolesError: '',
+        isLoadingEditRoles: true,
+      },
+    });
     usersApi
       .getRoles(user.id)
       .then(({ roleIds, primaryRoleId }) => {
         const safeRoleIds = roleIds?.length ? roleIds : [user.role];
         const safePrimary = primaryRoleId || user.role;
-        setEditAssignedRoleIds(safeRoleIds);
-        setEditPrimaryRoleId(safePrimary);
-        setInitialEditAssignedRoleIds(safeRoleIds);
-        setInitialEditPrimaryRoleId(safePrimary);
+        dispatch({
+          type: 'set',
+          values: {
+            editAssignedRoleIds: safeRoleIds,
+            editPrimaryRoleId: safePrimary,
+            initialEditAssignedRoleIds: safeRoleIds,
+            initialEditPrimaryRoleId: safePrimary,
+          },
+        });
       })
       .catch((err) => {
         console.error('Failed to load user roles:', err);
-        setEditRolesError((err as Error).message || 'Failed to load roles');
         const fallback = [user.role];
-        setEditAssignedRoleIds(fallback);
-        setEditPrimaryRoleId(user.role);
-        setInitialEditAssignedRoleIds(fallback);
-        setInitialEditPrimaryRoleId(user.role);
+        dispatch({
+          type: 'set',
+          values: {
+            editRolesError: (err as Error).message || 'Failed to load roles',
+            editAssignedRoleIds: fallback,
+            editPrimaryRoleId: user.role,
+            initialEditAssignedRoleIds: fallback,
+            initialEditPrimaryRoleId: user.role,
+          },
+        });
       })
       .finally(() => {
-        setIsLoadingEditRoles(false);
+        dispatch({ type: 'set', values: { isLoadingEditRoles: false } });
       });
   };
 
   const openAuthMethodDialog = (user: User) => {
     const method = user.authMethod || 'local';
-    setAuthMethodUser(user);
-    setAuthMethodDraft(method);
-    setAuthProviderDraft(user.authProviderId || '');
-    setAuthMethodError('');
+    dispatch({
+      type: 'set',
+      values: {
+        authMethodUser: user,
+        authMethodDraft: method,
+        authProviderDraft: user.authProviderId || '',
+        authMethodError: '',
+      },
+    });
   };
 
   const closeAuthMethodDialog = () => {
     if (isSavingAuthMethod) return;
-    setAuthMethodUser(null);
-    setAuthMethodError('');
+    dispatch({ type: 'set', values: { authMethodUser: null, authMethodError: '' } });
   };
 
   const saveAuthMethod = async () => {
     if (!authMethodUser) return;
     const requiresProvider = isSsoAuthMethod(authMethodDraft);
     if (requiresProvider && !authProviderDraft) {
-      setAuthMethodError(t('hr:workforce.authMethod.providerRequired'));
+      dispatch({
+        type: 'set',
+        values: { authMethodError: t('hr:workforce.authMethod.providerRequired') },
+      });
       return;
     }
-    setIsSavingAuthMethod(true);
-    setAuthMethodError('');
+    dispatch({ type: 'set', values: { isSavingAuthMethod: true, authMethodError: '' } });
     try {
       await onUpdateUserAuthMethod(
         authMethodUser.id,
         authMethodDraft,
         requiresProvider ? authProviderDraft : null,
       );
-      setAuthMethodUser(null);
+      dispatch({ type: 'set', values: { authMethodUser: null } });
     } catch (err) {
-      setAuthMethodError((err as Error).message || t('common:messages.errorOccurred'));
+      dispatch({
+        type: 'set',
+        values: { authMethodError: (err as Error).message || t('common:messages.errorOccurred') },
+      });
     } finally {
-      setIsSavingAuthMethod(false);
+      dispatch({ type: 'set', values: { isSavingAuthMethod: false } });
     }
   };
 
   const openTotpResetDialog = (user: User) => {
-    setTotpResetUser(user);
-    setTotpResetError('');
+    dispatch({ type: 'set', values: { totpResetUser: user, totpResetError: '' } });
   };
 
   const closeTotpResetDialog = () => {
     if (isResettingTotp) return;
-    setTotpResetUser(null);
-    setTotpResetError('');
+    dispatch({ type: 'set', values: { totpResetUser: null, totpResetError: '' } });
   };
 
   const confirmTotpReset = async () => {
     if (!totpResetUser) return;
-    setIsResettingTotp(true);
-    setTotpResetError('');
+    dispatch({ type: 'set', values: { isResettingTotp: true, totpResetError: '' } });
     try {
       await onResetUserTotp(totpResetUser.id);
-      setTotpResetUser(null);
+      dispatch({ type: 'set', values: { totpResetUser: null } });
       toastSuccess(t('hr:totpReset.success'));
     } catch (err) {
-      setTotpResetError((err as Error).message || t('common:messages.errorOccurred'));
+      dispatch({
+        type: 'set',
+        values: { totpResetError: (err as Error).message || t('common:messages.errorOccurred') },
+      });
     } finally {
-      setIsResettingTotp(false);
+      dispatch({ type: 'set', values: { isResettingTotp: false } });
     }
   };
 
   const closeEditModal = () => {
-    setEditingUser(null);
-    setEditRolesError('');
-    setEditFormErrors({});
+    dispatch({
+      type: 'set',
+      values: { editingUser: null, editRolesError: '', editFormErrors: {} },
+    });
   };
 
   const saveEdit = async () => {
@@ -620,7 +807,7 @@ const UserManagement: React.FC<UserManagementProps> = ({
       }
 
       if (Object.keys(newErrors).length > 0) {
-        setEditFormErrors(newErrors);
+        dispatch({ type: 'set', values: { editFormErrors: newErrors } });
         return;
       }
 
@@ -660,21 +847,27 @@ const UserManagement: React.FC<UserManagementProps> = ({
         }
       } else if (hasRoleAssignmentChanges) {
         if (!editAssignedRoleIds.includes(editPrimaryRoleId)) {
-          setEditRolesError(t('hr:workforce.primaryRoleMustBeAssigned'));
+          dispatch({
+            type: 'set',
+            values: { editRolesError: t('hr:workforce.primaryRoleMustBeAssigned') },
+          });
           return;
         }
         if (editAssignedRoleIds.length < 1) {
-          setEditRolesError(t('hr:workforce.assignedRolesRequired'));
+          dispatch({
+            type: 'set',
+            values: { editRolesError: t('hr:workforce.assignedRolesRequired') },
+          });
           return;
         }
-        setIsLoadingEditRoles(true);
+        dispatch({ type: 'set', values: { isLoadingEditRoles: true } });
         try {
           await onUpdateUserRoles(editingUser.id, editAssignedRoleIds, editPrimaryRoleId);
         } catch {
           // onUpdateUserRoles already surfaced an error
           return;
         } finally {
-          setIsLoadingEditRoles(false);
+          dispatch({ type: 'set', values: { isLoadingEditRoles: false } });
         }
       }
 
@@ -1162,9 +1355,14 @@ const UserManagement: React.FC<UserManagementProps> = ({
                 value={authMethodDraft}
                 onValueChange={(value) => {
                   const next = value as UserAuthMethod;
-                  setAuthMethodDraft(next);
-                  setAuthProviderDraft('');
-                  setAuthMethodError('');
+                  dispatch({
+                    type: 'set',
+                    values: {
+                      authMethodDraft: next,
+                      authProviderDraft: '',
+                      authMethodError: '',
+                    },
+                  });
                 }}
               >
                 <SelectTrigger className="w-full">
@@ -1190,8 +1388,10 @@ const UserManagement: React.FC<UserManagementProps> = ({
                 <Select
                   value={authProviderDraft || undefined}
                   onValueChange={(value) => {
-                    setAuthProviderDraft(value);
-                    setAuthMethodError('');
+                    dispatch({
+                      type: 'set',
+                      values: { authProviderDraft: value, authMethodError: '' },
+                    });
                   }}
                 >
                   <SelectTrigger className="w-full">
@@ -1287,9 +1487,9 @@ const UserManagement: React.FC<UserManagementProps> = ({
                     type="text"
                     value={editFirstName}
                     onChange={(e) => {
-                      setEditFirstName(e.target.value);
+                      dispatch({ type: 'set', values: { editFirstName: e.target.value } });
                       if (editFormErrors.firstName) {
-                        setEditFormErrors((prev) => ({ ...prev, firstName: '' }));
+                        dispatch({ type: 'patchEditFormErrors', value: { firstName: '' } });
                       }
                     }}
                     aria-label={t('hr:workforce.name')}
@@ -1311,9 +1511,9 @@ const UserManagement: React.FC<UserManagementProps> = ({
                     type="text"
                     value={editSurname}
                     onChange={(e) => {
-                      setEditSurname(e.target.value);
+                      dispatch({ type: 'set', values: { editSurname: e.target.value } });
                       if (editFormErrors.surname) {
-                        setEditFormErrors((prev) => ({ ...prev, surname: '' }));
+                        dispatch({ type: 'patchEditFormErrors', value: { surname: '' } });
                       }
                     }}
                     aria-label={t('hr:workforce.surname')}
@@ -1337,9 +1537,9 @@ const UserManagement: React.FC<UserManagementProps> = ({
                   type="email"
                   value={editEmail}
                   onChange={(e) => {
-                    setEditEmail(e.target.value);
+                    dispatch({ type: 'set', values: { editEmail: e.target.value } });
                     if (editFormErrors.email) {
-                      setEditFormErrors((prev) => ({ ...prev, email: '' }));
+                      dispatch({ type: 'patchEditFormErrors', value: { email: '' } });
                     }
                   }}
                   placeholder="e.g. alice.smith@example.com"
@@ -1383,12 +1583,7 @@ const UserManagement: React.FC<UserManagementProps> = ({
                                       disabled={isPrimary && checked}
                                       onChange={() => {
                                         if (isPrimary && checked) return;
-                                        setEditAssignedRoleIds((prev) => {
-                                          if (prev.includes(r.id)) {
-                                            return prev.filter((id) => id !== r.id);
-                                          }
-                                          return [...prev, r.id];
-                                        });
+                                        dispatch({ type: 'toggleEditAssignedRole', roleId: r.id });
                                       }}
                                     />
                                     <span className="text-sm font-semibold text-zinc-700 truncate">
@@ -1416,7 +1611,9 @@ const UserManagement: React.FC<UserManagementProps> = ({
                           return role ? [{ id: role.id, name: role.name }] : [];
                         })}
                         value={editPrimaryRoleId}
-                        onChange={(val) => setEditPrimaryRoleId(val as string)}
+                        onChange={(val) =>
+                          dispatch({ type: 'set', values: { editPrimaryRoleId: val as string } })
+                        }
                         buttonClassName="py-2 text-sm"
                         disabled={isLoadingEditRoles || editAssignedRoleIds.length < 1}
                       />
@@ -1436,7 +1633,9 @@ const UserManagement: React.FC<UserManagementProps> = ({
                         label={t('hr:workforce.role')}
                         options={roleOptions}
                         value={editRole}
-                        onChange={(val) => setEditRole(val as string)}
+                        onChange={(val) =>
+                          dispatch({ type: 'set', values: { editRole: val as string } })
+                        }
                         buttonClassName="py-2 text-sm"
                         disabled={isEditingSelf}
                       />
@@ -1461,7 +1660,9 @@ const UserManagement: React.FC<UserManagementProps> = ({
                     </div>
                     <ValidatedNumberInput
                       value={editCostPerHour}
-                      onValueChange={setEditCostPerHour}
+                      onValueChange={(value) =>
+                        dispatch({ type: 'set', values: { editCostPerHour: value } })
+                      }
                       className="flex-1 px-4 py-2 bg-transparent outline-none text-sm font-semibold"
                       placeholder="0.00"
                     />
@@ -1474,7 +1675,12 @@ const UserManagement: React.FC<UserManagementProps> = ({
                   <div>
                     <p className="text-sm font-bold text-zinc-700">{t('hr:workforce.disabled')}</p>
                   </div>
-                  <Toggle checked={editIsDisabled} onChange={setEditIsDisabled} />
+                  <Toggle
+                    checked={editIsDisabled}
+                    onChange={(checked) =>
+                      dispatch({ type: 'set', values: { editIsDisabled: checked } })
+                    }
+                  />
                 </div>
               )}
             </div>
@@ -1530,14 +1736,19 @@ const UserManagement: React.FC<UserManagementProps> = ({
                     value={newFirstName}
                     onChange={(e) => {
                       const val = e.target.value;
-                      setNewFirstName(val);
+                      const values: Partial<UserManagementState> = { newFirstName: val };
                       if (!usernameManuallyEdited.current) {
                         const surname = sanitizeUsernamePart(newSurname);
                         const first = sanitizeUsernamePart(val);
-                        setNewUsername(first && surname ? `${first}.${surname}` : first || surname);
+                        values.newUsername =
+                          first && surname ? `${first}.${surname}` : first || surname;
                       }
+                      dispatch({ type: 'set', values });
                       if (formErrors.firstName || formErrors.general) {
-                        setFormErrors((prev) => ({ ...prev, firstName: '', general: '' }));
+                        dispatch({
+                          type: 'patchFormErrors',
+                          value: { firstName: '', general: '' },
+                        });
                       }
                     }}
                     placeholder="e.g. Alice"
@@ -1561,14 +1772,16 @@ const UserManagement: React.FC<UserManagementProps> = ({
                     value={newSurname}
                     onChange={(e) => {
                       const val = e.target.value;
-                      setNewSurname(val);
+                      const values: Partial<UserManagementState> = { newSurname: val };
                       if (!usernameManuallyEdited.current) {
                         const first = sanitizeUsernamePart(newFirstName);
                         const surname = sanitizeUsernamePart(val);
-                        setNewUsername(first && surname ? `${first}.${surname}` : first || surname);
+                        values.newUsername =
+                          first && surname ? `${first}.${surname}` : first || surname;
                       }
+                      dispatch({ type: 'set', values });
                       if (formErrors.surname || formErrors.general) {
-                        setFormErrors((prev) => ({ ...prev, surname: '', general: '' }));
+                        dispatch({ type: 'patchFormErrors', value: { surname: '', general: '' } });
                       }
                     }}
                     placeholder="e.g. Smith"
@@ -1587,9 +1800,9 @@ const UserManagement: React.FC<UserManagementProps> = ({
                   type="email"
                   value={newEmail}
                   onChange={(e) => {
-                    setNewEmail(e.target.value);
+                    dispatch({ type: 'set', values: { newEmail: e.target.value } });
                     if (formErrors.email || formErrors.general) {
-                      setFormErrors((prev) => ({ ...prev, email: '', general: '' }));
+                      dispatch({ type: 'patchFormErrors', value: { email: '', general: '' } });
                     }
                   }}
                   placeholder="e.g. alice.smith@example.com"
@@ -1610,9 +1823,9 @@ const UserManagement: React.FC<UserManagementProps> = ({
                   value={newUsername}
                   onChange={(e) => {
                     usernameManuallyEdited.current = true;
-                    setNewUsername(e.target.value);
+                    dispatch({ type: 'set', values: { newUsername: e.target.value } });
                     if (formErrors.username || formErrors.general) {
-                      setFormErrors((prev) => ({ ...prev, username: '', general: '' }));
+                      dispatch({ type: 'patchFormErrors', value: { username: '', general: '' } });
                     }
                   }}
                   placeholder="e.g. alice.smith"
@@ -1636,9 +1849,9 @@ const UserManagement: React.FC<UserManagementProps> = ({
                     type={showNewPassword ? 'text' : 'password'}
                     value={newPassword}
                     onChange={(e) => {
-                      setNewPassword(e.target.value);
+                      dispatch({ type: 'set', values: { newPassword: e.target.value } });
                       if (formErrors.password || formErrors.general) {
-                        setFormErrors((prev) => ({ ...prev, password: '', general: '' }));
+                        dispatch({ type: 'patchFormErrors', value: { password: '', general: '' } });
                       }
                     }}
                     placeholder={t('hr:workforce.password')}
@@ -1649,7 +1862,9 @@ const UserManagement: React.FC<UserManagementProps> = ({
                   />
                   <button
                     type="button"
-                    onClick={() => setShowNewPassword((prev) => !prev)}
+                    onClick={() =>
+                      dispatch({ type: 'set', values: { showNewPassword: !showNewPassword } })
+                    }
                     aria-label={
                       showNewPassword
                         ? t('common:labels.hidePassword')
@@ -1674,7 +1889,7 @@ const UserManagement: React.FC<UserManagementProps> = ({
                 label={t('hr:workforce.role')}
                 options={roleOptions}
                 value={newRole}
-                onChange={(val) => setNewRole(val as string)}
+                onChange={(val) => dispatch({ type: 'set', values: { newRole: val as string } })}
               />
 
               {formErrors.general && (
@@ -1693,7 +1908,9 @@ const UserManagement: React.FC<UserManagementProps> = ({
 
       {canCreateUsers && (
         <div className="flex justify-end">
-          <HeaderAddButton onClick={() => setIsCreateModalOpen(true)}>
+          <HeaderAddButton
+            onClick={() => dispatch({ type: 'set', values: { isCreateModalOpen: true } })}
+          >
             {t('hr:workforce.addUser')}
           </HeaderAddButton>
         </div>
@@ -1747,7 +1964,9 @@ const UserManagement: React.FC<UserManagementProps> = ({
                   <SelectControl
                     options={clientFilterOptions}
                     value={filterClientId}
-                    onChange={(val) => setFilterClientId(val as string)}
+                    onChange={(val) =>
+                      dispatch({ type: 'set', values: { filterClientId: val as string } })
+                    }
                     placeholder={t('hr:workforce.filterByClient')}
                     searchable={true}
                     buttonClassName="w-full px-3 py-2 bg-white border border-zinc-200 rounded-lg text-sm font-semibold text-zinc-700 shadow-sm"
@@ -1755,7 +1974,9 @@ const UserManagement: React.FC<UserManagementProps> = ({
                   <SelectControl
                     options={projectFilterOptions}
                     value={filterProjectId}
-                    onChange={(val) => setFilterProjectId(val as string)}
+                    onChange={(val) =>
+                      dispatch({ type: 'set', values: { filterProjectId: val as string } })
+                    }
                     placeholder={t('hr:workforce.filterByProject')}
                     searchable={true}
                     buttonClassName="w-full px-3 py-2 bg-white border border-zinc-200 rounded-lg text-sm font-semibold text-zinc-700 shadow-sm"
@@ -1782,7 +2003,9 @@ const UserManagement: React.FC<UserManagementProps> = ({
                         placeholder={t('hr:workforce.searchClients')}
                         aria-label={t('hr:workforce.searchClients')}
                         value={clientSearch}
-                        onChange={(e) => setClientSearch(e.target.value)}
+                        onChange={(e) =>
+                          dispatch({ type: 'set', values: { clientSearch: e.target.value } })
+                        }
                         className="w-full px-3 py-1.5 text-sm border border-zinc-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none"
                       />
                     </div>
@@ -1841,7 +2064,9 @@ const UserManagement: React.FC<UserManagementProps> = ({
                         placeholder={t('hr:workforce.searchProjects')}
                         aria-label={t('hr:workforce.searchProjects')}
                         value={projectSearch}
-                        onChange={(e) => setProjectSearch(e.target.value)}
+                        onChange={(e) =>
+                          dispatch({ type: 'set', values: { projectSearch: e.target.value } })
+                        }
                         className="w-full px-3 py-1.5 text-sm border border-zinc-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none"
                       />
                     </div>
@@ -1906,7 +2131,9 @@ const UserManagement: React.FC<UserManagementProps> = ({
                           placeholder={t('hr:workforce.searchTasks')}
                           aria-label={t('hr:workforce.searchTasks')}
                           value={taskSearch}
-                          onChange={(e) => setTaskSearch(e.target.value)}
+                          onChange={(e) =>
+                            dispatch({ type: 'set', values: { taskSearch: e.target.value } })
+                          }
                           className="w-full px-3 py-1.5 text-sm border border-zinc-200 rounded-lg focus:ring-2 focus:ring-praetor outline-none"
                         />
                       </div>

--- a/components/catalog/InternalListingView.tsx
+++ b/components/catalog/InternalListingView.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useReducer, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { FieldLabel, RequiredMark } from '@/components/ui/field';
@@ -71,6 +71,106 @@ const calcMargine = (costo: number, molPercentage: number) =>
 const getDisplayTypeName = (typeName: string) =>
   typeName.charAt(0).toUpperCase() + typeName.slice(1);
 
+const EMPTY_FORM_DATA: Partial<Product> = {
+  name: '',
+  productCode: '',
+  description: '',
+  costo: undefined,
+  molPercentage: undefined,
+  costUnit: 'unit',
+  category: '',
+  subcategory: '',
+  type: '',
+};
+
+interface ListingState {
+  // Product Types State
+  productTypes: InternalProductType[];
+  isLoadingTypes: boolean;
+  // Type Management State
+  isManageTypesModalOpen: boolean;
+  editingType: InternalProductType | null;
+  newTypeName: string;
+  newTypeCostUnit: 'unit' | 'hours';
+  typeError: string | null;
+  isSavingType: boolean;
+  // Main product modal state
+  isModalOpen: boolean;
+  editingProduct: Product | null;
+  isDeleteConfirmOpen: boolean;
+  productToDelete: Product | null;
+  errors: Record<string, string>;
+  serverError: string | null;
+  // Category Management State
+  isManageCategoriesModalOpen: boolean;
+  categories: InternalProductCategory[];
+  isLoadingCategories: boolean;
+  editingCategory: InternalProductCategory | null;
+  newCategoryName: string;
+  categoryError: string | null;
+  isSavingCategory: boolean;
+  // Subcategory Management State
+  isManageSubcategoriesModalOpen: boolean;
+  subcategories: InternalProductSubcategory[];
+  isLoadingSubcategories: boolean;
+  editingSubcategory: InternalProductSubcategory | null;
+  newSubcategoryName: string;
+  subcategoryError: string | null;
+  isSavingSubcategory: boolean;
+  // Form State
+  formData: Partial<Product>;
+}
+
+const INITIAL_LISTING_STATE: ListingState = {
+  productTypes: [],
+  isLoadingTypes: true,
+  isManageTypesModalOpen: false,
+  editingType: null,
+  newTypeName: '',
+  newTypeCostUnit: 'unit',
+  typeError: null,
+  isSavingType: false,
+  isModalOpen: false,
+  editingProduct: null,
+  isDeleteConfirmOpen: false,
+  productToDelete: null,
+  errors: {},
+  serverError: null,
+  isManageCategoriesModalOpen: false,
+  categories: [],
+  isLoadingCategories: false,
+  editingCategory: null,
+  newCategoryName: '',
+  categoryError: null,
+  isSavingCategory: false,
+  isManageSubcategoriesModalOpen: false,
+  subcategories: [],
+  isLoadingSubcategories: false,
+  editingSubcategory: null,
+  newSubcategoryName: '',
+  subcategoryError: null,
+  isSavingSubcategory: false,
+  formData: EMPTY_FORM_DATA,
+};
+
+type ListingAction =
+  | { type: 'merge'; patch: Partial<ListingState> }
+  | { type: 'patchForm'; patch: Partial<Product> }
+  | { type: 'patchErrors'; patch: Record<string, string> };
+
+const listingReducer = (state: ListingState, action: ListingAction): ListingState => {
+  switch (action.type) {
+    case 'merge':
+      return { ...state, ...action.patch };
+    case 'patchForm':
+      return { ...state, formData: { ...state.formData, ...action.patch } };
+    case 'patchErrors':
+      return { ...state, errors: { ...state.errors, ...action.patch } };
+    default:
+      return state;
+  }
+};
+
 const InternalListingView: React.FC<InternalListingViewProps> = ({
   products,
   productFilterId,
@@ -104,58 +204,45 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
     return value ? { [column]: [value] } : undefined;
   }, [productFilterId, products]);
 
-  // Product Types State
-  const [productTypes, setProductTypes] = useState<InternalProductType[]>([]);
-  const [isLoadingTypes, setIsLoadingTypes] = useState(true);
+  const [state, dispatch] = useReducer(listingReducer, INITIAL_LISTING_STATE);
+  const {
+    productTypes,
+    isLoadingTypes,
+    isManageTypesModalOpen,
+    editingType,
+    newTypeName,
+    newTypeCostUnit,
+    typeError,
+    isSavingType,
+    isModalOpen,
+    editingProduct,
+    isDeleteConfirmOpen,
+    productToDelete,
+    errors,
+    serverError,
+    isManageCategoriesModalOpen,
+    categories,
+    isLoadingCategories,
+    editingCategory,
+    newCategoryName,
+    categoryError,
+    isSavingCategory,
+    isManageSubcategoriesModalOpen,
+    subcategories,
+    isLoadingSubcategories,
+    editingSubcategory,
+    newSubcategoryName,
+    subcategoryError,
+    isSavingSubcategory,
+    formData,
+  } = state;
 
-  // Type Management State
-  const [isManageTypesModalOpen, setIsManageTypesModalOpen] = useState(false);
-  const [editingType, setEditingType] = useState<InternalProductType | null>(null);
-  const [newTypeName, setNewTypeName] = useState('');
-  const [newTypeCostUnit, setNewTypeCostUnit] = useState<'unit' | 'hours'>('unit');
-  const [typeError, setTypeError] = useState<string | null>(null);
-  const [isSavingType, setIsSavingType] = useState(false);
+  // Mirror of formData for stable useCallback closures that previously read the
+  // latest value via setFormData((prev) => ...). Keeps callback identities stable
+  // while still observing the newest form data.
+  const formDataRef = useRef(formData);
+  formDataRef.current = formData;
 
-  // Main product modal state
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const [editingProduct, setEditingProduct] = useState<Product | null>(null);
-  const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
-  const [productToDelete, setProductToDelete] = useState<Product | null>(null);
-  const [errors, setErrors] = useState<Record<string, string>>({});
-  const [serverError, setServerError] = useState<string | null>(null);
-
-  // Category Management State
-  const [isManageCategoriesModalOpen, setIsManageCategoriesModalOpen] = useState(false);
-  const [categories, setCategories] = useState<InternalProductCategory[]>([]);
-  const [isLoadingCategories, setIsLoadingCategories] = useState(false);
-  const [editingCategory, setEditingCategory] = useState<InternalProductCategory | null>(null);
-  const [newCategoryName, setNewCategoryName] = useState('');
-  const [categoryError, setCategoryError] = useState<string | null>(null);
-  const [isSavingCategory, setIsSavingCategory] = useState(false);
-
-  // Subcategory Management State
-  const [isManageSubcategoriesModalOpen, setIsManageSubcategoriesModalOpen] = useState(false);
-  const [subcategories, setSubcategories] = useState<InternalProductSubcategory[]>([]);
-  const [isLoadingSubcategories, setIsLoadingSubcategories] = useState(false);
-  const [editingSubcategory, setEditingSubcategory] = useState<InternalProductSubcategory | null>(
-    null,
-  );
-  const [newSubcategoryName, setNewSubcategoryName] = useState('');
-  const [subcategoryError, setSubcategoryError] = useState<string | null>(null);
-  const [isSavingSubcategory, setIsSavingSubcategory] = useState(false);
-
-  // Form State
-  const [formData, setFormData] = useState<Partial<Product>>({
-    name: '',
-    productCode: '',
-    description: '',
-    costo: undefined,
-    molPercentage: undefined,
-    costUnit: 'unit',
-    category: '',
-    subcategory: '',
-    type: '',
-  });
   const defaultProductType = productTypes[0];
   const defaultTypeName = defaultProductType?.name || '';
   const defaultTypeCostUnit = defaultProductType?.costUnit || 'unit';
@@ -165,11 +252,11 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
     const loadTypes = async () => {
       try {
         const types = await api.products.listProductTypes();
-        setProductTypes(types);
+        dispatch({ type: 'merge', patch: { productTypes: types } });
       } catch (err) {
         console.error('Failed to load product types:', err);
       } finally {
-        setIsLoadingTypes(false);
+        dispatch({ type: 'merge', patch: { isLoadingTypes: false } });
       }
     };
     loadTypes();
@@ -178,38 +265,38 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
   // Load categories when type changes or category modal opens
   const loadCategories = useCallback(async (type: string) => {
     if (!type) {
-      setCategories([]);
+      dispatch({ type: 'merge', patch: { categories: [] } });
       return [];
     }
-    setIsLoadingCategories(true);
+    dispatch({ type: 'merge', patch: { isLoadingCategories: true } });
     try {
       const cats = await api.products.listInternalCategories(type);
-      setCategories(cats);
+      dispatch({ type: 'merge', patch: { categories: cats } });
       return cats;
     } catch (err) {
       console.error('Failed to load categories:', err);
       return [];
     } finally {
-      setIsLoadingCategories(false);
+      dispatch({ type: 'merge', patch: { isLoadingCategories: false } });
     }
   }, []);
 
   // Load subcategories when category changes or subcategory modal opens
   const loadSubcategories = useCallback(async (type: string, category: string) => {
     if (!type || !category) {
-      setSubcategories([]);
+      dispatch({ type: 'merge', patch: { subcategories: [] } });
       return [];
     }
-    setIsLoadingSubcategories(true);
+    dispatch({ type: 'merge', patch: { isLoadingSubcategories: true } });
     try {
       const subs = await api.products.listInternalSubcategories(type, category);
-      setSubcategories(subs);
+      dispatch({ type: 'merge', patch: { subcategories: subs } });
       return subs;
     } catch (err) {
       console.error('Failed to load subcategories:', err);
       return [];
     } finally {
-      setIsLoadingSubcategories(false);
+      dispatch({ type: 'merge', patch: { isLoadingSubcategories: false } });
     }
   }, []);
 
@@ -217,32 +304,40 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
     (type: string, nextCategories: InternalProductCategory[]) => {
       const firstCategory = nextCategories[0];
       if (!firstCategory) return;
-      setFormData((prev) => {
-        if (prev.type !== type || prev.category) return prev;
-        return { ...prev, category: firstCategory.name, subcategory: '' };
+      // Preserves the original guard: only auto-select when the type still matches
+      // and no category is chosen yet.
+      if (formDataRef.current.type !== type || formDataRef.current.category) return;
+      dispatch({
+        type: 'patchForm',
+        patch: { category: firstCategory.name, subcategory: '' },
       });
     },
     [],
   );
 
   const openAddModal = () => {
-    setEditingProduct(null);
-    setCategories([]);
-    setSubcategories([]);
-    setFormData({
-      name: '',
-      productCode: '',
-      description: '',
-      costo: undefined,
-      molPercentage: undefined,
-      costUnit: defaultTypeCostUnit,
-      category: '',
-      subcategory: '',
-      type: defaultTypeName,
+    dispatch({
+      type: 'merge',
+      patch: {
+        editingProduct: null,
+        categories: [],
+        subcategories: [],
+        formData: {
+          name: '',
+          productCode: '',
+          description: '',
+          costo: undefined,
+          molPercentage: undefined,
+          costUnit: defaultTypeCostUnit,
+          category: '',
+          subcategory: '',
+          type: defaultTypeName,
+        },
+        errors: {},
+        serverError: null,
+        isModalOpen: true,
+      },
     });
-    setErrors({});
-    setServerError(null);
-    setIsModalOpen(true);
     if (defaultTypeName) {
       void loadCategories(defaultTypeName).then((nextCategories) => {
         selectFirstCategoryForType(defaultTypeName, nextCategories);
@@ -253,43 +348,47 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
   };
 
   const openEditModal = (product: Product) => {
-    setEditingProduct(product);
     // Look up cost unit from product types, fallback to the product's current value
     const typeData = productTypes.find((t) => t.name === product.type);
     const typeName = product.type || (productTypes[0]?.name ?? '');
     const categoryName = product.category || '';
-    setCategories([]);
-    setSubcategories([]);
-    setFormData({
-      name: product.name || '',
-      productCode: product.productCode || '',
-      description: product.description || '',
-      costo: product.costo || 0,
-      molPercentage: product.molPercentage || 0,
-      costUnit: typeData?.costUnit || product.costUnit || 'unit',
-      category: categoryName,
-      subcategory: product.subcategory || '',
-      type: typeName,
+    dispatch({
+      type: 'merge',
+      patch: {
+        editingProduct: product,
+        categories: [],
+        subcategories: [],
+        formData: {
+          name: product.name || '',
+          productCode: product.productCode || '',
+          description: product.description || '',
+          costo: product.costo || 0,
+          molPercentage: product.molPercentage || 0,
+          costUnit: typeData?.costUnit || product.costUnit || 'unit',
+          category: categoryName,
+          subcategory: product.subcategory || '',
+          type: typeName,
+        },
+        errors: {},
+        serverError: null,
+        isModalOpen: true,
+      },
     });
-    setErrors({});
-    setServerError(null);
-    setIsModalOpen(true);
     if (typeName) void loadCategories(typeName);
     if (typeName && categoryName) void loadSubcategories(typeName, categoryName);
   };
 
   const handleNumericValueChange = (field: 'costo' | 'molPercentage') => (value: string) => {
     const parsed = parseNumberInputValue(value, undefined);
-    setFormData((prev) => ({ ...prev, [field]: parsed }));
+    dispatch({ type: 'patchForm', patch: { [field]: parsed } });
     if (errors[field]) {
-      setErrors((prev) => ({ ...prev, [field]: '' }));
+      dispatch({ type: 'patchErrors', patch: { [field]: '' } });
     }
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    setErrors({});
-    setServerError(null);
+    dispatch({ type: 'merge', patch: { errors: {}, serverError: null } });
 
     const newErrors: Record<string, string> = {};
     if (!formData.name?.trim()) newErrors.name = t('common:validation.productNameRequired');
@@ -329,7 +428,7 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
     }
 
     if (Object.keys(newErrors).length > 0) {
-      setErrors(newErrors);
+      dispatch({ type: 'merge', patch: { errors: newErrors } });
       return;
     }
 
@@ -348,55 +447,77 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
           molPercentage: formData.molPercentage !== undefined ? formData.molPercentage : undefined,
         });
       }
-      setIsModalOpen(false);
+      dispatch({ type: 'merge', patch: { isModalOpen: false } });
     } catch (err: unknown) {
       if (err instanceof Error && err.message.includes('unique')) {
         if (err.message.toLowerCase().includes('product code')) {
-          setErrors({ ...newErrors, productCode: t('common:validation.productCodeUnique') });
+          dispatch({
+            type: 'merge',
+            patch: {
+              errors: { ...newErrors, productCode: t('common:validation.productCodeUnique') },
+            },
+          });
         } else {
-          setErrors({ ...newErrors, name: t('common:validation.productNameUnique') });
+          dispatch({
+            type: 'merge',
+            patch: { errors: { ...newErrors, name: t('common:validation.productNameUnique') } },
+          });
         }
       } else {
-        setServerError(err instanceof Error ? err.message : 'An error occurred');
+        dispatch({
+          type: 'merge',
+          patch: { serverError: err instanceof Error ? err.message : 'An error occurred' },
+        });
       }
     }
   };
 
   const confirmDelete = (product: Product) => {
-    setProductToDelete(product);
-    setIsDeleteConfirmOpen(true);
+    dispatch({
+      type: 'merge',
+      patch: { productToDelete: product, isDeleteConfirmOpen: true },
+    });
   };
 
   const handleDelete = () => {
     if (productToDelete) {
       onDeleteProduct(productToDelete.id);
-      setIsDeleteConfirmOpen(false);
-      setProductToDelete(null);
+      dispatch({
+        type: 'merge',
+        patch: { isDeleteConfirmOpen: false, productToDelete: null },
+      });
     }
   };
 
   // Category Management Handlers
   const handleOpenManageCategories = () => {
-    setIsManageCategoriesModalOpen(true);
-    setEditingCategory(null);
-    setNewCategoryName('');
-    setCategoryError(null);
+    dispatch({
+      type: 'merge',
+      patch: {
+        isManageCategoriesModalOpen: true,
+        editingCategory: null,
+        newCategoryName: '',
+        categoryError: null,
+      },
+    });
   };
 
   const handleSaveCategory = async () => {
     if (!newCategoryName.trim()) {
-      setCategoryError(t('crm:internalListing.categoryNameRequired'));
+      dispatch({
+        type: 'merge',
+        patch: { categoryError: t('crm:internalListing.categoryNameRequired') },
+      });
       return;
     }
 
     const selectedType = formData.type || defaultTypeName;
     if (!selectedType) {
-      setCategoryError(t('common:validation.typeRequired'));
+      dispatch({ type: 'merge', patch: { categoryError: t('common:validation.typeRequired') } });
       return;
     }
 
-    setIsSavingCategory(true);
-    setCategoryError(null);
+    dispatch({ type: 'merge', patch: { isSavingCategory: true, categoryError: null } });
 
     try {
       if (editingCategory) {
@@ -419,23 +540,26 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
         formData.category === editingCategory.name &&
         formData.type === editingCategory.type
       ) {
-        setFormData((prev) => ({ ...prev, category: newCategoryName.trim() }));
+        dispatch({ type: 'patchForm', patch: { category: newCategoryName.trim() } });
       }
 
       // Reset form
-      setEditingCategory(null);
-      setNewCategoryName('');
+      dispatch({ type: 'merge', patch: { editingCategory: null, newCategoryName: '' } });
     } catch (err: unknown) {
-      setCategoryError(err instanceof Error ? err.message : 'An error occurred');
+      dispatch({
+        type: 'merge',
+        patch: { categoryError: err instanceof Error ? err.message : 'An error occurred' },
+      });
     } finally {
-      setIsSavingCategory(false);
+      dispatch({ type: 'merge', patch: { isSavingCategory: false } });
     }
   };
 
   const handleEditCategory = (category: InternalProductCategory) => {
-    setEditingCategory(category);
-    setNewCategoryName(category.name);
-    setCategoryError(null);
+    dispatch({
+      type: 'merge',
+      patch: { editingCategory: category, newCategoryName: category.name, categoryError: null },
+    });
   };
 
   const handleDeleteCategory = async (category: InternalProductCategory) => {
@@ -456,39 +580,47 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
 
       // If the deleted category was selected, clear it
       if (formData.category === category.name && formData.type === category.type) {
-        setFormData((prev) => ({ ...prev, category: '', subcategory: '' }));
+        dispatch({ type: 'patchForm', patch: { category: '', subcategory: '' } });
       }
 
       // Reload categories
       await loadCategories(category.type);
     } catch (err: unknown) {
-      setCategoryError(err instanceof Error ? err.message : 'An error occurred');
+      dispatch({
+        type: 'merge',
+        patch: { categoryError: err instanceof Error ? err.message : 'An error occurred' },
+      });
     }
   };
 
   const handleCancelCategoryEdit = () => {
-    setEditingCategory(null);
-    setNewCategoryName('');
-    setCategoryError(null);
+    dispatch({
+      type: 'merge',
+      patch: { editingCategory: null, newCategoryName: '', categoryError: null },
+    });
   };
 
   // Product Type Management Handlers
   const handleOpenManageTypes = () => {
-    setIsManageTypesModalOpen(true);
-    setEditingType(null);
-    setNewTypeName('');
-    setNewTypeCostUnit('unit');
-    setTypeError(null);
+    dispatch({
+      type: 'merge',
+      patch: {
+        isManageTypesModalOpen: true,
+        editingType: null,
+        newTypeName: '',
+        newTypeCostUnit: 'unit',
+        typeError: null,
+      },
+    });
   };
 
   const handleSaveType = async () => {
     if (!newTypeName.trim()) {
-      setTypeError(t('crm:internalListing.typeNameRequired'));
+      dispatch({ type: 'merge', patch: { typeError: t('crm:internalListing.typeNameRequired') } });
       return;
     }
 
-    setIsSavingType(true);
-    setTypeError(null);
+    dispatch({ type: 'merge', patch: { isSavingType: true, typeError: null } });
 
     try {
       if (editingType) {
@@ -505,49 +637,63 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
 
       // Reload types
       const types = await api.products.listProductTypes();
-      setProductTypes(types);
+      dispatch({ type: 'merge', patch: { productTypes: types } });
 
       // If the renamed type was selected, update formData
       if (editingType && formData.type === editingType.name) {
-        setFormData((prev) => ({
-          ...prev,
-          type: newTypeName.trim(),
-          costUnit: newTypeCostUnit,
-        }));
+        dispatch({
+          type: 'patchForm',
+          patch: {
+            type: newTypeName.trim(),
+            costUnit: newTypeCostUnit,
+          },
+        });
       }
 
       // Reset form
-      setEditingType(null);
-      setNewTypeName('');
-      setNewTypeCostUnit('unit');
+      dispatch({
+        type: 'merge',
+        patch: { editingType: null, newTypeName: '', newTypeCostUnit: 'unit' },
+      });
     } catch (err: unknown) {
-      setTypeError(err instanceof Error ? err.message : 'An error occurred');
+      dispatch({
+        type: 'merge',
+        patch: { typeError: err instanceof Error ? err.message : 'An error occurred' },
+      });
     } finally {
-      setIsSavingType(false);
+      dispatch({ type: 'merge', patch: { isSavingType: false } });
     }
   };
 
   const handleEditType = (type: InternalProductType) => {
-    setEditingType(type);
-    setNewTypeName(type.name);
-    setNewTypeCostUnit(type.costUnit);
-    setTypeError(null);
+    dispatch({
+      type: 'merge',
+      patch: {
+        editingType: type,
+        newTypeName: type.name,
+        newTypeCostUnit: type.costUnit,
+        typeError: null,
+      },
+    });
   };
 
   const handleDeleteType = async (type: InternalProductType) => {
     if (type.productCount > 0 || type.categoryCount > 0) {
-      setTypeError(
-        t('crm:internalListing.typeDeleteBlocked', {
-          productCount: type.productCount,
-          categoryCount: type.categoryCount,
-          name: type.name,
-        }),
-      );
+      dispatch({
+        type: 'merge',
+        patch: {
+          typeError: t('crm:internalListing.typeDeleteBlocked', {
+            productCount: type.productCount,
+            categoryCount: type.categoryCount,
+            name: type.name,
+          }),
+        },
+      });
       return;
     }
 
     try {
-      setTypeError(null);
+      dispatch({ type: 'merge', patch: { typeError: null } });
       await onDeleteProductType(type.id);
 
       // If the deleted type was selected, clear it
@@ -555,53 +701,65 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
         const remainingTypes = productTypes.filter((t) => t.id !== type.id);
         const nextType = remainingTypes[0]?.name || '';
         const nextCostUnit = remainingTypes[0]?.costUnit || 'unit';
-        setFormData((prev) => ({
-          ...prev,
-          type: nextType,
-          costUnit: nextCostUnit,
-          category: '',
-          subcategory: '',
-        }));
+        dispatch({
+          type: 'patchForm',
+          patch: {
+            type: nextType,
+            costUnit: nextCostUnit,
+            category: '',
+            subcategory: '',
+          },
+        });
       }
 
       // Reload types
       const types = await api.products.listProductTypes();
-      setProductTypes(types);
+      dispatch({ type: 'merge', patch: { productTypes: types } });
     } catch (err: unknown) {
-      setTypeError(err instanceof Error ? err.message : 'An error occurred');
+      dispatch({
+        type: 'merge',
+        patch: { typeError: err instanceof Error ? err.message : 'An error occurred' },
+      });
     }
   };
 
   const handleCancelTypeEdit = () => {
-    setEditingType(null);
-    setNewTypeName('');
-    setNewTypeCostUnit('unit');
-    setTypeError(null);
+    dispatch({
+      type: 'merge',
+      patch: { editingType: null, newTypeName: '', newTypeCostUnit: 'unit', typeError: null },
+    });
   };
 
   // Subcategory Management Handlers
   const handleOpenManageSubcategories = () => {
     if (!formData.category) return;
-    setIsManageSubcategoriesModalOpen(true);
-    setEditingSubcategory(null);
-    setNewSubcategoryName('');
-    setSubcategoryError(null);
+    dispatch({
+      type: 'merge',
+      patch: {
+        isManageSubcategoriesModalOpen: true,
+        editingSubcategory: null,
+        newSubcategoryName: '',
+        subcategoryError: null,
+      },
+    });
   };
 
   const handleSaveSubcategory = async () => {
     if (!newSubcategoryName.trim()) {
-      setSubcategoryError(t('crm:internalListing.subcategoryNameRequired'));
+      dispatch({
+        type: 'merge',
+        patch: { subcategoryError: t('crm:internalListing.subcategoryNameRequired') },
+      });
       return;
     }
 
     const selectedType = formData.type || defaultTypeName;
     if (!selectedType) {
-      setSubcategoryError(t('common:validation.typeRequired'));
+      dispatch({ type: 'merge', patch: { subcategoryError: t('common:validation.typeRequired') } });
       return;
     }
 
-    setIsSavingSubcategory(true);
-    setSubcategoryError(null);
+    dispatch({ type: 'merge', patch: { isSavingSubcategory: true, subcategoryError: null } });
 
     try {
       if (editingSubcategory) {
@@ -624,29 +782,36 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
 
       // If the renamed subcategory was selected, update formData
       if (editingSubcategory && formData.subcategory === editingSubcategory.name) {
-        setFormData((prev) => ({ ...prev, subcategory: newSubcategoryName.trim() }));
+        dispatch({ type: 'patchForm', patch: { subcategory: newSubcategoryName.trim() } });
       }
 
       // Reset form
-      setEditingSubcategory(null);
-      setNewSubcategoryName('');
+      dispatch({ type: 'merge', patch: { editingSubcategory: null, newSubcategoryName: '' } });
     } catch (err: unknown) {
-      setSubcategoryError(err instanceof Error ? err.message : 'An error occurred');
+      dispatch({
+        type: 'merge',
+        patch: { subcategoryError: err instanceof Error ? err.message : 'An error occurred' },
+      });
     } finally {
-      setIsSavingSubcategory(false);
+      dispatch({ type: 'merge', patch: { isSavingSubcategory: false } });
     }
   };
 
   const handleEditSubcategory = (subcategory: InternalProductSubcategory) => {
-    setEditingSubcategory(subcategory);
-    setNewSubcategoryName(subcategory.name);
-    setSubcategoryError(null);
+    dispatch({
+      type: 'merge',
+      patch: {
+        editingSubcategory: subcategory,
+        newSubcategoryName: subcategory.name,
+        subcategoryError: null,
+      },
+    });
   };
 
   const handleDeleteSubcategory = async (subcategory: InternalProductSubcategory) => {
     const selectedType = formData.type || defaultTypeName;
     if (!selectedType) {
-      setSubcategoryError(t('common:validation.typeRequired'));
+      dispatch({ type: 'merge', patch: { subcategoryError: t('common:validation.typeRequired') } });
       return;
     }
 
@@ -667,20 +832,24 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
 
       // If the deleted subcategory was selected, clear it
       if (formData.subcategory === subcategory.name) {
-        setFormData((prev) => ({ ...prev, subcategory: '' }));
+        dispatch({ type: 'patchForm', patch: { subcategory: '' } });
       }
 
       // Reload subcategories
       await loadSubcategories(selectedType, formData.category || '');
     } catch (err: unknown) {
-      setSubcategoryError(err instanceof Error ? err.message : 'An error occurred');
+      dispatch({
+        type: 'merge',
+        patch: { subcategoryError: err instanceof Error ? err.message : 'An error occurred' },
+      });
     }
   };
 
   const handleCancelSubcategoryEdit = () => {
-    setEditingSubcategory(null);
-    setNewSubcategoryName('');
-    setSubcategoryError(null);
+    dispatch({
+      type: 'merge',
+      patch: { editingSubcategory: null, newSubcategoryName: '', subcategoryError: null },
+    });
   };
 
   // Get unique categories from the API (includes both persisted and product-derived)
@@ -707,18 +876,21 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
     const typeName = val;
     const typeData = productTypes.find((t) => t.name === typeName);
     // Reset category and subcategory, then load the category list for the selected type.
-    setCategories([]);
-    setSubcategories([]);
-    setFormData((prev) => ({
-      ...prev,
-      type: typeName,
-      costUnit: typeData?.costUnit || 'unit',
-      category: '',
-      subcategory: '',
-    }));
-    if (errors.type) {
-      setErrors((prev) => ({ ...prev, type: '' }));
-    }
+    dispatch({
+      type: 'merge',
+      patch: {
+        categories: [],
+        subcategories: [],
+        formData: {
+          ...formData,
+          type: typeName,
+          costUnit: typeData?.costUnit || 'unit',
+          category: '',
+          subcategory: '',
+        },
+        ...(errors.type ? { errors: { ...errors, type: '' } } : {}),
+      },
+    });
     void loadCategories(typeName).then((nextCategories) => {
       if (!editingProduct) {
         selectFirstCategoryForType(typeName, nextCategories);
@@ -744,7 +916,7 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
       {/* Manage Types Modal */}
       <Modal
         isOpen={isManageTypesModalOpen}
-        onClose={() => setIsManageTypesModalOpen(false)}
+        onClose={() => dispatch({ type: 'merge', patch: { isManageTypesModalOpen: false } })}
         zIndex={70}
       >
         <ModalContent size="2xl">
@@ -755,7 +927,9 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
               </span>
               {t('crm:internalListing.manageTypes')}
             </ModalTitle>
-            <ModalCloseButton onClick={() => setIsManageTypesModalOpen(false)} />
+            <ModalCloseButton
+              onClick={() => dispatch({ type: 'merge', patch: { isManageTypesModalOpen: false } })}
+            />
           </ModalHeader>
 
           <ModalBody className="max-h-[60vh] space-y-4">
@@ -767,7 +941,9 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
                   <Input
                     type="text"
                     value={newTypeName}
-                    onChange={(e) => setNewTypeName(e.target.value)}
+                    onChange={(e) =>
+                      dispatch({ type: 'merge', patch: { newTypeName: e.target.value } })
+                    }
                     placeholder={t('crm:internalListing.typeNamePlaceholder')}
                     className="flex-1"
                     onKeyDown={(e) => e.key === 'Enter' && handleSaveType()}
@@ -778,7 +954,12 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
                       { id: 'hours', name: t('crm:internalListing.hour') },
                     ]}
                     value={newTypeCostUnit}
-                    onChange={(val) => setNewTypeCostUnit(val as 'unit' | 'hours')}
+                    onChange={(val) =>
+                      dispatch({
+                        type: 'merge',
+                        patch: { newTypeCostUnit: val as 'unit' | 'hours' },
+                      })
+                    }
                     searchable={false}
                     buttonClassName="py-2 text-sm w-28"
                   />
@@ -931,7 +1112,7 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
       {/* Manage Categories Modal */}
       <Modal
         isOpen={isManageCategoriesModalOpen}
-        onClose={() => setIsManageCategoriesModalOpen(false)}
+        onClose={() => dispatch({ type: 'merge', patch: { isManageCategoriesModalOpen: false } })}
         zIndex={70}
       >
         <ModalContent size="2xl">
@@ -942,7 +1123,11 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
               </span>
               {t('crm:internalListing.manageCategories')}
             </ModalTitle>
-            <ModalCloseButton onClick={() => setIsManageCategoriesModalOpen(false)} />
+            <ModalCloseButton
+              onClick={() =>
+                dispatch({ type: 'merge', patch: { isManageCategoriesModalOpen: false } })
+              }
+            />
           </ModalHeader>
 
           <ModalBody className="max-h-[60vh] space-y-4">
@@ -953,7 +1138,9 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
                 <Input
                   type="text"
                   value={newCategoryName}
-                  onChange={(e) => setNewCategoryName(e.target.value)}
+                  onChange={(e) =>
+                    dispatch({ type: 'merge', patch: { newCategoryName: e.target.value } })
+                  }
                   placeholder={t('crm:internalListing.categoryNamePlaceholder')}
                   onKeyDown={(e) => e.key === 'Enter' && handleSaveCategory()}
                 />
@@ -1080,7 +1267,9 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
       {/* Manage Subcategories Modal */}
       <Modal
         isOpen={isManageSubcategoriesModalOpen}
-        onClose={() => setIsManageSubcategoriesModalOpen(false)}
+        onClose={() =>
+          dispatch({ type: 'merge', patch: { isManageSubcategoriesModalOpen: false } })
+        }
         zIndex={70}
       >
         <ModalContent size="2xl">
@@ -1094,7 +1283,11 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
                 ({formData.category})
               </span>
             </ModalTitle>
-            <ModalCloseButton onClick={() => setIsManageSubcategoriesModalOpen(false)} />
+            <ModalCloseButton
+              onClick={() =>
+                dispatch({ type: 'merge', patch: { isManageSubcategoriesModalOpen: false } })
+              }
+            />
           </ModalHeader>
 
           <ModalBody className="max-h-[60vh] space-y-4">
@@ -1105,7 +1298,9 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
                 <Input
                   type="text"
                   value={newSubcategoryName}
-                  onChange={(e) => setNewSubcategoryName(e.target.value)}
+                  onChange={(e) =>
+                    dispatch({ type: 'merge', patch: { newSubcategoryName: e.target.value } })
+                  }
                   placeholder={t('crm:internalListing.subcategoryNamePlaceholder')}
                   onKeyDown={(e) => e.key === 'Enter' && handleSaveSubcategory()}
                 />
@@ -1232,7 +1427,10 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
       </Modal>
 
       {/* Add/Edit Product Modal */}
-      <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)}>
+      <Modal
+        isOpen={isModalOpen}
+        onClose={() => dispatch({ type: 'merge', patch: { isModalOpen: false } })}
+      >
         <ModalContent size="2xl" className="max-h-[90vh]">
           <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col">
             <ModalHeader>
@@ -1247,7 +1445,9 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
                   ? t('crm:internalListing.editProductTitle')
                   : t('crm:internalListing.addProductTitle')}
               </ModalTitle>
-              <ModalCloseButton onClick={() => setIsModalOpen(false)} />
+              <ModalCloseButton
+                onClick={() => dispatch({ type: 'merge', patch: { isModalOpen: false } })}
+              />
             </ModalHeader>
 
             <ModalBody className="flex-1 space-y-8">
@@ -1270,8 +1470,8 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
                       type="text"
                       value={formData.name}
                       onChange={(e) => {
-                        setFormData((prev) => ({ ...prev, name: e.target.value }));
-                        if (errors.name) setErrors((prev) => ({ ...prev, name: '' }));
+                        dispatch({ type: 'patchForm', patch: { name: e.target.value } });
+                        if (errors.name) dispatch({ type: 'patchErrors', patch: { name: '' } });
                       }}
                       placeholder={t('crm:internalListing.productNamePlaceholder')}
                       className={errors.name ? 'border-destructive' : undefined}
@@ -1287,8 +1487,9 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
                       type="text"
                       value={formData.productCode}
                       onChange={(e) => {
-                        setFormData((prev) => ({ ...prev, productCode: e.target.value }));
-                        if (errors.productCode) setErrors((prev) => ({ ...prev, productCode: '' }));
+                        dispatch({ type: 'patchForm', patch: { productCode: e.target.value } });
+                        if (errors.productCode)
+                          dispatch({ type: 'patchErrors', patch: { productCode: '' } });
                       }}
                       placeholder={t('common:form.placeholderCode')}
                       className={errors.productCode ? 'border-destructive' : undefined}
@@ -1308,7 +1509,7 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
                     <Textarea
                       value={formData.description || ''}
                       onChange={(e) =>
-                        setFormData((prev) => ({ ...prev, description: e.target.value }))
+                        dispatch({ type: 'patchForm', patch: { description: e.target.value } })
                       }
                       placeholder={t('crm:internalListing.productDescriptionPlaceholder')}
                       rows={2}
@@ -1365,12 +1566,17 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
                       value={formData.category || ''}
                       onChange={(val) => {
                         const categoryName = val as string;
-                        setSubcategories([]);
-                        setFormData((prev) => ({
-                          ...prev,
-                          category: categoryName,
-                          subcategory: '',
-                        }));
+                        dispatch({
+                          type: 'merge',
+                          patch: {
+                            subcategories: [],
+                            formData: {
+                              ...formData,
+                              category: categoryName,
+                              subcategory: '',
+                            },
+                          },
+                        });
                         if (formData.type && categoryName) {
                           void loadSubcategories(formData.type, categoryName);
                         }
@@ -1399,7 +1605,7 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
                       options={subcategoryOptions}
                       value={formData.subcategory || ''}
                       onChange={(val) =>
-                        setFormData((prev) => ({ ...prev, subcategory: val as string }))
+                        dispatch({ type: 'patchForm', patch: { subcategory: val as string } })
                       }
                       placeholder={
                         !formData.category
@@ -1481,7 +1687,11 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
             </ModalBody>
 
             <ModalFooter>
-              <Button type="button" variant="outline" onClick={() => setIsModalOpen(false)}>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => dispatch({ type: 'merge', patch: { isModalOpen: false } })}
+              >
                 {t('common:buttons.cancel')}
               </Button>
               <Button type="submit">
@@ -1497,7 +1707,7 @@ const InternalListingView: React.FC<InternalListingViewProps> = ({
       {/* Delete Confirmation Modal */}
       <DeleteConfirmModal
         isOpen={isDeleteConfirmOpen}
-        onClose={() => setIsDeleteConfirmOpen(false)}
+        onClose={() => dispatch({ type: 'merge', patch: { isDeleteConfirmOpen: false } })}
         onConfirm={handleDelete}
         title={t('crm:internalListing.deleteProductTitle')}
         description={t('crm:internalListing.deleteConfirm', {

--- a/components/projects/ProjectsView.tsx
+++ b/components/projects/ProjectsView.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useReducer, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { Field, FieldError, FieldLabel, RequiredMark } from '@/components/ui/field';
@@ -132,6 +132,131 @@ export interface ProjectsViewProps {
   onNavigateToProject?: (projectId: string) => void;
 }
 
+interface ProjectsViewState {
+  // Modal state — create only
+  isModalOpen: boolean;
+  isDeleteConfirmOpen: boolean;
+  projectToDelete: Project | null;
+  managingProjectId: string | null;
+  // Form state
+  name: string;
+  orderId: string;
+  clientId: string;
+  description: string;
+  billingType: StoredBillingType;
+  billingFrequency: BillingFrequency;
+  offerId: string;
+  startDate: string;
+  endDate: string;
+  revenue: string;
+  errors: Record<string, string>;
+  draftTasks: DraftTask[];
+}
+
+const INITIAL_PROJECTS_STATE: ProjectsViewState = {
+  isModalOpen: false,
+  isDeleteConfirmOpen: false,
+  projectToDelete: null,
+  managingProjectId: null,
+  name: '',
+  orderId: '',
+  clientId: '',
+  description: '',
+  billingType: 'time_and_materials',
+  billingFrequency: 'monthly',
+  offerId: '',
+  startDate: '',
+  endDate: '',
+  revenue: '',
+  errors: {},
+  draftTasks: [],
+};
+
+type ProjectsViewAction =
+  | { type: 'setName'; value: string }
+  | { type: 'setOrderId'; value: string }
+  | { type: 'setClientId'; value: string }
+  | { type: 'setDescription'; value: string }
+  | { type: 'setBillingType'; value: StoredBillingType }
+  | { type: 'setBillingFrequency'; value: BillingFrequency }
+  | { type: 'setOfferId'; value: string }
+  | { type: 'setStartDate'; value: string }
+  | { type: 'setEndDate'; value: string }
+  | { type: 'setRevenue'; value: string }
+  | { type: 'setErrors'; value: Record<string, string> }
+  | { type: 'patchErrors'; value: Record<string, string> }
+  | { type: 'setDraftTasks'; value: DraftTask[] }
+  | { type: 'openAddModal' }
+  | { type: 'closeModal' }
+  | { type: 'promptDelete'; project: Project }
+  | { type: 'setManagingProjectId'; value: string | null };
+
+const projectsViewReducer = (
+  state: ProjectsViewState,
+  action: ProjectsViewAction,
+): ProjectsViewState => {
+  switch (action.type) {
+    case 'setName':
+      return { ...state, name: action.value };
+    case 'setOrderId':
+      return { ...state, orderId: action.value };
+    case 'setClientId':
+      return { ...state, clientId: action.value };
+    case 'setDescription':
+      return { ...state, description: action.value };
+    case 'setBillingType':
+      return { ...state, billingType: action.value };
+    case 'setBillingFrequency':
+      return { ...state, billingFrequency: action.value };
+    case 'setOfferId':
+      return { ...state, offerId: action.value };
+    case 'setStartDate':
+      return { ...state, startDate: action.value };
+    case 'setEndDate':
+      return { ...state, endDate: action.value };
+    case 'setRevenue':
+      return { ...state, revenue: action.value };
+    case 'setErrors':
+      return { ...state, errors: action.value };
+    case 'patchErrors':
+      return { ...state, errors: { ...state.errors, ...action.value } };
+    case 'setDraftTasks':
+      return { ...state, draftTasks: action.value };
+    case 'openAddModal':
+      return {
+        ...state,
+        name: '',
+        orderId: '',
+        clientId: '',
+        description: '',
+        billingType: 'time_and_materials',
+        billingFrequency: 'monthly',
+        offerId: '',
+        startDate: '',
+        endDate: '',
+        revenue: '',
+        draftTasks: [],
+        errors: {},
+        isModalOpen: true,
+      };
+    case 'closeModal':
+      return {
+        ...state,
+        isModalOpen: false,
+        isDeleteConfirmOpen: false,
+        projectToDelete: null,
+        draftTasks: [],
+        errors: {},
+      };
+    case 'promptDelete':
+      return { ...state, projectToDelete: action.project, isDeleteConfirmOpen: true };
+    case 'setManagingProjectId':
+      return { ...state, managingProjectId: action.value };
+    default:
+      return state;
+  }
+};
+
 const ProjectsView: React.FC<ProjectsViewProps> = ({
   projects,
   clients,
@@ -156,25 +281,25 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
     buildPermission('projects.assignments', 'update'),
   );
 
-  // Modal state — create only
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
-  const [projectToDelete, setProjectToDelete] = useState<Project | null>(null);
-  const [managingProjectId, setManagingProjectId] = useState<string | null>(null);
-
-  // Form state
-  const [name, setName] = useState('');
-  const [orderId, setOrderId] = useState('');
-  const [clientId, setClientId] = useState('');
-  const [description, setDescription] = useState('');
-  const [billingType, setBillingType] = useState<StoredBillingType>('time_and_materials');
-  const [billingFrequency, setBillingFrequency] = useState<BillingFrequency>('monthly');
-  const [offerId, setOfferId] = useState('');
-  const [startDate, setStartDate] = useState('');
-  const [endDate, setEndDate] = useState('');
-  const [revenue, setRevenue] = useState('');
-  const [errors, setErrors] = useState<Record<string, string>>({});
-  const [draftTasks, setDraftTasks] = useState<DraftTask[]>([]);
+  const [state, dispatch] = useReducer(projectsViewReducer, INITIAL_PROJECTS_STATE);
+  const {
+    isModalOpen,
+    isDeleteConfirmOpen,
+    projectToDelete,
+    managingProjectId,
+    name,
+    orderId,
+    clientId,
+    description,
+    billingType,
+    billingFrequency,
+    offerId,
+    startDate,
+    endDate,
+    revenue,
+    errors,
+    draftTasks,
+  } = state;
 
   const projectIds = useMemo(() => projects.map((p) => p.id), [projects]);
   const projectIdsKey = useMemo(() => projectIds.join('\u0000'), [projectIds]);
@@ -254,27 +379,11 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
 
   const openAddModal = () => {
     if (!canCreateProjects) return;
-    setName('');
-    setOrderId('');
-    setClientId('');
-    setDescription('');
-    setBillingType('time_and_materials');
-    setBillingFrequency('monthly');
-    setOfferId('');
-    setStartDate('');
-    setEndDate('');
-    setRevenue('');
-    setDraftTasks([]);
-    setErrors({});
-    setIsModalOpen(true);
+    dispatch({ type: 'openAddModal' });
   };
 
   const closeModal = () => {
-    setIsModalOpen(false);
-    setIsDeleteConfirmOpen(false);
-    setProjectToDelete(null);
-    setDraftTasks([]);
-    setErrors({});
+    dispatch({ type: 'closeModal' });
   };
 
   // Reset a currently-bound order/offer if it no longer matches `nextClientId`. The
@@ -283,28 +392,28 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
     if (keep !== 'offer' && offerId) {
       const current = offers.find((o) => o.id === offerId);
       if (!current || current.clientId !== nextClientId) {
-        setOfferId('');
-        if (errors.offerId) setErrors((prev) => ({ ...prev, offerId: '' }));
+        dispatch({ type: 'setOfferId', value: '' });
+        if (errors.offerId) dispatch({ type: 'patchErrors', value: { offerId: '' } });
       }
     }
     if (keep !== 'order' && orderId) {
       const current = orders.find((o) => o.id === orderId);
       if (!current || current.clientId !== nextClientId) {
-        setOrderId('');
-        if (errors.orderId) setErrors((prev) => ({ ...prev, orderId: '' }));
+        dispatch({ type: 'setOrderId', value: '' });
+        if (errors.orderId) dispatch({ type: 'patchErrors', value: { orderId: '' } });
       }
     }
   };
 
   const applyClientChange = (nextClientId: string) => {
-    setClientId(nextClientId);
-    if (errors.clientId) setErrors((prev) => ({ ...prev, clientId: '' }));
+    dispatch({ type: 'setClientId', value: nextClientId });
+    if (errors.clientId) dispatch({ type: 'patchErrors', value: { clientId: '' } });
     clearStaleClientLinks(nextClientId, null);
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    setErrors({});
+    dispatch({ type: 'setErrors', value: {} });
 
     if (!canCreateProjects) return;
 
@@ -318,7 +427,7 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
       newErrors.dateRange = t('projects:projects.dateRangeInvalid');
     }
     if (Object.keys(newErrors).length > 0) {
-      setErrors(newErrors);
+      dispatch({ type: 'setErrors', value: newErrors });
       return;
     }
 
@@ -357,8 +466,7 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
   };
 
   const promptDelete = (project: Project) => {
-    setProjectToDelete(project);
-    setIsDeleteConfirmOpen(true);
+    dispatch({ type: 'promptDelete', project });
   };
 
   const handleDelete = () => {
@@ -371,33 +479,37 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
 
   const openAssignments = (projectId: string) => {
     if (!canManageAssignments) return;
-    setManagingProjectId(projectId);
+    dispatch({ type: 'setManagingProjectId', value: projectId });
   };
 
   const closeAssignments = () => {
-    setManagingProjectId(null);
+    dispatch({ type: 'setManagingProjectId', value: null });
   };
 
   // Draft task helpers
   const addDraftTask = () => {
-    setDraftTasks((prev) => [
-      ...prev,
-      {
-        _id: String(Date.now() + Math.random()),
-        name: '',
-        billingType,
-        billingFrequency: billingType === 'time_and_materials' ? 'monthly' : billingFrequency,
-        monthlyEffort: '',
-        expectedEffort: '',
-        revenue: '',
-        notes: '',
-      },
-    ]);
+    dispatch({
+      type: 'setDraftTasks',
+      value: [
+        ...draftTasks,
+        {
+          _id: String(Date.now() + Math.random()),
+          name: '',
+          billingType,
+          billingFrequency: billingType === 'time_and_materials' ? 'monthly' : billingFrequency,
+          monthlyEffort: '',
+          expectedEffort: '',
+          revenue: '',
+          notes: '',
+        },
+      ],
+    });
   };
 
   const updateDraftTask = (id: string, field: keyof Omit<DraftTask, '_id'>, value: string) => {
-    setDraftTasks((prev) =>
-      prev.map((t) => {
+    dispatch({
+      type: 'setDraftTasks',
+      value: draftTasks.map((t) => {
         if (t._id !== id) return t;
         if (field === 'billingType') {
           const nextBillingType = value as StoredBillingType;
@@ -410,11 +522,11 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
         }
         return { ...t, [field]: value };
       }),
-    );
+    });
   };
 
   const removeDraftTask = (id: string) => {
-    setDraftTasks((prev) => prev.filter((t) => t._id !== id));
+    dispatch({ type: 'setDraftTasks', value: draftTasks.filter((t) => t._id !== id) });
   };
 
   const getDerivedProjectBillingType = (project: Project): BillingType => {
@@ -677,12 +789,14 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
                         value={orderId}
                         onChange={(val) => {
                           const nextOrderId = val as string;
-                          setOrderId(nextOrderId);
-                          if (errors.orderId) setErrors((prev) => ({ ...prev, orderId: '' }));
+                          dispatch({ type: 'setOrderId', value: nextOrderId });
+                          if (errors.orderId)
+                            dispatch({ type: 'patchErrors', value: { orderId: '' } });
                           const nextOrder = orders.find((o) => o.id === nextOrderId);
                           if (!nextOrder) return;
-                          setClientId(nextOrder.clientId);
-                          if (errors.clientId) setErrors((prev) => ({ ...prev, clientId: '' }));
+                          dispatch({ type: 'setClientId', value: nextOrder.clientId });
+                          if (errors.clientId)
+                            dispatch({ type: 'patchErrors', value: { clientId: '' } });
                           clearStaleClientLinks(nextOrder.clientId, 'order');
                         }}
                         label={t('projects:projects.orderOptionalLabel')}
@@ -737,8 +851,8 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
                         value={name}
                         aria-invalid={Boolean(errors.name)}
                         onChange={(e) => {
-                          setName(e.target.value);
-                          if (errors.name) setErrors((prev) => ({ ...prev, name: '' }));
+                          dispatch({ type: 'setName', value: e.target.value });
+                          if (errors.name) dispatch({ type: 'patchErrors', value: { name: '' } });
                         }}
                         placeholder={t('projects:projects.projectNamePlaceholder')}
                       />
@@ -753,7 +867,7 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
                     <Textarea
                       id="project-description"
                       value={description}
-                      onChange={(e) => setDescription(e.target.value)}
+                      onChange={(e) => dispatch({ type: 'setDescription', value: e.target.value })}
                       placeholder={t('projects:projects.descriptionPlaceholder')}
                       rows={3}
                       className="min-h-20 resize-none"
@@ -771,9 +885,12 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
                         value={startDate}
                         aria-invalid={Boolean(errors.startDate || errors.dateRange)}
                         onChange={(value) => {
-                          setStartDate(value);
+                          dispatch({ type: 'setStartDate', value });
                           if (errors.startDate || errors.dateRange) {
-                            setErrors((prev) => ({ ...prev, startDate: '', dateRange: '' }));
+                            dispatch({
+                              type: 'patchErrors',
+                              value: { startDate: '', dateRange: '' },
+                            });
                           }
                         }}
                       />
@@ -789,9 +906,12 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
                         value={endDate}
                         aria-invalid={Boolean(errors.endDate || errors.dateRange)}
                         onChange={(value) => {
-                          setEndDate(value);
+                          dispatch({ type: 'setEndDate', value });
                           if (errors.endDate || errors.dateRange) {
-                            setErrors((prev) => ({ ...prev, endDate: '', dateRange: '' }));
+                            dispatch({
+                              type: 'patchErrors',
+                              value: { endDate: '', dateRange: '' },
+                            });
                           }
                         }}
                       />
@@ -810,13 +930,15 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
                         value={offerId}
                         onChange={(val) => {
                           const nextOfferId = val as string;
-                          setOfferId(nextOfferId);
-                          if (errors.offerId) setErrors((prev) => ({ ...prev, offerId: '' }));
+                          dispatch({ type: 'setOfferId', value: nextOfferId });
+                          if (errors.offerId)
+                            dispatch({ type: 'patchErrors', value: { offerId: '' } });
                           const nextOffer = offers.find((o) => o.id === nextOfferId);
                           if (!nextOffer) return;
                           if (nextOffer.clientId !== clientId) {
-                            setClientId(nextOffer.clientId);
-                            if (errors.clientId) setErrors((prev) => ({ ...prev, clientId: '' }));
+                            dispatch({ type: 'setClientId', value: nextOffer.clientId });
+                            if (errors.clientId)
+                              dispatch({ type: 'patchErrors', value: { clientId: '' } });
                           }
                           clearStaleClientLinks(nextOffer.clientId, 'offer');
                         }}
@@ -843,7 +965,7 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
                         placeholder="0.00"
                         value={revenueSource === 'manual' ? revenue : displayedRevenue.toFixed(2)}
                         readOnly={revenueSource !== 'manual'}
-                        onChange={(e) => setRevenue(e.target.value)}
+                        onChange={(e) => dispatch({ type: 'setRevenue', value: e.target.value })}
                       />
                       <p className="text-xs text-muted-foreground">
                         {revenueHintBySource[revenueSource]}
@@ -858,9 +980,9 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
                       value={billingType}
                       onChange={(val) => {
                         const nextBillingType = val as StoredBillingType;
-                        setBillingType(nextBillingType);
+                        dispatch({ type: 'setBillingType', value: nextBillingType });
                         if (nextBillingType === 'time_and_materials')
-                          setBillingFrequency('monthly');
+                          dispatch({ type: 'setBillingFrequency', value: 'monthly' });
                       }}
                       label={t('projects:projects.billingType')}
                       searchable={false}
@@ -876,7 +998,9 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
                             )
                       }
                       value={billingType === 'time_and_materials' ? 'monthly' : billingFrequency}
-                      onChange={(val) => setBillingFrequency(val as BillingFrequency)}
+                      onChange={(val) =>
+                        dispatch({ type: 'setBillingFrequency', value: val as BillingFrequency })
+                      }
                       label={t('projects:projects.billingFrequency')}
                       disabled={billingType === 'time_and_materials'}
                       searchable={false}

--- a/components/projects/projectRuleRegistry.ts
+++ b/components/projects/projectRuleRegistry.ts
@@ -1,8 +1,7 @@
 import type { Permission, ProjectRuleConditionValueType } from '../../types';
 
-export const PROJECT_RULE_NUMBER_OPERATORS = ['gt', 'gte', 'lt', 'lte', 'eq', 'neq'] as const;
-export const PROJECT_RULE_ENUM_OPERATORS = ['eq', 'neq'] as const;
-export const PROJECT_RULE_CONDITION_VALUE_TYPES = ['literal', 'field'] as const;
+const PROJECT_RULE_NUMBER_OPERATORS = ['gt', 'gte', 'lt', 'lte', 'eq', 'neq'] as const;
+const PROJECT_RULE_ENUM_OPERATORS = ['eq', 'neq'] as const;
 
 export type ProjectRuleNumberOperator = (typeof PROJECT_RULE_NUMBER_OPERATORS)[number];
 export type ProjectRuleEnumOperator = (typeof PROJECT_RULE_ENUM_OPERATORS)[number];
@@ -17,7 +16,7 @@ export type ProjectRuleFieldDefinition = {
   requiresPermission?: Permission;
 };
 
-export const PROJECT_RULE_FIELD_DEFINITIONS: readonly ProjectRuleFieldDefinition[] = [
+const PROJECT_RULE_FIELD_DEFINITIONS: readonly ProjectRuleFieldDefinition[] = [
   { id: 'revenue', kind: 'number', operators: PROJECT_RULE_NUMBER_OPERATORS },
   {
     id: 'cost_to_date',
@@ -67,7 +66,7 @@ const enumValuesMatch = (
   );
 };
 
-export const areProjectRuleFieldsComparable = (leftField: string, rightField: string) => {
+const areProjectRuleFieldsComparable = (leftField: string, rightField: string) => {
   const leftDefinition = getProjectRuleFieldDefinition(leftField);
   const rightDefinition = getProjectRuleFieldDefinition(rightField);
   if (!leftDefinition || !rightDefinition) return false;

--- a/components/sales/ClientOffersView.tsx
+++ b/components/sales/ClientOffersView.tsx
@@ -1,6 +1,6 @@
 import { RotateCcw } from 'lucide-react';
 import type React from 'react';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useReducer, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { LinkedRecordBanner } from '@/components/shared/LinkedRecordBanner';
 import { Button } from '@/components/ui/button';
@@ -148,6 +148,101 @@ const getDiscountPercentageLabelValue = (
     getDiscountPercentageValue(discount, discountType, subtotal, discountAmount),
   )}%`;
 
+interface ClientOffersViewState {
+  editingOffer: ClientOffer | null;
+  offerToDelete: ClientOffer | null;
+  offerToRevert: ClientOffer | null;
+  revertReason: string;
+  isModalOpen: boolean;
+  isDeleteConfirmOpen: boolean;
+  isRevertConfirmOpen: boolean;
+  isSubmitting: boolean;
+  isDeleting: boolean;
+  isReverting: boolean;
+}
+
+const INITIAL_CLIENT_OFFERS_VIEW_STATE: ClientOffersViewState = {
+  editingOffer: null,
+  offerToDelete: null,
+  offerToRevert: null,
+  revertReason: '',
+  isModalOpen: false,
+  isDeleteConfirmOpen: false,
+  isRevertConfirmOpen: false,
+  isSubmitting: false,
+  isDeleting: false,
+  isReverting: false,
+};
+
+type ClientOffersViewAction =
+  | { type: 'openEditModal'; offer: ClientOffer }
+  | { type: 'openAddModal' }
+  | { type: 'setEditingOffer'; offer: ClientOffer | null }
+  | { type: 'closeModal' }
+  | { type: 'openRevertConfirm'; offer: ClientOffer }
+  | { type: 'closeRevertConfirm' }
+  | { type: 'revertSuccess' }
+  | { type: 'setRevertReason'; value: string }
+  | { type: 'setIsReverting'; value: boolean }
+  | { type: 'promptDelete'; offer: ClientOffer }
+  | { type: 'closeDeleteConfirm' }
+  | { type: 'deleteSuccess' }
+  | { type: 'setIsDeleting'; value: boolean }
+  | { type: 'setIsSubmitting'; value: boolean };
+
+const clientOffersViewReducer = (
+  state: ClientOffersViewState,
+  action: ClientOffersViewAction,
+): ClientOffersViewState => {
+  switch (action.type) {
+    case 'openEditModal':
+      return { ...state, editingOffer: action.offer, isModalOpen: true };
+    case 'openAddModal':
+      return { ...state, editingOffer: null, isModalOpen: true };
+    case 'setEditingOffer':
+      return { ...state, editingOffer: action.offer };
+    case 'closeModal':
+      return { ...state, isModalOpen: false };
+    case 'openRevertConfirm':
+      return {
+        ...state,
+        offerToRevert: action.offer,
+        revertReason: '',
+        isRevertConfirmOpen: true,
+      };
+    case 'closeRevertConfirm':
+      return {
+        ...state,
+        isRevertConfirmOpen: false,
+        offerToRevert: null,
+        revertReason: '',
+      };
+    case 'revertSuccess':
+      return {
+        ...state,
+        isRevertConfirmOpen: false,
+        offerToRevert: null,
+        revertReason: '',
+      };
+    case 'setRevertReason':
+      return { ...state, revertReason: action.value };
+    case 'setIsReverting':
+      return { ...state, isReverting: action.value };
+    case 'promptDelete':
+      return { ...state, offerToDelete: action.offer, isDeleteConfirmOpen: true };
+    case 'closeDeleteConfirm':
+      return { ...state, isDeleteConfirmOpen: false };
+    case 'deleteSuccess':
+      return { ...state, isDeleteConfirmOpen: false, offerToDelete: null };
+    case 'setIsDeleting':
+      return { ...state, isDeleting: action.value };
+    case 'setIsSubmitting':
+      return { ...state, isSubmitting: action.value };
+    default:
+      return state;
+  }
+};
+
 const ClientOffersView: React.FC<ClientOffersViewProps> = ({
   offers,
   clients,
@@ -276,19 +371,22 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
     });
   };
 
-  const [editingOffer, setEditingOffer] = useState<ClientOffer | null>(null);
-  const [offerToDelete, setOfferToDelete] = useState<ClientOffer | null>(null);
-  const [offerToRevert, setOfferToRevert] = useState<ClientOffer | null>(null);
-  const [revertReason, setRevertReason] = useState('');
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
-  const [isRevertConfirmOpen, setIsRevertConfirmOpen] = useState(false);
+  const [state, dispatch] = useReducer(clientOffersViewReducer, INITIAL_CLIENT_OFFERS_VIEW_STATE);
+  const {
+    editingOffer,
+    offerToDelete,
+    offerToRevert,
+    revertReason,
+    isModalOpen,
+    isDeleteConfirmOpen,
+    isRevertConfirmOpen,
+    isSubmitting,
+    isDeleting,
+    isReverting,
+  } = state;
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [formData, setFormData] = useState<Partial<ClientOffer>>(() => getDefaultFormData());
   const [previewVersion, setPreviewVersion] = useState<OfferVersion | null>(null);
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [isDeleting, setIsDeleting] = useState(false);
-  const [isReverting, setIsReverting] = useState(false);
 
   const baseReadOnly = Boolean(editingOffer && editingOffer.status !== 'draft');
   const isReadOnly = baseReadOnly || previewVersion !== null;
@@ -325,11 +423,10 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
   }, [offerFilterId, quoteFilterId]);
 
   const openEditModal = useCallback((offer: ClientOffer) => {
-    setEditingOffer(offer);
+    dispatch({ type: 'openEditModal', offer });
     setFormData(offerToFormData(offer));
     setErrors({});
     setPreviewVersion(null);
-    setIsModalOpen(true);
   }, []);
 
   const handleVersionPreview = useCallback(
@@ -354,7 +451,7 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
 
   const handleVersionRestored = useCallback(
     (updated: ClientOffer) => {
-      setEditingOffer(updated);
+      dispatch({ type: 'setEditingOffer', offer: updated });
       setFormData(offerToFormData(updated));
       setPreviewVersion(null);
       onOfferRestored?.(updated);
@@ -387,31 +484,25 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
   };
 
   const openRevertConfirm = (offer: ClientOffer) => {
-    setOfferToRevert(offer);
-    setRevertReason('');
-    setIsRevertConfirmOpen(true);
+    dispatch({ type: 'openRevertConfirm', offer });
   };
 
   const closeRevertConfirm = () => {
     if (isReverting) return;
-    setIsRevertConfirmOpen(false);
-    setOfferToRevert(null);
-    setRevertReason('');
+    dispatch({ type: 'closeRevertConfirm' });
   };
 
   const handleRevertToDraft = async () => {
     if (!offerToRevert || !onRevertOfferToDraft || isReverting) return;
-    setIsReverting(true);
+    dispatch({ type: 'setIsReverting', value: true });
     try {
       const reason = revertReason.trim();
       await onRevertOfferToDraft(offerToRevert.id, reason || undefined);
-      setIsRevertConfirmOpen(false);
-      setOfferToRevert(null);
-      setRevertReason('');
+      dispatch({ type: 'revertSuccess' });
     } catch (err) {
       toastError((err as Error).message || t('sales:clientOffers.failedToUpdateStatus'));
     } finally {
-      setIsReverting(false);
+      dispatch({ type: 'setIsReverting', value: false });
     }
   };
 
@@ -823,8 +914,7 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                       type="button"
                       onClick={(e) => {
                         e.stopPropagation();
-                        setOfferToDelete(row);
-                        setIsDeleteConfirmOpen(true);
+                        dispatch({ type: 'promptDelete', offer: row });
                       }}
                       aria-label={t('common:buttons.delete')}
                       className="p-2 text-red-600 rounded-lg transition-all hover:text-red-600 hover:bg-red-50"
@@ -843,11 +933,10 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
   ];
 
   const openAddModal = () => {
-    setEditingOffer(null);
+    dispatch({ type: 'openAddModal' });
     setFormData(getDefaultFormData());
     setErrors({});
     setPreviewVersion(null);
-    setIsModalOpen(true);
   };
 
   const handleClientChange = (clientId: string) => {
@@ -1033,7 +1122,7 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
       })),
     };
 
-    setIsSubmitting(true);
+    dispatch({ type: 'setIsSubmitting', value: true });
     try {
       if (editingOffer) {
         await onUpdateOffer(editingOffer.id, payload);
@@ -1044,14 +1133,14 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
       toastError((err as Error).message || t('sales:clientOffers.failedToSave'));
       return;
     } finally {
-      setIsSubmitting(false);
+      dispatch({ type: 'setIsSubmitting', value: false });
     }
-    setIsModalOpen(false);
+    dispatch({ type: 'closeModal' });
   };
 
   return (
     <div className="space-y-6 animate-in fade-in duration-500">
-      <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)}>
+      <Modal isOpen={isModalOpen} onClose={() => dispatch({ type: 'closeModal' })}>
         <div className="flex max-w-[calc(100vw-2rem)] items-start gap-4">
           <ModalContent size="full" className="max-h-[90vh]">
             <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col">
@@ -1069,7 +1158,7 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                       ? t('sales:clientOffers.editOffer', { defaultValue: 'Edit offer' })
                       : t('sales:clientOffers.newOffer', { defaultValue: 'New offer' })}
                 </ModalTitle>
-                <ModalCloseButton onClick={() => setIsModalOpen(false)} />
+                <ModalCloseButton onClick={() => dispatch({ type: 'closeModal' })} />
               </ModalHeader>
 
               <ModalBody className="flex-1 space-y-5">
@@ -1881,7 +1970,11 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
               </ModalBody>
 
               <ModalFooter>
-                <Button type="button" variant="outline" onClick={() => setIsModalOpen(false)}>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => dispatch({ type: 'closeModal' })}
+                >
                   {t('common:buttons.cancel')}
                 </Button>
                 {!isReadOnly && (
@@ -1938,7 +2031,9 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                 <Textarea
                   id="client-offer-revert-reason"
                   value={revertReason}
-                  onChange={(event) => setRevertReason(event.target.value)}
+                  onChange={(event) =>
+                    dispatch({ type: 'setRevertReason', value: event.target.value })
+                  }
                   disabled={isReverting}
                   placeholder={t('sales:clientOffers.revertReasonPlaceholder', {
                     defaultValue: 'Optional note for the audit trail',
@@ -1977,20 +2072,19 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
         isOpen={isDeleteConfirmOpen}
         onClose={() => {
           if (isDeleting) return;
-          setIsDeleteConfirmOpen(false);
+          dispatch({ type: 'closeDeleteConfirm' });
         }}
         onConfirm={async () => {
           if (!offerToDelete) return;
           if (isDeleting) return;
-          setIsDeleting(true);
+          dispatch({ type: 'setIsDeleting', value: true });
           try {
             await onDeleteOffer(offerToDelete.id);
-            setIsDeleteConfirmOpen(false);
-            setOfferToDelete(null);
+            dispatch({ type: 'deleteSuccess' });
           } catch (err) {
             toastError((err as Error).message || t('sales:clientOffers.failedToDelete'));
           } finally {
-            setIsDeleting(false);
+            dispatch({ type: 'setIsDeleting', value: false });
           }
         }}
         isDeleting={isDeleting}

--- a/components/sales/ClientQuotesView.tsx
+++ b/components/sales/ClientQuotesView.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useReducer, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { LinkedRecordBanner } from '@/components/shared/LinkedRecordBanner';
 import { Button } from '@/components/ui/button';
@@ -128,6 +128,78 @@ const quoteToFormData = (quote: Quote): Partial<Quote> => ({
   notes: quote.notes || '',
 });
 
+interface PendingClientChange {
+  clientId: string;
+  clientName: string;
+}
+
+interface ClientQuotesViewState {
+  isModalOpen: boolean;
+  editingQuote: Quote | null;
+  isDeleteConfirmOpen: boolean;
+  quoteToDelete: Quote | null;
+  pendingClientChange: PendingClientChange | null;
+  isSubmitting: boolean;
+  isDeleting: boolean;
+}
+
+const INITIAL_CLIENT_QUOTES_VIEW_STATE: ClientQuotesViewState = {
+  isModalOpen: false,
+  editingQuote: null,
+  isDeleteConfirmOpen: false,
+  quoteToDelete: null,
+  pendingClientChange: null,
+  isSubmitting: false,
+  isDeleting: false,
+};
+
+type ClientQuotesViewAction =
+  | { type: 'openAddModal' }
+  | { type: 'openEditModal'; quote: Quote }
+  | { type: 'closeModal' }
+  | { type: 'setEditingQuote'; quote: Quote | null }
+  | { type: 'setPendingClientChange'; value: PendingClientChange | null }
+  | { type: 'setIsSubmitting'; value: boolean }
+  | { type: 'confirmDelete'; quote: Quote }
+  | { type: 'closeDeleteConfirm' }
+  | { type: 'deleteSuccess' }
+  | { type: 'setIsDeleting'; value: boolean };
+
+const clientQuotesViewReducer = (
+  state: ClientQuotesViewState,
+  action: ClientQuotesViewAction,
+): ClientQuotesViewState => {
+  switch (action.type) {
+    case 'openAddModal':
+      return { ...state, editingQuote: null, pendingClientChange: null, isModalOpen: true };
+    case 'openEditModal':
+      return {
+        ...state,
+        editingQuote: action.quote,
+        pendingClientChange: null,
+        isModalOpen: true,
+      };
+    case 'closeModal':
+      return { ...state, isModalOpen: false };
+    case 'setEditingQuote':
+      return { ...state, editingQuote: action.quote };
+    case 'setPendingClientChange':
+      return { ...state, pendingClientChange: action.value };
+    case 'setIsSubmitting':
+      return { ...state, isSubmitting: action.value };
+    case 'confirmDelete':
+      return { ...state, quoteToDelete: action.quote, isDeleteConfirmOpen: true };
+    case 'closeDeleteConfirm':
+      return { ...state, isDeleteConfirmOpen: false };
+    case 'deleteSuccess':
+      return { ...state, isDeleteConfirmOpen: false, quoteToDelete: null };
+    case 'setIsDeleting':
+      return { ...state, isDeleting: action.value };
+    default:
+      return state;
+  }
+};
+
 const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
   quotes,
   clients,
@@ -173,17 +245,17 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
     [t],
   );
 
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const [editingQuote, setEditingQuote] = useState<Quote | null>(null);
-  const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
-  const [quoteToDelete, setQuoteToDelete] = useState<Quote | null>(null);
-  const [pendingClientChange, setPendingClientChange] = useState<{
-    clientId: string;
-    clientName: string;
-  } | null>(null);
+  const [state, dispatch] = useReducer(clientQuotesViewReducer, INITIAL_CLIENT_QUOTES_VIEW_STATE);
+  const {
+    isModalOpen,
+    editingQuote,
+    isDeleteConfirmOpen,
+    quoteToDelete,
+    pendingClientChange,
+    isSubmitting,
+    isDeleting,
+  } = state;
   const [errors, setErrors] = useState<Record<string, string>>({});
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [isDeleting, setIsDeleting] = useState(false);
 
   const getStatusLabel = useCallback(
     (status: string) => {
@@ -288,26 +360,22 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
   }, []);
 
   const closeModal = useCallback(() => {
-    setIsModalOpen(false);
+    dispatch({ type: 'closeModal' });
     setPreviewVersion(null);
   }, []);
 
   const openAddModal = () => {
-    setEditingQuote(null);
-    setPendingClientChange(null);
+    dispatch({ type: 'openAddModal' });
     setFormData(getDefaultFormData());
     setErrors({});
     setPreviewVersion(null);
-    setIsModalOpen(true);
   };
 
   const openEditModal = useCallback((quote: Quote) => {
-    setEditingQuote(quote);
-    setPendingClientChange(null);
+    dispatch({ type: 'openEditModal', quote });
     setFormData(quoteToFormData(quote));
     setErrors({});
     setPreviewVersion(null);
-    setIsModalOpen(true);
   }, []);
 
   const handleVersionPreview = useCallback(
@@ -333,7 +401,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
 
   const handleVersionRestored = useCallback(
     (updated: Quote) => {
-      setEditingQuote(updated);
+      dispatch({ type: 'setEditingQuote', quote: updated });
       setFormData(quoteToFormData(updated));
       setPreviewVersion(null);
       onQuoteRestored?.(updated);
@@ -432,7 +500,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
       items: itemsWithSnapshots,
     };
 
-    setIsSubmitting(true);
+    dispatch({ type: 'setIsSubmitting', value: true });
     try {
       if (editingQuote) {
         await onUpdateQuote(editingQuote.id, payload);
@@ -443,14 +511,13 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
       toastError((err as Error).message || t('sales:clientQuotes.failedToSave'));
       return;
     } finally {
-      setIsSubmitting(false);
+      dispatch({ type: 'setIsSubmitting', value: false });
     }
     closeModal();
   };
 
   const confirmDelete = useCallback((quote: Quote) => {
-    setQuoteToDelete(quote);
-    setIsDeleteConfirmOpen(true);
+    dispatch({ type: 'confirmDelete', quote });
   }, []);
 
   const handleStatusUpdate = async (id: string, updates: Partial<Quote>) => {
@@ -464,21 +531,20 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
   const handleDelete = async () => {
     if (!quoteToDelete) return;
     if (isDeleting) return;
-    setIsDeleting(true);
+    dispatch({ type: 'setIsDeleting', value: true });
     try {
       await onDeleteQuote(quoteToDelete.id);
-      setIsDeleteConfirmOpen(false);
-      setQuoteToDelete(null);
+      dispatch({ type: 'deleteSuccess' });
     } catch (err) {
       toastError((err as Error).message || t('sales:clientQuotes.failedToDelete'));
     } finally {
-      setIsDeleting(false);
+      dispatch({ type: 'setIsDeleting', value: false });
     }
   };
 
   const applyClientChange = (clientId: string, clientName: string, shouldReprice: boolean) => {
     if (isReadOnly) return;
-    setPendingClientChange(null);
+    dispatch({ type: 'setPendingClientChange', value: null });
     setFormData((prev) => {
       const updatedItems = shouldReprice
         ? (prev.items || []).map((item) => {
@@ -548,7 +614,10 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
       Boolean(formData.items && formData.items.length > 0);
 
     if (shouldPromptReprice) {
-      setPendingClientChange({ clientId, clientName: nextClientName });
+      dispatch({
+        type: 'setPendingClientChange',
+        value: { clientId, clientName: nextClientName },
+      });
       return;
     }
 
@@ -2237,7 +2306,10 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
         </div>
       </Modal>
 
-      <Modal isOpen={Boolean(pendingClientChange)} onClose={() => setPendingClientChange(null)}>
+      <Modal
+        isOpen={Boolean(pendingClientChange)}
+        onClose={() => dispatch({ type: 'setPendingClientChange', value: null })}
+      >
         <ModalContent size="sm">
           <div className="space-y-5 p-6">
             <div>
@@ -2263,7 +2335,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
               <Button
                 type="button"
                 variant="outline"
-                onClick={() => setPendingClientChange(null)}
+                onClick={() => dispatch({ type: 'setPendingClientChange', value: null })}
                 className="w-full"
               >
                 {t('sales:clientQuotes.clientChangeRepriceCancel')}
@@ -2278,7 +2350,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
         isOpen={isDeleteConfirmOpen}
         onClose={() => {
           if (isDeleting) return;
-          setIsDeleteConfirmOpen(false);
+          dispatch({ type: 'closeDeleteConfirm' });
         }}
         onConfirm={handleDelete}
         isDeleting={isDeleting}

--- a/components/sales/SupplierQuotesView.tsx
+++ b/components/sales/SupplierQuotesView.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useReducer } from 'react';
 import { useTranslation } from 'react-i18next';
 import { LinkedRecordBanner } from '@/components/shared/LinkedRecordBanner';
 import { Button } from '@/components/ui/button';
@@ -117,6 +117,153 @@ const getDefaultFormData = (): Partial<SupplierQuote> => ({
   notes: '',
 });
 
+interface SupplierQuotesViewState {
+  editingQuote: SupplierQuote | null;
+  quoteToDelete: SupplierQuote | null;
+  isModalOpen: boolean;
+  isDeleteConfirmOpen: boolean;
+  errors: Record<string, string>;
+  formData: Partial<SupplierQuote>;
+  previewVersion: SupplierQuoteVersion | null;
+  isSubmitting: boolean;
+  isDeleting: boolean;
+}
+
+const getInitialSupplierQuotesState = (): SupplierQuotesViewState => ({
+  editingQuote: null,
+  quoteToDelete: null,
+  isModalOpen: false,
+  isDeleteConfirmOpen: false,
+  errors: {},
+  formData: getDefaultFormData(),
+  previewVersion: null,
+  isSubmitting: false,
+  isDeleting: false,
+});
+
+type SupplierQuotesViewAction =
+  | { type: 'setEditingQuote'; value: SupplierQuote | null }
+  | { type: 'setQuoteToDelete'; value: SupplierQuote | null }
+  | { type: 'setIsModalOpen'; value: boolean }
+  | { type: 'setIsDeleteConfirmOpen'; value: boolean }
+  | { type: 'setErrors'; value: Record<string, string> }
+  | { type: 'clearError'; key: string }
+  | { type: 'setFormData'; value: Partial<SupplierQuote> }
+  | { type: 'patchFormData'; value: Partial<SupplierQuote> }
+  | { type: 'setPreviewVersion'; value: SupplierQuoteVersion | null }
+  | { type: 'setIsSubmitting'; value: boolean }
+  | { type: 'setIsDeleting'; value: boolean }
+  | { type: 'closeModal' }
+  | { type: 'openAddModal' }
+  | { type: 'openEditModal'; quote: SupplierQuote; formData: Partial<SupplierQuote> }
+  | { type: 'previewVersion'; version: SupplierQuoteVersion; formData: Partial<SupplierQuote> }
+  | { type: 'restoreVersion'; quote: SupplierQuote; formData: Partial<SupplierQuote> }
+  | { type: 'updateItem'; index: number; field: keyof SupplierQuoteItem; value: string | number }
+  | { type: 'addItem'; item: SupplierQuoteItem }
+  | { type: 'removeItem'; index: number }
+  | { type: 'setItem'; index: number; item: SupplierQuoteItem };
+
+const supplierQuotesViewReducer = (
+  state: SupplierQuotesViewState,
+  action: SupplierQuotesViewAction,
+): SupplierQuotesViewState => {
+  switch (action.type) {
+    case 'setEditingQuote':
+      return { ...state, editingQuote: action.value };
+    case 'setQuoteToDelete':
+      return { ...state, quoteToDelete: action.value };
+    case 'setIsModalOpen':
+      return { ...state, isModalOpen: action.value };
+    case 'setIsDeleteConfirmOpen':
+      return { ...state, isDeleteConfirmOpen: action.value };
+    case 'setErrors':
+      return { ...state, errors: action.value };
+    case 'clearError': {
+      const next = { ...state.errors };
+      delete next[action.key];
+      return { ...state, errors: next };
+    }
+    case 'setFormData':
+      return { ...state, formData: action.value };
+    case 'patchFormData':
+      return { ...state, formData: { ...state.formData, ...action.value } };
+    case 'setPreviewVersion':
+      return { ...state, previewVersion: action.value };
+    case 'setIsSubmitting':
+      return { ...state, isSubmitting: action.value };
+    case 'setIsDeleting':
+      return { ...state, isDeleting: action.value };
+    case 'closeModal':
+      return { ...state, isModalOpen: false, previewVersion: null };
+    case 'openAddModal':
+      return {
+        ...state,
+        editingQuote: null,
+        formData: getDefaultFormData(),
+        errors: {},
+        previewVersion: null,
+        isModalOpen: true,
+      };
+    case 'openEditModal':
+      return {
+        ...state,
+        editingQuote: action.quote,
+        formData: action.formData,
+        errors: {},
+        previewVersion: null,
+        isModalOpen: true,
+      };
+    case 'previewVersion':
+      return {
+        ...state,
+        previewVersion: action.version,
+        formData: action.formData,
+        errors: {},
+      };
+    case 'restoreVersion':
+      return {
+        ...state,
+        editingQuote: action.quote,
+        formData: action.formData,
+        previewVersion: null,
+      };
+    case 'updateItem': {
+      const items = [...(state.formData.items || [])];
+      const current = items[action.index];
+      if (!current) return state;
+      const next = { ...current, [action.field]: action.value };
+      // Prezzo listino / Sconto a noi edits re-derive the whole line at the persisted DB scale in
+      // the same update, so the rounded list price/discount and the net cost — and every total that
+      // reads them — stay in lockstep with what the server will store.
+      if (action.field === 'listPrice' || action.field === 'discountPercent') {
+        const pricing = deriveLinePricing(next.listPrice, next.discountPercent);
+        next.listPrice = pricing.listPrice;
+        next.discountPercent = pricing.discountPercent;
+        next.unitPrice = pricing.unitPrice;
+      }
+      items[action.index] = next;
+      return { ...state, formData: { ...state.formData, items } };
+    }
+    case 'addItem':
+      return {
+        ...state,
+        formData: { ...state.formData, items: [...(state.formData.items || []), action.item] },
+      };
+    case 'removeItem': {
+      const items = [...(state.formData.items || [])];
+      items.splice(action.index, 1);
+      return { ...state, formData: { ...state.formData, items } };
+    }
+    case 'setItem': {
+      const items = [...(state.formData.items || [])];
+      items[action.index] = action.item;
+      return { ...state, formData: { ...state.formData, items } };
+    }
+    default:
+      return state;
+  }
+};
+
 const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
   quotes,
   suppliers,
@@ -161,15 +308,22 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
     return undefined;
   }, [quoteFilterId]);
 
-  const [editingQuote, setEditingQuote] = useState<SupplierQuote | null>(null);
-  const [quoteToDelete, setQuoteToDelete] = useState<SupplierQuote | null>(null);
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
-  const [errors, setErrors] = useState<Record<string, string>>({});
-  const [formData, setFormData] = useState<Partial<SupplierQuote>>(() => getDefaultFormData());
-  const [previewVersion, setPreviewVersion] = useState<SupplierQuoteVersion | null>(null);
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [isDeleting, setIsDeleting] = useState(false);
+  const [state, dispatch] = useReducer(
+    supplierQuotesViewReducer,
+    undefined,
+    getInitialSupplierQuotesState,
+  );
+  const {
+    editingQuote,
+    quoteToDelete,
+    isModalOpen,
+    isDeleteConfirmOpen,
+    errors,
+    formData,
+    previewVersion,
+    isSubmitting,
+    isDeleting,
+  } = state;
 
   const baseReadOnly = Boolean(editingQuote && editingQuote.status !== 'draft');
   const isReadOnly = baseReadOnly || previewVersion !== null;
@@ -200,16 +354,11 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
   const itemInputClassName = 'font-medium';
 
   const closeModal = useCallback(() => {
-    setIsModalOpen(false);
-    setPreviewVersion(null);
+    dispatch({ type: 'closeModal' });
   }, []);
 
   const openAddModal = useCallback(() => {
-    setEditingQuote(null);
-    setFormData(getDefaultFormData());
-    setErrors({});
-    setPreviewVersion(null);
-    setIsModalOpen(true);
+    dispatch({ type: 'openAddModal' });
   }, []);
 
   const quoteToFormData = useCallback(
@@ -222,42 +371,40 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
 
   const openEditModal = useCallback(
     (quote: SupplierQuote) => {
-      setEditingQuote(quote);
-      setFormData(quoteToFormData(quote));
-      setErrors({});
-      setPreviewVersion(null);
-      setIsModalOpen(true);
+      dispatch({ type: 'openEditModal', quote, formData: quoteToFormData(quote) });
     },
     [quoteToFormData],
   );
 
   const handleVersionPreview = useCallback(
     (version: SupplierQuoteVersion) => {
-      setPreviewVersion(version);
-      setFormData({
-        ...version.snapshot.quote,
-        id: editingQuote?.id ?? version.snapshot.quote.id,
-        items: version.snapshot.items,
-        expirationDate: version.snapshot.quote.expirationDate
-          ? normalizeDateOnlyString(version.snapshot.quote.expirationDate)
-          : '',
-        status: version.snapshot.quote.status as SupplierQuote['status'],
+      dispatch({
+        type: 'previewVersion',
+        version,
+        formData: {
+          ...version.snapshot.quote,
+          id: editingQuote?.id ?? version.snapshot.quote.id,
+          items: version.snapshot.items,
+          expirationDate: version.snapshot.quote.expirationDate
+            ? normalizeDateOnlyString(version.snapshot.quote.expirationDate)
+            : '',
+          status: version.snapshot.quote.status as SupplierQuote['status'],
+        },
       });
-      setErrors({});
     },
     [editingQuote],
   );
 
   const handleClearPreview = useCallback(() => {
-    if (editingQuote) setFormData(quoteToFormData(editingQuote));
-    setPreviewVersion(null);
+    if (editingQuote) {
+      dispatch({ type: 'setFormData', value: quoteToFormData(editingQuote) });
+    }
+    dispatch({ type: 'setPreviewVersion', value: null });
   }, [editingQuote, quoteToFormData]);
 
   const handleVersionRestored = useCallback(
     (updated: SupplierQuote) => {
-      setEditingQuote(updated);
-      setFormData(quoteToFormData(updated));
-      setPreviewVersion(null);
+      dispatch({ type: 'restoreVersion', quote: updated, formData: quoteToFormData(updated) });
       onQuoteRestored?.(updated);
     },
     [onQuoteRestored, quoteToFormData],
@@ -274,11 +421,10 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
   const handleSupplierChange = useCallback(
     (supplierId: string) => {
       const supplier = suppliers.find((item) => item.id === supplierId);
-      setFormData((prev) => ({
-        ...prev,
-        supplierId,
-        supplierName: supplier?.name || '',
-      }));
+      dispatch({
+        type: 'patchFormData',
+        value: { supplierId, supplierName: supplier?.name || '' },
+      });
     },
     [suppliers],
   );
@@ -289,9 +435,11 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
   const clientOptions = useMemo(() => {
     const options = [
       { id: '', name: t('sales:supplierQuotes.noClient', { defaultValue: 'No customer' }) },
-      ...clients
-        .filter((client) => !client.isDisabled || client.id === editingQuote?.clientId)
-        .map((client) => ({ id: client.id, name: client.name })),
+      ...clients.flatMap((client) =>
+        !client.isDisabled || client.id === editingQuote?.clientId
+          ? [{ id: client.id, name: client.name }]
+          : [],
+      ),
     ];
     // The linked client may be missing from a user-scoped /clients list (no crm.clients_all.view
     // and not assigned to it). Synthesize an option from the quote's stored name so the select
@@ -306,11 +454,10 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
   const handleClientChange = useCallback(
     (clientId: string) => {
       const client = clients.find((item) => item.id === clientId);
-      setFormData((prev) => ({
-        ...prev,
-        clientId: clientId || null,
-        clientName: client?.name || null,
-      }));
+      dispatch({
+        type: 'patchFormData',
+        value: { clientId: clientId || null, clientName: client?.name || null },
+      });
     },
     [clients],
   );
@@ -318,56 +465,33 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
   const updateItem = useCallback(
     (index: number, field: keyof SupplierQuoteItem, value: string | number) => {
       if (isReadOnly) return;
-      setFormData((prev) => {
-        const items = [...(prev.items || [])];
-        const current = items[index];
-        if (!current) return prev;
-        const next = { ...current, [field]: value };
-        // Prezzo listino / Sconto a noi edits re-derive the whole line at the persisted DB scale in
-        // the same update, so the rounded list price/discount and the net cost — and every total that
-        // reads them — stay in lockstep with what the server will store.
-        if (field === 'listPrice' || field === 'discountPercent') {
-          const pricing = deriveLinePricing(next.listPrice, next.discountPercent);
-          next.listPrice = pricing.listPrice;
-          next.discountPercent = pricing.discountPercent;
-          next.unitPrice = pricing.unitPrice;
-        }
-        items[index] = next;
-        return { ...prev, items };
-      });
+      dispatch({ type: 'updateItem', index, field, value });
     },
     [isReadOnly],
   );
 
   const addItem = useCallback(() => {
     if (isReadOnly) return;
-    setFormData((prev) => ({
-      ...prev,
-      items: [
-        ...(prev.items || []),
-        {
-          id: `tmp-${Date.now()}`,
-          quoteId: editingQuote?.id || '',
-          productName: '',
-          quantity: 1,
-          listPrice: 0,
-          discountPercent: 0,
-          unitPrice: 0,
-          unitType: 'unit' as const,
-          note: '',
-        },
-      ],
-    }));
+    dispatch({
+      type: 'addItem',
+      item: {
+        id: `tmp-${Date.now()}`,
+        quoteId: editingQuote?.id || '',
+        productName: '',
+        quantity: 1,
+        listPrice: 0,
+        discountPercent: 0,
+        unitPrice: 0,
+        unitType: 'unit' as const,
+        note: '',
+      },
+    });
   }, [editingQuote?.id, isReadOnly]);
 
   const removeItem = useCallback(
     (index: number) => {
       if (isReadOnly) return;
-      setFormData((prev) => {
-        const items = [...(prev.items || [])];
-        items.splice(index, 1);
-        return { ...prev, items };
-      });
+      dispatch({ type: 'removeItem', index });
     },
     [isReadOnly],
   );
@@ -382,15 +506,17 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
     const baseListPrice = item.listPrice ?? item.unitPrice ?? 0;
     const adjustedListPrice = convertUnitPrice(baseListPrice, oldType, newType);
     const pricing = deriveLinePricing(adjustedListPrice, item.discountPercent ?? 0);
-    const newItems = [...(formData.items || [])];
-    newItems[index] = {
-      ...newItems[index],
-      unitType: newType,
-      listPrice: pricing.listPrice,
-      discountPercent: pricing.discountPercent,
-      unitPrice: pricing.unitPrice,
-    };
-    setFormData((prev) => ({ ...prev, items: newItems }));
+    dispatch({
+      type: 'setItem',
+      index,
+      item: {
+        ...item,
+        unitType: newType,
+        listPrice: pricing.listPrice,
+        discountPercent: pricing.discountPercent,
+        unitPrice: pricing.unitPrice,
+      },
+    });
   };
 
   const handleStatusUpdate = useCallback(
@@ -708,8 +834,8 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
                         type="button"
                         onClick={(event) => {
                           event.stopPropagation();
-                          setQuoteToDelete(row);
-                          setIsDeleteConfirmOpen(true);
+                          dispatch({ type: 'setQuoteToDelete', value: row });
+                          dispatch({ type: 'setIsDeleteConfirmOpen', value: true });
                         }}
                         aria-label={t('common:buttons.delete', { defaultValue: 'Delete' })}
                         className="p-2 rounded-lg transition-all text-red-600 hover:text-red-600 hover:bg-red-50"
@@ -799,7 +925,7 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
     }
 
     if (Object.keys(nextErrors).length > 0) {
-      setErrors(nextErrors);
+      dispatch({ type: 'setErrors', value: nextErrors });
       return;
     }
 
@@ -816,7 +942,7 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
       })),
     };
 
-    setIsSubmitting(true);
+    dispatch({ type: 'setIsSubmitting', value: true });
     try {
       if (editingQuote) {
         await onUpdateQuote(editingQuote.id, payload);
@@ -827,7 +953,7 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
       toastError((err as Error).message || t('sales:supplierQuotes.failedToSave'));
       return;
     } finally {
-      setIsSubmitting(false);
+      dispatch({ type: 'setIsSubmitting', value: false });
     }
     closeModal();
   };
@@ -970,16 +1096,9 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
                         value={formData.id || ''}
                         disabled={isReadOnly}
                         onChange={(event) => {
-                          setFormData((prev) => ({
-                            ...prev,
-                            id: event.target.value,
-                          }));
+                          dispatch({ type: 'patchFormData', value: { id: event.target.value } });
                           if (errors.id) {
-                            setErrors((prev) => {
-                              const next = { ...prev };
-                              delete next.id;
-                              return next;
-                            });
+                            dispatch({ type: 'clearError', key: 'id' });
                           }
                         }}
                         className={errors.id ? 'border-red-300' : ''}
@@ -993,10 +1112,10 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
                         options={paymentTermsOptions}
                         value={formData.paymentTerms || 'immediate'}
                         onChange={(value) =>
-                          setFormData((prev) => ({
-                            ...prev,
-                            paymentTerms: value as SupplierQuote['paymentTerms'],
-                          }))
+                          dispatch({
+                            type: 'patchFormData',
+                            value: { paymentTerms: value as SupplierQuote['paymentTerms'] },
+                          })
                         }
                         searchable={false}
                         disabled={isReadOnly}
@@ -1017,7 +1136,7 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
                         value={formData.expirationDate || ''}
                         disabled={isReadOnly}
                         onChange={(value) =>
-                          setFormData((prev) => ({ ...prev, expirationDate: value }))
+                          dispatch({ type: 'patchFormData', value: { expirationDate: value } })
                         }
                       />
                     </Field>
@@ -1382,7 +1501,7 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
                         defaultValue: 'Optional notes...',
                       })}
                       onChange={(event) =>
-                        setFormData((prev) => ({ ...prev, notes: event.target.value }))
+                        dispatch({ type: 'patchFormData', value: { notes: event.target.value } })
                       }
                       className="min-h-28 resize-none"
                     />
@@ -1445,20 +1564,20 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
         isOpen={isDeleteConfirmOpen}
         onClose={() => {
           if (isDeleting) return;
-          setIsDeleteConfirmOpen(false);
+          dispatch({ type: 'setIsDeleteConfirmOpen', value: false });
         }}
         onConfirm={async () => {
           if (!quoteToDelete) return;
           if (isDeleting) return;
-          setIsDeleting(true);
+          dispatch({ type: 'setIsDeleting', value: true });
           try {
             await onDeleteQuote(quoteToDelete.id);
-            setIsDeleteConfirmOpen(false);
-            setQuoteToDelete(null);
+            dispatch({ type: 'setIsDeleteConfirmOpen', value: false });
+            dispatch({ type: 'setQuoteToDelete', value: null });
           } catch (err) {
             toastError((err as Error).message || t('sales:supplierQuotes.failedToDelete'));
           } finally {
-            setIsDeleting(false);
+            dispatch({ type: 'setIsDeleting', value: false });
           }
         }}
         isDeleting={isDeleting}

--- a/components/shared/DateField.tsx
+++ b/components/shared/DateField.tsx
@@ -1,6 +1,6 @@
 import { CalendarDays } from 'lucide-react';
 import type React from 'react';
-import { useState } from 'react';
+import { useId, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { inputBaseClassName } from '@/components/ui/inputStyles';
@@ -50,6 +50,8 @@ const DateField: React.FC<DateFieldProps> = ({
 }) => {
   const { t, i18n } = useTranslation('common');
   const [isOpen, setIsOpen] = useState(false);
+  // Stable id linking the combobox trigger to its popover (the calendar) via aria-controls.
+  const contentId = useId();
 
   const normalized = value ? normalizeDateOnlyString(value) : '';
   const displayValue = normalized
@@ -78,6 +80,10 @@ const DateField: React.FC<DateFieldProps> = ({
         <button
           id={id}
           type="button"
+          role="combobox"
+          aria-expanded={isOpen}
+          aria-haspopup="dialog"
+          aria-controls={contentId}
           disabled={disabled}
           aria-invalid={ariaInvalid}
           aria-label={ariaLabel}
@@ -95,7 +101,7 @@ const DateField: React.FC<DateFieldProps> = ({
           </span>
         </button>
       </PopoverTrigger>
-      <PopoverContent align="start" className="w-72 space-y-2.5 p-3">
+      <PopoverContent id={contentId} align="start" className="w-72 space-y-2.5 p-3">
         <Calendar
           selectedDate={normalized || undefined}
           onDateSelect={handleDateSelect}

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -458,12 +458,6 @@ const sanitizeColumnWidths = (
   );
 };
 
-const numberRecordsEqual = (a: Record<string, number>, b: Record<string, number>) => {
-  const aEntries = Object.entries(a);
-  const bEntries = Object.entries(b);
-  return aEntries.length === bEntries.length && aEntries.every(([key, value]) => b[key] === value);
-};
-
 const FONT_SIZES = ['xs', 'sm', 'base'] as const;
 type FontSize = (typeof FONT_SIZES)[number];
 
@@ -1143,16 +1137,17 @@ const StandardTable = <T extends object>({
 
   const fontSizeClass = fontSize === 'xs' ? 'text-xs' : fontSize === 'sm' ? 'text-sm' : 'text-base';
 
+  // Persist the clamped column widths whenever they change. The table renders from
+  // `clampedColumnSizing` (a memo derived from the raw sizing state), and `onColumnSizingChange`
+  // already clamps on every user resize, so there's no need to write the clamped value back into
+  // state from here — persisting the derived value directly avoids an extra render.
   useEffect(() => {
-    const next = clampColumnSizing(columnSizing);
-    if (!numberRecordsEqual(columnSizing, next)) {
-      setColumnSizing(next);
-      return;
-    }
-    if (typeof window !== 'undefined') {
-      localStorage.setItem(getStorageKey(title, STORAGE_SUFFIX.colWidths), JSON.stringify(next));
-    }
-  }, [clampColumnSizing, columnSizing, title]);
+    if (typeof window === 'undefined') return;
+    localStorage.setItem(
+      getStorageKey(title, STORAGE_SUFFIX.colWidths),
+      JSON.stringify(clampedColumnSizing),
+    );
+  }, [clampedColumnSizing, title]);
 
   const getValue = useCallback((row: T, col: Column<T>) => {
     if (col.accessorFn) return col.accessorFn(row);

--- a/components/ui/use-shadcn-theme.ts
+++ b/components/ui/use-shadcn-theme.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useSyncExternalStore } from 'react';
 import {
   getBrowserTheme,
   getResolvedTheme,
@@ -21,28 +21,24 @@ const getActiveScopedTheme = (): ResolvedTheme | undefined => {
   return isResolvedTheme(scopedTheme) ? scopedTheme : undefined;
 };
 
-export const getCurrentShadcnTheme = () => getActiveScopedTheme() ?? getResolvedTheme();
+const getCurrentShadcnTheme = () => getActiveScopedTheme() ?? getResolvedTheme();
 
 export const getShadcnThemeClassName = (theme: ResolvedTheme) => {
   return theme === 'dark' ? 'dark' : undefined;
 };
 
-export const useResolvedShadcnTheme = () => {
-  const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>(() => getCurrentShadcnTheme());
-
-  useEffect(() => {
-    const syncTheme = () => {
-      const nextTheme = getCurrentShadcnTheme();
-      setResolvedTheme((current) => (current === nextTheme ? current : nextTheme));
-    };
-
-    syncTheme();
-    window.addEventListener(THEME_CHANGE_EVENT, syncTheme);
-    return () => window.removeEventListener(THEME_CHANGE_EVENT, syncTheme);
-  }, []);
-
-  return resolvedTheme;
+// Subscribe to in-app theme changes (dispatched as THEME_CHANGE_EVENT). Returns a no-op
+// unsubscribe on the server where there is no window to listen on.
+const subscribeShadcnTheme = (onStoreChange: () => void): (() => void) => {
+  if (typeof window === 'undefined') return () => {};
+  window.addEventListener(THEME_CHANGE_EVENT, onStoreChange);
+  return () => window.removeEventListener(THEME_CHANGE_EVENT, onStoreChange);
 };
+
+// The resolved theme is external mutable state (a DOM attribute updated outside React), so read
+// it through useSyncExternalStore rather than mirroring it into useState via a mount effect.
+export const useResolvedShadcnTheme = (): ResolvedTheme =>
+  useSyncExternalStore(subscribeShadcnTheme, getCurrentShadcnTheme, getCurrentShadcnTheme);
 
 /**
  * Track the OS/browser color scheme, ignoring any saved theme preference. Used

--- a/server/db/demoSeed.ts
+++ b/server/db/demoSeed.ts
@@ -787,11 +787,14 @@ export const runDemoSeedRefresh = async ({
     await client.query('COMMIT');
     inTransaction = false;
 
-    for (const user of DEMO_USERS) {
-      if (user.role === 'top_manager') {
-        await userAssignmentsRepo.syncTopManagerAssignmentsForUser(user.id);
-      }
-    }
+    // Each sync runs in its own transaction (default db executor) against a distinct user's
+    // assignment rows, so the per-user fan-outs are independent and run concurrently. This is
+    // a bounded, fixed set (DEMO_USERS), so there's no connection-pool-storm risk.
+    await Promise.all(
+      DEMO_USERS.filter((user) => user.role === 'top_manager').map((user) =>
+        userAssignmentsRepo.syncTopManagerAssignmentsForUser(user.id),
+      ),
+    );
   } catch (err) {
     if (inTransaction) {
       await client.query('ROLLBACK');

--- a/server/routes/branding.ts
+++ b/server/routes/branding.ts
@@ -161,8 +161,12 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         return reply.code(413).send({ error: 'Logo exceeds the 2 MB limit' });
       }
 
-      const existing = await brandingRepo.get();
-      const saved = await saveBrandingLogo(buffer, originalName);
+      // The current-record read and the disk write touch different resources, so run them at
+      // the same time; `existing` is only consulted afterwards to clean up the superseded file.
+      const [existing, saved] = await Promise.all([
+        brandingRepo.get(),
+        saveBrandingLogo(buffer, originalName),
+      ]);
       let updated: AppBrandingRecord;
       try {
         updated = await brandingRepo.setLogo({

--- a/server/routes/clients-orders.ts
+++ b/server/routes/clients-orders.ts
@@ -1058,9 +1058,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         const supplierBackedItems = existingItems.filter((it) => it.supplierSaleItemId);
         if (supplierBackedItems.length > 0) {
           const incomingBySupplierItemId = new Map(
-            (normalizedItems ?? [])
-              .filter((it) => it.supplierSaleItemId)
-              .map((it) => [it.supplierSaleItemId as string, it] as const),
+            (normalizedItems ?? []).flatMap((it) =>
+              it.supplierSaleItemId ? [[it.supplierSaleItemId as string, it] as const] : [],
+            ),
           );
           const desyncsSupplierOrder = supplierBackedItems.some((existing) => {
             const incoming = incomingBySupplierItemId.get(existing.supplierSaleItemId as string);

--- a/server/routes/general-settings.ts
+++ b/server/routes/general-settings.ts
@@ -602,7 +602,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       // Compare via JSON of the sorted arrays so a role id containing the delimiter character can't
       // collide (ids are free-form strings) and wrongly skip the security-critical revocation below.
       const sameRoleSet = (a: string[], b: string[]): boolean =>
-        a.length === b.length && JSON.stringify([...a].sort()) === JSON.stringify([...b].sort());
+        a.length === b.length && JSON.stringify(a.toSorted()) === JSON.stringify(b.toSorted());
       const enforcementRelevantChange =
         resultEnableTotp !== (previousSettings?.enableTotp ?? true) ||
         resultEnforceTotp !== (previousSettings?.enforceTotp ?? false) ||

--- a/server/routes/settings.ts
+++ b/server/routes/settings.ts
@@ -46,6 +46,9 @@ const rilWeekdayTransferDefaultsSchema = {
   additionalProperties: false,
 } as const;
 
+// Set of valid weekday keys for O(1) membership checks inside the sanitizer loop below.
+const RIL_WEEKDAY_SET: ReadonlySet<string> = new Set(settingsRepo.RIL_WEEKDAYS);
+
 // Sanitize the per-weekday default-transfer map: drop unknown keys, trim values, and omit
 // blanks (a blank means "no default for that day"). `undefined` means the field was not sent,
 // so the existing column is preserved; an object (even `{}`) replaces the stored value.
@@ -60,7 +63,7 @@ const parseRilWeekdayTransferDefaults = (
   }
   const out: settingsRepo.RilWeekdayTransferDefaults = {};
   for (const [key, raw] of Object.entries(value)) {
-    if (!(settingsRepo.RIL_WEEKDAYS as readonly string[]).includes(key)) {
+    if (!RIL_WEEKDAY_SET.has(key)) {
       return { ok: false, message: `rilWeekdayTransferDefaults has an invalid weekday: ${key}` };
     }
     if (typeof raw !== 'string') {

--- a/test/components/projects/ProjectsView.test.ts
+++ b/test/components/projects/ProjectsView.test.ts
@@ -87,7 +87,7 @@ describe('ProjectsView create-form validation', () => {
       new URL('../../../components/projects/ProjectsView.tsx', import.meta.url),
     ).text();
     expect(source).toContain('const nextOrder = orders.find((o) => o.id === nextOrderId);');
-    expect(source).toContain('setClientId(nextOrder.clientId);');
+    expect(source).toContain("dispatch({ type: 'setClientId', value: nextOrder.clientId });");
     expect(source).toContain('disabled={Boolean(selectedOrder)}');
   });
 
@@ -99,15 +99,19 @@ describe('ProjectsView create-form validation', () => {
       "if (offer.status !== 'sent' && offer.status !== 'accepted') return options;",
     );
     expect(source).toContain('if (clientId && offer.clientId !== clientId) return options;');
-    expect(source).toContain('setClientId(nextOffer.clientId);');
+    expect(source).toContain("dispatch({ type: 'setClientId', value: nextOffer.clientId });");
   });
 
   test('changing the order or offer clears any stale sibling link via the shared helper', async () => {
     const source = await Bun.file(
       new URL('../../../components/projects/ProjectsView.tsx', import.meta.url),
     ).text();
-    expect(source).toMatch(/setOrderId\(nextOrderId\)[\s\S]{0,600}['"]order['"]/);
-    expect(source).toMatch(/setOfferId\(nextOfferId\)[\s\S]{0,600}['"]offer['"]/);
+    expect(source).toMatch(
+      /setOrderId['"],\s*value:\s*nextOrderId\s*\}\)[\s\S]{0,900}['"]order['"]/,
+    );
+    expect(source).toMatch(
+      /setOfferId['"],\s*value:\s*nextOfferId\s*\}\)[\s\S]{0,900}['"]offer['"]/,
+    );
   });
 });
 

--- a/test/components/shared/DateField.test.tsx
+++ b/test/components/shared/DateField.test.tsx
@@ -17,7 +17,7 @@ describe('<DateField />', () => {
 
   test('renders the selected date formatted for the locale', () => {
     render(<DateField value="2024-03-15" onChange={() => {}} />);
-    const trigger = screen.getByRole('button');
+    const trigger = screen.getByRole('combobox');
     // en locale → 2-digit month/day, numeric year
     expect(trigger.textContent).toContain('03/15/2024');
   });
@@ -27,7 +27,7 @@ describe('<DateField />', () => {
     const user = userEvent.setup();
     render(<DateField value="2024-03-10" onChange={onChange} />);
 
-    await user.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('combobox'));
     const day20 = await screen.findByText('20');
     await user.click(day20);
 
@@ -39,7 +39,7 @@ describe('<DateField />', () => {
     const user = userEvent.setup();
     render(<DateField value="2024-03-10" onChange={onChange} />);
 
-    await user.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('combobox'));
     const clear = await screen.findByText('buttons.clear');
     await user.click(clear);
 
@@ -50,7 +50,7 @@ describe('<DateField />', () => {
     const user = userEvent.setup();
     render(<DateField value="2024-03-10" required onChange={() => {}} />);
 
-    await user.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('combobox'));
     // Wait for the calendar to mount before asserting the clear button is absent.
     await screen.findByText('20');
     expect(screen.queryByText('buttons.clear')).not.toBeInTheDocument();
@@ -58,13 +58,13 @@ describe('<DateField />', () => {
 
   test('disabled field keeps the calendar closed', () => {
     render(<DateField value="2024-03-10" disabled onChange={() => {}} />);
-    const trigger = screen.getByRole('button');
+    const trigger = screen.getByRole('combobox');
     expect(trigger).toBeDisabled();
     expect(screen.queryByText('20')).not.toBeInTheDocument();
   });
 
   test('reflects an aria-invalid state on the trigger', () => {
     render(<DateField value="" onChange={() => {}} aria-invalid />);
-    expect(screen.getByRole('button')).toHaveAttribute('aria-invalid', 'true');
+    expect(screen.getByRole('combobox')).toHaveAttribute('aria-invalid', 'true');
   });
 });

--- a/utils/hashCanonicalization.ts
+++ b/utils/hashCanonicalization.ts
@@ -5,7 +5,7 @@ export const stripHashPrefix = (hash: string): string => hash.replace('#/', '').
 // Query-string key used by quick-view deep links (e.g.
 // `#/sales/supplier-quotes?filterId=SQ-001`). Keep the reader in App.tsx and the
 // `buildViewDeepLink` writer below in sync with this constant.
-export const VIEW_DEEP_LINK_FILTER_PARAM = 'filterId';
+const VIEW_DEEP_LINK_FILTER_PARAM = 'filterId';
 
 export interface ParsedViewHash {
   // View path with any query string stripped and legacy aliases canonicalized.

--- a/utils/numbers.ts
+++ b/utils/numbers.ts
@@ -2,9 +2,6 @@ import type { DiscountType, DurationUnit, SupplierUnitType } from '../types';
 
 const CURRENCY_DECIMAL_PLACES = 2;
 
-// Duration display units (issue #757). `durationMonths` is the canonical pricing multiplier
-// (always whole months); `durationUnit` only controls how that value is shown/entered.
-export const DURATION_UNITS: readonly DurationUnit[] = ['months', 'years'];
 const MONTHS_PER_YEAR = 12;
 
 const shiftDecimal = (value: number, decimalPlaces: number): number => {

--- a/utils/permissions.ts
+++ b/utils/permissions.ts
@@ -144,7 +144,7 @@ export const hasPermission = (permissions: Permission[] | undefined, permission:
 export const hasAnyPermission = (permissions: Permission[] | undefined, required: Permission[]) =>
   required.some((permission) => hasPermission(permissions, permission));
 
-export const scopeResourceFor = (resource: PermissionResource): PermissionResource | undefined => {
+const scopeResourceFor = (resource: PermissionResource): PermissionResource | undefined => {
   const scoped = `${resource}_all`;
   return PERMISSION_DEFINITIONS.some((definition) => definition.id === scoped) ? scoped : undefined;
 };
@@ -198,7 +198,7 @@ export const VIEW_PERMISSION_MAP: Record<View, Permission> = {
   'docs/frontend': buildPermission('docs.frontend', 'view'),
 };
 
-export const VIEW_PERMISSION_OPTIONS: Record<View, Permission[]> = Object.fromEntries(
+const VIEW_PERMISSION_OPTIONS: Record<View, Permission[]> = Object.fromEntries(
   Object.entries(VIEW_PERMISSION_MAP).map(([view, permission]) => {
     const [resource, action] = permission.split(/\.(?=[^.]+$)/) as [
       PermissionResource,

--- a/utils/ril.ts
+++ b/utils/ril.ts
@@ -6,7 +6,7 @@ export type RilLocale = 'en' | 'it';
 
 // Lowercase English weekday names, keyed by JS `Date.getDay()` (0=Sun..6=Sat). Used to look up
 // the per-weekday default "Trasferta" preference when generating rows.
-export const RIL_WEEKDAY_NAMES = [
+const RIL_WEEKDAY_NAMES = [
   'sunday',
   'monday',
   'tuesday',
@@ -93,8 +93,6 @@ const RIL_LOCATION_LABELS: Record<RilLocale, { office: string; remote: string }>
   it: { office: 'In sede', remote: 'Telelavoro' },
 };
 
-export const getRilLocationLabels = (locale: RilLocale) => RIL_LOCATION_LABELS[locale];
-
 export const DEFAULT_RIL_NOTE_OPTIONS: readonly RilNoteOption[] = [
   { value: 'P', label: 'Ferie' },
   { value: 'P2', label: 'Permesso' },
@@ -110,7 +108,7 @@ export const DEFAULT_RIL_EXIT_TIME = '18:00';
 const DEFAULT_LUNCH_BREAK_MINUTES = 60;
 export const RIL_LUNCH_BREAK_START_MINUTES = 13 * 60;
 
-export const isValidRilStartTime = (value: string | undefined | null): value is string =>
+const isValidRilStartTime = (value: string | undefined | null): value is string =>
   typeof value === 'string' && TIME_OF_DAY_PATTERN.test(value);
 
 export const getRilMonthBounds = (monthKey: string): RilMonthBounds => {
@@ -133,7 +131,7 @@ export const getRilMonthBounds = (monthKey: string): RilMonthBounds => {
 export const getCurrentRilMonthKey = (date: Date = new Date()): string =>
   `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
 
-export const parseRilTimeToMinutes = (value: string): number => {
+const parseRilTimeToMinutes = (value: string): number => {
   if (!isValidRilStartTime(value)) return 0;
   const [hours, minutes] = value.split(':').map(Number);
   return hours * 60 + minutes;
@@ -225,7 +223,7 @@ export const calculateRilWorkedHoursFromTimes = (
   return Math.max(0, (elapsedMinutes - lunchMinutes) / 60);
 };
 
-export const formatRilMinutesAsClock = (minutes: number): string => {
+const formatRilMinutesAsClock = (minutes: number): string => {
   const safeMinutes = Math.max(0, Math.round(minutes));
   const hours = Math.floor(safeMinutes / 60);
   const mins = safeMinutes % 60;

--- a/utils/rilExport.ts
+++ b/utils/rilExport.ts
@@ -273,7 +273,7 @@ export const buildRilWorkbook = (input: RilWorkbookInput): Workbook => {
   return workbook;
 };
 
-export const writeRilWorkbookBuffer = async (input: RilWorkbookInput) => {
+const writeRilWorkbookBuffer = async (input: RilWorkbookInput) => {
   const workbook = buildRilWorkbook(input);
   return workbook.xlsx.writeBuffer();
 };

--- a/utils/toast.ts
+++ b/utils/toast.ts
@@ -3,5 +3,3 @@ import { toast } from 'sonner';
 export const toastError = (message: string) => toast.error(message);
 
 export const toastSuccess = (message: string) => toast.success(message);
-
-export { toast };


### PR DESCRIPTION
## What

Genuine, behavior-preserving fixes for `react-doctor` findings. Score **66 → 68/100**, warnings **152 → 109**.

| Category | Before | After |
|---|---|---|
| Bugs | 44 | 29 |
| Performance | 45 | 38 |
| Accessibility | 5 | 1 |
| Maintainability | 58 | 41 |

### Changes
- **Accessibility** — accessible label on the hidden branding file-input; `role="status"` → `<output>` (2FA banners); DateField trigger given a proper `combobox` role with `aria-controls`/`aria-expanded` (so `aria-invalid` is valid on it).
- **Dead code** — dropped 17 unused exports, one unused util, and a stray re-export.
- **Performance** — `[...a].sort()` → `toSorted()`; `.filter().map()` → one-pass `flatMap`; `Array.includes` in a loop → `Set` lookup; parallelized two genuinely-independent `await`s (branding read + disk write) and an independent demo-seed loop.
- **Bugs (React)** — converted 11 components from many `useState` calls to a single `useReducer`; `use-shadcn-theme` now uses `useSyncExternalStore`; `BrandingSettings` syncs the prop without a derived-state effect; `Login` short-lived 2FA tokens moved to refs (they were only read in handlers); `StandardTable` persists clamped column sizing without re-clamping state via an effect.

## Why

Reduce real React/JS smells flagged by react-doctor without changing behavior.

## Verification
- `bun run lint` (i18n + tsc + biome) — clean
- `bun test` — **3422** server + **1710** frontend tests pass, 0 fail
- react-doctor re-run confirms the targeted findings cleared with no new ones

## Reviewer notes
- Two test files were updated to match refactors, not weakened: `DateField.test.tsx` queries the trigger by `combobox` instead of `button`; `ProjectsView.test.ts` source-text assertions track the new `dispatch(...)` calls.
- **The score stops at 68, not higher, by design of this codebase — not for lack of fixes.** react-doctor's score is computed by a remote API and is near-insensitive to Bugs/Performance/Maintainability findings (removing 43 genuine findings moved it only +2). ~49 of the remaining 109 findings are false positives in *correct* code that can't be fixed without introducing bugs: Drizzle single-connection transaction awaits (parallelizing them is a real bug), SSE stream reads, ID-collision retry loops, editable form state, the intentional users↔roles schema cycle, test entry-point files, and generated TypeDoc output. Reaching 90 would require disabling rules / excluding files, which was intentionally avoided here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
