### PR TITLE
administration(fix): use shadcn delete user dialog

### DIFF
--- a/components/administration/UserManagement.tsx
+++ b/components/administration/UserManagement.tsx
@@ -1,4 +1,4 @@
-import { Eye, EyeOff, UserPlus } from 'lucide-react';
+import { Eye, EyeOff, Trash2, TriangleAlert, UserPlus } from 'lucide-react';
 import React, { useReducer } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
@@ -1295,40 +1295,35 @@ const UserManagement: React.FC<UserManagementProps> = ({
 
   return (
     <div className="space-y-6 animate-in slide-in-from-bottom-2 duration-500">
-      {/* Delete Confirmation Modal */}
-      <Modal isOpen={isDeleteConfirmOpen} onClose={cancelDelete}>
-        <div className="bg-card rounded-2xl shadow-2xl w-full max-w-sm overflow-hidden animate-in zoom-in duration-200">
-          <div className="p-6 text-center space-y-4">
-            <div className="size-12 bg-red-500/10 rounded-full flex items-center justify-center mx-auto">
-              <i className="fa-solid fa-triangle-exclamation text-red-600 dark:text-red-400 text-xl"></i>
+      <Dialog
+        open={isDeleteConfirmOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            cancelDelete();
+          }
+        }}
+      >
+        <DialogContent className="sm:max-w-md" showCloseButton={false}>
+          <DialogHeader className="items-center text-center sm:text-center">
+            <div className="mb-1 flex size-12 items-center justify-center rounded-full bg-destructive/10 text-destructive">
+              <TriangleAlert aria-hidden="true" />
             </div>
-            <div>
-              <h3 className="text-lg font-semibold text-foreground">
-                {t('hr:workforce.deleteUser')}
-              </h3>
-              <p className="text-sm text-muted-foreground mt-2 leading-relaxed">
-                {t('hr:workforce.deleteConfirmMessage', { name: userToDelete?.name })}
-              </p>
-            </div>
-            <div className="flex gap-3 pt-2">
-              <button
-                type="button"
-                onClick={cancelDelete}
-                className="flex-1 py-3 text-sm font-bold text-muted-foreground hover:bg-muted rounded-xl transition-colors"
-              >
-                {t('common:buttons.cancel')}
-              </button>
-              <button
-                type="button"
-                onClick={handleDelete}
-                className="flex-1 py-3 bg-red-600 text-white text-sm font-bold rounded-xl shadow-lg shadow-red-200 hover:bg-red-700 transition-all active:scale-95"
-              >
-                {t('hr:workforce.yesDelete')}
-              </button>
-            </div>
-          </div>
-        </div>
-      </Modal>
+            <DialogTitle>{t('hr:workforce.deleteUser')}</DialogTitle>
+            <DialogDescription className="leading-relaxed">
+              {t('hr:workforce.deleteConfirmMessage', { name: userToDelete?.name })}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="sm:justify-center">
+            <Button type="button" variant="outline" onClick={cancelDelete}>
+              {t('common:buttons.cancel')}
+            </Button>
+            <Button type="button" variant="destructive" onClick={handleDelete}>
+              <Trash2 data-icon="inline-start" aria-hidden="true" />
+              {t('hr:workforce.yesDelete')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       <Dialog
         open={!!authMethodUser}

--- a/test/components/administration/UserManagement.test.tsx
+++ b/test/components/administration/UserManagement.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { ComponentProps } from 'react';
 import type { User } from '../../../types';
@@ -226,6 +226,35 @@ describe('<UserManagement />', () => {
 
     expect(props.onUpdateUser).toHaveBeenCalledWith('u2', { isDisabled: true });
     expect(usersApiMock.getRoles).not.toHaveBeenCalled();
+  });
+
+  test('delete confirmation uses shadcn dialog primitives and confirms selected user', async () => {
+    const user = userEvent.setup();
+    const props = renderUserManagement();
+    const bobRow = getRowFor('Bob Brown');
+    const actionButton = bobRow.querySelector('[aria-label="table.rowActions"]');
+    if (!actionButton) throw new Error('Could not find row actions button');
+
+    await user.click(actionButton);
+    await user.click(await screen.findByRole('button', { name: 'hr:workforce.deleteUser' }));
+
+    const dialog = await screen.findByRole('dialog');
+    expect(dialog.getAttribute('data-slot')).toBe('dialog-content');
+    expect(dialog.getAttribute('data-shadcn-theme-scope')).toBe('');
+    expect(screen.getByText('hr:workforce.deleteConfirmMessage')).toBeInTheDocument();
+
+    const cancelButton = within(dialog).getByRole('button', { name: 'common:buttons.cancel' });
+    const confirmButton = within(dialog).getByRole('button', { name: 'hr:workforce.yesDelete' });
+    expect(cancelButton.getAttribute('data-slot')).toBe('button');
+    expect(cancelButton.getAttribute('data-variant')).toBe('outline');
+    expect(confirmButton.getAttribute('data-slot')).toBe('button');
+    expect(confirmButton.getAttribute('data-variant')).toBe('destructive');
+    expect(within(dialog).queryByRole('button', { name: 'Close' })).not.toBeInTheDocument();
+
+    await user.click(confirmButton);
+
+    expect(props.onDeleteUser).toHaveBeenCalledWith('u2');
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
   });
 
   test('locks synced identity fields for non-local users and omits them from account updates', async () => {
@@ -651,7 +680,7 @@ describe('<UserManagement />', () => {
 });
 
 describe('UserManagement dark-mode form chrome', () => {
-  test('edit, delete, and role-assignment modal chrome uses theme tokens, not light zinc', async () => {
+  test('edit and role-assignment modal chrome uses theme tokens, not light zinc', async () => {
     const source = await readComponentSource('administration/UserManagement.tsx');
 
     // Modal panels, the roles list box, section labels, and the role-selector cards adapt to the


### PR DESCRIPTION
## Summary
- Replaces the Administration > Users delete confirmation modal with shadcn dialog primitives.
- Preserves the existing delete/cancel behavior while avoiding an extra default close control.

## Changes
- Uses `Dialog`, `DialogHeader`, `DialogDescription`, `DialogFooter`, and shadcn `Button` for the delete-user confirmation.
- Adds lucide warning/delete icons with theme-token styling.
- Adds regression coverage for the shadcn dialog/buttons, selected-user deletion, and absence of the default close button.

## Testing
- `bun test test/components/administration/UserManagement.test.tsx`
- `bun run lint`
- `bun run test:frontend`
- `bun run test:server`
- `bun run test:react-doctor` stayed `62/100` with `141` warnings

## Risks / Rollout
- Low risk. Change is scoped to the user-delete confirmation UI and its component test.
- No migrations, config changes, API changes, or documentation updates required.

## Issues
Fixes #825