### PR TITLE
auth(fix): keep LDAP role mapping inputs focused

### DIFF
--- a/components/administration/AuthSettings.tsx
+++ b/components/administration/AuthSettings.tsx
@@ -2185,69 +2185,88 @@ const RoleMappings: React.FC<RoleMappingsProps> = ({
   onAdd,
   onRemove,
   onChange,
-}) => (
-  <div>
-    <div className="flex justify-between items-center mb-4">
-      <h4 className="text-sm font-semibold text-foreground">{heading}</h4>
-      <Button
-        type="button"
-        variant="secondary"
-        size="sm"
-        onClick={onAdd}
-        className="text-xs font-bold"
-      >
-        <Plus aria-hidden="true" />
-        {addLabel}
-      </Button>
-    </div>
-    <div className="space-y-3">
-      {mappings.length === 0 ? (
-        <p className="text-xs text-muted-foreground italic">{noMappingsLabel}</p>
-      ) : (
-        mappings.map((mapping, index) => (
-          <div
-            key={`${mapping.externalGroup || 'external-group'}:${mapping.role || roleOptions[0]?.id || 'user'}`}
-            className="flex gap-4 items-start"
-          >
-            <div className="flex-1">
-              <Input
-                type="text"
-                value={mapping.externalGroup}
-                onChange={(event) => onChange(index, 'externalGroup', event.target.value)}
-                placeholder={externalPlaceholder}
-                aria-label={externalPlaceholder}
-                aria-invalid={!!errors[`${errorPrefix}${index}`]}
-                className="font-mono"
-              />
-              {errors[`${errorPrefix}${index}`] && (
-                <FieldError
-                  className="mt-1"
-                  errors={[{ message: errors[`${errorPrefix}${index}`] }]}
+}) => {
+  const nextKeyRef = useRef(0);
+  const rowKeysRef = useRef<string[]>([]);
+
+  while (rowKeysRef.current.length < mappings.length) {
+    rowKeysRef.current.push(`role-mapping-${nextKeyRef.current}`);
+    nextKeyRef.current += 1;
+  }
+
+  if (rowKeysRef.current.length > mappings.length) {
+    rowKeysRef.current.length = mappings.length;
+  }
+
+  const handleRemove = (index: number) => {
+    rowKeysRef.current.splice(index, 1);
+    onRemove(index);
+  };
+
+  return (
+    <div>
+      <div className="flex justify-between items-center mb-4">
+        <h4 className="text-sm font-semibold text-foreground">{heading}</h4>
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          onClick={onAdd}
+          className="text-xs font-bold"
+        >
+          <Plus aria-hidden="true" />
+          {addLabel}
+        </Button>
+      </div>
+      <div className="space-y-3">
+        {mappings.length === 0 ? (
+          <p className="text-xs text-muted-foreground italic">{noMappingsLabel}</p>
+        ) : (
+          mappings.map((mapping, index) => (
+            <div key={rowKeysRef.current[index]} className="flex gap-4 items-start">
+              <div className="flex-1">
+                <Input
+                  type="text"
+                  value={mapping.externalGroup}
+                  onChange={(event) => onChange(index, 'externalGroup', event.target.value)}
+                  placeholder={externalPlaceholder}
+                  aria-label={externalPlaceholder}
+                  aria-invalid={!!errors[`${errorPrefix}${index}`]}
+                  className="font-mono"
                 />
-              )}
-            </div>
-            <ArrowRight aria-hidden="true" className="size-3 text-muted-foreground mt-3 shrink-0" />
-            <div className="w-44">
-              <SelectControl
-                options={roleOptions}
-                value={mapping.role || roleOptions[0]?.id || 'user'}
-                onChange={(role) => onChange(index, 'role', role as string)}
+                {errors[`${errorPrefix}${index}`] && (
+                  <FieldError
+                    className="mt-1"
+                    errors={[{ message: errors[`${errorPrefix}${index}`] }]}
+                  />
+                )}
+              </div>
+              <ArrowRight
+                aria-hidden="true"
+                className="size-3 text-muted-foreground mt-3 shrink-0"
               />
+              <div className="w-44">
+                <SelectControl
+                  options={roleOptions}
+                  value={mapping.role || roleOptions[0]?.id || 'user'}
+                  onChange={(role) => onChange(index, 'role', role as string)}
+                />
+              </div>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                onClick={() => handleRemove(index)}
+                className="text-muted-foreground hover:text-destructive"
+              >
+                <Trash2 aria-hidden="true" />
+              </Button>
             </div>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-sm"
-              onClick={() => onRemove(index)}
-              className="text-muted-foreground hover:text-destructive"
-            >
-              <Trash2 aria-hidden="true" />
-            </Button>
-          </div>
-        ))
-      )}
+          ))
+        )}
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default AuthSettings;

--- a/test/components/administration/AuthSettings.test.tsx
+++ b/test/components/administration/AuthSettings.test.tsx
@@ -209,6 +209,25 @@ describe('<AuthSettings />', () => {
     expect(submitted.autoProvisionAll).toBe(true);
   });
 
+  test('keeps focus in the LDAP role mapping input while typing', () => {
+    renderAuthSettings();
+
+    fireEvent.click(screen.getByRole('button', { name: 'admin.ldap.addMapping' }));
+    const input = screen.getByRole('textbox', {
+      name: 'admin.ldap.ldapGroupPlaceholder',
+    }) as HTMLInputElement;
+
+    input.focus();
+    fireEvent.change(input, { target: { value: 'CN=Praetor Admins' } });
+
+    const updatedInput = screen.getByRole('textbox', {
+      name: 'admin.ldap.ldapGroupPlaceholder',
+    }) as HTMLInputElement;
+    expect(updatedInput).toBe(input);
+    expect(updatedInput.value).toBe('CN=Praetor Admins');
+    expect(document.activeElement).toBe(updatedInput);
+  });
+
   describe('2FA org policy (MFA tab)', () => {
     const openMfaTab = () => {
       fireEvent.click(screen.getByRole('button', { name: 'admin.tabs.mfa' }));


### PR DESCRIPTION
## Summary
- Fixes LDAP/SSO role mapping rows so editing a group name no longer remounts the textbox and drops focus.
- Adds regression coverage for LDAP role mapping input focus.

## Changes
- Generates stable local row keys in `AuthSettings` `RoleMappings` instead of deriving React keys from editable mapping values.
- Keeps LDAP/SSO payloads, APIs, persistence, and role-mapping behavior unchanged.

## Testing
- `bun test ./test/components/administration/AuthSettings.test.tsx` passed. The file still prints two pre-existing React `act(...)` warnings in masked-secret tests.
- `bun run lint` passed.
- `bun run test:react-doctor` stayed at `84 / 100` with 31 issues.
- `git diff --check` passed.

## Risks / Rollout
- Low risk. Frontend-only rendering fix scoped to the shared role mapping control; no migrations, API changes, or auth semantics changes.

## Issues
Issue: Not linked