### PR TITLE
fix(login): remove required-field asterisks from username/password labels

### DIFF
--- a/components/Login.tsx
+++ b/components/Login.tsx
@@ -409,10 +409,7 @@ const Login: React.FC<LoginProps> = ({
                   name="username"
                   render={({ field, fieldState }) => (
                     <Field data-invalid={fieldState.invalid}>
-                      <FieldLabel
-                        className="text-xs font-bold uppercase tracking-wider text-muted-foreground"
-                        required
-                      >
+                      <FieldLabel className="text-xs font-bold uppercase tracking-wider text-muted-foreground">
                         {t('common:labels.username')}
                       </FieldLabel>
                       <Input
@@ -433,10 +430,7 @@ const Login: React.FC<LoginProps> = ({
                   name="password"
                   render={({ field, fieldState }) => (
                     <Field data-invalid={fieldState.invalid}>
-                      <FieldLabel
-                        className="text-xs font-bold uppercase tracking-wider text-muted-foreground"
-                        required
-                      >
+                      <FieldLabel className="text-xs font-bold uppercase tracking-wider text-muted-foreground">
                         {t('common:labels.password')}
                       </FieldLabel>
                       <div className="relative">

--- a/test/components/Login.test.tsx
+++ b/test/components/Login.test.tsx
@@ -183,6 +183,15 @@ describe('<Login />', () => {
     expect(screen.getByPlaceholderText('auth:login.password')).toBeInTheDocument();
   });
 
+  test('username and password labels omit the required asterisk', () => {
+    // The login form intentionally drops the red required-field markers, so the
+    // RequiredMark "*" rendered by FieldLabel's `required` prop must be absent.
+    render(<Login onLogin={() => {}} />);
+    expect(screen.getByText('common:labels.username')).toBeInTheDocument();
+    expect(screen.getByText('common:labels.password')).toBeInTheDocument();
+    expect(screen.queryByText('*')).not.toBeInTheDocument();
+  });
+
   test('submitting empty fields shows usernameRequired and passwordRequired errors', async () => {
     render(<Login onLogin={() => {}} />);
     const submit = screen.getByRole('button', { name: /auth:login.signIn/ });


### PR DESCRIPTION
## What changed

Dropped the `required` prop from the username and password `FieldLabel`s in `components/Login.tsx`. That prop is what renders `RequiredMark` (the `text-destructive` `*`), so the red markers no longer appear on the login screen.

The shared `components/ui/field.tsx` component is **untouched**, so every other (data-entry) form keeps the required markers added in #764.

## Why

The required-field markers added across all forms in #764 don't belong on the login screen: both fields are self-evidently required, and the asterisks just add visual noise to the sign-in card.

## Reviewer notes

- **Regression test** added in `test/components/Login.test.tsx` — asserts the username/password labels render without a `*`. Verified it **fails on the old code** (asterisks present) and **passes on the fix**.
- Full `<Login />` suite: 33/33 pass · Biome clean · `tsc --noEmit` exit 0.
- **react-doctor**: 73/100 before and after — no regression.
- **Docs**: the only related mention (`docs-site/.../faq.md`, "I cannot save a document") is scoped to document-entry forms, which still show their markers — so it stays accurate and needs no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)