### PR TITLE
ui(fix): make time input picker theme-aware

### DIFF
--- a/components/shared/DatePickerButton.tsx
+++ b/components/shared/DatePickerButton.tsx
@@ -131,7 +131,7 @@ const DatePickerButton: React.FC<DatePickerButtonProps> = ({
               aria-label={t('labels.time')}
               value={formatTimeValue(hours, minutes)}
               onChange={handleTimeChange}
-              className="h-9 flex-1 rounded-full bg-transparent px-4 text-sm font-semibold tabular-nums text-foreground dark:bg-transparent dark:[color-scheme:dark]"
+              className="h-9 flex-1 rounded-full bg-transparent px-4 text-sm font-semibold tabular-nums text-foreground dark:bg-transparent"
             />
             <Button
               type="button"

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -11,6 +11,7 @@ function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
       className={cn(
         inputBaseClassName,
         'selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground',
+        type === 'time' && '[color-scheme:light] dark:[color-scheme:dark]',
         className,
       )}
       {...props}

--- a/test/components/ui/Input.test.tsx
+++ b/test/components/ui/Input.test.tsx
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'bun:test';
+import { screen } from '@testing-library/react';
+import { Input } from '../../../components/ui/input';
+import { render } from '../../helpers/render';
+
+describe('<Input />', () => {
+  test('uses a theme-aware native picker color scheme for time inputs', () => {
+    render(<Input aria-label="Start time" type="time" />);
+
+    const input = screen.getByLabelText('Start time');
+
+    expect(input.className).toContain('[color-scheme:light]');
+    expect(input.className).toContain('dark:[color-scheme:dark]');
+  });
+
+  test('does not add native picker color-scheme classes to regular inputs', () => {
+    render(<Input aria-label="Name" />);
+
+    expect(screen.getByLabelText('Name').className).not.toContain('color-scheme');
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes native time input picker icons so they remain visible in dark mode.
- Centralizes the time-input `color-scheme` treatment in the shared shadcn `Input` primitive.

## Changes
- Adds theme-aware `color-scheme` classes for `type="time"` inputs.
- Removes the now-duplicated dark-mode picker class from `DatePickerButton`.
- Adds regression coverage for time inputs and regular inputs.

## Testing
- `bun test .\test\components\ui\Input.test.tsx` passed.
- `bun test .\test\components\ui\Input.test.tsx .\test\components\DatePickerButton.test.tsx` passed; existing Radix popover `act(...)` warnings were emitted by `DatePickerButton` tests.
- `git diff --check` passed.
- `bun run lint` passed.
- `bun run test:react-doctor` stayed at `84/100` before and after.
- `bun run test:frontend` did not pass due to existing failures in `test/components/sales/ClientQuotesView.test.tsx`; that file also fails when run isolated and is outside this change surface.

## Risks / Rollout
- Low risk. Change is scoped to shared input styling for native time pickers and removes a duplicate call-site class.
- No migrations, API changes, or documentation changes.

## Issues
Issue: Not linked