### PR TITLE
seed(fix): align demo invoice codes with defaults

### DIFF
--- a/server/db/demoSeed.ts
+++ b/server/db/demoSeed.ts
@@ -21,6 +21,8 @@ import {
   DEMO_USERS,
   DEMO_WORK_UNITS,
   getDemoSeedYear,
+  LEGACY_DEMO_INVOICE_IDS,
+  LEGACY_DEMO_SUPPLIER_INVOICE_IDS,
 } from './demoSeedManifest.ts';
 import pool, { query } from './index.ts';
 
@@ -360,41 +362,75 @@ const insertDemoUsersAndSettings = async (client: PoolClient, counts: Record<str
 export const assertNoDemoDocumentIdConflicts = async (client: PoolClient, seedYear: number) => {
   const demoIds = buildDemoIds(seedYear);
   const demoClientOwnerIds = [...COMPATIBILITY_DEFAULTS.clients, ...demoIds.clients];
+  const invoiceClientOwnerIds = demoIds.clients;
   const result = await client.query<{ table_name: string; id: string }>(
-    `WITH conflicts AS (
-       SELECT 'quotes' AS table_name, id
+    `WITH demo_inputs AS (
+       SELECT
+         $1::text[] AS quote_ids,
+         $2::text[] AS customer_offer_ids,
+         $3::text[] AS sale_ids,
+         $4::text[] AS invoice_ids,
+         $5::text[] AS supplier_quote_ids,
+         $6::text[] AS supplier_sale_ids,
+         $7::text[] AS supplier_invoice_ids,
+         $8::text[] AS client_owner_ids,
+         $9::text[] AS invoice_client_owner_ids,
+         $10::text[] AS supplier_owner_ids
+     ),
+     conflicts AS (
+       SELECT 'quotes' AS table_name, quotes.id
        FROM quotes
-       WHERE id = ANY($1::text[])
-         AND COALESCE(client_id, '') <> ALL($6::text[])
+       CROSS JOIN demo_inputs
+       WHERE quotes.id = ANY(demo_inputs.quote_ids)
+         AND COALESCE(quotes.client_id, '') <> ALL(demo_inputs.client_owner_ids)
        UNION ALL
-       SELECT 'customer_offers' AS table_name, id
+       SELECT 'customer_offers' AS table_name, customer_offers.id
        FROM customer_offers
-       WHERE id = ANY($2::text[])
-         AND COALESCE(client_id, '') <> ALL($6::text[])
+       CROSS JOIN demo_inputs
+       WHERE customer_offers.id = ANY(demo_inputs.customer_offer_ids)
+         AND COALESCE(customer_offers.client_id, '') <> ALL(demo_inputs.client_owner_ids)
        UNION ALL
-       SELECT 'sales' AS table_name, id
+       SELECT 'sales' AS table_name, sales.id
        FROM sales
-       WHERE id = ANY($3::text[])
-         AND COALESCE(client_id, '') <> ALL($6::text[])
+       CROSS JOIN demo_inputs
+       WHERE sales.id = ANY(demo_inputs.sale_ids)
+         AND COALESCE(sales.client_id, '') <> ALL(demo_inputs.client_owner_ids)
        UNION ALL
-       SELECT 'supplier_quotes' AS table_name, id
+       SELECT 'invoices' AS table_name, invoices.id
+       FROM invoices
+       CROSS JOIN demo_inputs
+       WHERE invoices.id = ANY(demo_inputs.invoice_ids)
+         AND COALESCE(invoices.client_id, '') <> ALL(demo_inputs.invoice_client_owner_ids)
+       UNION ALL
+       SELECT 'supplier_quotes' AS table_name, supplier_quotes.id
        FROM supplier_quotes
-       WHERE id = ANY($4::text[])
-         AND COALESCE(supplier_id, '') <> ALL($7::text[])
+       CROSS JOIN demo_inputs
+       WHERE supplier_quotes.id = ANY(demo_inputs.supplier_quote_ids)
+         AND COALESCE(supplier_quotes.supplier_id, '') <> ALL(demo_inputs.supplier_owner_ids)
        UNION ALL
-       SELECT 'supplier_sales' AS table_name, id
+       SELECT 'supplier_sales' AS table_name, supplier_sales.id
        FROM supplier_sales
-       WHERE id = ANY($5::text[])
-         AND COALESCE(supplier_id, '') <> ALL($7::text[])
+       CROSS JOIN demo_inputs
+       WHERE supplier_sales.id = ANY(demo_inputs.supplier_sale_ids)
+         AND COALESCE(supplier_sales.supplier_id, '') <> ALL(demo_inputs.supplier_owner_ids)
+       UNION ALL
+       SELECT 'supplier_invoices' AS table_name, supplier_invoices.id
+       FROM supplier_invoices
+       CROSS JOIN demo_inputs
+       WHERE supplier_invoices.id = ANY(demo_inputs.supplier_invoice_ids)
+         AND COALESCE(supplier_invoices.supplier_id, '') <> ALL(demo_inputs.supplier_owner_ids)
      )
      SELECT table_name, id FROM conflicts ORDER BY table_name, id LIMIT 10`,
     [
       demoIds.quotes,
       demoIds.customerOffers,
       demoIds.sales,
+      demoIds.invoices,
       demoIds.supplierQuotes,
       demoIds.supplierSales,
+      demoIds.supplierInvoices,
       demoClientOwnerIds,
+      invoiceClientOwnerIds,
       demoIds.suppliers,
     ],
   );
@@ -412,6 +448,11 @@ export const cleanupDemoNamespace = async (
 ) => {
   const demoDocuments = buildDemoDocumentSeedManifest(seedYear);
   const demoIds = buildDemoIds(seedYear);
+  const cleanupInvoiceIds = [...demoIds.invoices, ...LEGACY_DEMO_INVOICE_IDS];
+  const cleanupSupplierInvoiceIds = [
+    ...demoIds.supplierInvoices,
+    ...LEGACY_DEMO_SUPPLIER_INVOICE_IDS,
+  ];
   const cleanupCountsByTable: Record<string, number> = {};
 
   incrementCount(
@@ -492,7 +533,7 @@ export const cleanupDemoNamespace = async (
     'supplier_invoice_items',
     await executeDelete(client, 'supplier_invoice_items', (builder) => {
       pushTextArrayPredicate(builder, 'id', DEMO_ITEM_IDS.supplierInvoiceItems);
-      pushTextArrayPredicate(builder, 'invoice_id', demoIds.supplierInvoices);
+      pushTextArrayPredicate(builder, 'invoice_id', cleanupSupplierInvoiceIds);
       pushTextArrayPredicate(builder, 'product_id', demoIds.products);
     }),
   );
@@ -501,7 +542,7 @@ export const cleanupDemoNamespace = async (
     cleanupCountsByTable,
     'supplier_invoices',
     await executeDelete(client, 'supplier_invoices', (builder) => {
-      pushTextArrayPredicate(builder, 'id', demoIds.supplierInvoices);
+      pushTextArrayPredicate(builder, 'id', cleanupSupplierInvoiceIds);
       pushTextArrayPredicate(builder, 'supplier_id', demoIds.suppliers);
       pushTextArrayPredicate(
         builder,
@@ -559,7 +600,7 @@ export const cleanupDemoNamespace = async (
     'invoice_items',
     await executeDelete(client, 'invoice_items', (builder) => {
       pushTextArrayPredicate(builder, 'id', DEMO_ITEM_IDS.invoiceItems);
-      pushTextArrayPredicate(builder, 'invoice_id', demoIds.invoices);
+      pushTextArrayPredicate(builder, 'invoice_id', cleanupInvoiceIds);
       pushTextArrayPredicate(builder, 'product_id', demoIds.products);
     }),
   );
@@ -568,7 +609,7 @@ export const cleanupDemoNamespace = async (
     cleanupCountsByTable,
     'invoices',
     await executeDelete(client, 'invoices', (builder) => {
-      pushTextArrayPredicate(builder, 'id', demoIds.invoices);
+      pushTextArrayPredicate(builder, 'id', cleanupInvoiceIds);
       pushTextArrayPredicate(builder, 'client_id', demoIds.clients);
       pushTextArrayPredicate(
         builder,

--- a/server/db/demoSeedManifest.ts
+++ b/server/db/demoSeedManifest.ts
@@ -369,11 +369,11 @@ export const buildDemoDocumentSeedManifest = (seedYear = getDemoSeedYear()) => {
       { id: code('client_order', 5), linkedOfferId: null },
     ],
     invoices: [
-      { id: 'dm_inv_01', linkedSaleId: null },
-      { id: 'dm_inv_02', linkedSaleId: null },
-      { id: 'dm_inv_03', linkedSaleId: code('client_order', 4) },
-      { id: 'dm_inv_04', linkedSaleId: null },
-      { id: 'dm_inv_05', linkedSaleId: null },
+      { id: code('client_invoice', 1), linkedSaleId: null },
+      { id: code('client_invoice', 2), linkedSaleId: null },
+      { id: code('client_invoice', 3), linkedSaleId: code('client_order', 4) },
+      { id: code('client_invoice', 4), linkedSaleId: null },
+      { id: code('client_invoice', 5), linkedSaleId: null },
     ],
     supplierQuotes: rangeDocumentCodes('supplier_quote', 14, seedYear),
     supplierSales: [
@@ -399,11 +399,11 @@ export const buildDemoDocumentSeedManifest = (seedYear = getDemoSeedYear()) => {
       },
     ],
     supplierInvoices: [
-      { id: 'dm_sinv_01', linkedSaleId: null },
-      { id: 'dm_sinv_02', linkedSaleId: null },
-      { id: 'dm_sinv_03', linkedSaleId: code('supplier_order', 4) },
-      { id: 'dm_sinv_04', linkedSaleId: null },
-      { id: 'dm_sinv_05', linkedSaleId: null },
+      { id: code('supplier_invoice', 1), linkedSaleId: null },
+      { id: code('supplier_invoice', 2), linkedSaleId: null },
+      { id: code('supplier_invoice', 3), linkedSaleId: code('supplier_order', 4) },
+      { id: code('supplier_invoice', 4), linkedSaleId: null },
+      { id: code('supplier_invoice', 5), linkedSaleId: null },
     ],
   };
 };
@@ -558,6 +558,9 @@ export const DEMO_ITEM_IDS = {
   supplierSaleItems: rangeIds('dm_ssi_', 6),
   supplierInvoiceItems: rangeIds('dm_sinv_item_', 6),
 } as const;
+
+export const LEGACY_DEMO_INVOICE_IDS = rangeIds('dm_inv_', 5);
+export const LEGACY_DEMO_SUPPLIER_INVOICE_IDS = rangeIds('dm_sinv_', 5);
 
 export const buildDemoIds = (seedYear = getDemoSeedYear()) => {
   const documents = buildDemoDocumentSeedManifest(seedYear);

--- a/server/db/seed.sql
+++ b/server/db/seed.sql
@@ -51,7 +51,7 @@ ON CONFLICT (user_id) DO NOTHING;
 
 -- Refreshable demo dataset.
 -- Demo document records use the same default code templates exposed in admin settings
--- (PREV/OFF/FORN/ORD/SORD + YY + padded sequence). Non-document demo records keep dm_* ids.
+-- (PREV/OFF/FORN/ORD/SORD/INV/SINV + YY + padded sequence). Non-document demo records keep dm_* ids.
 -- The app-layer orchestrator executes these statements in a controlled refresh workflow after
 -- cleanup, verification, manager assignment, and cache invalidation steps are prepared.
 
@@ -86,7 +86,9 @@ FROM (
         ('client_offer', 'OFF', 5),
         ('supplier_quote', 'FORN', 14),
         ('client_order', 'ORD', 5),
-        ('supplier_order', 'SORD', 5)
+        ('supplier_order', 'SORD', 5),
+        ('client_invoice', 'INV', 5),
+        ('supplier_invoice', 'SINV', 5)
 ) AS modules(module_id, prefix, max_sequence)
 CROSS JOIN LATERAL generate_series(1, modules.max_sequence) AS sequence;
 
@@ -110,7 +112,9 @@ VALUES
     ('client_offer', pg_temp.demo_seed_year(), 6, CURRENT_TIMESTAMP),
     ('supplier_quote', pg_temp.demo_seed_year(), 15, CURRENT_TIMESTAMP),
     ('client_order', pg_temp.demo_seed_year(), 6, CURRENT_TIMESTAMP),
-    ('supplier_order', pg_temp.demo_seed_year(), 6, CURRENT_TIMESTAMP)
+    ('supplier_order', pg_temp.demo_seed_year(), 6, CURRENT_TIMESTAMP),
+    ('client_invoice', pg_temp.demo_seed_year(), 6, CURRENT_TIMESTAMP),
+    ('supplier_invoice', pg_temp.demo_seed_year(), 6, CURRENT_TIMESTAMP)
 ON CONFLICT (module_id, year) DO UPDATE SET
     next_sequence = GREATEST(document_code_counters.next_sequence, EXCLUDED.next_sequence),
     updated_at = CURRENT_TIMESTAMP;
@@ -785,11 +789,11 @@ INSERT INTO invoices (
     created_at,
     updated_at
 ) VALUES
-    ('dm_inv_01', NULL, 'dm_cli_02', 'Helios Energy Services S.r.l.', CURRENT_DATE - INTERVAL '18 days', CURRENT_DATE + INTERVAL '12 days', 'draft', 1090.00, 1090.00, 0.00, 'Editable draft invoice.', CURRENT_TIMESTAMP - INTERVAL '18 days', CURRENT_TIMESTAMP - INTERVAL '17 days'),
-    ('dm_inv_02', NULL, 'dm_cli_03', 'Comune di Verona - Innovazione Digitale', CURRENT_DATE - INTERVAL '30 days', CURRENT_DATE + INTERVAL '5 days', 'sent', 1795.00, 1795.00, 600.00, 'Partially paid invoice with remaining balance.', CURRENT_TIMESTAMP - INTERVAL '30 days', CURRENT_TIMESTAMP - INTERVAL '5 days'),
-    ('dm_inv_03', pg_temp.demo_document_code('client_order', 4), 'dm_cli_01', 'Northwind Retail Italia S.p.A.', CURRENT_DATE - INTERVAL '20 days', CURRENT_DATE + INTERVAL '10 days', 'paid', 6303.25, 6303.25, 6303.25, 'Fully paid invoice linked to the confirmed demo order.', CURRENT_TIMESTAMP - INTERVAL '20 days', CURRENT_TIMESTAMP - INTERVAL '2 days'),
-    ('dm_inv_04', NULL, 'dm_cli_01', 'Northwind Retail Italia S.p.A.', CURRENT_DATE - INTERVAL '45 days', CURRENT_DATE - INTERVAL '15 days', 'overdue', 10020.00, 10020.00, 0.00, 'Outstanding overdue invoice for collections reporting.', CURRENT_TIMESTAMP - INTERVAL '45 days', CURRENT_TIMESTAMP - INTERVAL '14 days'),
-    ('dm_inv_05', NULL, 'dm_cli_04', 'Giulia Ferri', CURRENT_DATE - INTERVAL '12 days', CURRENT_DATE + INTERVAL '20 days', 'cancelled', 1600.00, 1600.00, 0.00, 'Cancelled invoice retained for status coverage.', CURRENT_TIMESTAMP - INTERVAL '12 days', CURRENT_TIMESTAMP - INTERVAL '11 days')
+    (pg_temp.demo_document_code('client_invoice', 1), NULL, 'dm_cli_02', 'Helios Energy Services S.r.l.', CURRENT_DATE - INTERVAL '18 days', CURRENT_DATE + INTERVAL '12 days', 'draft', 1090.00, 1090.00, 0.00, 'Editable draft invoice.', CURRENT_TIMESTAMP - INTERVAL '18 days', CURRENT_TIMESTAMP - INTERVAL '17 days'),
+    (pg_temp.demo_document_code('client_invoice', 2), NULL, 'dm_cli_03', 'Comune di Verona - Innovazione Digitale', CURRENT_DATE - INTERVAL '30 days', CURRENT_DATE + INTERVAL '5 days', 'sent', 1795.00, 1795.00, 600.00, 'Partially paid invoice with remaining balance.', CURRENT_TIMESTAMP - INTERVAL '30 days', CURRENT_TIMESTAMP - INTERVAL '5 days'),
+    (pg_temp.demo_document_code('client_invoice', 3), pg_temp.demo_document_code('client_order', 4), 'dm_cli_01', 'Northwind Retail Italia S.p.A.', CURRENT_DATE - INTERVAL '20 days', CURRENT_DATE + INTERVAL '10 days', 'paid', 6303.25, 6303.25, 6303.25, 'Fully paid invoice linked to the confirmed demo order.', CURRENT_TIMESTAMP - INTERVAL '20 days', CURRENT_TIMESTAMP - INTERVAL '2 days'),
+    (pg_temp.demo_document_code('client_invoice', 4), NULL, 'dm_cli_01', 'Northwind Retail Italia S.p.A.', CURRENT_DATE - INTERVAL '45 days', CURRENT_DATE - INTERVAL '15 days', 'overdue', 10020.00, 10020.00, 0.00, 'Outstanding overdue invoice for collections reporting.', CURRENT_TIMESTAMP - INTERVAL '45 days', CURRENT_TIMESTAMP - INTERVAL '14 days'),
+    (pg_temp.demo_document_code('client_invoice', 5), NULL, 'dm_cli_04', 'Giulia Ferri', CURRENT_DATE - INTERVAL '12 days', CURRENT_DATE + INTERVAL '20 days', 'cancelled', 1600.00, 1600.00, 0.00, 'Cancelled invoice retained for status coverage.', CURRENT_TIMESTAMP - INTERVAL '12 days', CURRENT_TIMESTAMP - INTERVAL '11 days')
 ON CONFLICT (id) DO UPDATE SET
     linked_sale_id = EXCLUDED.linked_sale_id,
     client_id = EXCLUDED.client_id,
@@ -813,12 +817,12 @@ INSERT INTO invoice_items (
     unit_price,
     discount
 ) VALUES
-    ('dm_inv_item_01', 'dm_inv_01', 'dm_prd_04', 'Workshop Training Day', 1.00, 1090.00, 0.00),
-    ('dm_inv_item_02', 'dm_inv_02', 'dm_prd_07', 'Managed Firewall Appliance', 1.00, 1795.00, 0.00),
-    ('dm_inv_item_03', 'dm_inv_03', 'dm_prd_01', 'Strategy Assessment', 4.00, 1230.00, 5.00),
-    ('dm_inv_item_04', 'dm_inv_03', 'dm_prd_02', 'Deployment Sprint', 1.00, 1715.00, 5.00),
-    ('dm_inv_item_05', 'dm_inv_04', 'dm_prd_03', 'Managed Support Retainer', 12.00, 835.00, 0.00),
-    ('dm_inv_item_06', 'dm_inv_05', 'dm_prd_08', 'Branded Print Kit', 10.00, 160.00, 0.00)
+    ('dm_inv_item_01', pg_temp.demo_document_code('client_invoice', 1), 'dm_prd_04', 'Workshop Training Day', 1.00, 1090.00, 0.00),
+    ('dm_inv_item_02', pg_temp.demo_document_code('client_invoice', 2), 'dm_prd_07', 'Managed Firewall Appliance', 1.00, 1795.00, 0.00),
+    ('dm_inv_item_03', pg_temp.demo_document_code('client_invoice', 3), 'dm_prd_01', 'Strategy Assessment', 4.00, 1230.00, 5.00),
+    ('dm_inv_item_04', pg_temp.demo_document_code('client_invoice', 3), 'dm_prd_02', 'Deployment Sprint', 1.00, 1715.00, 5.00),
+    ('dm_inv_item_05', pg_temp.demo_document_code('client_invoice', 4), 'dm_prd_03', 'Managed Support Retainer', 12.00, 835.00, 0.00),
+    ('dm_inv_item_06', pg_temp.demo_document_code('client_invoice', 5), 'dm_prd_08', 'Branded Print Kit', 10.00, 160.00, 0.00)
 ON CONFLICT (id) DO UPDATE SET
     invoice_id = EXCLUDED.invoice_id,
     product_id = EXCLUDED.product_id,
@@ -1049,11 +1053,11 @@ INSERT INTO supplier_invoices (
     created_at,
     updated_at
 ) VALUES
-    ('dm_sinv_01', NULL, 'dm_sup_01', 'TechSource Distribution', CURRENT_DATE - INTERVAL '18 days', CURRENT_DATE + INTERVAL '12 days', 'draft', 1920.00, 1920.00, 0.00, 'Editable draft supplier invoice.', CURRENT_TIMESTAMP - INTERVAL '18 days', CURRENT_TIMESTAMP - INTERVAL '17 days'),
-    ('dm_sinv_02', NULL, 'dm_sup_02', 'CloudSeat Licensing', CURRENT_DATE - INTERVAL '32 days', CURRENT_DATE + INTERVAL '3 days', 'sent', 14560.00, 14560.00, 4000.00, 'Partially settled supplier invoice kept in sent state.', CURRENT_TIMESTAMP - INTERVAL '32 days', CURRENT_TIMESTAMP - INTERVAL '6 days'),
-    ('dm_sinv_03', pg_temp.demo_document_code('supplier_order', 4), 'dm_sup_03', 'SecureEdge Systems', CURRENT_DATE - INTERVAL '19 days', CURRENT_DATE + INTERVAL '11 days', 'paid', 6130.00, 6130.00, 6130.00, 'Paid supplier invoice linked to a sent order.', CURRENT_TIMESTAMP - INTERVAL '19 days', CURRENT_TIMESTAMP - INTERVAL '2 days'),
-    ('dm_sinv_04', NULL, 'dm_sup_04', 'PrintLogistics Hub', CURRENT_DATE - INTERVAL '48 days', CURRENT_DATE - INTERVAL '12 days', 'overdue', 23600.00, 23600.00, 0.00, 'Overdue supplier invoice kept for state coverage.', CURRENT_TIMESTAMP - INTERVAL '48 days', CURRENT_TIMESTAMP - INTERVAL '10 days'),
-    ('dm_sinv_05', NULL, 'dm_sup_01', 'TechSource Distribution', CURRENT_DATE - INTERVAL '11 days', CURRENT_DATE + INTERVAL '18 days', 'cancelled', 960.00, 960.00, 0.00, 'Cancelled supplier invoice kept for state coverage.', CURRENT_TIMESTAMP - INTERVAL '11 days', CURRENT_TIMESTAMP - INTERVAL '10 days')
+    (pg_temp.demo_document_code('supplier_invoice', 1), NULL, 'dm_sup_01', 'TechSource Distribution', CURRENT_DATE - INTERVAL '18 days', CURRENT_DATE + INTERVAL '12 days', 'draft', 1920.00, 1920.00, 0.00, 'Editable draft supplier invoice.', CURRENT_TIMESTAMP - INTERVAL '18 days', CURRENT_TIMESTAMP - INTERVAL '17 days'),
+    (pg_temp.demo_document_code('supplier_invoice', 2), NULL, 'dm_sup_02', 'CloudSeat Licensing', CURRENT_DATE - INTERVAL '32 days', CURRENT_DATE + INTERVAL '3 days', 'sent', 14560.00, 14560.00, 4000.00, 'Partially settled supplier invoice kept in sent state.', CURRENT_TIMESTAMP - INTERVAL '32 days', CURRENT_TIMESTAMP - INTERVAL '6 days'),
+    (pg_temp.demo_document_code('supplier_invoice', 3), pg_temp.demo_document_code('supplier_order', 4), 'dm_sup_03', 'SecureEdge Systems', CURRENT_DATE - INTERVAL '19 days', CURRENT_DATE + INTERVAL '11 days', 'paid', 6130.00, 6130.00, 6130.00, 'Paid supplier invoice linked to a sent order.', CURRENT_TIMESTAMP - INTERVAL '19 days', CURRENT_TIMESTAMP - INTERVAL '2 days'),
+    (pg_temp.demo_document_code('supplier_invoice', 4), NULL, 'dm_sup_04', 'PrintLogistics Hub', CURRENT_DATE - INTERVAL '48 days', CURRENT_DATE - INTERVAL '12 days', 'overdue', 23600.00, 23600.00, 0.00, 'Overdue supplier invoice kept for state coverage.', CURRENT_TIMESTAMP - INTERVAL '48 days', CURRENT_TIMESTAMP - INTERVAL '10 days'),
+    (pg_temp.demo_document_code('supplier_invoice', 5), NULL, 'dm_sup_01', 'TechSource Distribution', CURRENT_DATE - INTERVAL '11 days', CURRENT_DATE + INTERVAL '18 days', 'cancelled', 960.00, 960.00, 0.00, 'Cancelled supplier invoice kept for state coverage.', CURRENT_TIMESTAMP - INTERVAL '11 days', CURRENT_TIMESTAMP - INTERVAL '10 days')
 ON CONFLICT (id) DO UPDATE SET
     linked_sale_id = EXCLUDED.linked_sale_id,
     supplier_id = EXCLUDED.supplier_id,
@@ -1077,12 +1081,12 @@ INSERT INTO supplier_invoice_items (
     unit_price,
     discount
 ) VALUES
-    ('dm_sinv_item_01', 'dm_sinv_01', 'dm_prd_05', 'Business Laptop Bundle', 2.00, 960.00, 0.00),
-    ('dm_sinv_item_02', 'dm_sinv_02', 'dm_prd_06', 'Microsoft 365 Annual Seat', 80.00, 182.00, 0.00),
-    ('dm_sinv_item_03', 'dm_sinv_03', 'dm_prd_07', 'Managed Firewall Appliance', 1.00, 1410.00, 0.00),
-    ('dm_sinv_item_04', 'dm_sinv_03', 'dm_prd_08', 'Branded Print Kit', 40.00, 118.00, 0.00),
-    ('dm_sinv_item_05', 'dm_sinv_04', 'dm_prd_08', 'Branded Print Kit', 200.00, 118.00, 0.00),
-    ('dm_sinv_item_06', 'dm_sinv_05', 'dm_prd_05', 'Business Laptop Bundle', 1.00, 960.00, 0.00)
+    ('dm_sinv_item_01', pg_temp.demo_document_code('supplier_invoice', 1), 'dm_prd_05', 'Business Laptop Bundle', 2.00, 960.00, 0.00),
+    ('dm_sinv_item_02', pg_temp.demo_document_code('supplier_invoice', 2), 'dm_prd_06', 'Microsoft 365 Annual Seat', 80.00, 182.00, 0.00),
+    ('dm_sinv_item_03', pg_temp.demo_document_code('supplier_invoice', 3), 'dm_prd_07', 'Managed Firewall Appliance', 1.00, 1410.00, 0.00),
+    ('dm_sinv_item_04', pg_temp.demo_document_code('supplier_invoice', 3), 'dm_prd_08', 'Branded Print Kit', 40.00, 118.00, 0.00),
+    ('dm_sinv_item_05', pg_temp.demo_document_code('supplier_invoice', 4), 'dm_prd_08', 'Branded Print Kit', 200.00, 118.00, 0.00),
+    ('dm_sinv_item_06', pg_temp.demo_document_code('supplier_invoice', 5), 'dm_prd_05', 'Business Laptop Bundle', 1.00, 960.00, 0.00)
 ON CONFLICT (id) DO UPDATE SET
     invoice_id = EXCLUDED.invoice_id,
     product_id = EXCLUDED.product_id,

--- a/server/test/db/demoSeed.test.ts
+++ b/server/test/db/demoSeed.test.ts
@@ -14,8 +14,10 @@ import {
   DEMO_CUSTOMER_OFFERS,
   DEMO_EXPECTED_COUNTS,
   DEMO_IDS,
+  DEMO_INVOICES,
   DEMO_QUOTES,
   DEMO_SALES,
+  DEMO_SUPPLIER_INVOICES,
   DEMO_SUPPLIER_QUOTES,
   DEMO_SUPPLIER_SALES,
   DEMO_TOP_MANAGER_USER_IDS,
@@ -23,6 +25,8 @@ import {
   DEMO_USER_PROJECT_ASSIGNMENTS,
   DEMO_USER_TASK_ASSIGNMENTS,
   DEMO_USERS,
+  LEGACY_DEMO_INVOICE_IDS,
+  LEGACY_DEMO_SUPPLIER_INVOICE_IDS,
 } from '../../db/demoSeedManifest.ts';
 import {
   DOCUMENT_CODE_MODULES,
@@ -170,6 +174,21 @@ describe('cleanupDemoNamespace', () => {
     expect(findDelete(calls, 'sales')?.params?.[0]).toEqual(
       documentCodesFor('client_order', 5, 2027),
     );
+    const cleanupInvoiceIds = [
+      ...documentCodesFor('client_invoice', 5, 2027),
+      ...LEGACY_DEMO_INVOICE_IDS,
+    ];
+    const cleanupSupplierInvoiceIds = [
+      ...documentCodesFor('supplier_invoice', 5, 2027),
+      ...LEGACY_DEMO_SUPPLIER_INVOICE_IDS,
+    ];
+
+    expect(findDelete(calls, 'invoice_items')?.params?.[1]).toEqual(cleanupInvoiceIds);
+    expect(findDelete(calls, 'invoices')?.params?.[0]).toEqual(cleanupInvoiceIds);
+    expect(findDelete(calls, 'supplier_invoice_items')?.params?.[1]).toEqual(
+      cleanupSupplierInvoiceIds,
+    );
+    expect(findDelete(calls, 'supplier_invoices')?.params?.[0]).toEqual(cleanupSupplierInvoiceIds);
   });
 });
 
@@ -181,6 +200,26 @@ describe('assertNoDemoDocumentIdConflicts', () => {
     await expect(assertNoDemoDocumentIdConflicts(client, 2027)).rejects.toThrow(
       `Demo seed document ID collision with non-demo records: quotes:${conflictingId}`,
     );
+  });
+
+  test('guards client and supplier invoices that now use default document codes', async () => {
+    const { calls, client } = buildQueryRecorder(0);
+
+    await assertNoDemoDocumentIdConflicts(client, 2027);
+
+    expect(calls[0]?.sql).toContain("SELECT 'invoices' AS table_name");
+    expect(calls[0]?.sql).toContain("SELECT 'supplier_invoices' AS table_name");
+    expect(calls[0]?.sql).toContain('$8::text[] AS client_owner_ids');
+    expect(calls[0]?.sql).toContain('$9::text[] AS invoice_client_owner_ids');
+    expect(calls[0]?.sql).toContain('$10::text[] AS supplier_owner_ids');
+    expect(calls[0]?.sql).toContain('ALL(demo_inputs.client_owner_ids)');
+    expect(calls[0]?.sql).toContain('ALL(demo_inputs.invoice_client_owner_ids)');
+    expect(calls[0]?.sql).toContain('ALL(demo_inputs.supplier_owner_ids)');
+    expect(calls[0]?.params?.[3]).toEqual(documentCodesFor('client_invoice', 5, 2027));
+    expect(calls[0]?.params?.[6]).toEqual(documentCodesFor('supplier_invoice', 5, 2027));
+    expect(calls[0]?.params?.[8]).toEqual(buildDemoIds(2027).clients);
+    expect(calls[0]?.params?.[8]).not.toContain('c1');
+    expect(calls[0]?.params?.[8]).not.toContain('c2');
   });
 
   test('passes when the runtime demo codes are unused by non-demo rows', async () => {
@@ -195,7 +234,7 @@ describe('assertNoDemoDocumentIdConflicts', () => {
 
     await assertNoDemoDocumentIdConflicts(client, 2027);
 
-    expect(calls[0]?.params?.[5]).toEqual([
+    expect(calls[0]?.params?.[7]).toEqual([
       ...COMPATIBILITY_DEFAULTS.clients,
       ...buildDemoIds(2027).clients,
     ]);
@@ -222,6 +261,10 @@ describe('demoSeedManifest assignment coverage', () => {
     );
     expect(DEMO_SALES.map((row) => row.id)).toEqual(documentCodesFor('client_order', 5));
     expect(DEMO_SUPPLIER_SALES.map((row) => row.id)).toEqual(documentCodesFor('supplier_order', 5));
+    expect(DEMO_INVOICES.map((row) => row.id)).toEqual(documentCodesFor('client_invoice', 5));
+    expect(DEMO_SUPPLIER_INVOICES.map((row) => row.id)).toEqual(
+      documentCodesFor('supplier_invoice', 5),
+    );
   });
 
   test('seed.sql document rows and counters match the default-code manifest', () => {
@@ -240,6 +283,32 @@ describe('demoSeedManifest assignment coverage', () => {
     expect(parseInsertValuesBlocks(SEED_SQL, 'supplier_sales').map((row) => row.id)).toEqual(
       DEMO_SUPPLIER_SALES.map((row) => row.id),
     );
+    expect(parseInsertValuesBlocks(SEED_SQL, 'invoices').map((row) => row.id)).toEqual(
+      DEMO_INVOICES.map((row) => row.id),
+    );
+    expect(parseInsertValuesBlocks(SEED_SQL, 'invoice_items').map((row) => row.invoice_id)).toEqual(
+      [
+        DEMO_INVOICES[0]?.id,
+        DEMO_INVOICES[1]?.id,
+        DEMO_INVOICES[2]?.id,
+        DEMO_INVOICES[2]?.id,
+        DEMO_INVOICES[3]?.id,
+        DEMO_INVOICES[4]?.id,
+      ],
+    );
+    expect(parseInsertValuesBlocks(SEED_SQL, 'supplier_invoices').map((row) => row.id)).toEqual(
+      DEMO_SUPPLIER_INVOICES.map((row) => row.id),
+    );
+    expect(
+      parseInsertValuesBlocks(SEED_SQL, 'supplier_invoice_items').map((row) => row.invoice_id),
+    ).toEqual([
+      DEMO_SUPPLIER_INVOICES[0]?.id,
+      DEMO_SUPPLIER_INVOICES[1]?.id,
+      DEMO_SUPPLIER_INVOICES[2]?.id,
+      DEMO_SUPPLIER_INVOICES[2]?.id,
+      DEMO_SUPPLIER_INVOICES[3]?.id,
+      DEMO_SUPPLIER_INVOICES[4]?.id,
+    ]);
 
     const counters = Object.fromEntries(
       parseInsertValuesBlocks(SEED_SQL, 'document_code_counters').map((row) => [
@@ -253,6 +322,8 @@ describe('demoSeedManifest assignment coverage', () => {
       supplier_quote: 15,
       client_order: 6,
       supplier_order: 6,
+      client_invoice: 6,
+      supplier_invoice: 6,
     });
   });
 


### PR DESCRIPTION
## Summary
- Aligns demo client and supplier invoice IDs with the default document code templates (`INV_YY_0001` and `SINV_YY_0001`).
- Extends demo seed cleanup and collision protection to include invoice document codes.
- Adds regression coverage for invoice codes, item links, counters, cleanup, and guard SQL.

## Changes
- Updates the demo seed manifest and SQL to generate client/supplier invoices through `demo_document_code`.
- Advances demo document counters for `client_invoice` and `supplier_invoice` to the next sequence.
- Simplifies the collision guard SQL with named `demo_inputs` fields to avoid fragile positional-owner checks.

## Testing
- `bun test server/test/db/demoSeed.test.ts`
- `bun test server/test/db/demoSeed.test.ts server/test/db/seedTaskReferences.test.ts server/test/db/seedSchemaColumns.test.ts server/test/db/seedProjectCoherence.test.ts`
- `bun run lint`
- `bun run test:react-doctor` (`100/100`)

## Risks / Rollout
- Low risk. Change is scoped to refreshable demo seed data and its regression tests.
- Existing non-demo documents are protected by the expanded collision guard before cleanup.

## Issues
Issue: Not linked