### PR TITLE
settings(fix): improve MCP token form layout

### DIFF
--- a/components/UserSettings.tsx
+++ b/components/UserSettings.tsx
@@ -23,7 +23,7 @@ import {
   User,
 } from 'lucide-react';
 import type React from 'react';
-import { useCallback, useEffect, useMemo, useReducer, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { siModelcontextprotocol } from 'simple-icons';
 import TotpSetupWizard from '@/components/TotpSetupWizard';
@@ -53,6 +53,7 @@ import {
 import { Field, FieldDescription, FieldLabel } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
 import { InputOTP, InputOTPGroup, InputOTPSlot } from '@/components/ui/input-otp';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import {
   Select,
   SelectContent,
@@ -2211,6 +2212,7 @@ const McpSetupPromptField: React.FC<{ controller: UserSettingsController }> = ({
 );
 
 const McpTokenCreateForm: React.FC<{ controller: UserSettingsController }> = ({ controller }) => {
+  const [isScopeHelpOpen, setIsScopeHelpOpen] = useState(false);
   const scopeDescription =
     controller.mcpTokenScope === 'read_only'
       ? controller.t('mcp.scopeReadOnlyDescription')
@@ -2237,20 +2239,27 @@ const McpTokenCreateForm: React.FC<{ controller: UserSettingsController }> = ({ 
       <Field>
         <div className="flex items-center gap-1">
           <FieldLabel htmlFor="mcp-token-scope">{controller.t('mcp.scopeLabel')}</FieldLabel>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-xs"
-                className="text-muted-foreground hover:text-foreground"
-                aria-label={scopeDescription}
-              >
-                <CircleHelp aria-hidden="true" className="size-3.5" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>{scopeDescription}</TooltipContent>
-          </Tooltip>
+          <Popover open={isScopeHelpOpen} onOpenChange={setIsScopeHelpOpen}>
+            <Tooltip disabled={isScopeHelpOpen}>
+              <TooltipTrigger asChild>
+                <PopoverTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-xs"
+                    className="text-muted-foreground hover:text-foreground"
+                    aria-label={scopeDescription}
+                  >
+                    <CircleHelp aria-hidden="true" className="size-3.5" />
+                  </Button>
+                </PopoverTrigger>
+              </TooltipTrigger>
+              <TooltipContent>{scopeDescription}</TooltipContent>
+            </Tooltip>
+            <PopoverContent align="start" className="w-72 p-3 text-sm">
+              {scopeDescription}
+            </PopoverContent>
+          </Popover>
         </div>
         <Select
           value={controller.mcpTokenScope}

--- a/components/UserSettings.tsx
+++ b/components/UserSettings.tsx
@@ -3,6 +3,7 @@ import {
   AlertCircle,
   CalendarDays,
   Check,
+  CircleHelp,
   Contrast,
   Globe,
   KeyRound,
@@ -60,6 +61,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 import { ApiError } from '@/services/api/client';
 import praetorFaviconUrl from '../praetor-favicon.png';
@@ -2208,58 +2210,76 @@ const McpSetupPromptField: React.FC<{ controller: UserSettingsController }> = ({
   </Field>
 );
 
-const McpTokenCreateForm: React.FC<{ controller: UserSettingsController }> = ({ controller }) => (
-  <form
-    onSubmit={controller.handleCreateMcpToken}
-    className="grid grid-cols-1 gap-3 md:grid-cols-[1fr_minmax(10rem,auto)_auto]"
-  >
-    <Field>
-      <FieldLabel htmlFor="mcp-token-name" required>
-        {controller.t('mcp.nameLabel')}
-      </FieldLabel>
-      <Input
-        id="mcp-token-name"
-        type="text"
-        value={controller.mcpTokenName}
-        onChange={(event) => controller.setMcpTokenName(event.target.value)}
-        placeholder={controller.t('mcp.namePlaceholder')}
-        maxLength={120}
-      />
-    </Field>
-    <Field>
-      <FieldLabel htmlFor="mcp-token-scope">{controller.t('mcp.scopeLabel')}</FieldLabel>
-      <Select
-        value={controller.mcpTokenScope}
-        onValueChange={(value) => controller.setMcpTokenScope(value as McpTokenScope)}
-      >
-        <SelectTrigger id="mcp-token-scope">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="full">{controller.t('mcp.scopeFull')}</SelectItem>
-          <SelectItem value="read_only">{controller.t('mcp.scopeReadOnly')}</SelectItem>
-        </SelectContent>
-      </Select>
-      <FieldDescription>
-        {controller.mcpTokenScope === 'read_only'
-          ? controller.t('mcp.scopeReadOnlyDescription')
-          : controller.t('mcp.scopeFullDescription')}
-      </FieldDescription>
-    </Field>
-    <Button
-      type="submit"
-      disabled={controller.isCreatingMcpToken || !controller.mcpTokenName.trim()}
-      className="self-end"
+const McpTokenCreateForm: React.FC<{ controller: UserSettingsController }> = ({ controller }) => {
+  const scopeDescription =
+    controller.mcpTokenScope === 'read_only'
+      ? controller.t('mcp.scopeReadOnlyDescription')
+      : controller.t('mcp.scopeFullDescription');
+
+  return (
+    <form
+      onSubmit={controller.handleCreateMcpToken}
+      className="grid grid-cols-1 gap-3 md:grid-cols-[minmax(0,2fr)_minmax(10rem,1fr)_auto]"
     >
-      {controller.isCreatingMcpToken ? (
-        <i className="fa-solid fa-circle-notch fa-spin"></i>
-      ) : (
-        <McpIcon className="size-4" />
-      )}
-      {controller.t('mcp.create')}
-    </Button>
-  </form>
-);
+      <Field>
+        <FieldLabel htmlFor="mcp-token-name" className="min-h-6" required>
+          {controller.t('mcp.nameLabel')}
+        </FieldLabel>
+        <Input
+          id="mcp-token-name"
+          type="text"
+          value={controller.mcpTokenName}
+          onChange={(event) => controller.setMcpTokenName(event.target.value)}
+          placeholder={controller.t('mcp.namePlaceholder')}
+          maxLength={120}
+        />
+      </Field>
+      <Field>
+        <div className="flex items-center gap-1">
+          <FieldLabel htmlFor="mcp-token-scope">{controller.t('mcp.scopeLabel')}</FieldLabel>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                className="text-muted-foreground hover:text-foreground"
+                aria-label={scopeDescription}
+              >
+                <CircleHelp aria-hidden="true" className="size-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{scopeDescription}</TooltipContent>
+          </Tooltip>
+        </div>
+        <Select
+          value={controller.mcpTokenScope}
+          onValueChange={(value) => controller.setMcpTokenScope(value as McpTokenScope)}
+        >
+          <SelectTrigger id="mcp-token-scope">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="full">{controller.t('mcp.scopeFull')}</SelectItem>
+            <SelectItem value="read_only">{controller.t('mcp.scopeReadOnly')}</SelectItem>
+          </SelectContent>
+        </Select>
+      </Field>
+      <Button
+        type="submit"
+        disabled={controller.isCreatingMcpToken || !controller.mcpTokenName.trim()}
+        className="self-end"
+      >
+        {controller.isCreatingMcpToken ? (
+          <i className="fa-solid fa-circle-notch fa-spin"></i>
+        ) : (
+          <McpIcon className="size-4" />
+        )}
+        {controller.t('mcp.create')}
+      </Button>
+    </form>
+  );
+};
 
 const McpRawTokenNotice: React.FC<{ controller: UserSettingsController }> = ({ controller }) => {
   if (!controller.rawMcpToken) return null;

--- a/test/components/UserSettings.test.tsx
+++ b/test/components/UserSettings.test.tsx
@@ -407,6 +407,22 @@ describe('<UserSettings /> MCP tokens', () => {
     expect(await screen.findByRole('tooltip')).toHaveTextContent('mcp.scopeReadOnlyDescription');
   });
 
+  test('opens the scope description when activated from touch input', async () => {
+    renderSettings();
+
+    await act(async () => fireEvent.click(screen.getByRole('button', { name: /mcp.title/ })));
+
+    const scopeHelp = await screen.findByRole('button', { name: 'mcp.scopeFullDescription' });
+    fireEvent.pointerDown(scopeHelp, { pointerType: 'touch' });
+    fireEvent.click(scopeHelp);
+
+    await waitFor(() =>
+      expect(document.querySelector('[data-slot="popover-content"]')).toHaveTextContent(
+        'mcp.scopeFullDescription',
+      ),
+    );
+  });
+
   test('creates a token and displays the raw token once', async () => {
     renderSettings();
     fireEvent.click(screen.getByRole('button', { name: /mcp.title/ }));

--- a/test/components/UserSettings.test.tsx
+++ b/test/components/UserSettings.test.tsx
@@ -1,9 +1,10 @@
 import { beforeEach, describe, expect, mock } from 'bun:test';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import type { PersonalAccessToken, Settings } from '../../services/api';
 import type { UserAuthMethod } from '../../types';
 import { installI18nMock } from '../helpers/i18n';
 import { settleComponentTasks, reactTest as test } from '../helpers/reactTest';
+import { render } from '../helpers/render';
 
 installI18nMock();
 
@@ -378,6 +379,32 @@ describe('<UserSettings /> MCP tokens', () => {
     expect(setupPrompt.value).toContain('MCP server URL:');
     expect(setupPrompt.value).toContain('<paste your Praetor MCP token here>');
     expect(setupPrompt.value).toContain('Do not send it in chat messages');
+  });
+
+  test('shows the scope description in a tooltip and gives the token name more room', async () => {
+    renderSettings();
+
+    await act(async () => fireEvent.click(screen.getByRole('button', { name: /mcp.title/ })));
+
+    const nameInput = await screen.findByPlaceholderText('mcp.namePlaceholder');
+    expect(nameInput.closest('form')).toHaveClass(
+      'md:grid-cols-[minmax(0,2fr)_minmax(10rem,1fr)_auto]',
+    );
+    expect(screen.queryByText('mcp.scopeFullDescription')).not.toBeInTheDocument();
+
+    const scopeHelp = screen.getByRole('button', { name: 'mcp.scopeFullDescription' });
+    expect(scopeHelp).toBeInTheDocument();
+
+    fireEvent.click(document.getElementById('mcp-token-scope') as HTMLButtonElement);
+    fireEvent.click(screen.getByRole('option', { name: 'mcp.scopeReadOnly' }));
+    expect(screen.queryByText('mcp.scopeReadOnlyDescription')).not.toBeInTheDocument();
+
+    const readOnlyScopeHelp = screen.getByRole('button', {
+      name: 'mcp.scopeReadOnlyDescription',
+    });
+    fireEvent.focus(readOnlyScopeHelp);
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent('mcp.scopeReadOnlyDescription');
   });
 
   test('creates a token and displays the raw token once', async () => {


### PR DESCRIPTION
## Summary
- Moves the MCP token scope description from inline help text into an accessible tooltip beside the scope field label.
- Gives the token name field more horizontal space while preserving the stacked mobile layout.

## Changes
- Adds a keyboard-focusable shadcn tooltip whose content follows the selected full-access or read-only scope.
- Uses a 2:1 responsive grid ratio for token name versus scope and keeps field controls vertically aligned.
- Adds regression coverage for the layout, hidden inline description, tooltip focus behavior, and dynamic read-only content.
- Updates the UserSettings test renderer to reuse the app-aligned TooltipProvider helper.

## Testing
- `bun test test/components/UserSettings.test.tsx` — 34 passed
- `bun run test:frontend` — 2,224 passed
- `bun run build` — passed, including the production login smoke test
- `bun run lint` — passed (i18n, TypeScript, and Biome)
- `bun run test:react-doctor` — 100/100
- Three consecutive clean iterative review/simplify cycles

## Risks / Rollout
- Low risk: UI-only change scoped to the personal MCP token form.
- No database, API, permission, configuration, or migration changes.
- User documentation remains accurate because token behavior and the creation flow are unchanged.
- The build retains the existing Vite warning for chunks larger than 500 kB; this change does not affect bundling strategy.

## Issues
Issue: Not linked