### PR TITLE
app(release): bump version to 0.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praetor",
   "private": true,
-  "version": "0.8.1",
+  "version": "0.8.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "praetor-server",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Praetor API Server",
   "main": "index.ts",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bumps the Praetor app and backend package versions from 0.8.1 to 0.8.2.

## Changes
- Updates the root `package.json` version.
- Updates `server/package.json` to keep the backend package version aligned.

## Testing
- `bun run test:react-doctor` (baseline before change: 84/100, after change: 84/100)
- `bun run lint`
- `bun run test` (2008 pass, 0 fail)

## Risks / Rollout
- Low risk. This is a package metadata-only patch version bump with no runtime behavior change.

## Issues
Issue: Not linked