### PR TITLE
auth(test): cover idle timeout reductions after rotation

### DIFF
--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -282,6 +282,9 @@ export const authenticateToken = async (request: FastifyRequest, reply: FastifyR
     }
 
     const sessionIdleTimeoutMinutes = await getConfiguredSessionIdleTimeoutMinutes();
+    // Rotation happens after this check, so the presented token's signed iat is the previous
+    // successful request time. Comparing it with the current database policy enforces a timeout
+    // reduction on the very next request, before a new token can advance iat.
     if (now - decoded.iat * 1000 > sessionIdleTimeoutMinutesToMs(sessionIdleTimeoutMinutes)) {
       return reply.code(403).send({ error: 'Invalid or expired token' });
     }

--- a/server/test/middleware/auth.test.ts
+++ b/server/test/middleware/auth.test.ts
@@ -263,17 +263,20 @@ describe('authenticateToken', () => {
     expect(reply.body).toEqual({ error: 'Session expired (max duration exceeded)' });
   });
 
-  test('403 when token exceeds the configured idle timeout but is still within jwt exp', async () => {
+  test('403s on the first request after an idle-timeout reduction despite the old jwt exp', async () => {
     generalSettingsGetMock.mockResolvedValue({ sessionIdleTimeoutMinutes: 5 });
+    // This token was last rotated six minutes ago under a longer policy. Its old two-hour exp is
+    // still valid, but iat records the previous request and must be checked against the new policy.
     const issuedAtSeconds = Math.floor((Date.now() - 6 * 60 * 1000) / 1000);
-    const request = buildFakeRequest(
-      signToken({
-        userId: 'u1',
-        sessionStart: Date.now() - 6 * 60 * 1000,
-        issuedAtSeconds,
-        expiresIn: '2h',
-      }),
-    );
+    const token = signToken({
+      userId: 'u1',
+      sessionStart: Date.now() - 6 * 60 * 1000,
+      issuedAtSeconds,
+      expiresIn: '2h',
+    });
+    const decoded = decodeForAssertion(token);
+    expect((decoded.exp as number) * 1000).toBeGreaterThan(Date.now());
+    const request = buildFakeRequest(token);
     const reply = buildFakeReply();
 
     await authenticateToken(request as never, reply as never);


### PR DESCRIPTION
## Summary
- Clarifies why the presented JWT's signed `iat` is the previous authenticated activity time: rotation occurs only after the live idle-timeout check.
- Strengthens regression coverage showing that a reduced timeout is enforced on the next request even while the token's older `exp` remains valid.

## Changes
- Documented the middleware ordering invariant beside the current-policy idle check.
- Made the regression test assert that JWT expiration is still in the future before verifying rejection by the reduced database policy.
- Kept runtime token behavior unchanged; the review confirmed the reported rotation gap is a false positive.

## Testing
- `bun test ./test/middleware/auth.test.ts` — 53 passed
- `bun run test:server` — 4,057 passed, 28 skipped, 0 failed
- `bun run test:frontend` — 2,273 passed, 0 failed
- `bun run lint` — passed (i18n, backend/frontend typecheck, Biome)
- `bun run build` — passed, including production login smoke test
- `bun run test:react-doctor` — unchanged at 84/100; exits non-zero for the existing `DashboardGrid.tsx` finding

## Risks / Rollout
- Low risk: runtime authentication behavior is unchanged; this PR documents and tests the existing enforcement ordering.
- No database migrations, configuration changes, dependency changes, or deployment sequencing requirements.
- Existing build chunk-size warnings and React Doctor findings are unchanged.

## Issues
Closes #898