### PR TITLE
fix(ui): vertically center line delete button under floated quick-view gutter

### DIFF
--- a/components/accounting/ClientsInvoicesView.tsx
+++ b/components/accounting/ClientsInvoicesView.tsx
@@ -772,8 +772,8 @@ const ClientsInvoicesView: React.FC<ClientsInvoicesViewProps> = ({
                         key={item.id}
                         className="space-y-3 rounded-md border border-border bg-muted/30 p-3"
                       >
-                        <div className="flex items-start gap-2">
-                          <div className="grid flex-1 grid-cols-1 gap-2 lg:grid-cols-14 lg:pt-5">
+                        <div className="flex items-start gap-2 lg:items-center lg:pt-5">
+                          <div className="grid flex-1 grid-cols-1 gap-2 lg:grid-cols-14">
                             <div className="space-y-1 lg:col-span-3 min-w-0">
                               <FieldLabel className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground lg:hidden">
                                 {t('common:labels.product')}

--- a/components/accounting/ClientsOrdersView.tsx
+++ b/components/accounting/ClientsOrdersView.tsx
@@ -1115,8 +1115,8 @@ const ClientsOrdersView: React.FC<ClientsOrdersViewProps> = ({
                             key={item.id}
                             className="space-y-3 rounded-md border border-border bg-muted/30 p-3"
                           >
-                            <div className="flex items-start gap-2 lg:items-center">
-                              <div className="grid flex-1 grid-cols-1 gap-2 lg:grid-cols-14 lg:items-center lg:pt-5">
+                            <div className="flex items-start gap-2 lg:items-center lg:pt-5">
+                              <div className="grid flex-1 grid-cols-1 gap-2 lg:grid-cols-14 lg:items-center">
                                 <div className="min-w-0 space-y-1 lg:col-span-2 lg:space-y-0">
                                   <FieldLabel className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground lg:hidden">
                                     {t('accounting:clientsOrders.supplierOrderColumn', {

--- a/components/sales/ClientOffersView.tsx
+++ b/components/sales/ClientOffersView.tsx
@@ -1650,8 +1650,8 @@ const ClientOffersView: React.FC<ClientOffersViewProps> = ({
                                 </div>
                               </div>
                             </div>
-                            <div className="hidden lg:flex gap-2 items-center">
-                              <div className="flex-1 min-w-0 grid grid-cols-16 gap-2 items-center pt-5">
+                            <div className="hidden lg:flex gap-2 items-center pt-5">
+                              <div className="flex-1 min-w-0 grid grid-cols-16 gap-2 items-center">
                                 <div className="relative col-span-3 min-w-0">
                                   {canViewSupplierQuotes && (
                                     <QuickViewLinkButton

--- a/components/sales/ClientQuotesView.tsx
+++ b/components/sales/ClientQuotesView.tsx
@@ -1962,8 +1962,8 @@ const ClientQuotesView: React.FC<ClientQuotesViewProps> = ({
                                 </div>
                               </div>
                             </div>
-                            <div className="hidden lg:flex gap-2 items-center">
-                              <div className="flex-1 min-w-0 grid grid-cols-16 gap-2 items-center pt-5">
+                            <div className="hidden lg:flex gap-2 items-center pt-5">
+                              <div className="flex-1 min-w-0 grid grid-cols-16 gap-2 items-center">
                                 <div className="relative col-span-3 min-w-0">
                                   {canViewSupplierQuotes && (
                                     <QuickViewLinkButton

--- a/components/shared/QuickViewLinkButton.tsx
+++ b/components/shared/QuickViewLinkButton.tsx
@@ -18,8 +18,11 @@ import { cn } from '@/lib/utils';
  * control, consuming no inline width) on the dense desktop line-item grids, and
  * stays inline below `lg` for the stacked/mobile layouts that show a field label
  * above the control. So a single responsive cell can use the same prop as the
- * dedicated desktop blocks. The owning cell must be `position: relative` and the
- * row must reserve top room on `lg` (e.g. `pt-5` / `lg:pt-5`).
+ * dedicated desktop blocks. The owning cell must be `position: relative`, and the
+ * top room (`pt-5` / `lg:pt-5`) must be reserved on the flex row that holds both the
+ * line grid and its sibling action buttons (with `items-center`) — not on the grid
+ * alone, or the sibling delete button won't share the gutter and will misalign with
+ * the inputs.
  */
 const QuickViewLinkButton: React.FC<{
   href: string | null;

--- a/test/components/accounting/ClientsInvoicesView.test.tsx
+++ b/test/components/accounting/ClientsInvoicesView.test.tsx
@@ -136,6 +136,20 @@ describe('ClientsInvoicesView modal styling', () => {
     ]);
   });
 
+  // Regression: the lg:pt-5 gutter that reserves room for the floated product quick-view shortcut
+  // must live on the row flex that also holds the trash button — not on the inner grid. When it
+  // sits on the grid, the sibling delete button (items-start) pins to the gutter's top edge and
+  // floats above the inputs. Moving it to the row (with lg:items-center) keeps them aligned.
+  test('delete button shares the floated quick-view gutter so it stays aligned with the line', async () => {
+    const source = await readComponentSource('accounting/ClientsInvoicesView.tsx');
+
+    expectSourceContainsAll(source, [
+      'className="flex items-start gap-2 lg:items-center lg:pt-5"',
+      'className="grid flex-1 grid-cols-1 gap-2 lg:grid-cols-14"',
+    ]);
+    expectSourceOmitsAll(source, ['lg:grid-cols-14 lg:pt-5']);
+  });
+
   test('item rows render unit, currency, and percentage beside inputs instead of headers', async () => {
     const source = await readComponentSource('accounting/ClientsInvoicesView.tsx');
 

--- a/test/components/accounting/ClientsInvoicesView.test.tsx
+++ b/test/components/accounting/ClientsInvoicesView.test.tsx
@@ -136,10 +136,8 @@ describe('ClientsInvoicesView modal styling', () => {
     ]);
   });
 
-  // Regression: the lg:pt-5 gutter that reserves room for the floated product quick-view shortcut
-  // must live on the row flex that also holds the trash button — not on the inner grid. When it
-  // sits on the grid, the sibling delete button (items-start) pins to the gutter's top edge and
-  // floats above the inputs. Moving it to the row (with lg:items-center) keeps them aligned.
+  // Regression: the `lg:pt-5` quick-view gutter must sit on the row flex (with `lg:items-center`,
+  // alongside the trash button), not the inner grid — else the delete button misaligns above the inputs.
   test('delete button shares the floated quick-view gutter so it stays aligned with the line', async () => {
     const source = await readComponentSource('accounting/ClientsInvoicesView.tsx');
 

--- a/test/components/accounting/ClientsOrdersView.test.tsx
+++ b/test/components/accounting/ClientsOrdersView.test.tsx
@@ -239,9 +239,8 @@ describe('<ClientsOrdersView />', () => {
     const source = await readComponentSource('accounting/ClientsOrdersView.tsx');
 
     expectSourceContainsAll(source, [
-      // lg:pt-5 reserves the top gutter the floated product quick-view shortcut sits in (desktop).
-      // It lives on the row flex (not the grid) so the trash button shares the gutter and stays
-      // vertically centered with the inputs instead of floating above them.
+      // lg:pt-5 quick-view gutter lives on the row flex (with the trash button), not the grid, so
+      // the delete button stays vertically aligned with the inputs.
       'className="flex items-start gap-2 lg:items-center lg:pt-5"',
       'className="grid flex-1 grid-cols-1 gap-2 lg:grid-cols-14 lg:items-center"',
       'className="min-w-0 space-y-1 lg:col-span-2 lg:space-y-0"',

--- a/test/components/accounting/ClientsOrdersView.test.tsx
+++ b/test/components/accounting/ClientsOrdersView.test.tsx
@@ -239,9 +239,11 @@ describe('<ClientsOrdersView />', () => {
     const source = await readComponentSource('accounting/ClientsOrdersView.tsx');
 
     expectSourceContainsAll(source, [
-      'className="flex items-start gap-2 lg:items-center"',
       // lg:pt-5 reserves the top gutter the floated product quick-view shortcut sits in (desktop).
-      'className="grid flex-1 grid-cols-1 gap-2 lg:grid-cols-14 lg:items-center lg:pt-5"',
+      // It lives on the row flex (not the grid) so the trash button shares the gutter and stays
+      // vertically centered with the inputs instead of floating above them.
+      'className="flex items-start gap-2 lg:items-center lg:pt-5"',
+      'className="grid flex-1 grid-cols-1 gap-2 lg:grid-cols-14 lg:items-center"',
       'className="min-w-0 space-y-1 lg:col-span-2 lg:space-y-0"',
       'className="flex h-9 items-center rounded-md border border-border bg-background px-3"',
       // Quantity and duration controls both center their compact value input + unit selector.

--- a/test/components/sales/SalesModalStyling.test.ts
+++ b/test/components/sales/SalesModalStyling.test.ts
@@ -85,4 +85,21 @@ describe('sales modal styling', () => {
     ]);
     expectSourceOmitsAll(source, ['rounded-2xl bg-white', '<button']);
   });
+
+  // Regression: the desktop product-line `pt-5` gutter that reserves room for the floated
+  // quick-view shortcut must live on the row flex that also holds the trash button — not on the
+  // inner grid. When it sits on the grid, the sibling delete button centers against the grid's
+  // padded box and floats ~10px above the inputs instead of aligning with the row.
+  test.each([
+    ['client quotes', 'sales/ClientQuotesView.tsx'],
+    ['client offers', 'sales/ClientOffersView.tsx'],
+  ])('%s desktop line row shares the quick-view gutter with the delete button', async (_name, path) => {
+    const source = await readComponentSource(path);
+
+    expectSourceContainsAll(source, [
+      'className="hidden lg:flex gap-2 items-center pt-5"',
+      'className="flex-1 min-w-0 grid grid-cols-16 gap-2 items-center"',
+    ]);
+    expectSourceOmitsAll(source, ['grid grid-cols-16 gap-2 items-center pt-5']);
+  });
 });

--- a/test/components/sales/SalesModalStyling.test.ts
+++ b/test/components/sales/SalesModalStyling.test.ts
@@ -86,10 +86,8 @@ describe('sales modal styling', () => {
     expectSourceOmitsAll(source, ['rounded-2xl bg-white', '<button']);
   });
 
-  // Regression: the desktop product-line `pt-5` gutter that reserves room for the floated
-  // quick-view shortcut must live on the row flex that also holds the trash button — not on the
-  // inner grid. When it sits on the grid, the sibling delete button centers against the grid's
-  // padded box and floats ~10px above the inputs instead of aligning with the row.
+  // Regression: the desktop line's `pt-5` quick-view gutter must sit on the row flex (which also
+  // holds the trash button), not the inner grid — else the sibling delete button floats above the row.
   test.each([
     ['client quotes', 'sales/ClientQuotesView.tsx'],
     ['client offers', 'sales/ClientOffersView.tsx'],


### PR DESCRIPTION
## What

Fixes the vertical misalignment of the per-line **delete (trash) button** in the product/service line-item dialogs. Since the per-line **quick-view** shortcut was introduced, the trash button has sat ~10px above the input row (and on the invoices row, pinned to the top edge) instead of lining up with the values.

| | |
|---|---|
| **Before** | trash button floats above the line inputs |
| **After** | trash button vertically centered with the line inputs |

## Why

Each desktop line grid reserves top room for the floated `QuickViewLinkButton` via `pt-5` / `lg:pt-5` — but that reservation was placed **on the inner grid**. The trash button is a flex **sibling** of that grid, so `items-center` centered it against the grid's *padded* box (lifting it above the inputs), and on the invoices row `items-start` pinned it to the gutter's top edge.

The floated button is `position: absolute` against its **own** `relative` cell, while the trash button lives **outside** the grid — so the shared gutter must be reserved on the **row flex that holds both**, not on the grid alone.

## What changed

- Moved the `pt-5` / `lg:pt-5` gutter from the inner grid onto the outer row flex (adding `lg:items-center` on the invoices row where it was missing) so the grid content and the delete button share the same padded box and stay aligned. The floated quick-view button's position is unchanged.
  - `components/sales/ClientOffersView.tsx`
  - `components/sales/ClientQuotesView.tsx`
  - `components/accounting/ClientsOrdersView.tsx`
  - `components/accounting/ClientsInvoicesView.tsx`
- Tightened the `QuickViewLinkButton` doc comment to name the **action-row flex** (not the inner grid) as where the gutter is reserved — closing the ambiguity that caused the original misplacement.

## Tests

- Added/updated source-styling regression assertions (one per affected view) in `SalesModalStyling.test.ts`, `ClientsInvoicesView.test.tsx`, and `ClientsOrdersView.test.tsx`. Verified they **fail on the old grid-gutter placement** and **pass on the row-gutter placement**.

## Reviewer notes

- Pure CSS class relocation + comment changes — **no behavior/runtime change**. The mobile/stacked layouts (which use *inline* quick-view buttons, no gutter) are untouched and unaffected.
- Scope confirmed: all 6 `floating` quick-view usages across the codebase live in these 4 desktop rows; supplier-side views don't use the floated shortcut.
- Verified green: full lint (i18n + server/frontend `tsc` + biome), and the affected suites at **67 pass / 0 fail**.
