### PR TITLE
fix(ui): make dialog warning banners dark-mode compatible (#768)

### DIFF
--- a/components/sales/ClientOffersView.tsx
+++ b/components/sales/ClientOffersView.tsx
@@ -1163,8 +1163,8 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
 
               <ModalBody className="flex-1 space-y-5">
                 {previewVersion && (
-                  <div className="flex items-center justify-between gap-3 px-4 py-3 rounded-xl border border-amber-300 bg-amber-50">
-                    <span className="text-amber-800 text-xs font-bold flex items-center gap-2">
+                  <div className="flex items-center justify-between gap-3 px-4 py-3 rounded-xl border border-amber-500/30 bg-amber-500/10">
+                    <span className="text-amber-800 dark:text-amber-300 text-xs font-bold flex items-center gap-2">
                       <i className="fa-solid fa-clock-rotate-left"></i>
                       {t('sales:clientOffers.versionHistory.previewBanner', {
                         date: formatInsertDateTime(previewVersion.createdAt, i18n.language),
@@ -1175,7 +1175,7 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                       type="button"
                       variant="link"
                       onClick={handleClearPreview}
-                      className="h-auto px-0 text-xs font-semibold text-amber-800"
+                      className="h-auto px-0 text-xs font-semibold text-amber-800 dark:text-amber-300"
                     >
                       {t('sales:clientOffers.versionHistory.backToCurrent', {
                         defaultValue: 'Back to current',
@@ -1201,8 +1201,8 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                 )}
 
                 {isReadOnly && (
-                  <div className="flex items-center gap-3 px-4 py-3 rounded-xl border border-amber-200 bg-amber-50">
-                    <span className="text-amber-700 text-xs font-bold">
+                  <div className="flex items-center gap-3 px-4 py-3 rounded-xl border border-amber-500/30 bg-amber-500/10">
+                    <span className="text-amber-700 dark:text-amber-300 text-xs font-bold">
                       {t('sales:clientOffers.readOnlyStatus', {
                         defaultValue: 'Read-only due to non-draft status',
                       })}

--- a/components/sales/ClientQuotesView.tsx
+++ b/components/sales/ClientQuotesView.tsx
@@ -1452,8 +1452,8 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
 
               <ModalBody className="flex-1 space-y-5">
                 {previewVersion && (
-                  <div className="flex items-center justify-between gap-3 px-4 py-3 rounded-xl border border-amber-300 bg-amber-50">
-                    <span className="text-amber-800 text-xs font-bold flex items-center gap-2">
+                  <div className="flex items-center justify-between gap-3 px-4 py-3 rounded-xl border border-amber-500/30 bg-amber-500/10">
+                    <span className="text-amber-800 dark:text-amber-300 text-xs font-bold flex items-center gap-2">
                       <i className="fa-solid fa-clock-rotate-left"></i>
                       {t('sales:clientQuotes.versionHistory.previewBanner', {
                         date: formatInsertDateTime(previewVersion.createdAt, i18n.language),
@@ -1464,7 +1464,7 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                       type="button"
                       variant="link"
                       onClick={handleClearPreview}
-                      className="h-auto px-0 text-xs font-semibold text-amber-800"
+                      className="h-auto px-0 text-xs font-semibold text-amber-800 dark:text-amber-300"
                     >
                       {t('sales:clientQuotes.versionHistory.backToCurrent', {
                         defaultValue: 'Back to current',
@@ -1473,8 +1473,8 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                   </div>
                 )}
                 {baseReadOnly && (
-                  <div className="flex items-center gap-3 px-4 py-3 rounded-xl border border-amber-200 bg-amber-50">
-                    <span className="text-amber-700 text-xs font-bold">
+                  <div className="flex items-center gap-3 px-4 py-3 rounded-xl border border-amber-500/30 bg-amber-500/10">
+                    <span className="text-amber-700 dark:text-amber-300 text-xs font-bold">
                       {editingQuote?.linkedOfferId
                         ? t('sales:clientQuotes.readOnlyBecauseOffer', {
                             defaultValue: 'Read-only due to linked offer',

--- a/components/sales/SupplierQuotesView.tsx
+++ b/components/sales/SupplierQuotesView.tsx
@@ -985,8 +985,8 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
 
               <ModalBody className="flex-1 space-y-5">
                 {previewVersion && (
-                  <div className="flex items-center justify-between gap-3 px-4 py-3 rounded-xl border border-amber-300 bg-amber-50">
-                    <span className="text-amber-800 text-xs font-bold flex items-center gap-2">
+                  <div className="flex items-center justify-between gap-3 px-4 py-3 rounded-xl border border-amber-500/30 bg-amber-500/10">
+                    <span className="text-amber-800 dark:text-amber-300 text-xs font-bold flex items-center gap-2">
                       <i className="fa-solid fa-clock-rotate-left"></i>
                       {t('sales:supplierQuotes.versionHistory.previewBanner', {
                         date: formatInsertDateTime(previewVersion.createdAt, i18n.language),
@@ -997,7 +997,7 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
                       type="button"
                       variant="link"
                       onClick={handleClearPreview}
-                      className="h-auto px-0 text-xs font-semibold text-amber-800"
+                      className="h-auto px-0 text-xs font-semibold text-amber-800 dark:text-amber-300"
                     >
                       {t('sales:supplierQuotes.versionHistory.backToCurrent', {
                         defaultValue: 'Back to current',
@@ -1006,8 +1006,10 @@ const SupplierQuotesView: React.FC<SupplierQuotesViewProps> = ({
                   </div>
                 )}
                 {baseReadOnly && (
-                  <div className="flex items-center gap-3 px-4 py-3 rounded-xl border border-amber-200 bg-amber-50">
-                    <span className="text-amber-700 text-xs font-bold">{readOnlyReason}</span>
+                  <div className="flex items-center gap-3 px-4 py-3 rounded-xl border border-amber-500/30 bg-amber-500/10">
+                    <span className="text-amber-700 dark:text-amber-300 text-xs font-bold">
+                      {readOnlyReason}
+                    </span>
                   </div>
                 )}
                 {editingQuote?.linkedOrderId && (

--- a/test/components/SupplierQuotesView.test.tsx
+++ b/test/components/SupplierQuotesView.test.tsx
@@ -3,6 +3,11 @@ import { fireEvent, screen, within } from '@testing-library/react';
 import type { Client, Product, Supplier, SupplierQuote } from '../../types';
 import { installI18nMock } from '../helpers/i18n';
 import { render } from '../helpers/render';
+import {
+  expectSourceContainsAll,
+  expectSourceOmitsAll,
+  readComponentSource,
+} from './modalStylingTestUtils';
 
 installI18nMock();
 
@@ -304,5 +309,22 @@ describe('<SupplierQuotesView /> optional customer association (issue #759)', ()
     const trigger = document.getElementById('supplier-quote-client');
     expect(trigger?.textContent).toContain('Hidden Customer');
     expect(trigger?.textContent).not.toContain('sales:supplierQuotes.selectClient');
+  });
+});
+
+describe('<SupplierQuotesView /> dark-mode banners (issue #768)', () => {
+  test('dialog warning banners avoid light-only amber classes', async () => {
+    const source = await readComponentSource('sales/SupplierQuotesView.tsx');
+    // Read-only + version-preview banners use translucent amber plus an explicit dark-mode
+    // text color, matching the dark-mode-compatible accounting orders banners.
+    expectSourceContainsAll(source, [
+      'border border-amber-500/30 bg-amber-500/10',
+      'dark:text-amber-300',
+    ]);
+    // The old light-only banner backgrounds (a pale cream slab on the dark dialog) are gone.
+    expectSourceOmitsAll(source, [
+      'border border-amber-200 bg-amber-50',
+      'border border-amber-300 bg-amber-50',
+    ]);
   });
 });

--- a/test/components/sales/ClientOffersView.test.tsx
+++ b/test/components/sales/ClientOffersView.test.tsx
@@ -4,6 +4,11 @@ import userEvent from '@testing-library/user-event';
 import type { Client, ClientOffer, Product, SupplierQuote } from '../../../types';
 import { installI18nMock } from '../../helpers/i18n';
 import { render } from '../../helpers/render';
+import {
+  expectSourceContainsAll,
+  expectSourceOmitsAll,
+  readComponentSource,
+} from '../modalStylingTestUtils';
 
 installI18nMock({ includeInterpolatedValues: true });
 
@@ -540,5 +545,22 @@ describe('<ClientOffersView /> quick-view shortcuts', () => {
         name: 'sales:clientQuotes.supplierQuoteShortcutUnavailable',
       }).length,
     ).toBeGreaterThan(0);
+  });
+});
+
+describe('<ClientOffersView /> dark-mode banners (issue #768)', () => {
+  test('dialog warning banners avoid light-only amber classes', async () => {
+    const source = await readComponentSource('sales/ClientOffersView.tsx');
+    // Read-only + version-preview banners use translucent amber plus an explicit dark-mode
+    // text color, matching the dark-mode-compatible accounting orders banners.
+    expectSourceContainsAll(source, [
+      'border border-amber-500/30 bg-amber-500/10',
+      'dark:text-amber-300',
+    ]);
+    // The old light-only banner backgrounds (a pale cream slab on the dark dialog) are gone.
+    expectSourceOmitsAll(source, [
+      'border border-amber-200 bg-amber-50',
+      'border border-amber-300 bg-amber-50',
+    ]);
   });
 });

--- a/test/components/sales/ClientQuotesView.test.tsx
+++ b/test/components/sales/ClientQuotesView.test.tsx
@@ -3,6 +3,11 @@ import { fireEvent, screen } from '@testing-library/react';
 import type { Client, Quote } from '../../../types';
 import { installI18nMock } from '../../helpers/i18n';
 import { render } from '../../helpers/render';
+import {
+  expectSourceContainsAll,
+  expectSourceOmitsAll,
+  readComponentSource,
+} from '../modalStylingTestUtils';
 
 installI18nMock();
 
@@ -285,5 +290,53 @@ describe('<ClientQuotesView />', () => {
     expect(screen.getAllByText('4800.00 EUR').length).toBeGreaterThan(0);
     // Margin = 4800 − (60 × 2 × 24 = 2880) = 1920.00.
     expect(screen.getAllByText('1920.00 EUR').length).toBeGreaterThan(0);
+  });
+
+  test('the read-only banner renders dark-mode-compatible amber, not a light slab (issue #768)', async () => {
+    // A finalized (accepted) quote opens the dialog read-only and surfaces the warning banner.
+    const acceptedQuote: Quote = { ...quotes[0], id: 'Q-ACCEPTED', status: 'accepted' };
+
+    render(
+      <ClientQuotesView
+        quotes={[acceptedQuote]}
+        clients={clients}
+        products={[]}
+        supplierQuotes={[]}
+        currency="EUR"
+        onAddQuote={mock(() => Promise.resolve())}
+        onUpdateQuote={mock(() => Promise.resolve())}
+        onDeleteQuote={mock(() => Promise.resolve())}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('Q-ACCEPTED'));
+    await screen.findByRole('dialog');
+
+    const label = screen.getByText('sales:clientQuotes.readOnlyBecauseFinal');
+    // The label carries an explicit dark-mode color so it stays legible on the dark dialog.
+    expect(label.className).toContain('dark:text-amber-300');
+    // The banner background is translucent amber (renders on both themes) instead of the old
+    // solid bg-amber-50 cream that looked broken in dark mode (issue #768).
+    const banner = label.closest('div');
+    expect(banner?.className).toContain('bg-amber-500/10');
+    expect(banner?.className).toContain('border-amber-500/30');
+    // The old solid-cream banner border is gone (bg-amber-50 is a prefix of bg-amber-500/10,
+    // so assert on the unambiguous old border token instead).
+    expect(banner?.className).not.toContain('border-amber-200');
+  });
+
+  test('dialog warning banners avoid light-only amber classes (issue #768)', async () => {
+    const source = await readComponentSource('sales/ClientQuotesView.tsx');
+    // Read-only + version-preview banners use translucent amber plus an explicit dark-mode
+    // text color, matching the dark-mode-compatible accounting orders banners.
+    expectSourceContainsAll(source, [
+      'border border-amber-500/30 bg-amber-500/10',
+      'dark:text-amber-300',
+    ]);
+    // The old light-only banner backgrounds (a pale cream slab on the dark dialog) are gone.
+    expectSourceOmitsAll(source, [
+      'border border-amber-200 bg-amber-50',
+      'border border-amber-300 bg-amber-50',
+    ]);
   });
 });


### PR DESCRIPTION
## Problem

Closes #768. The read-only and version-preview warning banners inside the **client quote**, **client offer**, and **supplier quote** edit dialogs used a hardcoded light palette (`bg-amber-50` + `border-amber-200`/`border-amber-300`, with no `dark:` variant). On the dark dialog surface they rendered as a pale cream slab — see the screenshot in the issue (the "Sola lettura per stato finalizzato" banner in *Visualizza Preventivo*).

## Fix

Switch all six banners to the translucent amber treatment **already shipped on the accounting orders views** (`ClientsOrdersView` / `SupplierOrdersView`):

- container: `border-amber-500/30 bg-amber-500/10` (theme-agnostic translucent amber)
- label: add `dark:text-amber-300` so the text stays legible in dark mode

Layout (rounded-xl, spacing, the version-preview "Back to current" action) is unchanged — only the colour classes move. This also unifies the read-only banners across sales and accounting so they look identical.

### Files touched
- `components/sales/ClientQuotesView.tsx`
- `components/sales/ClientOffersView.tsx`
- `components/sales/SupplierQuotesView.tsx`

## Tests
- New `ClientQuotesView` test opens a finalized (accepted) quote dialog and asserts the rendered read-only banner carries `dark:text-amber-300` + the translucent `bg-amber-500/10` / `border-amber-500/30` background (and no longer the old `border-amber-200`).
- Source-based banner-style guards added for all three views (mirroring the existing `modalStylingTestUtils` pattern).
- Verified the new tests **fail on the pre-fix component** and pass after.
- `bun run lint` ✓ · full frontend suite **1715 pass / 0 fail** ✓ · React Doctor **73/100** (unchanged from baseline) ✓.

No functional/API/routing change, so user docs are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)