### PR TITLE
app(chore): bump version to 0.10.0

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Praetor API",
     "description": "Praetor API documentation",
-    "version": "0.9.1"
+    "version": "0.10.0"
   },
   "components": {
     "securitySchemes": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praetor",
   "private": true,
-  "version": "0.9.1",
+  "version": "0.10.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "praetor-server",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Praetor API Server",
   "main": "index.ts",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bumps Praetor from 0.9.1 to the next minor version, 0.10.0.
- Keeps frontend, backend, and generated API metadata aligned.

## Changes
- Updates the root application package version.
- Updates the server package version used by runtime API and MCP metadata.
- Regenerates the OpenAPI document with version 0.10.0.

## Testing
- bun run docs:api
- bun run typecheck
- bun run test (2,261 passed)
- bun run test:react-doctor (100/100 before and after)

## Risks / Rollout
- Low risk. Metadata-only release change with no database, configuration, or behavioral changes.

## Issues
Issue: Not linked