### PR TITLE
seed(fix): refresh complete demo namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ data volume.
 
 The compose setup defaults backend `TRUST_PROXY=1` for the bundled Caddy -> API hop.
 Set `DEMO_SEEDING=true` in `.env` when you want the stack to provision the canonical demo users and demo business data.
-That refresh flow is intended for demo and test stacks, owns the canonical demo namespace, and supports reused Docker volumes.
+That refresh flow is intended for demo and test stacks, owns the canonical demo namespace,
+refreshes compatibility clients/projects/tasks, and resets the seeded demo users' assignments,
+notifications, and time entries so reused Docker volumes return to the curated demo state.
 The demo users include HR profile data such as employee codes, departments, contract status, work locations, emergency contacts, and sample internal/external employee records.
 
 To rerun the same refresh manually against an existing backend database:

--- a/server/db/demoSeed.ts
+++ b/server/db/demoSeed.ts
@@ -4,6 +4,8 @@ import * as userAssignmentsRepo from '../repositories/userAssignmentsRepo.ts';
 import { createChildLogger, serializeError } from '../utils/logger.ts';
 import { ensureBootstrapAdmin } from './bootstrapAdmin.ts';
 import {
+  COMPATIBILITY_DEFAULTS,
+  DEMO_ASSIGNMENT_TARGET_IDS,
   DEMO_CLIENTS,
   DEMO_CUSTOMER_OFFERS,
   DEMO_EXPECTED_COUNTS,
@@ -18,6 +20,7 @@ import {
   DEMO_SUPPLIER_INVOICES,
   DEMO_SUPPLIER_SALES,
   DEMO_SUPPLIERS,
+  DEMO_TOP_MANAGER_USER_IDS,
   DEMO_USER_IDS,
   DEMO_USERS,
   DEMO_WORK_UNITS,
@@ -57,6 +60,7 @@ type VerificationStep = {
   table: string;
   countColumn?: string;
   ids: readonly string[];
+  userIds?: readonly string[];
   expected: number;
 };
 
@@ -142,13 +146,42 @@ const loadDemoStatements = () => {
   return splitSqlStatements(seedSql.slice(markerIndex));
 };
 
-const insertCompatibilityDefaults = async (client: PoolClient, counts: Record<string, number>) => {
+export const insertCompatibilityDefaults = async (
+  client: PoolClient,
+  counts: Record<string, number>,
+) => {
   const clientsResult = await executeStatement(
     client,
     `INSERT INTO clients (id, name, created_at) VALUES
         ('c1', 'Acme Corp', '2024-01-15 09:30:00'),
         ('c2', 'Global Tech', '2024-03-05 14:15:00')
-     ON CONFLICT (id) DO NOTHING`,
+     ON CONFLICT (id) DO UPDATE SET
+       name = EXCLUDED.name,
+       created_at = EXCLUDED.created_at,
+       is_disabled = FALSE,
+       type = DEFAULT,
+       contact_name = NULL,
+       client_code = NULL,
+       email = NULL,
+       phone = NULL,
+       address = NULL,
+       description = NULL,
+       ateco_code = NULL,
+       website = NULL,
+       sector = NULL,
+       number_of_employees = NULL,
+       revenue = NULL,
+       fiscal_code = NULL,
+       vat_number = NULL,
+       tax_code = NULL,
+       office_count_range = NULL,
+       contacts = DEFAULT,
+       address_country = NULL,
+       address_state = NULL,
+       address_cap = NULL,
+       address_province = NULL,
+       address_civic_number = NULL,
+       address_line = NULL`,
   );
   incrementCount(counts, 'clients', clientsResult.rowCount ?? 0);
 
@@ -160,7 +193,20 @@ const insertCompatibilityDefaults = async (client: PoolClient, counts: Record<st
         ('p1', 'Website Redesign', 'c1', 'Complete overhaul of the main marketing site.', (CURRENT_DATE - INTERVAL '30 days')::date, (CURRENT_DATE + INTERVAL '30 days')::date, 'attivo', TRUE),
         ('p2', 'Mobile App', 'c1', 'Native iOS and Android application development.', (CURRENT_DATE - INTERVAL '28 days')::date, (CURRENT_DATE + INTERVAL '28 days')::date, 'attivo', TRUE),
         ('p3', 'Internal Research', 'c2', 'Ongoing research into new market trends.', (CURRENT_DATE - INTERVAL '25 days')::date, (CURRENT_DATE + INTERVAL '25 days')::date, 'attivo', TRUE)
-     ON CONFLICT (id) DO NOTHING`,
+     ON CONFLICT (id) DO UPDATE SET
+       name = EXCLUDED.name,
+       client_id = EXCLUDED.client_id,
+       description = EXCLUDED.description,
+       start_date = EXCLUDED.start_date,
+       end_date = EXCLUDED.end_date,
+       tipo = EXCLUDED.tipo,
+       tipo_confirmed = EXCLUDED.tipo_confirmed,
+       is_disabled = FALSE,
+       order_id = NULL,
+       offer_id = NULL,
+       revenue = NULL,
+       billing_type = DEFAULT,
+       billing_frequency = DEFAULT`,
   );
   incrementCount(counts, 'projects', projectsResult.rowCount ?? 0);
 
@@ -172,7 +218,23 @@ const insertCompatibilityDefaults = async (client: PoolClient, counts: Record<st
         ('t3', 'API Integration', 'p2', 'Connecting the app to the backend services.'),
         ('t4', 'General Support', 'p3', 'Misc administrative tasks and support.'),
         ('t5', 'Market Analysis', 'p3', 'Competitive landscape and pricing research.')
-     ON CONFLICT (id) DO NOTHING`,
+     ON CONFLICT (id) DO UPDATE SET
+       name = EXCLUDED.name,
+       project_id = EXCLUDED.project_id,
+       description = EXCLUDED.description,
+       is_recurring = DEFAULT,
+       recurrence_pattern = NULL,
+       recurrence_start = NULL,
+       recurrence_end = NULL,
+       recurrence_duration = DEFAULT,
+       expected_effort = DEFAULT,
+       revenue = DEFAULT,
+       duration = DEFAULT,
+       notes = NULL,
+       is_disabled = FALSE,
+       billing_type = DEFAULT,
+       billing_frequency = DEFAULT,
+       monthly_effort = DEFAULT`,
   );
   incrementCount(counts, 'tasks', tasksResult.rowCount ?? 0);
 };
@@ -289,7 +351,7 @@ const insertDemoUsersAndSettings = async (client: PoolClient, counts: Record<str
   incrementCount(counts, 'settings', settingsResult.rowCount ?? 0);
 };
 
-const cleanupDemoNamespace = async (client: PoolClient, demoUserIds: DemoUserCleanupIds) => {
+export const cleanupDemoNamespace = async (client: PoolClient, demoUserIds: DemoUserCleanupIds) => {
   const cleanupCountsByTable: Record<string, number> = {};
 
   incrementCount(
@@ -297,6 +359,31 @@ const cleanupDemoNamespace = async (client: PoolClient, demoUserIds: DemoUserCle
     'time_entries',
     await executeDelete(client, 'time_entries', (builder) => {
       pushTextArrayPredicate(builder, 'id', DEMO_IDS.timeEntries);
+      pushTextArrayPredicate(builder, 'user_id', demoUserIds.dependentUserIds);
+    }),
+  );
+
+  incrementCount(
+    cleanupCountsByTable,
+    'user_tasks',
+    await executeDelete(client, 'user_tasks', (builder) => {
+      pushTextArrayPredicate(builder, 'user_id', demoUserIds.dependentUserIds);
+    }),
+  );
+
+  incrementCount(
+    cleanupCountsByTable,
+    'user_projects',
+    await executeDelete(client, 'user_projects', (builder) => {
+      pushTextArrayPredicate(builder, 'user_id', demoUserIds.dependentUserIds);
+    }),
+  );
+
+  incrementCount(
+    cleanupCountsByTable,
+    'user_clients',
+    await executeDelete(client, 'user_clients', (builder) => {
+      pushTextArrayPredicate(builder, 'user_id', demoUserIds.dependentUserIds);
     }),
   );
 
@@ -305,6 +392,7 @@ const cleanupDemoNamespace = async (client: PoolClient, demoUserIds: DemoUserCle
     'user_work_units',
     await executeDelete(client, 'user_work_units', (builder) => {
       pushTextArrayPredicate(builder, 'work_unit_id', DEMO_IDS.workUnits);
+      pushTextArrayPredicate(builder, 'user_id', demoUserIds.dependentUserIds);
     }),
   );
 
@@ -313,6 +401,7 @@ const cleanupDemoNamespace = async (client: PoolClient, demoUserIds: DemoUserCle
     'work_unit_managers',
     await executeDelete(client, 'work_unit_managers', (builder) => {
       pushTextArrayPredicate(builder, 'work_unit_id', DEMO_IDS.workUnits);
+      pushTextArrayPredicate(builder, 'user_id', demoUserIds.dependentUserIds);
     }),
   );
 
@@ -334,6 +423,7 @@ const cleanupDemoNamespace = async (client: PoolClient, demoUserIds: DemoUserCle
     'notifications',
     await executeDelete(client, 'notifications', (builder) => {
       pushTextArrayPredicate(builder, 'id', DEMO_NOTIFICATIONS);
+      pushTextArrayPredicate(builder, 'user_id', demoUserIds.dependentUserIds);
     }),
   );
 
@@ -532,6 +622,7 @@ const cleanupDemoNamespace = async (client: PoolClient, demoUserIds: DemoUserCle
     cleanupCountsByTable,
     'tasks',
     await executeDelete(client, 'tasks', (builder) => {
+      pushTextArrayPredicate(builder, 'id', DEMO_IDS.tasks);
       pushTextArrayPredicate(builder, 'project_id', DEMO_IDS.projects);
     }),
   );
@@ -630,7 +721,11 @@ const verificationSteps: VerificationStep[] = [
     ids: DEMO_IDS.settingsUserIds,
     expected: DEMO_EXPECTED_COUNTS.settings,
   },
-  { table: 'clients', ids: DEMO_IDS.clients, expected: DEMO_EXPECTED_COUNTS.clients },
+  {
+    table: 'clients',
+    ids: [...COMPATIBILITY_DEFAULTS.clients, ...DEMO_IDS.clients],
+    expected: DEMO_EXPECTED_COUNTS.clients,
+  },
   { table: 'suppliers', ids: DEMO_IDS.suppliers, expected: DEMO_EXPECTED_COUNTS.suppliers },
   { table: 'products', ids: DEMO_IDS.products, expected: DEMO_EXPECTED_COUNTS.products },
   { table: 'quotes', ids: DEMO_IDS.quotes, expected: DEMO_EXPECTED_COUNTS.quotes },
@@ -691,7 +786,16 @@ const verificationSteps: VerificationStep[] = [
     ids: DEMO_ITEM_IDS.supplierInvoiceItems,
     expected: DEMO_EXPECTED_COUNTS.supplier_invoice_items,
   },
-  { table: 'projects', ids: DEMO_IDS.projects, expected: DEMO_EXPECTED_COUNTS.projects },
+  {
+    table: 'projects',
+    ids: [...COMPATIBILITY_DEFAULTS.projects, ...DEMO_IDS.projects],
+    expected: DEMO_EXPECTED_COUNTS.projects,
+  },
+  {
+    table: 'tasks',
+    ids: [...COMPATIBILITY_DEFAULTS.tasks, ...DEMO_IDS.tasks],
+    expected: DEMO_EXPECTED_COUNTS.tasks,
+  },
   {
     table: 'notifications',
     ids: DEMO_IDS.notifications,
@@ -710,6 +814,27 @@ const verificationSteps: VerificationStep[] = [
     ids: DEMO_IDS.workUnits,
     expected: DEMO_EXPECTED_COUNTS.user_work_units,
   },
+  {
+    table: 'user_clients',
+    countColumn: 'client_id',
+    ids: DEMO_ASSIGNMENT_TARGET_IDS.clients,
+    userIds: DEMO_USER_IDS,
+    expected: DEMO_EXPECTED_COUNTS.user_clients,
+  },
+  {
+    table: 'user_projects',
+    countColumn: 'project_id',
+    ids: DEMO_ASSIGNMENT_TARGET_IDS.projects,
+    userIds: DEMO_USER_IDS,
+    expected: DEMO_EXPECTED_COUNTS.user_projects,
+  },
+  {
+    table: 'user_tasks',
+    countColumn: 'task_id',
+    ids: DEMO_ASSIGNMENT_TARGET_IDS.tasks,
+    userIds: DEMO_USER_IDS,
+    expected: DEMO_EXPECTED_COUNTS.user_tasks,
+  },
   { table: 'time_entries', ids: DEMO_IDS.timeEntries, expected: DEMO_EXPECTED_COUNTS.time_entries },
 ];
 
@@ -719,9 +844,11 @@ const verifyDemoDataset = async () => {
 
   for (const step of verificationSteps) {
     const countColumn = step.countColumn ?? 'id';
+    const userFilter = step.userIds ? ' AND user_id = ANY($2::text[])' : '';
+    const params = step.userIds ? [step.ids, step.userIds] : [step.ids];
     const result = await query(
-      `SELECT COUNT(*)::int AS count FROM ${step.table} WHERE ${countColumn} = ANY($1::text[])`,
-      [step.ids],
+      `SELECT COUNT(*)::int AS count FROM ${step.table} WHERE ${countColumn} = ANY($1::text[])${userFilter}`,
+      params,
     );
     const actual = Number(result.rows[0]?.count ?? 0);
     verificationCountsByTable[step.table] = actual;
@@ -791,8 +918,8 @@ export const runDemoSeedRefresh = async ({
     // assignment rows, so the per-user fan-outs are independent and run concurrently. This is
     // a bounded, fixed set (DEMO_USERS), so there's no connection-pool-storm risk.
     await Promise.all(
-      DEMO_USERS.filter((user) => user.role === 'top_manager').map((user) =>
-        userAssignmentsRepo.syncTopManagerAssignmentsForUser(user.id),
+      DEMO_TOP_MANAGER_USER_IDS.map((userId) =>
+        userAssignmentsRepo.syncTopManagerAssignmentsForUser(userId),
       ),
     );
   } catch (err) {

--- a/server/db/demoSeedManifest.ts
+++ b/server/db/demoSeedManifest.ts
@@ -407,6 +407,8 @@ export const DEMO_PROJECTS = [
   { id: 'dm_proj_02', name: `DM-CLI-001_DM-SVC-DEPLOY_${currentYear}` },
 ] as const;
 
+export const DEMO_TASKS = rangeIds('dm_task_', 5);
+
 export const DEMO_NOTIFICATIONS = ['dm_notif_01', 'dm_notif_02'] as const;
 
 export const DEMO_WORK_UNITS = [
@@ -450,6 +452,79 @@ export const DEMO_USER_WORK_UNITS = [
   { userId: 'u9', workUnitId: 'dm_wu_03' },
 ] as const;
 
+export const DEMO_USER_CLIENT_ASSIGNMENTS = [
+  { userId: 'u2', targetId: 'c1' },
+  { userId: 'u2', targetId: 'c2' },
+  { userId: 'u2', targetId: 'dm_cli_01' },
+  { userId: 'u3', targetId: 'c1' },
+  { userId: 'u3', targetId: 'dm_cli_01' },
+  { userId: 'u4', targetId: 'c1' },
+  { userId: 'u4', targetId: 'c2' },
+  { userId: 'u4', targetId: 'dm_cli_01' },
+  { userId: 'u5', targetId: 'c1' },
+  { userId: 'u5', targetId: 'dm_cli_01' },
+  { userId: 'u6', targetId: 'c1' },
+  { userId: 'u6', targetId: 'dm_cli_01' },
+  { userId: 'u7', targetId: 'c2' },
+  { userId: 'u8', targetId: 'c2' },
+] as const;
+
+export const DEMO_USER_PROJECT_ASSIGNMENTS = [
+  { userId: 'u2', targetId: 'p1' },
+  { userId: 'u2', targetId: 'p2' },
+  { userId: 'u2', targetId: 'p3' },
+  { userId: 'u2', targetId: 'dm_proj_01' },
+  { userId: 'u2', targetId: 'dm_proj_02' },
+  { userId: 'u3', targetId: 'p1' },
+  { userId: 'u3', targetId: 'p2' },
+  { userId: 'u3', targetId: 'dm_proj_02' },
+  { userId: 'u4', targetId: 'p1' },
+  { userId: 'u4', targetId: 'p2' },
+  { userId: 'u4', targetId: 'p3' },
+  { userId: 'u4', targetId: 'dm_proj_01' },
+  { userId: 'u4', targetId: 'dm_proj_02' },
+  { userId: 'u5', targetId: 'p1' },
+  { userId: 'u5', targetId: 'p2' },
+  { userId: 'u5', targetId: 'dm_proj_02' },
+  { userId: 'u6', targetId: 'p1' },
+  { userId: 'u6', targetId: 'p2' },
+  { userId: 'u6', targetId: 'dm_proj_01' },
+  { userId: 'u7', targetId: 'p3' },
+  { userId: 'u8', targetId: 'p3' },
+] as const;
+
+export const DEMO_USER_TASK_ASSIGNMENTS = [
+  { userId: 'u2', targetId: 't1' },
+  { userId: 'u2', targetId: 't2' },
+  { userId: 'u2', targetId: 't3' },
+  { userId: 'u2', targetId: 't4' },
+  { userId: 'u3', targetId: 't1' },
+  { userId: 'u3', targetId: 't2' },
+  { userId: 'u3', targetId: 't3' },
+  { userId: 'u4', targetId: 't1' },
+  { userId: 'u4', targetId: 't2' },
+  { userId: 'u4', targetId: 't3' },
+  { userId: 'u4', targetId: 't4' },
+  { userId: 'u5', targetId: 't1' },
+  { userId: 'u5', targetId: 't2' },
+  { userId: 'u5', targetId: 't3' },
+  { userId: 'u6', targetId: 't1' },
+  { userId: 'u6', targetId: 't2' },
+  { userId: 'u6', targetId: 't3' },
+  { userId: 'u7', targetId: 't4' },
+  { userId: 'u8', targetId: 't4' },
+  { userId: 'u2', targetId: 't5' },
+  { userId: 'u3', targetId: 't5' },
+  { userId: 'u4', targetId: 't5' },
+  { userId: 'u7', targetId: 't5' },
+  { userId: 'u8', targetId: 't5' },
+  { userId: 'u2', targetId: 'dm_task_01' },
+  { userId: 'u6', targetId: 'dm_task_02' },
+  { userId: 'u2', targetId: 'dm_task_03' },
+  { userId: 'u5', targetId: 'dm_task_04' },
+  { userId: 'u3', targetId: 'dm_task_05' },
+] as const;
+
 export const DEMO_TIME_ENTRY_IDS = rangeIds('dm_te_', 25);
 
 export const DEMO_ITEM_IDS = {
@@ -474,6 +549,7 @@ export const DEMO_IDS = {
   supplierSales: DEMO_SUPPLIER_SALES.map((item) => item.id),
   supplierInvoices: DEMO_SUPPLIER_INVOICES.map((item) => item.id),
   projects: DEMO_PROJECTS.map((item) => item.id),
+  tasks: [...DEMO_TASKS],
   notifications: [...DEMO_NOTIFICATIONS],
   workUnits: DEMO_WORK_UNITS.map((item) => item.id),
   timeEntries: [...DEMO_TIME_ENTRY_IDS],
@@ -481,10 +557,34 @@ export const DEMO_IDS = {
   settingsUserIds: [...DEMO_USER_IDS],
 } as const;
 
+export const DEMO_ASSIGNMENT_TARGET_IDS = {
+  clients: [...COMPATIBILITY_DEFAULTS.clients, ...DEMO_IDS.clients],
+  projects: [...COMPATIBILITY_DEFAULTS.projects, ...DEMO_IDS.projects],
+  tasks: [...COMPATIBILITY_DEFAULTS.tasks, ...DEMO_IDS.tasks],
+} as const;
+
+export const DEMO_TOP_MANAGER_USER_IDS = DEMO_USERS.reduce<string[]>((ids, user) => {
+  if (user.role === 'top_manager') ids.push(user.id);
+  return ids;
+}, []);
+
+type DemoUserAssignment = { userId: string; targetId: string };
+
+const countSeededAssignmentsWithTopManagers = (
+  manualAssignments: readonly DemoUserAssignment[],
+  targetIds: readonly string[],
+) =>
+  new Set([
+    ...manualAssignments.map((assignment) => `${assignment.userId}\0${assignment.targetId}`),
+    ...DEMO_TOP_MANAGER_USER_IDS.flatMap((userId) =>
+      targetIds.map((targetId) => `${userId}\0${targetId}`),
+    ),
+  ]).size;
+
 export const DEMO_EXPECTED_COUNTS = {
   users: DEMO_USERS.length,
   settings: DEMO_USERS.length,
-  clients: DEMO_CLIENTS.length,
+  clients: COMPATIBILITY_DEFAULTS.clients.length + DEMO_CLIENTS.length,
   suppliers: DEMO_SUPPLIERS.length,
   products: DEMO_PRODUCTS.length,
   quotes: DEMO_QUOTES.length,
@@ -501,10 +601,23 @@ export const DEMO_EXPECTED_COUNTS = {
   supplier_sale_items: DEMO_ITEM_IDS.supplierSaleItems.length,
   supplier_invoices: DEMO_SUPPLIER_INVOICES.length,
   supplier_invoice_items: DEMO_ITEM_IDS.supplierInvoiceItems.length,
-  projects: DEMO_PROJECTS.length,
+  projects: COMPATIBILITY_DEFAULTS.projects.length + DEMO_PROJECTS.length,
+  tasks: COMPATIBILITY_DEFAULTS.tasks.length + DEMO_TASKS.length,
   notifications: DEMO_NOTIFICATIONS.length,
   work_units: DEMO_WORK_UNITS.length,
   work_unit_managers: DEMO_WORK_UNIT_MANAGERS.length,
   user_work_units: DEMO_USER_WORK_UNITS.length,
+  user_clients: countSeededAssignmentsWithTopManagers(
+    DEMO_USER_CLIENT_ASSIGNMENTS,
+    DEMO_ASSIGNMENT_TARGET_IDS.clients,
+  ),
+  user_projects: countSeededAssignmentsWithTopManagers(
+    DEMO_USER_PROJECT_ASSIGNMENTS,
+    DEMO_ASSIGNMENT_TARGET_IDS.projects,
+  ),
+  user_tasks: countSeededAssignmentsWithTopManagers(
+    DEMO_USER_TASK_ASSIGNMENTS,
+    DEMO_ASSIGNMENT_TARGET_IDS.tasks,
+  ),
   time_entries: DEMO_TIME_ENTRY_IDS.length,
 } as const;

--- a/server/test/db/demoSeed.test.ts
+++ b/server/test/db/demoSeed.test.ts
@@ -1,6 +1,26 @@
 import { describe, expect, test } from 'bun:test';
-import { selectDemoUserCleanupIds } from '../../db/demoSeed.ts';
-import { DEMO_USERS } from '../../db/demoSeedManifest.ts';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { PoolClient } from 'pg';
+import {
+  cleanupDemoNamespace,
+  insertCompatibilityDefaults,
+  selectDemoUserCleanupIds,
+} from '../../db/demoSeed.ts';
+import {
+  COMPATIBILITY_DEFAULTS,
+  DEMO_EXPECTED_COUNTS,
+  DEMO_IDS,
+  DEMO_TOP_MANAGER_USER_IDS,
+  DEMO_USER_CLIENT_ASSIGNMENTS,
+  DEMO_USER_PROJECT_ASSIGNMENTS,
+  DEMO_USER_TASK_ASSIGNMENTS,
+  DEMO_USERS,
+} from '../../db/demoSeedManifest.ts';
+import { parseInsertValuesBlocks } from './seedSqlParsing.ts';
+
+const SERVER_ROOT = join(import.meta.dirname, '..', '..');
+const SEED_SQL = readFileSync(join(SERVER_ROOT, 'db', 'seed.sql'), 'utf-8');
 
 const CONTRACT_TYPES = new Set([
   'permanent',
@@ -13,6 +33,38 @@ const CONTRACT_TYPES = new Set([
 const EMPLOYMENT_STATUSES = new Set(['active', 'onboarding', 'on_leave', 'terminated']);
 const WORK_LOCATIONS = new Set(['office', 'remote', 'hybrid', 'customer_site', 'other']);
 
+type QueryCall = { sql: string; params: unknown[] | undefined };
+
+const buildQueryRecorder = (rowCount = 1) => {
+  const calls: QueryCall[] = [];
+  const client = {
+    query: async (sql: string, params?: unknown[]) => {
+      calls.push({ sql, params });
+      return { rowCount, rows: [] };
+    },
+  } as unknown as PoolClient;
+
+  return { calls, client };
+};
+
+const findDelete = (calls: QueryCall[], table: string) =>
+  calls.find((call) => call.sql.startsWith(`DELETE FROM ${table} `));
+
+type DemoAssignment = { userId: string; targetId: string };
+
+const sortAssignments = (assignments: readonly DemoAssignment[]) =>
+  assignments
+    .map((assignment) => `${assignment.userId}:${assignment.targetId}`)
+    .sort((a, b) => a.localeCompare(b));
+
+const parsedAssignments = (table: string, targetColumn: string) =>
+  sortAssignments(
+    parseInsertValuesBlocks(SEED_SQL, table).map((row) => ({
+      userId: row.user_id,
+      targetId: row[targetColumn] ?? '',
+    })),
+  );
+
 describe('selectDemoUserCleanupIds', () => {
   test('preserves canonical demo users so cascading user data survives demo reseed', () => {
     expect(
@@ -21,6 +73,100 @@ describe('selectDemoUserCleanupIds', () => {
       dependentUserIds: ['u2', 'u3', 'legacy-manager'],
       userIdsToDelete: ['legacy-manager'],
     });
+  });
+});
+
+describe('insertCompatibilityDefaults', () => {
+  test('refreshes existing compatibility rows instead of leaving stale conflicts untouched', async () => {
+    const { calls, client } = buildQueryRecorder();
+
+    await insertCompatibilityDefaults(client, {});
+
+    expect(calls).toHaveLength(3);
+    expect(calls[0]?.sql).toContain('ON CONFLICT (id) DO UPDATE SET');
+    expect(calls[0]?.sql).toContain('name = EXCLUDED.name');
+    expect(calls[0]?.sql).toContain('is_disabled = FALSE');
+    expect(calls[0]?.sql).toContain('contacts = DEFAULT');
+    expect(calls[0]?.sql).toContain('client_code = NULL');
+    expect(calls[1]?.sql).toContain('description = EXCLUDED.description');
+    expect(calls[1]?.sql).toContain('tipo_confirmed = EXCLUDED.tipo_confirmed');
+    expect(calls[1]?.sql).toContain('order_id = NULL');
+    expect(calls[1]?.sql).toContain('billing_type = DEFAULT');
+    expect(calls[2]?.sql).toContain('project_id = EXCLUDED.project_id');
+    expect(calls[2]?.sql).toContain('is_recurring = DEFAULT');
+    expect(calls[2]?.sql).toContain('monthly_effort = DEFAULT');
+  });
+});
+
+describe('cleanupDemoNamespace', () => {
+  test('clears preserved demo users from assignment tables before reseeding', async () => {
+    const { calls, client } = buildQueryRecorder();
+
+    await cleanupDemoNamespace(client, {
+      dependentUserIds: ['u2', 'u3', 'legacy-manager'],
+      userIdsToDelete: ['legacy-manager'],
+    });
+
+    for (const table of ['user_clients', 'user_projects', 'user_tasks']) {
+      const call = findDelete(calls, table);
+      expect(call?.sql).toContain('user_id = ANY($1::text[])');
+      expect(call?.params).toEqual([['u2', 'u3', 'legacy-manager']]);
+    }
+  });
+
+  test('clears demo-user activity that would survive because canonical users are preserved', async () => {
+    const { calls, client } = buildQueryRecorder();
+
+    await cleanupDemoNamespace(client, {
+      dependentUserIds: ['u2', 'u3'],
+      userIdsToDelete: [],
+    });
+
+    expect(findDelete(calls, 'time_entries')?.sql).toContain('user_id = ANY($2::text[])');
+    expect(findDelete(calls, 'notifications')?.sql).toContain('user_id = ANY($2::text[])');
+    expect(findDelete(calls, 'user_work_units')?.sql).toContain('user_id = ANY($2::text[])');
+    expect(findDelete(calls, 'work_unit_managers')?.sql).toContain('user_id = ANY($2::text[])');
+  });
+});
+
+describe('demoSeedManifest assignment coverage', () => {
+  test('seed.sql task ids match the compatibility and demo task manifests', () => {
+    expect(
+      parseInsertValuesBlocks(SEED_SQL, 'tasks')
+        .map((row) => row.id)
+        .sort(),
+    ).toEqual([...COMPATIBILITY_DEFAULTS.tasks, ...DEMO_IDS.tasks].sort());
+  });
+
+  test('seed.sql user assignment rows match the demo manifest', () => {
+    expect(parsedAssignments('user_clients', 'client_id')).toEqual(
+      sortAssignments(DEMO_USER_CLIENT_ASSIGNMENTS),
+    );
+    expect(parsedAssignments('user_projects', 'project_id')).toEqual(
+      sortAssignments(DEMO_USER_PROJECT_ASSIGNMENTS),
+    );
+    expect(parsedAssignments('user_tasks', 'task_id')).toEqual(
+      sortAssignments(DEMO_USER_TASK_ASSIGNMENTS),
+    );
+  });
+
+  test('assignment verification counts include top-manager refresh rows', () => {
+    expect(DEMO_TOP_MANAGER_USER_IDS).toEqual(['u9']);
+    expect(DEMO_EXPECTED_COUNTS.user_clients).toBe(
+      DEMO_USER_CLIENT_ASSIGNMENTS.length +
+        DEMO_TOP_MANAGER_USER_IDS.length *
+          (COMPATIBILITY_DEFAULTS.clients.length + DEMO_IDS.clients.length),
+    );
+    expect(DEMO_EXPECTED_COUNTS.user_projects).toBe(
+      DEMO_USER_PROJECT_ASSIGNMENTS.length +
+        DEMO_TOP_MANAGER_USER_IDS.length *
+          (COMPATIBILITY_DEFAULTS.projects.length + DEMO_IDS.projects.length),
+    );
+    expect(DEMO_EXPECTED_COUNTS.user_tasks).toBe(
+      DEMO_USER_TASK_ASSIGNMENTS.length +
+        DEMO_TOP_MANAGER_USER_IDS.length *
+          (COMPATIBILITY_DEFAULTS.tasks.length + DEMO_IDS.tasks.length),
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- Makes demo seed refresh reset the full canonical demo namespace instead of leaving stale compatibility and preserved-user data behind.
- Adds regression coverage for compatibility upserts, assignment cleanup, and manifest drift against `seed.sql`.

## Changes
- Refreshes existing compatibility clients, projects, and tasks with canonical values and default/null resets.
- Clears preserved demo users from assignment/activity tables before reseeding.
- Verifies compatibility rows, demo tasks, and user assignment fan-outs after refresh.
- Documents the stronger refresh behavior in the README.

## Testing
- `bun x biome check --write server/db/demoSeed.ts server/db/demoSeedManifest.ts server/test/db/demoSeed.test.ts README.md`
- `bun test ./server/test/db/demoSeed.test.ts ./server/test/db/seedProjectCoherence.test.ts ./server/test/db/seedTaskReferences.test.ts`
- `bun run typecheck`
- `bun run test:server`
- `bun run test:react-doctor` (`61/100`, `136 warnings`; baseline was `61/100`, `137 warnings`)

## Risks / Rollout
- Low to medium risk, scoped to demo/test seed refresh behavior.
- Existing non-demo records are not broadly deleted; cleanup remains bounded to canonical demo IDs and preserved demo user dependencies.

## Issues
Issue: Not linked