### PR TITLE
app(fix): restore production login boot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Praetor is an AI-enhanced ERP application for time tracking, project management,
 ### Frontend (root directory)
 ```bash
 bun run dev          # Start dev server (port 3000)
-bun run build        # Build user docs, then the production frontend
+bun run build        # Build user docs and the production frontend, then smoke-test login boot
 bun run preview      # Preview the production frontend build
 bun run typecheck    # Type-check backend and frontend
 bun run test         # Run backend and frontend unit tests

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "bun run docs:user && vite build",
+    "build": "bun run docs:user && vite build && bun scripts/verify-production-build.mjs dist",
     "preview": "vite preview",
     "i18n:check": "bun scripts/check-i18n-keys.mjs",
     "typecheck": "tsc -p server/tsconfig.json && tsc -p tsconfig.json",

--- a/scripts/verify-production-build.mjs
+++ b/scripts/verify-production-build.mjs
@@ -1,0 +1,67 @@
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { GlobalRegistrator } from '@happy-dom/global-registrator/lib/index.js';
+
+const buildDir = path.resolve(process.argv[2] ?? 'dist');
+const indexPath = path.join(buildDir, 'index.html');
+
+const waitFor = async (predicate, timeoutMs = 2_000) => {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) return false;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  return true;
+};
+
+const verifyProductionBuild = async () => {
+  if (!existsSync(indexPath)) {
+    throw new Error(`Production entrypoint not found: ${indexPath}`);
+  }
+
+  const indexHtml = readFileSync(indexPath, 'utf8');
+  const entrySource = indexHtml.match(
+    /<script[^>]+type=["']module["'][^>]+src=["']([^"']+)["']/i,
+  )?.[1];
+  if (!entrySource) {
+    throw new Error(`Module entrypoint not found in ${indexPath}`);
+  }
+
+  const entryPath = path.resolve(buildDir, entrySource.replace(/^\/+/, ''));
+  if (!existsSync(entryPath)) {
+    throw new Error(`Production bundle not found: ${entryPath}`);
+  }
+
+  GlobalRegistrator.register({ url: 'http://localhost/' });
+  document.body.innerHTML = '<div id="root"></div>';
+
+  // Keep the smoke test independent from a running API. An unauthenticated boot
+  // must still render the login form after its public/auth probes settle.
+  globalThis.fetch = async () =>
+    new Response(JSON.stringify({ message: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'content-type': 'application/json' },
+    });
+
+  await import(pathToFileURL(entryPath).href);
+
+  const rendered = await waitFor(
+    () =>
+      document.querySelector('input[name="username"]') !== null &&
+      document.querySelector('input[name="password"]') !== null,
+  );
+  if (!rendered) {
+    throw new Error('Production bundle loaded without rendering the login form');
+  }
+
+  console.log('Production bundle smoke test passed: login form rendered.');
+};
+
+verifyProductionBuild().then(
+  () => process.exit(0),
+  (error) => {
+    console.error(error);
+    process.exit(1);
+  },
+);

--- a/test/build/productionBundle.test.ts
+++ b/test/build/productionBundle.test.ts
@@ -1,0 +1,48 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const repoRoot = path.resolve(import.meta.dir, '../..');
+const outputDir = mkdtempSync(path.join(tmpdir(), 'praetor-production-build-'));
+
+const run = async (command: string[]) => {
+  const process = Bun.spawn(command, {
+    cwd: repoRoot,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const [exitCode, stdout, stderr] = await Promise.all([
+    process.exited,
+    new Response(process.stdout).text(),
+    new Response(process.stderr).text(),
+  ]);
+  return { exitCode, output: `${stdout}\n${stderr}`.trim() };
+};
+
+afterAll(() => {
+  const relativeToTemp = path.relative(tmpdir(), outputDir);
+  if (relativeToTemp.startsWith('..') || path.isAbsolute(relativeToTemp)) {
+    throw new Error(`Refusing to remove non-temporary build directory: ${outputDir}`);
+  }
+  rmSync(outputDir, { recursive: true, force: true });
+});
+
+describe('production bundle', () => {
+  test('boots far enough to render the login form', async () => {
+    const build = await run([
+      process.execPath,
+      'x',
+      'vite',
+      'build',
+      '--outDir',
+      outputDir,
+      '--emptyOutDir',
+    ]);
+    expect(build.exitCode, build.output).toBe(0);
+
+    const smoke = await run([process.execPath, 'scripts/verify-production-build.mjs', outputDir]);
+    expect(smoke.exitCode, smoke.output).toBe(0);
+    expect(smoke.output).toContain('login form rendered');
+  }, 180_000);
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,6 @@ import pkg from './package.json' with { type: 'json' };
 import { getBuildDate } from './scripts/build-date.ts';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const normalizedRootDir = __dirname.replaceAll('\\', '/');
 
 const docsFrontendDir = path.resolve(__dirname, 'docs', 'frontend');
 const docsUserDir = path.resolve(__dirname, 'docs-site', 'dist');
@@ -84,28 +83,6 @@ export default defineConfig(({ mode }) => {
         '@': path.resolve(__dirname, '.'),
       },
       preserveSymlinks,
-    },
-    build: {
-      rolldownOptions: {
-        output: {
-          codeSplitting: {
-            minSize: 20 * 1024,
-            maxSize: 450 * 1024,
-            groups: [
-              {
-                name: 'vendor',
-                test: /node_modules[\\/]/,
-                priority: 20,
-              },
-              {
-                name: 'application',
-                test: (moduleId) => moduleId.replaceAll('\\', '/').startsWith(normalizedRootDir),
-                priority: 10,
-              },
-            ],
-          },
-        },
-      },
     },
   };
 });


### PR DESCRIPTION
## Summary
- Restores the production login page by removing the Vite/Rolldown split configuration that emitted cyclic vendor chunks with undefined initializers.
- Adds a production-bundle smoke test so invalid bundles fail during tests and `bun run build`.

## Changes
- Return production bundling to Vite 8's default chunking while preserving application-level lazy imports.
- Add a Happy DOM smoke verifier that imports the emitted entrypoint with API calls isolated and asserts the unauthenticated login form renders.
- Add regression coverage that builds into a temporary directory and runs the verifier.
- Document the additional build verification step in `AGENTS.md`.

## Testing
- `bun run test` — 2,223 tests passed.
- `bun run lint` — passed, including i18n checks, backend/frontend typecheck, and Biome.
- `bun run build` — passed; production login smoke test rendered the form.
- `bun run test:react-doctor` — 100/100 before and after.
- Browser verification against the production build — login form rendered with no console errors.

## Risks / Rollout
- Frontend-only change; no database, API, authentication-contract, or configuration migration.
- Deployment requires rebuilding and redeploying the frontend assets.
- Vite again reports its non-blocking warning for chunks above 500 kB. A future performance change should split at safe application boundaries and retain this smoke test.
- Rollback is a normal code revert, but restoring the previous broad vendor/application split would also restore the login crash.

## Issues
Issue: Not linked
