### PR TITLE
chore(ci): remove React Doctor from CI test run

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview",
     "i18n:check": "bun scripts/check-i18n-keys.mjs",
     "typecheck": "tsc -p server/tsconfig.json && tsc -p tsconfig.json",
-    "test": "bun run test:server && bun run test:frontend && bun run test:react-doctor",
+    "test": "bun run test:server && bun run test:frontend",
     "test:server": "cd server && bun test ./test",
     "test:frontend": "bun test ./test",
     "test:react-doctor": "bun x -y react-doctor@latest .",


### PR DESCRIPTION
## What

Removes React Doctor from the CI pipeline. The CI **Tests** job runs `bun run test`, whose `test` script chained `&& bun run test:react-doctor` as its final step — so React Doctor ran on every pull request.

```diff
- "test": "bun run test:server && bun run test:frontend && bun run test:react-doctor",
+ "test": "bun run test:server && bun run test:frontend",
```

## Why

The React Doctor score is produced by a remote, opaque service that is flaky as a CI gate: it can refuse to score outright, and the result is dominated by false positives unrelated to the diff under review. That made it an unreliable signal to block PRs on.

## Notes for reviewers

- React Doctor was **not** referenced directly in `.github/workflows/ci.yml`; it ran transitively via `bun run test`. This is its only CI entry point — the release workflow runs no tests, and the husky pre-commit hook runs only lint-staged + `tsc --noEmit`.
- The standalone `test:react-doctor` script in `package.json` is **kept**, so it can still be run manually/locally via `bun run test:react-doctor`.
- `CLAUDE.md` / `AGENTS.md` still describe React Doctor as a per-change *manual* score gate. Those instructions remain valid since the script still exists, so they're left untouched here — the manual gate can be retired separately if desired.

## Testing

- Pre-commit hook (biome + `tsc --noEmit`) passed.
- `package.json` remains valid JSON; the `test` chain references only existing scripts (`test:server`, `test:frontend`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
