### PR TITLE
fix(version): sync app version metadata

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Praetor API",
     "description": "Praetor API documentation",
-    "version": "0.7.0"
+    "version": "0.8.0"
   },
   "components": {
     "securitySchemes": {

--- a/server/app.ts
+++ b/server/app.ts
@@ -41,6 +41,7 @@ import viewsRoutes from './routes/views.ts';
 import webhooksRoutes from './routes/webhooks.ts';
 import workUnitsRoutes from './routes/work-units.ts';
 import { ajvFormatsPlugin, ajvFormatsPluginOptions } from './utils/ajv-formats.ts';
+import { APP_VERSION } from './utils/app-version.ts';
 import { loggerOptions, serializeError } from './utils/logger.ts';
 import { GLOBAL_RATE_LIMIT } from './utils/rate-limit.ts';
 
@@ -151,7 +152,7 @@ export const buildApp = async () => {
       info: {
         title: 'Praetor API',
         description: 'Praetor API documentation',
-        version: '0.7.0',
+        version: APP_VERSION,
       },
       components: {
         securitySchemes: {

--- a/server/routes/mcp.ts
+++ b/server/routes/mcp.ts
@@ -26,6 +26,7 @@ import {
   TimeEntryServiceError,
   updateTimeEntry,
 } from '../services/timeEntries.ts';
+import { APP_VERSION } from '../utils/app-version.ts';
 import {
   effectiveQuoteStatusFromDate,
   effectiveSupplierQuoteStatusFromDate,
@@ -239,7 +240,7 @@ const runBulkTimeEntryTool = async <T>(
 
 const buildServer = () => {
   const server = new McpServer(
-    { name: 'praetor', version: '0.7.0' },
+    { name: 'praetor', version: APP_VERSION },
     {
       instructions:
         'Use Praetor tools to inspect and update ERP data. Tool results are scoped to the authenticated MCP token user and their current Praetor role permissions.',

--- a/server/test/routes/mcp.test.ts
+++ b/server/test/routes/mcp.test.ts
@@ -17,6 +17,7 @@ import * as realTasksRepo from '../../repositories/tasksRepo.ts';
 import * as realUsersRepo from '../../repositories/usersRepo.ts';
 import * as realWorkUnitsRepo from '../../repositories/workUnitsRepo.ts';
 import * as realTimeEntriesService from '../../services/timeEntries.ts';
+import { APP_VERSION } from '../../utils/app-version.ts';
 import { buildRouteTestApp } from '../helpers/buildRouteTestApp.ts';
 
 const mcpAuthSnap = { ...realMcpAuth };
@@ -359,7 +360,7 @@ describe('/api/mcp', () => {
 
     expect(res.statusCode).toBe(200);
     const body = parseMcpBody(res.body);
-    expect(body.result.serverInfo).toEqual({ name: 'praetor', version: '0.7.0' });
+    expect(body.result.serverInfo).toEqual({ name: 'praetor', version: APP_VERSION });
   });
 
   test('lists tools and calls permission-scoped list tools', async () => {

--- a/server/utils/app-version.ts
+++ b/server/utils/app-version.ts
@@ -1,0 +1,3 @@
+import serverPackage from '../package.json' with { type: 'json' };
+
+export const APP_VERSION = serverPackage.version;


### PR DESCRIPTION
## Summary
- Fixes stale Praetor API and MCP version metadata so it follows server/package.json.
- Regenerates the OpenAPI spec with version 