### PR TITLE
fix(projects): serialize task revenue updates

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -78,7 +78,11 @@ import { makeQuoteHandlers } from './hooks/handlers/quoteHandlers';
 import { makeSupplierHandlers } from './hooks/handlers/supplierHandlers';
 import { makeSupplierInvoiceHandlers } from './hooks/handlers/supplierInvoiceHandlers';
 import { makeSupplierQuoteHandlers } from './hooks/handlers/supplierQuoteHandlers';
-import { makeTaskHandlers } from './hooks/handlers/taskHandlers';
+import {
+  createTaskUpdateQueueState,
+  makeTaskHandlers,
+  type TaskUpdateQueueState,
+} from './hooks/handlers/taskHandlers';
 import { makeUserHandlers } from './hooks/handlers/userHandlers';
 import { useAuth } from './hooks/useAuth';
 import { listRequest, useModuleLoader } from './hooks/useModuleLoader';
@@ -762,6 +766,11 @@ const AppContent: React.FC = () => {
   const [supplierOrders, setSupplierOrders] = useState<SupplierSaleOrder[]>([]);
   const [supplierInvoices, setSupplierInvoices] = useState<SupplierInvoice[]>([]);
   const [entries, setEntries] = useState<TimeEntry[]>([]);
+  const taskUpdateQueueStateRef = useRef<TaskUpdateQueueState | null>(null);
+  if (taskUpdateQueueStateRef.current === null) {
+    taskUpdateQueueStateRef.current = createTaskUpdateQueueState();
+  }
+  const taskUpdateQueueState = taskUpdateQueueStateRef.current;
   // Bumped on logout/role-switch so in-flight cursor streams stop appending stale rows.
   const entriesStreamTokenRef = useRef(0);
   // Bumped on navigation/auth reset so stale module-load completions cannot commit state.
@@ -2396,8 +2405,9 @@ const AppContent: React.FC = () => {
         setProjectTasks,
         setEntries,
         generateRecurringEntries,
+        taskUpdateQueueState,
       }),
-    [projectTasks, generateRecurringEntries],
+    [projectTasks, generateRecurringEntries, taskUpdateQueueState],
   );
 
   const handleAddEntry = entryHandlers.add;

--- a/hooks/handlers/taskHandlers.ts
+++ b/hooks/handlers/taskHandlers.ts
@@ -13,13 +13,15 @@ export type TaskHandlersDeps = {
 
 export type TaskUpdateQueueState = {
   queuedTaskUpdates: Map<string, Promise<void>>;
-  latestTaskUpdateSeqById: Map<string, number>;
+  latestTaskUpdateSeqByField: Map<string, number>;
   nextTaskUpdateSeq: number;
 };
 
+const taskUpdateFieldKey = (taskId: string, field: string): string => `${taskId}\u0000${field}`;
+
 export const createTaskUpdateQueueState = (): TaskUpdateQueueState => ({
   queuedTaskUpdates: new Map(),
-  latestTaskUpdateSeqById: new Map(),
+  latestTaskUpdateSeqByField: new Map(),
   nextTaskUpdateSeq: 0,
 });
 
@@ -33,13 +35,26 @@ export const makeTaskHandlers = (deps: TaskHandlersDeps) => {
   } = deps;
 
   const update = async (id: string, updates: Partial<ProjectTask>) => {
-    const { queuedTaskUpdates, latestTaskUpdateSeqById } = taskUpdateQueueState;
+    const { queuedTaskUpdates, latestTaskUpdateSeqByField } = taskUpdateQueueState;
+    const updateFields = Object.keys(updates);
     const updateSeq = ++taskUpdateQueueState.nextTaskUpdateSeq;
-    latestTaskUpdateSeqById.set(id, updateSeq);
+    for (const field of updateFields) {
+      latestTaskUpdateSeqByField.set(taskUpdateFieldKey(id, field), updateSeq);
+    }
     const priorUpdate = queuedTaskUpdates.get(id) ?? Promise.resolve();
     const runUpdate = async () => {
-      if (latestTaskUpdateSeqById.get(id) !== updateSeq) return;
-      const updated = await api.tasks.update(id, updates);
+      const activeUpdates =
+        updateFields.length === 0
+          ? updates
+          : (Object.fromEntries(
+              Object.entries(updates).filter(
+                ([field]) =>
+                  latestTaskUpdateSeqByField.get(taskUpdateFieldKey(id, field)) === updateSeq,
+              ),
+            ) as Partial<ProjectTask>);
+      if (updateFields.length > 0 && Object.keys(activeUpdates).length === 0) return;
+
+      const updated = await api.tasks.update(id, activeUpdates);
       setProjectTasks((prev) => prev.map((t) => (t.id === id ? updated : t)));
     };
     const updateRequest = queuedTaskUpdates.has(id)
@@ -54,8 +69,11 @@ export const makeTaskHandlers = (deps: TaskHandlersDeps) => {
       if (queuedTaskUpdates.get(id) === updateRequest) {
         queuedTaskUpdates.delete(id);
       }
-      if (latestTaskUpdateSeqById.get(id) === updateSeq) {
-        latestTaskUpdateSeqById.delete(id);
+      for (const field of updateFields) {
+        const key = taskUpdateFieldKey(id, field);
+        if (latestTaskUpdateSeqByField.get(key) === updateSeq) {
+          latestTaskUpdateSeqByField.delete(key);
+        }
       }
     }
   };

--- a/hooks/handlers/taskHandlers.ts
+++ b/hooks/handlers/taskHandlers.ts
@@ -8,17 +8,55 @@ export type TaskHandlersDeps = {
   setProjectTasks: React.Dispatch<React.SetStateAction<ProjectTask[]>>;
   setEntries: React.Dispatch<React.SetStateAction<TimeEntry[]>>;
   generateRecurringEntries: () => Promise<void> | void;
+  taskUpdateQueueState: TaskUpdateQueueState;
 };
 
+export type TaskUpdateQueueState = {
+  queuedTaskUpdates: Map<string, Promise<void>>;
+  latestTaskUpdateSeqById: Map<string, number>;
+  nextTaskUpdateSeq: number;
+};
+
+export const createTaskUpdateQueueState = (): TaskUpdateQueueState => ({
+  queuedTaskUpdates: new Map(),
+  latestTaskUpdateSeqById: new Map(),
+  nextTaskUpdateSeq: 0,
+});
+
 export const makeTaskHandlers = (deps: TaskHandlersDeps) => {
-  const { projectTasks, setProjectTasks, setEntries, generateRecurringEntries } = deps;
+  const {
+    projectTasks,
+    setProjectTasks,
+    setEntries,
+    generateRecurringEntries,
+    taskUpdateQueueState,
+  } = deps;
 
   const update = async (id: string, updates: Partial<ProjectTask>) => {
-    try {
+    const { queuedTaskUpdates, latestTaskUpdateSeqById } = taskUpdateQueueState;
+    const updateSeq = ++taskUpdateQueueState.nextTaskUpdateSeq;
+    latestTaskUpdateSeqById.set(id, updateSeq);
+    const priorUpdate = queuedTaskUpdates.get(id) ?? Promise.resolve();
+    const runUpdate = async () => {
+      if (latestTaskUpdateSeqById.get(id) !== updateSeq) return;
       const updated = await api.tasks.update(id, updates);
       setProjectTasks((prev) => prev.map((t) => (t.id === id ? updated : t)));
+    };
+    const updateRequest = queuedTaskUpdates.has(id)
+      ? priorUpdate.catch(() => undefined).then(runUpdate)
+      : runUpdate();
+    queuedTaskUpdates.set(id, updateRequest);
+    try {
+      await updateRequest;
     } catch (err) {
       console.error('Failed to update task:', err);
+    } finally {
+      if (queuedTaskUpdates.get(id) === updateRequest) {
+        queuedTaskUpdates.delete(id);
+      }
+      if (latestTaskUpdateSeqById.get(id) === updateSeq) {
+        latestTaskUpdateSeqById.delete(id);
+      }
     }
   };
 

--- a/test/handlers/taskHandlers.test.ts
+++ b/test/handlers/taskHandlers.test.ts
@@ -26,12 +26,15 @@ mock.module('../../services/api', () => ({
 
 clearSpyStateAfterAll();
 
-const { makeTaskHandlers } = await import('../../hooks/handlers/taskHandlers');
+const { createTaskUpdateQueueState, makeTaskHandlers } = await import(
+  '../../hooks/handlers/taskHandlers'
+);
 
 type TaskLike = {
   id: string;
   name: string;
   projectId: string;
+  revenue?: number;
   isRecurring?: boolean;
   recurrencePattern?: string;
   recurrenceStart?: string;
@@ -56,19 +59,119 @@ const makeStubSetter = <T>(initial: T[]) => {
   };
 };
 
+const deferValue = <T>() => {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+beforeEach(() => {
+  Object.values(apiMocks).forEach((m) => {
+    m.mockClear();
+  });
+});
+
+afterEach(() => {
+  Object.values(apiMocks).forEach((m) => {
+    m.mockReset();
+  });
+});
+
+describe('makeTaskHandlers.update', () => {
+  test('serializes same-task revenue edits so the latest value wins locally and on the server', async () => {
+    const requests: Array<{
+      id: string;
+      updates: Partial<TaskLike>;
+      deferred: ReturnType<typeof deferValue<TaskLike>>;
+    }> = [];
+    apiMocks.tasksUpdate.mockImplementation((id: string, updates: unknown) => {
+      const deferred = deferValue<TaskLike>();
+      requests.push({ id, updates: updates as Partial<TaskLike>, deferred });
+      return deferred.promise;
+    });
+    const tasks = makeStubSetter<TaskLike>([
+      { id: 't1', name: 'task-A', projectId: 'p1', revenue: 10 },
+    ]);
+    const handlers = makeTaskHandlers({
+      projectTasks: tasks.get() as never,
+      setProjectTasks: tasks.setter,
+      setEntries: makeStubSetter<EntryLike>([]).setter,
+      generateRecurringEntries: mock(() => Promise.resolve()),
+      taskUpdateQueueState: createTaskUpdateQueueState(),
+    });
+
+    const firstUpdate = handlers.update('t1', { revenue: 100 });
+    const secondUpdate = handlers.update('t1', { revenue: 250 });
+    await Promise.resolve();
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0].updates).toEqual({ revenue: 100 });
+
+    requests[0].deferred.resolve({ id: 't1', name: 'task-A', projectId: 'p1', revenue: 100 });
+    await firstUpdate;
+    await Promise.resolve();
+
+    expect(tasks.get()[0].revenue).toBe(100);
+    expect(requests).toHaveLength(2);
+    expect(requests[1].updates).toEqual({ revenue: 250 });
+
+    requests[1].deferred.resolve({ id: 't1', name: 'task-A', projectId: 'p1', revenue: 250 });
+    await secondUpdate;
+
+    expect(tasks.get()[0].revenue).toBe(250);
+  });
+
+  test('keeps the last committed task value when a newer queued edit fails', async () => {
+    const requests: Array<{
+      updates: Partial<TaskLike>;
+      deferred: ReturnType<typeof deferValue<TaskLike>>;
+    }> = [];
+    apiMocks.tasksUpdate.mockImplementation((_id: string, updates: unknown) => {
+      const deferred = deferValue<TaskLike>();
+      requests.push({ updates: updates as Partial<TaskLike>, deferred });
+      return deferred.promise;
+    });
+    const tasks = makeStubSetter<TaskLike>([
+      { id: 't1', name: 'task-A', projectId: 'p1', revenue: 10 },
+    ]);
+    const handlers = makeTaskHandlers({
+      projectTasks: tasks.get() as never,
+      setProjectTasks: tasks.setter,
+      setEntries: makeStubSetter<EntryLike>([]).setter,
+      generateRecurringEntries: mock(() => Promise.resolve()),
+      taskUpdateQueueState: createTaskUpdateQueueState(),
+    });
+
+    const originalError = console.error;
+    console.error = mock(() => {}) as unknown as typeof console.error;
+    try {
+      const firstUpdate = handlers.update('t1', { revenue: 100 });
+      const secondUpdate = handlers.update('t1', { revenue: 250 });
+      await Promise.resolve();
+
+      requests[0].deferred.resolve({ id: 't1', name: 'task-A', projectId: 'p1', revenue: 100 });
+      await firstUpdate;
+      await Promise.resolve();
+
+      expect(tasks.get()[0].revenue).toBe(100);
+      expect(requests).toHaveLength(2);
+      expect(requests[1].updates).toEqual({ revenue: 250 });
+
+      requests[1].deferred.reject(new Error('validation failed'));
+      await secondUpdate;
+
+      expect(tasks.get()[0].revenue).toBe(100);
+    } finally {
+      console.error = originalError;
+    }
+  });
+});
+
 describe('makeTaskHandlers.makeRecurring', () => {
-  beforeEach(() => {
-    Object.values(apiMocks).forEach((m) => {
-      m.mockClear();
-    });
-  });
-
-  afterEach(() => {
-    Object.values(apiMocks).forEach((m) => {
-      m.mockReset();
-    });
-  });
-
   test('first-time recurring: skips placeholder cleanup, updates task, regenerates', async () => {
     apiMocks.tasksUpdate.mockImplementation((id: string, updates: unknown) =>
       Promise.resolve({ id, name: 'task-A', projectId: 'p1', ...(updates as object) }),
@@ -83,6 +186,7 @@ describe('makeTaskHandlers.makeRecurring', () => {
       setProjectTasks: tasks.setter,
       setEntries: entries.setter,
       generateRecurringEntries: generateSpy as never,
+      taskUpdateQueueState: createTaskUpdateQueueState(),
     });
 
     await handlers.makeRecurring('t1', 'weekly', '2026-05-01', '2026-12-01', 8);
@@ -114,6 +218,7 @@ describe('makeTaskHandlers.makeRecurring', () => {
       setProjectTasks: tasks.setter,
       setEntries: makeStubSetter<EntryLike>([]).setter,
       generateRecurringEntries: generateSpy as never,
+      taskUpdateQueueState: createTaskUpdateQueueState(),
     });
 
     await handlers.makeRecurring('t1', 'daily', '2026-05-01');
@@ -145,6 +250,7 @@ describe('makeTaskHandlers.makeRecurring', () => {
       setProjectTasks: tasks.setter,
       setEntries: makeStubSetter<EntryLike>([]).setter,
       generateRecurringEntries: generateSpy as never,
+      taskUpdateQueueState: createTaskUpdateQueueState(),
     });
 
     const makeRecurringPromise = handlers.makeRecurring('t1', 'weekly', '2026-05-01');
@@ -200,6 +306,7 @@ describe('makeTaskHandlers.makeRecurring', () => {
       setProjectTasks: tasks.setter,
       setEntries: entries.setter,
       generateRecurringEntries: mock(() => Promise.resolve()),
+      taskUpdateQueueState: createTaskUpdateQueueState(),
     });
 
     await handlers.makeRecurring('t1', 'monthly', '2026-05-01', undefined, 4);
@@ -232,6 +339,7 @@ describe('makeTaskHandlers.makeRecurring', () => {
       setProjectTasks: tasks.setter,
       setEntries: makeStubSetter<EntryLike>([]).setter,
       generateRecurringEntries: mock(() => Promise.resolve()),
+      taskUpdateQueueState: createTaskUpdateQueueState(),
     });
 
     await handlers.makeRecurring('t1', 'daily');

--- a/test/handlers/taskHandlers.test.ts
+++ b/test/handlers/taskHandlers.test.ts
@@ -34,6 +34,7 @@ type TaskLike = {
   id: string;
   name: string;
   projectId: string;
+  expectedEffort?: number;
   revenue?: number;
   isRecurring?: boolean;
   recurrencePattern?: string;
@@ -168,6 +169,77 @@ describe('makeTaskHandlers.update', () => {
     } finally {
       console.error = originalError;
     }
+  });
+
+  test('preserves queued edits for different fields on the same task', async () => {
+    const requests: Array<{
+      updates: Partial<TaskLike>;
+      deferred: ReturnType<typeof deferValue<TaskLike>>;
+    }> = [];
+    apiMocks.tasksUpdate.mockImplementation((_id: string, updates: unknown) => {
+      const deferred = deferValue<TaskLike>();
+      requests.push({ updates: updates as Partial<TaskLike>, deferred });
+      return deferred.promise;
+    });
+    const tasks = makeStubSetter<TaskLike>([
+      { id: 't1', name: 'task-A', projectId: 'p1', expectedEffort: 1, revenue: 10 },
+    ]);
+    const handlers = makeTaskHandlers({
+      projectTasks: tasks.get() as never,
+      setProjectTasks: tasks.setter,
+      setEntries: makeStubSetter<EntryLike>([]).setter,
+      generateRecurringEntries: mock(() => Promise.resolve()),
+      taskUpdateQueueState: createTaskUpdateQueueState(),
+    });
+
+    const firstUpdate = handlers.update('t1', { name: 'task-renamed' });
+    const secondUpdate = handlers.update('t1', { revenue: 250 });
+    const thirdUpdate = handlers.update('t1', { expectedEffort: 8 });
+    await Promise.resolve();
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0].updates).toEqual({ name: 'task-renamed' });
+
+    requests[0].deferred.resolve({
+      id: 't1',
+      name: 'task-renamed',
+      projectId: 'p1',
+      expectedEffort: 1,
+      revenue: 10,
+    });
+    await firstUpdate;
+    await Promise.resolve();
+
+    expect(requests).toHaveLength(2);
+    expect(requests[1].updates).toEqual({ revenue: 250 });
+
+    requests[1].deferred.resolve({
+      id: 't1',
+      name: 'task-renamed',
+      projectId: 'p1',
+      expectedEffort: 1,
+      revenue: 250,
+    });
+    await secondUpdate;
+    await Promise.resolve();
+
+    expect(requests).toHaveLength(3);
+    expect(requests[2].updates).toEqual({ expectedEffort: 8 });
+
+    requests[2].deferred.resolve({
+      id: 't1',
+      name: 'task-renamed',
+      projectId: 'p1',
+      expectedEffort: 8,
+      revenue: 250,
+    });
+    await thirdUpdate;
+
+    expect(tasks.get()[0]).toMatchObject({
+      name: 'task-renamed',
+      expectedEffort: 8,
+      revenue: 250,
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- Fixes a race where rapid task revenue edits could leave project revenue totals showing stale values.
- Serializes same-task updates while preserving the last server-confirmed task value if a later edit fails.

## Changes
- Adds per-app task update queue state and wires it into task handlers.
- Skips obsolete queued task updates before sending them to the API.
- Adds regression coverage for rapid same-task revenue edits and failed queued edits.

## Testing
- `bun test ./test/handlers/taskHandlers.test.ts`: 7 pass
- `bun run lint`: passed
- `bun run test:frontend`: 1933 pass
- `bun x -y react-doctor@latest .`: 49/100 Critical, unchanged from baseline; exits 1 because of the pre-existing `@types/bun` Socket score issue.

## Risks / Rollout
- Low risk. Change is scoped to frontend task update ordering and local state application.
- No migrations, API contract changes, permissions changes, or production config changes.

## Issues
Issue: Not linked