### PR TITLE
release(chore): bump app to 0.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praetor",
   "private": true,
-  "version": "0.8.0",
+  "version": "0.8.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "praetor-server",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Praetor API Server",
   "main": "index.ts",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bumps the Praetor app package version from `0.8.0` to `0.8.1`.
- Keeps the frontend and server package manifests in sync for the patch release.

## Changes
- Updates `package.json` to `0.8.1`.
- Updates `server/package.json` to `0.8.1`.

## Testing
- `bun run test:react-doctor` before changes: 62/100, 141 warnings.
- `bun run test:react-doctor` after changes: 62/100, 141 warnings.
- `bun run lint`

## Risks / Rollout
- Low risk. Manifest-only patch version bump; no runtime behavior, database, auth, API, or documentation behavior changes.

## Issues
- Not linked