### PR TITLE
app(fix): localize loading spinner text

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -3536,14 +3536,18 @@ const AppContentView: React.FC<{ controller: AppContentController }> = ({ contro
   return <AuthenticatedAppShell controller={controller} />;
 };
 
-const AppLoadingScreen: React.FC = () => (
-  <div className="min-h-screen bg-zinc-100 flex items-center justify-center">
-    <div className="text-center">
-      <i className="fa-solid fa-circle-notch fa-spin text-4xl text-praetor mb-4"></i>
-      <p className="text-zinc-600 font-medium">Loading…</p>
+const AppLoadingScreen: React.FC = () => {
+  const { t } = useTranslation('common');
+
+  return (
+    <div className="min-h-screen bg-zinc-100 flex items-center justify-center">
+      <div className="text-center">
+        <i className="fa-solid fa-circle-notch fa-spin text-4xl text-praetor mb-4"></i>
+        <p className="text-zinc-600 font-medium">{t('common:states.loading')}</p>
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 const TechnicalDocsRoute: React.FC<{
   controller: AppContentController;
@@ -3662,14 +3666,18 @@ const AuthenticatedRouteContent: React.FC<{
   );
 };
 
-const ModulePendingScreen: React.FC = () => (
-  <div className="flex h-[calc(100vh-180px)] min-h-[420px] items-center justify-center rounded-lg border border-border bg-card text-card-foreground shadow-sm">
-    <div className="text-center">
-      <i className="fa-solid fa-circle-notch fa-spin text-3xl text-primary mb-3" />
-      <p className="text-sm font-medium text-muted-foreground">Loading…</p>
+const ModulePendingScreen: React.FC = () => {
+  const { t } = useTranslation('common');
+
+  return (
+    <div className="flex h-[calc(100vh-180px)] min-h-[420px] items-center justify-center rounded-lg border border-border bg-card text-card-foreground shadow-sm">
+      <div className="text-center">
+        <i className="fa-solid fa-circle-notch fa-spin text-3xl text-primary mb-3" />
+        <p className="text-sm font-medium text-muted-foreground">{t('common:states.loading')}</p>
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 const ModuleFailureBanner: React.FC<{ failures: string[] }> = ({ failures }) => {
   if (failures.length === 0) return null;

--- a/test/App.loadingSpinnerI18n.test.ts
+++ b/test/App.loadingSpinnerI18n.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'bun:test';
+
+const source = await Bun.file(new URL('../App.tsx', import.meta.url)).text();
+
+const getComponentSource = (name: string, nextName: string) => {
+  const start = source.indexOf(`const ${name}`);
+  const end = source.indexOf(`const ${nextName}`, start);
+
+  expect(start).toBeGreaterThan(-1);
+  expect(end).toBeGreaterThan(start);
+
+  return source.slice(start, end);
+};
+
+describe('App loading spinner translations', () => {
+  test.each([
+    ['AppLoadingScreen', 'TechnicalDocsRoute'],
+    ['ModulePendingScreen', 'ModuleFailureBanner'],
+  ])('%s uses the common loading translation', (componentName, nextComponentName) => {
+    const component = getComponentSource(componentName, nextComponentName);
+
+    expect(component).toContain("useTranslation('common')");
+    expect(component).toContain("t('common:states.loading')");
+    expect(component).not.toContain('Loading…');
+  });
+});


### PR DESCRIPTION
## Summary
- Localizes the loading text shown during initial authentication and module loading.
- Reuses the existing `common:states.loading` translations for English and Italian.

## Changes
- Replaces both hardcoded `Loading…` labels in `App.tsx` with `react-i18next` lookups.
- Adds regression coverage for the application and module loading screens.
- User documentation reviewed; no update is needed for this localized status-text change.

## Testing
- `bun test test/App.loadingSpinnerI18n.test.ts`
- `bun run test:frontend` — 2177 passed, 0 failed
- `bun run i18n:check`
- `bun run typecheck`
- `bunx --bun biome check App.tsx test/App.loadingSpinnerI18n.test.ts`
- `bun run build`
- `bun run test:react-doctor` — score unchanged at 62/100; exits non-zero for pre-existing findings

## Risks / Rollout
- Low risk. The change only affects loading labels and introduces no migrations, API changes, configuration changes, or dependency updates.
- Existing build warnings remain for the missing Astro sitemap `site` option and large chunks.

## Issues
Issue: Not linked