### PR TITLE
notifications(fix): localize admin password warning

### DIFF
--- a/components/shared/NotificationBell.tsx
+++ b/components/shared/NotificationBell.tsx
@@ -116,6 +116,9 @@ const NotificationBell: React.FC<NotificationBellProps> = ({
         project: notification.data?.projectName ?? '',
       });
     }
+    if (notification.type === 'admin_password_warning') {
+      return t('notifications.adminPasswordWarningTitle');
+    }
     if (isRilPreferencesTip(notification)) {
       return t('notifications.rilPreferencesTipTitle');
     }

--- a/locales/en/layout.json
+++ b/locales/en/layout.json
@@ -107,6 +107,7 @@
     "newProjects": "{{count}} new projects available",
     "newProject": "1 new project available",
     "projectRuleTriggered": "{{rule}} triggered for {{project}}",
+    "adminPasswordWarningTitle": "Change the default admin password",
     "rilPreferencesTipTitle": "Set up your RIL travel preferences",
     "rilPreferencesTipMessage": "Choose the default travel value for each weekday so your RIL is pre-filled correctly.",
     "rilPreferencesTipAction": "Set preferences",

--- a/locales/it/layout.json
+++ b/locales/it/layout.json
@@ -107,6 +107,7 @@
     "newProjects": "{{count}} nuovi progetti disponibili",
     "newProject": "1 nuovo progetto disponibile",
     "projectRuleTriggered": "{{rule}} attivata per {{project}}",
+    "adminPasswordWarningTitle": "Cambia la password predefinita dell'amministratore",
     "rilPreferencesTipTitle": "Configura le preferenze di trasferta RIL",
     "rilPreferencesTipMessage": "Scegli il valore di trasferta predefinito per ogni giorno feriale, così il RIL verrà precompilato correttamente.",
     "rilPreferencesTipAction": "Configura preferenze",

--- a/test/components/NotificationBell.test.tsx
+++ b/test/components/NotificationBell.test.tsx
@@ -121,7 +121,7 @@ describe('<NotificationBell />', () => {
     expect(readTitle.className).not.toContain('text-zinc-600');
   });
 
-  test('admin password warning notifications use the warning icon', () => {
+  test('admin password warning notifications use the localized title and warning icon', () => {
     const warning: Notification = {
       id: 'admin-default-password-warning',
       userId: 'u1',
@@ -135,7 +135,8 @@ describe('<NotificationBell />', () => {
 
     openDropdown();
 
-    expect(screen.getByText('Change the default admin password')).toBeInTheDocument();
+    expect(screen.getByText('notifications.adminPasswordWarningTitle')).toBeInTheDocument();
+    expect(screen.queryByText('Change the default admin password')).not.toBeInTheDocument();
     expect(container.querySelector('i.fa-triangle-exclamation')).not.toBeNull();
     expect(container.querySelector('i.fa-folder-tree')).toBeNull();
   });

--- a/test/i18n/layout.test.ts
+++ b/test/i18n/layout.test.ts
@@ -18,4 +18,13 @@ describe('layout translations', () => {
     expect(itLayout.routes.resales).toBe('Rivendite');
     expect(itLayout.titles.resales).toBe('Rivendite');
   });
+
+  test('admin password warning has localized notification text', () => {
+    expect(enLayout.notifications.adminPasswordWarningTitle).toBe(
+      'Change the default admin password',
+    );
+    expect(itLayout.notifications.adminPasswordWarningTitle).toBe(
+      "Cambia la password predefinita dell'amministratore",
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- Localizes the default admin password warning in the notification menu.
- Ensures existing persisted warnings render in the active UI language by using their notification type.

## Changes
- Maps `admin_password_warning` notifications to a layout translation key.
- Adds English and Italian catalog entries.
- Adds component and locale regression coverage.

## Testing
- `bun test test\components\NotificationBell.test.tsx test\i18n\layout.test.ts`
- `bun run test:frontend` (2,273 passed)
- `bun run i18n:check`
- `bun run typecheck`
- `bun run build`
- `bunx --bun biome check components\shared\NotificationBell.tsx locales\it\layout.json locales\en\layout.json test\components\NotificationBell.test.tsx test\i18n\layout.test.ts`

## Risks / Rollout
- Low risk: display-only localization change with no API, database, permission, configuration, or migration impact.
- Existing notification rows remain compatible because localization is selected from the persisted type.
- React Doctor remains at 84/100 with the same pre-existing findings; the production build retains its existing large-chunk warning.

## Issues
Issue: Not linked
