### PR TITLE
fix(ui): drop redundant "Ordine fornitore" pill above supplier cost in client orders

### DIFF
--- a/components/accounting/ClientsOrdersView.tsx
+++ b/components/accounting/ClientsOrdersView.tsx
@@ -81,9 +81,6 @@ const DEFAULT_UNIT_TYPE: SupplierUnitType = 'hours';
 
 const compactInputClass = 'h-9 text-center font-medium';
 
-const pillBadgeClass =
-  'px-2 py-0.5 rounded-full text-white text-[8px] font-black uppercase tracking-wider';
-
 const convertHourlyToUnit = (hourlyPrice: number, unitType: SupplierUnitType | undefined) =>
   convertUnitPrice(hourlyPrice, 'hours', unitType || DEFAULT_UNIT_TYPE);
 
@@ -1243,27 +1240,18 @@ const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
                                   <FieldLabel className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground lg:hidden">
                                     {t('crm:internalListing.cost')}
                                   </FieldLabel>
-                                  <div className="flex min-h-9 flex-col items-center justify-center gap-1">
-                                    {item.supplierSaleId && (
-                                      <span className={`${pillBadgeClass} bg-blue-600`}>
-                                        {t('accounting:clientsOrders.supplierOrderBadge', {
-                                          defaultValue: 'Supplier order',
-                                        })}
-                                      </span>
-                                    )}
-                                    <div className="flex items-center gap-1">
-                                      <ValidatedNumberInput
-                                        value={unitCost}
-                                        formatDecimals={2}
-                                        onValueChange={handleCostChange}
-                                        disabled={isReadOnly}
-                                        className={compactInputClass}
-                                      />
-                                      <span className="shrink-0 text-[9px] font-medium text-muted-foreground">
-                                        {currency}
-                                      </span>
-                                      {item.supplierQuoteItemId && <SupplierQuoteCostHint />}
-                                    </div>
+                                  <div className="flex h-9 items-center justify-center gap-1">
+                                    <ValidatedNumberInput
+                                      value={unitCost}
+                                      formatDecimals={2}
+                                      onValueChange={handleCostChange}
+                                      disabled={isReadOnly}
+                                      className={compactInputClass}
+                                    />
+                                    <span className="shrink-0 text-[9px] font-medium text-muted-foreground">
+                                      {currency}
+                                    </span>
+                                    {item.supplierQuoteItemId && <SupplierQuoteCostHint />}
                                   </div>
                                 </div>
                                 <div className="space-y-1 lg:col-span-1 lg:space-y-0">

--- a/docs-site/src/content/docs/en/sales-accounting.md
+++ b/docs-site/src/content/docs/en/sales-accounting.md
@@ -43,7 +43,7 @@ Customer and supplier orders consolidate operational information. Before confirm
 
 A sale order created from an accepted offer starts as a **Draft** and stays fully editable (client, rows, discounts, notes, and payment terms) while it is a draft. It becomes read-only only after it is **Confirmed** or **Denied**.
 
-Rows that automatically generated a **supplier order** (marked with the *Supplier order* badge) stay locked even in draft: they cannot be removed, nor can their product or quantity change, so the linked procurement order never falls out of sync. You can still update their sale price, add other rows, and edit the header fields.
+Rows that automatically generated a **supplier order** (identifiable from the *Supplier order* column) stay locked even in draft: they cannot be removed, nor can their product or quantity change, so the linked procurement order never falls out of sync. You can still update their sale price, add other rows, and edit the header fields.
 
 ## Invoices
 

--- a/docs-site/src/content/docs/sales-accounting.md
+++ b/docs-site/src/content/docs/sales-accounting.md
@@ -43,7 +43,7 @@ Gli ordini clienti e fornitori consolidano le informazioni operative. Prima di c
 
 Un ordine di vendita creato da un'offerta accettata nasce in stato **Bozza** e resta completamente modificabile (cliente, righe, sconti, note e condizioni di pagamento) finché è in bozza. Passa in sola lettura solo dopo essere stato **Confermato** o **Rifiutato**.
 
-Le righe che hanno generato automaticamente un **ordine fornitore** (contrassegnate dal badge *Ordine fornitore*) restano bloccate anche in bozza: non possono essere rimosse né modificate nel prodotto o nella quantità, così l'ordine di approvvigionamento collegato non resta disallineato. Puoi comunque aggiornarne il prezzo di vendita, aggiungere altre righe e modificare i campi di testata.
+Le righe che hanno generato automaticamente un **ordine fornitore** (identificabili dalla colonna *Ordine fornitore*) restano bloccate anche in bozza: non possono essere rimosse né modificate nel prodotto o nella quantità, così l'ordine di approvvigionamento collegato non resta disallineato. Puoi comunque aggiornarne il prezzo di vendita, aggiungere altre righe e modificare i campi di testata.
 
 ## Fatture
 

--- a/locales/en/accounting.json
+++ b/locales/en/accounting.json
@@ -45,7 +45,6 @@
     "orderNumber": "Order Number",
     "supplierOrderColumn": "Supplier Order",
     "noSupplierOrder": "No supplier order",
-    "supplierOrderBadge": "Supplier order",
     "supplierOrderLineLocked": "This line is linked to a supplier order and cannot be removed here.",
     "paymentDueDate": "Payment due date",
     "failedToSave": "Failed to save the order. Please retry.",

--- a/locales/it/accounting.json
+++ b/locales/it/accounting.json
@@ -45,7 +45,6 @@
     "orderNumber": "Numero ordine",
     "supplierOrderColumn": "Ordine fornitore",
     "noSupplierOrder": "Nessun ordine fornitore",
-    "supplierOrderBadge": "Ordine fornitore",
     "supplierOrderLineLocked": "Questa riga è collegata a un ordine fornitore e non può essere rimossa qui.",
     "paymentDueDate": "Data scadenza pagamento",
     "failedToSave": "Impossibile salvare l'ordine. Riprova.",

--- a/test/components/sales/SupplierQuoteCostTooltip.test.ts
+++ b/test/components/sales/SupplierQuoteCostTooltip.test.ts
@@ -30,14 +30,20 @@ describe('supplier-quote cost hint', () => {
     expectSourceOmitsAll(source, REMOVED_BADGE_MARKERS);
   });
 
-  test('client orders shows the cost hint and keeps the supplier-order badge', async () => {
+  test('client orders shows the cost hint without a supplier-order badge', async () => {
     const source = await readComponentSource('accounting/ClientsOrdersView.tsx');
 
     expectSourceContainsAll(source, [
       "import SupplierQuoteCostHint from '../shared/SupplierQuoteCostHint';",
       '{item.supplierQuoteItemId && <SupplierQuoteCostHint />}',
-      "t('accounting:clientsOrders.supplierOrderBadge'",
     ]);
-    expectSourceOmitsAll(source, ['sales:clientQuotes.supplierQuoteBadge', 'bg-emerald-600']);
+    // The blue "Ordine fornitore" pill above the cost was redundant with the
+    // dedicated supplier-order column and the cost hint, so it was removed.
+    expectSourceOmitsAll(source, [
+      'sales:clientQuotes.supplierQuoteBadge',
+      'bg-emerald-600',
+      'accounting:clientsOrders.supplierOrderBadge',
+      'bg-blue-600',
+    ]);
   });
 });


### PR DESCRIPTION
## What

Removes the blue **"ORDINE FORNITORE"** pill that rendered above a supplier-backed line's cost in the client orders dialog. The cost cell is flattened from a stacked `flex-col` wrapper into a single `flex h-9` row matching its sibling columns (Duration, MOL).

## Why

The pill was redundant. Supplier-backed lines are already identified by the dedicated **Ordine fornitore** column (supplier name + order ID) and by the cost "i" tooltip (`SupplierQuoteCostHint`), so the pill conveyed nothing new while cluttering the cost cell. No information is lost by removing it.

## Changes

- **`components/accounting/ClientsOrdersView.tsx`** — remove the pill `<span>` and the now-unused `pillBadgeClass` const; flatten the cost cell wrapper to a single centered row. The cost input, currency, and the `SupplierQuoteCostHint` icon are kept.
- **`locales/{it,en}/accounting.json`** — drop the now-unused `supplierOrderBadge` translation key.
- **`test/components/sales/SupplierQuoteCostTooltip.test.ts`** — flip the existing source-marker assertion: it previously required the badge to be present, it now asserts `accounting:clientsOrders.supplierOrderBadge` / `bg-blue-600` are absent. Fails on the old code, passes on the fix.
- **`docs-site/src/content/docs/{,en/}sales-accounting.md`** — reference the *Ordine fornitore* column instead of the removed badge.

## Verification

- Biome clean, `tsc --noEmit` clean
- 19/19 affected tests pass (`SupplierQuoteCostTooltip`, `ClientsOrdersView`)
- react-doctor 73/100 (held at the project ceiling — no regression; this is a pure deletion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
