### PR TITLE
seed(fix): use default document codes in demo seed

### DIFF
--- a/server/db/demoSeed.ts
+++ b/server/db/demoSeed.ts
@@ -4,26 +4,23 @@ import * as userAssignmentsRepo from '../repositories/userAssignmentsRepo.ts';
 import { createChildLogger, serializeError } from '../utils/logger.ts';
 import { ensureBootstrapAdmin } from './bootstrapAdmin.ts';
 import {
+  buildDemoAssignmentTargetIds,
+  buildDemoDocumentSeedManifest,
+  buildDemoIds,
   COMPATIBILITY_DEFAULTS,
-  DEMO_ASSIGNMENT_TARGET_IDS,
   DEMO_CLIENTS,
-  DEMO_CUSTOMER_OFFERS,
   DEMO_EXPECTED_COUNTS,
-  DEMO_IDS,
-  DEMO_INVOICES,
   DEMO_ITEM_IDS,
   DEMO_NOTIFICATIONS,
   DEMO_PASSWORD_HASH,
   DEMO_PRODUCTS,
   DEMO_PROJECTS,
-  DEMO_SALES,
-  DEMO_SUPPLIER_INVOICES,
-  DEMO_SUPPLIER_SALES,
   DEMO_SUPPLIERS,
   DEMO_TOP_MANAGER_USER_IDS,
   DEMO_USER_IDS,
   DEMO_USERS,
   DEMO_WORK_UNITS,
+  getDemoSeedYear,
 } from './demoSeedManifest.ts';
 import pool, { query } from './index.ts';
 
@@ -68,6 +65,9 @@ type DemoUserCleanupIds = {
   dependentUserIds: string[];
   userIdsToDelete: string[];
 };
+
+type RuntimeDemoIds = ReturnType<typeof buildDemoIds>;
+type RuntimeDemoAssignmentTargetIds = ReturnType<typeof buildDemoAssignmentTargetIds>;
 
 const nonEmpty = <T>(values: readonly (T | null | undefined)[]) =>
   values.filter((value): value is T => value !== null && value !== undefined);
@@ -136,6 +136,12 @@ const executeDelete = async (
 
 const executeStatement = async (client: PoolClient, sql: string, params?: unknown[]) =>
   client.query(sql, params);
+
+const setDemoSeedYear = async (client: PoolClient, seedYear: number) => {
+  await executeStatement(client, "SELECT set_config('praetor.demo_seed_year', $1, true)", [
+    String(seedYear),
+  ]);
+};
 
 const loadDemoStatements = () => {
   const seedSql = readFileSync(seedPath, 'utf8');
@@ -351,14 +357,67 @@ const insertDemoUsersAndSettings = async (client: PoolClient, counts: Record<str
   incrementCount(counts, 'settings', settingsResult.rowCount ?? 0);
 };
 
-export const cleanupDemoNamespace = async (client: PoolClient, demoUserIds: DemoUserCleanupIds) => {
+export const assertNoDemoDocumentIdConflicts = async (client: PoolClient, seedYear: number) => {
+  const demoIds = buildDemoIds(seedYear);
+  const result = await client.query<{ table_name: string; id: string }>(
+    `WITH conflicts AS (
+       SELECT 'quotes' AS table_name, id
+       FROM quotes
+       WHERE id = ANY($1::text[])
+         AND COALESCE(client_id, '') <> ALL($6::text[])
+       UNION ALL
+       SELECT 'customer_offers' AS table_name, id
+       FROM customer_offers
+       WHERE id = ANY($2::text[])
+         AND COALESCE(client_id, '') <> ALL($6::text[])
+       UNION ALL
+       SELECT 'sales' AS table_name, id
+       FROM sales
+       WHERE id = ANY($3::text[])
+         AND COALESCE(client_id, '') <> ALL($6::text[])
+       UNION ALL
+       SELECT 'supplier_quotes' AS table_name, id
+       FROM supplier_quotes
+       WHERE id = ANY($4::text[])
+         AND COALESCE(supplier_id, '') <> ALL($7::text[])
+       UNION ALL
+       SELECT 'supplier_sales' AS table_name, id
+       FROM supplier_sales
+       WHERE id = ANY($5::text[])
+         AND COALESCE(supplier_id, '') <> ALL($7::text[])
+     )
+     SELECT table_name, id FROM conflicts ORDER BY table_name, id LIMIT 10`,
+    [
+      demoIds.quotes,
+      demoIds.customerOffers,
+      demoIds.sales,
+      demoIds.supplierQuotes,
+      demoIds.supplierSales,
+      demoIds.clients,
+      demoIds.suppliers,
+    ],
+  );
+
+  if (result.rows.length > 0) {
+    const examples = result.rows.map((row) => `${row.table_name}:${row.id}`).join(', ');
+    throw new Error(`Demo seed document ID collision with non-demo records: ${examples}`);
+  }
+};
+
+export const cleanupDemoNamespace = async (
+  client: PoolClient,
+  demoUserIds: DemoUserCleanupIds,
+  seedYear = getDemoSeedYear(),
+) => {
+  const demoDocuments = buildDemoDocumentSeedManifest(seedYear);
+  const demoIds = buildDemoIds(seedYear);
   const cleanupCountsByTable: Record<string, number> = {};
 
   incrementCount(
     cleanupCountsByTable,
     'time_entries',
     await executeDelete(client, 'time_entries', (builder) => {
-      pushTextArrayPredicate(builder, 'id', DEMO_IDS.timeEntries);
+      pushTextArrayPredicate(builder, 'id', demoIds.timeEntries);
       pushTextArrayPredicate(builder, 'user_id', demoUserIds.dependentUserIds);
     }),
   );
@@ -391,7 +450,7 @@ export const cleanupDemoNamespace = async (client: PoolClient, demoUserIds: Demo
     cleanupCountsByTable,
     'user_work_units',
     await executeDelete(client, 'user_work_units', (builder) => {
-      pushTextArrayPredicate(builder, 'work_unit_id', DEMO_IDS.workUnits);
+      pushTextArrayPredicate(builder, 'work_unit_id', demoIds.workUnits);
       pushTextArrayPredicate(builder, 'user_id', demoUserIds.dependentUserIds);
     }),
   );
@@ -400,7 +459,7 @@ export const cleanupDemoNamespace = async (client: PoolClient, demoUserIds: Demo
     cleanupCountsByTable,
     'work_unit_managers',
     await executeDelete(client, 'work_unit_managers', (builder) => {
-      pushTextArrayPredicate(builder, 'work_unit_id', DEMO_IDS.workUnits);
+      pushTextArrayPredicate(builder, 'work_unit_id', demoIds.workUnits);
       pushTextArrayPredicate(builder, 'user_id', demoUserIds.dependentUserIds);
     }),
   );
@@ -409,7 +468,7 @@ export const cleanupDemoNamespace = async (client: PoolClient, demoUserIds: Demo
     cleanupCountsByTable,
     'work_units',
     await executeDelete(client, 'work_units', (builder) => {
-      pushTextArrayPredicate(builder, 'id', DEMO_IDS.workUnits);
+      pushTextArrayPredicate(builder, 'id', demoIds.workUnits);
       pushTextArrayPredicate(
         builder,
         'name',
@@ -432,8 +491,8 @@ export const cleanupDemoNamespace = async (client: PoolClient, demoUserIds: Demo
     'supplier_invoice_items',
     await executeDelete(client, 'supplier_invoice_items', (builder) => {
       pushTextArrayPredicate(builder, 'id', DEMO_ITEM_IDS.supplierInvoiceItems);
-      pushTextArrayPredicate(builder, 'invoice_id', DEMO_IDS.supplierInvoices);
-      pushTextArrayPredicate(builder, 'product_id', DEMO_IDS.products);
+      pushTextArrayPredicate(builder, 'invoice_id', demoIds.supplierInvoices);
+      pushTextArrayPredicate(builder, 'product_id', demoIds.products);
     }),
   );
 
@@ -441,12 +500,12 @@ export const cleanupDemoNamespace = async (client: PoolClient, demoUserIds: Demo
     cleanupCountsByTable,
     'supplier_invoices',
     await executeDelete(client, 'supplier_invoices', (builder) => {
-      pushTextArrayPredicate(builder, 'id', DEMO_IDS.supplierInvoices);
-      pushTextArrayPredicate(builder, 'supplier_id', DEMO_IDS.suppliers);
+      pushTextArrayPredicate(builder, 'id', demoIds.supplierInvoices);
+      pushTextArrayPredicate(builder, 'supplier_id', demoIds.suppliers);
       pushTextArrayPredicate(
         builder,
         'linked_sale_id',
-        nonEmpty(DEMO_SUPPLIER_INVOICES.map((invoice) => invoice.linkedSaleId)),
+        nonEmpty(demoDocuments.supplierInvoices.map((invoice) => invoice.linkedSaleId)),
       );
     }),
   );
@@ -456,8 +515,8 @@ export const cleanupDemoNamespace = async (client: PoolClient, demoUserIds: Demo
     'supplier_sale_items',
     await executeDelete(client, 'supplier_sale_items', (builder) => {
       pushTextArrayPredicate(builder, 'id', DEMO_ITEM_IDS.supplierSaleItems);
-      pushTextArrayPredicate(builder, 'sale_id', DEMO_IDS.supplierSales);
-      pushTextArrayPredicate(builder, 'product_id', DEMO_IDS.products);
+      pushTextArrayPredicate(builder, 'sale_id', demoIds.supplierSales);
+      pushTextArrayPredicate(builder, 'product_id', demoIds.products);
     }),
   );
 
@@ -465,12 +524,12 @@ export const cleanupDemoNamespace = async (client: PoolClient, demoUserIds: Demo
     cleanupCountsByTable,
     'supplier_sales',
     await executeDelete(client, 'supplier_sales', (builder) => {
-      pushTextArrayPredicate(builder, 'id', DEMO_IDS.supplierSales);
-      pushTextArrayPredicate(builder, 'supplier_id', DEMO_IDS.suppliers);
+      pushTextArrayPredicate(builder, 'id', demoIds.supplierSales);
+      pushTextArrayPredicate(builder, 'supplier_id', demoIds.suppliers);
       pushTextArrayPredicate(
         builder,
         'linked_quote_id',
-        nonEmpty(DEMO_SUPPLIER_SALES.map((sale) => sale.linkedQuoteId)),
+        nonEmpty(demoDocuments.supplierSales.map((sale) => sale.linkedQuoteId)),
       );
     }),
   );
@@ -480,8 +539,8 @@ export const cleanupDemoNamespace = async (client: PoolClient, demoUserIds: Demo
     'supplier_quote_items',
     await executeDelete(client, 'supplier_quote_items', (builder) => {
       pushTextArrayPredicate(builder, 'id', DEMO_ITEM_IDS.supplierQuoteItems);
-      pushTextArrayPredicate(builder, 'quote_id', DEMO_IDS.supplierQuotes);
-      pushTextArrayPredicate(builder, 'product_id', DEMO_IDS.products);
+      pushTextArrayPredicate(builder, 'quote_id', demoIds.supplierQuotes);
+      pushTextArrayPredicate(builder, 'product_id', demoIds.products);
     }),
   );
 
@@ -489,8 +548,8 @@ export const cleanupDemoNamespace = async (client: PoolClient, demoUserIds: Demo
     cleanupCountsByTable,
     'supplier_quotes',
     await executeDelete(client, 'supplier_quotes', (builder) => {
-      pushTextArrayPredicate(builder, 'id', DEMO_IDS.supplierQuotes);
-      pushTextArrayPredicate(builder, 'supplier_id', DEMO_IDS.suppliers);
+      pushTextArrayPredicate(builder, 'id', demoIds.supplierQuotes);
+      pushTextArrayPredicate(builder, 'supplier_id', demoIds.suppliers);
     }),
   );
 
@@ -499,8 +558,8 @@ export const cleanupDemoNamespace = async (client: PoolClient, demoUserIds: Demo
     'invoice_items',
     await executeDelete(client, 'invoice_items', (builder) => {
       pushTextArrayPredicate(builder, 'id', DEMO_ITEM_IDS.invoiceItems);
-      pushTextArrayPredicate(builder, 'invoice_id', DEMO_IDS.invoices);
-      pushTextArrayPredicate(builder, 'product_id', DEMO_IDS.products);
+      pushTextArrayPredicate(builder, 'invoice_id', demoIds.invoices);
+      pushTextArrayPredicate(builder, 'product_id', demoIds.products);
     }),
   );
 
@@ -508,12 +567,12 @@ export const cleanupDemoNamespace = async (client: PoolClient, demoUserIds: Demo
     cleanupCountsByTable,
     'invoices',
     await executeDelete(client, 'invoices', (builder) => {
-      pushTextArrayPredicate(builder, 'id', DEMO_IDS.invoices);
-      pushTextArrayPredicate(builder, 'client_id', DEMO_IDS.clients);
+      pushTextArrayPredicate(builder, 'id', demoIds.invoices);
+      pushTextArrayPredicate(builder, 'client_id', demoIds.clients);
       pushTextArrayPredicate(
         builder,
         'linked_sale_id',
-        nonEmpty(DEMO_INVOICES.map((invoice) => invoice.linkedSaleId)),
+        nonEmpty(demoDocuments.invoices.map((invoice) => invoice.linkedSaleId)),
       );
     }),
   );
@@ -523,8 +582,8 @@ export const cleanupDemoNamespace = async (client: PoolClient, demoUserIds: Demo
     'sale_items',
     await executeDelete(client, 'sale_items', (builder) => {
       pushTextArrayPredicate(builder, 'id', DEMO_ITEM_IDS.saleItems);
-      pushTextArrayPredicate(builder, 'sale_id', DEMO_IDS.sales);
-      pushTextArrayPredicate(builder, 'product_id', DEMO_IDS.products);
+      pushTextArrayPredicate(builder, 'sale_id', demoIds.sales);
+      pushTextArrayPredicate(builder, 'product_id', demoIds.products);
     }),
   );
 
@@ -532,12 +591,12 @@ export const cleanupDemoNamespace = async (client: PoolClient, demoUserIds: Demo
     cleanupCountsByTable,
     'sales',
     await executeDelete(client, 'sales', (builder) => {
-      pushTextArrayPredicate(builder, 'id', DEMO_IDS.sales);
-      pushTextArrayPredicate(builder, 'client_id', DEMO_IDS.clients);
+      pushTextArrayPredicate(builder, 'id', demoIds.sales);
+      pushTextArrayPredicate(builder, 'client_id', demoIds.clients);
       pushTextArrayPredicate(
         builder,
         'linked_offer_id',
-        nonEmpty(DEMO_SALES.map((sale) => sale.linkedOfferId)),
+        nonEmpty(demoDocuments.sales.map((sale) => sale.linkedOfferId)),
       );
     }),
   );
@@ -547,8 +606,8 @@ export const cleanupDemoNamespace = async (client: PoolClient, demoUserIds: Demo
     'customer_offer_items',
     await executeDelete(client, 'customer_offer_items', (builder) => {
       pushTextArrayPredicate(builder, 'id', DEMO_ITEM_IDS.customerOfferItems);
-      pushTextArrayPredicate(builder, 'offer_id', DEMO_IDS.customerOffers);
-      pushTextArrayPredicate(builder, 'product_id', DEMO_IDS.products);
+      pushTextArrayPredicate(builder, 'offer_id', demoIds.customerOffers);
+      pushTextArrayPredicate(builder, 'product_id', demoIds.products);
     }),
   );
 
@@ -556,12 +615,12 @@ export const cleanupDemoNamespace = async (client: PoolClient, demoUserIds: Demo
     cleanupCountsByTable,
     'customer_offers',
     await executeDelete(client, 'customer_offers', (builder) => {
-      pushTextArrayPredicate(builder, 'id', DEMO_IDS.customerOffers);
-      pushTextArrayPredicate(builder, 'client_id', DEMO_IDS.clients);
+      pushTextArrayPredicate(builder, 'id', demoIds.customerOffers);
+      pushTextArrayPredicate(builder, 'client_id', demoIds.clients);
       pushTextArrayPredicate(
         builder,
         'linked_quote_id',
-        DEMO_CUSTOMER_OFFERS.map((offer) => offer.linkedQuoteId),
+        demoDocuments.customerOffers.map((offer) => offer.linkedQuoteId),
       );
     }),
   );
@@ -571,8 +630,8 @@ export const cleanupDemoNamespace = async (client: PoolClient, demoUserIds: Demo
     'quote_items',
     await executeDelete(client, 'quote_items', (builder) => {
       pushTextArrayPredicate(builder, 'id', DEMO_ITEM_IDS.quoteItems);
-      pushTextArrayPredicate(builder, 'quote_id', DEMO_IDS.quotes);
-      pushTextArrayPredicate(builder, 'product_id', DEMO_IDS.products);
+      pushTextArrayPredicate(builder, 'quote_id', demoIds.quotes);
+      pushTextArrayPredicate(builder, 'product_id', demoIds.products);
     }),
   );
 
@@ -580,8 +639,8 @@ export const cleanupDemoNamespace = async (client: PoolClient, demoUserIds: Demo
     cleanupCountsByTable,
     'quotes',
     await executeDelete(client, 'quotes', (builder) => {
-      pushTextArrayPredicate(builder, 'id', DEMO_IDS.quotes);
-      pushTextArrayPredicate(builder, 'client_id', DEMO_IDS.clients);
+      pushTextArrayPredicate(builder, 'id', demoIds.quotes);
+      pushTextArrayPredicate(builder, 'client_id', demoIds.clients);
     }),
   );
 
@@ -589,7 +648,7 @@ export const cleanupDemoNamespace = async (client: PoolClient, demoUserIds: Demo
     cleanupCountsByTable,
     'products',
     await executeDelete(client, 'products', (builder) => {
-      pushTextArrayPredicate(builder, 'id', DEMO_IDS.products);
+      pushTextArrayPredicate(builder, 'id', demoIds.products);
       pushTextArrayPredicate(
         builder,
         'product_code',
@@ -600,7 +659,7 @@ export const cleanupDemoNamespace = async (client: PoolClient, demoUserIds: Demo
         'name',
         DEMO_PRODUCTS.map((product) => product.name),
       );
-      pushTextArrayPredicate(builder, 'supplier_id', DEMO_IDS.suppliers);
+      pushTextArrayPredicate(builder, 'supplier_id', demoIds.suppliers);
     }),
   );
 
@@ -608,13 +667,13 @@ export const cleanupDemoNamespace = async (client: PoolClient, demoUserIds: Demo
     cleanupCountsByTable,
     'projects',
     await executeDelete(client, 'projects', (builder) => {
-      pushTextArrayPredicate(builder, 'id', DEMO_IDS.projects);
+      pushTextArrayPredicate(builder, 'id', demoIds.projects);
       pushTextArrayPredicate(
         builder,
         'name',
         DEMO_PROJECTS.map((project) => project.name),
       );
-      pushTextArrayPredicate(builder, 'client_id', DEMO_IDS.clients);
+      pushTextArrayPredicate(builder, 'client_id', demoIds.clients);
     }),
   );
 
@@ -622,8 +681,8 @@ export const cleanupDemoNamespace = async (client: PoolClient, demoUserIds: Demo
     cleanupCountsByTable,
     'tasks',
     await executeDelete(client, 'tasks', (builder) => {
-      pushTextArrayPredicate(builder, 'id', DEMO_IDS.tasks);
-      pushTextArrayPredicate(builder, 'project_id', DEMO_IDS.projects);
+      pushTextArrayPredicate(builder, 'id', demoIds.tasks);
+      pushTextArrayPredicate(builder, 'project_id', demoIds.projects);
     }),
   );
 
@@ -631,7 +690,7 @@ export const cleanupDemoNamespace = async (client: PoolClient, demoUserIds: Demo
     cleanupCountsByTable,
     'suppliers',
     await executeDelete(client, 'suppliers', (builder) => {
-      pushTextArrayPredicate(builder, 'id', DEMO_IDS.suppliers);
+      pushTextArrayPredicate(builder, 'id', demoIds.suppliers);
       pushTextArrayPredicate(
         builder,
         'supplier_code',
@@ -644,7 +703,7 @@ export const cleanupDemoNamespace = async (client: PoolClient, demoUserIds: Demo
     cleanupCountsByTable,
     'clients',
     await executeDelete(client, 'clients', (builder) => {
-      pushTextArrayPredicate(builder, 'id', DEMO_IDS.clients);
+      pushTextArrayPredicate(builder, 'id', demoIds.clients);
       pushTextArrayPredicate(
         builder,
         'client_code',
@@ -713,22 +772,25 @@ const executeDemoStatements = async (client: PoolClient, counts: Record<string, 
   return failedStatements;
 };
 
-const verificationSteps: VerificationStep[] = [
+const buildVerificationSteps = (
+  demoIds: RuntimeDemoIds,
+  assignmentTargetIds: RuntimeDemoAssignmentTargetIds,
+): VerificationStep[] => [
   { table: 'users', countColumn: 'id', ids: DEMO_USER_IDS, expected: DEMO_EXPECTED_COUNTS.users },
   {
     table: 'settings',
     countColumn: 'user_id',
-    ids: DEMO_IDS.settingsUserIds,
+    ids: demoIds.settingsUserIds,
     expected: DEMO_EXPECTED_COUNTS.settings,
   },
   {
     table: 'clients',
-    ids: [...COMPATIBILITY_DEFAULTS.clients, ...DEMO_IDS.clients],
+    ids: [...COMPATIBILITY_DEFAULTS.clients, ...demoIds.clients],
     expected: DEMO_EXPECTED_COUNTS.clients,
   },
-  { table: 'suppliers', ids: DEMO_IDS.suppliers, expected: DEMO_EXPECTED_COUNTS.suppliers },
-  { table: 'products', ids: DEMO_IDS.products, expected: DEMO_EXPECTED_COUNTS.products },
-  { table: 'quotes', ids: DEMO_IDS.quotes, expected: DEMO_EXPECTED_COUNTS.quotes },
+  { table: 'suppliers', ids: demoIds.suppliers, expected: DEMO_EXPECTED_COUNTS.suppliers },
+  { table: 'products', ids: demoIds.products, expected: DEMO_EXPECTED_COUNTS.products },
+  { table: 'quotes', ids: demoIds.quotes, expected: DEMO_EXPECTED_COUNTS.quotes },
   {
     table: 'quote_items',
     ids: DEMO_ITEM_IDS.quoteItems,
@@ -736,7 +798,7 @@ const verificationSteps: VerificationStep[] = [
   },
   {
     table: 'customer_offers',
-    ids: DEMO_IDS.customerOffers,
+    ids: demoIds.customerOffers,
     expected: DEMO_EXPECTED_COUNTS.customer_offers,
   },
   {
@@ -744,13 +806,13 @@ const verificationSteps: VerificationStep[] = [
     ids: DEMO_ITEM_IDS.customerOfferItems,
     expected: DEMO_EXPECTED_COUNTS.customer_offer_items,
   },
-  { table: 'sales', ids: DEMO_IDS.sales, expected: DEMO_EXPECTED_COUNTS.sales },
+  { table: 'sales', ids: demoIds.sales, expected: DEMO_EXPECTED_COUNTS.sales },
   {
     table: 'sale_items',
     ids: DEMO_ITEM_IDS.saleItems,
     expected: DEMO_EXPECTED_COUNTS.sale_items,
   },
-  { table: 'invoices', ids: DEMO_IDS.invoices, expected: DEMO_EXPECTED_COUNTS.invoices },
+  { table: 'invoices', ids: demoIds.invoices, expected: DEMO_EXPECTED_COUNTS.invoices },
   {
     table: 'invoice_items',
     ids: DEMO_ITEM_IDS.invoiceItems,
@@ -758,7 +820,7 @@ const verificationSteps: VerificationStep[] = [
   },
   {
     table: 'supplier_quotes',
-    ids: DEMO_IDS.supplierQuotes,
+    ids: demoIds.supplierQuotes,
     expected: DEMO_EXPECTED_COUNTS.supplier_quotes,
   },
   {
@@ -768,7 +830,7 @@ const verificationSteps: VerificationStep[] = [
   },
   {
     table: 'supplier_sales',
-    ids: DEMO_IDS.supplierSales,
+    ids: demoIds.supplierSales,
     expected: DEMO_EXPECTED_COUNTS.supplier_sales,
   },
   {
@@ -778,7 +840,7 @@ const verificationSteps: VerificationStep[] = [
   },
   {
     table: 'supplier_invoices',
-    ids: DEMO_IDS.supplierInvoices,
+    ids: demoIds.supplierInvoices,
     expected: DEMO_EXPECTED_COUNTS.supplier_invoices,
   },
   {
@@ -788,57 +850,60 @@ const verificationSteps: VerificationStep[] = [
   },
   {
     table: 'projects',
-    ids: [...COMPATIBILITY_DEFAULTS.projects, ...DEMO_IDS.projects],
+    ids: [...COMPATIBILITY_DEFAULTS.projects, ...demoIds.projects],
     expected: DEMO_EXPECTED_COUNTS.projects,
   },
   {
     table: 'tasks',
-    ids: [...COMPATIBILITY_DEFAULTS.tasks, ...DEMO_IDS.tasks],
+    ids: [...COMPATIBILITY_DEFAULTS.tasks, ...demoIds.tasks],
     expected: DEMO_EXPECTED_COUNTS.tasks,
   },
   {
     table: 'notifications',
-    ids: DEMO_IDS.notifications,
+    ids: demoIds.notifications,
     expected: DEMO_EXPECTED_COUNTS.notifications,
   },
-  { table: 'work_units', ids: DEMO_IDS.workUnits, expected: DEMO_EXPECTED_COUNTS.work_units },
+  { table: 'work_units', ids: demoIds.workUnits, expected: DEMO_EXPECTED_COUNTS.work_units },
   {
     table: 'work_unit_managers',
     countColumn: 'work_unit_id',
-    ids: DEMO_IDS.workUnits,
+    ids: demoIds.workUnits,
     expected: DEMO_EXPECTED_COUNTS.work_unit_managers,
   },
   {
     table: 'user_work_units',
     countColumn: 'work_unit_id',
-    ids: DEMO_IDS.workUnits,
+    ids: demoIds.workUnits,
     expected: DEMO_EXPECTED_COUNTS.user_work_units,
   },
   {
     table: 'user_clients',
     countColumn: 'client_id',
-    ids: DEMO_ASSIGNMENT_TARGET_IDS.clients,
+    ids: assignmentTargetIds.clients,
     userIds: DEMO_USER_IDS,
     expected: DEMO_EXPECTED_COUNTS.user_clients,
   },
   {
     table: 'user_projects',
     countColumn: 'project_id',
-    ids: DEMO_ASSIGNMENT_TARGET_IDS.projects,
+    ids: assignmentTargetIds.projects,
     userIds: DEMO_USER_IDS,
     expected: DEMO_EXPECTED_COUNTS.user_projects,
   },
   {
     table: 'user_tasks',
     countColumn: 'task_id',
-    ids: DEMO_ASSIGNMENT_TARGET_IDS.tasks,
+    ids: assignmentTargetIds.tasks,
     userIds: DEMO_USER_IDS,
     expected: DEMO_EXPECTED_COUNTS.user_tasks,
   },
-  { table: 'time_entries', ids: DEMO_IDS.timeEntries, expected: DEMO_EXPECTED_COUNTS.time_entries },
+  { table: 'time_entries', ids: demoIds.timeEntries, expected: DEMO_EXPECTED_COUNTS.time_entries },
 ];
 
-const verifyDemoDataset = async () => {
+const verifyDemoDataset = async (seedYear: number) => {
+  const demoIds = buildDemoIds(seedYear);
+  const assignmentTargetIds = buildDemoAssignmentTargetIds(demoIds);
+  const verificationSteps = buildVerificationSteps(demoIds, assignmentTargetIds);
   const verificationCountsByTable: Record<string, number> = {};
   const mismatches: Array<{ table: string; expected: number; actual: number }> = [];
 
@@ -875,7 +940,7 @@ const collectDemoUserCleanupIds = async (client: PoolClient) => {
      FROM users
      WHERE id = ANY($1::text[]) OR username = ANY($2::text[])
      ORDER BY id`,
-    [DEMO_IDS.users, DEMO_USERS.map((user) => user.username)],
+    [DEMO_USER_IDS, DEMO_USERS.map((user) => user.username)],
   );
   return selectDemoUserCleanupIds(result.rows);
 };
@@ -885,6 +950,7 @@ export const runDemoSeedRefresh = async ({
 }: {
   source: DemoSeedSource;
 }): Promise<DemoSeedResult> => {
+  const seedYear = getDemoSeedYear();
   const insertCountsByTable: Record<string, number> = {};
   let cleanupCountsByTable: Record<string, number> = {};
   let verificationCountsByTable: Record<string, number> = {};
@@ -901,7 +967,10 @@ export const runDemoSeedRefresh = async ({
     await client.query('BEGIN');
     inTransaction = true;
 
-    cleanupCountsByTable = await cleanupDemoNamespace(client, demoUserIds);
+    await setDemoSeedYear(client, seedYear);
+    await assertNoDemoDocumentIdConflicts(client, seedYear);
+
+    cleanupCountsByTable = await cleanupDemoNamespace(client, demoUserIds, seedYear);
     await insertCompatibilityDefaults(client, insertCountsByTable);
     await insertDemoUsersAndSettings(client, insertCountsByTable);
 
@@ -944,7 +1013,7 @@ export const runDemoSeedRefresh = async ({
   }
 
   try {
-    const verification = await verifyDemoDataset();
+    const verification = await verifyDemoDataset(seedYear);
     verificationCountsByTable = verification.verificationCountsByTable;
 
     if (verification.mismatches.length > 0) {

--- a/server/db/demoSeedManifest.ts
+++ b/server/db/demoSeedManifest.ts
@@ -1,9 +1,22 @@
+import {
+  DOCUMENT_CODE_MODULES,
+  type DocumentCodeModuleId,
+  renderDocumentCode,
+} from '../utils/document-codes.ts';
 import type { UserContractType, UserEmploymentStatus, UserWorkLocation } from './schema/users.ts';
 
 const rangeIds = (prefix: string, count: number, pad = 2) =>
   Array.from({ length: count }, (_, index) => `${prefix}${String(index + 1).padStart(pad, '0')}`);
 
 const currentYear = new Date().getFullYear();
+
+const demoDocumentCode = (moduleId: DocumentCodeModuleId, sequence: number) =>
+  renderDocumentCode(DOCUMENT_CODE_MODULES[moduleId], { year: currentYear, sequence });
+
+const rangeDocumentCodes = (moduleId: DocumentCodeModuleId, count: number) =>
+  Array.from({ length: count }, (_, index) => ({
+    id: demoDocumentCode(moduleId, index + 1),
+  }));
 
 export const DEMO_PASSWORD_HASH = '$2a$12$z5H7VrzTpLImYWSH3xufKufCiGB0n9CSlNMOrRBRIxq.6mvuVS7uy';
 
@@ -326,81 +339,64 @@ export const DEMO_PRODUCTS = [
   { id: 'dm_prd_09', productCode: 'DM-DISABLED-001', name: 'Legacy Token Pack' },
 ] as const;
 
-export const DEMO_QUOTES = [
-  { id: 'dm_cq_01' },
-  { id: 'dm_cq_02' },
-  { id: 'dm_cq_03' },
-  { id: 'dm_cq_04' },
-  { id: 'dm_cq_05' },
-  { id: 'dm_cq_06' },
-  { id: 'dm_cq_07' },
-  { id: 'dm_cq_08' },
-  { id: 'dm_cq_09' },
-  { id: 'dm_cq_10' },
-  // Accepted "procurement drivers" (#779 derived supplier statuses): their 1-to-1 links keep
-  // the order-backed supplier quotes dm_sq_11..14 in the Accepted state.
-  { id: 'dm_cq_11' },
-  { id: 'dm_cq_12' },
-  { id: 'dm_cq_13' },
-  { id: 'dm_cq_14' },
-] as const;
+export const DEMO_QUOTES = rangeDocumentCodes('client_quote', 14);
 
 export const DEMO_CUSTOMER_OFFERS = [
-  { id: 'dm_co_01', linkedQuoteId: 'dm_cq_04' },
-  { id: 'dm_co_02', linkedQuoteId: 'dm_cq_05' },
-  { id: 'dm_co_03', linkedQuoteId: 'dm_cq_06' },
-  { id: 'dm_co_04', linkedQuoteId: 'dm_cq_07' },
-  { id: 'dm_co_05', linkedQuoteId: 'dm_cq_08' },
-] as const;
+  { id: demoDocumentCode('client_offer', 1), linkedQuoteId: demoDocumentCode('client_quote', 4) },
+  { id: demoDocumentCode('client_offer', 2), linkedQuoteId: demoDocumentCode('client_quote', 5) },
+  { id: demoDocumentCode('client_offer', 3), linkedQuoteId: demoDocumentCode('client_quote', 6) },
+  { id: demoDocumentCode('client_offer', 4), linkedQuoteId: demoDocumentCode('client_quote', 7) },
+  { id: demoDocumentCode('client_offer', 5), linkedQuoteId: demoDocumentCode('client_quote', 8) },
+];
 
 export const DEMO_SALES = [
-  { id: 'dm_so_01', linkedOfferId: null },
-  { id: 'dm_so_02', linkedOfferId: 'dm_co_04' },
-  { id: 'dm_so_03', linkedOfferId: null },
-  { id: 'dm_so_04', linkedOfferId: 'dm_co_03' },
-  { id: 'dm_so_05', linkedOfferId: null },
-] as const;
+  { id: demoDocumentCode('client_order', 1), linkedOfferId: null },
+  { id: demoDocumentCode('client_order', 2), linkedOfferId: demoDocumentCode('client_offer', 4) },
+  { id: demoDocumentCode('client_order', 3), linkedOfferId: null },
+  { id: demoDocumentCode('client_order', 4), linkedOfferId: demoDocumentCode('client_offer', 3) },
+  { id: demoDocumentCode('client_order', 5), linkedOfferId: null },
+];
 
 export const DEMO_INVOICES = [
   { id: 'dm_inv_01', linkedSaleId: null },
   { id: 'dm_inv_02', linkedSaleId: null },
-  { id: 'dm_inv_03', linkedSaleId: 'dm_so_04' },
+  { id: 'dm_inv_03', linkedSaleId: demoDocumentCode('client_order', 4) },
   { id: 'dm_inv_04', linkedSaleId: null },
   { id: 'dm_inv_05', linkedSaleId: null },
-] as const;
+];
 
-export const DEMO_SUPPLIER_QUOTES = [
-  { id: 'dm_sq_01' },
-  { id: 'dm_sq_02' },
-  { id: 'dm_sq_03' },
-  { id: 'dm_sq_04' },
-  { id: 'dm_sq_05' },
-  { id: 'dm_sq_06' },
-  { id: 'dm_sq_07' },
-  { id: 'dm_sq_08' },
-  { id: 'dm_sq_09' },
-  { id: 'dm_sq_10' },
-  { id: 'dm_sq_11' },
-  { id: 'dm_sq_12' },
-  { id: 'dm_sq_13' },
-  { id: 'dm_sq_14' },
-] as const;
+export const DEMO_SUPPLIER_QUOTES = rangeDocumentCodes('supplier_quote', 14);
 
 export const DEMO_SUPPLIER_SALES = [
-  { id: 'dm_ss_01', linkedQuoteId: 'dm_sq_11' },
-  { id: 'dm_ss_02', linkedQuoteId: 'dm_sq_07' },
-  { id: 'dm_ss_03', linkedQuoteId: 'dm_sq_12' },
-  { id: 'dm_ss_04', linkedQuoteId: 'dm_sq_13' },
-  { id: 'dm_ss_05', linkedQuoteId: 'dm_sq_14' },
-] as const;
+  {
+    id: demoDocumentCode('supplier_order', 1),
+    linkedQuoteId: demoDocumentCode('supplier_quote', 11),
+  },
+  {
+    id: demoDocumentCode('supplier_order', 2),
+    linkedQuoteId: demoDocumentCode('supplier_quote', 7),
+  },
+  {
+    id: demoDocumentCode('supplier_order', 3),
+    linkedQuoteId: demoDocumentCode('supplier_quote', 12),
+  },
+  {
+    id: demoDocumentCode('supplier_order', 4),
+    linkedQuoteId: demoDocumentCode('supplier_quote', 13),
+  },
+  {
+    id: demoDocumentCode('supplier_order', 5),
+    linkedQuoteId: demoDocumentCode('supplier_quote', 14),
+  },
+];
 
 export const DEMO_SUPPLIER_INVOICES = [
   { id: 'dm_sinv_01', linkedSaleId: null },
   { id: 'dm_sinv_02', linkedSaleId: null },
-  { id: 'dm_sinv_03', linkedSaleId: 'dm_ss_04' },
+  { id: 'dm_sinv_03', linkedSaleId: demoDocumentCode('supplier_order', 4) },
   { id: 'dm_sinv_04', linkedSaleId: null },
   { id: 'dm_sinv_05', linkedSaleId: null },
-] as const;
+];
 
 export const DEMO_PROJECTS = [
   { id: 'dm_proj_01', name: `DM-CLI-001_DM-SVC-AUDIT_${currentYear}` },

--- a/server/db/demoSeedManifest.ts
+++ b/server/db/demoSeedManifest.ts
@@ -8,14 +8,23 @@ import type { UserContractType, UserEmploymentStatus, UserWorkLocation } from '.
 const rangeIds = (prefix: string, count: number, pad = 2) =>
   Array.from({ length: count }, (_, index) => `${prefix}${String(index + 1).padStart(pad, '0')}`);
 
-const currentYear = new Date().getFullYear();
+export const getDemoSeedYear = () => new Date().getFullYear();
 
-const demoDocumentCode = (moduleId: DocumentCodeModuleId, sequence: number) =>
-  renderDocumentCode(DOCUMENT_CODE_MODULES[moduleId], { year: currentYear, sequence });
+const currentYear = getDemoSeedYear();
 
-const rangeDocumentCodes = (moduleId: DocumentCodeModuleId, count: number) =>
+export const demoDocumentCode = (
+  moduleId: DocumentCodeModuleId,
+  sequence: number,
+  seedYear = getDemoSeedYear(),
+) => renderDocumentCode(DOCUMENT_CODE_MODULES[moduleId], { year: seedYear, sequence });
+
+const rangeDocumentCodes = (
+  moduleId: DocumentCodeModuleId,
+  count: number,
+  seedYear = getDemoSeedYear(),
+) =>
   Array.from({ length: count }, (_, index) => ({
-    id: demoDocumentCode(moduleId, index + 1),
+    id: demoDocumentCode(moduleId, index + 1, seedYear),
   }));
 
 export const DEMO_PASSWORD_HASH = '$2a$12$z5H7VrzTpLImYWSH3xufKufCiGB0n9CSlNMOrRBRIxq.6mvuVS7uy';
@@ -339,64 +348,81 @@ export const DEMO_PRODUCTS = [
   { id: 'dm_prd_09', productCode: 'DM-DISABLED-001', name: 'Legacy Token Pack' },
 ] as const;
 
-export const DEMO_QUOTES = rangeDocumentCodes('client_quote', 14);
+export const buildDemoDocumentSeedManifest = (seedYear = getDemoSeedYear()) => {
+  const code = (moduleId: DocumentCodeModuleId, sequence: number) =>
+    demoDocumentCode(moduleId, sequence, seedYear);
 
-export const DEMO_CUSTOMER_OFFERS = [
-  { id: demoDocumentCode('client_offer', 1), linkedQuoteId: demoDocumentCode('client_quote', 4) },
-  { id: demoDocumentCode('client_offer', 2), linkedQuoteId: demoDocumentCode('client_quote', 5) },
-  { id: demoDocumentCode('client_offer', 3), linkedQuoteId: demoDocumentCode('client_quote', 6) },
-  { id: demoDocumentCode('client_offer', 4), linkedQuoteId: demoDocumentCode('client_quote', 7) },
-  { id: demoDocumentCode('client_offer', 5), linkedQuoteId: demoDocumentCode('client_quote', 8) },
-];
+  return {
+    quotes: rangeDocumentCodes('client_quote', 14, seedYear),
+    customerOffers: [
+      { id: code('client_offer', 1), linkedQuoteId: code('client_quote', 4) },
+      { id: code('client_offer', 2), linkedQuoteId: code('client_quote', 5) },
+      { id: code('client_offer', 3), linkedQuoteId: code('client_quote', 6) },
+      { id: code('client_offer', 4), linkedQuoteId: code('client_quote', 7) },
+      { id: code('client_offer', 5), linkedQuoteId: code('client_quote', 8) },
+    ],
+    sales: [
+      { id: code('client_order', 1), linkedOfferId: null },
+      { id: code('client_order', 2), linkedOfferId: code('client_offer', 4) },
+      { id: code('client_order', 3), linkedOfferId: null },
+      { id: code('client_order', 4), linkedOfferId: code('client_offer', 3) },
+      { id: code('client_order', 5), linkedOfferId: null },
+    ],
+    invoices: [
+      { id: 'dm_inv_01', linkedSaleId: null },
+      { id: 'dm_inv_02', linkedSaleId: null },
+      { id: 'dm_inv_03', linkedSaleId: code('client_order', 4) },
+      { id: 'dm_inv_04', linkedSaleId: null },
+      { id: 'dm_inv_05', linkedSaleId: null },
+    ],
+    supplierQuotes: rangeDocumentCodes('supplier_quote', 14, seedYear),
+    supplierSales: [
+      {
+        id: code('supplier_order', 1),
+        linkedQuoteId: code('supplier_quote', 11),
+      },
+      {
+        id: code('supplier_order', 2),
+        linkedQuoteId: code('supplier_quote', 7),
+      },
+      {
+        id: code('supplier_order', 3),
+        linkedQuoteId: code('supplier_quote', 12),
+      },
+      {
+        id: code('supplier_order', 4),
+        linkedQuoteId: code('supplier_quote', 13),
+      },
+      {
+        id: code('supplier_order', 5),
+        linkedQuoteId: code('supplier_quote', 14),
+      },
+    ],
+    supplierInvoices: [
+      { id: 'dm_sinv_01', linkedSaleId: null },
+      { id: 'dm_sinv_02', linkedSaleId: null },
+      { id: 'dm_sinv_03', linkedSaleId: code('supplier_order', 4) },
+      { id: 'dm_sinv_04', linkedSaleId: null },
+      { id: 'dm_sinv_05', linkedSaleId: null },
+    ],
+  };
+};
 
-export const DEMO_SALES = [
-  { id: demoDocumentCode('client_order', 1), linkedOfferId: null },
-  { id: demoDocumentCode('client_order', 2), linkedOfferId: demoDocumentCode('client_offer', 4) },
-  { id: demoDocumentCode('client_order', 3), linkedOfferId: null },
-  { id: demoDocumentCode('client_order', 4), linkedOfferId: demoDocumentCode('client_offer', 3) },
-  { id: demoDocumentCode('client_order', 5), linkedOfferId: null },
-];
+const DEFAULT_DEMO_DOCUMENTS = buildDemoDocumentSeedManifest(currentYear);
 
-export const DEMO_INVOICES = [
-  { id: 'dm_inv_01', linkedSaleId: null },
-  { id: 'dm_inv_02', linkedSaleId: null },
-  { id: 'dm_inv_03', linkedSaleId: demoDocumentCode('client_order', 4) },
-  { id: 'dm_inv_04', linkedSaleId: null },
-  { id: 'dm_inv_05', linkedSaleId: null },
-];
+export const DEMO_QUOTES = DEFAULT_DEMO_DOCUMENTS.quotes;
 
-export const DEMO_SUPPLIER_QUOTES = rangeDocumentCodes('supplier_quote', 14);
+export const DEMO_CUSTOMER_OFFERS = DEFAULT_DEMO_DOCUMENTS.customerOffers;
 
-export const DEMO_SUPPLIER_SALES = [
-  {
-    id: demoDocumentCode('supplier_order', 1),
-    linkedQuoteId: demoDocumentCode('supplier_quote', 11),
-  },
-  {
-    id: demoDocumentCode('supplier_order', 2),
-    linkedQuoteId: demoDocumentCode('supplier_quote', 7),
-  },
-  {
-    id: demoDocumentCode('supplier_order', 3),
-    linkedQuoteId: demoDocumentCode('supplier_quote', 12),
-  },
-  {
-    id: demoDocumentCode('supplier_order', 4),
-    linkedQuoteId: demoDocumentCode('supplier_quote', 13),
-  },
-  {
-    id: demoDocumentCode('supplier_order', 5),
-    linkedQuoteId: demoDocumentCode('supplier_quote', 14),
-  },
-];
+export const DEMO_SALES = DEFAULT_DEMO_DOCUMENTS.sales;
 
-export const DEMO_SUPPLIER_INVOICES = [
-  { id: 'dm_sinv_01', linkedSaleId: null },
-  { id: 'dm_sinv_02', linkedSaleId: null },
-  { id: 'dm_sinv_03', linkedSaleId: demoDocumentCode('supplier_order', 4) },
-  { id: 'dm_sinv_04', linkedSaleId: null },
-  { id: 'dm_sinv_05', linkedSaleId: null },
-];
+export const DEMO_INVOICES = DEFAULT_DEMO_DOCUMENTS.invoices;
+
+export const DEMO_SUPPLIER_QUOTES = DEFAULT_DEMO_DOCUMENTS.supplierQuotes;
+
+export const DEMO_SUPPLIER_SALES = DEFAULT_DEMO_DOCUMENTS.supplierSales;
+
+export const DEMO_SUPPLIER_INVOICES = DEFAULT_DEMO_DOCUMENTS.supplierInvoices;
 
 export const DEMO_PROJECTS = [
   { id: 'dm_proj_01', name: `DM-CLI-001_DM-SVC-AUDIT_${currentYear}` },
@@ -533,31 +559,39 @@ export const DEMO_ITEM_IDS = {
   supplierInvoiceItems: rangeIds('dm_sinv_item_', 6),
 } as const;
 
-export const DEMO_IDS = {
-  clients: DEMO_CLIENTS.map((item) => item.id),
-  suppliers: DEMO_SUPPLIERS.map((item) => item.id),
-  products: DEMO_PRODUCTS.map((item) => item.id),
-  quotes: DEMO_QUOTES.map((item) => item.id),
-  customerOffers: DEMO_CUSTOMER_OFFERS.map((item) => item.id),
-  sales: DEMO_SALES.map((item) => item.id),
-  invoices: DEMO_INVOICES.map((item) => item.id),
-  supplierQuotes: DEMO_SUPPLIER_QUOTES.map((item) => item.id),
-  supplierSales: DEMO_SUPPLIER_SALES.map((item) => item.id),
-  supplierInvoices: DEMO_SUPPLIER_INVOICES.map((item) => item.id),
-  projects: DEMO_PROJECTS.map((item) => item.id),
-  tasks: [...DEMO_TASKS],
-  notifications: [...DEMO_NOTIFICATIONS],
-  workUnits: DEMO_WORK_UNITS.map((item) => item.id),
-  timeEntries: [...DEMO_TIME_ENTRY_IDS],
-  users: [...DEMO_USER_IDS],
-  settingsUserIds: [...DEMO_USER_IDS],
-} as const;
+export const buildDemoIds = (seedYear = getDemoSeedYear()) => {
+  const documents = buildDemoDocumentSeedManifest(seedYear);
 
-export const DEMO_ASSIGNMENT_TARGET_IDS = {
-  clients: [...COMPATIBILITY_DEFAULTS.clients, ...DEMO_IDS.clients],
-  projects: [...COMPATIBILITY_DEFAULTS.projects, ...DEMO_IDS.projects],
-  tasks: [...COMPATIBILITY_DEFAULTS.tasks, ...DEMO_IDS.tasks],
-} as const;
+  return {
+    clients: DEMO_CLIENTS.map((item) => item.id),
+    suppliers: DEMO_SUPPLIERS.map((item) => item.id),
+    products: DEMO_PRODUCTS.map((item) => item.id),
+    quotes: documents.quotes.map((item) => item.id),
+    customerOffers: documents.customerOffers.map((item) => item.id),
+    sales: documents.sales.map((item) => item.id),
+    invoices: documents.invoices.map((item) => item.id),
+    supplierQuotes: documents.supplierQuotes.map((item) => item.id),
+    supplierSales: documents.supplierSales.map((item) => item.id),
+    supplierInvoices: documents.supplierInvoices.map((item) => item.id),
+    projects: DEMO_PROJECTS.map((item) => item.id),
+    tasks: [...DEMO_TASKS],
+    notifications: [...DEMO_NOTIFICATIONS],
+    workUnits: DEMO_WORK_UNITS.map((item) => item.id),
+    timeEntries: [...DEMO_TIME_ENTRY_IDS],
+    users: [...DEMO_USER_IDS],
+    settingsUserIds: [...DEMO_USER_IDS],
+  };
+};
+
+export const DEMO_IDS = buildDemoIds(currentYear);
+
+export const buildDemoAssignmentTargetIds = (demoIds = DEMO_IDS) => ({
+  clients: [...COMPATIBILITY_DEFAULTS.clients, ...demoIds.clients],
+  projects: [...COMPATIBILITY_DEFAULTS.projects, ...demoIds.projects],
+  tasks: [...COMPATIBILITY_DEFAULTS.tasks, ...demoIds.tasks],
+});
+
+export const DEMO_ASSIGNMENT_TARGET_IDS = buildDemoAssignmentTargetIds(DEMO_IDS);
 
 export const DEMO_TOP_MANAGER_USER_IDS = DEMO_USERS.reduce<string[]>((ids, user) => {
   if (user.role === 'top_manager') ids.push(user.id);

--- a/server/db/seed.sql
+++ b/server/db/seed.sql
@@ -64,11 +64,22 @@ CREATE TEMP TABLE demo_document_codes (
     PRIMARY KEY (module_id, sequence)
 ) ON COMMIT DROP;
 
+CREATE OR REPLACE FUNCTION pg_temp.demo_seed_year()
+RETURNS integer
+LANGUAGE sql
+STABLE
+AS $$
+    SELECT COALESCE(
+        NULLIF(current_setting('praetor.demo_seed_year', true), '')::integer,
+        EXTRACT(YEAR FROM CURRENT_DATE)::integer
+    )
+$$;
+
 INSERT INTO demo_document_codes (module_id, sequence, code)
 SELECT
     module_id,
     sequence,
-    prefix || '_' || TO_CHAR(CURRENT_DATE, 'YY') || '_' || LPAD(sequence::text, 4, '0')
+    prefix || '_' || RIGHT(pg_temp.demo_seed_year()::text, 2) || '_' || LPAD(sequence::text, 4, '0')
 FROM (
     VALUES
         ('client_quote', 'PREV', 14),
@@ -90,13 +101,60 @@ AS $$
       AND codes.sequence = _sequence
 $$;
 
+CREATE TEMP TABLE demo_document_code_conflicts (
+    table_name text NOT NULL,
+    id text NOT NULL
+) ON COMMIT DROP;
+
+INSERT INTO demo_document_code_conflicts (table_name, id)
+SELECT 'quotes', q.id
+FROM quotes q
+JOIN pg_temp.demo_document_codes codes
+  ON codes.module_id = 'client_quote'
+ AND codes.code = q.id
+WHERE q.client_id NOT IN ('dm_cli_01', 'dm_cli_02', 'dm_cli_03', 'dm_cli_04', 'dm_cli_05')
+UNION ALL
+SELECT 'customer_offers', o.id
+FROM customer_offers o
+JOIN pg_temp.demo_document_codes codes
+  ON codes.module_id = 'client_offer'
+ AND codes.code = o.id
+WHERE o.client_id NOT IN ('dm_cli_01', 'dm_cli_02', 'dm_cli_03', 'dm_cli_04', 'dm_cli_05')
+UNION ALL
+SELECT 'sales', s.id
+FROM sales s
+JOIN pg_temp.demo_document_codes codes
+  ON codes.module_id = 'client_order'
+ AND codes.code = s.id
+WHERE s.client_id NOT IN ('dm_cli_01', 'dm_cli_02', 'dm_cli_03', 'dm_cli_04', 'dm_cli_05')
+UNION ALL
+SELECT 'supplier_quotes', sq.id
+FROM supplier_quotes sq
+JOIN pg_temp.demo_document_codes codes
+  ON codes.module_id = 'supplier_quote'
+ AND codes.code = sq.id
+WHERE sq.supplier_id NOT IN ('dm_sup_01', 'dm_sup_02', 'dm_sup_03', 'dm_sup_04', 'dm_sup_05')
+UNION ALL
+SELECT 'supplier_sales', ss.id
+FROM supplier_sales ss
+JOIN pg_temp.demo_document_codes codes
+  ON codes.module_id = 'supplier_order'
+ AND codes.code = ss.id
+WHERE ss.supplier_id NOT IN ('dm_sup_01', 'dm_sup_02', 'dm_sup_03', 'dm_sup_04', 'dm_sup_05');
+
+SELECT CASE
+    WHEN EXISTS (SELECT 1 FROM pg_temp.demo_document_code_conflicts)
+        THEN 'Demo seed document code collision with existing non-demo document rows'::integer
+    ELSE 0
+END;
+
 INSERT INTO document_code_counters (module_id, year, next_sequence, updated_at)
 VALUES
-    ('client_quote', EXTRACT(YEAR FROM CURRENT_DATE)::integer, 15, CURRENT_TIMESTAMP),
-    ('client_offer', EXTRACT(YEAR FROM CURRENT_DATE)::integer, 6, CURRENT_TIMESTAMP),
-    ('supplier_quote', EXTRACT(YEAR FROM CURRENT_DATE)::integer, 15, CURRENT_TIMESTAMP),
-    ('client_order', EXTRACT(YEAR FROM CURRENT_DATE)::integer, 6, CURRENT_TIMESTAMP),
-    ('supplier_order', EXTRACT(YEAR FROM CURRENT_DATE)::integer, 6, CURRENT_TIMESTAMP)
+    ('client_quote', pg_temp.demo_seed_year(), 15, CURRENT_TIMESTAMP),
+    ('client_offer', pg_temp.demo_seed_year(), 6, CURRENT_TIMESTAMP),
+    ('supplier_quote', pg_temp.demo_seed_year(), 15, CURRENT_TIMESTAMP),
+    ('client_order', pg_temp.demo_seed_year(), 6, CURRENT_TIMESTAMP),
+    ('supplier_order', pg_temp.demo_seed_year(), 6, CURRENT_TIMESTAMP)
 ON CONFLICT (module_id, year) DO UPDATE SET
     next_sequence = GREATEST(document_code_counters.next_sequence, EXCLUDED.next_sequence),
     updated_at = CURRENT_TIMESTAMP;

--- a/server/db/seed.sql
+++ b/server/db/seed.sql
@@ -50,10 +50,56 @@ INSERT INTO settings (user_id, full_name, email) VALUES
 ON CONFLICT (user_id) DO NOTHING;
 
 -- Refreshable demo dataset.
--- Demo records intentionally use dm_* ids and DM-* business codes so reseeding restores the
--- curated showcase rows in place without deleting non-demo records that reference demo entities.
+-- Demo document records use the same default code templates exposed in admin settings
+-- (PREV/OFF/FORN/ORD/SORD + YY + padded sequence). Non-document demo records keep dm_* ids.
 -- The app-layer orchestrator executes these statements in a controlled refresh workflow after
 -- cleanup, verification, manager assignment, and cache invalidation steps are prepared.
+
+DROP TABLE IF EXISTS pg_temp.demo_document_codes;
+
+CREATE TEMP TABLE demo_document_codes (
+    module_id text NOT NULL,
+    sequence integer NOT NULL,
+    code text NOT NULL,
+    PRIMARY KEY (module_id, sequence)
+) ON COMMIT DROP;
+
+INSERT INTO demo_document_codes (module_id, sequence, code)
+SELECT
+    module_id,
+    sequence,
+    prefix || '_' || TO_CHAR(CURRENT_DATE, 'YY') || '_' || LPAD(sequence::text, 4, '0')
+FROM (
+    VALUES
+        ('client_quote', 'PREV', 14),
+        ('client_offer', 'OFF', 5),
+        ('supplier_quote', 'FORN', 14),
+        ('client_order', 'ORD', 5),
+        ('supplier_order', 'SORD', 5)
+) AS modules(module_id, prefix, max_sequence)
+CROSS JOIN LATERAL generate_series(1, modules.max_sequence) AS sequence;
+
+CREATE OR REPLACE FUNCTION pg_temp.demo_document_code(_module_id text, _sequence integer)
+RETURNS text
+LANGUAGE sql
+STABLE
+AS $$
+    SELECT codes.code
+    FROM pg_temp.demo_document_codes AS codes
+    WHERE codes.module_id = _module_id
+      AND codes.sequence = _sequence
+$$;
+
+INSERT INTO document_code_counters (module_id, year, next_sequence, updated_at)
+VALUES
+    ('client_quote', EXTRACT(YEAR FROM CURRENT_DATE)::integer, 15, CURRENT_TIMESTAMP),
+    ('client_offer', EXTRACT(YEAR FROM CURRENT_DATE)::integer, 6, CURRENT_TIMESTAMP),
+    ('supplier_quote', EXTRACT(YEAR FROM CURRENT_DATE)::integer, 15, CURRENT_TIMESTAMP),
+    ('client_order', EXTRACT(YEAR FROM CURRENT_DATE)::integer, 6, CURRENT_TIMESTAMP),
+    ('supplier_order', EXTRACT(YEAR FROM CURRENT_DATE)::integer, 6, CURRENT_TIMESTAMP)
+ON CONFLICT (module_id, year) DO UPDATE SET
+    next_sequence = GREATEST(document_code_counters.next_sequence, EXCLUDED.next_sequence),
+    updated_at = CURRENT_TIMESTAMP;
 
 INSERT INTO clients (
     id,
@@ -475,20 +521,20 @@ INSERT INTO quotes (
     created_at,
     updated_at
 ) VALUES
-    ('dm_cq_01', 'dm_cli_01', 'Northwind Retail Italia S.p.A.', '30gg', 2.00, 'draft', CURRENT_DATE + INTERVAL '45 days', 'qcc_email', 'Editable draft quote with two services.', CURRENT_TIMESTAMP - INTERVAL '150 days', CURRENT_TIMESTAMP - INTERVAL '149 days'),
-    ('dm_cq_02', 'dm_cli_02', 'Helios Energy Services S.r.l.', '45gg', 3.00, 'sent', CURRENT_DATE + INTERVAL '22 days', 'qcc_email', 'Sent quote waiting for customer feedback.', CURRENT_TIMESTAMP - INTERVAL '130 days', CURRENT_TIMESTAMP - INTERVAL '126 days'),
-    ('dm_cq_03', 'dm_cli_03', 'Comune di Verona - Innovazione Digitale', '60gg', 0.00, 'accepted', CURRENT_DATE + INTERVAL '28 days', 'qcc_email', 'Accepted quote intentionally left without an offer to expose the CTA.', CURRENT_TIMESTAMP - INTERVAL '112 days', CURRENT_TIMESTAMP - INTERVAL '108 days'),
-    ('dm_cq_04', 'dm_cli_01', 'Northwind Retail Italia S.p.A.', '30gg', 4.00, 'accepted', CURRENT_DATE + INTERVAL '30 days', 'qcc_email', 'Accepted quote with a draft offer downstream.', CURRENT_TIMESTAMP - INTERVAL '101 days', CURRENT_TIMESTAMP - INTERVAL '96 days'),
-    ('dm_cq_05', 'dm_cli_02', 'Helios Energy Services S.r.l.', '45gg', 1.50, 'accepted', CURRENT_DATE + INTERVAL '26 days', 'qcc_email', 'Accepted quote with a sent offer downstream.', CURRENT_TIMESTAMP - INTERVAL '92 days', CURRENT_TIMESTAMP - INTERVAL '88 days'),
-    ('dm_cq_06', 'dm_cli_01', 'Northwind Retail Italia S.p.A.', '30gg', 0.00, 'accepted', CURRENT_DATE + INTERVAL '24 days', 'qcc_email', 'Accepted assessment + deployment quote that flowed into an accepted offer and a confirmed order.', CURRENT_TIMESTAMP - INTERVAL '78 days', CURRENT_TIMESTAMP - INTERVAL '72 days'),
-    ('dm_cq_07', 'dm_cli_03', 'Comune di Verona - Innovazione Digitale', '60gg', 2.50, 'accepted', CURRENT_DATE + INTERVAL '20 days', 'qcc_email', 'Accepted quote linked to an accepted offer that already generated an order.', CURRENT_TIMESTAMP - INTERVAL '66 days', CURRENT_TIMESTAMP - INTERVAL '61 days'),
-    ('dm_cq_08', 'dm_cli_04', 'Giulia Ferri', 'immediate', 0.00, 'accepted', CURRENT_DATE + INTERVAL '12 days', 'qcc_email', 'Accepted quote linked to a denied offer.', CURRENT_TIMESTAMP - INTERVAL '58 days', CURRENT_TIMESTAMP - INTERVAL '54 days'),
-    ('dm_cq_09', 'dm_cli_02', 'Helios Energy Services S.r.l.', '30gg', 5.00, 'denied', CURRENT_DATE + INTERVAL '10 days', 'qcc_email', 'Rejected customer quote kept for history coverage.', CURRENT_TIMESTAMP - INTERVAL '36 days', CURRENT_TIMESTAMP - INTERVAL '34 days'),
-    ('dm_cq_10', 'dm_cli_01', 'Northwind Retail Italia S.p.A.', '30gg', 0.00, 'sent', CURRENT_DATE - INTERVAL '5 days', 'qcc_email', 'Expired quote to exercise historical and expired state handling.', CURRENT_TIMESTAMP - INTERVAL '24 days', CURRENT_TIMESTAMP - INTERVAL '20 days'),
-    ('dm_cq_11', 'dm_cli_01', 'Northwind Retail Italia S.p.A.', '30gg', 0.00, 'accepted', CURRENT_DATE + INTERVAL '14 days', 'qcc_email', 'Accepted procurement driver: its 1-to-1 link keeps supplier quote dm_sq_11 in the Accepted state (#779 derived status).', CURRENT_TIMESTAMP - INTERVAL '53 days', CURRENT_TIMESTAMP - INTERVAL '49 days'),
-    ('dm_cq_12', 'dm_cli_02', 'Helios Energy Services S.r.l.', '45gg', 0.00, 'accepted', CURRENT_DATE + INTERVAL '11 days', 'qcc_email', 'Accepted procurement driver for supplier quote dm_sq_12.', CURRENT_TIMESTAMP - INTERVAL '42 days', CURRENT_TIMESTAMP - INTERVAL '37 days'),
-    ('dm_cq_13', 'dm_cli_03', 'Comune di Verona - Innovazione Digitale', '60gg', 0.00, 'accepted', CURRENT_DATE + INTERVAL '8 days', 'qcc_email', 'Accepted procurement driver for supplier quote dm_sq_13.', CURRENT_TIMESTAMP - INTERVAL '33 days', CURRENT_TIMESTAMP - INTERVAL '28 days'),
-    ('dm_cq_14', 'dm_cli_04', 'Giulia Ferri', '30gg', 0.00, 'accepted', CURRENT_DATE + INTERVAL '6 days', 'qcc_email', 'Accepted procurement driver for supplier quote dm_sq_14.', CURRENT_TIMESTAMP - INTERVAL '25 days', CURRENT_TIMESTAMP - INTERVAL '21 days')
+    (pg_temp.demo_document_code('client_quote', 1), 'dm_cli_01', 'Northwind Retail Italia S.p.A.', '30gg', 2.00, 'draft', CURRENT_DATE + INTERVAL '45 days', 'qcc_email', 'Editable draft quote with two services.', CURRENT_TIMESTAMP - INTERVAL '150 days', CURRENT_TIMESTAMP - INTERVAL '149 days'),
+    (pg_temp.demo_document_code('client_quote', 2), 'dm_cli_02', 'Helios Energy Services S.r.l.', '45gg', 3.00, 'sent', CURRENT_DATE + INTERVAL '22 days', 'qcc_email', 'Sent quote waiting for customer feedback.', CURRENT_TIMESTAMP - INTERVAL '130 days', CURRENT_TIMESTAMP - INTERVAL '126 days'),
+    (pg_temp.demo_document_code('client_quote', 3), 'dm_cli_03', 'Comune di Verona - Innovazione Digitale', '60gg', 0.00, 'accepted', CURRENT_DATE + INTERVAL '28 days', 'qcc_email', 'Accepted quote intentionally left without an offer to expose the CTA.', CURRENT_TIMESTAMP - INTERVAL '112 days', CURRENT_TIMESTAMP - INTERVAL '108 days'),
+    (pg_temp.demo_document_code('client_quote', 4), 'dm_cli_01', 'Northwind Retail Italia S.p.A.', '30gg', 4.00, 'accepted', CURRENT_DATE + INTERVAL '30 days', 'qcc_email', 'Accepted quote with a draft offer downstream.', CURRENT_TIMESTAMP - INTERVAL '101 days', CURRENT_TIMESTAMP - INTERVAL '96 days'),
+    (pg_temp.demo_document_code('client_quote', 5), 'dm_cli_02', 'Helios Energy Services S.r.l.', '45gg', 1.50, 'accepted', CURRENT_DATE + INTERVAL '26 days', 'qcc_email', 'Accepted quote with a sent offer downstream.', CURRENT_TIMESTAMP - INTERVAL '92 days', CURRENT_TIMESTAMP - INTERVAL '88 days'),
+    (pg_temp.demo_document_code('client_quote', 6), 'dm_cli_01', 'Northwind Retail Italia S.p.A.', '30gg', 0.00, 'accepted', CURRENT_DATE + INTERVAL '24 days', 'qcc_email', 'Accepted assessment + deployment quote that flowed into an accepted offer and a confirmed order.', CURRENT_TIMESTAMP - INTERVAL '78 days', CURRENT_TIMESTAMP - INTERVAL '72 days'),
+    (pg_temp.demo_document_code('client_quote', 7), 'dm_cli_03', 'Comune di Verona - Innovazione Digitale', '60gg', 2.50, 'accepted', CURRENT_DATE + INTERVAL '20 days', 'qcc_email', 'Accepted quote linked to an accepted offer that already generated an order.', CURRENT_TIMESTAMP - INTERVAL '66 days', CURRENT_TIMESTAMP - INTERVAL '61 days'),
+    (pg_temp.demo_document_code('client_quote', 8), 'dm_cli_04', 'Giulia Ferri', 'immediate', 0.00, 'accepted', CURRENT_DATE + INTERVAL '12 days', 'qcc_email', 'Accepted quote linked to a denied offer.', CURRENT_TIMESTAMP - INTERVAL '58 days', CURRENT_TIMESTAMP - INTERVAL '54 days'),
+    (pg_temp.demo_document_code('client_quote', 9), 'dm_cli_02', 'Helios Energy Services S.r.l.', '30gg', 5.00, 'denied', CURRENT_DATE + INTERVAL '10 days', 'qcc_email', 'Rejected customer quote kept for history coverage.', CURRENT_TIMESTAMP - INTERVAL '36 days', CURRENT_TIMESTAMP - INTERVAL '34 days'),
+    (pg_temp.demo_document_code('client_quote', 10), 'dm_cli_01', 'Northwind Retail Italia S.p.A.', '30gg', 0.00, 'sent', CURRENT_DATE - INTERVAL '5 days', 'qcc_email', 'Expired quote to exercise historical and expired state handling.', CURRENT_TIMESTAMP - INTERVAL '24 days', CURRENT_TIMESTAMP - INTERVAL '20 days'),
+    (pg_temp.demo_document_code('client_quote', 11), 'dm_cli_01', 'Northwind Retail Italia S.p.A.', '30gg', 0.00, 'accepted', CURRENT_DATE + INTERVAL '14 days', 'qcc_email', 'Accepted procurement driver: its 1-to-1 link keeps the paired supplier quote in the Accepted state (#779 derived status).', CURRENT_TIMESTAMP - INTERVAL '53 days', CURRENT_TIMESTAMP - INTERVAL '49 days'),
+    (pg_temp.demo_document_code('client_quote', 12), 'dm_cli_02', 'Helios Energy Services S.r.l.', '45gg', 0.00, 'accepted', CURRENT_DATE + INTERVAL '11 days', 'qcc_email', 'Accepted procurement driver for the paired supplier quote.', CURRENT_TIMESTAMP - INTERVAL '42 days', CURRENT_TIMESTAMP - INTERVAL '37 days'),
+    (pg_temp.demo_document_code('client_quote', 13), 'dm_cli_03', 'Comune di Verona - Innovazione Digitale', '60gg', 0.00, 'accepted', CURRENT_DATE + INTERVAL '8 days', 'qcc_email', 'Accepted procurement driver for the paired supplier quote.', CURRENT_TIMESTAMP - INTERVAL '33 days', CURRENT_TIMESTAMP - INTERVAL '28 days'),
+    (pg_temp.demo_document_code('client_quote', 14), 'dm_cli_04', 'Giulia Ferri', '30gg', 0.00, 'accepted', CURRENT_DATE + INTERVAL '6 days', 'qcc_email', 'Accepted procurement driver for the paired supplier quote.', CURRENT_TIMESTAMP - INTERVAL '25 days', CURRENT_TIMESTAMP - INTERVAL '21 days')
 ON CONFLICT (id) DO UPDATE SET
     client_id = EXCLUDED.client_id,
     client_name = EXCLUDED.client_name,
@@ -526,25 +572,25 @@ SELECT
     v.note
 FROM (
     VALUES
-        ('dm_cqi_01', 'dm_cq_01', 'dm_prd_01', 5.00, 1230.00, 0.00, 'Discovery workshops and stakeholder interviews'),
-        ('dm_cqi_02', 'dm_cq_01', 'dm_prd_02', 2.00, 1715.00, 0.00, 'Deployment sprint for first release wave'),
-        ('dm_cqi_03', 'dm_cq_02', 'dm_prd_05', 12.00, 1159.00, 3.00, 'Endpoint refresh lot for field technicians'),
-        ('dm_cqi_04', 'dm_cq_03', 'dm_prd_06', 40.00, 225.00, 0.00, 'Accepted subscription bundle intentionally kept without downstream offer'),
-        ('dm_cqi_05', 'dm_cq_04', 'dm_prd_01', 3.00, 1230.00, 0.00, 'Strategic assessment package'),
-        ('dm_cqi_06', 'dm_cq_04', 'dm_prd_04', 1.00, 1090.00, 5.00, 'Executive training day'),
-        ('dm_cqi_07', 'dm_cq_05', 'dm_prd_07', 2.00, 1795.00, 0.00, 'Firewall appliances for branch perimeter refresh'),
-        ('dm_cqi_08', 'dm_cq_06', 'dm_prd_01', 4.00, 1230.00, 0.00, 'Strategy assessment lot for the operations engagement'),
-        ('dm_cqi_15', 'dm_cq_06', 'dm_prd_02', 1.00, 1715.00, 0.00, 'Deployment sprint for the phase-one rollout'),
-        ('dm_cqi_09', 'dm_cq_07', 'dm_prd_08', 2.00, 160.00, 0.00, 'Print collateral for the public-sector rollout'),
-        ('dm_cqi_10', 'dm_cq_07', 'dm_prd_02', 1.00, 1715.00, 0.00, 'Deployment sprint for the first implementation lot'),
-        ('dm_cqi_11', 'dm_cq_08', 'dm_prd_04', 2.00, 1090.00, 0.00, 'Training package for a small customer'),
-        ('dm_cqi_12', 'dm_cq_09', 'dm_prd_05', 3.00, 1159.00, 0.00, 'Rejected hardware offer kept for reporting'),
-        ('dm_cqi_13', 'dm_cq_10', 'dm_prd_03', 6.00, 835.00, 0.00, 'Managed support bundle that expired before confirmation'),
-        ('dm_cqi_14', 'dm_cq_10', 'dm_prd_08', 15.00, 160.00, 0.00, 'Print collateral add-on on the expired quote'),
-        ('dm_cqi_16', 'dm_cq_11', 'dm_prd_05', 4.00, 1180.00, 0.00, 'Hardware lot driving the editable draft supplier order'),
-        ('dm_cqi_17', 'dm_cq_12', 'dm_prd_06', 80.00, 225.00, 0.00, 'Licensing lot driving the sent supplier order'),
-        ('dm_cqi_18', 'dm_cq_13', 'dm_prd_07', 1.00, 1795.00, 0.00, 'Security appliance driving the invoiced supplier order'),
-        ('dm_cqi_19', 'dm_cq_14', 'dm_prd_05', 2.00, 1180.00, 0.00, 'Hardware lot driving the sent supplier order')
+        ('dm_cqi_01', pg_temp.demo_document_code('client_quote', 1), 'dm_prd_01', 5.00, 1230.00, 0.00, 'Discovery workshops and stakeholder interviews'),
+        ('dm_cqi_02', pg_temp.demo_document_code('client_quote', 1), 'dm_prd_02', 2.00, 1715.00, 0.00, 'Deployment sprint for first release wave'),
+        ('dm_cqi_03', pg_temp.demo_document_code('client_quote', 2), 'dm_prd_05', 12.00, 1159.00, 3.00, 'Endpoint refresh lot for field technicians'),
+        ('dm_cqi_04', pg_temp.demo_document_code('client_quote', 3), 'dm_prd_06', 40.00, 225.00, 0.00, 'Accepted subscription bundle intentionally kept without downstream offer'),
+        ('dm_cqi_05', pg_temp.demo_document_code('client_quote', 4), 'dm_prd_01', 3.00, 1230.00, 0.00, 'Strategic assessment package'),
+        ('dm_cqi_06', pg_temp.demo_document_code('client_quote', 4), 'dm_prd_04', 1.00, 1090.00, 5.00, 'Executive training day'),
+        ('dm_cqi_07', pg_temp.demo_document_code('client_quote', 5), 'dm_prd_07', 2.00, 1795.00, 0.00, 'Firewall appliances for branch perimeter refresh'),
+        ('dm_cqi_08', pg_temp.demo_document_code('client_quote', 6), 'dm_prd_01', 4.00, 1230.00, 0.00, 'Strategy assessment lot for the operations engagement'),
+        ('dm_cqi_15', pg_temp.demo_document_code('client_quote', 6), 'dm_prd_02', 1.00, 1715.00, 0.00, 'Deployment sprint for the phase-one rollout'),
+        ('dm_cqi_09', pg_temp.demo_document_code('client_quote', 7), 'dm_prd_08', 2.00, 160.00, 0.00, 'Print collateral for the public-sector rollout'),
+        ('dm_cqi_10', pg_temp.demo_document_code('client_quote', 7), 'dm_prd_02', 1.00, 1715.00, 0.00, 'Deployment sprint for the first implementation lot'),
+        ('dm_cqi_11', pg_temp.demo_document_code('client_quote', 8), 'dm_prd_04', 2.00, 1090.00, 0.00, 'Training package for a small customer'),
+        ('dm_cqi_12', pg_temp.demo_document_code('client_quote', 9), 'dm_prd_05', 3.00, 1159.00, 0.00, 'Rejected hardware offer kept for reporting'),
+        ('dm_cqi_13', pg_temp.demo_document_code('client_quote', 10), 'dm_prd_03', 6.00, 835.00, 0.00, 'Managed support bundle that expired before confirmation'),
+        ('dm_cqi_14', pg_temp.demo_document_code('client_quote', 10), 'dm_prd_08', 15.00, 160.00, 0.00, 'Print collateral add-on on the expired quote'),
+        ('dm_cqi_16', pg_temp.demo_document_code('client_quote', 11), 'dm_prd_05', 4.00, 1180.00, 0.00, 'Hardware lot driving the editable draft supplier order'),
+        ('dm_cqi_17', pg_temp.demo_document_code('client_quote', 12), 'dm_prd_06', 80.00, 225.00, 0.00, 'Licensing lot driving the sent supplier order'),
+        ('dm_cqi_18', pg_temp.demo_document_code('client_quote', 13), 'dm_prd_07', 1.00, 1795.00, 0.00, 'Security appliance driving the invoiced supplier order'),
+        ('dm_cqi_19', pg_temp.demo_document_code('client_quote', 14), 'dm_prd_05', 2.00, 1180.00, 0.00, 'Hardware lot driving the sent supplier order')
 ) AS v(id, quote_id, product_id, quantity, unit_price, discount, note)
 JOIN products p ON p.id = v.product_id
 ON CONFLICT (id) DO UPDATE SET
@@ -571,11 +617,11 @@ INSERT INTO customer_offers (
     created_at,
     updated_at
 ) VALUES
-    ('dm_co_01', 'dm_cq_04', 'dm_cli_01', 'Northwind Retail Italia S.p.A.', '30gg', 4.00, 'draft', CURRENT_DATE + INTERVAL '24 days', 'Editable draft offer created from an accepted quote.', CURRENT_TIMESTAMP - INTERVAL '90 days', CURRENT_TIMESTAMP - INTERVAL '88 days'),
-    ('dm_co_02', 'dm_cq_05', 'dm_cli_02', 'Helios Energy Services S.r.l.', '45gg', 1.50, 'sent', CURRENT_DATE + INTERVAL '22 days', 'Sent offer waiting for customer reply.', CURRENT_TIMESTAMP - INTERVAL '80 days', CURRENT_TIMESTAMP - INTERVAL '77 days'),
-    ('dm_co_03', 'dm_cq_06', 'dm_cli_01', 'Northwind Retail Italia S.p.A.', '30gg', 0.00, 'accepted', CURRENT_DATE + INTERVAL '18 days', 'Accepted offer converted into the confirmed delivery order that spawned the demo projects.', CURRENT_TIMESTAMP - INTERVAL '68 days', CURRENT_TIMESTAMP - INTERVAL '65 days'),
-    ('dm_co_04', 'dm_cq_07', 'dm_cli_03', 'Comune di Verona - Innovazione Digitale', '60gg', 2.50, 'accepted', CURRENT_DATE + INTERVAL '16 days', 'Accepted offer already converted into an order.', CURRENT_TIMESTAMP - INTERVAL '56 days', CURRENT_TIMESTAMP - INTERVAL '52 days'),
-    ('dm_co_05', 'dm_cq_08', 'dm_cli_04', 'Giulia Ferri', 'immediate', 0.00, 'denied', CURRENT_DATE + INTERVAL '8 days', 'Denied offer for historical state coverage.', CURRENT_TIMESTAMP - INTERVAL '46 days', CURRENT_TIMESTAMP - INTERVAL '43 days')
+    (pg_temp.demo_document_code('client_offer', 1), pg_temp.demo_document_code('client_quote', 4), 'dm_cli_01', 'Northwind Retail Italia S.p.A.', '30gg', 4.00, 'draft', CURRENT_DATE + INTERVAL '24 days', 'Editable draft offer created from an accepted quote.', CURRENT_TIMESTAMP - INTERVAL '90 days', CURRENT_TIMESTAMP - INTERVAL '88 days'),
+    (pg_temp.demo_document_code('client_offer', 2), pg_temp.demo_document_code('client_quote', 5), 'dm_cli_02', 'Helios Energy Services S.r.l.', '45gg', 1.50, 'sent', CURRENT_DATE + INTERVAL '22 days', 'Sent offer waiting for customer reply.', CURRENT_TIMESTAMP - INTERVAL '80 days', CURRENT_TIMESTAMP - INTERVAL '77 days'),
+    (pg_temp.demo_document_code('client_offer', 3), pg_temp.demo_document_code('client_quote', 6), 'dm_cli_01', 'Northwind Retail Italia S.p.A.', '30gg', 0.00, 'accepted', CURRENT_DATE + INTERVAL '18 days', 'Accepted offer converted into the confirmed delivery order that spawned the demo projects.', CURRENT_TIMESTAMP - INTERVAL '68 days', CURRENT_TIMESTAMP - INTERVAL '65 days'),
+    (pg_temp.demo_document_code('client_offer', 4), pg_temp.demo_document_code('client_quote', 7), 'dm_cli_03', 'Comune di Verona - Innovazione Digitale', '60gg', 2.50, 'accepted', CURRENT_DATE + INTERVAL '16 days', 'Accepted offer already converted into an order.', CURRENT_TIMESTAMP - INTERVAL '56 days', CURRENT_TIMESTAMP - INTERVAL '52 days'),
+    (pg_temp.demo_document_code('client_offer', 5), pg_temp.demo_document_code('client_quote', 8), 'dm_cli_04', 'Giulia Ferri', 'immediate', 0.00, 'denied', CURRENT_DATE + INTERVAL '8 days', 'Denied offer for historical state coverage.', CURRENT_TIMESTAMP - INTERVAL '46 days', CURRENT_TIMESTAMP - INTERVAL '43 days')
 ON CONFLICT (id) DO UPDATE SET
     linked_quote_id = EXCLUDED.linked_quote_id,
     client_id = EXCLUDED.client_id,
@@ -613,14 +659,14 @@ SELECT
     v.note
 FROM (
     VALUES
-        ('dm_coi_01', 'dm_co_01', 'dm_prd_01', 3.00, 1230.00, 0.00, 'Draft offer line copied from the accepted quote'),
-        ('dm_coi_02', 'dm_co_01', 'dm_prd_04', 1.00, 1090.00, 5.00, 'Editable training line'),
-        ('dm_coi_03', 'dm_co_02', 'dm_prd_07', 2.00, 1795.00, 0.00, 'Pending security appliance offer'),
-        ('dm_coi_04', 'dm_co_03', 'dm_prd_01', 4.00, 1230.00, 5.00, 'Accepted assessment lot for the operations engagement'),
-        ('dm_coi_08', 'dm_co_03', 'dm_prd_02', 1.00, 1715.00, 5.00, 'Accepted deployment sprint for the phase-one rollout'),
-        ('dm_coi_05', 'dm_co_04', 'dm_prd_01', 2.00, 1230.00, 0.00, 'Accepted assessment lot'),
-        ('dm_coi_06', 'dm_co_04', 'dm_prd_02', 1.00, 1715.00, 0.00, 'Accepted deployment sprint'),
-        ('dm_coi_07', 'dm_co_05', 'dm_prd_04', 2.00, 1090.00, 0.00, 'Denied training offer')
+        ('dm_coi_01', pg_temp.demo_document_code('client_offer', 1), 'dm_prd_01', 3.00, 1230.00, 0.00, 'Draft offer line copied from the accepted quote'),
+        ('dm_coi_02', pg_temp.demo_document_code('client_offer', 1), 'dm_prd_04', 1.00, 1090.00, 5.00, 'Editable training line'),
+        ('dm_coi_03', pg_temp.demo_document_code('client_offer', 2), 'dm_prd_07', 2.00, 1795.00, 0.00, 'Pending security appliance offer'),
+        ('dm_coi_04', pg_temp.demo_document_code('client_offer', 3), 'dm_prd_01', 4.00, 1230.00, 5.00, 'Accepted assessment lot for the operations engagement'),
+        ('dm_coi_08', pg_temp.demo_document_code('client_offer', 3), 'dm_prd_02', 1.00, 1715.00, 5.00, 'Accepted deployment sprint for the phase-one rollout'),
+        ('dm_coi_05', pg_temp.demo_document_code('client_offer', 4), 'dm_prd_01', 2.00, 1230.00, 0.00, 'Accepted assessment lot'),
+        ('dm_coi_06', pg_temp.demo_document_code('client_offer', 4), 'dm_prd_02', 1.00, 1715.00, 0.00, 'Accepted deployment sprint'),
+        ('dm_coi_07', pg_temp.demo_document_code('client_offer', 5), 'dm_prd_04', 2.00, 1090.00, 0.00, 'Denied training offer')
 ) AS v(id, offer_id, product_id, quantity, unit_price, discount, note)
 JOIN products p ON p.id = v.product_id
 ON CONFLICT (id) DO UPDATE SET
@@ -647,11 +693,11 @@ INSERT INTO sales (
     created_at,
     updated_at
 ) VALUES
-    ('dm_so_01', NULL, NULL, 'dm_cli_04', 'Giulia Ferri', 'immediate', 0.00, 'draft', 'Editable manual sale order used for direct accounting workflow.', CURRENT_TIMESTAMP - INTERVAL '42 days', CURRENT_TIMESTAMP - INTERVAL '41 days'),
-    ('dm_so_02', 'dm_cq_07', 'dm_co_04', 'dm_cli_03', 'Comune di Verona - Innovazione Digitale', '60gg', 2.50, 'confirmed', 'Linked order generated from an accepted offer and confirmed.', CURRENT_TIMESTAMP - INTERVAL '33 days', CURRENT_TIMESTAMP - INTERVAL '30 days'),
-    ('dm_so_03', NULL, NULL, 'dm_cli_01', 'Northwind Retail Italia S.p.A.', '30gg', 1.50, 'confirmed', 'Confirmed manual order intentionally left without an invoice.', CURRENT_TIMESTAMP - INTERVAL '28 days', CURRENT_TIMESTAMP - INTERVAL '24 days'),
-    ('dm_so_04', 'dm_cq_06', 'dm_co_03', 'dm_cli_01', 'Northwind Retail Italia S.p.A.', '30gg', 0.00, 'confirmed', 'Confirmed order generated from the accepted Northwind offer, already invoiced, and used to generate the demo delivery projects. The linked projects keep explicit project revenue instead of importing the order total automatically.', CURRENT_TIMESTAMP - INTERVAL '21 days', CURRENT_TIMESTAMP - INTERVAL '18 days'),
-    ('dm_so_05', NULL, NULL, 'dm_cli_02', 'Helios Energy Services S.r.l.', '45gg', 0.00, 'denied', 'Denied order retained for accounting history coverage.', CURRENT_TIMESTAMP - INTERVAL '16 days', CURRENT_TIMESTAMP - INTERVAL '14 days')
+    (pg_temp.demo_document_code('client_order', 1), NULL, NULL, 'dm_cli_04', 'Giulia Ferri', 'immediate', 0.00, 'draft', 'Editable manual sale order used for direct accounting workflow.', CURRENT_TIMESTAMP - INTERVAL '42 days', CURRENT_TIMESTAMP - INTERVAL '41 days'),
+    (pg_temp.demo_document_code('client_order', 2), pg_temp.demo_document_code('client_quote', 7), pg_temp.demo_document_code('client_offer', 4), 'dm_cli_03', 'Comune di Verona - Innovazione Digitale', '60gg', 2.50, 'confirmed', 'Linked order generated from an accepted offer and confirmed.', CURRENT_TIMESTAMP - INTERVAL '33 days', CURRENT_TIMESTAMP - INTERVAL '30 days'),
+    (pg_temp.demo_document_code('client_order', 3), NULL, NULL, 'dm_cli_01', 'Northwind Retail Italia S.p.A.', '30gg', 1.50, 'confirmed', 'Confirmed manual order intentionally left without an invoice.', CURRENT_TIMESTAMP - INTERVAL '28 days', CURRENT_TIMESTAMP - INTERVAL '24 days'),
+    (pg_temp.demo_document_code('client_order', 4), pg_temp.demo_document_code('client_quote', 6), pg_temp.demo_document_code('client_offer', 3), 'dm_cli_01', 'Northwind Retail Italia S.p.A.', '30gg', 0.00, 'confirmed', 'Confirmed order generated from the accepted Northwind offer, already invoiced, and used to generate the demo delivery projects. The linked projects keep explicit project revenue instead of importing the order total automatically.', CURRENT_TIMESTAMP - INTERVAL '21 days', CURRENT_TIMESTAMP - INTERVAL '18 days'),
+    (pg_temp.demo_document_code('client_order', 5), NULL, NULL, 'dm_cli_02', 'Helios Energy Services S.r.l.', '45gg', 0.00, 'denied', 'Denied order retained for accounting history coverage.', CURRENT_TIMESTAMP - INTERVAL '16 days', CURRENT_TIMESTAMP - INTERVAL '14 days')
 ON CONFLICT (id) DO UPDATE SET
     linked_quote_id = EXCLUDED.linked_quote_id,
     linked_offer_id = EXCLUDED.linked_offer_id,
@@ -689,14 +735,14 @@ SELECT
     v.note
 FROM (
     VALUES
-        ('dm_soi_01', 'dm_so_01', 'dm_prd_08', 25.00, 160.00, 0.00, 'Draft order for event print materials'),
-        ('dm_soi_02', 'dm_so_02', 'dm_prd_01', 2.00, 1230.00, 0.00, 'Linked assessment lot on a confirmed order'),
-        ('dm_soi_03', 'dm_so_02', 'dm_prd_02', 1.00, 1715.00, 0.00, 'Linked deployment lot on a confirmed order'),
-        ('dm_soi_04', 'dm_so_03', 'dm_prd_03', 6.00, 835.00, 0.00, 'Confirmed support retainer kept open without invoice'),
-        ('dm_soi_05', 'dm_so_03', 'dm_prd_06', 20.00, 210.00, 0.00, 'Confirmed software add-on still ready for invoicing'),
-        ('dm_soi_06', 'dm_so_04', 'dm_prd_01', 4.00, 1230.00, 5.00, 'Assessment track for operations'),
-        ('dm_soi_07', 'dm_so_04', 'dm_prd_02', 1.00, 1715.00, 5.00, 'Deployment wave for phase one'),
-        ('dm_soi_08', 'dm_so_05', 'dm_prd_05', 3.00, 1159.00, 0.00, 'Denied hardware order')
+        ('dm_soi_01', pg_temp.demo_document_code('client_order', 1), 'dm_prd_08', 25.00, 160.00, 0.00, 'Draft order for event print materials'),
+        ('dm_soi_02', pg_temp.demo_document_code('client_order', 2), 'dm_prd_01', 2.00, 1230.00, 0.00, 'Linked assessment lot on a confirmed order'),
+        ('dm_soi_03', pg_temp.demo_document_code('client_order', 2), 'dm_prd_02', 1.00, 1715.00, 0.00, 'Linked deployment lot on a confirmed order'),
+        ('dm_soi_04', pg_temp.demo_document_code('client_order', 3), 'dm_prd_03', 6.00, 835.00, 0.00, 'Confirmed support retainer kept open without invoice'),
+        ('dm_soi_05', pg_temp.demo_document_code('client_order', 3), 'dm_prd_06', 20.00, 210.00, 0.00, 'Confirmed software add-on still ready for invoicing'),
+        ('dm_soi_06', pg_temp.demo_document_code('client_order', 4), 'dm_prd_01', 4.00, 1230.00, 5.00, 'Assessment track for operations'),
+        ('dm_soi_07', pg_temp.demo_document_code('client_order', 4), 'dm_prd_02', 1.00, 1715.00, 5.00, 'Deployment wave for phase one'),
+        ('dm_soi_08', pg_temp.demo_document_code('client_order', 5), 'dm_prd_05', 3.00, 1159.00, 0.00, 'Denied hardware order')
 ) AS v(id, sale_id, product_id, quantity, unit_price, discount, note)
 JOIN products p ON p.id = v.product_id
 ON CONFLICT (id) DO UPDATE SET
@@ -727,7 +773,7 @@ INSERT INTO invoices (
 ) VALUES
     ('dm_inv_01', NULL, 'dm_cli_02', 'Helios Energy Services S.r.l.', CURRENT_DATE - INTERVAL '18 days', CURRENT_DATE + INTERVAL '12 days', 'draft', 1090.00, 1090.00, 0.00, 'Editable draft invoice.', CURRENT_TIMESTAMP - INTERVAL '18 days', CURRENT_TIMESTAMP - INTERVAL '17 days'),
     ('dm_inv_02', NULL, 'dm_cli_03', 'Comune di Verona - Innovazione Digitale', CURRENT_DATE - INTERVAL '30 days', CURRENT_DATE + INTERVAL '5 days', 'sent', 1795.00, 1795.00, 600.00, 'Partially paid invoice with remaining balance.', CURRENT_TIMESTAMP - INTERVAL '30 days', CURRENT_TIMESTAMP - INTERVAL '5 days'),
-    ('dm_inv_03', 'dm_so_04', 'dm_cli_01', 'Northwind Retail Italia S.p.A.', CURRENT_DATE - INTERVAL '20 days', CURRENT_DATE + INTERVAL '10 days', 'paid', 6303.25, 6303.25, 6303.25, 'Fully paid invoice linked to the confirmed demo order.', CURRENT_TIMESTAMP - INTERVAL '20 days', CURRENT_TIMESTAMP - INTERVAL '2 days'),
+    ('dm_inv_03', pg_temp.demo_document_code('client_order', 4), 'dm_cli_01', 'Northwind Retail Italia S.p.A.', CURRENT_DATE - INTERVAL '20 days', CURRENT_DATE + INTERVAL '10 days', 'paid', 6303.25, 6303.25, 6303.25, 'Fully paid invoice linked to the confirmed demo order.', CURRENT_TIMESTAMP - INTERVAL '20 days', CURRENT_TIMESTAMP - INTERVAL '2 days'),
     ('dm_inv_04', NULL, 'dm_cli_01', 'Northwind Retail Italia S.p.A.', CURRENT_DATE - INTERVAL '45 days', CURRENT_DATE - INTERVAL '15 days', 'overdue', 10020.00, 10020.00, 0.00, 'Outstanding overdue invoice for collections reporting.', CURRENT_TIMESTAMP - INTERVAL '45 days', CURRENT_TIMESTAMP - INTERVAL '14 days'),
     ('dm_inv_05', NULL, 'dm_cli_04', 'Giulia Ferri', CURRENT_DATE - INTERVAL '12 days', CURRENT_DATE + INTERVAL '20 days', 'cancelled', 1600.00, 1600.00, 0.00, 'Cancelled invoice retained for status coverage.', CURRENT_TIMESTAMP - INTERVAL '12 days', CURRENT_TIMESTAMP - INTERVAL '11 days')
 ON CONFLICT (id) DO UPDATE SET
@@ -781,20 +827,20 @@ INSERT INTO supplier_quotes (
     created_at,
     updated_at
 ) VALUES
-    ('dm_sq_01', 'dm_sup_01', 'TechSource Distribution', 'dm_cli_01', 'Northwind Retail Italia S.p.A.', '30gg', 'draft', CURRENT_DATE + INTERVAL '35 days', 'qcc_email', 'Editable supplier quote for hardware procurement.', CURRENT_TIMESTAMP - INTERVAL '145 days', CURRENT_TIMESTAMP - INTERVAL '144 days'),
-    ('dm_sq_02', 'dm_sup_02', 'CloudSeat Licensing', 'dm_cli_02', 'Helios Energy Services S.r.l.', '45gg', 'draft', CURRENT_DATE + INTERVAL '28 days', 'qcc_email', 'Sent supplier quote pending vendor response.', CURRENT_TIMESTAMP - INTERVAL '132 days', CURRENT_TIMESTAMP - INTERVAL '130 days'),
-    ('dm_sq_03', 'dm_sup_03', 'SecureEdge Systems', 'dm_cli_03', 'Comune di Verona - Innovazione Digitale', '60gg', 'draft', CURRENT_DATE + INTERVAL '26 days', 'qcc_email', 'Accepted supplier quote intentionally left without an offer.', CURRENT_TIMESTAMP - INTERVAL '118 days', CURRENT_TIMESTAMP - INTERVAL '114 days'),
-    ('dm_sq_04', 'dm_sup_01', 'TechSource Distribution', 'dm_cli_04', 'Giulia Ferri', '30gg', 'draft', CURRENT_DATE + INTERVAL '24 days', 'qcc_email', 'In offer: driven by the draft offer on the linked quote dm_cq_04 (#779 derived status).', CURRENT_TIMESTAMP - INTERVAL '104 days', CURRENT_TIMESTAMP - INTERVAL '100 days'),
-    ('dm_sq_05', 'dm_sup_02', 'CloudSeat Licensing', 'dm_cli_05', 'Atlas Legacy Holdings', '45gg', 'draft', CURRENT_DATE + INTERVAL '20 days', 'qcc_email', 'In offer: driven by the sent offer on the linked quote dm_cq_05.', CURRENT_TIMESTAMP - INTERVAL '94 days', CURRENT_TIMESTAMP - INTERVAL '89 days'),
-    ('dm_sq_06', 'dm_sup_03', 'SecureEdge Systems', 'dm_cli_01', 'Northwind Retail Italia S.p.A.', '60gg', 'draft', CURRENT_DATE + INTERVAL '18 days', 'qcc_email', 'Accepted supplier quote linked to an accepted offer ready for order creation.', CURRENT_TIMESTAMP - INTERVAL '82 days', CURRENT_TIMESTAMP - INTERVAL '78 days'),
-    ('dm_sq_07', 'dm_sup_04', 'PrintLogistics Hub', 'dm_cli_02', 'Helios Energy Services S.r.l.', '30gg', 'draft', CURRENT_DATE + INTERVAL '16 days', 'qcc_email', 'Accepted supplier quote linked to an order already in progress.', CURRENT_TIMESTAMP - INTERVAL '70 days', CURRENT_TIMESTAMP - INTERVAL '66 days'),
-    ('dm_sq_08', 'dm_sup_01', 'TechSource Distribution', 'dm_cli_03', 'Comune di Verona - Innovazione Digitale', '30gg', 'draft', CURRENT_DATE + INTERVAL '12 days', 'qcc_email', 'Denied: driven by the denied offer on the linked quote dm_cq_08.', CURRENT_TIMESTAMP - INTERVAL '60 days', CURRENT_TIMESTAMP - INTERVAL '57 days'),
-    ('dm_sq_09', 'dm_sup_02', 'CloudSeat Licensing', 'dm_cli_04', 'Giulia Ferri', '45gg', 'draft', CURRENT_DATE + INTERVAL '9 days', 'qcc_email', 'Denied supplier quote kept for history coverage.', CURRENT_TIMESTAMP - INTERVAL '39 days', CURRENT_TIMESTAMP - INTERVAL '37 days'),
-    ('dm_sq_10', 'dm_sup_04', 'PrintLogistics Hub', 'dm_cli_05', 'Atlas Legacy Holdings', '30gg', 'draft', CURRENT_DATE - INTERVAL '6 days', 'qcc_email', 'Expired supplier quote.', CURRENT_TIMESTAMP - INTERVAL '22 days', CURRENT_TIMESTAMP - INTERVAL '19 days'),
-    ('dm_sq_11', 'dm_sup_01', 'TechSource Distribution', 'dm_cli_01', 'Northwind Retail Italia S.p.A.', '30gg', 'draft', CURRENT_DATE + INTERVAL '14 days', 'qcc_email', 'Accepted supplier quote linked to a draft order for editable procurement flow.', CURRENT_TIMESTAMP - INTERVAL '52 days', CURRENT_TIMESTAMP - INTERVAL '48 days'),
-    ('dm_sq_12', 'dm_sup_02', 'CloudSeat Licensing', 'dm_cli_02', 'Helios Energy Services S.r.l.', '45gg', 'draft', CURRENT_DATE + INTERVAL '11 days', 'qcc_email', 'Accepted supplier quote linked to a sent licensing order without an invoice.', CURRENT_TIMESTAMP - INTERVAL '41 days', CURRENT_TIMESTAMP - INTERVAL '36 days'),
-    ('dm_sq_13', 'dm_sup_03', 'SecureEdge Systems', 'dm_cli_03', 'Comune di Verona - Innovazione Digitale', '60gg', 'draft', CURRENT_DATE + INTERVAL '8 days', 'qcc_email', 'Accepted supplier quote linked to a sent order already invoiced.', CURRENT_TIMESTAMP - INTERVAL '32 days', CURRENT_TIMESTAMP - INTERVAL '27 days'),
-    ('dm_sq_14', 'dm_sup_01', 'TechSource Distribution', 'dm_cli_04', 'Giulia Ferri', '30gg', 'draft', CURRENT_DATE + INTERVAL '6 days', 'qcc_email', 'Accepted supplier quote linked to a sent supplier order for history coverage.', CURRENT_TIMESTAMP - INTERVAL '24 days', CURRENT_TIMESTAMP - INTERVAL '20 days')
+    (pg_temp.demo_document_code('supplier_quote', 1), 'dm_sup_01', 'TechSource Distribution', 'dm_cli_01', 'Northwind Retail Italia S.p.A.', '30gg', 'draft', CURRENT_DATE + INTERVAL '35 days', 'qcc_email', 'Editable supplier quote for hardware procurement.', CURRENT_TIMESTAMP - INTERVAL '145 days', CURRENT_TIMESTAMP - INTERVAL '144 days'),
+    (pg_temp.demo_document_code('supplier_quote', 2), 'dm_sup_02', 'CloudSeat Licensing', 'dm_cli_02', 'Helios Energy Services S.r.l.', '45gg', 'draft', CURRENT_DATE + INTERVAL '28 days', 'qcc_email', 'Sent supplier quote pending vendor response.', CURRENT_TIMESTAMP - INTERVAL '132 days', CURRENT_TIMESTAMP - INTERVAL '130 days'),
+    (pg_temp.demo_document_code('supplier_quote', 3), 'dm_sup_03', 'SecureEdge Systems', 'dm_cli_03', 'Comune di Verona - Innovazione Digitale', '60gg', 'draft', CURRENT_DATE + INTERVAL '26 days', 'qcc_email', 'Accepted supplier quote intentionally left without an offer.', CURRENT_TIMESTAMP - INTERVAL '118 days', CURRENT_TIMESTAMP - INTERVAL '114 days'),
+    (pg_temp.demo_document_code('supplier_quote', 4), 'dm_sup_01', 'TechSource Distribution', 'dm_cli_04', 'Giulia Ferri', '30gg', 'draft', CURRENT_DATE + INTERVAL '24 days', 'qcc_email', 'In offer: driven by the draft offer on the linked client quote (#779 derived status).', CURRENT_TIMESTAMP - INTERVAL '104 days', CURRENT_TIMESTAMP - INTERVAL '100 days'),
+    (pg_temp.demo_document_code('supplier_quote', 5), 'dm_sup_02', 'CloudSeat Licensing', 'dm_cli_05', 'Atlas Legacy Holdings', '45gg', 'draft', CURRENT_DATE + INTERVAL '20 days', 'qcc_email', 'In offer: driven by the sent offer on the linked client quote.', CURRENT_TIMESTAMP - INTERVAL '94 days', CURRENT_TIMESTAMP - INTERVAL '89 days'),
+    (pg_temp.demo_document_code('supplier_quote', 6), 'dm_sup_03', 'SecureEdge Systems', 'dm_cli_01', 'Northwind Retail Italia S.p.A.', '60gg', 'draft', CURRENT_DATE + INTERVAL '18 days', 'qcc_email', 'Accepted supplier quote linked to an accepted offer ready for order creation.', CURRENT_TIMESTAMP - INTERVAL '82 days', CURRENT_TIMESTAMP - INTERVAL '78 days'),
+    (pg_temp.demo_document_code('supplier_quote', 7), 'dm_sup_04', 'PrintLogistics Hub', 'dm_cli_02', 'Helios Energy Services S.r.l.', '30gg', 'draft', CURRENT_DATE + INTERVAL '16 days', 'qcc_email', 'Accepted supplier quote linked to an order already in progress.', CURRENT_TIMESTAMP - INTERVAL '70 days', CURRENT_TIMESTAMP - INTERVAL '66 days'),
+    (pg_temp.demo_document_code('supplier_quote', 8), 'dm_sup_01', 'TechSource Distribution', 'dm_cli_03', 'Comune di Verona - Innovazione Digitale', '30gg', 'draft', CURRENT_DATE + INTERVAL '12 days', 'qcc_email', 'Denied: driven by the denied offer on the linked client quote.', CURRENT_TIMESTAMP - INTERVAL '60 days', CURRENT_TIMESTAMP - INTERVAL '57 days'),
+    (pg_temp.demo_document_code('supplier_quote', 9), 'dm_sup_02', 'CloudSeat Licensing', 'dm_cli_04', 'Giulia Ferri', '45gg', 'draft', CURRENT_DATE + INTERVAL '9 days', 'qcc_email', 'Denied supplier quote kept for history coverage.', CURRENT_TIMESTAMP - INTERVAL '39 days', CURRENT_TIMESTAMP - INTERVAL '37 days'),
+    (pg_temp.demo_document_code('supplier_quote', 10), 'dm_sup_04', 'PrintLogistics Hub', 'dm_cli_05', 'Atlas Legacy Holdings', '30gg', 'draft', CURRENT_DATE - INTERVAL '6 days', 'qcc_email', 'Expired supplier quote.', CURRENT_TIMESTAMP - INTERVAL '22 days', CURRENT_TIMESTAMP - INTERVAL '19 days'),
+    (pg_temp.demo_document_code('supplier_quote', 11), 'dm_sup_01', 'TechSource Distribution', 'dm_cli_01', 'Northwind Retail Italia S.p.A.', '30gg', 'draft', CURRENT_DATE + INTERVAL '14 days', 'qcc_email', 'Accepted supplier quote linked to a draft order for editable procurement flow.', CURRENT_TIMESTAMP - INTERVAL '52 days', CURRENT_TIMESTAMP - INTERVAL '48 days'),
+    (pg_temp.demo_document_code('supplier_quote', 12), 'dm_sup_02', 'CloudSeat Licensing', 'dm_cli_02', 'Helios Energy Services S.r.l.', '45gg', 'draft', CURRENT_DATE + INTERVAL '11 days', 'qcc_email', 'Accepted supplier quote linked to a sent licensing order without an invoice.', CURRENT_TIMESTAMP - INTERVAL '41 days', CURRENT_TIMESTAMP - INTERVAL '36 days'),
+    (pg_temp.demo_document_code('supplier_quote', 13), 'dm_sup_03', 'SecureEdge Systems', 'dm_cli_03', 'Comune di Verona - Innovazione Digitale', '60gg', 'draft', CURRENT_DATE + INTERVAL '8 days', 'qcc_email', 'Accepted supplier quote linked to a sent order already invoiced.', CURRENT_TIMESTAMP - INTERVAL '32 days', CURRENT_TIMESTAMP - INTERVAL '27 days'),
+    (pg_temp.demo_document_code('supplier_quote', 14), 'dm_sup_01', 'TechSource Distribution', 'dm_cli_04', 'Giulia Ferri', '30gg', 'draft', CURRENT_DATE + INTERVAL '6 days', 'qcc_email', 'Accepted supplier quote linked to a sent supplier order for history coverage.', CURRENT_TIMESTAMP - INTERVAL '24 days', CURRENT_TIMESTAMP - INTERVAL '20 days')
 ON CONFLICT (id) DO UPDATE SET
     supplier_id = EXCLUDED.supplier_id,
     supplier_name = EXCLUDED.supplier_name,
@@ -827,21 +873,21 @@ SELECT
     v.note
 FROM (
     VALUES
-        ('dm_sqi_01', 'dm_sq_01', 'dm_prd_05', 8.00, 960.00, 'Draft laptop procurement lot'),
-        ('dm_sqi_02', 'dm_sq_02', 'dm_prd_05', 12.00, 960.00, 'Hardware refresh quote pending vendor response'),
-        ('dm_sqi_03', 'dm_sq_03', 'dm_prd_06', 40.00, 180.00, 'Subscription bundle quote, accepted, no downstream order'),
-        ('dm_sqi_04', 'dm_sq_04', 'dm_prd_01', 3.00, 980.00, 'Strategic assessment quote pending supplier order creation'),
-        ('dm_sqi_05', 'dm_sq_05', 'dm_prd_07', 2.00, 1435.00, 'Firewall appliance quote pending supplier order creation'),
-        ('dm_sqi_06', 'dm_sq_06', 'dm_prd_02', 1.00, 1370.00, 'Deployment sprint quote linked to an accepted offer'),
-        ('dm_sqi_07', 'dm_sq_07', 'dm_prd_08', 200.00, 118.00, 'Accepted quote feeding an order already in progress'),
-        ('dm_sqi_08', 'dm_sq_08', 'dm_prd_04', 2.00, 870.00, 'Training package quote, denied via its offer'),
-        ('dm_sqi_09', 'dm_sq_09', 'dm_prd_05', 3.00, 925.00, 'Denied hardware quote kept for history coverage'),
-        ('dm_sqi_10', 'dm_sq_10', 'dm_prd_08', 150.00, 119.00, 'Expired print procurement request'),
-        ('dm_sqi_11', 'dm_sq_11', 'dm_prd_05', 4.00, 960.00, 'Accepted quote feeding the editable draft procurement order'),
-        ('dm_sqi_12', 'dm_sq_12', 'dm_prd_06', 80.00, 182.00, 'Accepted quote feeding the sent licensing order'),
-        ('dm_sqi_13', 'dm_sq_13', 'dm_prd_07', 1.00, 1410.00, 'Accepted quote feeding the invoiced security order'),
-        ('dm_sqi_14', 'dm_sq_13', 'dm_prd_08', 40.00, 118.00, 'Accepted quote feeding the invoiced print materials order'),
-        ('dm_sqi_15', 'dm_sq_14', 'dm_prd_05', 2.00, 965.00, 'Accepted quote feeding the sent supplier order')
+        ('dm_sqi_01', pg_temp.demo_document_code('supplier_quote', 1), 'dm_prd_05', 8.00, 960.00, 'Draft laptop procurement lot'),
+        ('dm_sqi_02', pg_temp.demo_document_code('supplier_quote', 2), 'dm_prd_05', 12.00, 960.00, 'Hardware refresh quote pending vendor response'),
+        ('dm_sqi_03', pg_temp.demo_document_code('supplier_quote', 3), 'dm_prd_06', 40.00, 180.00, 'Subscription bundle quote, accepted, no downstream order'),
+        ('dm_sqi_04', pg_temp.demo_document_code('supplier_quote', 4), 'dm_prd_01', 3.00, 980.00, 'Strategic assessment quote pending supplier order creation'),
+        ('dm_sqi_05', pg_temp.demo_document_code('supplier_quote', 5), 'dm_prd_07', 2.00, 1435.00, 'Firewall appliance quote pending supplier order creation'),
+        ('dm_sqi_06', pg_temp.demo_document_code('supplier_quote', 6), 'dm_prd_02', 1.00, 1370.00, 'Deployment sprint quote linked to an accepted offer'),
+        ('dm_sqi_07', pg_temp.demo_document_code('supplier_quote', 7), 'dm_prd_08', 200.00, 118.00, 'Accepted quote feeding an order already in progress'),
+        ('dm_sqi_08', pg_temp.demo_document_code('supplier_quote', 8), 'dm_prd_04', 2.00, 870.00, 'Training package quote, denied via its offer'),
+        ('dm_sqi_09', pg_temp.demo_document_code('supplier_quote', 9), 'dm_prd_05', 3.00, 925.00, 'Denied hardware quote kept for history coverage'),
+        ('dm_sqi_10', pg_temp.demo_document_code('supplier_quote', 10), 'dm_prd_08', 150.00, 119.00, 'Expired print procurement request'),
+        ('dm_sqi_11', pg_temp.demo_document_code('supplier_quote', 11), 'dm_prd_05', 4.00, 960.00, 'Accepted quote feeding the editable draft procurement order'),
+        ('dm_sqi_12', pg_temp.demo_document_code('supplier_quote', 12), 'dm_prd_06', 80.00, 182.00, 'Accepted quote feeding the sent licensing order'),
+        ('dm_sqi_13', pg_temp.demo_document_code('supplier_quote', 13), 'dm_prd_07', 1.00, 1410.00, 'Accepted quote feeding the invoiced security order'),
+        ('dm_sqi_14', pg_temp.demo_document_code('supplier_quote', 13), 'dm_prd_08', 40.00, 118.00, 'Accepted quote feeding the invoiced print materials order'),
+        ('dm_sqi_15', pg_temp.demo_document_code('supplier_quote', 14), 'dm_prd_05', 2.00, 965.00, 'Accepted quote feeding the sent supplier order')
 ) AS v(id, quote_id, product_id, quantity, unit_price, note)
 JOIN products p ON p.id = v.product_id
 ON CONFLICT (id) DO UPDATE SET
@@ -857,50 +903,52 @@ ON CONFLICT (id) DO UPDATE SET
 -- quote's visible state follows the most-advanced client quote whose LINES source it
 -- (quote_items.supplier_quote_id) and that quote's offer chain. The status mapping is the
 -- same as the old 1-to-1 header link; only the mechanism moved to per-line sourcing.
---   dm_sq_01 sourced by nobody              -> Draft (selectable in the client-quote dialog)
---   dm_sq_02 <- dm_cq_02 line (sent)        -> Sent
---   dm_sq_03 <- dm_cq_03 line (accepted)    -> Accepted (no offer downstream)
---   dm_sq_04 <- dm_cq_04 line (draft offer)    -> Offer
---   dm_sq_05 <- dm_cq_05 line (sent offer)     -> Offer
---   dm_sq_06 <- dm_cq_06 line (accepted offer) -> Accepted
---   dm_sq_07 <- dm_cq_07 line (accepted offer) -> Accepted (supplier order in progress)
---   dm_sq_08 <- dm_cq_08 line (denied offer)   -> Denied
---   dm_sq_09 <- dm_cq_09 line (denied quote)   -> Denied
---   dm_sq_10 sourced by nobody              -> Expired (own past expiration date)
---   dm_sq_11..14 <- dm_cq_11..14 lines      -> Accepted (drivers for the seeded supplier orders)
+--   FORN #01 sourced by nobody              -> Draft (selectable in the client-quote dialog)
+--   FORN #02 <- PREV #02 line (sent)        -> Sent
+--   FORN #03 <- PREV #03 line (accepted)    -> Accepted (no offer downstream)
+--   FORN #04 <- PREV #04 line (draft offer)    -> Offer
+--   FORN #05 <- PREV #05 line (sent offer)     -> Offer
+--   FORN #06 <- PREV #06 line (accepted offer) -> Accepted
+--   FORN #07 <- PREV #07 line (accepted offer) -> Accepted (supplier order in progress)
+--   FORN #08 <- PREV #08 line (denied offer)   -> Denied
+--   FORN #09 <- PREV #09 line (denied quote)   -> Denied
+--   FORN #10 sourced by nobody              -> Expired (own past expiration date)
+--   FORN #11..14 <- PREV #11..14 lines      -> Accepted (drivers for the seeded supplier orders)
 -- The header column is vestigial under line sourcing; null it so nothing reads a stale link.
-UPDATE quotes SET linked_supplier_quote_id = NULL WHERE id LIKE 'dm_cq_%';
+UPDATE quotes
+SET linked_supplier_quote_id = NULL
+WHERE id IN (SELECT code FROM pg_temp.demo_document_codes WHERE module_id = 'client_quote');
 
 -- One representative line of each demo client quote sources its supplier quote. The stored
 -- supplier_quote_unit_price is the supplier item's net cost and stays BELOW the line's sale
 -- price, so every sourced line shows a healthy margin. Accepted/denied client quotes are
 -- read-only, so their lines never surface the "Data drifted - sync?" chip even though the seeded
--- snapshot is a point-in-time copy; the one editable exception is dm_cq_02 below.
+-- snapshot is a point-in-time copy; the one editable exception is PREV #02 below.
 UPDATE quote_items AS qi SET
     supplier_quote_id = v.sq_id,
     supplier_quote_item_id = v.sqi_id,
     supplier_quote_supplier_name = v.supplier_name,
     supplier_quote_unit_price = v.unit_price
 FROM (VALUES
-    ('dm_cqi_04', 'dm_sq_03', 'dm_sqi_03', 'SecureEdge Systems', 180.00),
-    ('dm_cqi_05', 'dm_sq_04', 'dm_sqi_04', 'TechSource Distribution', 980.00),
-    ('dm_cqi_07', 'dm_sq_05', 'dm_sqi_05', 'CloudSeat Licensing', 1435.00),
-    ('dm_cqi_15', 'dm_sq_06', 'dm_sqi_06', 'SecureEdge Systems', 1370.00),
-    ('dm_cqi_09', 'dm_sq_07', 'dm_sqi_07', 'PrintLogistics Hub', 118.00),
-    ('dm_cqi_11', 'dm_sq_08', 'dm_sqi_08', 'TechSource Distribution', 870.00),
-    ('dm_cqi_12', 'dm_sq_09', 'dm_sqi_09', 'CloudSeat Licensing', 925.00),
-    ('dm_cqi_16', 'dm_sq_11', 'dm_sqi_11', 'TechSource Distribution', 960.00),
-    ('dm_cqi_17', 'dm_sq_12', 'dm_sqi_12', 'CloudSeat Licensing', 182.00),
-    ('dm_cqi_18', 'dm_sq_13', 'dm_sqi_13', 'SecureEdge Systems', 1410.00),
-    ('dm_cqi_19', 'dm_sq_14', 'dm_sqi_15', 'TechSource Distribution', 965.00)
+    ('dm_cqi_04', pg_temp.demo_document_code('supplier_quote', 3), 'dm_sqi_03', 'SecureEdge Systems', 180.00),
+    ('dm_cqi_05', pg_temp.demo_document_code('supplier_quote', 4), 'dm_sqi_04', 'TechSource Distribution', 980.00),
+    ('dm_cqi_07', pg_temp.demo_document_code('supplier_quote', 5), 'dm_sqi_05', 'CloudSeat Licensing', 1435.00),
+    ('dm_cqi_15', pg_temp.demo_document_code('supplier_quote', 6), 'dm_sqi_06', 'SecureEdge Systems', 1370.00),
+    ('dm_cqi_09', pg_temp.demo_document_code('supplier_quote', 7), 'dm_sqi_07', 'PrintLogistics Hub', 118.00),
+    ('dm_cqi_11', pg_temp.demo_document_code('supplier_quote', 8), 'dm_sqi_08', 'TechSource Distribution', 870.00),
+    ('dm_cqi_12', pg_temp.demo_document_code('supplier_quote', 9), 'dm_sqi_09', 'CloudSeat Licensing', 925.00),
+    ('dm_cqi_16', pg_temp.demo_document_code('supplier_quote', 11), 'dm_sqi_11', 'TechSource Distribution', 960.00),
+    ('dm_cqi_17', pg_temp.demo_document_code('supplier_quote', 12), 'dm_sqi_12', 'CloudSeat Licensing', 182.00),
+    ('dm_cqi_18', pg_temp.demo_document_code('supplier_quote', 13), 'dm_sqi_13', 'SecureEdge Systems', 1410.00),
+    ('dm_cqi_19', pg_temp.demo_document_code('supplier_quote', 14), 'dm_sqi_15', 'TechSource Distribution', 965.00)
 ) AS v(cqi_id, sq_id, sqi_id, supplier_name, unit_price)
 WHERE qi.id = v.cqi_id;
 
--- Editable stale-data demo (#779 reverse sync): dm_cq_02 is sent (still editable), so its
+-- Editable stale-data demo (#779 reverse sync): PREV #02 is sent (still editable), so its
 -- sourced line surfaces the "Data drifted - sync?" chip because the stored snapshot price (940)
 -- sits behind dm_sqi_02's current net cost (960). Refreshing pulls the live supplier values.
 UPDATE quote_items SET
-    supplier_quote_id = 'dm_sq_02',
+    supplier_quote_id = pg_temp.demo_document_code('supplier_quote', 2),
     supplier_quote_item_id = 'dm_sqi_02',
     supplier_quote_supplier_name = 'CloudSeat Licensing',
     supplier_quote_unit_price = 940.00
@@ -918,11 +966,11 @@ INSERT INTO supplier_sales (
     created_at,
     updated_at
 ) VALUES
-    ('dm_ss_01', 'dm_sq_11', 'dm_sup_01', 'TechSource Distribution', '30gg', 0.00, 'draft', 'Editable supplier order generated from an accepted hardware quote.', CURRENT_TIMESTAMP - INTERVAL '40 days', CURRENT_TIMESTAMP - INTERVAL '39 days'),
-    ('dm_ss_02', 'dm_sq_07', 'dm_sup_04', 'PrintLogistics Hub', '30gg', 2.00, 'sent', 'Linked supplier order already in progress.', CURRENT_TIMESTAMP - INTERVAL '31 days', CURRENT_TIMESTAMP - INTERVAL '29 days'),
-    ('dm_ss_03', 'dm_sq_12', 'dm_sup_02', 'CloudSeat Licensing', '45gg', 0.00, 'sent', 'Sent supplier order generated from an accepted licensing quote and intentionally left without an invoice.', CURRENT_TIMESTAMP - INTERVAL '27 days', CURRENT_TIMESTAMP - INTERVAL '24 days'),
-    ('dm_ss_04', 'dm_sq_13', 'dm_sup_03', 'SecureEdge Systems', '60gg', 0.00, 'sent', 'Sent supplier order generated from an accepted security quote and already invoiced.', CURRENT_TIMESTAMP - INTERVAL '20 days', CURRENT_TIMESTAMP - INTERVAL '17 days'),
-    ('dm_ss_05', 'dm_sq_14', 'dm_sup_01', 'TechSource Distribution', '30gg', 0.00, 'sent', 'Sent supplier order generated from an accepted quote for history coverage.', CURRENT_TIMESTAMP - INTERVAL '15 days', CURRENT_TIMESTAMP - INTERVAL '13 days')
+    (pg_temp.demo_document_code('supplier_order', 1), pg_temp.demo_document_code('supplier_quote', 11), 'dm_sup_01', 'TechSource Distribution', '30gg', 0.00, 'draft', 'Editable supplier order generated from an accepted hardware quote.', CURRENT_TIMESTAMP - INTERVAL '40 days', CURRENT_TIMESTAMP - INTERVAL '39 days'),
+    (pg_temp.demo_document_code('supplier_order', 2), pg_temp.demo_document_code('supplier_quote', 7), 'dm_sup_04', 'PrintLogistics Hub', '30gg', 2.00, 'sent', 'Linked supplier order already in progress.', CURRENT_TIMESTAMP - INTERVAL '31 days', CURRENT_TIMESTAMP - INTERVAL '29 days'),
+    (pg_temp.demo_document_code('supplier_order', 3), pg_temp.demo_document_code('supplier_quote', 12), 'dm_sup_02', 'CloudSeat Licensing', '45gg', 0.00, 'sent', 'Sent supplier order generated from an accepted licensing quote and intentionally left without an invoice.', CURRENT_TIMESTAMP - INTERVAL '27 days', CURRENT_TIMESTAMP - INTERVAL '24 days'),
+    (pg_temp.demo_document_code('supplier_order', 4), pg_temp.demo_document_code('supplier_quote', 13), 'dm_sup_03', 'SecureEdge Systems', '60gg', 0.00, 'sent', 'Sent supplier order generated from an accepted security quote and already invoiced.', CURRENT_TIMESTAMP - INTERVAL '20 days', CURRENT_TIMESTAMP - INTERVAL '17 days'),
+    (pg_temp.demo_document_code('supplier_order', 5), pg_temp.demo_document_code('supplier_quote', 14), 'dm_sup_01', 'TechSource Distribution', '30gg', 0.00, 'sent', 'Sent supplier order generated from an accepted quote for history coverage.', CURRENT_TIMESTAMP - INTERVAL '15 days', CURRENT_TIMESTAMP - INTERVAL '13 days')
 ON CONFLICT (id) DO UPDATE SET
     linked_quote_id = EXCLUDED.linked_quote_id,
     supplier_id = EXCLUDED.supplier_id,
@@ -955,12 +1003,12 @@ SELECT
     v.note
 FROM (
     VALUES
-        ('dm_ssi_01', 'dm_ss_01', 'dm_prd_05', 4.00, 960.00, 0.00, 'Draft hardware procurement order'),
-        ('dm_ssi_02', 'dm_ss_02', 'dm_prd_08', 200.00, 118.00, 2.00, 'Linked print procurement order in sent status'),
-        ('dm_ssi_03', 'dm_ss_03', 'dm_prd_06', 80.00, 182.00, 0.00, 'Sent licensing order without invoice'),
-        ('dm_ssi_04', 'dm_ss_04', 'dm_prd_07', 1.00, 1410.00, 0.00, 'Sent security appliance order'),
-        ('dm_ssi_05', 'dm_ss_04', 'dm_prd_08', 40.00, 118.00, 0.00, 'Sent print materials order'),
-        ('dm_ssi_06', 'dm_ss_05', 'dm_prd_05', 2.00, 965.00, 0.00, 'Sent supplier hardware order')
+        ('dm_ssi_01', pg_temp.demo_document_code('supplier_order', 1), 'dm_prd_05', 4.00, 960.00, 0.00, 'Draft hardware procurement order'),
+        ('dm_ssi_02', pg_temp.demo_document_code('supplier_order', 2), 'dm_prd_08', 200.00, 118.00, 2.00, 'Linked print procurement order in sent status'),
+        ('dm_ssi_03', pg_temp.demo_document_code('supplier_order', 3), 'dm_prd_06', 80.00, 182.00, 0.00, 'Sent licensing order without invoice'),
+        ('dm_ssi_04', pg_temp.demo_document_code('supplier_order', 4), 'dm_prd_07', 1.00, 1410.00, 0.00, 'Sent security appliance order'),
+        ('dm_ssi_05', pg_temp.demo_document_code('supplier_order', 4), 'dm_prd_08', 40.00, 118.00, 0.00, 'Sent print materials order'),
+        ('dm_ssi_06', pg_temp.demo_document_code('supplier_order', 5), 'dm_prd_05', 2.00, 965.00, 0.00, 'Sent supplier hardware order')
 ) AS v(id, sale_id, product_id, quantity, unit_price, discount, note)
 JOIN products p ON p.id = v.product_id
 ON CONFLICT (id) DO UPDATE SET
@@ -989,7 +1037,7 @@ INSERT INTO supplier_invoices (
 ) VALUES
     ('dm_sinv_01', NULL, 'dm_sup_01', 'TechSource Distribution', CURRENT_DATE - INTERVAL '18 days', CURRENT_DATE + INTERVAL '12 days', 'draft', 1920.00, 1920.00, 0.00, 'Editable draft supplier invoice.', CURRENT_TIMESTAMP - INTERVAL '18 days', CURRENT_TIMESTAMP - INTERVAL '17 days'),
     ('dm_sinv_02', NULL, 'dm_sup_02', 'CloudSeat Licensing', CURRENT_DATE - INTERVAL '32 days', CURRENT_DATE + INTERVAL '3 days', 'sent', 14560.00, 14560.00, 4000.00, 'Partially settled supplier invoice kept in sent state.', CURRENT_TIMESTAMP - INTERVAL '32 days', CURRENT_TIMESTAMP - INTERVAL '6 days'),
-    ('dm_sinv_03', 'dm_ss_04', 'dm_sup_03', 'SecureEdge Systems', CURRENT_DATE - INTERVAL '19 days', CURRENT_DATE + INTERVAL '11 days', 'paid', 6130.00, 6130.00, 6130.00, 'Paid supplier invoice linked to a sent order.', CURRENT_TIMESTAMP - INTERVAL '19 days', CURRENT_TIMESTAMP - INTERVAL '2 days'),
+    ('dm_sinv_03', pg_temp.demo_document_code('supplier_order', 4), 'dm_sup_03', 'SecureEdge Systems', CURRENT_DATE - INTERVAL '19 days', CURRENT_DATE + INTERVAL '11 days', 'paid', 6130.00, 6130.00, 6130.00, 'Paid supplier invoice linked to a sent order.', CURRENT_TIMESTAMP - INTERVAL '19 days', CURRENT_TIMESTAMP - INTERVAL '2 days'),
     ('dm_sinv_04', NULL, 'dm_sup_04', 'PrintLogistics Hub', CURRENT_DATE - INTERVAL '48 days', CURRENT_DATE - INTERVAL '12 days', 'overdue', 23600.00, 23600.00, 0.00, 'Overdue supplier invoice kept for state coverage.', CURRENT_TIMESTAMP - INTERVAL '48 days', CURRENT_TIMESTAMP - INTERVAL '10 days'),
     ('dm_sinv_05', NULL, 'dm_sup_01', 'TechSource Distribution', CURRENT_DATE - INTERVAL '11 days', CURRENT_DATE + INTERVAL '18 days', 'cancelled', 960.00, 960.00, 0.00, 'Cancelled supplier invoice kept for state coverage.', CURRENT_TIMESTAMP - INTERVAL '11 days', CURRENT_TIMESTAMP - INTERVAL '10 days')
 ON CONFLICT (id) DO UPDATE SET
@@ -1029,8 +1077,8 @@ ON CONFLICT (id) DO UPDATE SET
     unit_price = EXCLUDED.unit_price,
     discount = EXCLUDED.discount;
 
--- Demo delivery projects generated from the confirmed order dm_so_04 (← offer dm_co_03 ←
--- quote dm_cq_06), all for client dm_cli_01. order_id/offer_id mirror the chain the app
+-- Demo delivery projects generated from the confirmed client order #04 (offer #03 <-
+-- quote #06), all for client dm_cli_01. order_id/offer_id mirror the chain the app
 -- enforces when a project is created (offer + client must match). start_date/end_date wrap
 -- the dm_te_21..dm_te_25 time entries below, and revenue splits the order/invoice total of
 -- 6303.25 across the two product lines (assessment 4674.00 + deployment 1629.25).
@@ -1056,8 +1104,8 @@ INSERT INTO projects (
         'Assessment track for operations',
         FALSE,
         CURRENT_TIMESTAMP - INTERVAL '18 days',
-        'dm_so_04',
-        'dm_co_03',
+        pg_temp.demo_document_code('client_order', 4),
+        pg_temp.demo_document_code('client_offer', 3),
         (CURRENT_DATE - INTERVAL '18 days')::date,
         (CURRENT_DATE + INTERVAL '30 days')::date,
         4674.00, 'attivo', TRUE
@@ -1069,8 +1117,8 @@ INSERT INTO projects (
         'Deployment wave for phase one',
         FALSE,
         CURRENT_TIMESTAMP - INTERVAL '18 days',
-        'dm_so_04',
-        'dm_co_03',
+        pg_temp.demo_document_code('client_order', 4),
+        pg_temp.demo_document_code('client_offer', 3),
         (CURRENT_DATE - INTERVAL '18 days')::date,
         (CURRENT_DATE + INTERVAL '60 days')::date,
         1629.25, 'attivo', TRUE
@@ -1126,7 +1174,7 @@ INSERT INTO notifications (
                 'DM-CLI-001_DM-SVC-DEPLOY_' || TO_CHAR(CURRENT_DATE, 'YYYY')
             ),
             'orderId',
-            'dm_so_04',
+            pg_temp.demo_document_code('client_order', 4),
             'clientName',
             'Northwind Retail Italia S.p.A.'
         ),
@@ -1146,7 +1194,7 @@ INSERT INTO notifications (
                 'DM-CLI-001_DM-SVC-DEPLOY_' || TO_CHAR(CURRENT_DATE, 'YYYY')
             ),
             'orderId',
-            'dm_so_04',
+            pg_temp.demo_document_code('client_order', 4),
             'clientName',
             'Northwind Retail Italia S.p.A.'
         ),

--- a/server/test/db/demoSeed.test.ts
+++ b/server/test/db/demoSeed.test.ts
@@ -3,11 +3,13 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { PoolClient } from 'pg';
 import {
+  assertNoDemoDocumentIdConflicts,
   cleanupDemoNamespace,
   insertCompatibilityDefaults,
   selectDemoUserCleanupIds,
 } from '../../db/demoSeed.ts';
 import {
+  buildDemoIds,
   COMPATIBILITY_DEFAULTS,
   DEMO_CUSTOMER_OFFERS,
   DEMO_EXPECTED_COUNTS,
@@ -43,22 +45,26 @@ const CONTRACT_TYPES = new Set([
 const EMPLOYMENT_STATUSES = new Set(['active', 'onboarding', 'on_leave', 'terminated']);
 const WORK_LOCATIONS = new Set(['office', 'remote', 'hybrid', 'customer_site', 'other']);
 
-const documentCodesFor = (moduleId: DocumentCodeModuleId, count: number) =>
+const documentCodesFor = (
+  moduleId: DocumentCodeModuleId,
+  count: number,
+  year = new Date().getFullYear(),
+) =>
   Array.from({ length: count }, (_, index) =>
     renderDocumentCode(DOCUMENT_CODE_MODULES[moduleId], {
-      year: new Date().getFullYear(),
+      year,
       sequence: index + 1,
     }),
   );
 
 type QueryCall = { sql: string; params: unknown[] | undefined };
 
-const buildQueryRecorder = (rowCount = 1) => {
+const buildQueryRecorder = (rowCount = 1, rows: unknown[] = []) => {
   const calls: QueryCall[] = [];
   const client = {
     query: async (sql: string, params?: unknown[]) => {
       calls.push({ sql, params });
-      return { rowCount, rows: [] };
+      return { rowCount, rows };
     },
   } as unknown as PoolClient;
 
@@ -144,6 +150,44 @@ describe('cleanupDemoNamespace', () => {
     expect(findDelete(calls, 'notifications')?.sql).toContain('user_id = ANY($2::text[])');
     expect(findDelete(calls, 'user_work_units')?.sql).toContain('user_id = ANY($2::text[])');
     expect(findDelete(calls, 'work_unit_managers')?.sql).toContain('user_id = ANY($2::text[])');
+  });
+
+  test('uses the provided seed year when cleaning default-code documents', async () => {
+    const { calls, client } = buildQueryRecorder();
+
+    await cleanupDemoNamespace(
+      client,
+      {
+        dependentUserIds: ['u2', 'u3'],
+        userIdsToDelete: [],
+      },
+      2027,
+    );
+
+    expect(findDelete(calls, 'quotes')?.params?.[0]).toEqual(
+      documentCodesFor('client_quote', 14, 2027),
+    );
+    expect(findDelete(calls, 'sales')?.params?.[0]).toEqual(
+      documentCodesFor('client_order', 5, 2027),
+    );
+  });
+});
+
+describe('assertNoDemoDocumentIdConflicts', () => {
+  test('fails before cleanup can overwrite real documents using default demo codes', async () => {
+    const conflictingId = documentCodesFor('client_quote', 1, 2027)[0];
+    const { client } = buildQueryRecorder(1, [{ table_name: 'quotes', id: conflictingId }]);
+
+    await expect(assertNoDemoDocumentIdConflicts(client, 2027)).rejects.toThrow(
+      `Demo seed document ID collision with non-demo records: quotes:${conflictingId}`,
+    );
+  });
+
+  test('passes when the runtime demo codes are unused by non-demo rows', async () => {
+    const { calls, client } = buildQueryRecorder(0);
+
+    await expect(assertNoDemoDocumentIdConflicts(client, 2027)).resolves.toBeUndefined();
+    expect(calls[0]?.params?.[0]).toEqual(buildDemoIds(2027).quotes);
   });
 });
 

--- a/server/test/db/demoSeed.test.ts
+++ b/server/test/db/demoSeed.test.ts
@@ -9,14 +9,24 @@ import {
 } from '../../db/demoSeed.ts';
 import {
   COMPATIBILITY_DEFAULTS,
+  DEMO_CUSTOMER_OFFERS,
   DEMO_EXPECTED_COUNTS,
   DEMO_IDS,
+  DEMO_QUOTES,
+  DEMO_SALES,
+  DEMO_SUPPLIER_QUOTES,
+  DEMO_SUPPLIER_SALES,
   DEMO_TOP_MANAGER_USER_IDS,
   DEMO_USER_CLIENT_ASSIGNMENTS,
   DEMO_USER_PROJECT_ASSIGNMENTS,
   DEMO_USER_TASK_ASSIGNMENTS,
   DEMO_USERS,
 } from '../../db/demoSeedManifest.ts';
+import {
+  DOCUMENT_CODE_MODULES,
+  type DocumentCodeModuleId,
+  renderDocumentCode,
+} from '../../utils/document-codes.ts';
 import { parseInsertValuesBlocks } from './seedSqlParsing.ts';
 
 const SERVER_ROOT = join(import.meta.dirname, '..', '..');
@@ -32,6 +42,14 @@ const CONTRACT_TYPES = new Set([
 ]);
 const EMPLOYMENT_STATUSES = new Set(['active', 'onboarding', 'on_leave', 'terminated']);
 const WORK_LOCATIONS = new Set(['office', 'remote', 'hybrid', 'customer_site', 'other']);
+
+const documentCodesFor = (moduleId: DocumentCodeModuleId, count: number) =>
+  Array.from({ length: count }, (_, index) =>
+    renderDocumentCode(DOCUMENT_CODE_MODULES[moduleId], {
+      year: new Date().getFullYear(),
+      sequence: index + 1,
+    }),
+  );
 
 type QueryCall = { sql: string; params: unknown[] | undefined };
 
@@ -130,6 +148,48 @@ describe('cleanupDemoNamespace', () => {
 });
 
 describe('demoSeedManifest assignment coverage', () => {
+  test('manifest document IDs use the admin default document code templates', () => {
+    expect(DEMO_QUOTES.map((row) => row.id)).toEqual(documentCodesFor('client_quote', 14));
+    expect(DEMO_CUSTOMER_OFFERS.map((row) => row.id)).toEqual(documentCodesFor('client_offer', 5));
+    expect(DEMO_SUPPLIER_QUOTES.map((row) => row.id)).toEqual(
+      documentCodesFor('supplier_quote', 14),
+    );
+    expect(DEMO_SALES.map((row) => row.id)).toEqual(documentCodesFor('client_order', 5));
+    expect(DEMO_SUPPLIER_SALES.map((row) => row.id)).toEqual(documentCodesFor('supplier_order', 5));
+  });
+
+  test('seed.sql document rows and counters match the default-code manifest', () => {
+    expect(parseInsertValuesBlocks(SEED_SQL, 'quotes').map((row) => row.id)).toEqual(
+      DEMO_QUOTES.map((row) => row.id),
+    );
+    expect(parseInsertValuesBlocks(SEED_SQL, 'customer_offers').map((row) => row.id)).toEqual(
+      DEMO_CUSTOMER_OFFERS.map((row) => row.id),
+    );
+    expect(parseInsertValuesBlocks(SEED_SQL, 'supplier_quotes').map((row) => row.id)).toEqual(
+      DEMO_SUPPLIER_QUOTES.map((row) => row.id),
+    );
+    expect(parseInsertValuesBlocks(SEED_SQL, 'sales').map((row) => row.id)).toEqual(
+      DEMO_SALES.map((row) => row.id),
+    );
+    expect(parseInsertValuesBlocks(SEED_SQL, 'supplier_sales').map((row) => row.id)).toEqual(
+      DEMO_SUPPLIER_SALES.map((row) => row.id),
+    );
+
+    const counters = Object.fromEntries(
+      parseInsertValuesBlocks(SEED_SQL, 'document_code_counters').map((row) => [
+        row.module_id,
+        Number(row.next_sequence),
+      ]),
+    );
+    expect(counters).toEqual({
+      client_quote: 15,
+      client_offer: 6,
+      supplier_quote: 15,
+      client_order: 6,
+      supplier_order: 6,
+    });
+  });
+
   test('seed.sql task ids match the compatibility and demo task manifests', () => {
     expect(
       parseInsertValuesBlocks(SEED_SQL, 'tasks')

--- a/server/test/db/seedProjectCoherence.test.ts
+++ b/server/test/db/seedProjectCoherence.test.ts
@@ -190,8 +190,12 @@ describe('demoSeedManifest stays in sync with seed.sql', () => {
     );
   });
 
-  test('dm_so_04 linked offer matches DEMO_SALES', () => {
-    const manifest = DEMO_SALES.find((sale) => sale.id === 'dm_so_04');
-    expect(sales.get('dm_so_04')?.linkedOfferId).toBe(manifest?.linkedOfferId ?? null);
+  test('delivery order linked offer matches DEMO_SALES', () => {
+    const orderId = projects.get('dm_proj_01')?.orderId;
+    expect(orderId).toBeTruthy();
+    const manifest = DEMO_SALES.find((sale) => sale.id === orderId);
+    expect(orderId ? sales.get(orderId)?.linkedOfferId : null).toBe(
+      manifest?.linkedOfferId ?? null,
+    );
   });
 });

--- a/server/test/db/seedSqlParsing.ts
+++ b/server/test/db/seedSqlParsing.ts
@@ -3,6 +3,12 @@
 // literals and nested parentheses. Used by seedTaskReferences.test.ts and
 // seedProjectCoherence.test.ts.
 
+import {
+  DOCUMENT_CODE_MODULES,
+  isDocumentCodeModuleId,
+  renderDocumentCode,
+} from '../../utils/document-codes.ts';
+
 type TopLevelEvent = { type: 'comma' | 'open' | 'close'; index: number };
 
 // Walk a SQL fragment yielding top-level commas and the outer `(...)` boundaries while
@@ -55,6 +61,16 @@ const splitTopLevelCommas = (input: string): string[] => {
 // cells (NULL, numbers, expressions) are returned trimmed as-is.
 export const unquote = (value: string): string => {
   const trimmed = value.trim();
+  const documentCode = trimmed.match(/^pg_temp\.demo_document_code\('([^']+)',\s*(\d+)\)$/);
+  if (documentCode) {
+    const moduleId = documentCode[1];
+    if (isDocumentCodeModuleId(moduleId)) {
+      return renderDocumentCode(DOCUMENT_CODE_MODULES[moduleId], {
+        year: new Date().getFullYear(),
+        sequence: Number(documentCode[2]),
+      });
+    }
+  }
   const m = trimmed.match(/^'((?:''|[^'])*)'$/);
   return m ? m[1].replace(/''/g, "'") : trimmed;
 };

--- a/server/test/db/seedSupplierQuoteSourcing.test.ts
+++ b/server/test/db/seedSupplierQuoteSourcing.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { DEMO_SUPPLIER_QUOTES } from '../../db/demoSeedManifest.ts';
 import { effectiveSupplierQuoteStatus } from '../../utils/quote-status.ts';
 import {
   dateOffsetDays,
@@ -96,12 +97,12 @@ const parseSourcing = (sql: string): Sourcing[] => {
   }
 
   const single = sql.match(
-    /UPDATE quote_items SET\s+supplier_quote_id = '([^']+)',\s+supplier_quote_item_id = '([^']+)',\s+supplier_quote_supplier_name = '([^']+)',\s+supplier_quote_unit_price = ([\d.]+)\s+WHERE id = '([^']+)'/,
+    /UPDATE quote_items SET\s+supplier_quote_id = (pg_temp\.demo_document_code\('[^']+',\s*\d+\)|'[^']+'),\s+supplier_quote_item_id = '([^']+)',\s+supplier_quote_supplier_name = '([^']+)',\s+supplier_quote_unit_price = ([\d.]+)\s+WHERE id = '([^']+)'/,
   );
   if (single) {
     rows.push({
       cqiId: single[5],
-      supplierQuoteId: single[1],
+      supplierQuoteId: unquote(single[1]),
       supplierItemId: single[2],
       supplierName: single[3],
       snapshot: Number(single[4]),
@@ -113,23 +114,33 @@ const parseSourcing = (sql: string): Sourcing[] => {
 
 const sourcing = parseSourcing(SEED_SQL);
 
-// The status each demo supplier quote must DERIVE under line sourcing (mirrors the seed comment).
-const EXPECTED_STATUS: Record<string, string> = {
-  dm_sq_01: 'draft', // sourced by nobody → selectable in the client-quote dialog
-  dm_sq_02: 'sent',
-  dm_sq_03: 'accepted',
-  dm_sq_04: 'offer',
-  dm_sq_05: 'offer',
-  dm_sq_06: 'accepted',
-  dm_sq_07: 'accepted',
-  dm_sq_08: 'denied',
-  dm_sq_09: 'denied',
-  dm_sq_10: 'expired', // sourced by nobody, own expiration past
-  dm_sq_11: 'accepted',
-  dm_sq_12: 'accepted',
-  dm_sq_13: 'accepted',
-  dm_sq_14: 'accepted',
+const supplierQuoteId = (sequence: number) => {
+  const quote = DEMO_SUPPLIER_QUOTES[sequence - 1];
+  if (!quote) throw new Error(`Missing demo supplier quote sequence ${sequence}`);
+  return quote.id;
 };
+
+// The status each demo supplier quote must DERIVE under line sourcing (mirrors the seed comment).
+const EXPECTED_STATUS_BY_SEQUENCE = [
+  'draft',
+  'sent',
+  'accepted',
+  'offer',
+  'offer',
+  'accepted',
+  'accepted',
+  'denied',
+  'denied',
+  'expired',
+  'accepted',
+  'accepted',
+  'accepted',
+  'accepted',
+] as const;
+
+const EXPECTED_STATUS = Object.fromEntries(
+  EXPECTED_STATUS_BY_SEQUENCE.map((status, index) => [supplierQuoteId(index + 1), status]),
+);
 
 const sourcingFor = (supplierQuoteId: string) =>
   sourcing.filter((row) => row.supplierQuoteId === supplierQuoteId);
@@ -193,9 +204,9 @@ describe('seed.sql line-sourced supplier-quote linkage (#779 / PR #812)', () => 
     }
   });
 
-  test('dm_sq_01 (draft picker candidate) and dm_sq_10 (expired) are sourced by nobody', () => {
-    expect(sourcingFor('dm_sq_01')).toEqual([]);
-    expect(sourcingFor('dm_sq_10')).toEqual([]);
+  test('draft picker candidate and expired supplier quote are sourced by nobody', () => {
+    expect(sourcingFor(supplierQuoteId(1))).toEqual([]);
+    expect(sourcingFor(supplierQuoteId(10))).toEqual([]);
   });
 
   test('every sourced line keeps a positive margin (snapshot net cost below its sale price)', () => {
@@ -209,7 +220,7 @@ describe('seed.sql line-sourced supplier-quote linkage (#779 / PR #812)', () => 
   test('each sourced line shares its supplier item product (the resolver 400s a mismatch)', () => {
     // resolveQuoteItemSnapshots (server/routes/client-quotes.ts) rejects a sourced line whose
     // productId differs from its supplier item's, so a seeded mismatch is latent-invalid data that
-    // 400s the moment the line is edited (and breaks the editable dm_cq_02 stale-data demo).
+    // 400s the moment the line is edited (and breaks the editable PREV #02 stale-data demo).
     for (const row of sourcing) {
       const lineProduct = quoteItems.get(row.cqiId)?.productId;
       const supplierProduct = supplierItems.get(row.supplierItemId)?.productId;
@@ -221,7 +232,7 @@ describe('seed.sql line-sourced supplier-quote linkage (#779 / PR #812)', () => 
     for (const row of sourcing) {
       const live = supplierItems.get(row.supplierItemId)?.cost ?? 0;
       if (row.cqiId === 'dm_cqi_03') {
-        // dm_cq_02 is sent (editable) → its line intentionally lags so the refresh chip shows.
+        // PREV #02 is sent (editable) -> its line intentionally lags so the refresh chip shows.
         expect(row.snapshot).toBeLessThan(live);
       } else {
         // Read-only (accepted/denied) quotes never show the chip, but the snapshot still mirrors


### PR DESCRIPTION
## Summary
- Updates the demo seed so customer quotes, customer offers, supplier quotes, customer orders, and supplier orders use the admin default document code formats.
- Seeds current-year document code counters without lowering already advanced counters.
- Updates static seed tests to derive expected document IDs from the manifest/default renderer instead of legacy `dm_*` document IDs.

## Changes
- Replaces demo document IDs with `PREV_{YY}_{SEQ}`, `OFF_{YY}_{SEQ}`, `FORN_{YY}_{SEQ}`, `ORD_{YY}_{SEQ}`, and `SORD_{YY}_{SEQ}`.
- Updates related seed references across line items, offers, orders, invoice links, supplier sourcing, supplier orders, notifications, and derived projects.
- Keeps non-document technical IDs unchanged.

## Testing
- `cd server; bun test ./test/db/demoSeed.test.ts ./test/db/seedProjectCoherence.test.ts ./test/db/seedSupplierQuoteSourcing.test.ts ./test/utils/document-codes.test.ts`
- `bun run typecheck`
- `bun run test:server`
- `git diff --check`
- `bun run test:react-doctor` (62/100, 141 warnings; unchanged from baseline)

## Risks / Rollout
- Medium-low risk. This changes demo seed content and FK references only; no API or schema changes.
- Existing advanced document counters are preserved by `GREATEST(existing, seeded)`.

## Issues
Issue: Not linked