### PR TITLE
fix(ui): make Login screen banners dark-mode compatible

### DIFF
--- a/components/Login.tsx
+++ b/components/Login.tsx
@@ -327,18 +327,22 @@ const Login: React.FC<LoginProps> = ({
           <p className="mt-2 text-sm text-muted-foreground">{t('auth:login.title')}</p>
 
           {logoutReason === 'inactivity' && (
-            <div className="mt-6 flex w-full items-start gap-3 rounded-xl border border-amber-200 bg-amber-50 p-4 animate-in fade-in slide-in-from-top-2">
-              <i className="fa-solid fa-clock mt-0.5 text-amber-500"></i>
+            <div className="mt-6 flex w-full items-start gap-3 rounded-xl border border-amber-500/30 bg-amber-500/10 p-4 animate-in fade-in slide-in-from-top-2">
+              <i className="fa-solid fa-clock mt-0.5 text-amber-500 dark:text-amber-400"></i>
               <div className="flex-1">
-                <p className="text-sm font-bold text-amber-800">{t('auth:session.expired')}</p>
-                <p className="text-xs text-amber-600">{t('auth:session.expiredMessage')}</p>
+                <p className="text-sm font-bold text-amber-800 dark:text-amber-300">
+                  {t('auth:session.expired')}
+                </p>
+                <p className="text-xs text-amber-600 dark:text-amber-400">
+                  {t('auth:session.expiredMessage')}
+                </p>
               </div>
               {onClearLogoutReason && (
                 <button
                   type="button"
                   onClick={onClearLogoutReason}
                   aria-label={t('common:buttons.close')}
-                  className="text-amber-400 transition-colors hover:text-amber-600"
+                  className="text-amber-400 transition-colors hover:text-amber-600 dark:hover:text-amber-300"
                 >
                   <i className="fa-solid fa-xmark"></i>
                 </button>
@@ -349,21 +353,23 @@ const Login: React.FC<LoginProps> = ({
           {serverUnreachable && (
             <div
               role="alert"
-              className="mt-6 flex w-full items-start gap-3 rounded-xl border border-red-200 bg-red-50 p-4 animate-in fade-in slide-in-from-top-2"
+              className="mt-6 flex w-full items-start gap-3 rounded-xl border border-red-500/30 bg-red-500/10 p-4 animate-in fade-in slide-in-from-top-2"
             >
-              <i className="fa-solid fa-triangle-exclamation mt-0.5 text-red-500"></i>
+              <i className="fa-solid fa-triangle-exclamation mt-0.5 text-red-500 dark:text-red-400"></i>
               <div className="flex-1">
-                <p className="text-sm font-bold text-red-800">
+                <p className="text-sm font-bold text-red-800 dark:text-red-300">
                   {t('auth:session.serverUnreachableTitle')}
                 </p>
-                <p className="text-xs text-red-600">{t('auth:session.serverUnreachableMessage')}</p>
+                <p className="text-xs text-red-600 dark:text-red-400">
+                  {t('auth:session.serverUnreachableMessage')}
+                </p>
               </div>
               {onDismissServerUnreachable && (
                 <button
                   type="button"
                   aria-label={t('common:buttons.close')}
                   onClick={onDismissServerUnreachable}
-                  className="text-red-400 transition-colors hover:text-red-600"
+                  className="text-red-400 transition-colors hover:text-red-600 dark:hover:text-red-300"
                 >
                   <i className="fa-solid fa-xmark"></i>
                 </button>

--- a/test/components/Login.test.tsx
+++ b/test/components/Login.test.tsx
@@ -487,6 +487,39 @@ describe('<Login />', () => {
       expect(logo.classList.contains('brightness-0')).toBe(false);
       expect(logo.classList.contains('invert')).toBe(false);
     });
+
+    // The logout/error banners used a hardcoded light palette (bg-amber-50 / bg-red-50 with no
+    // dark: variant), so they rendered as a pale slab on the dark login page. They now use the
+    // same translucent treatment as the dialog banners plus explicit dark-mode text colors.
+    test('the inactivity logout banner uses theme-aware amber, not a light slab', () => {
+      render(<Login onLogin={() => {}} logoutReason="inactivity" />);
+      const title = screen.getByText('auth:session.expired');
+      const banner = title.parentElement?.parentElement;
+
+      expect(banner?.classList.contains('bg-amber-500/10')).toBe(true);
+      expect(banner?.classList.contains('border-amber-500/30')).toBe(true);
+      // The old solid light slab is gone.
+      expect(banner?.classList.contains('bg-amber-50')).toBe(false);
+      expect(banner?.classList.contains('border-amber-200')).toBe(false);
+      // The title carries an explicit dark-mode color so it stays legible on the dark page.
+      expect(title.classList.contains('dark:text-amber-300')).toBe(true);
+    });
+
+    test('the server-unreachable banner uses theme-aware red, not a light slab', () => {
+      render(<Login onLogin={() => {}} serverUnreachable />);
+      // The red banner carries role="alert".
+      const banner = screen.getByRole('alert');
+
+      expect(banner.classList.contains('bg-red-500/10')).toBe(true);
+      expect(banner.classList.contains('border-red-500/30')).toBe(true);
+      expect(banner.classList.contains('bg-red-50')).toBe(false);
+      expect(banner.classList.contains('border-red-200')).toBe(false);
+      expect(
+        screen
+          .getByText('auth:session.serverUnreachableTitle')
+          .classList.contains('dark:text-red-300'),
+      ).toBe(true);
+    });
   });
 
   describe('custom branding', () => {


### PR DESCRIPTION
## Context

Follow-up to the dialog-banner dark-mode fixes in [#787](https://github.com/xBounceIT/praetor/pull/787) (amber) and [#790](https://github.com/xBounceIT/praetor/pull/790) (red). The Login screen is theme-aware (it already flattens the logo via `isDark` and uses `text-muted-foreground`), but its two alert banners used a hardcoded light palette with no `dark:` variant, so they rendered as a pale slab on the dark login page.

## Fix

Apply the established pattern to both `components/Login.tsx` banners:

- **inactivity-logout (amber)** banner → `bg-amber-500/10` + `border-amber-500/30`
- **server-unreachable (red)** banner → `bg-red-500/10` + `border-red-500/30`

…plus `dark:` variants for the title (`dark:text-amber-300` / `dark:text-red-300`), sub-text, icon, and dismiss-button tints. Light-mode appearance is unchanged.

## Tests
- Two tests added to the existing `Login.test.tsx` **dark-mode appearance** suite, rendering each banner (`logoutReason="inactivity"` / `serverUnreachable`) and asserting the theme-aware classes are present and the old `bg-amber-50` / `bg-red-50` slab classes are gone (exact-token `classList.contains`, matching the suite's style).
- **Verified the new tests fail on the old markup and pass on the fix.**
- `bun run lint` ✓ · full frontend suite **1715 pass / 0 fail** ✓ · React Doctor **73/100** (unchanged from baseline) ✓.

No functional/API/routing change, so user docs are unchanged.

## Still out of scope (noted in #790)
Form-field invalid-state backgrounds (`border-red-500 bg-red-50`) in `ClientsView`, `InternalListingView`, and `SecretField` — a different pattern (input theming, not banners) worth a separate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)