### PR TITLE
app(chore): bump version to 0.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praetor",
   "private": true,
-  "version": "0.8.1",
+  "version": "0.8.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "praetor-server",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Praetor API Server",
   "main": "index.ts",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump Praetor from `0.8.1` to `0.8.2`.
- Keep frontend and backend package metadata in sync for the patch release.

## Changes
- Updates the root `package.json` version to `0.8.2`.
- Updates `server/package.json` version to `0.8.2`.
- No lockfile, runtime behavior, API, routing, or docs changes were needed.

## Testing
- `bun run test:react-doctor` before change: `84 / 100`, 31 warnings.
- `bun run test:react-doctor` after change: `84 / 100`, 31 warnings.
- `bun run lint` passed.
- `bun run test` did not pass; it reported 3 frontend failures in `test/components/sales/ClientQuotesView.test.tsx` before the command wrapper timed out:
  - `<ClientQuotesView /> edit action gating (#812 round 13) > enables back-to-draft for an offer quote whose linked offer is still draft`
  - `<ClientQuotesView /> line-item delete confirmation > confirms before removing a product line and removes it only after confirming`
  - `<ClientQuotesView /> line-item delete confirmation > keeps the product line when the confirmation is dismissed`
- `bun test test\components\sales\ClientQuotesView.test.tsx` failed with the same 3 tests. The failures are in existing sales UI tests and are unrelated to this metadata-only version bump.

## Risks / Rollout
- Low risk. This only changes package version metadata.

## Issues
Issue: Not linked