### PR TITLE
app(chore): bump version to 0.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praetor",
   "private": true,
-  "version": "0.8.2",
+  "version": "0.8.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "praetor-server",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Praetor API Server",
   "main": "index.ts",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bumps the Praetor application and server package version from 0.8.2 to 0.8.3.

## Changes
- Updates the root application manifest.
- Updates the server manifest.
- Leaves dependencies and lockfiles unchanged.

## Testing
- `bun run lint`
- `bun run test` (2,068 passed)
- `bun run test:react-doctor -- --no-score --no-telemetry -y` (29 existing warnings before and after; numeric scoring disabled to keep scan data local)

## Risks / Rollout
- Low risk: metadata-only patch bump with no runtime, API, database, dependency, or documentation behavior changes.

## Issues
Issue: Not linked