### PR TITLE
projects(feature): show list dates

### DIFF
--- a/components/projects/ProjectsView.tsx
+++ b/components/projects/ProjectsView.tsx
@@ -34,7 +34,7 @@ import type {
   StoredBillingType,
   User,
 } from '../../types';
-import { formatInsertDate } from '../../utils/date';
+import { formatDateOnlyForLocale, formatInsertDate } from '../../utils/date';
 import { buildPermission, hasPermission, hasScopedActionPermission } from '../../utils/permissions';
 import DateField from '../shared/DateField';
 import DeleteConfirmModal from '../shared/DeleteConfirmModal';
@@ -888,6 +888,30 @@ const useProjectsController = ({
       cell: ({ row }) => (
         <span className="text-xs text-slate-500 whitespace-nowrap">
           {row.createdAt ? formatInsertDate(row.createdAt, i18n.language) : '—'}
+        </span>
+      ),
+    },
+    {
+      header: t('projects:projects.tableHeaders.startDate'),
+      accessorKey: 'startDate',
+      className: 'whitespace-nowrap',
+      filterFormat: (value) =>
+        value ? formatDateOnlyForLocale(String(value), i18n.language) : '-',
+      cell: ({ row }) => (
+        <span className="text-xs text-slate-500 whitespace-nowrap">
+          {row.startDate ? formatDateOnlyForLocale(row.startDate, i18n.language) : '-'}
+        </span>
+      ),
+    },
+    {
+      header: t('projects:projects.tableHeaders.endDate'),
+      accessorKey: 'endDate',
+      className: 'whitespace-nowrap',
+      filterFormat: (value) =>
+        value ? formatDateOnlyForLocale(String(value), i18n.language) : '-',
+      cell: ({ row }) => (
+        <span className="text-xs text-slate-500 whitespace-nowrap">
+          {row.endDate ? formatDateOnlyForLocale(row.endDate, i18n.language) : '-'}
         </span>
       ),
     },

--- a/components/projects/ResalesView.tsx
+++ b/components/projects/ResalesView.tsx
@@ -673,12 +673,31 @@ const useResalesController = ({
           ),
       },
       {
+        id: 'startDate',
+        header: t('resales.columns.startDate'),
+        accessorKey: 'startDate',
+        className: 'whitespace-nowrap',
+        filterFormat: (value) =>
+          value ? formatDateOnlyForLocale(String(value), i18n.language) : '-',
+        cell: ({ row }) =>
+          row.startDate ? (
+            <span className="text-xs text-muted-foreground whitespace-nowrap">
+              {formatDateOnlyForLocale(row.startDate, i18n.language)}
+            </span>
+          ) : (
+            <span className="text-xs text-muted-foreground">-</span>
+          ),
+      },
+      {
         id: 'dueDate',
-        header: t('resales.columns.dueDate'),
+        header: t('resales.columns.endDate'),
         accessorKey: 'dueDate',
+        className: 'whitespace-nowrap',
+        filterFormat: (value) =>
+          value ? formatDateOnlyForLocale(String(value), i18n.language) : '-',
         cell: ({ row }) =>
           row.dueDate ? (
-            <span className="text-xs text-muted-foreground">
+            <span className="text-xs text-muted-foreground whitespace-nowrap">
               {formatDateOnlyForLocale(row.dueDate, i18n.language)}
             </span>
           ) : (

--- a/docs-site/src/content/docs/crm-projects.md
+++ b/docs-site/src/content/docs/crm-projects.md
@@ -27,7 +27,7 @@ Aggiorna il listino quando cambiano costi, margini o condizioni di vendita, cos�
 
 ## Commesse e attività
 
-Le commesse collegano clienti, attività e registrazioni di tempo. Il modulo resta **Progetti**, ma le pagine operative sono **Commesse** e **Rivendite**. Dentro **Commesse**, usa le tab **Commesse** e **Attività** per passare dall'archivio commesse alla gestione attività.
+Le commesse collegano clienti, attività e registrazioni di tempo. Il modulo resta **Progetti**, ma le pagine operative sono **Commesse** e **Rivendite**. Dentro **Commesse**, usa le tab **Commesse** e **Attività** per passare dall'archivio commesse alla gestione attività; l'archivio mostra anche data inizio e data fine di ogni commessa.
 
 Per ogni commessa e attività puoi indicare il tipo di consuntivazione (canone o a misura) e la frequenza (mensile o una tantum) in modo indipendente: entrambi i tipi di consuntivazione supportano entrambe le frequenze. Se le attività usano un tipo diverso da quello della commessa, la commessa viene mostrata come mista.
 
@@ -56,7 +56,7 @@ Quando una commessa termina, verifica che le attività siano coerenti e che non 
 
 ### Rivendite
 
-La voce **Rivendite** nel modulo Progetti gestisce operazioni economiche separate da attività operative, timesheet e assegnazioni utenti. La pagina è divisa nelle tab **Rivendite** e **Attività**: la prima mostra l'elenco rivendite, mentre la tab attività si abilita dopo aver selezionato una rivendita e contiene riepilogo economico e attività rivendita. In creazione devi selezionare un **ordine cliente**, un solo **ordine fornitore** collegato a quell'ordine cliente, indicare **data inizio** e **scadenza rivendita** obbligatorie e aggiungere almeno una **attività rivendita** nella tabella iniziale: il sistema accetta l'ordine fornitore solo se almeno una riga dell'ordine cliente lo referenzia.
+La voce **Rivendite** nel modulo Progetti gestisce operazioni economiche separate da attività operative, timesheet e assegnazioni utenti. La pagina è divisa nelle tab **Rivendite** e **Attività**: la prima mostra l'elenco rivendite con data inizio e data fine, mentre la tab attività si abilita dopo aver selezionato una rivendita e contiene riepilogo economico e attività rivendita. In creazione devi selezionare un **ordine cliente**, un solo **ordine fornitore** collegato a quell'ordine cliente, indicare **data inizio** e **scadenza rivendita** obbligatorie e aggiungere almeno una **attività rivendita** nella tabella iniziale: il sistema accetta l'ordine fornitore solo se almeno una riga dell'ordine cliente lo referenzia.
 
 Ogni rivendita mostra il **Ricavo Rivendita** come somma dei ricavi inseriti nelle sue attività. Il **Costo Rivendita** ufficiale è invece importato dal totale dell'ordine fornitore e non viene modificato manualmente. Nel form di creazione entrambi i valori sono mostrati in sola lettura mentre compili le attività. Le attività rivendita restano compilate a mano e includono nome attività, fatturazione (mensile, trimestrale, annuale o una tantum), categoria, costo, ricavo, stato rilasciato, scadenza indipendente e note.
 

--- a/docs-site/src/content/docs/en/crm-projects.md
+++ b/docs-site/src/content/docs/en/crm-projects.md
@@ -27,7 +27,7 @@ Update the listing when costs, margins, or sales conditions change so new docume
 
 ## Jobs and tasks
 
-Jobs connect customers, tasks, and time entries. The module remains named **Projects**, but its operational pages are **Jobs** and **Resales**. Inside **Jobs**, use the **Jobs** and **Tasks** tabs to switch between the jobs archive and task management.
+Jobs connect customers, tasks, and time entries. The module remains named **Projects**, but its operational pages are **Jobs** and **Resales**. Inside **Jobs**, use the **Jobs** and **Tasks** tabs to switch between the jobs archive and task management; the archive also shows each job's start and end dates.
 
 For each job and task, you can set the billing type (retainer or time and materials) and the billing frequency (monthly or one-time) independently — both billing types support either frequency. If tasks use a billing type that differs from the job, the job is shown as mixed.
 
@@ -56,7 +56,7 @@ When a job ends, check that tasks are consistent and that no pending entries rem
 
 ### Resales
 
-The **Resales** entry in the Projects module manages economic resale operations separately from operational tasks, timesheets, and user assignments. The page is split into **Resales** and **Activities** tabs: the first tab shows the resales list, while Activities becomes available after selecting a resale and contains the economic summary plus resale activities. When creating a resale, you must select a **client order**, exactly one **supplier order** linked to that client order, set the required **start date** and **resale due date**, and add at least one **resale activity** in the initial activities table: the system accepts the supplier order only when at least one client-order line references it.
+The **Resales** entry in the Projects module manages economic resale operations separately from operational tasks, timesheets, and user assignments. The page is split into **Resales** and **Activities** tabs: the first tab shows the resales list with start and end dates, while Activities becomes available after selecting a resale and contains the economic summary plus resale activities. When creating a resale, you must select a **client order**, exactly one **supplier order** linked to that client order, set the required **start date** and **resale due date**, and add at least one **resale activity** in the initial activities table: the system accepts the supplier order only when at least one client-order line references it.
 
 Each resale shows **Resale revenue** as the sum of the revenues entered on its activities. The official **Resale cost** is imported from the supplier order total and is not edited manually. The create form shows both values as read-only fields while you fill in the activities. Resale activities are entered manually and include activity name, billing frequency (monthly, quarterly, annual, or one-time), category, cost, revenue, released status, independent due date, and notes.
 

--- a/locales/en/projects.json
+++ b/locales/en/projects.json
@@ -109,6 +109,8 @@
       "projectName": "Job Name",
       "description": "Description",
       "insertDate": "Insert Date",
+      "startDate": "Start Date",
+      "endDate": "End Date",
       "progress": "Progress",
       "status": "Status",
       "actions": "Actions"
@@ -375,6 +377,8 @@
       "supplierCost": "Supplier order cost",
       "activityCost": "Activity cost",
       "variance": "Variance",
+      "startDate": "Start date",
+      "endDate": "End date",
       "dueDate": "Due date",
       "activityName": "Activity name",
       "billing": "Billing",

--- a/locales/it/projects.json
+++ b/locales/it/projects.json
@@ -109,6 +109,8 @@
       "projectName": "Nome Commessa",
       "description": "Descrizione",
       "insertDate": "Data Inserimento",
+      "startDate": "Data Inizio",
+      "endDate": "Data Fine",
       "progress": "Avanzamento",
       "status": "Stato",
       "actions": "Azioni"
@@ -375,6 +377,8 @@
       "supplierCost": "Costo ordine fornitore",
       "activityCost": "Costo attività",
       "variance": "Varianza",
+      "startDate": "Data inizio",
+      "endDate": "Data fine",
       "dueDate": "Scadenza",
       "activityName": "Nome attività",
       "billing": "Fatturazione",

--- a/services/api/normalizers.ts
+++ b/services/api/normalizers.ts
@@ -284,6 +284,8 @@ export const normalizeProduct = (p: Product): Product => ({
 
 export const normalizeProject = (p: Project): Project => ({
   ...p,
+  startDate: p.startDate ? normalizeDateOnlyString(p.startDate) : null,
+  endDate: p.endDate ? normalizeDateOnlyString(p.endDate) : null,
   revenue: p.revenue === undefined || p.revenue === null ? null : Number(p.revenue),
   ...normalizeProjectBilling(p.billingType, p.billingFrequency),
   // `tipo` defaults to 'attivo' (the rollout default); `tipoConfirmed` to false so a

--- a/test/components/projects/ProjectsView.test.ts
+++ b/test/components/projects/ProjectsView.test.ts
@@ -124,6 +124,22 @@ describe('ProjectsView create-form validation', () => {
     expect(source).toContain('accessorFn: (row) => formatTipo(row.tipo)');
   });
 
+  test('shows localized start and end dates in the commissions archive', async () => {
+    const source = await Bun.file(
+      new URL('../../../components/projects/ProjectsView.tsx', import.meta.url),
+    ).text();
+    expect(source).toContain(
+      "import { formatDateOnlyForLocale, formatInsertDate } from '../../utils/date'",
+    );
+    expect(source).toContain("header: t('projects:projects.tableHeaders.startDate')");
+    expect(source).toContain("header: t('projects:projects.tableHeaders.endDate')");
+    expect(source).toContain("accessorKey: 'startDate'");
+    expect(source).toContain("accessorKey: 'endDate'");
+    expect(source).toContain('formatDateOnlyForLocale(row.startDate, i18n.language)');
+    expect(source).toContain('formatDateOnlyForLocale(row.endDate, i18n.language)');
+    expect(source).toContain('formatDateOnlyForLocale(String(value), i18n.language)');
+  });
+
   test('tipo labels and values exist in both locales (issue #784)', async () => {
     const en = await Bun.file(new URL('../../../locales/en/projects.json', import.meta.url)).json();
     const it = await Bun.file(new URL('../../../locales/it/projects.json', import.meta.url)).json();
@@ -136,10 +152,14 @@ describe('ProjectsView create-form validation', () => {
       expect(loc.projects.offerOptionalLabel).toBeTruthy();
       expect(loc.projects.noOfferLinked).toBeTruthy();
       expect(loc.projects.entityLabel).toBeTruthy();
+      expect(loc.projects.tableHeaders.startDate).toBeTruthy();
+      expect(loc.projects.tableHeaders.endDate).toBeTruthy();
       expect(loc.tabs.commissions).toBeTruthy();
       expect(loc.tabs.tasks).toBeTruthy();
       expect(loc.projects.tipoValues.attivo).toBeTruthy();
       expect(loc.projects.tipoValues.passivo).toBeTruthy();
+      expect(loc.resales.columns.startDate).toBeTruthy();
+      expect(loc.resales.columns.endDate).toBeTruthy();
       expect(loc.resales.tabs.activities).toBeTruthy();
       expect(loc.resales.selectResaleForActivities).toBeTruthy();
     }

--- a/test/components/projects/ResalesView.test.ts
+++ b/test/components/projects/ResalesView.test.ts
@@ -207,6 +207,17 @@ describe('ResalesView wiring', () => {
     }
   });
 
+  test('shows localized start and end dates in the resales archive', async () => {
+    const source = await readSource();
+    expect(source).toContain("header: t('resales." + "columns.startDate')");
+    expect(source).toContain("header: t('resales." + "columns.endDate')");
+    expect(source).toContain("accessorKey: 'startDate'");
+    expect(source).toContain("accessorKey: 'dueDate'");
+    expect(source).toContain('formatDateOnlyForLocale(row.startDate, i18n.language)');
+    expect(source).toContain('formatDateOnlyForLocale(row.dueDate, i18n.language)');
+    expect(source).toContain('formatDateOnlyForLocale(String(value), i18n.language)');
+  });
+
   test('shows supplier cost variance without blocking save', async () => {
     const source = await readSource();
     expect(source).toContain('controller.selectedResale.costVariance');

--- a/test/services/normalizers.test.ts
+++ b/test/services/normalizers.test.ts
@@ -973,6 +973,17 @@ describe('normalizeProject', () => {
       billingFrequency: 'one_time',
     });
   });
+
+  test('normalizes project date-only fields from datetime payloads', () => {
+    const project = make<Project>(baseProject, {
+      startDate: '2026-04-01T12:00:00.000Z',
+      endDate: '2026-04-30T12:00:00.000Z',
+    });
+    expect(normalizeProject(project)).toMatchObject({
+      startDate: '2026-04-01',
+      endDate: '2026-04-30',
+    });
+  });
 });
 
 describe('normalizeResale', () => {


### PR DESCRIPTION
## Summary
- Show start/end dates in the projects list and start/end dates in the resales list.
- Treat resale `dueDate` as the list-level end date while keeping activity due-date labels unchanged.
- Normalize project date-only fields from datetime API payloads and update IT/EN docs and translations.

## Changes
- Adds localized date columns to `ProjectsView` and `ResalesView` with sortable ISO accessors and formatted display/filter values.
- Extends `normalizeProject` to strip datetime payloads to `YYYY-MM-DD` for `startDate` and `endDate`.
- Adds focused source/normalizer coverage plus user documentation updates.

## Testing
- `bun test test/components/projects/ProjectsView.test.ts test/components/projects/ResalesView.test.ts test/services/normalizers.test.ts`
- `bun run lint`
- `bun run test:react-doctor` remained `84/100` before and after the change.

## Risks / Rollout
- Low risk. Change is frontend display and client-side normalization only; no migrations, API shape changes, auth, billing, or permissions changes.

## Issues
Issue: Not linked