### PR TITLE
sales(fix): inherit supplier quote duration

### DIFF
--- a/components/sales/ClientOffersView.tsx
+++ b/components/sales/ClientOffersView.tsx
@@ -56,6 +56,7 @@ import {
   buildSupplierQuoteItemIndex,
   isSupplierLineLocked,
   isSupplierLineStale,
+  pickedSupplierLineFields,
   refreshedSupplierLineFields,
 } from '../../utils/supplierLineSync';
 import { toastError } from '../../utils/toast';
@@ -1155,18 +1156,9 @@ const useClientOffersController = ({
             current.productCost = netCost;
             current.productMolPercentage = null;
           }
-          // Same math as the refresh chip: refreshedSupplierLineFields recomputes the sale price
-          // from the picked cost and the line MOL, converting FROM the supplier item's own unit
-          // (#812 round 14) — the picked cost is priced in that unit, so converting from a
-          // hardcoded 'hours' multiplied a days-priced item by 8 on initial selection.
-          const refreshed = refreshedSupplierLineFields(current, selectedQuoteItem);
-          current.quantity = refreshed.quantity;
-          current.supplierQuoteUnitPrice = refreshed.supplierQuoteUnitPrice;
-          // Pick-time baseline: lets the server tell a deliberate pre-save edit (pushed onto the
-          // supplier item) from an untouched stale snapshot (server values win).
-          current.supplierQuoteBaseQuantity = refreshed.supplierQuoteBaseQuantity;
-          current.supplierQuoteBaseUnitPrice = refreshed.supplierQuoteBaseUnitPrice;
-          current.unitPrice = refreshed.unitPrice;
+          // Pull quantity, cost, sale price, and duration from the supplier item. The helper also
+          // stamps the pick-time quantity/cost baseline used by the server's genuine-edit check.
+          Object.assign(current, pickedSupplierLineFields(current, selectedQuoteItem));
         }
       }
 

--- a/components/sales/ClientQuotesView.tsx
+++ b/components/sales/ClientQuotesView.tsx
@@ -64,6 +64,7 @@ import {
   buildSupplierQuoteItemIndex,
   isSupplierLineLocked,
   isSupplierLineStale,
+  pickedSupplierLineFields,
   refreshedSupplierLineFields,
 } from '../../utils/supplierLineSync';
 import { toastError } from '../../utils/toast';
@@ -932,18 +933,12 @@ const useClientQuotesController = ({
           newItems[index].productCost = netCost;
           newItems[index].productMolPercentage = null;
         }
-        // Same math as the refresh chip: refreshedSupplierLineFields recomputes the sale price
-        // from the picked cost and the line MOL, converting FROM the supplier item's own unit
-        // (#812 round 14) — the picked cost is priced in that unit, so converting from a
-        // hardcoded 'hours' multiplied a days-priced item by 8 on initial selection.
-        const refreshed = refreshedSupplierLineFields(newItems[index], selectedQuoteItem);
-        newItems[index].quantity = refreshed.quantity;
-        newItems[index].supplierQuoteUnitPrice = refreshed.supplierQuoteUnitPrice;
-        // Pick-time baseline: lets the server tell a deliberate pre-save edit (pushed onto the
-        // supplier item) from an untouched stale snapshot (server values win).
-        newItems[index].supplierQuoteBaseQuantity = refreshed.supplierQuoteBaseQuantity;
-        newItems[index].supplierQuoteBaseUnitPrice = refreshed.supplierQuoteBaseUnitPrice;
-        newItems[index].unitPrice = refreshed.unitPrice;
+        // Pull quantity, cost, sale price, and duration from the supplier item. The helper also
+        // stamps the pick-time quantity/cost baseline used by the server's genuine-edit check.
+        Object.assign(
+          newItems[index],
+          pickedSupplierLineFields(newItems[index], selectedQuoteItem),
+        );
       } else {
         // Supplier quote item not found - clear supplier quote and revert
         newItems[index].supplierQuoteItemId = null;

--- a/docs-site/src/content/docs/en/sales-accounting.md
+++ b/docs-site/src/content/docs/en/sales-accounting.md
@@ -29,6 +29,8 @@ While creating or editing a draft, supplier items already used by a line in the 
 
 Each picker option starts with the supplier quote code in square brackets, for example `[SQ-001]`.
 
+When you select a supplier quote item, the client line also inherits its **Duration**, preserving both the canonical month value and the displayed unit (**Months**, **Years**, or **N/A**); you can then customize it on the client document.
+
 When creating or editing a **quote** or an **offer**, each **Products / Services** row that references a **Supplier Quote** or a **product** shows a quick-view icon; on **client orders** and **client invoices** the same icon opens the row's linked **product**. Open it to inspect the linked record on its pre-filtered page in a new browser tab, without closing or changing the document in progress. The icon is always shown (so rows stay aligned) when you have permission to access the destination view: if the row has no record to open, it stays visible but disabled, with a tooltip saying so. On the destination page the filter is applied through the column's native filter (**Code**), so it stays visible and you can clear it from the filter menu to return to the full list. Removing a row asks for confirmation first: clicking the trash icon opens a prompt, so an accidental click never drops a product line until you confirm.
 
 In offer summaries, the **Discount** row always shows the equivalent percentage in parentheses, even when the global discount is entered as a fixed amount. The discount amount remains visible in currency on the right.

--- a/docs-site/src/content/docs/sales-accounting.md
+++ b/docs-site/src/content/docs/sales-accounting.md
@@ -29,6 +29,8 @@ Durante la creazione o la modifica di una bozza, le voci fornitore già usate in
 
 Ogni opzione della selezione mostra all'inizio il codice del preventivo fornitore tra parentesi quadrate, per esempio `[PF-001]`.
 
+Quando selezioni la voce di un preventivo fornitore, la riga cliente eredita anche la **Durata**, mantenendo sia il valore canonico in mesi sia l'unità visualizzata (**Mesi**, **Anni** o **N/D**); puoi poi personalizzarla nel documento cliente.
+
 Quando crei o modifichi un **preventivo** o un'**offerta**, ogni riga di **Prodotti / Servizi** che fa riferimento a un **Preventivo Fornitore** o a un **prodotto** mostra un'icona di apertura rapida; negli **ordini cliente** e nelle **fatture clienti** la stessa icona apre il **prodotto** collegato della riga. Aprila per consultare il record collegato nella sua pagina già filtrata in una nuova scheda del browser, senza chiudere né modificare il documento in corso. L'icona è sempre presente (così le righe restano allineate) quando hai il permesso di accedere alla vista di destinazione: se la riga non ha un riferimento da aprire resta visibile ma disabilitata, con un tooltip che lo segnala. Sulla pagina di destinazione il filtro è applicato tramite il filtro nativo della colonna (**Codice**), così resta visibile e puoi rimuoverlo dal menu del filtro per tornare all'elenco completo. La rimozione di una riga chiede prima conferma: il clic sull'icona del cestino apre una richiesta di conferma, così un clic accidentale non elimina mai un prodotto finché non confermi.
 
 Nel riepilogo delle offerte, la riga **Sconto** mostra sempre la percentuale equivalente tra parentesi, anche quando lo sconto globale è inserito come importo fisso. L'importo dello sconto resta visibile in valuta sulla destra.

--- a/test/components/sales/ClientQuotesView.test.tsx
+++ b/test/components/sales/ClientQuotesView.test.tsx
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ApiError } from '../../../services/api/client';
-import type { Client, Quote } from '../../../types';
+import type { Client, Quote, SupplierQuote } from '../../../types';
 import { installI18nMock } from '../../helpers/i18n';
 import { LineDeleteConfirmStub } from '../../helpers/lineItemDeleteConfirm';
 import { render } from '../../helpers/render';
@@ -232,6 +232,64 @@ describe('<ClientQuotesView />', () => {
       .filter((el): el is HTMLInputElement => el instanceof HTMLInputElement);
     expect(durationInputs.length).toBeGreaterThan(0);
     expect(durationInputs[0].value).toBe('1');
+  });
+
+  test('inherits duration and its unit when selecting a supplier quote item', () => {
+    const supplierQuote: SupplierQuote = {
+      id: 'SQ-DURATION',
+      supplierId: 'supplier-1',
+      supplierName: 'Acme Supplies',
+      items: [
+        {
+          id: 'sqi-duration',
+          quoteId: 'SQ-DURATION',
+          productName: 'Managed Service',
+          quantity: 1,
+          listPrice: 120,
+          discountPercent: 0,
+          unitPrice: 120,
+          unitType: 'unit',
+          durationMonths: 24,
+          durationUnit: 'years',
+        },
+      ],
+      paymentTerms: 'immediate',
+      status: 'draft',
+      expirationDate: STABLE_FUTURE_EXPIRATION_DATE,
+      createdAt: Date.UTC(2026, 4, 14),
+      updatedAt: Date.UTC(2026, 4, 14),
+    };
+
+    render(
+      <ClientQuotesView
+        quotes={[]}
+        clients={clients}
+        products={[]}
+        supplierQuotes={[supplierQuote]}
+        currency="EUR"
+        onAddQuote={mock(() => Promise.resolve())}
+        onUpdateQuote={mock(() => Promise.resolve())}
+        onDeleteQuote={mock(() => Promise.resolve())}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'sales:clientQuotes.createNewQuote' }));
+    fireEvent.click(screen.getByText('sales:clientQuotes.addProduct'));
+    fireEvent.click(
+      screen.getAllByRole('button', { name: 'sales:clientQuotes.noSupplierQuote' })[0],
+    );
+    fireEvent.click(
+      screen.getByRole('option', {
+        name: /Acme Supplies · Managed Service \(120\.00\)$/,
+      }),
+    );
+
+    const durationInputs = screen
+      .getAllByPlaceholderText('sales:clientQuotes.durationColumn')
+      .filter((element): element is HTMLInputElement => element instanceof HTMLInputElement);
+    expect(durationInputs.length).toBeGreaterThan(0);
+    expect(durationInputs.every((input) => input.value === '2')).toBe(true);
+    expect(screen.getAllByText('sales:clientQuotes.years').length).toBeGreaterThan(0);
   });
 
   test('defaults a new quote to the first communication channel and shows inline management', () => {

--- a/test/utils/supplierLineSync.test.ts
+++ b/test/utils/supplierLineSync.test.ts
@@ -4,6 +4,7 @@ import {
   buildSupplierQuoteItemIndex,
   isSupplierLineLocked,
   isSupplierLineStale,
+  pickedSupplierLineFields,
   refreshedSupplierLineFields,
 } from '../../utils/supplierLineSync';
 
@@ -178,5 +179,17 @@ describe('refreshedSupplierLineFields', () => {
       supplierItem({ unitType: 'days', unitPrice: 80 }),
     );
     expect(fields.unitPrice).toBe(10);
+  });
+});
+
+describe('pickedSupplierLineFields', () => {
+  test('inherits the supplier duration value and display unit on initial selection', () => {
+    const fields = pickedSupplierLineFields(
+      { productMolPercentage: 20, unitType: 'hours' },
+      supplierItem({ durationMonths: 24, durationUnit: 'years' }),
+    );
+
+    expect(fields.durationMonths).toBe(24);
+    expect(fields.durationUnit).toBe('years');
   });
 });

--- a/utils/supplierLineSync.ts
+++ b/utils/supplierLineSync.ts
@@ -1,5 +1,10 @@
 import type { SupplierQuote, SupplierUnitType } from '../types';
-import { calcProductSalePrice, convertUnitPrice } from './numbers';
+import {
+  calcProductSalePrice,
+  convertUnitPrice,
+  getEffectiveDurationMonths,
+  normalizeDurationUnit,
+} from './numbers';
 import { isFrozenEffectiveStatus } from './quoteStatus';
 
 // Shared #779 bidirectional-sync helpers for the client-quote and client-offer line editors.
@@ -110,3 +115,16 @@ export const refreshedSupplierLineFields = (
     ),
   };
 };
+
+// A freshly picked supplier item also initializes the client line's duration. Keep this separate
+// from the refresh helper above: quantity/cost are bidirectionally synchronized after linking,
+// while duration is only inherited when the supplier item is selected and can then be customized
+// independently on the client document.
+export const pickedSupplierLineFields = (
+  line: { productMolPercentage?: number | string | null; unitType?: SupplierUnitType },
+  source: SupplierQuote['items'][number],
+) => ({
+  ...refreshedSupplierLineFields(line, source),
+  durationMonths: getEffectiveDurationMonths(source),
+  durationUnit: normalizeDurationUnit(source.durationUnit),
+});


### PR DESCRIPTION
## Summary
- Inherits duration value and display unit when a supplier quote item is selected in a client quote or offer.
- Keeps duration independently customizable on the client document after the initial selection.

## Changes
- Adds a shared pick-time supplier-line mapping that extends the existing quantity/cost mapping with normalized duration fields.
- Applies the mapping to client quote and client offer line-item pickers.
- Adds unit and UI regression coverage for the supplier-item selection flow.
- Updates Italian and English user documentation.

## Testing
- `bun test test/utils/supplierLineSync.test.ts test/components/ClientQuotesView.test.tsx test/components/sales/ClientQuotesView.test.tsx test/components/sales/ClientOffersView.test.tsx` — 84 passed
- `bun run test:frontend` — 2,070 passed
- `bun run lint`
- `bun run build`
- `bun run test:react-doctor` — 85/100, unchanged

## Risks / Rollout
- Low risk. The change is limited to initial client-line population and does not add migrations, API changes, or dependency updates.
- Existing quantity/cost refresh behavior remains unchanged; duration is inherited only when the supplier item is selected.

## Issues
Issue: Not linked