### PR TITLE
feat(hr): preview Competence Center members as initials with +N overflow (#761)

### DIFF
--- a/components/WorkUnitsView.tsx
+++ b/components/WorkUnitsView.tsx
@@ -376,7 +376,7 @@ const WorkUnitCard: React.FC<{
               <p className="font-bold text-[10px] text-zinc-400 uppercase tracking-wider">
                 {t('hr:competenceCenters.members')}
               </p>
-              {unit.members && unit.members.length > 0 ? (
+              {unit.members?.length ? (
                 <MemberAvatarGroup members={unit.members} className="mt-1.5" />
               ) : (
                 <p className="text-sm text-zinc-400 italic">

--- a/components/WorkUnitsView.tsx
+++ b/components/WorkUnitsView.tsx
@@ -379,8 +379,8 @@ const WorkUnitCard: React.FC<{
               {unit.members && unit.members.length > 0 ? (
                 <MemberAvatarGroup members={unit.members} className="mt-1.5" />
               ) : (
-                <p className="font-bold text-sm text-zinc-700">
-                  {unit.userCount || 0} {t('hr:competenceCenters.users')}
+                <p className="text-sm text-zinc-400 italic">
+                  {t('hr:competenceCenters.noMembersAssigned')}
                 </p>
               )}
             </div>

--- a/components/WorkUnitsView.tsx
+++ b/components/WorkUnitsView.tsx
@@ -10,6 +10,7 @@ import { workUnitsApi } from '../services/api/workUnits';
 import type { User, WorkUnit } from '../types';
 import { hasScopedActionPermission } from '../utils/permissions';
 import HeaderAddButton from './shared/HeaderAddButton';
+import MemberAvatarGroup from './shared/MemberAvatarGroup';
 import Modal from './shared/Modal';
 import {
   ModalBody,
@@ -366,18 +367,22 @@ const WorkUnitCard: React.FC<{
           </div>
         </div>
 
-        <div className="flex items-center justify-between">
+        <div className="flex items-center justify-between gap-3">
           <div className="flex items-center gap-3">
-            <div className="flex size-8 items-center justify-center rounded-full bg-zinc-100 font-bold text-xs text-zinc-500">
+            <div className="flex size-8 shrink-0 items-center justify-center rounded-full bg-zinc-100 font-bold text-xs text-zinc-500">
               <i className="fa-solid fa-users" aria-hidden="true"></i>
             </div>
             <div>
               <p className="font-bold text-[10px] text-zinc-400 uppercase tracking-wider">
                 {t('hr:competenceCenters.members')}
               </p>
-              <p className="font-bold text-sm text-zinc-700">
-                {unit.userCount || 0} {t('hr:competenceCenters.users')}
-              </p>
+              {unit.members && unit.members.length > 0 ? (
+                <MemberAvatarGroup members={unit.members} className="mt-1.5" />
+              ) : (
+                <p className="font-bold text-sm text-zinc-700">
+                  {unit.userCount || 0} {t('hr:competenceCenters.users')}
+                </p>
+              )}
             </div>
           </div>
           {canManageMembers && (

--- a/components/projects/ProjectDetailView.tsx
+++ b/components/projects/ProjectDetailView.tsx
@@ -1438,11 +1438,20 @@ const ProjectDetailView: React.FC<ProjectDetailViewProps> = ({
                 !assignedLoading && assignedUsers.length > 0 ? (
                   <div className="flex [&>*+*]:-ml-2">
                     {assignedUsers.slice(0, 6).map((u) => (
-                      <Avatar key={u.id} className="size-7 border-2 border-card">
-                        <AvatarFallback className="text-[10px]">
-                          {getInitials(u.name)}
-                        </AvatarFallback>
-                      </Avatar>
+                      <Tooltip key={u.id}>
+                        <TooltipTrigger asChild>
+                          <Avatar
+                            role="img"
+                            aria-label={u.name}
+                            className="size-7 border-2 border-card"
+                          >
+                            <AvatarFallback className="text-[10px]">
+                              {getInitials(u.name)}
+                            </AvatarFallback>
+                          </Avatar>
+                        </TooltipTrigger>
+                        <TooltipContent>{u.name}</TooltipContent>
+                      </Tooltip>
                     ))}
                     {assignedUsers.length > 6 && (
                       <div className="flex size-7 items-center justify-center rounded-full border-2 border-card bg-muted text-[10px] font-medium text-muted-foreground">

--- a/components/shared/MemberAvatarGroup.tsx
+++ b/components/shared/MemberAvatarGroup.tsx
@@ -1,6 +1,7 @@
 import type React from 'react';
 import { Avatar, AvatarFallback, AvatarGroup } from '@/components/ui/avatar';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { getInitials } from '@/utils/initials';
 
 export interface MemberAvatarGroupMember {
   id: string;
@@ -14,31 +15,26 @@ export interface MemberAvatarGroupProps {
   className?: string;
 }
 
-// Initials from a display name: first letter of the first and last word, or the first
-// two letters of a single-word name. Mirrors the avatar abbreviations used elsewhere in
-// the app (ViewOwnerAvatar, the project dashboard team-size avatars).
-const getInitials = (name: string): string => {
-  const parts = name.trim().split(/\s+/).filter(Boolean);
-  if (parts.length === 0) return '?';
-  const initials =
-    parts.length === 1 ? parts[0].slice(0, 2) : parts[0][0] + parts[parts.length - 1][0];
-  return initials.toUpperCase();
-};
-
-const avatarClassName = 'size-7';
+// `ring-2 ring-background` is applied directly on each avatar rather than relying on
+// AvatarGroup's `*:data-[slot=avatar]` ring selector: wrapping the Avatar in a Radix
+// `TooltipTrigger asChild` merges the trigger's `data-slot="tooltip-trigger"` onto the
+// avatar element, so the group's avatar-scoped selector would no longer match it.
+const avatarClassName = 'size-7 ring-2 ring-background';
 const fallbackClassName = 'bg-muted text-[10px] font-medium text-muted-foreground';
+const overflowBadgeClassName =
+  'relative flex size-7 shrink-0 items-center justify-center rounded-full bg-muted text-[10px] font-medium text-muted-foreground ring-2 ring-background';
 
 /**
  * Overlapping row of member initials with the full name on hover (per-badge tooltip).
- * When there are more members than `max`, the remainder collapses into a `+N` badge whose
- * tooltip lists every member, so the complete membership is visible without opening the
- * card. Renders nothing for an empty member list. Issue #761.
+ * When there are more members than `max`, the remainder collapses into a `+N` badge that
+ * is keyboard-focusable and whose tooltip lists the whole membership, so the complete set
+ * is reachable without opening the card. Renders nothing for an empty member list. Issue #761.
  */
 const MemberAvatarGroup: React.FC<MemberAvatarGroupProps> = ({ members, max = 5, className }) => {
   if (members.length === 0) return null;
 
   const visible = members.slice(0, max);
-  const overflowCount = members.length - visible.length;
+  const overflow = members.slice(max);
 
   return (
     <AvatarGroup className={className}>
@@ -54,16 +50,19 @@ const MemberAvatarGroup: React.FC<MemberAvatarGroupProps> = ({ members, max = 5,
           <TooltipContent>{member.name}</TooltipContent>
         </Tooltip>
       ))}
-      {overflowCount > 0 && (
+      {overflow.length > 0 && (
         <Tooltip>
           <TooltipTrigger asChild>
-            <span
-              role="img"
-              aria-label={members.map((member) => member.name).join(', ')}
-              className="relative flex size-7 shrink-0 items-center justify-center rounded-full bg-muted text-[10px] font-medium text-muted-foreground ring-2 ring-background"
+            {/* A real button so the full-roster tooltip is reachable by keyboard focus;
+                labelled with only the hidden members so screen readers don't re-announce
+                the visible ones. */}
+            <button
+              type="button"
+              aria-label={overflow.map((member) => member.name).join(', ')}
+              className={overflowBadgeClassName}
             >
-              +{overflowCount}
-            </span>
+              +{overflow.length}
+            </button>
           </TooltipTrigger>
           <TooltipContent>
             <ul className="space-y-0.5 text-left">

--- a/components/shared/MemberAvatarGroup.tsx
+++ b/components/shared/MemberAvatarGroup.tsx
@@ -20,7 +20,9 @@ export interface MemberAvatarGroupProps {
 // `TooltipTrigger asChild` merges the trigger's `data-slot="tooltip-trigger"` onto the
 // avatar element, so the group's avatar-scoped selector would no longer match it.
 const avatarClassName = 'size-7 ring-2 ring-background';
-const fallbackClassName = 'bg-muted text-[10px] font-medium text-muted-foreground';
+// AvatarFallback already provides `bg-muted text-muted-foreground`; only the smaller
+// initials size and weight are additive here.
+const fallbackClassName = 'text-[10px] font-medium';
 const overflowBadgeClassName =
   'relative flex size-7 shrink-0 items-center justify-center rounded-full bg-muted text-[10px] font-medium text-muted-foreground ring-2 ring-background';
 

--- a/components/shared/MemberAvatarGroup.tsx
+++ b/components/shared/MemberAvatarGroup.tsx
@@ -15,16 +15,17 @@ export interface MemberAvatarGroupProps {
   className?: string;
 }
 
-// `ring-2 ring-background` is applied directly on each avatar rather than relying on
-// AvatarGroup's `*:data-[slot=avatar]` ring selector: wrapping the Avatar in a Radix
-// `TooltipTrigger asChild` merges the trigger's `data-slot="tooltip-trigger"` onto the
-// avatar element, so the group's avatar-scoped selector would no longer match it.
-const avatarClassName = 'size-7 ring-2 ring-background';
+// `border-2 border-card` matches the card surface, so the overlapping avatars read as clean
+// cut-outs (same treatment as the project dashboard team avatars). `ring-background` paints
+// the page background instead, which is darker than the card in dark mode and shows up as a
+// black ring. The separator is applied directly on each avatar rather than via AvatarGroup's
+// `*:data-[slot=avatar]` selector, which the `TooltipTrigger asChild` data-slot merge defeats.
+const avatarClassName = 'size-7 border-2 border-card';
 // AvatarFallback already provides `bg-muted text-muted-foreground`; only the smaller
 // initials size and weight are additive here.
 const fallbackClassName = 'text-[10px] font-medium';
 const overflowBadgeClassName =
-  'relative flex size-7 shrink-0 items-center justify-center rounded-full bg-muted text-[10px] font-medium text-muted-foreground ring-2 ring-background';
+  'relative flex size-7 shrink-0 items-center justify-center rounded-full border-2 border-card bg-muted text-[10px] font-medium text-muted-foreground';
 
 /**
  * Overlapping row of member initials with the full name on hover (per-badge tooltip).

--- a/components/shared/MemberAvatarGroup.tsx
+++ b/components/shared/MemberAvatarGroup.tsx
@@ -1,0 +1,81 @@
+import type React from 'react';
+import { Avatar, AvatarFallback, AvatarGroup } from '@/components/ui/avatar';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+
+export interface MemberAvatarGroupMember {
+  id: string;
+  name: string;
+}
+
+export interface MemberAvatarGroupProps {
+  members: MemberAvatarGroupMember[];
+  /** How many initials to show inline before collapsing the rest into a `+N` badge. */
+  max?: number;
+  className?: string;
+}
+
+// Initials from a display name: first letter of the first and last word, or the first
+// two letters of a single-word name. Mirrors the avatar abbreviations used elsewhere in
+// the app (ViewOwnerAvatar, the project dashboard team-size avatars).
+const getInitials = (name: string): string => {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return '?';
+  const initials =
+    parts.length === 1 ? parts[0].slice(0, 2) : parts[0][0] + parts[parts.length - 1][0];
+  return initials.toUpperCase();
+};
+
+const avatarClassName = 'size-7';
+const fallbackClassName = 'bg-muted text-[10px] font-medium text-muted-foreground';
+
+/**
+ * Overlapping row of member initials with the full name on hover (per-badge tooltip).
+ * When there are more members than `max`, the remainder collapses into a `+N` badge whose
+ * tooltip lists every member, so the complete membership is visible without opening the
+ * card. Renders nothing for an empty member list. Issue #761.
+ */
+const MemberAvatarGroup: React.FC<MemberAvatarGroupProps> = ({ members, max = 5, className }) => {
+  if (members.length === 0) return null;
+
+  const visible = members.slice(0, max);
+  const overflowCount = members.length - visible.length;
+
+  return (
+    <AvatarGroup className={className}>
+      {visible.map((member) => (
+        <Tooltip key={member.id}>
+          <TooltipTrigger asChild>
+            <Avatar role="img" aria-label={member.name} className={avatarClassName}>
+              <AvatarFallback className={fallbackClassName}>
+                {getInitials(member.name)}
+              </AvatarFallback>
+            </Avatar>
+          </TooltipTrigger>
+          <TooltipContent>{member.name}</TooltipContent>
+        </Tooltip>
+      ))}
+      {overflowCount > 0 && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span
+              role="img"
+              aria-label={members.map((member) => member.name).join(', ')}
+              className="relative flex size-7 shrink-0 items-center justify-center rounded-full bg-muted text-[10px] font-medium text-muted-foreground ring-2 ring-background"
+            >
+              +{overflowCount}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>
+            <ul className="space-y-0.5 text-left">
+              {members.map((member) => (
+                <li key={member.id}>{member.name}</li>
+              ))}
+            </ul>
+          </TooltipContent>
+        </Tooltip>
+      )}
+    </AvatarGroup>
+  );
+};
+
+export default MemberAvatarGroup;

--- a/components/shared/ViewOwnerAvatar.tsx
+++ b/components/shared/ViewOwnerAvatar.tsx
@@ -2,17 +2,7 @@ import type React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
-
-// Initials for a shared view's owner, derived from the display name (the view
-// DTOs only carry `ownerName`, not avatar initials). First letter of the first
-// and last word, or the first two letters of a single word.
-const initialsFromName = (name: string): string => {
-  const parts = name.trim().split(/\s+/).filter(Boolean);
-  if (parts.length === 0) return '?';
-  const initials =
-    parts.length === 1 ? parts[0].slice(0, 2) : parts[0][0] + parts[parts.length - 1][0];
-  return initials.toUpperCase();
-};
+import { getInitials } from '@/utils/initials';
 
 export interface ViewOwnerAvatarProps {
   ownerName: string;
@@ -39,7 +29,7 @@ const ViewOwnerAvatar: React.FC<ViewOwnerAvatarProps> = ({ ownerName, className 
             className,
           )}
         >
-          <span aria-hidden="true">{initialsFromName(ownerName)}</span>
+          <span aria-hidden="true">{getInitials(ownerName)}</span>
           <span className="sr-only">{label}</span>
         </span>
       </TooltipTrigger>

--- a/docs-site/src/content/docs/en/hr.md
+++ b/docs-site/src/content/docs/en/hr.md
@@ -39,3 +39,5 @@ Without the matching HR permissions, HR fields are omitted from user API respons
 ## Competence centers
 
 Competence centers connect people, costs, and assignments. Keep HR profiles current before analyzing costs, availability, and team composition on projects.
+
+Each competence center card shows the initials of its assigned members; hover an initial to read the full name. When members exceed the space available, a `+N` badge sums up the rest and, on hover, lists the complete membership so you can see it without opening the card.

--- a/docs-site/src/content/docs/hr.md
+++ b/docs-site/src/content/docs/hr.md
@@ -39,3 +39,5 @@ Senza i permessi HR corretti, i campi HR non vengono restituiti dalle API utenti
 ## Competence Center
 
 I Competence Center collegano persone, costi e assegnazioni. Mantieni aggiornate le anagrafiche HR prima di analizzare costi, disponibilità e composizione dei team sui progetti.
+
+Ogni scheda Competence Center mostra le iniziali dei membri assegnati: passa il mouse su un'iniziale per vederne il nome completo. Quando i membri superano lo spazio disponibile, un badge `+N` riassume i restanti e, al passaggio del mouse, ne elenca l'intera composizione senza dover aprire la scheda.

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -29348,6 +29348,24 @@
                           ]
                         }
                       },
+                      "members": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "name"
+                          ]
+                        }
+                      },
                       "description": {
                         "type": [
                           "null",
@@ -29570,6 +29588,24 @@
                       "type": "string"
                     },
                     "managers": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name"
+                        ]
+                      }
+                    },
+                    "members": {
                       "type": "array",
                       "items": {
                         "type": "object",
@@ -29819,6 +29855,24 @@
                       "type": "string"
                     },
                     "managers": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "name"
+                        ]
+                      }
+                    },
+                    "members": {
                       "type": "array",
                       "items": {
                         "type": "object",

--- a/locales/en/hr.json
+++ b/locales/en/hr.json
@@ -136,6 +136,7 @@
     "noCompetenceCentersAssigned": "No competence centers assigned",
     "noCompetenceCentersAssignedDescription": "You are not assigned to any competence centers. Please contact a top manager for assistance.",
     "noManagersAssigned": "No managers assigned",
+    "noMembersAssigned": "No members assigned",
     "users": "users",
     "noUsersFound": "No users found matching your search.",
     "addRemoveUsers": "Add or remove users from {{name}}"

--- a/locales/it/hr.json
+++ b/locales/it/hr.json
@@ -136,6 +136,7 @@
     "noCompetenceCentersAssigned": "Nessun Competence Center assegnato",
     "noCompetenceCentersAssignedDescription": "Non sei assegnato a nessun Competence Center. Contatta un top manager per assistenza.",
     "noManagersAssigned": "Nessun manager assegnato",
+    "noMembersAssigned": "Nessun membro assegnato",
     "users": "utenti",
     "noUsersFound": "Nessun utente trovato corrispondente alla tua ricerca.",
     "addRemoveUsers": "Aggiungi o rimuovi utenti da {{name}}"

--- a/server/repositories/workUnitsRepo.ts
+++ b/server/repositories/workUnitsRepo.ts
@@ -5,11 +5,13 @@ import { workUnitManagers } from '../db/schema/workUnitManagers.ts';
 import { workUnits } from '../db/schema/workUnits.ts';
 
 export type Manager = { id: string; name: string };
+export type Member = { id: string; name: string };
 
 export type WorkUnit = {
   id: string;
   name: string;
   managers: Manager[];
+  members: Member[];
   description: string | null;
   isDisabled: boolean;
   userCount: number;
@@ -18,7 +20,9 @@ export type WorkUnit = {
 // SQL fragment used by findById/listAll/listManagedBy. Uses raw aliases (`w`, `wum`, `u`, `uw`)
 // because the JSON aggregate / scalar subquery shape is awkward to express in the query builder
 // and the legacy SQL is already battle-tested. The `AS "isDisabled"`/`AS "userCount"` aliases
-// emit the camelCase keys directly, which is why these functions skip a mapRow step.
+// emit the camelCase keys directly, which is why these functions skip a mapRow step. The
+// `members` aggregate carries the assigned users (id + name) so the UI can render member
+// initials on each card without a follow-up fetch; ordered by name for a stable display.
 const baseSelect = sql`
   SELECT w.id, w.name, w.description, w.is_disabled AS "isDisabled",
     (
@@ -27,6 +31,15 @@ const baseSelect = sql`
       JOIN users u ON wum.user_id = u.id
       WHERE wum.work_unit_id = w.id
     ) AS managers,
+    (
+      SELECT COALESCE(
+        json_agg(json_build_object('id', mu.id, 'name', mu.name) ORDER BY mu.name),
+        '[]'
+      )
+      FROM user_work_units muw
+      JOIN users mu ON muw.user_id = mu.id
+      WHERE muw.work_unit_id = w.id
+    ) AS members,
     (SELECT COUNT(*)::int FROM user_work_units uw WHERE uw.work_unit_id = w.id) AS "userCount"
   FROM work_units w
 `;

--- a/server/routes/mcp.ts
+++ b/server/routes/mcp.ts
@@ -561,7 +561,10 @@ const buildServer = () => {
             canViewEmails: hasEmailView,
           }),
         ),
-        workUnits: visibleWorkUnits.map((unit) => ({
+        // Drop the `members` array (id + name) carried by the work-unit shape: this tool
+        // exposes only member user IDs, and member display names would bypass the per-user
+        // `maskUser` scoping applied to `users` above.
+        workUnits: visibleWorkUnits.map(({ members: _members, ...unit }) => ({
           ...unit,
           userIds: userIdsByWorkUnit.get(unit.id) ?? [],
         })),

--- a/server/routes/mcp.ts
+++ b/server/routes/mcp.ts
@@ -544,16 +544,6 @@ const buildServer = () => {
           : await workUnitsRepo.listManagedBy(user.id)
         : [];
 
-      const memberRows = await workUnitsRepo.listUserIdsByUnitIds(
-        visibleWorkUnits.map((unit) => unit.id),
-      );
-      const userIdsByWorkUnit = new Map<string, string[]>();
-      for (const row of memberRows) {
-        const current = userIdsByWorkUnit.get(row.workUnitId) ?? [];
-        current.push(row.userId);
-        userIdsByWorkUnit.set(row.workUnitId, current);
-      }
-
       return jsonResult({
         users: users.map((entry) =>
           maskUser(entry, {
@@ -561,12 +551,13 @@ const buildServer = () => {
             canViewEmails: hasEmailView,
           }),
         ),
-        // Drop the `members` array (id + name) carried by the work-unit shape: this tool
-        // exposes only member user IDs, and member display names would bypass the per-user
-        // `maskUser` scoping applied to `users` above.
-        workUnits: visibleWorkUnits.map(({ members: _members, ...unit }) => ({
+        // Expose only member user IDs, derived from the members the repo already returns
+        // (no second user_work_units query). The member display names are deliberately
+        // dropped here — they would bypass the per-user `maskUser` scoping applied to
+        // `users` above.
+        workUnits: visibleWorkUnits.map(({ members, ...unit }) => ({
           ...unit,
-          userIds: userIdsByWorkUnit.get(unit.id) ?? [],
+          userIds: members.map((member) => member.id),
         })),
         scope: {
           canViewAllUsers: hasAllUsersView,

--- a/server/routes/work-units.ts
+++ b/server/routes/work-units.ts
@@ -40,6 +40,7 @@ const workUnitSchema = {
     id: { type: 'string' },
     name: { type: 'string' },
     managers: { type: 'array', items: managerSchema },
+    members: { type: 'array', items: managerSchema },
     description: { type: ['string', 'null'] },
     isDisabled: { type: 'boolean' },
     userCount: { type: 'number' },

--- a/server/test/repositories/workUnitsRepo.test.ts
+++ b/server/test/repositories/workUnitsRepo.test.ts
@@ -21,6 +21,7 @@ const aggRow = {
   description: 'Eng team',
   isDisabled: false,
   managers: [{ id: 'u-1', name: 'Alice' }],
+  members: [{ id: 'u-1', name: 'Alice' }],
   userCount: 7,
 };
 
@@ -35,6 +36,16 @@ describe('findById', () => {
   test('returns null when not found', async () => {
     exec.enqueue({ rows: [] });
     expect(await workUnitsRepo.findById('wu-x', testDb)).toBeNull();
+  });
+
+  test('baseSelect aggregates assigned members (id + name) from user_work_units', async () => {
+    exec.enqueue({ rows: [aggRow] });
+    const result = await workUnitsRepo.findById('wu-1', testDb);
+    const emitted = exec.calls[0].sql.toLowerCase();
+    expect(emitted).toContain('as members');
+    expect(emitted).toContain('from user_work_units muw');
+    expect(emitted).toContain("json_build_object('id', mu.id, 'name', mu.name)");
+    expect(result?.members).toEqual([{ id: 'u-1', name: 'Alice' }]);
   });
 });
 

--- a/server/test/routes/mcp.test.ts
+++ b/server/test/routes/mcp.test.ts
@@ -295,10 +295,6 @@ beforeEach(async () => {
       userCount: 2,
     },
   ]);
-  workUnitsListUserIdsByUnitIdsMock.mockResolvedValue([
-    { workUnitId: 'wu1', userId: 'u1' },
-    { workUnitId: 'wu1', userId: 'u2' },
-  ]);
   notificationsListForUserMock.mockResolvedValue([]);
   notificationsCountUnreadForUserMock.mockResolvedValue(0);
   markNotificationReadForUserMock.mockResolvedValue(true);
@@ -577,7 +573,8 @@ describe('/api/mcp', () => {
       canViewExternal: false,
     });
     expect(workUnitsListManagedByMock).toHaveBeenCalledWith('u1');
-    expect(workUnitsListUserIdsByUnitIdsMock).toHaveBeenCalledWith(['wu1']);
+    // userIds is derived from the members the repo already returns — no second query.
+    expect(workUnitsListUserIdsByUnitIdsMock).not.toHaveBeenCalled();
     expect(usersListAllForAdminMock).not.toHaveBeenCalled();
     expect(workUnitsListAllMock).not.toHaveBeenCalled();
   });
@@ -723,11 +720,11 @@ describe('/api/mcp', () => {
         name: 'Operations',
         description: 'Ops',
         managers: [{ id: 'u2', name: 'Bob' }],
+        members: [{ id: 'u2', name: 'Bob' }],
         isDisabled: false,
         userCount: 1,
       },
     ]);
-    workUnitsListUserIdsByUnitIdsMock.mockResolvedValue([{ workUnitId: 'wu-all', userId: 'u2' }]);
 
     const res = await rpc({
       jsonrpc: '2.0',

--- a/server/test/routes/mcp.test.ts
+++ b/server/test/routes/mcp.test.ts
@@ -285,6 +285,12 @@ beforeEach(async () => {
       name: 'Engineering',
       description: null,
       managers: [{ id: 'u1', name: 'Alice' }],
+      // The repo carries member display names; the hierarchy tool must NOT leak them
+      // (it exposes only userIds). The response assertion below omits `members`.
+      members: [
+        { id: 'u1', name: 'Alice' },
+        { id: 'u2', name: 'Bob' },
+      ],
       isDisabled: false,
       userCount: 2,
     },
@@ -545,6 +551,8 @@ describe('/api/mcp', () => {
         isAdminOnly: false,
       },
     ]);
+    // `members` is intentionally absent: the tool exposes only `userIds`, never member
+    // display names (toEqual is exact, so a regression that leaks `members` fails here).
     expect(body.result.structuredContent.workUnits).toEqual([
       {
         id: 'wu1',

--- a/server/test/routes/work-units.test.ts
+++ b/server/test/routes/work-units.test.ts
@@ -123,9 +123,13 @@ const SAMPLE_UNIT = {
   id: 'wu-1',
   name: 'Engineering',
   managers: [{ id: 'u1', name: 'Alice' }],
+  members: [
+    { id: 'u1', name: 'Alice' },
+    { id: 'u2', name: 'Bob' },
+  ],
   description: null,
   isDisabled: false,
-  userCount: 3,
+  userCount: 2,
 };
 
 const allMocks = [
@@ -182,6 +186,11 @@ describe('GET /api/work-units', () => {
     expect(res.statusCode).toBe(200);
     expect(listAllMock).toHaveBeenCalledTimes(1);
     expect(listManagedByMock).not.toHaveBeenCalled();
+    // The member list is serialized for the card preview (issue #761).
+    expect(JSON.parse(res.body)[0].members).toEqual([
+      { id: 'u1', name: 'Alice' },
+      { id: 'u2', name: 'Bob' },
+    ]);
   });
 
   test('200 without all-view → listManagedBy(viewer.id)', async () => {

--- a/test/components/hr/WorkUnitsView.memberAvatars.test.tsx
+++ b/test/components/hr/WorkUnitsView.memberAvatars.test.tsx
@@ -1,0 +1,79 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { screen } from '@testing-library/react';
+import type { User, WorkUnit } from '../../../types';
+import { installI18nMock } from '../../helpers/i18n';
+import { clearSpyStateAfterAll } from '../../helpers/mockCleanup.ts';
+import { render } from '../../helpers/render';
+
+installI18nMock();
+
+mock.module('../../../services/api/workUnits', () => ({
+  workUnitsApi: {
+    getUsers: mock(async () => []),
+    updateUsers: mock(async () => {}),
+  },
+}));
+
+clearSpyStateAfterAll();
+
+const WorkUnitsView = (await import('../../../components/WorkUnitsView')).default;
+
+const PERMISSIONS = ['hr.work_units.view'];
+const noop = mock(() => Promise.resolve()) as unknown as never;
+
+const renderView = (workUnits: WorkUnit[]) =>
+  render(
+    <WorkUnitsView
+      workUnits={workUnits}
+      users={[] as User[]}
+      permissions={PERMISSIONS}
+      onAddWorkUnit={noop}
+      onUpdateWorkUnit={noop}
+      onDeleteWorkUnit={noop}
+      refreshWorkUnits={noop}
+    />,
+  );
+
+describe('<WorkUnitsView /> member preview (issue #761)', () => {
+  test('renders member initials with a +N overflow badge instead of the count', () => {
+    renderView([
+      {
+        id: 'wu-1',
+        name: 'Engineering',
+        managers: [{ id: 'u1', name: 'Andrea Scognamiglio' }],
+        members: [
+          { id: 'u1', name: 'Andrea Scognamiglio' },
+          { id: 'u2', name: 'Bob Bridge' },
+          { id: 'u3', name: 'Carla Conti' },
+          { id: 'u4', name: 'Dario Dini' },
+          { id: 'u5', name: 'Elsa Espo' },
+          { id: 'u6', name: 'Franco Fini' },
+        ],
+        userCount: 6,
+      },
+    ]);
+
+    expect(screen.getByText('AS')).toBeInTheDocument();
+    // Each badge surfaces the member's full name as its accessible label.
+    expect(screen.getByLabelText('Andrea Scognamiglio')).toBeInTheDocument();
+    // 6 members, inline cap of 5 → one collapses into a "+1" badge.
+    expect(screen.getByText('+1')).toBeInTheDocument();
+    // The "{count} utenti" line is replaced by the avatar row.
+    expect(screen.queryByText(/competenceCenters\.users/)).not.toBeInTheDocument();
+  });
+
+  test('keeps the member count as the empty state when a unit has no members', () => {
+    renderView([
+      {
+        id: 'wu-2',
+        name: 'Design',
+        managers: [],
+        members: [],
+        userCount: 0,
+      },
+    ]);
+
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+    expect(screen.getByText(/competenceCenters\.users/)).toBeInTheDocument();
+  });
+});

--- a/test/components/hr/WorkUnitsView.memberAvatars.test.tsx
+++ b/test/components/hr/WorkUnitsView.memberAvatars.test.tsx
@@ -58,11 +58,12 @@ describe('<WorkUnitsView /> member preview (issue #761)', () => {
     expect(screen.getByLabelText('Andrea Scognamiglio')).toBeInTheDocument();
     // 6 members, inline cap of 5 → one collapses into a "+1" badge.
     expect(screen.getByText('+1')).toBeInTheDocument();
-    // The "{count} utenti" line is replaced by the avatar row.
+    // The avatar row replaces both the count line and the empty-state text.
     expect(screen.queryByText(/competenceCenters\.users/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/competenceCenters\.noMembersAssigned/)).not.toBeInTheDocument();
   });
 
-  test('keeps the member count as the empty state when a unit has no members', () => {
+  test('shows a "no members assigned" empty state when a unit has no members', () => {
     renderView([
       {
         id: 'wu-2',
@@ -74,6 +75,6 @@ describe('<WorkUnitsView /> member preview (issue #761)', () => {
     ]);
 
     expect(screen.queryByRole('img')).not.toBeInTheDocument();
-    expect(screen.getByText(/competenceCenters\.users/)).toBeInTheDocument();
+    expect(screen.getByText(/competenceCenters\.noMembersAssigned/)).toBeInTheDocument();
   });
 });

--- a/test/components/projects/ProjectDetailView.test.ts
+++ b/test/components/projects/ProjectDetailView.test.ts
@@ -139,6 +139,17 @@ describe('ProjectDetailView wiring', () => {
     expect(source).toMatch(/widgetPermitted\('teamSize'\) && \(\s*<DashboardItem id="teamSize"/);
     expect(source).toMatch(/id === 'teamSize'\) return canManageAssignments/);
   });
+
+  test('team-size member avatars expose the full name via a hover tooltip', async () => {
+    // Each assigned-user circle in the team-size KPI is wrapped in a shadcn Tooltip so the
+    // initials reveal the full name on hover (and carry it as the avatar's accessible name).
+    const source = await readSource();
+    expect(source).toMatch(
+      /assignedUsers\.slice\(0, 6\)\.map\(\(u\) => \(\s*<Tooltip key=\{u\.id\}>\s*<TooltipTrigger asChild>/,
+    );
+    expect(source).toMatch(/<Avatar\s+role="img"\s+aria-label=\{u\.name\}/);
+    expect(source).toMatch(/<TooltipContent>\{u\.name\}<\/TooltipContent>/);
+  });
 });
 
 describe('ProjectDetailView chart scaling on wide displays', () => {

--- a/test/components/shared/MemberAvatarGroup.test.tsx
+++ b/test/components/shared/MemberAvatarGroup.test.tsx
@@ -25,23 +25,26 @@ describe('<MemberAvatarGroup />', () => {
   });
 
   test('collapses the remainder into a +N badge once the limit is exceeded', () => {
-    // 7 members, default max 5 → 5 initials + a "+2" overflow badge.
+    // 7 members, default max 5 → 5 inline avatars (role="img") + a "+2" overflow badge.
     render(<MemberAvatarGroup members={makeMembers(7)} />);
     expect(screen.getByText('+2')).toBeInTheDocument();
-    // 5 visible avatars + the overflow badge are all role="img".
-    expect(screen.getAllByRole('img')).toHaveLength(6);
+    expect(screen.getAllByRole('img')).toHaveLength(5);
   });
 
-  test('the overflow badge exposes the full membership for hover/screen readers', () => {
+  test('the overflow badge is a keyboard-focusable button labelled with only the hidden members', () => {
     render(<MemberAvatarGroup members={makeMembers(7)} />);
-    // "Member 7" is hidden from the inline row, so the only element naming it is the badge.
-    expect(screen.getByLabelText(/Member 7/)).toHaveTextContent('+2');
+    // A <button> is inherently focusable, so the full-roster tooltip is reachable by keyboard.
+    const badge = screen.getByRole('button', { name: 'Member 6, Member 7' });
+    expect(badge).toHaveTextContent('+2');
+    // The 5 visible avatars are NOT re-announced by the badge label.
+    expect(badge.getAttribute('aria-label')).not.toContain('Member 1');
   });
 
   test('honours a custom max', () => {
     render(<MemberAvatarGroup members={makeMembers(3)} max={2} />);
     expect(screen.getByText('+1')).toBeInTheDocument();
-    expect(screen.getAllByRole('img')).toHaveLength(3);
+    // 2 inline avatars; the 3rd member is collapsed into the badge.
+    expect(screen.getAllByRole('img')).toHaveLength(2);
   });
 
   test('renders nothing for an empty member list', () => {

--- a/test/components/shared/MemberAvatarGroup.test.tsx
+++ b/test/components/shared/MemberAvatarGroup.test.tsx
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'bun:test';
+import { screen } from '@testing-library/react';
+import MemberAvatarGroup from '../../../components/shared/MemberAvatarGroup';
+import { render } from '../../helpers/render';
+
+const makeMembers = (count: number) =>
+  Array.from({ length: count }, (_, i) => ({ id: `u-${i + 1}`, name: `Member ${i + 1}` }));
+
+describe('<MemberAvatarGroup />', () => {
+  test('renders first+last initials with the full name as accessible label', () => {
+    render(<MemberAvatarGroup members={[{ id: 'u-1', name: 'Andrea Scognamiglio' }]} />);
+    expect(screen.getByText('AS')).toBeInTheDocument();
+    expect(screen.getByLabelText('Andrea Scognamiglio')).toBeInTheDocument();
+  });
+
+  test('renders the first two letters for a single-word member name', () => {
+    render(<MemberAvatarGroup members={[{ id: 'u-1', name: 'Madonna' }]} />);
+    expect(screen.getByText('MA')).toBeInTheDocument();
+  });
+
+  test('shows every member inline and no overflow badge when within the limit', () => {
+    render(<MemberAvatarGroup members={makeMembers(3)} />);
+    expect(screen.getAllByRole('img')).toHaveLength(3);
+    expect(screen.queryByText(/^\+/)).not.toBeInTheDocument();
+  });
+
+  test('collapses the remainder into a +N badge once the limit is exceeded', () => {
+    // 7 members, default max 5 → 5 initials + a "+2" overflow badge.
+    render(<MemberAvatarGroup members={makeMembers(7)} />);
+    expect(screen.getByText('+2')).toBeInTheDocument();
+    // 5 visible avatars + the overflow badge are all role="img".
+    expect(screen.getAllByRole('img')).toHaveLength(6);
+  });
+
+  test('the overflow badge exposes the full membership for hover/screen readers', () => {
+    render(<MemberAvatarGroup members={makeMembers(7)} />);
+    // "Member 7" is hidden from the inline row, so the only element naming it is the badge.
+    expect(screen.getByLabelText(/Member 7/)).toHaveTextContent('+2');
+  });
+
+  test('honours a custom max', () => {
+    render(<MemberAvatarGroup members={makeMembers(3)} max={2} />);
+    expect(screen.getByText('+1')).toBeInTheDocument();
+    expect(screen.getAllByRole('img')).toHaveLength(3);
+  });
+
+  test('renders nothing for an empty member list', () => {
+    const { container } = render(<MemberAvatarGroup members={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/test/utils/initials.test.ts
+++ b/test/utils/initials.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'bun:test';
+import { getInitials } from '../../utils/initials';
+
+describe('getInitials', () => {
+  test('first+last initials for a multi-word name', () => {
+    expect(getInitials('Andrea Scognamiglio')).toBe('AS');
+    expect(getInitials('Top Manager')).toBe('TM');
+  });
+
+  test('uses first+last (not middle) for three or more words', () => {
+    expect(getInitials('Anna Maria Rossi')).toBe('AR');
+  });
+
+  test('first two letters for a single-word name', () => {
+    expect(getInitials('Madonna')).toBe('MA');
+  });
+
+  test('collapses extra whitespace between words', () => {
+    expect(getInitials('  Mario   Rossi  ')).toBe('MR');
+  });
+
+  test('falls back to "?" for a blank name', () => {
+    expect(getInitials('   ')).toBe('?');
+    expect(getInitials('')).toBe('?');
+  });
+
+  test('upper-cases lowercase names', () => {
+    expect(getInitials('mario rossi')).toBe('MR');
+  });
+});

--- a/types.ts
+++ b/types.ts
@@ -838,6 +838,7 @@ export interface WorkUnit {
   id: string;
   name: string;
   managers: { id: string; name: string }[];
+  members?: { id: string; name: string }[];
   description?: string;
   isDisabled?: boolean;
   userCount?: number;

--- a/utils/initials.ts
+++ b/utils/initials.ts
@@ -1,0 +1,13 @@
+/**
+ * Initials from a display name: the first letter of the first and last word, or the
+ * first two letters of a single-word name; `?` for a blank name. Shared source of truth
+ * for the avatar-style abbreviations used across the app (member avatars, shared-view
+ * owner badges, etc.) so the rule stays consistent in one place.
+ */
+export const getInitials = (name: string): string => {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return '?';
+  const initials =
+    parts.length === 1 ? parts[0].slice(0, 2) : parts[0][0] + parts[parts.length - 1][0];
+  return initials.toUpperCase();
+};


### PR DESCRIPTION
## Summary

Fixes #761. Competence Center cards (HR → Competence Center) previously showed only a member **count** (e.g. `2 utenti`), so you had to open a card to see who the members were. This surfaces the members directly on the card — a row of **initials** with the full name on hover, collapsing into a **`+N`** badge whose tooltip lists the whole membership — mirroring the project dashboard's team-size avatars.

## What changed

**Frontend**
- New reusable [`MemberAvatarGroup`](components/shared/MemberAvatarGroup.tsx): overlapping member initials, each with a name tooltip; overflow beyond `max` (default 5) collapses into a keyboard-focusable `+N` button whose tooltip lists every member. Renders nothing for an empty list.
- [`WorkUnitsView`](components/WorkUnitsView.tsx): the card's members section renders the avatar group when members exist, and a "no members assigned" empty state (mirroring the managers section) otherwise.
- Extracted the shared [`getInitials`](utils/initials.ts) helper and reused it in `MemberAvatarGroup` and `ViewOwnerAvatar` (removed a duplicate copy).

**Backend** (members weren't reaching the client before)
- [`workUnitsRepo`](server/repositories/workUnitsRepo.ts): `baseSelect` aggregates each unit's assigned members (`id` + `name`, ordered by name).
- [`work-units` route](server/routes/work-units.ts): `members` added to the response schema (Fastify strips fields not in the schema).
- [`types.ts`](types.ts): `members?` on the frontend `WorkUnit`.

## Notable: privacy fix surfaced during review

A multi-agent review caught that the new `members` array (id + **name**) rode the `...unit` spread in the MCP tool `praetor_get_users_hierarchy`, leaking member display names past that tool's per-user `maskUser` scoping. [`mcp.ts`](server/routes/mcp.ts) now exposes only member **IDs** — and derives them from the `members` the repo already returns, which also removed a redundant `user_work_units` query.

## Reviewer notes
- `members` = all `user_work_units` rows, which include managers (auto-added on assignment) — consistent with the existing `userCount` semantics.
- The whole `WorkUnitCard` is pre-existing hardcoded light-theme chrome; the new avatars use shadcn theme tokens per repo guidance. Theming the rest of the card is out of scope here.
- Follow-up (deliberately not in this PR): `ProjectDetailView` has its own `getInitials` + inline avatar row that could consume `MemberAvatarGroup`; left alone because migrating its initials rule would change that view's behavior.

## Testing
- New: `MemberAvatarGroup` (initials, overflow, a11y), `WorkUnitsView` preview wiring, `getInitials` unit tests, repo members-aggregate SQL, route serialization, and an MCP regression guard asserting names are not leaked.
- Full suites green: **backend 3508 pass / 0 fail**, **frontend 1804 pass / 0 fail**, lint (i18n + tsc + biome) clean.
- React Doctor score: 49 (unchanged baseline).
- HR docs (it/en) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
