### PR TITLE
catalog(fix): restore listing management actions

### DIFF
--- a/components/catalog/InternalListingView.tsx
+++ b/components/catalog/InternalListingView.tsx
@@ -688,8 +688,6 @@ const useInternalListingController = ({
         type: 'merge',
         patch: {
           typeError: t('crm:internalListing.typeDeleteBlocked', {
-            productCount: type.productCount,
-            categoryCount: type.categoryCount,
             name: type.name,
           }),
         },
@@ -1184,8 +1182,6 @@ const renderInternalListingTypeActions = (
 ) => {
   const isDeleteBlocked = type.productCount > 0 || type.categoryCount > 0;
   const deleteBlockedMessage = controller.t('crm:internalListing.typeDeleteBlocked', {
-    productCount: type.productCount,
-    categoryCount: type.categoryCount,
     name: type.name,
   });
 
@@ -1390,7 +1386,7 @@ const renderInternalListingCategoryActions = (
 ) => {
   const deleteBlockedMessage = controller.t(
     'crm:internalListing.deleteCategoryWithLinkedProducts',
-    { count: category.productCount, name: category.name },
+    { name: category.name },
   );
 
   return renderInternalListingEditDeleteActions({
@@ -1530,7 +1526,7 @@ const renderInternalListingSubcategoryActions = (
 ) => {
   const deleteBlockedMessage = controller.t(
     'crm:internalListing.deleteSubcategoryWithLinkedProducts',
-    { count: subcategory.productCount, name: subcategory.name },
+    { name: subcategory.name },
   );
 
   return renderInternalListingEditDeleteActions({

--- a/components/catalog/InternalListingView.tsx
+++ b/components/catalog/InternalListingView.tsx
@@ -1172,16 +1172,16 @@ const InternalListingTypesTable: React.FC<{ controller: InternalListingControlle
         id: 'actions',
         disableSorting: true,
         disableFiltering: true,
-        cell: ({ row: type }) => <InternalListingTypeActions controller={controller} type={type} />,
+        cell: ({ row: type }) => renderInternalListingTypeActions(controller, type),
       },
     ]}
   />
 );
 
-const InternalListingTypeActions: React.FC<{
-  controller: InternalListingController;
-  type: InternalProductType;
-}> = ({ controller, type }) => {
+const renderInternalListingTypeActions = (
+  controller: InternalListingController,
+  type: InternalProductType,
+) => {
   const isDeleteBlocked = type.productCount > 0 || type.categoryCount > 0;
   const deleteBlockedMessage = controller.t('crm:internalListing.typeDeleteBlocked', {
     productCount: type.productCount,
@@ -1189,38 +1189,37 @@ const InternalListingTypeActions: React.FC<{
     name: type.name,
   });
 
-  return (
-    <div className="flex items-center gap-1">
-      <InternalListingIconAction
-        icon="fa-pen"
-        label={controller.t('common:buttons.edit')}
-        onClick={() => controller.handleEditType(type)}
-      />
-      <InternalListingIconAction
-        icon="fa-trash"
-        label={controller.t('common:buttons.delete')}
-        onClick={() => controller.handleDeleteType(type)}
-        disabled={isDeleteBlocked}
-        disabledTooltip={deleteBlockedMessage}
-        danger
-      />
-    </div>
-  );
+  return renderInternalListingEditDeleteActions({
+    controller,
+    deleteDisabled: isDeleteBlocked,
+    deleteDisabledTooltip: deleteBlockedMessage,
+    onDelete: () => controller.handleDeleteType(type),
+    onEdit: () => controller.handleEditType(type),
+  });
 };
 
-const InternalListingIconAction: React.FC<{
+const renderInternalListingIconAction = ({
+  danger = false,
+  disabled = false,
+  disabledTooltip,
+  icon,
+  label,
+  onClick,
+}: {
   danger?: boolean;
   disabled?: boolean;
   disabledTooltip?: string;
   icon: string;
   label: string;
   onClick: () => void;
-}> = ({ danger = false, disabled = false, disabledTooltip, icon, label, onClick }) => (
+}) => (
   <Tooltip disabled={!disabled || !disabledTooltip}>
     <TooltipTrigger asChild>
       <span className="inline-flex">
-        <button
+        <Button
           type="button"
+          variant="ghost"
+          size="icon-xs"
           onClick={onClick}
           disabled={disabled}
           aria-label={label}
@@ -1232,12 +1231,42 @@ const InternalListingIconAction: React.FC<{
                 : 'text-zinc-400 hover:text-praetor hover:bg-zinc-100'
           }`}
         >
-          <i className={`fa-solid ${icon}`}></i>
-        </button>
+          <i className={`fa-solid ${icon}`} aria-hidden="true"></i>
+        </Button>
       </span>
     </TooltipTrigger>
     <TooltipContent>{disabled ? disabledTooltip : label}</TooltipContent>
   </Tooltip>
+);
+
+const renderInternalListingEditDeleteActions = ({
+  controller,
+  deleteDisabled,
+  deleteDisabledTooltip,
+  onDelete,
+  onEdit,
+}: {
+  controller: InternalListingController;
+  deleteDisabled: boolean;
+  deleteDisabledTooltip: string;
+  onDelete: () => void;
+  onEdit: () => void;
+}) => (
+  <div className="flex items-center gap-1">
+    {renderInternalListingIconAction({
+      icon: 'fa-pen',
+      label: controller.t('common:buttons.edit'),
+      onClick: onEdit,
+    })}
+    {renderInternalListingIconAction({
+      icon: 'fa-trash',
+      label: controller.t('common:buttons.delete'),
+      onClick: onDelete,
+      disabled: deleteDisabled,
+      disabledTooltip: deleteDisabledTooltip,
+      danger: true,
+    })}
+  </div>
 );
 
 const InternalListingCategoriesModal: React.FC<{ controller: InternalListingController }> = ({
@@ -1349,40 +1378,28 @@ const InternalListingCategoriesTable: React.FC<{ controller: InternalListingCont
         id: 'actions',
         disableSorting: true,
         disableFiltering: true,
-        cell: ({ row: category }) => (
-          <InternalListingCategoryActions controller={controller} category={category} />
-        ),
+        cell: ({ row: category }) => renderInternalListingCategoryActions(controller, category),
       },
     ]}
   />
 );
 
-const InternalListingCategoryActions: React.FC<{
-  category: InternalProductCategory;
-  controller: InternalListingController;
-}> = ({ category, controller }) => {
+const renderInternalListingCategoryActions = (
+  controller: InternalListingController,
+  category: InternalProductCategory,
+) => {
   const deleteBlockedMessage = controller.t(
     'crm:internalListing.deleteCategoryWithLinkedProducts',
     { count: category.productCount, name: category.name },
   );
 
-  return (
-    <div className="flex items-center gap-1">
-      <InternalListingIconAction
-        icon="fa-pen"
-        label={controller.t('common:buttons.edit')}
-        onClick={() => controller.handleEditCategory(category)}
-      />
-      <InternalListingIconAction
-        icon="fa-trash"
-        label={controller.t('common:buttons.delete')}
-        onClick={() => controller.handleDeleteCategory(category)}
-        disabled={category.hasLinkedProducts}
-        disabledTooltip={deleteBlockedMessage}
-        danger
-      />
-    </div>
-  );
+  return renderInternalListingEditDeleteActions({
+    controller,
+    deleteDisabled: category.hasLinkedProducts,
+    deleteDisabledTooltip: deleteBlockedMessage,
+    onDelete: () => controller.handleDeleteCategory(category),
+    onEdit: () => controller.handleEditCategory(category),
+  });
 };
 
 const InternalListingSubcategoriesModal: React.FC<{ controller: InternalListingController }> = ({
@@ -1500,40 +1517,29 @@ const InternalListingSubcategoriesTable: React.FC<{ controller: InternalListingC
         id: 'actions',
         disableSorting: true,
         disableFiltering: true,
-        cell: ({ row: subcategory }) => (
-          <InternalListingSubcategoryActions controller={controller} subcategory={subcategory} />
-        ),
+        cell: ({ row: subcategory }) =>
+          renderInternalListingSubcategoryActions(controller, subcategory),
       },
     ]}
   />
 );
 
-const InternalListingSubcategoryActions: React.FC<{
-  controller: InternalListingController;
-  subcategory: InternalProductSubcategory;
-}> = ({ controller, subcategory }) => {
+const renderInternalListingSubcategoryActions = (
+  controller: InternalListingController,
+  subcategory: InternalProductSubcategory,
+) => {
   const deleteBlockedMessage = controller.t(
     'crm:internalListing.deleteSubcategoryWithLinkedProducts',
     { count: subcategory.productCount, name: subcategory.name },
   );
 
-  return (
-    <div className="flex items-center gap-1">
-      <InternalListingIconAction
-        icon="fa-pen"
-        label={controller.t('common:buttons.edit')}
-        onClick={() => controller.handleEditSubcategory(subcategory)}
-      />
-      <InternalListingIconAction
-        icon="fa-trash"
-        label={controller.t('common:buttons.delete')}
-        onClick={() => controller.handleDeleteSubcategory(subcategory)}
-        disabled={subcategory.hasLinkedProducts}
-        disabledTooltip={deleteBlockedMessage}
-        danger
-      />
-    </div>
-  );
+  return renderInternalListingEditDeleteActions({
+    controller,
+    deleteDisabled: subcategory.hasLinkedProducts,
+    deleteDisabledTooltip: deleteBlockedMessage,
+    onDelete: () => controller.handleDeleteSubcategory(subcategory),
+    onEdit: () => controller.handleEditSubcategory(subcategory),
+  });
 };
 
 const InternalListingProductModal: React.FC<{ controller: InternalListingController }> = ({
@@ -1675,9 +1681,10 @@ const InternalListingTextField: React.FC<{
 
 const InternalListingFieldHeader: React.FC<{
   children: React.ReactNode;
+  manageLabel: string;
   onClick?: () => void;
   manageDisabled?: boolean;
-}> = ({ children, manageDisabled = false, onClick }) => (
+}> = ({ children, manageLabel, manageDisabled = false, onClick }) => (
   <div className="flex min-h-6 items-center justify-between gap-2">
     <FieldLabel>{children}</FieldLabel>
     {onClick && (
@@ -1690,7 +1697,7 @@ const InternalListingFieldHeader: React.FC<{
         className="gap-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"
       >
         <i className="fa-solid fa-gear" aria-hidden="true"></i>
-        Manage
+        {manageLabel}
       </Button>
     )}
   </div>
@@ -1703,7 +1710,10 @@ const InternalListingTypeSelect: React.FC<{ controller: InternalListingControlle
 
   return (
     <div className="space-y-1.5">
-      <InternalListingFieldHeader onClick={handleOpenManageTypes}>
+      <InternalListingFieldHeader
+        manageLabel={controller.t('common:buttons.manage')}
+        onClick={handleOpenManageTypes}
+      >
         {controller.t('crm:internalListing.type')} <RequiredMark />
       </InternalListingFieldHeader>
       <SelectControl
@@ -1729,7 +1739,10 @@ const InternalListingCategorySelect: React.FC<{ controller: InternalListingContr
 
   return (
     <div className="space-y-1.5">
-      <InternalListingFieldHeader onClick={handleOpenManageCategories}>
+      <InternalListingFieldHeader
+        manageLabel={controller.t('common:buttons.manage')}
+        onClick={handleOpenManageCategories}
+      >
         {controller.t('crm:internalListing.category')}
       </InternalListingFieldHeader>
       <SelectControl
@@ -1767,6 +1780,7 @@ const InternalListingSubcategorySelect: React.FC<{ controller: InternalListingCo
   return (
     <div className="space-y-1.5">
       <InternalListingFieldHeader
+        manageLabel={controller.t('common:buttons.manage')}
         onClick={handleOpenManageSubcategories}
         manageDisabled={!controller.formData.category}
       >
@@ -2081,9 +2095,8 @@ const getInternalListingProductColumns = (controller: InternalListingController)
     align: 'right' as const,
     disableSorting: true,
     disableFiltering: true,
-    cell: ({ row: product }: { row: Product }) => (
-      <InternalListingProductActions controller={controller} product={product} />
-    ),
+    cell: ({ row: product }: { row: Product }) =>
+      renderInternalListingProductActions(controller, product),
     className: 'px-8 py-5',
   },
 ];
@@ -2106,16 +2119,18 @@ const InternalListingCurrencyCell: React.FC<{
   );
 };
 
-const InternalListingProductActions: React.FC<{
-  controller: InternalListingController;
-  product: Product;
-}> = ({ controller, product }) => (
+const renderInternalListingProductActions = (
+  controller: InternalListingController,
+  product: Product,
+) => (
   <div className="flex justify-end gap-2">
     <Tooltip>
       <TooltipTrigger asChild>
         <span className="inline-flex">
-          <button
+          <Button
             type="button"
+            variant="ghost"
+            size="icon-sm"
             onClick={(event) => {
               event.stopPropagation();
               controller.onUpdateProduct(product.id, { isDisabled: !product.isDisabled });
@@ -2131,8 +2146,11 @@ const InternalListingProductActions: React.FC<{
                 : 'text-amber-700 hover:text-amber-600 hover:bg-amber-50'
             }`}
           >
-            <i className={`fa-solid ${product.isDisabled ? 'fa-rotate-left' : 'fa-ban'}`}></i>
-          </button>
+            <i
+              className={`fa-solid ${product.isDisabled ? 'fa-rotate-left' : 'fa-ban'}`}
+              aria-hidden="true"
+            ></i>
+          </Button>
         </span>
       </TooltipTrigger>
       <TooltipContent>
@@ -2144,8 +2162,10 @@ const InternalListingProductActions: React.FC<{
     <Tooltip>
       <TooltipTrigger asChild>
         <span className="inline-flex">
-          <button
+          <Button
             type="button"
+            variant="ghost"
+            size="icon-sm"
             onClick={(event) => {
               event.stopPropagation();
               controller.confirmDelete(product);
@@ -2153,8 +2173,8 @@ const InternalListingProductActions: React.FC<{
             aria-label={controller.t('common:buttons.delete')}
             className="p-2 text-red-600 hover:text-red-600 hover:bg-red-50 rounded-lg transition-all"
           >
-            <i className="fa-solid fa-trash-can"></i>
-          </button>
+            <i className="fa-solid fa-trash-can" aria-hidden="true"></i>
+          </Button>
         </span>
       </TooltipTrigger>
       <TooltipContent>{controller.t('crm:internalListing.deleteProductTooltip')}</TooltipContent>

--- a/docs-site/src/content/docs/crm-projects.md
+++ b/docs-site/src/content/docs/crm-projects.md
@@ -23,6 +23,8 @@ Non è possibile eliminare un cliente o un fornitore se sono presenti documenti 
 
 Il catalogo contiene prodotti, categorie, unità di misura e logiche di prezzo. Le informazioni del catalogo alimentano preventivi, offerte e documenti contabili.
 
+Nel modulo di creazione o modifica di un prodotto, il pulsante **Gestisci** sopra i campi **Tipo**, **Categoria** e **Sottocategoria** apre l'elenco delle relative voci. Da qui puoi aggiungere o rinominare una voce e, quando non è protetta da collegamenti esistenti, eliminarla.
+
 Aggiorna il listino quando cambiano costi, margini o condizioni di vendita, così i nuovi documenti partono da dati affidabili.
 
 ## Commesse e attività

--- a/docs-site/src/content/docs/en/crm-projects.md
+++ b/docs-site/src/content/docs/en/crm-projects.md
@@ -23,6 +23,8 @@ A customer or supplier cannot be deleted while any related financial document (q
 
 The catalog contains products, categories, units, and pricing logic. Catalog data feeds quotes, offers, and accounting documents.
 
+In the create or edit product form, the **Manage** button above the **Type**, **Category**, and **Subcategory** fields opens the corresponding list of values. From there you can add or rename a value and delete it when existing links do not protect it.
+
 Update the listing when costs, margins, or sales conditions change so new documents start from reliable data.
 
 ## Jobs and tasks

--- a/locales/en/crm.json
+++ b/locales/en/crm.json
@@ -211,7 +211,7 @@
     "typeNameRequired": "Type name is required",
     "noTypes": "No types found. Create your first product type.",
     "deleteTypeWithProducts": "Type '{{name}}' has {{productCount}} product(s) and {{categoryCount}} category(s). Are you sure you want to delete it?",
-    "typeDeleteBlocked": "Type '{{name}}' cannot be deleted while {{productCount}} product(s) and {{categoryCount}} category(s) still use it.",
+    "typeDeleteBlocked": "Type '{{name}}' cannot be deleted because it is still in use.",
     "editProductTooltip": "Edit Product",
     "disableProduct": "Disable Product",
     "enableProduct": "Enable Product",
@@ -255,9 +255,9 @@
     "products": "products",
     "costUnit": "Cost Unit",
     "deleteCategoryWithProducts": "Category '{{name}}' has {{count}} product(s). Are you sure you want to delete it? Products will become uncategorized.",
-    "deleteCategoryWithLinkedProducts": "Cannot delete category '{{name}}'. It has {{count}} product(s) linked to transactions (offers, orders, invoices). Remove the products from transactions first.",
+    "deleteCategoryWithLinkedProducts": "Category '{{name}}' cannot be deleted because it is still in use.",
     "deleteSubcategoryWithProducts": "Subcategory '{{name}}' has {{count}} product(s). Are you sure you want to delete it? Products will lose their subcategory.",
-    "deleteSubcategoryWithLinkedProducts": "Cannot delete subcategory '{{name}}'. It has {{count}} product(s) linked to transactions (offers, orders, invoices). Remove the products from transactions first."
+    "deleteSubcategoryWithLinkedProducts": "Subcategory '{{name}}' cannot be deleted because it is still in use."
   },
   "sales": {
     "title": "Sales",

--- a/locales/it/crm.json
+++ b/locales/it/crm.json
@@ -210,7 +210,7 @@
     "typeNameRequired": "Il nome del tipo è obbligatorio",
     "noTypes": "Nessun tipo trovato. Crea il tuo primo tipo di prodotto.",
     "deleteTypeWithProducts": "Il tipo '{{name}}' ha {{productCount}} prodotto(i) e {{categoryCount}} categoria(e). Sei sicuro di volerlo eliminare?",
-    "typeDeleteBlocked": "Il tipo '{{name}}' non puo essere eliminato mentre {{productCount}} prodotto(i) e {{categoryCount}} categoria(e) lo stanno ancora utilizzando.",
+    "typeDeleteBlocked": "Il tipo '{{name}}' non può essere eliminato perché è ancora in uso.",
     "editProductTooltip": "Modifica Prodotto",
     "disableProduct": "Disabilita Prodotto",
     "enableProduct": "Abilita Prodotto",
@@ -254,9 +254,9 @@
     "products": "prodotti",
     "costUnit": "Unità di Costo",
     "deleteCategoryWithProducts": "La categoria '{{name}}' ha {{count}} prodotto(i). Sei sicuro di volerla eliminare? I prodotti diventeranno senza categoria.",
-    "deleteCategoryWithLinkedProducts": "Impossibile eliminare la categoria '{{name}}'. Ha {{count}} prodotto(i) collegati a transazioni (offerte, ordini, fatture). Rimuovi prima i prodotti dalle transazioni.",
+    "deleteCategoryWithLinkedProducts": "La categoria '{{name}}' non può essere eliminata perché è ancora in uso.",
     "deleteSubcategoryWithProducts": "La sottocategoria '{{name}}' ha {{count}} prodotto(i). Sei sicuro di volerla eliminare? I prodotti perderanno la sottocategoria.",
-    "deleteSubcategoryWithLinkedProducts": "Impossibile eliminare la sottocategoria '{{name}}'. Ha {{count}} prodotto(i) collegati a transazioni (offerte, ordini, fatture). Rimuovi prima i prodotti dalle transazioni."
+    "deleteSubcategoryWithLinkedProducts": "La sottocategoria '{{name}}' non può essere eliminata perché è ancora in uso."
   },
   "sales": {
     "title": "Vendite",

--- a/test/components/catalog/InternalListingView.test.tsx
+++ b/test/components/catalog/InternalListingView.test.tsx
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, mock, test } from 'bun:test';
-import { screen } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type {
+  InternalProductCategory,
+  InternalProductSubcategory,
+  InternalProductType,
+} from '../../../services/api/products';
 import type { Product } from '../../../types';
 import { installI18nMock } from '../../helpers/i18n';
 import { render } from '../../helpers/render';
@@ -8,12 +14,16 @@ installI18nMock();
 
 // InternalListingView loads product types / categories on mount; stub the API so
 // the view renders without real network calls.
+let productTypes: InternalProductType[] = [];
+let categories: InternalProductCategory[] = [];
+let subcategories: InternalProductSubcategory[] = [];
+
 mock.module('../../../services/api', () => ({
   default: {
     products: {
-      listProductTypes: () => Promise.resolve([]),
-      listInternalCategories: () => Promise.resolve([]),
-      listInternalSubcategories: () => Promise.resolve([]),
+      listProductTypes: () => Promise.resolve(productTypes),
+      listInternalCategories: () => Promise.resolve(categories),
+      listInternalSubcategories: () => Promise.resolve(subcategories),
     },
   },
 }));
@@ -55,6 +65,9 @@ const products: Product[] = [
 ];
 
 afterEach(() => {
+  productTypes = [];
+  categories = [];
+  subcategories = [];
   document.body.style.overflow = '';
   // StandardTable persists saved views / active view per table title; clear so
   // state set in one test can't leak into the next.
@@ -71,6 +84,7 @@ describe('<InternalListingView /> productFilterId', () => {
     render(<InternalListingView {...baseProps} products={products} />);
     expect(screen.getByText('Solar Panel')).toBeInTheDocument();
     expect(screen.getByText('Wind Turbine')).toBeInTheDocument();
+    expect(screen.getAllByLabelText('table.rowActions')).toHaveLength(products.length);
   });
 
   test("pre-filters the table to the linked product's code (visible Codice column)", () => {
@@ -159,5 +173,126 @@ describe('<InternalListingView /> productFilterId', () => {
     expect(
       screen.getByRole('button', { name: /table\.filters .*productCode/i }),
     ).toBeInTheDocument();
+  });
+});
+
+describe('<InternalListingView /> managed catalog values', () => {
+  test('localizes Manage and exposes edit/delete actions for types, categories, and subcategories', async () => {
+    productTypes = [
+      {
+        id: 'type-consulting',
+        name: 'consulting',
+        costUnit: 'hours',
+        productCount: 0,
+        categoryCount: 0,
+      },
+      {
+        id: 'type-supply',
+        name: 'supply',
+        costUnit: 'unit',
+        productCount: 0,
+        categoryCount: 0,
+      },
+    ];
+    categories = [
+      {
+        id: 'category-governance',
+        name: 'Governance',
+        type: 'supply',
+        costUnit: 'unit',
+        productCount: 0,
+        hasLinkedProducts: false,
+      },
+      {
+        id: 'category-operations',
+        name: 'Operations',
+        type: 'supply',
+        costUnit: 'unit',
+        productCount: 0,
+        hasLinkedProducts: false,
+      },
+    ];
+    subcategories = [
+      { name: 'Network', productCount: 0, hasLinkedProducts: false },
+      { name: 'Security', productCount: 0, hasLinkedProducts: false },
+    ];
+
+    const onDeleteProductType = mock((_id: string) => Promise.resolve());
+    const onDeleteInternalCategory = mock((_id: string) => Promise.resolve());
+    const onDeleteInternalSubcategory = mock((_name: string, _type: string, _category: string) =>
+      Promise.resolve(),
+    );
+    const user = userEvent.setup();
+
+    render(
+      <InternalListingView
+        {...baseProps}
+        products={[]}
+        onDeleteProductType={onDeleteProductType}
+        onDeleteInternalCategory={onDeleteInternalCategory}
+        onDeleteInternalSubcategory={onDeleteInternalSubcategory}
+      />,
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'crm:internalListing.addProduct' }));
+
+    const typeSelect = await screen.findByRole('combobox');
+    await waitFor(() => expect(typeSelect).toHaveTextContent('Consulting'));
+    fireEvent.click(typeSelect);
+    fireEvent.click(await screen.findByRole('option', { name: 'Supply' }));
+    await screen.findByText('Governance');
+
+    expect(screen.getAllByRole('button', { name: 'common:buttons.manage' })).toHaveLength(3);
+
+    const openActionsFor = async (name: string) => {
+      let actionButton: HTMLElement | null = null;
+      await waitFor(() => {
+        const row = screen
+          .getAllByText(name)
+          .map((element) => element.closest('tr'))
+          .find((element): element is HTMLTableRowElement => element !== null);
+        expect(row).toBeDefined();
+        actionButton = within(row as HTMLTableRowElement).getByRole('button', {
+          name: 'table.rowActions',
+        });
+      });
+      if (!actionButton) throw new Error('Missing row actions for ' + name);
+      fireEvent.pointerDown(actionButton, { button: 0, ctrlKey: false });
+    };
+    const deleteCurrentValue = async () => {
+      expect(
+        await screen.findByRole('button', { name: 'common:buttons.edit' }),
+      ).toBeInTheDocument();
+      await user.click(screen.getByRole('button', { name: 'common:buttons.delete' }));
+    };
+
+    const closeTopModal = () => {
+      const closeButtons = screen.getAllByRole('button', { name: 'Close' });
+      fireEvent.click(closeButtons.at(-1) as HTMLElement);
+    };
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'common:buttons.manage' })[0]);
+    await openActionsFor('Consulting');
+    await deleteCurrentValue();
+    await waitFor(() => expect(onDeleteProductType).toHaveBeenCalledWith('type-consulting'));
+    closeTopModal();
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'common:buttons.manage' })[1]);
+    await openActionsFor('Operations');
+    await deleteCurrentValue();
+    await waitFor(() =>
+      expect(onDeleteInternalCategory).toHaveBeenCalledWith('category-operations'),
+    );
+    closeTopModal();
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'common:buttons.manage' })[2]);
+    await openActionsFor('Security');
+    await deleteCurrentValue();
+    await waitFor(() =>
+      expect(onDeleteInternalSubcategory).toHaveBeenCalledWith('Security', 'supply', 'Governance'),
+    );
   });
 });

--- a/test/components/catalog/InternalListingView.test.tsx
+++ b/test/components/catalog/InternalListingView.test.tsx
@@ -177,7 +177,9 @@ describe('<InternalListingView /> productFilterId', () => {
 });
 
 describe('<InternalListingView /> managed catalog values', () => {
-  test('localizes Manage and exposes edit/delete actions for types, categories, and subcategories', async () => {
+  const setupManagedCatalogValues = async (
+    overrides: Partial<Parameters<typeof InternalListingView>[0]> = {},
+  ) => {
     productTypes = [
       {
         id: 'type-consulting',
@@ -217,22 +219,9 @@ describe('<InternalListingView /> managed catalog values', () => {
       { name: 'Security', productCount: 0, hasLinkedProducts: false },
     ];
 
-    const onDeleteProductType = mock((_id: string) => Promise.resolve());
-    const onDeleteInternalCategory = mock((_id: string) => Promise.resolve());
-    const onDeleteInternalSubcategory = mock((_name: string, _type: string, _category: string) =>
-      Promise.resolve(),
-    );
     const user = userEvent.setup();
 
-    render(
-      <InternalListingView
-        {...baseProps}
-        products={[]}
-        onDeleteProductType={onDeleteProductType}
-        onDeleteInternalCategory={onDeleteInternalCategory}
-        onDeleteInternalSubcategory={onDeleteInternalSubcategory}
-      />,
-    );
+    render(<InternalListingView {...baseProps} {...overrides} products={[]} />);
     await act(async () => {
       await Promise.resolve();
     });
@@ -245,52 +234,68 @@ describe('<InternalListingView /> managed catalog values', () => {
     fireEvent.click(await screen.findByRole('option', { name: 'Supply' }));
     await screen.findByText('Governance');
 
-    expect(screen.getAllByRole('button', { name: 'common:buttons.manage' })).toHaveLength(3);
+    const manageButtons = screen.getAllByRole('button', { name: 'common:buttons.manage' });
+    expect(manageButtons).toHaveLength(3);
 
-    const openActionsFor = async (name: string) => {
-      let actionButton: HTMLElement | null = null;
-      await waitFor(() => {
-        const row = screen
-          .getAllByText(name)
-          .map((element) => element.closest('tr'))
-          .find((element): element is HTMLTableRowElement => element !== null);
-        expect(row).toBeDefined();
-        actionButton = within(row as HTMLTableRowElement).getByRole('button', {
-          name: 'table.rowActions',
-        });
+    return { manageButtons, user };
+  };
+
+  const openActionsFor = async (name: string) => {
+    let actionButton: HTMLElement | null = null;
+    await waitFor(() => {
+      const row = screen
+        .getAllByText(name)
+        .map((element) => element.closest('tr'))
+        .find((element): element is HTMLTableRowElement => element !== null);
+      expect(row).toBeDefined();
+      actionButton = within(row as HTMLTableRowElement).getByRole('button', {
+        name: 'table.rowActions',
       });
-      if (!actionButton) throw new Error('Missing row actions for ' + name);
-      fireEvent.pointerDown(actionButton, { button: 0, ctrlKey: false });
-    };
-    const deleteCurrentValue = async () => {
-      expect(
-        await screen.findByRole('button', { name: 'common:buttons.edit' }),
-      ).toBeInTheDocument();
-      await user.click(screen.getByRole('button', { name: 'common:buttons.delete' }));
-    };
+    });
+    if (!actionButton) throw new Error('Missing row actions for ' + name);
+    fireEvent.pointerDown(actionButton, { button: 0, ctrlKey: false });
+  };
 
-    const closeTopModal = () => {
-      const closeButtons = screen.getAllByRole('button', { name: 'Close' });
-      fireEvent.click(closeButtons.at(-1) as HTMLElement);
-    };
+  const deleteCurrentValue = async (user: ReturnType<typeof userEvent.setup>) => {
+    expect(await screen.findByRole('button', { name: 'common:buttons.edit' })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'common:buttons.delete' }));
+  };
 
-    fireEvent.click(screen.getAllByRole('button', { name: 'common:buttons.manage' })[0]);
+  test('localizes Manage and exposes type edit/delete actions', async () => {
+    const onDeleteProductType = mock((_id: string) => Promise.resolve());
+    const { manageButtons, user } = await setupManagedCatalogValues({ onDeleteProductType });
+
+    fireEvent.click(manageButtons[0]);
     await openActionsFor('Consulting');
-    await deleteCurrentValue();
+    await deleteCurrentValue(user);
     await waitFor(() => expect(onDeleteProductType).toHaveBeenCalledWith('type-consulting'));
-    closeTopModal();
+  });
 
-    fireEvent.click(screen.getAllByRole('button', { name: 'common:buttons.manage' })[1]);
+  test('exposes category edit/delete actions', async () => {
+    const onDeleteInternalCategory = mock((_id: string) => Promise.resolve());
+    const { manageButtons, user } = await setupManagedCatalogValues({
+      onDeleteInternalCategory,
+    });
+
+    fireEvent.click(manageButtons[1]);
     await openActionsFor('Operations');
-    await deleteCurrentValue();
+    await deleteCurrentValue(user);
     await waitFor(() =>
       expect(onDeleteInternalCategory).toHaveBeenCalledWith('category-operations'),
     );
-    closeTopModal();
+  });
 
-    fireEvent.click(screen.getAllByRole('button', { name: 'common:buttons.manage' })[2]);
+  test('exposes subcategory edit/delete actions', async () => {
+    const onDeleteInternalSubcategory = mock((_name: string, _type: string, _category: string) =>
+      Promise.resolve(),
+    );
+    const { manageButtons, user } = await setupManagedCatalogValues({
+      onDeleteInternalSubcategory,
+    });
+
+    fireEvent.click(manageButtons[2]);
     await openActionsFor('Security');
-    await deleteCurrentValue();
+    await deleteCurrentValue(user);
     await waitFor(() =>
       expect(onDeleteInternalSubcategory).toHaveBeenCalledWith('Security', 'supply', 'Governance'),
     );


### PR DESCRIPTION
## Summary
- Restores the edit and delete actions in the internal listing type, category, and subcategory management dialogs.
- Localizes the shared Manage affordance and restores product-row action menus affected by the same rendering regression.

## Changes
- Renders concrete shadcn action controls that `StandardTable` can discover and expose through its row-action menu.
- Centralizes the shared edit/delete action composition while preserving existing linked-record deletion guards.
- Shortens blocked-deletion feedback to a concise "still in use" message in Italian and English.
- Adds regression coverage for all three managed value dialogs and product row actions.
- Documents the management workflow in the Italian and English user guides.

## Testing
- `bun test test/components/catalog/InternalListingView.test.tsx`
- `bun run lint`
- `bun run test` (2069 passed, 0 failed)
- `bun run test:react-doctor` (85/100, unchanged from baseline)

## Risks / Rollout
- Low risk. The change is limited to internal-listing UI action rendering and documentation.
- No database, API, permission, configuration, or dependency changes.
- Existing deletion protections for linked records remain unchanged.

## Issues
Issue: Not linked