### PR TITLE
server(fix): remove demo-backed documents during seed refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ data volume.
 The compose setup defaults backend `TRUST_PROXY=1` for the bundled Caddy -> API hop.
 Set `DEMO_SEEDING=true` in `.env` when you want the stack to provision the canonical demo users and demo business data.
 That refresh flow is intended for demo and test stacks, owns the canonical demo namespace,
-refreshes compatibility clients/projects/tasks, deletes financial documents backed by demo
-products, and resets the seeded demo users' assignments, notifications, and time entries so
+refreshes compatibility clients/projects/tasks, deletes financial documents and dependent
+resales backed by demo products, and resets the seeded demo users' assignments, notifications, and time entries so
 reused Docker volumes return to the curated demo state. Compatibility clients such as Acme
 Corp and Global Tech are not blanket financial-document owners; their documents are removed
 only when they use demo data such as demo products or seeded document IDs.

--- a/README.md
+++ b/README.md
@@ -67,8 +67,11 @@ data volume.
 The compose setup defaults backend `TRUST_PROXY=1` for the bundled Caddy -> API hop.
 Set `DEMO_SEEDING=true` in `.env` when you want the stack to provision the canonical demo users and demo business data.
 That refresh flow is intended for demo and test stacks, owns the canonical demo namespace,
-refreshes compatibility clients/projects/tasks, and resets the seeded demo users' assignments,
-notifications, and time entries so reused Docker volumes return to the curated demo state.
+refreshes compatibility clients/projects/tasks, deletes financial documents backed by demo
+products, and resets the seeded demo users' assignments, notifications, and time entries so
+reused Docker volumes return to the curated demo state. Compatibility clients such as Acme
+Corp and Global Tech are not blanket financial-document owners; their documents are removed
+only when they use demo data such as demo products or seeded document IDs.
 The demo users include HR profile data such as employee codes, departments, contract status, work locations, emergency contacts, and sample internal/external employee records.
 
 To rerun the same refresh manually against an existing backend database:

--- a/server/db/demoSeed.ts
+++ b/server/db/demoSeed.ts
@@ -147,6 +147,16 @@ const pushLowerTextArrayPredicateExcludingIds = (
   );
 };
 
+const pushTextArraySqlPredicate = (
+  builder: PredicateBuilder,
+  values: readonly string[],
+  renderPredicate: (valuesParam: string) => string,
+) => {
+  if (values.length === 0) return;
+  builder.params.push([...values]);
+  builder.parts.push(renderPredicate(`$${builder.params.length}::text[]`));
+};
+
 const demoProductIdsQuery = (
   productIdsParam: string,
   productCodesParam: string,
@@ -209,6 +219,12 @@ const supplierSaleIdsWithDemoProductLines = (demoProductIds: string) =>
   `SELECT id FROM supplier_sales
    WHERE id IN (${parentIdsWithDemoProductLines('supplier_sale_items', 'sale_id', demoProductIds)})
       OR linked_quote_id IN (${supplierQuoteIdsWithDemoProductLines(demoProductIds)})`;
+
+const clientSaleIdsForOwner = (ownerIdsParam: string) =>
+  `SELECT id FROM sales WHERE client_id = ANY(${ownerIdsParam})`;
+
+const supplierSaleIdsForOwner = (ownerIdsParam: string) =>
+  `SELECT id FROM supplier_sales WHERE supplier_id = ANY(${ownerIdsParam})`;
 
 const executeDelete = async (
   client: PoolClient,
@@ -738,6 +754,53 @@ export const cleanupDemoNamespace = async (
         builder,
         demoIds,
         (productIds) => `linked_sale_id IN (${supplierSaleIdsWithDemoProductLines(productIds)})`,
+      );
+    }),
+  );
+
+  incrementCount(
+    cleanupCountsByTable,
+    'resales',
+    await executeDelete(client, 'resales', (builder) => {
+      pushTextArrayPredicate(builder, 'client_order_id', demoIds.sales);
+      pushTextArrayPredicate(builder, 'supplier_order_id', demoIds.supplierSales);
+      pushTextArraySqlPredicate(
+        builder,
+        demoIds.clients,
+        (clientIds) => `client_order_id IN (${clientSaleIdsForOwner(clientIds)})`,
+      );
+      pushTextArraySqlPredicate(
+        builder,
+        demoIds.customerOffers,
+        (offerIds) =>
+          `client_order_id IN (SELECT id FROM sales WHERE linked_offer_id = ANY(${offerIds}))`,
+      );
+      pushTextArraySqlPredicate(
+        builder,
+        demoIds.quotes,
+        (quoteIds) =>
+          `client_order_id IN (SELECT id FROM sales WHERE linked_quote_id = ANY(${quoteIds}))`,
+      );
+      pushTextArraySqlPredicate(
+        builder,
+        demoIds.suppliers,
+        (supplierIds) => `supplier_order_id IN (${supplierSaleIdsForOwner(supplierIds)})`,
+      );
+      pushTextArraySqlPredicate(
+        builder,
+        demoIds.supplierQuotes,
+        (quoteIds) =>
+          `supplier_order_id IN (SELECT id FROM supplier_sales WHERE linked_quote_id = ANY(${quoteIds}))`,
+      );
+      pushDemoProductSqlPredicate(
+        builder,
+        demoIds,
+        (productIds) => `client_order_id IN (${clientSaleIdsWithDemoProductLines(productIds)})`,
+      );
+      pushDemoProductSqlPredicate(
+        builder,
+        demoIds,
+        (productIds) => `supplier_order_id IN (${supplierSaleIdsWithDemoProductLines(productIds)})`,
       );
     }),
   );

--- a/server/db/demoSeed.ts
+++ b/server/db/demoSeed.ts
@@ -5,7 +5,6 @@ import { createChildLogger, serializeError } from '../utils/logger.ts';
 import { ensureBootstrapAdmin } from './bootstrapAdmin.ts';
 import {
   buildDemoAssignmentTargetIds,
-  buildDemoDocumentSeedManifest,
   buildDemoIds,
   COMPATIBILITY_DEFAULT_CLIENTS,
   COMPATIBILITY_DEFAULTS,
@@ -71,9 +70,6 @@ type DemoUserCleanupIds = {
 
 type RuntimeDemoIds = ReturnType<typeof buildDemoIds>;
 type RuntimeDemoAssignmentTargetIds = ReturnType<typeof buildDemoAssignmentTargetIds>;
-
-const nonEmpty = <T>(values: readonly (T | null | undefined)[]) =>
-  values.filter((value): value is T => value !== null && value !== undefined);
 
 const incrementCount = (counts: Record<string, number>, table: string, delta: number) => {
   if (delta <= 0) return;
@@ -150,6 +146,69 @@ const pushLowerTextArrayPredicateExcludingIds = (
     excludedIds,
   );
 };
+
+const demoProductIdsQuery = (
+  productIdsParam: string,
+  productCodesParam: string,
+  productNamesParam: string,
+  supplierIdsParam: string,
+) => `SELECT id FROM products
+      WHERE id = ANY(${productIdsParam})
+         OR product_code = ANY(${productCodesParam})
+         OR name = ANY(${productNamesParam})
+         OR supplier_id = ANY(${supplierIdsParam})`;
+
+const pushDemoProductSqlPredicate = (
+  builder: PredicateBuilder,
+  demoIds: RuntimeDemoIds,
+  renderPredicate: (demoProductIds: string) => string,
+) => {
+  builder.params.push([...demoIds.products]);
+  const productIdsParam = `$${builder.params.length}::text[]`;
+  builder.params.push(DEMO_PRODUCTS.map((product) => product.productCode));
+  const productCodesParam = `$${builder.params.length}::text[]`;
+  builder.params.push(DEMO_PRODUCTS.map((product) => product.name));
+  const productNamesParam = `$${builder.params.length}::text[]`;
+  builder.params.push([...demoIds.suppliers]);
+  const supplierIdsParam = `$${builder.params.length}::text[]`;
+  builder.parts.push(
+    renderPredicate(
+      demoProductIdsQuery(productIdsParam, productCodesParam, productNamesParam, supplierIdsParam),
+    ),
+  );
+};
+
+const parentIdsWithDemoProductLines = (
+  itemTable: string,
+  parentIdColumn: string,
+  demoProductIds: string,
+) => `SELECT ${parentIdColumn} FROM ${itemTable} WHERE product_id IN (${demoProductIds})`;
+
+const quoteIdsWithDemoProductLines = (demoProductIds: string) =>
+  parentIdsWithDemoProductLines('quote_items', 'quote_id', demoProductIds);
+
+const customerOfferIdsWithDemoProductLines = (demoProductIds: string) =>
+  `SELECT id FROM customer_offers
+   WHERE id IN (${parentIdsWithDemoProductLines(
+     'customer_offer_items',
+     'offer_id',
+     demoProductIds,
+   )})
+      OR linked_quote_id IN (${quoteIdsWithDemoProductLines(demoProductIds)})`;
+
+const clientSaleIdsWithDemoProductLines = (demoProductIds: string) =>
+  `SELECT id FROM sales
+   WHERE id IN (${parentIdsWithDemoProductLines('sale_items', 'sale_id', demoProductIds)})
+      OR linked_offer_id IN (${customerOfferIdsWithDemoProductLines(demoProductIds)})
+      OR linked_quote_id IN (${quoteIdsWithDemoProductLines(demoProductIds)})`;
+
+const supplierQuoteIdsWithDemoProductLines = (demoProductIds: string) =>
+  parentIdsWithDemoProductLines('supplier_quote_items', 'quote_id', demoProductIds);
+
+const supplierSaleIdsWithDemoProductLines = (demoProductIds: string) =>
+  `SELECT id FROM supplier_sales
+   WHERE id IN (${parentIdsWithDemoProductLines('supplier_sale_items', 'sale_id', demoProductIds)})
+      OR linked_quote_id IN (${supplierQuoteIdsWithDemoProductLines(demoProductIds)})`;
 
 const executeDelete = async (
   client: PoolClient,
@@ -568,7 +627,6 @@ export const cleanupDemoNamespace = async (
   demoUserIds: DemoUserCleanupIds,
   seedYear = getDemoSeedYear(),
 ) => {
-  const demoDocuments = buildDemoDocumentSeedManifest(seedYear);
   const demoIds = buildDemoIds(seedYear);
   const cleanupInvoiceIds = [...demoIds.invoices, ...LEGACY_DEMO_INVOICE_IDS];
   const cleanupSupplierInvoiceIds = [
@@ -656,7 +714,6 @@ export const cleanupDemoNamespace = async (
     await executeDelete(client, 'supplier_invoice_items', (builder) => {
       pushTextArrayPredicate(builder, 'id', DEMO_ITEM_IDS.supplierInvoiceItems);
       pushTextArrayPredicate(builder, 'invoice_id', cleanupSupplierInvoiceIds);
-      pushTextArrayPredicate(builder, 'product_id', demoIds.products);
     }),
   );
 
@@ -666,10 +723,21 @@ export const cleanupDemoNamespace = async (
     await executeDelete(client, 'supplier_invoices', (builder) => {
       pushTextArrayPredicate(builder, 'id', cleanupSupplierInvoiceIds);
       pushTextArrayPredicate(builder, 'supplier_id', demoIds.suppliers);
-      pushTextArrayPredicate(
+      pushTextArrayPredicate(builder, 'linked_sale_id', demoIds.supplierSales);
+      pushDemoProductSqlPredicate(
         builder,
-        'linked_sale_id',
-        nonEmpty(demoDocuments.supplierInvoices.map((invoice) => invoice.linkedSaleId)),
+        demoIds,
+        (productIds) =>
+          `id IN (${parentIdsWithDemoProductLines(
+            'supplier_invoice_items',
+            'invoice_id',
+            productIds,
+          )})`,
+      );
+      pushDemoProductSqlPredicate(
+        builder,
+        demoIds,
+        (productIds) => `linked_sale_id IN (${supplierSaleIdsWithDemoProductLines(productIds)})`,
       );
     }),
   );
@@ -680,7 +748,6 @@ export const cleanupDemoNamespace = async (
     await executeDelete(client, 'supplier_sale_items', (builder) => {
       pushTextArrayPredicate(builder, 'id', DEMO_ITEM_IDS.supplierSaleItems);
       pushTextArrayPredicate(builder, 'sale_id', demoIds.supplierSales);
-      pushTextArrayPredicate(builder, 'product_id', demoIds.products);
     }),
   );
 
@@ -690,10 +757,17 @@ export const cleanupDemoNamespace = async (
     await executeDelete(client, 'supplier_sales', (builder) => {
       pushTextArrayPredicate(builder, 'id', demoIds.supplierSales);
       pushTextArrayPredicate(builder, 'supplier_id', demoIds.suppliers);
-      pushTextArrayPredicate(
+      pushTextArrayPredicate(builder, 'linked_quote_id', demoIds.supplierQuotes);
+      pushDemoProductSqlPredicate(
         builder,
-        'linked_quote_id',
-        nonEmpty(demoDocuments.supplierSales.map((sale) => sale.linkedQuoteId)),
+        demoIds,
+        (productIds) =>
+          `id IN (${parentIdsWithDemoProductLines('supplier_sale_items', 'sale_id', productIds)})`,
+      );
+      pushDemoProductSqlPredicate(
+        builder,
+        demoIds,
+        (productIds) => `linked_quote_id IN (${supplierQuoteIdsWithDemoProductLines(productIds)})`,
       );
     }),
   );
@@ -704,7 +778,6 @@ export const cleanupDemoNamespace = async (
     await executeDelete(client, 'supplier_quote_items', (builder) => {
       pushTextArrayPredicate(builder, 'id', DEMO_ITEM_IDS.supplierQuoteItems);
       pushTextArrayPredicate(builder, 'quote_id', demoIds.supplierQuotes);
-      pushTextArrayPredicate(builder, 'product_id', demoIds.products);
     }),
   );
 
@@ -714,6 +787,11 @@ export const cleanupDemoNamespace = async (
     await executeDelete(client, 'supplier_quotes', (builder) => {
       pushTextArrayPredicate(builder, 'id', demoIds.supplierQuotes);
       pushTextArrayPredicate(builder, 'supplier_id', demoIds.suppliers);
+      pushDemoProductSqlPredicate(
+        builder,
+        demoIds,
+        (productIds) => `id IN (${supplierQuoteIdsWithDemoProductLines(productIds)})`,
+      );
     }),
   );
 
@@ -723,7 +801,6 @@ export const cleanupDemoNamespace = async (
     await executeDelete(client, 'invoice_items', (builder) => {
       pushTextArrayPredicate(builder, 'id', DEMO_ITEM_IDS.invoiceItems);
       pushTextArrayPredicate(builder, 'invoice_id', cleanupInvoiceIds);
-      pushTextArrayPredicate(builder, 'product_id', demoIds.products);
     }),
   );
 
@@ -733,10 +810,17 @@ export const cleanupDemoNamespace = async (
     await executeDelete(client, 'invoices', (builder) => {
       pushTextArrayPredicate(builder, 'id', cleanupInvoiceIds);
       pushTextArrayPredicate(builder, 'client_id', demoIds.clients);
-      pushTextArrayPredicate(
+      pushTextArrayPredicate(builder, 'linked_sale_id', demoIds.sales);
+      pushDemoProductSqlPredicate(
         builder,
-        'linked_sale_id',
-        nonEmpty(demoDocuments.invoices.map((invoice) => invoice.linkedSaleId)),
+        demoIds,
+        (productIds) =>
+          `id IN (${parentIdsWithDemoProductLines('invoice_items', 'invoice_id', productIds)})`,
+      );
+      pushDemoProductSqlPredicate(
+        builder,
+        demoIds,
+        (productIds) => `linked_sale_id IN (${clientSaleIdsWithDemoProductLines(productIds)})`,
       );
     }),
   );
@@ -747,7 +831,6 @@ export const cleanupDemoNamespace = async (
     await executeDelete(client, 'sale_items', (builder) => {
       pushTextArrayPredicate(builder, 'id', DEMO_ITEM_IDS.saleItems);
       pushTextArrayPredicate(builder, 'sale_id', demoIds.sales);
-      pushTextArrayPredicate(builder, 'product_id', demoIds.products);
     }),
   );
 
@@ -757,10 +840,23 @@ export const cleanupDemoNamespace = async (
     await executeDelete(client, 'sales', (builder) => {
       pushTextArrayPredicate(builder, 'id', demoIds.sales);
       pushTextArrayPredicate(builder, 'client_id', demoIds.clients);
-      pushTextArrayPredicate(
+      pushTextArrayPredicate(builder, 'linked_offer_id', demoIds.customerOffers);
+      pushTextArrayPredicate(builder, 'linked_quote_id', demoIds.quotes);
+      pushDemoProductSqlPredicate(
         builder,
-        'linked_offer_id',
-        nonEmpty(demoDocuments.sales.map((sale) => sale.linkedOfferId)),
+        demoIds,
+        (productIds) =>
+          `id IN (${parentIdsWithDemoProductLines('sale_items', 'sale_id', productIds)})`,
+      );
+      pushDemoProductSqlPredicate(
+        builder,
+        demoIds,
+        (productIds) => `linked_offer_id IN (${customerOfferIdsWithDemoProductLines(productIds)})`,
+      );
+      pushDemoProductSqlPredicate(
+        builder,
+        demoIds,
+        (productIds) => `linked_quote_id IN (${quoteIdsWithDemoProductLines(productIds)})`,
       );
     }),
   );
@@ -771,7 +867,6 @@ export const cleanupDemoNamespace = async (
     await executeDelete(client, 'customer_offer_items', (builder) => {
       pushTextArrayPredicate(builder, 'id', DEMO_ITEM_IDS.customerOfferItems);
       pushTextArrayPredicate(builder, 'offer_id', demoIds.customerOffers);
-      pushTextArrayPredicate(builder, 'product_id', demoIds.products);
     }),
   );
 
@@ -781,10 +876,21 @@ export const cleanupDemoNamespace = async (
     await executeDelete(client, 'customer_offers', (builder) => {
       pushTextArrayPredicate(builder, 'id', demoIds.customerOffers);
       pushTextArrayPredicate(builder, 'client_id', demoIds.clients);
-      pushTextArrayPredicate(
+      pushTextArrayPredicate(builder, 'linked_quote_id', demoIds.quotes);
+      pushDemoProductSqlPredicate(
         builder,
-        'linked_quote_id',
-        demoDocuments.customerOffers.map((offer) => offer.linkedQuoteId),
+        demoIds,
+        (productIds) =>
+          `id IN (${parentIdsWithDemoProductLines(
+            'customer_offer_items',
+            'offer_id',
+            productIds,
+          )})`,
+      );
+      pushDemoProductSqlPredicate(
+        builder,
+        demoIds,
+        (productIds) => `linked_quote_id IN (${quoteIdsWithDemoProductLines(productIds)})`,
       );
     }),
   );
@@ -795,7 +901,6 @@ export const cleanupDemoNamespace = async (
     await executeDelete(client, 'quote_items', (builder) => {
       pushTextArrayPredicate(builder, 'id', DEMO_ITEM_IDS.quoteItems);
       pushTextArrayPredicate(builder, 'quote_id', demoIds.quotes);
-      pushTextArrayPredicate(builder, 'product_id', demoIds.products);
     }),
   );
 
@@ -805,6 +910,11 @@ export const cleanupDemoNamespace = async (
     await executeDelete(client, 'quotes', (builder) => {
       pushTextArrayPredicate(builder, 'id', demoIds.quotes);
       pushTextArrayPredicate(builder, 'client_id', demoIds.clients);
+      pushDemoProductSqlPredicate(
+        builder,
+        demoIds,
+        (productIds) => `id IN (${quoteIdsWithDemoProductLines(productIds)})`,
+      );
     }),
   );
 

--- a/server/test/db/demoSeed.test.ts
+++ b/server/test/db/demoSeed.test.ts
@@ -81,6 +81,9 @@ const buildQueryRecorder = (rowCount = 1, rows: unknown[] = []) => {
 const findDelete = (calls: QueryCall[], table: string) =>
   calls.find((call) => call.sql.startsWith(`DELETE FROM ${table} `));
 
+const findDeleteIndex = (calls: QueryCall[], table: string) =>
+  calls.findIndex((call) => call.sql.startsWith(`DELETE FROM ${table} `));
+
 const paramsContainAny = (call: QueryCall | undefined, values: readonly string[]) =>
   call?.params?.some(
     (param) => Array.isArray(param) && values.some((value) => param.includes(value)),
@@ -291,6 +294,35 @@ describe('cleanupDemoNamespace', () => {
     );
     expect(findDelete(calls, 'invoices')?.sql).toContain('linked_sale_id IN (SELECT id FROM sales');
 
+    const resaleDelete = findDelete(calls, 'resales');
+    expect(resaleDelete?.sql).toContain('client_order_id = ANY');
+    expect(resaleDelete?.sql).toContain('supplier_order_id = ANY');
+    expect(resaleDelete?.sql).toContain(
+      'client_order_id IN (SELECT id FROM sales WHERE client_id = ANY',
+    );
+    expect(resaleDelete?.sql).toContain(
+      'client_order_id IN (SELECT id FROM sales WHERE linked_offer_id = ANY',
+    );
+    expect(resaleDelete?.sql).toContain(
+      'client_order_id IN (SELECT id FROM sales WHERE linked_quote_id = ANY',
+    );
+    expect(resaleDelete?.sql).toContain(
+      'supplier_order_id IN (SELECT id FROM supplier_sales WHERE supplier_id = ANY',
+    );
+    expect(resaleDelete?.sql).toContain(
+      'supplier_order_id IN (SELECT id FROM supplier_sales WHERE linked_quote_id = ANY',
+    );
+    expect(resaleDelete?.sql).toContain('client_order_id IN (SELECT id FROM sales');
+    expect(resaleDelete?.sql).toContain('sale_items WHERE product_id IN (SELECT id FROM products');
+    expect(resaleDelete?.sql).toContain('supplier_order_id IN (SELECT id FROM supplier_sales');
+    expect(resaleDelete?.sql).toContain(
+      'supplier_sale_items WHERE product_id IN (SELECT id FROM products',
+    );
+    const resaleDeleteIndex = findDeleteIndex(calls, 'resales');
+    expect(resaleDeleteIndex).toBeGreaterThanOrEqual(0);
+    expect(resaleDeleteIndex).toBeLessThan(findDeleteIndex(calls, 'sales'));
+    expect(resaleDeleteIndex).toBeLessThan(findDeleteIndex(calls, 'supplier_sales'));
+
     expect(findDelete(calls, 'supplier_quotes')?.sql).toContain(
       'supplier_quote_items WHERE product_id IN (SELECT id FROM products',
     );
@@ -322,6 +354,20 @@ describe('cleanupDemoNamespace', () => {
       ),
     ).toBe(true);
     expect(paramsContainAny(quoteDelete, buildDemoIds(2027).suppliers)).toBe(true);
+    expect(paramsContainAny(resaleDelete, buildDemoIds(2027).products)).toBe(true);
+    expect(
+      paramsContainAny(
+        resaleDelete,
+        DEMO_PRODUCTS.map((product) => product.productCode),
+      ),
+    ).toBe(true);
+    expect(
+      paramsContainAny(
+        resaleDelete,
+        DEMO_PRODUCTS.map((product) => product.name),
+      ),
+    ).toBe(true);
+    expect(paramsContainAny(resaleDelete, buildDemoIds(2027).suppliers)).toBe(true);
   });
 
   test('does not treat compatibility clients as blanket financial document owners', async () => {
@@ -336,7 +382,7 @@ describe('cleanupDemoNamespace', () => {
       2027,
     );
 
-    for (const table of ['quotes', 'customer_offers', 'sales', 'invoices']) {
+    for (const table of ['quotes', 'customer_offers', 'sales', 'invoices', 'resales']) {
       expect(paramsContainAny(findDelete(calls, table), COMPATIBILITY_DEFAULTS.clients)).toBe(
         false,
       );

--- a/server/test/db/demoSeed.test.ts
+++ b/server/test/db/demoSeed.test.ts
@@ -17,6 +17,7 @@ import {
   DEMO_EXPECTED_COUNTS,
   DEMO_IDS,
   DEMO_INVOICES,
+  DEMO_PRODUCTS,
   DEMO_QUOTES,
   DEMO_SALES,
   DEMO_SUPPLIER_INVOICES,
@@ -79,6 +80,11 @@ const buildQueryRecorder = (rowCount = 1, rows: unknown[] = []) => {
 
 const findDelete = (calls: QueryCall[], table: string) =>
   calls.find((call) => call.sql.startsWith(`DELETE FROM ${table} `));
+
+const paramsContainAny = (call: QueryCall | undefined, values: readonly string[]) =>
+  call?.params?.some(
+    (param) => Array.isArray(param) && values.some((value) => param.includes(value)),
+  ) ?? false;
 
 type DemoAssignment = { userId: string; targetId: string };
 
@@ -236,6 +242,105 @@ describe('cleanupDemoNamespace', () => {
       compatibilityFiscalCodes,
       compatibilityClientIds,
     ]);
+  });
+
+  test('deletes demo-product financial documents at parent level', async () => {
+    const { calls, client } = buildQueryRecorder();
+
+    await cleanupDemoNamespace(
+      client,
+      {
+        dependentUserIds: ['u2', 'u3'],
+        userIdsToDelete: [],
+      },
+      2027,
+    );
+
+    for (const table of [
+      'quote_items',
+      'customer_offer_items',
+      'sale_items',
+      'invoice_items',
+      'supplier_quote_items',
+      'supplier_sale_items',
+      'supplier_invoice_items',
+    ]) {
+      expect(findDelete(calls, table)?.sql).not.toContain('product_id');
+    }
+
+    expect(findDelete(calls, 'quotes')?.sql).toContain(
+      'id IN (SELECT quote_id FROM quote_items WHERE product_id IN (SELECT id FROM products',
+    );
+    expect(findDelete(calls, 'customer_offers')?.sql).toContain(
+      'customer_offer_items WHERE product_id IN (SELECT id FROM products',
+    );
+    expect(findDelete(calls, 'customer_offers')?.sql).toContain(
+      'linked_quote_id IN (SELECT quote_id FROM quote_items WHERE product_id IN (SELECT id FROM products',
+    );
+    expect(findDelete(calls, 'sales')?.sql).toContain(
+      'sale_items WHERE product_id IN (SELECT id FROM products',
+    );
+    expect(findDelete(calls, 'sales')?.sql).toContain(
+      'linked_offer_id IN (SELECT id FROM customer_offers',
+    );
+    expect(findDelete(calls, 'sales')?.sql).toContain(
+      'linked_quote_id IN (SELECT quote_id FROM quote_items WHERE product_id IN (SELECT id FROM products',
+    );
+    expect(findDelete(calls, 'invoices')?.sql).toContain(
+      'invoice_items WHERE product_id IN (SELECT id FROM products',
+    );
+    expect(findDelete(calls, 'invoices')?.sql).toContain('linked_sale_id IN (SELECT id FROM sales');
+
+    expect(findDelete(calls, 'supplier_quotes')?.sql).toContain(
+      'supplier_quote_items WHERE product_id IN (SELECT id FROM products',
+    );
+    expect(findDelete(calls, 'supplier_sales')?.sql).toContain(
+      'supplier_sale_items WHERE product_id IN (SELECT id FROM products',
+    );
+    expect(findDelete(calls, 'supplier_sales')?.sql).toContain(
+      'linked_quote_id IN (SELECT quote_id FROM supplier_quote_items WHERE product_id IN (SELECT id FROM products',
+    );
+    expect(findDelete(calls, 'supplier_invoices')?.sql).toContain(
+      'supplier_invoice_items WHERE product_id IN (SELECT id FROM products',
+    );
+    expect(findDelete(calls, 'supplier_invoices')?.sql).toContain(
+      'linked_sale_id IN (SELECT id FROM supplier_sales',
+    );
+
+    const quoteDelete = findDelete(calls, 'quotes');
+    expect(paramsContainAny(quoteDelete, buildDemoIds(2027).products)).toBe(true);
+    expect(
+      paramsContainAny(
+        quoteDelete,
+        DEMO_PRODUCTS.map((product) => product.productCode),
+      ),
+    ).toBe(true);
+    expect(
+      paramsContainAny(
+        quoteDelete,
+        DEMO_PRODUCTS.map((product) => product.name),
+      ),
+    ).toBe(true);
+    expect(paramsContainAny(quoteDelete, buildDemoIds(2027).suppliers)).toBe(true);
+  });
+
+  test('does not treat compatibility clients as blanket financial document owners', async () => {
+    const { calls, client } = buildQueryRecorder();
+
+    await cleanupDemoNamespace(
+      client,
+      {
+        dependentUserIds: ['u2', 'u3'],
+        userIdsToDelete: [],
+      },
+      2027,
+    );
+
+    for (const table of ['quotes', 'customer_offers', 'sales', 'invoices']) {
+      expect(paramsContainAny(findDelete(calls, table), COMPATIBILITY_DEFAULTS.clients)).toBe(
+        false,
+      );
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- Deletes whole demo-dependent financial documents during demo seed refresh instead of removing only their line items.
- Matches demo-product ownership to the full product cleanup namespace and propagates cleanup through linked client and supplier document chains.
- Removes dependent resales before deleting matched client/supplier orders so `restrict` foreign keys cannot block the refresh.
- Documents that Acme/Global Tech compatibility-client documents are preserved unless they use demo data.

## Changes
- Adds parent-document cleanup helpers for client quote -> offer -> order -> invoice and supplier quote -> order -> invoice chains.
- Removes raw item-table `product_id` cleanup predicates that could leave zero-total headers behind.
- Clears resales tied to orders selected by demo IDs, demo owners, linked demo documents, or demo-product lines before deleting those orders.
- Adds regression coverage for client-side, supplier-side, resale, and compatibility-client cleanup behavior.

## Testing
- `cd server && bun test ./test/db/demoSeed.test.ts`
- `bun run test:react-doctor` (84/100, unchanged from pre-edit; 31 existing warnings)
- `bun run lint`
- `git diff --check`

## Risks / Rollout
- Low risk; scoped to demo seeding cleanup behavior.
- No database migration, REST API, frontend type, or UI contract changes.

## Issues
Issue: Not linked