### PR TITLE
timesheets(performance): optimize RIL page loading

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -166,6 +166,7 @@ import {
 } from './utils/ril';
 import { sourcesSupplierQuote } from './utils/supplierLineSync';
 import { applyBrowserTheme, applyTheme, getTheme } from './utils/theme';
+import { getTimesheetLoadRequirements } from './utils/timesheetLoadRequirements';
 import { toastError } from './utils/toast';
 import {
   filterTrackerCatalogs,
@@ -1237,6 +1238,7 @@ const useAppContentController = () => {
   const entriesStreamTokenRef = useRef(0);
   // Bumped on navigation/auth reset so stale module-load completions cannot commit state.
   const moduleLoadTokenRef = useRef(0);
+  const loadedTimesheetsViewRef = useRef<string | null>(null);
   const [localState, dispatchLocalState] = useReducer(
     appLocalStateReducer,
     INITIAL_APP_LOCAL_STATE,
@@ -2022,7 +2024,12 @@ const useAppContentController = () => {
     if (!isRouteAccessible) return;
     const module = getModuleFromView(activeView);
     if (!module) return;
-    if (isModuleLoaded(module)) return;
+    if (
+      isModuleLoaded(module) &&
+      (module !== 'timesheets' || loadedTimesheetsViewRef.current === activeView)
+    ) {
+      return;
+    }
     const loadToken = ++moduleLoadTokenRef.current;
     const isCurrentModuleLoad = () =>
       moduleLoadTokenRef.current === loadToken && activeLoadModuleRef.current === module;
@@ -2308,6 +2315,7 @@ const useAppContentController = () => {
         switch (module) {
           case 'timesheets': {
             if (!canViewTimesheets) return;
+            const requirements = getTimesheetLoadRequirements(activeView);
             // Merge incoming entries with existing state so an in-flight
             // optimistic insert (handleAddEntry / handleAddBulkEntries) isn't
             // dropped when the pager finally resolves. Preserve `prev`'s
@@ -2415,7 +2423,7 @@ const useAppContentController = () => {
               [
                 {
                   dataset: 'entries',
-                  enabled: canListEntries,
+                  enabled: requirements.entries && canListEntries,
                   load: () => api.entries.listPage({ limit: 500 }),
                   apply: (page) => {
                     const token = ++entriesStreamTokenRef.current;
@@ -2424,10 +2432,30 @@ const useAppContentController = () => {
                     if (page.nextCursor) void streamRemainingEntries(page.nextCursor, token);
                   },
                 },
-                listRequest('clients', canListClients, () => api.clients.list(), setClients),
-                listRequest('projects', canListProjects, () => api.projects.list(), setProjects),
-                listRequest('tasks', canListTasks, () => api.tasks.list(), setProjectTasks),
-                listRequest('users', canListUsers, () => api.users.list(), setUsers),
+                listRequest(
+                  'clients',
+                  requirements.clients && canListClients,
+                  () => api.clients.list(),
+                  setClients,
+                ),
+                listRequest(
+                  'projects',
+                  requirements.projects && canListProjects,
+                  () => api.projects.list(),
+                  setProjects,
+                ),
+                listRequest(
+                  'tasks',
+                  requirements.tasks && canListTasks,
+                  () => api.tasks.list(),
+                  setProjectTasks,
+                ),
+                listRequest(
+                  'users',
+                  requirements.users && canListUsers,
+                  () => api.users.list(),
+                  setUsers,
+                ),
               ],
               { shouldApply: isCurrentModuleLoad },
             );
@@ -2768,6 +2796,7 @@ const useAppContentController = () => {
         if (isCurrentModuleLoad()) {
           const uniqueFailures = Array.from(new Set(failedDatasets));
           recordFailures(module, uniqueFailures);
+          if (module === 'timesheets') loadedTimesheetsViewRef.current = activeView;
           markModuleLoaded(module);
         }
       }
@@ -2817,6 +2846,7 @@ const useAppContentController = () => {
   // Load target user assignments when the timesheet user switcher changes.
   useEffect(() => {
     if (!currentUser || !viewingUserId) return;
+    if (activeView !== 'timesheets/tracker') return;
 
     let isCancelled = false;
 
@@ -2890,7 +2920,7 @@ const useAppContentController = () => {
     return () => {
       isCancelled = true;
     };
-  }, [currentUser, viewingUserId, setViewingUserAssignmentState]);
+  }, [activeView, currentUser, viewingUserId, setViewingUserAssignmentState]);
 
   // Update viewingUserId when currentUser changes
   useEffect(() => {
@@ -3324,7 +3354,9 @@ const useAppContentController = () => {
     Boolean(
       activeModule &&
         activeModule !== 'settings' &&
-        (!loadedModules.has(activeModule) || isModuleLoading(activeModule)),
+        (!loadedModules.has(activeModule) ||
+          isModuleLoading(activeModule) ||
+          (activeModule === 'timesheets' && loadedTimesheetsViewRef.current !== activeView)),
     ) ||
     (activeView === 'reports/ai-reporting' && !hasLoadedGeneralSettings && !reportsSettingsFailed);
 
@@ -3743,7 +3775,6 @@ const TimesheetRoutes: React.FC<{ controller: AuthenticatedAppContentController 
           availableUsers={availableUsers}
           viewingUserId={viewingUserId}
           onViewUserChange={setViewingUserId}
-          projects={projects}
           settings={generalSettings}
           weekdayTransferDefaults={userSettings.rilWeekdayTransferDefaults}
         />

--- a/App.tsx
+++ b/App.tsx
@@ -2418,6 +2418,14 @@ const useAppContentController = () => {
                 cursor = page.nextCursor;
               }
             };
+            // RIL owns its entry fetch, so it skips the global entries dataset below. Start
+            // recurring materialization alongside the remaining preload, then await it before
+            // RilView mounts and requests the selected month.
+            const rilRecurringGeneration =
+              activeView === 'timesheets/ril' &&
+              hasPermission(permissions, buildPermission('timesheets.recurring', 'create'))
+                ? generateRecurringEntries()
+                : null;
             failedDatasets = await loadDatasets(
               module,
               [
@@ -2459,6 +2467,7 @@ const useAppContentController = () => {
               ],
               { shouldApply: isCurrentModuleLoad },
             );
+            if (rilRecurringGeneration) await rilRecurringGeneration;
             // Recurring generation fetches from the server independently of
             // local entries, so still run it when the initial entries fetch fails.
             if (failedDatasets.includes('entries')) {

--- a/components/timesheet/RilView.tsx
+++ b/components/timesheet/RilView.tsx
@@ -22,7 +22,7 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import api from '../../services/api';
-import type { GeneralSettings, Project, TimeEntry, User } from '../../types';
+import type { GeneralSettings, RilProjectReference, TimeEntry, User } from '../../types';
 import { formatDecimal } from '../../utils/numbers';
 import {
   applyRilDraftToRows,
@@ -67,7 +67,6 @@ interface RilViewProps {
   availableUsers: User[];
   viewingUserId: string;
   onViewUserChange: (userId: string) => void;
-  projects: Project[];
   settings: Pick<
     GeneralSettings,
     | 'rilCompanyName'
@@ -224,7 +223,6 @@ const useRilController = ({
   availableUsers,
   viewingUserId,
   onViewUserChange,
-  projects,
   settings,
   weekdayTransferDefaults,
 }: RilViewProps) => {
@@ -239,7 +237,8 @@ const useRilController = ({
   }));
   const { monthKey, rows, isLoading, isExporting, draftStatus, error } = state;
   const sourceEntriesRef = useRef<TimeEntry[]>([]);
-  const projectCatalogRef = useRef<Project[]>([]);
+  const projectCatalogRef = useRef<RilProjectReference[]>([]);
+  const projectCatalogUserIdRef = useRef<string | null>(null);
   const loadTokenRef = useRef(0);
   // Mirror of the latest rows so the debounced save reads current state without re-arming on
   // every keystroke.
@@ -331,7 +330,7 @@ const useRilController = ({
   };
 
   const generateRows = useCallback(
-    (entries: TimeEntry[], catalogProjects: Project[]) =>
+    (entries: TimeEntry[], catalogProjects: RilProjectReference[]) =>
       generateRilRows({
         year: monthBounds.year,
         month: monthBounds.month,
@@ -476,14 +475,19 @@ const useRilController = ({
       })()
         .then((draft) => ({ ok: true as const, draft }))
         .catch(() => ({ ok: false as const, draft: null }));
+      const projectCatalogPromise =
+        projectCatalogUserIdRef.current === effectiveUserId
+          ? Promise.resolve(projectCatalogRef.current)
+          : api.projects.listRilCatalog(effectiveUserId);
       const [nextEntries, nextProjects, draftResult] = await Promise.all([
         entriesPromise,
-        api.projects.list({ userId: effectiveUserId }),
+        projectCatalogPromise,
         draftPromise,
       ]);
       if (loadTokenRef.current === token && nextEntries) {
         sourceEntriesRef.current = nextEntries;
         projectCatalogRef.current = nextProjects;
+        projectCatalogUserIdRef.current = effectiveUserId;
         const baseRows = generateRows(nextEntries, nextProjects);
         if (draftResult.ok) {
           const merged = applyRilDraftToRows(baseRows, draftResult.draft?.rows, lunchBreakMinutes);
@@ -501,7 +505,8 @@ const useRilController = ({
     } catch (err) {
       if (loadTokenRef.current === token) {
         sourceEntriesRef.current = [];
-        projectCatalogRef.current = projects;
+        projectCatalogRef.current = [];
+        projectCatalogUserIdRef.current = null;
         dispatch({
           type: 'loadError',
           error: err instanceof Error ? err.message : 'Failed to load RIL data',
@@ -517,7 +522,6 @@ const useRilController = ({
     monthBounds.toDate,
     draftMonthKey,
     lunchBreakMinutes,
-    projects,
     enqueueDraftSave,
     getChangedDays,
   ]);

--- a/components/timesheet/RilView.tsx
+++ b/components/timesheet/RilView.tsx
@@ -176,6 +176,7 @@ type RilViewState = {
   monthKey: string;
   rows: RilRow[];
   isLoading: boolean;
+  loadedContext: string | null;
   isExporting: boolean;
   draftStatus: RilDraftStatus;
   error: string | null;
@@ -184,8 +185,8 @@ type RilViewState = {
 type RilViewAction =
   | { type: 'setMonthKey'; monthKey: string }
   | { type: 'loadStart' }
-  | { type: 'loadSuccess'; rows: RilRow[] }
-  | { type: 'loadError'; error: string; rows: RilRow[] }
+  | { type: 'loadSuccess'; context: string; rows: RilRow[] }
+  | { type: 'loadError'; context: string; error: string; rows: RilRow[] }
   | { type: 'setRows'; rows: RilRow[] }
   | { type: 'updateRows'; updater: (rows: RilRow[]) => RilRow[] }
   | { type: 'setError'; error: string }
@@ -196,13 +197,19 @@ type RilViewAction =
 const rilViewReducer = (state: RilViewState, action: RilViewAction): RilViewState => {
   switch (action.type) {
     case 'setMonthKey':
-      return { ...state, monthKey: action.monthKey };
+      return { ...state, monthKey: action.monthKey, isLoading: true, error: null };
     case 'loadStart':
       return { ...state, isLoading: true, error: null };
     case 'loadSuccess':
-      return { ...state, rows: action.rows, isLoading: false };
+      return { ...state, rows: action.rows, isLoading: false, loadedContext: action.context };
     case 'loadError':
-      return { ...state, rows: action.rows, isLoading: false, error: action.error };
+      return {
+        ...state,
+        rows: action.rows,
+        isLoading: false,
+        loadedContext: action.context,
+        error: action.error,
+      };
     case 'setRows':
       return { ...state, rows: action.rows };
     case 'updateRows':
@@ -230,12 +237,21 @@ const useRilController = ({
   const [state, dispatch] = useReducer(rilViewReducer, undefined, () => ({
     monthKey: getCurrentRilMonthKey(),
     rows: [],
-    isLoading: false,
+    isLoading: true,
+    loadedContext: null,
     isExporting: false,
     draftStatus: 'idle' as RilDraftStatus,
     error: null,
   }));
-  const { monthKey, rows, isLoading, isExporting, draftStatus, error } = state;
+  const {
+    monthKey,
+    rows,
+    isLoading: isLoadInFlight,
+    loadedContext,
+    isExporting,
+    draftStatus,
+    error,
+  } = state;
   const sourceEntriesRef = useRef<TimeEntry[]>([]);
   const projectCatalogRef = useRef<RilProjectReference[]>([]);
   const projectCatalogUserIdRef = useRef<string | null>(null);
@@ -269,6 +285,10 @@ const useRilController = ({
   const selectedUser = availableUsers.find((user) => user.id === effectiveUserId) ?? currentUser;
   const monthBounds = useMemo(() => getRilMonthBounds(normalizeMonthKey(monthKey)), [monthKey]);
   const draftMonthKey = monthBounds.monthKey;
+  const loadContext = `${effectiveUserId}::${draftMonthKey}`;
+  // A selected user or month can change before the loading effect starts. Treat rows as pending
+  // until the reducer confirms they belong to the exact context currently shown in the controls.
+  const isLoading = isLoadInFlight || loadedContext !== loadContext;
   const locale = getLocale(i18n.language);
   const defaultStartTime = settings.rilDefaultStartTime || DEFAULT_RIL_START_TIME;
   const defaultExitTime = settings.rilDefaultExitTime || DEFAULT_RIL_EXIT_TIME;
@@ -491,14 +511,14 @@ const useRilController = ({
         const baseRows = generateRows(nextEntries, nextProjects);
         if (draftResult.ok) {
           const merged = applyRilDraftToRows(baseRows, draftResult.draft?.rows, lunchBreakMinutes);
-          dispatch({ type: 'loadSuccess', rows: merged });
+          dispatch({ type: 'loadSuccess', context: loadContext, rows: merged });
           dispatch({
             type: 'setDraftStatus',
             draftStatus: draftResult.draft?.updatedAt ? 'saved' : 'idle',
           });
           draftSyncReadyRef.current = true;
         } else {
-          dispatch({ type: 'loadSuccess', rows: baseRows });
+          dispatch({ type: 'loadSuccess', context: loadContext, rows: baseRows });
           dispatch({ type: 'setDraftStatus', draftStatus: 'error' });
         }
       }
@@ -509,6 +529,7 @@ const useRilController = ({
         projectCatalogUserIdRef.current = null;
         dispatch({
           type: 'loadError',
+          context: loadContext,
           error: err instanceof Error ? err.message : 'Failed to load RIL data',
           rows: generateRows([], []),
         });
@@ -524,6 +545,7 @@ const useRilController = ({
     lunchBreakMinutes,
     enqueueDraftSave,
     getChangedDays,
+    loadContext,
   ]);
 
   useEffect(() => {
@@ -767,10 +789,27 @@ const RilViewLayout: React.FC<{ controller: RilController }> = ({ controller }) 
   <div className="space-y-6">
     <RilHeader controller={controller} />
     {controller.error && <RilErrorMessage message={controller.error} />}
-    <section className="grid items-start gap-4 xl:grid-cols-[minmax(0,1fr)_15rem]">
-      <RilDataTable controller={controller} />
-      <RilSummary controller={controller} />
-    </section>
+    {controller.isLoading ? (
+      <RilLoadingState controller={controller} />
+    ) : (
+      <section className="grid items-start gap-4 xl:grid-cols-[minmax(0,1fr)_15rem]">
+        <RilDataTable controller={controller} />
+        <RilSummary controller={controller} />
+      </section>
+    )}
+  </div>
+);
+
+const RilLoadingState: React.FC<{ controller: RilController }> = ({ controller }) => (
+  <div
+    role="status"
+    aria-label={controller.t('ril.loading')}
+    className="flex min-h-64 items-center justify-center rounded-md border border-border bg-card text-sm text-muted-foreground"
+  >
+    <span className="inline-flex items-center gap-2">
+      <Loader2 aria-hidden="true" className="size-4 animate-spin" />
+      {controller.t('ril.loading')}
+    </span>
   </div>
 );
 

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Praetor API",
     "description": "Praetor API documentation",
-    "version": "0.8.3"
+    "version": "0.9.0"
   },
   "components": {
     "securitySchemes": {
@@ -11062,6 +11062,205 @@
             }
           },
           "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/projects/ril-catalog": {
+      "get": {
+        "summary": "List the lightweight project catalog used for RIL order codes",
+        "tags": [
+          "ril"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "userId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "orderId": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "name",
+                      "orderId"
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
             "description": "Default Response",
             "content": {
               "application/json": {

--- a/locales/en/timesheets.json
+++ b/locales/en/timesheets.json
@@ -27,6 +27,7 @@
     "year": "Year",
     "reset": "Reset from timesheets",
     "exportExcel": "Export Excel",
+    "loading": "Loading RIL…",
     "loadFailed": "Failed to load RIL data",
     "exportFailed": "Failed to export RIL workbook",
     "missingTimes": "Add entrance and exit times for valid days before exporting: {{days}}",

--- a/locales/it/timesheets.json
+++ b/locales/it/timesheets.json
@@ -27,6 +27,7 @@
     "year": "Anno",
     "reset": "Ripristina dai timesheet",
     "exportExcel": "Esporta Excel",
+    "loading": "Caricamento RIL…",
     "loadFailed": "Impossibile caricare i dati RIL",
     "exportFailed": "Impossibile esportare il file RIL",
     "missingTimes": "Aggiungi entrata e uscita per i giorni validi prima di esportare: {{days}}",

--- a/server/repositories/projectsRepo.ts
+++ b/server/repositories/projectsRepo.ts
@@ -39,6 +39,8 @@ export type Project = {
   tipoConfirmed: boolean;
 };
 
+export type RilProjectCatalogItem = Pick<Project, 'id' | 'name' | 'orderId'>;
+
 const mapRow = (row: typeof projects.$inferSelect): Project => ({
   id: row.id,
   name: row.name,
@@ -135,6 +137,23 @@ export const listForUser = async (userId: string, exec: DbExecutor = db): Promis
   );
   return rows.map(mapRawRow);
 };
+
+/**
+ * Returns only the project fields used to derive RIL order codes. Keeping this query separate
+ * avoids the task billing subqueries and the full project payload required by project screens.
+ */
+export const listRilCatalogForUser = async (
+  userId: string,
+  exec: DbExecutor = db,
+): Promise<RilProjectCatalogItem[]> =>
+  executeRows<RilProjectCatalogItem>(
+    exec,
+    sql`SELECT p.id, p.name, p.order_id AS "orderId"
+          FROM projects p
+          INNER JOIN user_projects up ON p.id = up.project_id
+         WHERE up.user_id = ${userId}
+         ORDER BY p.name`,
+  );
 
 export const findById = async (id: string, exec: DbExecutor = db): Promise<Project | null> => {
   const rows = await executeRows<ProjectRawRow>(

--- a/server/routes/projects.ts
+++ b/server/routes/projects.ts
@@ -113,6 +113,16 @@ const projectOrderOptionSchema = {
   required: ['id', 'clientId', 'clientName', 'status', 'createdAt', 'updatedAt'],
 } as const;
 
+const rilProjectCatalogItemSchema = {
+  type: 'object',
+  properties: {
+    id: { type: 'string' },
+    name: { type: 'string' },
+    orderId: { type: ['string', 'null'] },
+  },
+  required: ['id', 'name', 'orderId'],
+} as const;
+
 const projectCreateBodySchema = {
   type: 'object',
   properties: {
@@ -168,6 +178,22 @@ const canAccessProject = makeAccessChecker(
   'projects.manage_all.view',
 );
 
+const canListProjectsForTargetUser = async (
+  request: FastifyRequest,
+  targetUserId: string,
+): Promise<boolean> => {
+  const actorId = request.user?.id;
+  if (!actorId) return false;
+  if (
+    targetUserId === actorId ||
+    hasPermission(request, 'projects.manage_all.view') ||
+    hasPermission(request, 'timesheets.tracker_all.view')
+  ) {
+    return true;
+  }
+  return workUnitsRepo.isUserManagedBy(actorId, targetUserId);
+};
+
 export default async function (fastify: FastifyInstance, _opts: unknown) {
   // GET / - List all projects
   fastify.get(
@@ -207,17 +233,52 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
 
       const targetUserId = targetUserIdResult.value;
       if (targetUserId) {
-        const canViewAllTimesheets = hasPermission(request, 'timesheets.tracker_all.view');
-        if (!canViewAll && !canViewAllTimesheets && targetUserId !== request.user.id) {
-          const allowed = await workUnitsRepo.isUserManagedBy(request.user.id, targetUserId);
-          if (!allowed) {
-            return reply.code(403).send({ message: 'Insufficient permissions' });
-          }
+        if (!(await canListProjectsForTargetUser(request, targetUserId))) {
+          return reply.code(403).send({ message: 'Insufficient permissions' });
         }
         return projectsRepo.listForUser(targetUserId);
       }
 
       return canViewAll ? projectsRepo.listAll() : projectsRepo.listForUser(request.user.id);
+    },
+  );
+
+  fastify.get(
+    '/ril-catalog',
+    {
+      onRequest: [
+        fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
+        authenticateToken,
+        requirePermission('timesheets.ril.view'),
+      ],
+      schema: {
+        tags: ['ril'],
+        summary: 'List the lightweight project catalog used for RIL order codes',
+        querystring: {
+          type: 'object',
+          properties: { userId: { type: 'string' } },
+          required: ['userId'],
+        },
+        response: {
+          200: { type: 'array', items: rilProjectCatalogItemSchema },
+          ...standardRateLimitedErrorResponses,
+        },
+      },
+    },
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      if (!assertAuthenticated(request, reply)) return;
+
+      const query = request.query as { userId?: unknown };
+      const targetUserIdResult = optionalNonEmptyString(query.userId, 'userId');
+      if (!targetUserIdResult.ok) return badRequest(reply, targetUserIdResult.message);
+      const targetUserId = targetUserIdResult.value;
+      if (!targetUserId) return badRequest(reply, 'userId is required');
+
+      if (!(await canListProjectsForTargetUser(request, targetUserId))) {
+        return reply.code(403).send({ message: 'Insufficient permissions' });
+      }
+
+      return projectsRepo.listRilCatalogForUser(targetUserId);
     },
   );
 

--- a/server/test/repositories/projectsRepo.test.ts
+++ b/server/test/repositories/projectsRepo.test.ts
@@ -124,6 +124,20 @@ describe('listForUser', () => {
   });
 });
 
+describe('listRilCatalogForUser', () => {
+  test('selects only RIL project-code fields without billing metadata', async () => {
+    exec.enqueue({ rows: [{ id: 'p-1', name: 'Alpha', orderId: 'ORD-1' }] });
+
+    const result = await projectsRepo.listRilCatalogForUser('u-1', testDb);
+
+    expect(result).toEqual([{ id: 'p-1', name: 'Alpha', orderId: 'ORD-1' }]);
+    expect(exec.calls[0].params).toContain('u-1');
+    expect(exec.calls[0].sql).toContain('INNER JOIN user_projects');
+    expect(exec.calls[0].sql).not.toContain('billing_type');
+    expect(exec.calls[0].sql).not.toContain('FROM tasks');
+  });
+});
+
 describe('listByIds', () => {
   test('returns a Map keyed by id and binds ids as one array parameter', async () => {
     exec.enqueue({ rows: [rawProjectRow] });

--- a/server/test/routes/projects.test.ts
+++ b/server/test/routes/projects.test.ts
@@ -39,6 +39,9 @@ const getRolePermissionsMock = mock();
 // projectsRepo mocks
 const listAllMock = mock();
 const listForUserMock = mock();
+const listRilCatalogForUserMock = mock(
+  async (): Promise<realProjectsRepo.RilProjectCatalogItem[]> => [],
+);
 const createMock = mock();
 const updateMock = mock();
 const findByIdMock = mock();
@@ -104,6 +107,7 @@ beforeAll(async () => {
     ...projectsRepoSnap,
     listAll: listAllMock,
     listForUser: listForUserMock,
+    listRilCatalogForUser: listRilCatalogForUserMock,
     create: createMock,
     update: updateMock,
     findById: findByIdMock,
@@ -228,6 +232,7 @@ const allMocks = [
   getRolePermissionsMock,
   listAllMock,
   listForUserMock,
+  listRilCatalogForUserMock,
   createMock,
   updateMock,
   findByIdMock,
@@ -394,6 +399,81 @@ describe('GET /api/projects', () => {
     });
 
     expect(res.statusCode).toBe(403);
+  });
+});
+
+describe('GET /api/projects/ril-catalog', () => {
+  test('200: returns the lightweight catalog for the current user', async () => {
+    getRolePermissionsMock.mockResolvedValue(['timesheets.ril.view']);
+    listRilCatalogForUserMock.mockResolvedValue([{ id: 'p-1', name: 'Website', orderId: 'ORD-1' }]);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/projects/ril-catalog?userId=u1',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body) as unknown).toEqual([
+      { id: 'p-1', name: 'Website', orderId: 'ORD-1' },
+    ]);
+    expect(listRilCatalogForUserMock).toHaveBeenCalledWith('u1');
+    expect(listForUserMock).not.toHaveBeenCalled();
+  });
+
+  test('200: returns a managed user catalog after hierarchy validation', async () => {
+    getRolePermissionsMock.mockResolvedValue(['timesheets.ril.view']);
+    listRilCatalogForUserMock.mockResolvedValue([]);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/projects/ril-catalog?userId=u2',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(isUserManagedByMock).toHaveBeenCalledWith('u1', 'u2');
+    expect(listRilCatalogForUserMock).toHaveBeenCalledWith('u2');
+  });
+
+  test('403: rejects an unmanaged user catalog', async () => {
+    getRolePermissionsMock.mockResolvedValue(['timesheets.ril.view']);
+    isUserManagedByMock.mockResolvedValue(false);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/projects/ril-catalog?userId=u2',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(listRilCatalogForUserMock).not.toHaveBeenCalled();
+  });
+
+  test('400: requires an explicit user id', async () => {
+    getRolePermissionsMock.mockResolvedValue(['timesheets.ril.view']);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/projects/ril-catalog',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(listRilCatalogForUserMock).not.toHaveBeenCalled();
+  });
+
+  test('403: requires RIL view permission', async () => {
+    getRolePermissionsMock.mockResolvedValue(['projects.manage.view']);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/projects/ril-catalog?userId=u1',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(listRilCatalogForUserMock).not.toHaveBeenCalled();
   });
 });
 

--- a/services/api/projects.ts
+++ b/services/api/projects.ts
@@ -4,6 +4,7 @@ import type {
   Project,
   ProjectStatus,
   ProjectTipo,
+  RilProjectReference,
   StoredBillingType,
 } from '../../types';
 import { fetchApi } from './client';
@@ -30,6 +31,11 @@ export const projectsApi = {
     return fetchApi<Project[]>(`/projects${query ? `?${query}` : ''}`).then((projects) =>
       projects.map(normalizeProject),
     );
+  },
+
+  listRilCatalog: (userId: string): Promise<RilProjectReference[]> => {
+    const params = new URLSearchParams({ userId });
+    return fetchApi<RilProjectReference[]>(`/projects/ril-catalog?${params.toString()}`);
   },
 
   listOrderOptions: (): Promise<ClientsOrder[]> =>

--- a/test/App.moduleLoadCancellation.test.ts
+++ b/test/App.moduleLoadCancellation.test.ts
@@ -16,7 +16,9 @@ describe('App.tsx module-load cancellation', () => {
     expect(source).toContain('isModuleLoaded,');
     expect(effectBody).toContain('const loadToken = ++moduleLoadTokenRef.current;');
     expect(effectBody).toContain('activeLoadModuleRef.current === module');
-    expect(effectBody).toContain('if (isModuleLoaded(module)) return;');
+    expect(effectBody).toContain('isModuleLoaded(module) &&');
+    expect(effectBody).toContain("module !== 'timesheets'");
+    expect(effectBody).toContain('loadedTimesheetsViewRef.current === activeView');
     expect(effectBody).not.toContain('if (loadedModules.has(module)) return;');
     expect(effectBody).toContain('return cancelModuleLoad;');
     expect(effectBody).toContain('moduleLoadTokenRef.current += 1;');

--- a/test/App.recurringGenerationOnEntriesLoad.test.ts
+++ b/test/App.recurringGenerationOnEntriesLoad.test.ts
@@ -29,4 +29,19 @@ describe('App.tsx recurring generation after entries load (#620)', () => {
     const occurrences = caseBody.match(/void\s+generateRecurringEntries\(\)/g) ?? [];
     expect(occurrences.length).toBeGreaterThanOrEqual(2);
   });
+
+  test('awaits recurring generation before mounting a direct RIL load', () => {
+    expect(caseBody).toContain('const rilRecurringGeneration =');
+    expect(caseBody).toContain("activeView === 'timesheets/ril'");
+    expect(caseBody).toContain(
+      "hasPermission(permissions, buildPermission('timesheets.recurring', 'create'))",
+    );
+
+    const generationStart = caseBody.indexOf('const rilRecurringGeneration =');
+    const datasetsStart = caseBody.indexOf('failedDatasets = await loadDatasets');
+    const generationAwait = caseBody.indexOf('await rilRecurringGeneration;');
+
+    expect(generationStart).toBeLessThan(datasetsStart);
+    expect(generationAwait).toBeGreaterThan(datasetsStart);
+  });
 });

--- a/test/App.rilModuleDatasets.test.ts
+++ b/test/App.rilModuleDatasets.test.ts
@@ -19,7 +19,7 @@ describe('App.tsx RIL module dataset permissions', () => {
     );
   });
 
-  test('RIL view permission loads users and projects used by the RIL page', () => {
+  test('RIL view permission authorizes users and project catalogs used by the RIL page', () => {
     expect(initializerFor('canListProjects')).toContain(
       "buildPermission('timesheets.ril', 'view')",
     );
@@ -34,6 +34,8 @@ describe('App.tsx RIL module dataset permissions', () => {
     const datasetStart = source.indexOf("dataset: 'entries'");
     expect(datasetStart).toBeGreaterThan(-1);
     const datasetEnd = source.indexOf('}', datasetStart);
-    expect(source.slice(datasetStart, datasetEnd)).toContain('enabled: canListEntries');
+    expect(source.slice(datasetStart, datasetEnd)).toContain(
+      'enabled: requirements.entries && canListEntries',
+    );
   });
 });

--- a/test/components/timesheet/RilView.test.tsx
+++ b/test/components/timesheet/RilView.test.tsx
@@ -64,7 +64,6 @@ const renderRilView = (settingsOverrides: Partial<GeneralSettings> = {}) =>
       availableUsers={[currentUser]}
       viewingUserId="u1"
       onViewUserChange={() => {}}
-      projects={projects}
       settings={{
         rilCompanyName: 'ACME',
         rilDefaultStartTime: '09:00',
@@ -83,14 +82,14 @@ const renderRilView = (settingsOverrides: Partial<GeneralSettings> = {}) =>
   );
 
 const mockProjectList = (value: Project[]) => {
-  api.projects.list.mockImplementation(() => Promise.resolve(value));
+  api.projects.listRilCatalog.mockImplementation(() => Promise.resolve(value));
 };
 
 describe('<RilView />', () => {
   beforeEach(() => {
     setSystemTime(new Date('2026-05-15T12:00:00Z'));
     api.entries.listPage.mockReset();
-    api.projects.list.mockReset();
+    api.projects.listRilCatalog.mockReset();
     mockProjectList(projects);
     api.entries.create.mockReset();
     api.entries.update.mockReset();
@@ -116,7 +115,7 @@ describe('<RilView />', () => {
         purpose: 'ril',
       }),
     );
-    expect(api.projects.list).toHaveBeenCalledWith({ userId: 'u1' });
+    expect(api.projects.listRilCatalog).toHaveBeenCalledWith('u1');
     expect(screen.getByText('ril.title')).toBeInTheDocument();
     expect(screen.queryByText('ril.tableTitle')).toBeNull();
     expect(screen.getByText('ril.columns.day')).toBeInTheDocument();
@@ -184,6 +183,7 @@ describe('<RilView />', () => {
         expect.objectContaining({ fromDate: '2025-06-01', toDate: '2025-06-30' }),
       ),
     );
+    expect(api.projects.listRilCatalog).toHaveBeenCalledTimes(1);
   });
 
   test('loads project catalog for the selected managed user', async () => {
@@ -211,7 +211,6 @@ describe('<RilView />', () => {
         availableUsers={[currentUser, managedUser]}
         viewingUserId="u2"
         onViewUserChange={() => {}}
-        projects={projects}
         settings={{
           rilCompanyName: 'ACME',
           rilDefaultStartTime: '09:00',
@@ -228,7 +227,7 @@ describe('<RilView />', () => {
       />,
     );
 
-    await waitFor(() => expect(api.projects.list).toHaveBeenCalledWith({ userId: 'u2' }));
+    await waitFor(() => expect(api.projects.listRilCatalog).toHaveBeenCalledWith('u2'));
     await waitFor(() =>
       expect(screen.getByRole('button', { name: /ril.exportExcel/ })).not.toBeDisabled(),
     );
@@ -840,7 +839,6 @@ describe('<RilView />', () => {
           availableUsers={[currentUser]}
           viewingUserId="u1"
           onViewUserChange={() => {}}
-          projects={projects}
           settings={{
             rilCompanyName: 'ACME',
             rilDefaultStartTime: '09:00',

--- a/test/components/timesheet/RilView.test.tsx
+++ b/test/components/timesheet/RilView.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, setSystemTime, test } from 'bun:test';
-import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
 import type { GeneralSettings, Project, TimeEntry, User } from '../../../types';
 import type { RilWorkbookInput } from '../../../utils/rilExport';
 import { installApiMock } from '../../helpers/api';
@@ -152,6 +152,29 @@ describe('<RilView />', () => {
     const lunchSummaryItem = screen.getByLabelText('ril.summary.lunchWindow').closest('div');
     expect(lunchSummaryItem?.querySelector('dt')?.className).toContain('whitespace-nowrap');
     expect(lunchSummaryItem?.querySelector('dd')?.className).toContain('whitespace-nowrap');
+  });
+
+  test('keeps the loading state visible until the RIL table is ready', async () => {
+    let resolveEntries!: (value: { entries: TimeEntry[]; nextCursor: null }) => void;
+    const pendingEntries = new Promise<{ entries: TimeEntry[]; nextCursor: null }>((resolve) => {
+      resolveEntries = resolve;
+    });
+    api.entries.listPage.mockImplementation(() => pendingEntries);
+
+    renderRilView();
+
+    expect(screen.getByRole('status', { name: 'ril.loading' })).toBeInTheDocument();
+    expect(screen.queryByText('ril.columns.day')).toBeNull();
+    expect(screen.queryByLabelText('ril.summary.title')).toBeNull();
+
+    await act(async () => {
+      resolveEntries({ entries: [], nextCursor: null });
+      await pendingEntries;
+    });
+
+    expect(await screen.findByText('ril.columns.day')).toBeInTheDocument();
+    expect(screen.queryByRole('status', { name: 'ril.loading' })).toBeNull();
+    expect(screen.getByLabelText('ril.summary.title')).toBeInTheDocument();
   });
 
   test('selecting month and year reloads and syncs the draft table', async () => {

--- a/test/helpers/api.ts
+++ b/test/helpers/api.ts
@@ -32,6 +32,7 @@ export const installApiMock = () => {
     clients: { list: noopList, create: noop, update: noop, delete: noop },
     projects: {
       list: noopList,
+      listRilCatalog: noopList,
       listOrderOptions: noopList,
       create: noop,
       update: noop,

--- a/test/utils/timesheetLoadRequirements.test.ts
+++ b/test/utils/timesheetLoadRequirements.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'bun:test';
+import { getTimesheetLoadRequirements } from '../../utils/timesheetLoadRequirements';
+
+describe('getTimesheetLoadRequirements', () => {
+  test('does not block RIL on tracker-only catalogs or the global entry stream', () => {
+    expect(getTimesheetLoadRequirements('timesheets/ril')).toEqual({
+      entries: false,
+      clients: false,
+      projects: false,
+      tasks: false,
+      users: true,
+    });
+  });
+
+  test('keeps the complete tracker preload', () => {
+    expect(getTimesheetLoadRequirements('timesheets/tracker')).toEqual({
+      entries: true,
+      clients: true,
+      projects: true,
+      tasks: true,
+      users: true,
+    });
+  });
+
+  test('loads only the catalogs used by recurring entries', () => {
+    expect(getTimesheetLoadRequirements('timesheets/recurring')).toEqual({
+      entries: false,
+      clients: true,
+      projects: true,
+      tasks: true,
+      users: false,
+    });
+  });
+});

--- a/types.ts
+++ b/types.ts
@@ -325,6 +325,11 @@ export interface Project {
   tipoConfirmed?: boolean;
 }
 
+/** Minimal project data needed to derive the order codes shown in a RIL sheet. */
+export type RilProjectReference = Pick<Project, 'id' | 'name'> & {
+  orderId: string | null;
+};
+
 export const RESALE_BILLING_FREQUENCIES = ['monthly', 'quarterly', 'annual', 'one_time'] as const;
 export type ResaleBillingFrequency = (typeof RESALE_BILLING_FREQUENCIES)[number];
 

--- a/utils/ril.ts
+++ b/utils/ril.ts
@@ -1,8 +1,9 @@
-import type { Project, RilNoteOption, TimeEntry } from '../types';
+import type { Project, RilNoteOption, RilProjectReference, TimeEntry } from '../types';
 import { dateOnlyStringToLocalDate, getLocalDateString } from './date';
 import { isItalianHoliday } from './holidays';
 
 export type RilLocale = 'en' | 'it';
+type RilProjectCodeSource = Project | RilProjectReference;
 
 // Lowercase English weekday names, keyed by JS `Date.getDay()` (0=Sun..6=Sat). Used to look up
 // the per-weekday default "Trasferta" preference when generating rows.
@@ -25,7 +26,7 @@ export interface RilGenerationOptions {
   year: number;
   month: number;
   entries: TimeEntry[];
-  projects?: Project[];
+  projects?: RilProjectCodeSource[];
   defaultStartTime?: string;
   defaultExitTime?: string;
   lunchBreakMinutes?: number;
@@ -263,7 +264,10 @@ export const formatRilHoursAsDuration = (hours: number): string => {
 
 export const roundRilPicapHours = (hours: number): number => Math.round(hours * 4) / 4;
 
-const getProjectCode = (entry: TimeEntry, projectById: Map<string, Project>): string => {
+const getProjectCode = (
+  entry: TimeEntry,
+  projectById: Map<string, RilProjectCodeSource>,
+): string => {
   const project = projectById.get(entry.projectId);
   const orderId = project?.orderId?.trim();
   return orderId || entry.projectName || project?.name || '';
@@ -302,7 +306,9 @@ export const generateRilRows = ({
   weekdayTransferDefaults,
 }: RilGenerationOptions): RilRow[] => {
   const daysInMonth = new Date(year, month, 0).getDate();
-  const projectById = new Map(projects.map((project) => [project.id, project]));
+  const projectById = new Map<string, RilProjectCodeSource>(
+    projects.map((project) => [project.id, project]),
+  );
   const entriesByDate = new Map<string, TimeEntry[]>();
   const monthPrefix = `${year}-${String(month).padStart(2, '0')}`;
   const normalizedNoteOptions = normalizeRilNoteOptions(noteOptions);

--- a/utils/timesheetLoadRequirements.ts
+++ b/utils/timesheetLoadRequirements.ts
@@ -1,0 +1,30 @@
+export type TimesheetLoadRequirements = Readonly<{
+  entries: boolean;
+  clients: boolean;
+  projects: boolean;
+  tasks: boolean;
+  users: boolean;
+}>;
+
+const NONE: TimesheetLoadRequirements = {
+  entries: false,
+  clients: false,
+  projects: false,
+  tasks: false,
+  users: false,
+};
+
+/** Returns the shared app datasets that must be ready before a timesheet route can mount. */
+export const getTimesheetLoadRequirements = (view: string): TimesheetLoadRequirements => {
+  switch (view) {
+    case 'timesheets/tracker':
+      return { entries: true, clients: true, projects: true, tasks: true, users: true };
+    case 'timesheets/ril':
+      // RIL loads its month entries, draft, and lightweight project catalog in RilView.
+      return { ...NONE, users: true };
+    case 'timesheets/recurring':
+      return { ...NONE, clients: true, projects: true, tasks: true };
+    default:
+      return NONE;
+  }
+};


### PR DESCRIPTION
## Summary
- Speeds up the RIL page by removing tracker-only datasets from its blocking module preload.
- Replaces the full billing-aware project fetch with a lightweight, permission-scoped RIL project catalog.
- Keeps the loading state visible until the selected user's complete table is ready, eliminating the transient zero-row view.
- Reuses the catalog across month and year changes while preserving managed-user access and draft behavior.

## Changes
- Adds route-specific timesheet dataset requirements so tracker, RIL, and recurring views load only what they use.
- Adds `GET /api/projects/ril-catalog` and a focused repository query returning only project ID, name, and order ID.
- Centralizes target-user project catalog authorization and keeps hierarchy/all-scope checks consistent.
- Prevents tracker assignment/catalog requests outside the tracker view.
- Ties table readiness to the selected user/month and swaps the loading state for the table and summary only after entries, draft, and project catalog have settled.
- Adds regression coverage for preload selection, permissions, lightweight SQL, managed users, catalog caching, and the loading-to-table transition.
- Regenerates the OpenAPI specification for the additive endpoint.

## Testing
- `bun run test` — 2,178 passed, 0 failed.
- `bun run lint`
- `bun run build`
- `bun run test:react-doctor` — 62/100 before and after; the same 106 pre-existing findings remain.
- Three consecutive clean iterative review/simplify cycles after the optimization fixes.

## Risks / Rollout
- Low risk. The API change is additive and requires the existing `timesheets.ril.view` permission; cross-user access retains the existing all-scope and manager-hierarchy checks.
- No database migration, backfill, seed, configuration, or persisted-data change.
- Deploy backend and frontend together in the normal application image. Rollback is code-only; no data restoration is required.
- Existing test act warnings, build bundle-size warning, and sitemap configuration warning are unchanged.

## Issues
Issue: Not linked