### PR TITLE
fix(projects): remove redundant revenue helper hint in create modal

### DIFF
--- a/components/projects/ProjectsView.tsx
+++ b/components/projects/ProjectsView.tsx
@@ -2,7 +2,13 @@ import type React from 'react';
 import { useEffect, useMemo, useReducer, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
-import { Field, FieldError, FieldLabel, RequiredMark } from '@/components/ui/field';
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+  RequiredMark,
+} from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -601,12 +607,11 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
     order: orderRevenue,
     manual: revenue ? parseFloat(revenue) : 0,
   };
-  const revenueHintBySource: Record<RevenueSource, string> = {
+  // Activities/order hints explain why the field is read-only; the manual source is
+  // omitted because the field label already says what to enter.
+  const revenueHintBySource: Partial<Record<RevenueSource, string>> = {
     activities: t('projects:projects.revenueFromActivities'),
     order: t('projects:projects.revenueFromOrder'),
-    // Manual entry needs no hint — the field label already says what to enter.
-    // The activities/order hints stay because they explain why the field is read-only.
-    manual: '',
   };
   const displayedRevenue = revenueBySource[revenueSource];
   const persistedRevenue = revenueSource === 'manual' && revenue ? parseFloat(revenue) : undefined;
@@ -970,9 +975,9 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
                         onChange={(e) => dispatch({ type: 'setRevenue', value: e.target.value })}
                       />
                       {revenueHintBySource[revenueSource] && (
-                        <p className="text-xs text-muted-foreground">
+                        <FieldDescription className="text-xs">
                           {revenueHintBySource[revenueSource]}
-                        </p>
+                        </FieldDescription>
                       )}
                     </Field>
                   </div>

--- a/components/projects/ProjectsView.tsx
+++ b/components/projects/ProjectsView.tsx
@@ -604,7 +604,9 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
   const revenueHintBySource: Record<RevenueSource, string> = {
     activities: t('projects:projects.revenueFromActivities'),
     order: t('projects:projects.revenueFromOrder'),
-    manual: t('projects:projects.revenueManualHint'),
+    // Manual entry needs no hint — the field label already says what to enter.
+    // The activities/order hints stay because they explain why the field is read-only.
+    manual: '',
   };
   const displayedRevenue = revenueBySource[revenueSource];
   const persistedRevenue = revenueSource === 'manual' && revenue ? parseFloat(revenue) : undefined;
@@ -967,9 +969,11 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
                         readOnly={revenueSource !== 'manual'}
                         onChange={(e) => dispatch({ type: 'setRevenue', value: e.target.value })}
                       />
-                      <p className="text-xs text-muted-foreground">
-                        {revenueHintBySource[revenueSource]}
-                      </p>
+                      {revenueHintBySource[revenueSource] && (
+                        <p className="text-xs text-muted-foreground">
+                          {revenueHintBySource[revenueSource]}
+                        </p>
+                      )}
                     </Field>
                   </div>
 

--- a/test/components/projects/ProjectsView.test.ts
+++ b/test/components/projects/ProjectsView.test.ts
@@ -82,6 +82,22 @@ describe('ProjectsView create-form validation', () => {
     );
   });
 
+  test('manual revenue source shows no helper hint, but activities/order still do', async () => {
+    const source = await Bun.file(
+      new URL('../../../components/projects/ProjectsView.tsx', import.meta.url),
+    ).text();
+    // The redundant manual hint was removed; the field label already explains the input.
+    expect(source).not.toContain("manual: t('projects:projects.revenueManualHint')");
+    // Pin the empty-string sentinel specifically — a bare `manual: ` substring would
+    // also match the old `manual: t(...)` code and give false confidence.
+    expect(source).toContain("manual: ''");
+    // Informative source hints remain.
+    expect(source).toContain("activities: t('projects:projects.revenueFromActivities')");
+    expect(source).toContain("order: t('projects:projects.revenueFromOrder')");
+    // The hint paragraph only renders when there is a hint to show.
+    expect(source).toContain('{revenueHintBySource[revenueSource] && (');
+  });
+
   test('order selector auto-fills the client and disables the client picker while bound', async () => {
     const source = await Bun.file(
       new URL('../../../components/projects/ProjectsView.tsx', import.meta.url),

--- a/test/components/projects/ProjectsView.test.ts
+++ b/test/components/projects/ProjectsView.test.ts
@@ -86,16 +86,15 @@ describe('ProjectsView create-form validation', () => {
     const source = await Bun.file(
       new URL('../../../components/projects/ProjectsView.tsx', import.meta.url),
     ).text();
-    // The redundant manual hint was removed; the field label already explains the input.
+    // The manual source is omitted from the hint map (Partial) — no redundant helper text.
+    expect(source).toContain('Partial<Record<RevenueSource, string>>');
     expect(source).not.toContain("manual: t('projects:projects.revenueManualHint')");
-    // Pin the empty-string sentinel specifically — a bare `manual: ` substring would
-    // also match the old `manual: t(...)` code and give false confidence.
-    expect(source).toContain("manual: ''");
     // Informative source hints remain.
     expect(source).toContain("activities: t('projects:projects.revenueFromActivities')");
     expect(source).toContain("order: t('projects:projects.revenueFromOrder')");
-    // The hint paragraph only renders when there is a hint to show.
+    // The hint renders through the shared FieldDescription primitive, only when present.
     expect(source).toContain('{revenueHintBySource[revenueSource] && (');
+    expect(source).toContain('<FieldDescription className="text-xs">');
   });
 
   test('order selector auto-fills the client and disables the client picker while bound', async () => {


### PR DESCRIPTION
## What

Removes the redundant helper text **"Inserisci il ricavo previsto del progetto."** shown under the **Ricavo progetto (€)** field in the project **creation** modal — it just restated the field label.

## Why

The manual-entry hint added nothing beyond the label. The hints for the *activities* and *order* revenue sources are kept, because those explain why the field becomes read-only (the value is computed from linked activities/order rather than typed).

## How

- `revenueHintBySource` is now a `Partial<Record<RevenueSource, string>>` that omits the `manual` source, so the type itself expresses "not every source has a hint" — no empty-string sentinel.
- The hint renders only when present (`{revenueHintBySource[revenueSource] && …}`), through the shared `FieldDescription` shadcn primitive instead of a raw `<p>`. This matches the `Field` / `FieldLabel` / `FieldError` family already used in this form; rendered output is unchanged (`text-xs` preserved via a `className` override).

## Scope / reviewer notes

- **Create modal only.** `ProjectDetailView` (the detail/edit view) still shows the same hint and still uses a raw `<p>`; left untouched per the original request. The two cleanups can be extended there on request.
- The shared `projects:projects.revenueManualHint` locale key is intentionally **not** deleted — `ProjectDetailView` still consumes it.
- Two commits: the behavior change, then a `/simplify` follow-up (FieldDescription primitive + Partial type).

## Testing

- New unit test in `test/components/projects/ProjectsView.test.ts` pins the behavior: `manual` key omitted, `activities`/`order` hints retained, render guard + `FieldDescription` usage asserted.
- `bun test` (ProjectsView): **11/11 pass** · Biome: **clean** · `tsc --noEmit`: **clean** · react-doctor: **73/100** (unchanged — render-only change).
