### PR TITLE
seed(fix): populate demo compatibility clients

### DIFF
--- a/server/db/demoSeed.ts
+++ b/server/db/demoSeed.ts
@@ -7,6 +7,7 @@ import {
   buildDemoAssignmentTargetIds,
   buildDemoDocumentSeedManifest,
   buildDemoIds,
+  COMPATIBILITY_DEFAULT_CLIENTS,
   COMPATIBILITY_DEFAULTS,
   DEMO_CLIENTS,
   DEMO_EXPECTED_COUNTS,
@@ -114,13 +115,38 @@ const pushTextArrayPredicate = (
   builder.parts.push(`${expression} = ANY($${builder.params.length}::text[])`);
 };
 
-const pushLowerTextArrayPredicate = (
+const pushTextArrayPredicateExcludingIds = (
+  builder: PredicateBuilder,
+  expression: string,
+  values: readonly string[],
+  excludedIds: readonly string[],
+) => {
+  if (values.length === 0) return;
+  if (excludedIds.length === 0) {
+    pushTextArrayPredicate(builder, expression, values);
+    return;
+  }
+  builder.params.push([...values]);
+  const valuesParam = builder.params.length;
+  builder.params.push([...excludedIds]);
+  const excludedIdsParam = builder.params.length;
+  builder.parts.push(
+    `(${expression} = ANY($${valuesParam}::text[]) AND id <> ALL($${excludedIdsParam}::text[]))`,
+  );
+};
+
+const pushLowerTextArrayPredicateExcludingIds = (
   builder: PredicateBuilder,
   column: string,
   values: readonly string[],
+  excludedIds: readonly string[],
 ) => {
-  const lowered = values.map((value) => value.toLowerCase());
-  pushTextArrayPredicate(builder, `LOWER(${column})`, lowered);
+  pushTextArrayPredicateExcludingIds(
+    builder,
+    `LOWER(${column})`,
+    values.map((value) => value.toLowerCase()),
+    excludedIds,
+  );
 };
 
 const executeDelete = async (
@@ -156,38 +182,134 @@ export const insertCompatibilityDefaults = async (
   client: PoolClient,
   counts: Record<string, number>,
 ) => {
+  await executeStatement(
+    client,
+    `UPDATE clients
+     SET
+       client_code = NULL,
+       fiscal_code = NULL,
+       vat_number = NULL,
+       tax_code = NULL
+     WHERE id = ANY($1::text[])`,
+    [[...COMPATIBILITY_DEFAULTS.clients]],
+  );
+
   const clientsResult = await executeStatement(
     client,
-    `INSERT INTO clients (id, name, created_at) VALUES
-        ('c1', 'Acme Corp', '2024-01-15 09:30:00'),
-        ('c2', 'Global Tech', '2024-03-05 14:15:00')
+    `INSERT INTO clients (
+       id,
+       name,
+       is_disabled,
+       created_at,
+       type,
+       contact_name,
+       client_code,
+       email,
+       phone,
+       address,
+       description,
+       ateco_code,
+       website,
+       sector,
+       number_of_employees,
+       revenue,
+       fiscal_code,
+       vat_number,
+       tax_code,
+       office_count_range,
+       contacts,
+       address_country,
+       address_state,
+       address_cap,
+       address_province,
+       address_civic_number,
+       address_line
+     ) VALUES
+        (
+          'c1',
+          'Acme Corp',
+          FALSE,
+          '2024-01-15 09:30:00',
+          'company',
+          'Marta Colombo',
+          'ACME-001',
+          'operations@acme-corp.demo',
+          '+39 02 5550 6101',
+          'Via Dante 7, 20121 Milano (MI), Italia',
+          'Compatibility client used by the legacy Website Redesign and Mobile App demo projects.',
+          '62.01.00',
+          'https://acme-corp.demo',
+          'SERVICES',
+          '50..250',
+          '11..50',
+          'IT20000000001',
+          'IT20000000001',
+          NULL,
+          '2...5',
+          '[{"fullName":"Marta Colombo","role":"Operations Manager","email":"operations@acme-corp.demo","phone":"+39 02 5550 6101"}]'::jsonb,
+          'Italia',
+          'Milano',
+          '20121',
+          'MI',
+          '7',
+          'Via Dante'
+        ),
+        (
+          'c2',
+          'Global Tech',
+          FALSE,
+          '2024-03-05 14:15:00',
+          'company',
+          'Andrea Bassi',
+          'GTECH-001',
+          'research@global-tech.demo',
+          '+39 011 5550 6202',
+          'Corso Vittorio Emanuele II 74, 10121 Torino (TO), Italia',
+          'Compatibility client used by the legacy Internal Research demo project.',
+          '72.19.09',
+          'https://global-tech.demo',
+          'SERVICES',
+          '< 50',
+          '< 10',
+          'IT20000000002',
+          'IT20000000002',
+          NULL,
+          '1',
+          '[{"fullName":"Andrea Bassi","role":"Innovation Lead","email":"research@global-tech.demo","phone":"+39 011 5550 6202"}]'::jsonb,
+          'Italia',
+          'Torino',
+          '10121',
+          'TO',
+          '74',
+          'Corso Vittorio Emanuele II'
+        )
      ON CONFLICT (id) DO UPDATE SET
        name = EXCLUDED.name,
        created_at = EXCLUDED.created_at,
        is_disabled = FALSE,
-       type = DEFAULT,
-       contact_name = NULL,
-       client_code = NULL,
-       email = NULL,
-       phone = NULL,
-       address = NULL,
-       description = NULL,
-       ateco_code = NULL,
-       website = NULL,
-       sector = NULL,
-       number_of_employees = NULL,
-       revenue = NULL,
-       fiscal_code = NULL,
-       vat_number = NULL,
+       type = EXCLUDED.type,
+       contact_name = EXCLUDED.contact_name,
+       client_code = EXCLUDED.client_code,
+       email = EXCLUDED.email,
+       phone = EXCLUDED.phone,
+       address = EXCLUDED.address,
+       description = EXCLUDED.description,
+       ateco_code = EXCLUDED.ateco_code,
+       website = EXCLUDED.website,
+       sector = EXCLUDED.sector,
+       number_of_employees = EXCLUDED.number_of_employees,
+       revenue = EXCLUDED.revenue,
+       fiscal_code = EXCLUDED.fiscal_code,
+       vat_number = EXCLUDED.vat_number,
        tax_code = NULL,
-       office_count_range = NULL,
-       contacts = DEFAULT,
-       address_country = NULL,
-       address_state = NULL,
-       address_cap = NULL,
-       address_province = NULL,
-       address_civic_number = NULL,
-       address_line = NULL`,
+       office_count_range = EXCLUDED.office_count_range,
+       contacts = EXCLUDED.contacts,
+       address_country = EXCLUDED.address_country,
+       address_state = EXCLUDED.address_state,
+       address_cap = EXCLUDED.address_cap,
+       address_province = EXCLUDED.address_province,
+       address_civic_number = EXCLUDED.address_civic_number,
+       address_line = EXCLUDED.address_line`,
   );
   incrementCount(counts, 'clients', clientsResult.rowCount ?? 0);
 
@@ -704,16 +826,45 @@ export const cleanupDemoNamespace = async (
     cleanupCountsByTable,
     'clients',
     await executeDelete(client, 'clients', (builder) => {
+      const compatibilityClientCodes = COMPATIBILITY_DEFAULT_CLIENTS.map(
+        (clientItem) => clientItem.clientCode,
+      );
+      const compatibilityFiscalCodes = COMPATIBILITY_DEFAULT_CLIENTS.map(
+        (clientItem) => clientItem.fiscalCode,
+      );
+      const demoClientCodes = DEMO_CLIENTS.map((clientItem) => clientItem.clientCode);
+      const demoFiscalCodes = DEMO_CLIENTS.map((clientItem) => clientItem.fiscalCode);
+
       pushTextArrayPredicate(builder, 'id', demoIds.clients);
-      pushTextArrayPredicate(
+      pushTextArrayPredicateExcludingIds(
         builder,
         'client_code',
-        DEMO_CLIENTS.map((clientItem) => clientItem.clientCode),
+        demoClientCodes,
+        COMPATIBILITY_DEFAULTS.clients,
       );
-      pushLowerTextArrayPredicate(
+      pushLowerTextArrayPredicateExcludingIds(
         builder,
         'fiscal_code',
-        DEMO_CLIENTS.map((clientItem) => clientItem.fiscalCode),
+        demoFiscalCodes,
+        COMPATIBILITY_DEFAULTS.clients,
+      );
+      pushTextArrayPredicateExcludingIds(
+        builder,
+        'client_code',
+        compatibilityClientCodes,
+        COMPATIBILITY_DEFAULTS.clients,
+      );
+      pushLowerTextArrayPredicateExcludingIds(
+        builder,
+        'fiscal_code',
+        compatibilityFiscalCodes,
+        COMPATIBILITY_DEFAULTS.clients,
+      );
+      pushLowerTextArrayPredicateExcludingIds(
+        builder,
+        'vat_number',
+        compatibilityFiscalCodes,
+        COMPATIBILITY_DEFAULTS.clients,
       );
     }),
   );

--- a/server/db/demoSeedManifest.ts
+++ b/server/db/demoSeedManifest.ts
@@ -314,8 +314,13 @@ export const DEMO_USERS = [
 export const DEMO_USER_IDS = DEMO_USERS.map((user) => user.id);
 export const DEMO_USERNAMES = DEMO_USERS.map((user) => user.username);
 
+export const COMPATIBILITY_DEFAULT_CLIENTS = [
+  { id: 'c1', clientCode: 'ACME-001', fiscalCode: 'IT20000000001' },
+  { id: 'c2', clientCode: 'GTECH-001', fiscalCode: 'IT20000000002' },
+] as const;
+
 export const COMPATIBILITY_DEFAULTS = {
-  clients: ['c1', 'c2'],
+  clients: COMPATIBILITY_DEFAULT_CLIENTS.map((client) => client.id),
   projects: ['p1', 'p2', 'p3'],
   tasks: ['t1', 't2', 't3', 't4', 't5'],
 } as const;

--- a/server/db/seed.sql
+++ b/server/db/seed.sql
@@ -20,10 +20,95 @@ FROM users u
 WHERE u.id IN ('u1', 'u2', 'u3', 'u9')
 ON CONFLICT DO NOTHING;
 
--- Lightweight defaults kept for compatibility with existing frontend constants
-INSERT INTO clients (id, name, created_at) VALUES
-    ('c1', 'Acme Corp', '2024-01-15 09:30:00'),
-    ('c2', 'Global Tech', '2024-03-05 14:15:00')
+-- Compatibility defaults kept for existing frontend constants and fully populated so
+-- the CRM directory does not show partial client rows in demo mode.
+INSERT INTO clients (
+    id,
+    name,
+    is_disabled,
+    created_at,
+    type,
+    contact_name,
+    client_code,
+    email,
+    phone,
+    address,
+    description,
+    ateco_code,
+    website,
+    sector,
+    number_of_employees,
+    revenue,
+    fiscal_code,
+    vat_number,
+    tax_code,
+    office_count_range,
+    contacts,
+    address_country,
+    address_state,
+    address_cap,
+    address_province,
+    address_civic_number,
+    address_line
+) VALUES
+    (
+        'c1',
+        'Acme Corp',
+        FALSE,
+        '2024-01-15 09:30:00',
+        'company',
+        'Marta Colombo',
+        'ACME-001',
+        'operations@acme-corp.demo',
+        '+39 02 5550 6101',
+        'Via Dante 7, 20121 Milano (MI), Italia',
+        'Compatibility client used by the legacy Website Redesign and Mobile App demo projects.',
+        '62.01.00',
+        'https://acme-corp.demo',
+        'SERVICES',
+        '50..250',
+        '11..50',
+        'IT20000000001',
+        'IT20000000001',
+        NULL,
+        '2...5',
+        '[{"fullName":"Marta Colombo","role":"Operations Manager","email":"operations@acme-corp.demo","phone":"+39 02 5550 6101"}]'::jsonb,
+        'Italia',
+        'Milano',
+        '20121',
+        'MI',
+        '7',
+        'Via Dante'
+    ),
+    (
+        'c2',
+        'Global Tech',
+        FALSE,
+        '2024-03-05 14:15:00',
+        'company',
+        'Andrea Bassi',
+        'GTECH-001',
+        'research@global-tech.demo',
+        '+39 011 5550 6202',
+        'Corso Vittorio Emanuele II 74, 10121 Torino (TO), Italia',
+        'Compatibility client used by the legacy Internal Research demo project.',
+        '72.19.09',
+        'https://global-tech.demo',
+        'SERVICES',
+        '< 50',
+        '< 10',
+        'IT20000000002',
+        'IT20000000002',
+        NULL,
+        '1',
+        '[{"fullName":"Andrea Bassi","role":"Innovation Lead","email":"research@global-tech.demo","phone":"+39 011 5550 6202"}]'::jsonb,
+        'Italia',
+        'Torino',
+        '10121',
+        'TO',
+        '74',
+        'Corso Vittorio Emanuele II'
+    )
 ON CONFLICT (id) DO NOTHING;
 
 -- start_date/end_date bracket the demo time entries logged against each project

--- a/server/test/db/demoSeed.test.ts
+++ b/server/test/db/demoSeed.test.ts
@@ -10,7 +10,9 @@ import {
 } from '../../db/demoSeed.ts';
 import {
   buildDemoIds,
+  COMPATIBILITY_DEFAULT_CLIENTS,
   COMPATIBILITY_DEFAULTS,
+  DEMO_CLIENTS,
   DEMO_CUSTOMER_OFFERS,
   DEMO_EXPECTED_COUNTS,
   DEMO_IDS,
@@ -106,19 +108,28 @@ describe('insertCompatibilityDefaults', () => {
 
     await insertCompatibilityDefaults(client, {});
 
-    expect(calls).toHaveLength(3);
-    expect(calls[0]?.sql).toContain('ON CONFLICT (id) DO UPDATE SET');
-    expect(calls[0]?.sql).toContain('name = EXCLUDED.name');
-    expect(calls[0]?.sql).toContain('is_disabled = FALSE');
-    expect(calls[0]?.sql).toContain('contacts = DEFAULT');
+    expect(calls).toHaveLength(4);
+    expect(calls[0]?.sql).toContain('UPDATE clients');
     expect(calls[0]?.sql).toContain('client_code = NULL');
-    expect(calls[1]?.sql).toContain('description = EXCLUDED.description');
-    expect(calls[1]?.sql).toContain('tipo_confirmed = EXCLUDED.tipo_confirmed');
-    expect(calls[1]?.sql).toContain('order_id = NULL');
-    expect(calls[1]?.sql).toContain('billing_type = DEFAULT');
-    expect(calls[2]?.sql).toContain('project_id = EXCLUDED.project_id');
-    expect(calls[2]?.sql).toContain('is_recurring = DEFAULT');
-    expect(calls[2]?.sql).toContain('monthly_effort = DEFAULT');
+    expect(calls[0]?.sql).toContain('fiscal_code = NULL');
+    expect(calls[0]?.sql).toContain('vat_number = NULL');
+    expect(calls[0]?.params).toEqual([[...COMPATIBILITY_DEFAULTS.clients]]);
+    expect(calls[1]?.sql).toContain('ON CONFLICT (id) DO UPDATE SET');
+    expect(calls[1]?.sql).toContain('name = EXCLUDED.name');
+    expect(calls[1]?.sql).toContain('is_disabled = FALSE');
+    expect(calls[1]?.sql).toContain('ACME-001');
+    expect(calls[1]?.sql).toContain('GTECH-001');
+    expect(calls[1]?.sql).toContain('contacts = EXCLUDED.contacts');
+    expect(calls[1]?.sql).toContain('client_code = EXCLUDED.client_code');
+    expect(calls[1]?.sql).toContain('fiscal_code = EXCLUDED.fiscal_code');
+    expect(calls[1]?.sql).toContain('address_line = EXCLUDED.address_line');
+    expect(calls[2]?.sql).toContain('description = EXCLUDED.description');
+    expect(calls[2]?.sql).toContain('tipo_confirmed = EXCLUDED.tipo_confirmed');
+    expect(calls[2]?.sql).toContain('order_id = NULL');
+    expect(calls[2]?.sql).toContain('billing_type = DEFAULT');
+    expect(calls[3]?.sql).toContain('project_id = EXCLUDED.project_id');
+    expect(calls[3]?.sql).toContain('is_recurring = DEFAULT');
+    expect(calls[3]?.sql).toContain('monthly_effort = DEFAULT');
   });
 });
 
@@ -170,6 +181,42 @@ describe('cleanupDemoNamespace', () => {
     expect(findDelete(calls, 'sales')?.params?.[0]).toEqual(
       documentCodesFor('client_order', 5, 2027),
     );
+  });
+
+  test('cleans compatibility client business-key collisions without deleting their ids', async () => {
+    const { calls, client } = buildQueryRecorder();
+
+    await cleanupDemoNamespace(
+      client,
+      {
+        dependentUserIds: ['u2', 'u3'],
+        userIdsToDelete: [],
+      },
+      2027,
+    );
+
+    const clientDelete = findDelete(calls, 'clients');
+    const compatibilityFiscalCodes = COMPATIBILITY_DEFAULT_CLIENTS.map((client) =>
+      client.fiscalCode.toLowerCase(),
+    );
+    const compatibilityClientIds = [...COMPATIBILITY_DEFAULTS.clients];
+    const demoFiscalCodes = DEMO_CLIENTS.map((client) => client.fiscalCode.toLowerCase());
+
+    expect(clientDelete?.sql).toContain('id <> ALL');
+    expect(clientDelete?.sql).toContain('LOWER(vat_number)');
+    expect(clientDelete?.params).toEqual([
+      buildDemoIds(2027).clients,
+      DEMO_CLIENTS.map((client) => client.clientCode),
+      compatibilityClientIds,
+      demoFiscalCodes,
+      compatibilityClientIds,
+      COMPATIBILITY_DEFAULT_CLIENTS.map((client) => client.clientCode),
+      compatibilityClientIds,
+      compatibilityFiscalCodes,
+      compatibilityClientIds,
+      compatibilityFiscalCodes,
+      compatibilityClientIds,
+    ]);
   });
 });
 
@@ -262,6 +309,46 @@ describe('demoSeedManifest assignment coverage', () => {
         .map((row) => row.id)
         .sort(),
     ).toEqual([...COMPATIBILITY_DEFAULTS.tasks, ...DEMO_IDS.tasks].sort());
+  });
+
+  test('seed.sql compatibility clients include complete CRM details', () => {
+    const compatibilityClientIds = new Set<string>(COMPATIBILITY_DEFAULTS.clients);
+    const compatibilityClients = parseInsertValuesBlocks(SEED_SQL, 'clients').filter((row) =>
+      compatibilityClientIds.has(row.id),
+    );
+
+    expect(compatibilityClients).toHaveLength(COMPATIBILITY_DEFAULTS.clients.length);
+    const compatibilityClientKeys = new Map<string, (typeof COMPATIBILITY_DEFAULT_CLIENTS)[number]>(
+      COMPATIBILITY_DEFAULT_CLIENTS.map((client) => [client.id, client]),
+    );
+    for (const client of compatibilityClients) {
+      const expected = compatibilityClientKeys.get(client.id);
+
+      if (!expected) throw new Error(`Missing compatibility client manifest row for ${client.id}`);
+      expect(client.type).toBe('company');
+      expect(client.is_disabled).toBe('FALSE');
+      expect(client.contact_name).not.toBe('NULL');
+      expect(client.client_code).toBe(expected.clientCode);
+      expect(client.email).toMatch(/@.+\.demo$/);
+      expect(client.phone).toMatch(/^\+39 /);
+      expect(client.address).not.toBe('NULL');
+      expect(client.description).not.toBe('NULL');
+      expect(client.ateco_code).toMatch(/^\d{2}\.\d{2}\.\d{2}$/);
+      expect(client.website).toMatch(/^https:\/\//);
+      expect(client.sector).not.toBe('NULL');
+      expect(client.number_of_employees).not.toBe('NULL');
+      expect(client.revenue).not.toBe('NULL');
+      expect(client.fiscal_code).toBe(expected.fiscalCode);
+      expect(client.vat_number).toBe(expected.fiscalCode);
+      expect(client.office_count_range).not.toBe('NULL');
+      expect(client.contacts).toContain('fullName');
+      expect(client.address_country).not.toBe('NULL');
+      expect(client.address_state).not.toBe('NULL');
+      expect(client.address_cap).toMatch(/^\d{5}$/);
+      expect(client.address_province).toMatch(/^[A-Z]{2}$/);
+      expect(client.address_civic_number).not.toBe('NULL');
+      expect(client.address_line).not.toBe('NULL');
+    }
   });
 
   test('seed.sql user assignment rows match the demo manifest', () => {


### PR DESCRIPTION
## Summary
- Populates the legacy compatibility demo clients `c1` and `c2` with full CRM fields so the client directory no longer shows partial rows for Acme Corp and Global Tech.
- Keeps the TypeScript demo refresh path and static `seed.sql` aligned for those compatibility clients.

## Changes
- Adds contact, code, tax, address, profile, website, and CRM metadata for `Acme Corp` and `Global Tech` in the demo seed.
- Adds manifest entries for compatibility client business keys used during cleanup.
- Narrows demo cleanup so compatibility business-key collisions are removed without deleting the preserved `c1`/`c2` rows.
- Adds regression coverage for complete compatibility client seed data and cleanup behavior.

## Testing
- `bun test server/test/db/demoSeed.test.ts`
- `bun run typecheck`
- `bunx biome check server/db/demoSeed.ts server/db/demoSeedManifest.ts server/test/db/demoSeed.test.ts`
- `git diff --check`
- `bun run test:server`
- `bun run test:react-doctor` (100 / 100 before and after)

## Risks / Rollout
- Low risk. Change is scoped to demo seed data and seed cleanup logic.
- No schema migration or API behavior change.

## Issues
Issue: Not linked