### PR TITLE
app(chore): bump version to 0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praetor",
   "private": true,
-  "version": "0.8.3",
+  "version": "0.9.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "praetor-server",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "Praetor API Server",
   "main": "index.ts",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bumps the Praetor application version from `0.8.3` to `0.9.0`.
- Keeps the frontend and backend package metadata aligned.

## Changes
- Updates the root application package version.
- Updates the server package version used by API and MCP version metadata.

## Testing
- `bun run typecheck`
- `bun test ./server/test/routes/mcp.test.ts` (17 passed)
- `bun run test:react-doctor` (62/100 before and after; exits nonzero for 106 pre-existing findings in unchanged React files)

## Risks / Rollout
- Low risk. Metadata-only change with no database migration or configuration change.

## Issues
Issue: Not linked