### PR TITLE
fix(ui): make red error banners dark-mode compatible

### DIFF
--- a/components/CRM/ClientsView.tsx
+++ b/components/CRM/ClientsView.tsx
@@ -1389,7 +1389,7 @@ const ClientsView: React.FC<ClientsViewProps> = ({
                 </h4>
 
                 {errors.contacts && (
-                  <div className="p-3 bg-red-50 border border-red-200 rounded-xl text-red-600 text-xs font-bold">
+                  <div className="p-3 bg-red-500/10 border border-red-500/30 rounded-xl text-red-600 dark:text-red-300 text-xs font-bold">
                     {errors.contacts}
                   </div>
                 )}
@@ -1820,7 +1820,7 @@ const ClientsView: React.FC<ClientsViewProps> = ({
               </div>
 
               {errors.general && (
-                <div className="p-4 bg-red-50 border border-red-200 rounded-xl flex items-center gap-3 text-red-600">
+                <div className="p-4 bg-red-500/10 border border-red-500/30 rounded-xl flex items-center gap-3 text-red-600 dark:text-red-300">
                   <i className="fa-solid fa-circle-exclamation text-lg"></i>
                   <p className="text-sm font-bold">{errors.general}</p>
                 </div>

--- a/components/reports/AiReportingView.tsx
+++ b/components/reports/AiReportingView.tsx
@@ -1295,7 +1295,7 @@ const AiReportingView: React.FC<AiReportingViewProps> = ({
         </div>
 
         {error && (
-          <div className="mb-3 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 mx-4 md:mx-6">
+          <div className="mb-3 rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-700 dark:text-red-300 mx-4 md:mx-6">
             {error}
           </div>
         )}

--- a/components/sales/SupplierQuoteAttachmentsSection.tsx
+++ b/components/sales/SupplierQuoteAttachmentsSection.tsx
@@ -285,7 +285,7 @@ const SupplierQuoteAttachmentsSection: React.FC<SupplierQuoteAttachmentsSectionP
       )}
 
       {attachmentState.error && (
-        <div className="rounded-xl border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">
+        <div className="rounded-xl border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-700 dark:text-red-300">
           {attachmentState.error}
         </div>
       )}

--- a/test/components/SupplierQuoteAttachmentsSection.test.tsx
+++ b/test/components/SupplierQuoteAttachmentsSection.test.tsx
@@ -4,6 +4,11 @@ import type { ReactNode } from 'react';
 import type { SupplierQuoteAttachment } from '../../types';
 import { clearSpyStateAfterAll } from '../helpers/mockCleanup.ts';
 import { render } from '../helpers/render';
+import {
+  expectSourceContainsAll,
+  expectSourceOmitsAll,
+  readComponentSource,
+} from './modalStylingTestUtils';
 
 // Stable t/i18n references - components that put `t` in useEffect dep arrays would otherwise
 // loop forever in tests because every render produces a fresh `t` identity.
@@ -265,5 +270,14 @@ describe('<SupplierQuoteAttachmentsSection />', () => {
     await waitFor(() =>
       expect(screen.getByText('Quotes become read-only once an order exists')).toBeInTheDocument(),
     );
+  });
+});
+
+describe('SupplierQuoteAttachmentsSection dark-mode error banner (issue #768 follow-up)', () => {
+  test('the upload-error banner avoids light-only red classes', async () => {
+    const source = await readComponentSource('sales/SupplierQuoteAttachmentsSection.tsx');
+    // Translucent red + explicit dark-mode text keeps the error legible on the dark dialog.
+    expectSourceContainsAll(source, ['border-red-500/30', 'bg-red-500/10', 'dark:text-red-300']);
+    expectSourceOmitsAll(source, ['border-red-200']);
   });
 });

--- a/test/components/crm/ClientsView.test.tsx
+++ b/test/components/crm/ClientsView.test.tsx
@@ -6,6 +6,11 @@ import type { Client, ClientProfileOption, ClientProfileOptionsByCategory } from
 import { installI18nMock } from '../../helpers/i18n';
 import { clearSpyStateAfterAll } from '../../helpers/mockCleanup.ts';
 import { render } from '../../helpers/render';
+import {
+  expectSourceContainsAll,
+  expectSourceOmitsAll,
+  readComponentSource,
+} from '../modalStylingTestUtils';
 
 installI18nMock();
 
@@ -178,5 +183,17 @@ describe('<ClientsView /> contact validation', () => {
 
     expect(props.onAddClient).not.toHaveBeenCalled();
     expect(screen.getByText('common:validation.required')).toBeInTheDocument();
+  });
+});
+
+describe('<ClientsView /> dark-mode error banners (issue #768 follow-up)', () => {
+  test('the contact + general validation banners avoid light-only red classes', async () => {
+    const source = await readComponentSource('CRM/ClientsView.tsx');
+    // Error banners use translucent red plus an explicit dark-mode text color so they read
+    // correctly on the dark dialog surface, matching the amber warning banners from #768.
+    expectSourceContainsAll(source, ['border-red-500/30', 'bg-red-500/10', 'dark:text-red-300']);
+    // The old light-only banner border (a pale red slab in dark mode) is gone. Input invalid
+    // states use border-red-500, so border-red-200 is unique to the message banners here.
+    expectSourceOmitsAll(source, ['border-red-200']);
   });
 });

--- a/test/components/reports/AiReportingView.test.tsx
+++ b/test/components/reports/AiReportingView.test.tsx
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  expectSourceContainsAll,
+  expectSourceOmitsAll,
+  readComponentSource,
+} from '../modalStylingTestUtils';
+
+describe('<AiReportingView /> dark-mode error banner (issue #768 follow-up)', () => {
+  test('the chat error banner avoids light-only red classes', async () => {
+    const source = await readComponentSource('reports/AiReportingView.tsx');
+    // The AI chat error banner uses translucent red plus an explicit dark-mode text color so it
+    // reads correctly on the dark themed surface, matching the amber warning banners from #768.
+    expect(source).toBeTruthy();
+    expectSourceContainsAll(source, ['border-red-500/30', 'bg-red-500/10', 'dark:text-red-300']);
+    // The old light-only banner border (a pale red slab in dark mode) is gone. The icon circles
+    // use bg-red-100 and the hover affordances use hover:bg-red-50, so border-red-200 was unique
+    // to the message banner here.
+    expectSourceOmitsAll(source, ['border-red-200']);
+  });
+});


### PR DESCRIPTION
## Context

Follow-up to #768 / [#787](https://github.com/xBounceIT/praetor/pull/787), which made the **amber warning** banners dark-mode compatible. While mapping those, I found the **red error/validation** banners share the exact same bug: a hardcoded light palette (`bg-red-50` + `border-red-200`, no `dark:` variant) that renders as a pale red slab on the dark dialog/themed surface.

## Fix

Apply the same translucent treatment used for the amber banners — `bg-red-500/10` + `border-red-500/30` — and add an explicit `dark:text-red-300` (keeping the existing `text-red-600`/`text-red-700` for light mode):

| Banner | Surface |
| --- | --- |
| `ClientsView` contact-validation banner | client add/edit dialog |
| `ClientsView` general-error banner | client add/edit dialog |
| `SupplierQuoteAttachmentsSection` upload-error banner | supplier-quote dialog |
| `AiReportingView` chat-error banner | themed reporting panel |

Only colour classes change; layout/spacing/markup are untouched. This keeps every alert banner (amber warnings + red errors) visually consistent across light and dark themes.

## Tests
- Source-based style guards (the existing `modalStylingTestUtils` pattern) for each component, asserting the translucent + `dark:text-red-300` classes are present and the old light-only `border-red-200` is gone. New file added for `AiReportingView` (it had no test).
- **Verified the new tests fail on the pre-fix components and pass after.**
- `bun run lint` ✓ · full frontend suite **1714 pass / 0 fail** ✓ · React Doctor **73/100** (unchanged from baseline) ✓.

No functional/API/routing change, so user docs are unchanged.

## Deliberately out of scope (same root cause, separate surfaces)
- **Login** logout/error banners (`Login.tsx`) — a separate auth screen with *both* amber and red banners; worth fixing together as its own change.
- **Form-field invalid-state backgrounds** (`border-red-500 bg-red-50` in `ClientsView`, `InternalListingView`, `SecretField`) — a different pattern (input theming, not banners).

🤖 Generated with [Claude Code](https://claude.com/claude-code)