### PR TITLE
fix(projects): label create-form draft-task delete action so its menu item isn't blank (#782)

### DIFF
--- a/components/projects/ProjectsView.tsx
+++ b/components/projects/ProjectsView.tsx
@@ -748,15 +748,23 @@ const ProjectsView: React.FC<ProjectsViewProps> = ({
       align: 'right',
       cell: ({ row }) => (
         <div className="flex justify-end">
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-xs"
-            onClick={() => removeDraftTask(row._id)}
-            className="text-muted-foreground hover:text-destructive"
-          >
-            <i className="fa-solid fa-trash-can text-xs"></i>
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="inline-flex">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  onClick={() => removeDraftTask(row._id)}
+                  aria-label={t('common:buttons.delete')}
+                  className="text-muted-foreground hover:text-destructive"
+                >
+                  <i className="fa-solid fa-trash-can text-xs"></i>
+                </Button>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>{t('common:buttons.delete')}</TooltipContent>
+          </Tooltip>
         </div>
       ),
     },

--- a/test/components/projects/ProjectsView.test.ts
+++ b/test/components/projects/ProjectsView.test.ts
@@ -130,9 +130,10 @@ describe('ProjectsView toolbar styling', () => {
 describe('ProjectsView draft-task delete action (issue #782)', () => {
   // StandardTable collapses an actions column into a "…" overflow menu and derives
   // each item's text from the control's tooltip / aria-label. The draft-task delete
-  // button had neither, so the menu item rendered icon-only — the blank label space
-  // read as white-on-white text in light mode. It must carry the shared delete label
-  // (matching ProjectTasksTable in the edit view) so the menu shows a coloured label.
+  // button had neither, so the menu item rendered icon-only with no label text — the
+  // blank space where "Elimina"/"Delete" belongs is what issue #782 reported as a
+  // wrong font colour in light mode. It must carry the shared delete label (matching
+  // ProjectTasksTable in the edit view) so the collapsed menu shows a labelled item.
   test('the remove-draft-task control is tooltip-wrapped and carries the delete label', async () => {
     const source = await Bun.file(
       new URL('../../../components/projects/ProjectsView.tsx', import.meta.url),

--- a/test/components/projects/ProjectsView.test.ts
+++ b/test/components/projects/ProjectsView.test.ts
@@ -126,3 +126,24 @@ describe('ProjectsView toolbar styling', () => {
     expect(source.match(/className=\{TABLE_CONTROL_BUTTON_CLASSNAME\}/g) ?? []).toHaveLength(1);
   });
 });
+
+describe('ProjectsView draft-task delete action (issue #782)', () => {
+  // StandardTable collapses an actions column into a "…" overflow menu and derives
+  // each item's text from the control's tooltip / aria-label. The draft-task delete
+  // button had neither, so the menu item rendered icon-only — the blank label space
+  // read as white-on-white text in light mode. It must carry the shared delete label
+  // (matching ProjectTasksTable in the edit view) so the menu shows a coloured label.
+  test('the remove-draft-task control is tooltip-wrapped and carries the delete label', async () => {
+    const source = await Bun.file(
+      new URL('../../../components/projects/ProjectsView.tsx', import.meta.url),
+    ).text();
+    // aria-label sits on the remove button itself (assistive-tech name + menu-label fallback).
+    expect(source).toMatch(
+      /onClick=\{\(\) => removeDraftTask\(row\._id\)\}[\s\S]{0,80}aria-label=\{t\('common:buttons\.delete'\)\}/,
+    );
+    // The same cell exposes the tooltip label StandardTable reads for the collapsed menu item.
+    expect(source).toMatch(
+      /removeDraftTask\(row\._id\)[\s\S]{0,400}<TooltipContent>\{t\('common:buttons\.delete'\)\}<\/TooltipContent>/,
+    );
+  });
+});


### PR DESCRIPTION
## What & why

Fixes #782 — "Font color wrong for delete tasks in light mode when creating project."

In the **create-project** dialog, opening a draft task's `…` row-action menu showed a red trash icon with a blank space where the **Delete** label belongs — the reporter read the empty space as a wrong/invisible font colour in light mode.

**Root cause:** `StandardTable` collapses an actions column into a `…` overflow menu and derives each item's text from the control's tooltip / `aria-label`. The create-form draft-task delete button was a bare icon `<Button>` with neither, so the extracted menu item rendered **icon-only with no label text**. Its sibling in the *edit* view (`ProjectTasksTable`) wraps the same button in a `<Tooltip>`, which is why that menu correctly shows the label.

**Fix:** Wrap the draft delete button in a `<Tooltip>` with an `aria-label`, mirroring the existing same-file (project-directory delete) and edit-view patterns. The collapsed menu now renders a properly-coloured (`text-popover-foreground`) "Elimina"/"Delete" label, and the icon button gains an accessible name.

## Changes

- `components/projects/ProjectsView.tsx` — wrap the draft-task delete button in `Tooltip`/`TooltipTrigger`/`TooltipContent` + `aria-label={t('common:buttons.delete')}`.
- `test/components/projects/ProjectsView.test.ts` — regression test (source-inspection, matching this file's existing convention) asserting the remove-draft-task control is tooltip-wrapped and carries the delete label.

## Reviewer notes

- **Why a source-inspection test, not a render test:** I first wrote a full render test, but rendering `ProjectsView` is fragile in the full `bun test` suite — it imports the `services/api` facade, whose static re-exports break under other tests' `mock.module` calls (`SyntaxError: Export named 'projectsApi' not found`). That's the documented reason this component is tested via source inspection. The rendered menu-label + colour contract is already covered behaviorally in `test/components/StandardTable.test.tsx` ("collapsed tooltip-wrapped actions use tooltip text as menu labels"). The new test was confirmed to **fail on the old code and pass on the fix**.
- No documentation change needed (the draft-task delete label isn't user-documented).

## Verification

- `bun run lint` (i18n + typecheck + biome, 883 files) ✓
- Full frontend suite: **1712 pass / 0 fail** ✓
- react-doctor: **73 → 73** (no regression) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
