### PR TITLE
app(chore): bump version to 0.9.1

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Praetor API",
     "description": "Praetor API documentation",
-    "version": "0.9.0"
+    "version": "0.9.1"
   },
   "components": {
     "securitySchemes": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praetor",
   "private": true,
-  "version": "0.9.0",
+  "version": "0.9.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "praetor-server",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Praetor API Server",
   "main": "index.ts",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bumps the Praetor application version from 0.9.0 to 0.9.1.
- Keeps frontend, backend, and generated API metadata aligned.

## Changes
- Updates the root application manifest version.
- Updates the server manifest version.
- Regenerates OpenAPI metadata with version 0.9.1.

## Testing
- `bun run docs:api`
- `bun run build`
- `bun run typecheck`
- `bun run test:react-doctor` (100/100 before and after)
- `git diff --check`

## Risks / Rollout
- Low risk. This is a metadata-only patch version bump with no database, configuration, or runtime behavior changes.

## Issues
Issue: Not linked