### PR TITLE
sso(security): prevent DNS rebinding in remote fetches

### DIFF
--- a/server/services/sso.ts
+++ b/server/services/sso.ts
@@ -1,7 +1,7 @@
 import type { LookupAddress } from 'node:dns';
 import dns from 'node:dns/promises';
 import type { IncomingMessage } from 'node:http';
-import https from 'node:https';
+import https, { type RequestOptions as HttpsRequestOptions } from 'node:https';
 import { isIP } from 'node:net';
 import { addAbortSignal, Readable } from 'node:stream';
 import { createBrotliDecompress, createGunzip, createInflate } from 'node:zlib';
@@ -532,12 +532,14 @@ export const isPrivateIp = (ip: string): boolean => {
 
 const remoteUrlHostname = (url: URL): string => url.hostname.replace(/^\[|\]$/g, '');
 
+type AutoSelectingHttpsRequestOptions = HttpsRequestOptions & { autoSelectFamily: true };
+
 /**
- * Resolves `url` once and returns the public address that the caller must connect to. Returning
- * the vetted address (instead of merely validating it) prevents DNS rebinding between the check
- * and the TCP connection.
+ * Resolves `url` once and returns the public addresses that the caller may connect to. Returning
+ * the vetted addresses (instead of merely validating them) prevents DNS rebinding between the
+ * check and the TCP connection.
  */
-const resolveSafeRemoteUrl = async (url: URL): Promise<LookupAddress> => {
+const resolveSafeRemoteAddresses = async (url: URL): Promise<LookupAddress[]> => {
   if (url.protocol !== 'https:') {
     throw new Error(`Refusing to fetch non-HTTPS URL: ${url.protocol}//...`);
   }
@@ -549,7 +551,7 @@ const resolveSafeRemoteUrl = async (url: URL): Promise<LookupAddress> => {
   if (addresses.some((a) => isPrivateIp(a.address))) {
     throw new Error(`Refusing to fetch URL with private/loopback host: ${url.hostname}`);
   }
-  return addresses[0];
+  return addresses;
 };
 
 const responseFromIncoming = (incoming: IncomingMessage, request: Request): Response => {
@@ -585,12 +587,13 @@ const responseFromIncoming = (incoming: IncomingMessage, request: Request): Resp
 };
 
 /**
- * Performs one HTTPS request against an already-vetted IP while retaining the original hostname
- * for the Host header, SNI, and certificate verification. No DNS lookup occurs in this function.
+ * Performs one HTTPS request using only already-vetted IPs while retaining the original hostname
+ * for the Host header, SNI, and certificate verification. The custom lookup enables connection
+ * family selection without another DNS query.
  */
 const fetchPinnedRemoteUrl = async (
   url: URL,
-  address: LookupAddress,
+  addresses: LookupAddress[],
   options: RequestInit = {},
 ): Promise<Response> => {
   const request = new Request(url.href, options);
@@ -601,27 +604,32 @@ const fetchPinnedRemoteUrl = async (
   const originalHostname = remoteUrlHostname(url);
 
   return new Promise<Response>((resolve, reject) => {
-    const outbound = https.request(
-      {
-        agent: false,
-        family: address.family,
-        headers: Object.fromEntries(headers.entries()),
-        hostname: address.address,
-        method: request.method,
-        path: `${url.pathname}${url.search}`,
-        port: url.port ? Number(url.port) : 443,
-        servername: isIP(originalHostname) === 0 ? originalHostname : undefined,
-        signal: request.signal,
-      },
-      (incoming) => {
-        try {
-          resolve(responseFromIncoming(incoming, request));
-        } catch (error) {
-          incoming.destroy();
-          reject(error);
+    const requestOptions: AutoSelectingHttpsRequestOptions = {
+      agent: false,
+      autoSelectFamily: true,
+      headers: Object.fromEntries(headers.entries()),
+      hostname: originalHostname,
+      lookup: (_hostname, lookupOptions, callback) => {
+        if (lookupOptions.all) {
+          callback(null, addresses);
+          return;
         }
+        callback(null, addresses[0].address, addresses[0].family);
       },
-    );
+      method: request.method,
+      path: `${url.pathname}${url.search}`,
+      port: url.port ? Number(url.port) : 443,
+      servername: isIP(originalHostname) === 0 ? originalHostname : undefined,
+      signal: request.signal,
+    };
+    const outbound = https.request(requestOptions, (incoming) => {
+      try {
+        resolve(responseFromIncoming(incoming, request));
+      } catch (error) {
+        incoming.destroy();
+        reject(error);
+      }
+    });
     outbound.once('error', reject);
     outbound.end(body);
   });
@@ -629,8 +637,8 @@ const fetchPinnedRemoteUrl = async (
 
 const safeOidcFetch: oidc.CustomFetch = async (url, options) => {
   const parsed = new URL(url);
-  const address = await resolveSafeRemoteUrl(parsed);
-  const response = await fetchPinnedRemoteUrl(parsed, address, options);
+  const addresses = await resolveSafeRemoteAddresses(parsed);
+  const response = await fetchPinnedRemoteUrl(parsed, addresses, options);
   return responseWithBoundedBody(response, options.method);
 };
 
@@ -659,7 +667,7 @@ const assertSafeOidcServerMetadata = async (
       } catch {
         throw new Error(`OIDC discovery ${field} is not a valid URL`);
       }
-      return [resolveSafeRemoteUrl(endpoint)];
+      return [resolveSafeRemoteAddresses(endpoint)];
     }),
   );
 };
@@ -733,7 +741,7 @@ const responseWithBoundedBody = (
  * Guarantees:
  *   - HTTPS only (no http:, file:, gopher:, etc).
  *   - Host resolved via DNS; rejects if any resolved address is private/loopback/link-local.
- *   - TCP connection pinned to the vetted address while TLS still verifies the original hostname.
+ *   - TCP connection restricted to vetted addresses while TLS verifies the original hostname.
  *   - 5-second total timeout via AbortController.
  *   - Bounded follows: each redirect target is re-validated identically.
  */
@@ -744,8 +752,8 @@ const safeFetchRemoteUrl = async (url: string): Promise<Response> => {
   try {
     for (let hops = 0; hops <= REMOTE_FETCH_REDIRECT_LIMIT; hops++) {
       const parsed = new URL(current);
-      const address = await resolveSafeRemoteUrl(parsed);
-      const response = await fetchPinnedRemoteUrl(parsed, address, {
+      const addresses = await resolveSafeRemoteAddresses(parsed);
+      const response = await fetchPinnedRemoteUrl(parsed, addresses, {
         signal: controller.signal,
         redirect: 'manual',
       });

--- a/server/services/sso.ts
+++ b/server/services/sso.ts
@@ -759,10 +759,10 @@ const safeFetchRemoteUrl = async (url: string): Promise<Response> => {
       });
       if (response.status >= 300 && response.status < 400) {
         const next = response.headers.get('location');
+        await response.body?.cancel().catch(() => undefined);
         if (!next) {
           throw new Error(`Redirect response without Location header from ${current}`);
         }
-        await response.body?.cancel();
         current = new URL(next, current).href;
         continue;
       }

--- a/server/services/sso.ts
+++ b/server/services/sso.ts
@@ -1,4 +1,10 @@
+import type { LookupAddress } from 'node:dns';
 import dns from 'node:dns/promises';
+import type { IncomingMessage } from 'node:http';
+import https from 'node:https';
+import { isIP } from 'node:net';
+import { addAbortSignal, Readable } from 'node:stream';
+import { createBrotliDecompress, createGunzip, createInflate } from 'node:zlib';
 import {
   type CacheItem,
   type CacheProvider,
@@ -524,27 +530,107 @@ export const isPrivateIp = (ip: string): boolean => {
   return false;
 };
 
+const remoteUrlHostname = (url: URL): string => url.hostname.replace(/^\[|\]$/g, '');
+
 /**
- * Throws if `url` is non-HTTPS or its hostname resolves to a private / loopback / link-local
- * address. Shared by the SSRF-fetch loop and the OIDC issuer pre-flight so the two cannot drift.
+ * Resolves `url` once and returns the public address that the caller must connect to. Returning
+ * the vetted address (instead of merely validating it) prevents DNS rebinding between the check
+ * and the TCP connection.
  */
-const assertSafeRemoteUrl = async (url: URL): Promise<void> => {
+const resolveSafeRemoteUrl = async (url: URL): Promise<LookupAddress> => {
   if (url.protocol !== 'https:') {
     throw new Error(`Refusing to fetch non-HTTPS URL: ${url.protocol}//...`);
   }
-  const addresses = await dns.lookup(url.hostname, { all: true });
+  const hostname = remoteUrlHostname(url);
+  const addresses = await dns.lookup(hostname, { all: true });
   if (addresses.length === 0) {
     throw new Error(`Could not resolve host ${url.hostname}`);
   }
   if (addresses.some((a) => isPrivateIp(a.address))) {
     throw new Error(`Refusing to fetch URL with private/loopback host: ${url.hostname}`);
   }
+  return addresses[0];
+};
+
+const responseFromIncoming = (incoming: IncomingMessage, request: Request): Response => {
+  const responseHeaders = new Headers();
+  for (let index = 0; index < incoming.rawHeaders.length; index += 2) {
+    responseHeaders.append(incoming.rawHeaders[index], incoming.rawHeaders[index + 1]);
+  }
+  const status = incoming.statusCode ?? 500;
+  const hasBody = request.method !== 'HEAD' && ![204, 205, 304].includes(status);
+  const contentEncoding = responseHeaders.get('content-encoding')?.trim().toLowerCase();
+  let responseBody: Readable = incoming;
+  if (contentEncoding === 'gzip' || contentEncoding === 'x-gzip') {
+    responseBody = incoming.pipe(createGunzip());
+  } else if (contentEncoding === 'deflate') {
+    responseBody = incoming.pipe(createInflate());
+  } else if (contentEncoding === 'br') {
+    responseBody = incoming.pipe(createBrotliDecompress());
+  }
+  if (responseBody !== incoming) {
+    responseHeaders.delete('content-encoding');
+    responseHeaders.delete('content-length');
+    responseBody.once('close', () => incoming.destroy());
+  }
+  addAbortSignal(request.signal, responseBody);
+  return new Response(
+    hasBody ? (Readable.toWeb(responseBody) as ReadableStream<Uint8Array>) : null,
+    {
+      headers: responseHeaders,
+      status,
+      statusText: incoming.statusMessage,
+    },
+  );
+};
+
+/**
+ * Performs one HTTPS request against an already-vetted IP while retaining the original hostname
+ * for the Host header, SNI, and certificate verification. No DNS lookup occurs in this function.
+ */
+const fetchPinnedRemoteUrl = async (
+  url: URL,
+  address: LookupAddress,
+  options: RequestInit = {},
+): Promise<Response> => {
+  const request = new Request(url.href, options);
+  const body = request.body ? Buffer.from(await request.arrayBuffer()) : undefined;
+  const headers = new Headers(request.headers);
+  headers.set('host', url.host);
+  headers.set('accept-encoding', 'gzip, deflate, br');
+  const originalHostname = remoteUrlHostname(url);
+
+  return new Promise<Response>((resolve, reject) => {
+    const outbound = https.request(
+      {
+        agent: false,
+        family: address.family,
+        headers: Object.fromEntries(headers.entries()),
+        hostname: address.address,
+        method: request.method,
+        path: `${url.pathname}${url.search}`,
+        port: url.port ? Number(url.port) : 443,
+        servername: isIP(originalHostname) === 0 ? originalHostname : undefined,
+        signal: request.signal,
+      },
+      (incoming) => {
+        try {
+          resolve(responseFromIncoming(incoming, request));
+        } catch (error) {
+          incoming.destroy();
+          reject(error);
+        }
+      },
+    );
+    outbound.once('error', reject);
+    outbound.end(body);
+  });
 };
 
 const safeOidcFetch: oidc.CustomFetch = async (url, options) => {
   const parsed = new URL(url);
-  await assertSafeRemoteUrl(parsed);
-  const response = await fetch(parsed, options);
+  const address = await resolveSafeRemoteUrl(parsed);
+  const response = await fetchPinnedRemoteUrl(parsed, address, options);
   return responseWithBoundedBody(response, options.method);
 };
 
@@ -573,52 +659,68 @@ const assertSafeOidcServerMetadata = async (
       } catch {
         throw new Error(`OIDC discovery ${field} is not a valid URL`);
       }
-      return [assertSafeRemoteUrl(endpoint)];
+      return [resolveSafeRemoteUrl(endpoint)];
     }),
   );
 };
 
-/**
- * Reads a response body as text, refusing to buffer more than REMOTE_FETCH_MAX_BYTES. Guards
- * against a hostile IdP that returns a huge metadata document hoping to OOM the backend.
- */
-const readBoundedText = async (response: Response): Promise<string> => {
-  return responseWithBoundedBody(response, 'GET').text();
-};
-
-const responseWithBoundedBody = (response: Response, method: string): Response => {
+const responseWithBoundedBody = (
+  response: Response,
+  method: string,
+  onComplete: () => void = () => undefined,
+): Response => {
+  let completed = false;
+  const complete = () => {
+    if (completed) return;
+    completed = true;
+    onComplete();
+  };
   const init = {
     headers: response.headers,
     status: response.status,
     statusText: response.statusText,
   };
   if (method.toUpperCase() === 'HEAD' || [204, 205, 304].includes(response.status)) {
+    complete();
     return new Response(null, init);
   }
 
   const declared = Number(response.headers.get('content-length'));
   if (Number.isFinite(declared) && declared > REMOTE_FETCH_MAX_BYTES) {
+    void response.body?.cancel();
+    complete();
     throw new Error(`Remote response too large (${declared} bytes)`);
   }
-  if (!response.body) return new Response(null, init);
+  if (!response.body) {
+    complete();
+    return new Response(null, init);
+  }
 
   let total = 0;
   const reader = response.body.getReader();
   const boundedBody = new ReadableStream<Uint8Array>({
     async pull(controller) {
-      const { done, value } = await reader.read();
-      if (done) {
-        controller.close();
-        return;
+      try {
+        const { done, value } = await reader.read();
+        if (done) {
+          complete();
+          controller.close();
+          return;
+        }
+        total += value.byteLength;
+        if (total > REMOTE_FETCH_MAX_BYTES) {
+          await reader.cancel().catch(() => undefined);
+          complete();
+          throw new Error(`Remote response exceeded ${REMOTE_FETCH_MAX_BYTES} bytes`);
+        }
+        controller.enqueue(value);
+      } catch (error) {
+        complete();
+        throw error;
       }
-      total += value.byteLength;
-      if (total > REMOTE_FETCH_MAX_BYTES) {
-        await reader.cancel().catch(() => undefined);
-        throw new Error(`Remote response exceeded ${REMOTE_FETCH_MAX_BYTES} bytes`);
-      }
-      controller.enqueue(value);
     },
     cancel(reason) {
+      complete();
       return reader.cancel(reason);
     },
   });
@@ -631,31 +733,38 @@ const responseWithBoundedBody = (response: Response, method: string): Response =
  * Guarantees:
  *   - HTTPS only (no http:, file:, gopher:, etc).
  *   - Host resolved via DNS; rejects if any resolved address is private/loopback/link-local.
+ *   - TCP connection pinned to the vetted address while TLS still verifies the original hostname.
  *   - 5-second total timeout via AbortController.
  *   - Bounded follows: each redirect target is re-validated identically.
  */
 const safeFetchRemoteUrl = async (url: string): Promise<Response> => {
   let current = url;
-  for (let hops = 0; hops <= REMOTE_FETCH_REDIRECT_LIMIT; hops++) {
-    await assertSafeRemoteUrl(new URL(current));
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), REMOTE_FETCH_TIMEOUT_MS);
-    try {
-      const response = await fetch(current, { signal: controller.signal, redirect: 'manual' });
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REMOTE_FETCH_TIMEOUT_MS);
+  try {
+    for (let hops = 0; hops <= REMOTE_FETCH_REDIRECT_LIMIT; hops++) {
+      const parsed = new URL(current);
+      const address = await resolveSafeRemoteUrl(parsed);
+      const response = await fetchPinnedRemoteUrl(parsed, address, {
+        signal: controller.signal,
+        redirect: 'manual',
+      });
       if (response.status >= 300 && response.status < 400) {
         const next = response.headers.get('location');
         if (!next) {
           throw new Error(`Redirect response without Location header from ${current}`);
         }
+        await response.body?.cancel();
         current = new URL(next, current).href;
         continue;
       }
-      return response;
-    } finally {
-      clearTimeout(timer);
+      return responseWithBoundedBody(response, 'GET', () => clearTimeout(timer));
     }
+    throw new Error('Exceeded redirect limit while fetching remote URL');
+  } catch (error) {
+    clearTimeout(timer);
+    throw error;
   }
-  throw new Error('Exceeded redirect limit while fetching remote URL');
 };
 
 const resolveSamlIdpConfig = async (provider: ssoProvidersRepo.SsoProvider) => {
@@ -664,8 +773,11 @@ const resolveSamlIdpConfig = async (provider: ssoProvidersRepo.SsoProvider) => {
   }
   if (provider.metadataUrl.trim()) {
     const response = await safeFetchRemoteUrl(provider.metadataUrl);
-    if (!response.ok) throw new Error(`Failed to fetch SAML metadata: HTTP ${response.status}`);
-    return { ...parseSamlMetadata(await readBoundedText(response)), source: 'metadataUrl' };
+    if (!response.ok) {
+      await response.body?.cancel();
+      throw new Error(`Failed to fetch SAML metadata: HTTP ${response.status}`);
+    }
+    return { ...parseSamlMetadata(await response.text()), source: 'metadataUrl' };
   }
   return {
     idpIssuer: provider.idpIssuer,
@@ -790,13 +902,16 @@ const createOidcConfig = async (provider: ssoProvidersRepo.SsoProvider) => {
     // Keep every openid-client HTTP request on the same SSRF/timeout policy as the SAML
     // metadata fetch. customFetch covers discovery, JWKS, token, UserInfo, and future OIDC calls.
     const issuerUrl = new URL(provider.issuerUrl);
-    const [config] = await Promise.all([
-      oidc.discovery(issuerUrl, provider.clientId, clientSecret || undefined, undefined, {
+    const config = await oidc.discovery(
+      issuerUrl,
+      provider.clientId,
+      clientSecret || undefined,
+      undefined,
+      {
         [oidc.customFetch]: safeOidcFetch,
         timeout: OIDC_REMOTE_FETCH_TIMEOUT_SECONDS,
-      }),
-      assertSafeRemoteUrl(issuerUrl),
-    ]);
+      },
+    );
     await assertSafeOidcServerMetadata(config, {
       includeEndSessionEndpoint: provider.endSessionEnabled,
     });

--- a/server/test/services/sso.test.ts
+++ b/server/test/services/sso.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { LookupAddress } from 'node:dns';
 import * as realDns from 'node:dns/promises';
 import { EventEmitter } from 'node:events';
 import type { IncomingMessage } from 'node:http';
@@ -26,8 +27,9 @@ const ssoLoginTicketsRepoSnap = { ...realSsoLoginTicketsRepo };
 
 const dnsLookupMock = mock();
 const pinnedFetchResponseMock = mock();
+type AutoSelectingRequestOptions = RequestOptions & { autoSelectFamily?: boolean };
 const httpsRequestMock = mock(
-  (options: RequestOptions, onResponse: (response: IncomingMessage) => void) => {
+  (options: AutoSelectingRequestOptions, onResponse: (response: IncomingMessage) => void) => {
     const outbound = new EventEmitter() as EventEmitter & {
       destroy: (error?: Error) => void;
       end: (body?: Uint8Array) => void;
@@ -458,7 +460,7 @@ describe('safeFetchRemoteUrl behavior (exercised via SAML metadata fetch)', () =
     // the post-redirect response successfully.
     await expect(sso.startSamlLogin('okta')).rejects.toThrow(/missing entry point/);
     expect(pinnedFetchResponseMock).toHaveBeenCalledTimes(2);
-    // resolveSafeRemoteUrl runs dns.lookup once per hop.
+    // resolveSafeRemoteAddresses runs dns.lookup once per hop.
     expect(dnsLookupMock).toHaveBeenCalledTimes(2);
   });
 
@@ -472,10 +474,36 @@ describe('safeFetchRemoteUrl behavior (exercised via SAML metadata fetch)', () =
     expect(dnsLookupMock).toHaveBeenCalledTimes(1);
     expect(httpsRequestMock).toHaveBeenCalledTimes(1);
     const requestOptions = httpsRequestMock.mock.calls[0][0];
-    expect(requestOptions.hostname).toBe('203.0.113.10');
+    expect(requestOptions.hostname).toBe('idp.example.com');
     expect(requestOptions.servername).toBe('idp.example.com');
     expect(requestOptions.headers).toMatchObject({ host: 'idp.example.com' });
     expect(requestOptions.agent).toBe(false);
+    expect(requestOptions.autoSelectFamily).toBe(true);
+  });
+
+  test('offers every vetted DNS address to connection family selection', async () => {
+    const addresses: LookupAddress[] = [
+      { address: '2606:4700:4700::1111', family: 6 },
+      { address: '203.0.113.10', family: 4 },
+    ];
+    dnsLookupMock.mockResolvedValue(addresses);
+    pinnedFetchResponseMock.mockResolvedValueOnce(
+      new Response('<EntityDescriptor entityID="x"/>', { status: 200 }),
+    );
+
+    await expect(sso.startSamlLogin('okta')).rejects.toThrow(/missing entry point/);
+
+    const requestOptions = httpsRequestMock.mock.calls[0][0];
+    const lookup = requestOptions.lookup;
+    if (!lookup) throw new Error('Expected a pinned HTTPS lookup');
+    const resolved = await new Promise<LookupAddress[]>((resolve, reject) => {
+      lookup('idp.example.com', { all: true }, (error, result) => {
+        if (error) reject(error);
+        else resolve(result as LookupAddress[]);
+      });
+    });
+    expect(resolved).toEqual(addresses);
+    expect(dnsLookupMock).toHaveBeenCalledTimes(1);
   });
 
   test('normalizes an IPv6 URL hostname for lookup and connects to the vetted literal', async () => {
@@ -742,7 +770,7 @@ describe('OIDC remote endpoint hardening', () => {
     expect(httpsRequestMock).toHaveBeenCalledTimes(1);
     expect(httpsRequestMock.mock.calls[0][0]).toMatchObject({
       agent: false,
-      hostname: '203.0.113.25',
+      hostname: 'idp.example.com',
       servername: 'idp.example.com',
     });
     expect(Buffer.from(pinnedFetchResponseMock.mock.calls[0][1]).toString()).toBe(

--- a/server/test/services/sso.test.ts
+++ b/server/test/services/sso.test.ts
@@ -1,5 +1,11 @@
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
 import * as realDns from 'node:dns/promises';
+import { EventEmitter } from 'node:events';
+import type { IncomingMessage } from 'node:http';
+import type { RequestOptions } from 'node:https';
+import * as realHttps from 'node:https';
+import { Readable } from 'node:stream';
+import { gzipSync } from 'node:zlib';
 import * as realNodeSaml from '@node-saml/node-saml';
 import * as realOidc from 'openid-client';
 import * as realSsoLoginTicketsRepo from '../../repositories/ssoLoginTicketsRepo.ts';
@@ -9,6 +15,7 @@ import * as realSsoUserSessionsRepo from '../../repositories/ssoUserSessionsRepo
 import * as realExternalAuth from '../../services/external-auth.ts';
 
 const dnsSnap = { ...realDns };
+const httpsSnap = { ...realHttps };
 const nodeSamlSnap = { ...realNodeSaml };
 const oidcSnap = { ...realOidc };
 const externalAuthSnap = { ...realExternalAuth };
@@ -18,6 +25,41 @@ const ssoUserSessionsRepoSnap = { ...realSsoUserSessionsRepo };
 const ssoLoginTicketsRepoSnap = { ...realSsoLoginTicketsRepo };
 
 const dnsLookupMock = mock();
+const pinnedFetchResponseMock = mock();
+const httpsRequestMock = mock(
+  (options: RequestOptions, onResponse: (response: IncomingMessage) => void) => {
+    const outbound = new EventEmitter() as EventEmitter & {
+      destroy: (error?: Error) => void;
+      end: (body?: Uint8Array) => void;
+    };
+    outbound.destroy = (error) => {
+      if (error) queueMicrotask(() => outbound.emit('error', error));
+    };
+    outbound.end = (body) => {
+      void Promise.resolve(pinnedFetchResponseMock(options, body)).then(
+        async (result) => {
+          if (!(result instanceof Response)) {
+            onResponse(result as IncomingMessage);
+            return;
+          }
+          const response = result as Response;
+          const bytes = response.body ? Buffer.from(await response.arrayBuffer()) : Buffer.alloc(0);
+          const incoming = Readable.from(bytes.length > 0 ? [bytes] : []) as IncomingMessage;
+          const rawHeaders: string[] = [];
+          response.headers.forEach((value, name) => {
+            rawHeaders.push(name, value);
+          });
+          incoming.statusCode = response.status;
+          incoming.statusMessage = response.statusText;
+          incoming.rawHeaders = rawHeaders;
+          onResponse(incoming);
+        },
+        (error) => outbound.emit('error', error),
+      );
+    };
+    return outbound as unknown as ReturnType<typeof realHttps.request>;
+  },
+);
 const findBySlugMock = mock();
 const findByIdMock = mock();
 const insertMock = mock();
@@ -61,6 +103,11 @@ beforeAll(async () => {
     ...dnsSnap,
     default: { ...dnsSnap, lookup: dnsLookupMock },
     lookup: dnsLookupMock,
+  }));
+  mock.module('node:https', () => ({
+    ...httpsSnap,
+    default: { ...httpsSnap, request: httpsRequestMock },
+    request: httpsRequestMock,
   }));
   mock.module('@node-saml/node-saml', () => ({
     ...nodeSamlSnap,
@@ -108,6 +155,7 @@ beforeAll(async () => {
 
 afterAll(() => {
   mock.module('node:dns/promises', () => dnsSnap);
+  mock.module('node:https', () => httpsSnap);
   mock.module('@node-saml/node-saml', () => nodeSamlSnap);
   mock.module('../../services/external-auth.ts', () => externalAuthSnap);
   mock.module('../../repositories/ssoProvidersRepo.ts', () => ssoProvidersRepoSnap);
@@ -118,8 +166,10 @@ afterAll(() => {
 });
 
 beforeEach(() => {
+  httpsRequestMock.mockClear();
   for (const m of [
     dnsLookupMock,
+    pinnedFetchResponseMock,
     findBySlugMock,
     findByIdMock,
     insertMock,
@@ -377,14 +427,10 @@ describe('startSamlLogin SSRF protections', () => {
 });
 
 describe('safeFetchRemoteUrl behavior (exercised via SAML metadata fetch)', () => {
-  const realFetch = globalThis.fetch;
   const originalSsoBase = process.env.SSO_CALLBACK_BASE_URL;
-  const fetchMock = mock();
 
   beforeEach(() => {
     process.env.SSO_CALLBACK_BASE_URL = 'https://app.example.com';
-    fetchMock.mockReset();
-    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
     findBySlugMock.mockResolvedValue({
       ...SAML_PROVIDER,
       metadataUrl: 'https://idp.example.com/metadata',
@@ -393,17 +439,13 @@ describe('safeFetchRemoteUrl behavior (exercised via SAML metadata fetch)', () =
     dnsLookupMock.mockResolvedValue([{ address: '203.0.113.10', family: 4 }]);
   });
 
-  afterEach(() => {
-    globalThis.fetch = realFetch;
-  });
-
   afterAll(() => {
     if (originalSsoBase === undefined) delete process.env.SSO_CALLBACK_BASE_URL;
     else process.env.SSO_CALLBACK_BASE_URL = originalSsoBase;
   });
 
   test('follows a single 302 redirect and re-validates the target', async () => {
-    fetchMock
+    pinnedFetchResponseMock
       .mockResolvedValueOnce(
         new Response(null, {
           status: 302,
@@ -415,18 +457,53 @@ describe('safeFetchRemoteUrl behavior (exercised via SAML metadata fetch)', () =
     // construction then fails with a domain-specific error proving safeFetchRemoteUrl returned
     // the post-redirect response successfully.
     await expect(sso.startSamlLogin('okta')).rejects.toThrow(/missing entry point/);
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    // assertSafeRemoteUrl runs dns.lookup once per hop.
+    expect(pinnedFetchResponseMock).toHaveBeenCalledTimes(2);
+    // resolveSafeRemoteUrl runs dns.lookup once per hop.
     expect(dnsLookupMock).toHaveBeenCalledTimes(2);
   });
 
+  test('pins the HTTPS connection to the vetted DNS address while preserving TLS hostname', async () => {
+    pinnedFetchResponseMock.mockResolvedValueOnce(
+      new Response('<EntityDescriptor entityID="x"/>', { status: 200 }),
+    );
+
+    await expect(sso.startSamlLogin('okta')).rejects.toThrow(/missing entry point/);
+
+    expect(dnsLookupMock).toHaveBeenCalledTimes(1);
+    expect(httpsRequestMock).toHaveBeenCalledTimes(1);
+    const requestOptions = httpsRequestMock.mock.calls[0][0];
+    expect(requestOptions.hostname).toBe('203.0.113.10');
+    expect(requestOptions.servername).toBe('idp.example.com');
+    expect(requestOptions.headers).toMatchObject({ host: 'idp.example.com' });
+    expect(requestOptions.agent).toBe(false);
+  });
+
+  test('normalizes an IPv6 URL hostname for lookup and connects to the vetted literal', async () => {
+    findBySlugMock.mockResolvedValue({
+      ...SAML_PROVIDER,
+      metadataUrl: 'https://[2606:4700:4700::1111]/metadata',
+    });
+    dnsLookupMock.mockResolvedValue([{ address: '2606:4700:4700::1111', family: 6 }]);
+    pinnedFetchResponseMock.mockResolvedValueOnce(
+      new Response('<EntityDescriptor entityID="x"/>', { status: 200 }),
+    );
+
+    await expect(sso.startSamlLogin('okta')).rejects.toThrow(/missing entry point/);
+
+    expect(dnsLookupMock).toHaveBeenCalledWith('2606:4700:4700::1111', { all: true });
+    expect(httpsRequestMock.mock.calls[0][0]).toMatchObject({
+      hostname: '2606:4700:4700::1111',
+      servername: undefined,
+    });
+  });
+
   test('throws when a redirect response is missing the Location header', async () => {
-    fetchMock.mockResolvedValueOnce(new Response(null, { status: 302 }));
+    pinnedFetchResponseMock.mockResolvedValueOnce(new Response(null, { status: 302 }));
     await expect(sso.startSamlLogin('okta')).rejects.toThrow(/Location header/);
   });
 
   test('rejects when a redirect target resolves to a private IP (per-hop revalidation)', async () => {
-    fetchMock.mockResolvedValueOnce(
+    pinnedFetchResponseMock.mockResolvedValueOnce(
       new Response(null, {
         status: 302,
         headers: { location: 'https://internal.example/m' },
@@ -438,9 +515,28 @@ describe('safeFetchRemoteUrl behavior (exercised via SAML metadata fetch)', () =
     await expect(sso.startSamlLogin('okta')).rejects.toThrow(/private\/loopback/);
   });
 
+  test('closes a compressed redirect stream before following the next hop', async () => {
+    const incoming = new Readable({ read() {} }) as IncomingMessage;
+    incoming.statusCode = 302;
+    incoming.statusMessage = 'Found';
+    incoming.rawHeaders = [
+      'content-encoding',
+      'gzip',
+      'location',
+      'https://idp2.example.com/metadata',
+    ];
+    pinnedFetchResponseMock
+      .mockResolvedValueOnce(incoming)
+      .mockResolvedValueOnce(new Response('<EntityDescriptor entityID="x"/>', { status: 200 }));
+
+    await expect(sso.startSamlLogin('okta')).rejects.toThrow(/missing entry point/);
+
+    expect(incoming.destroyed).toBe(true);
+  });
+
   test('rejects after exceeding the redirect limit', async () => {
     // Same Location each time — drives the loop to its bound.
-    fetchMock.mockResolvedValue(
+    pinnedFetchResponseMock.mockResolvedValue(
       new Response(null, {
         status: 302,
         headers: { location: 'https://idp.example.com/metadata' },
@@ -451,7 +547,7 @@ describe('safeFetchRemoteUrl behavior (exercised via SAML metadata fetch)', () =
 
   test('rejects when Content-Length declares a body larger than the cap', async () => {
     // No body, but the declared content-length is enough to fail the pre-stream check.
-    fetchMock.mockResolvedValueOnce(
+    pinnedFetchResponseMock.mockResolvedValueOnce(
       new Response(null, {
         status: 200,
         headers: { 'content-length': String(2 * 1024 * 1024) },
@@ -471,7 +567,34 @@ describe('safeFetchRemoteUrl behavior (exercised via SAML metadata fetch)', () =
         controller.close();
       },
     });
-    fetchMock.mockResolvedValueOnce(new Response(stream, { status: 200 }));
+    pinnedFetchResponseMock.mockResolvedValueOnce(new Response(stream, { status: 200 }));
+    await expect(sso.startSamlLogin('okta')).rejects.toThrow(/exceeded/);
+  });
+
+  test('decompresses gzip metadata before parsing and size enforcement', async () => {
+    const compressed = gzipSync('<EntityDescriptor entityID="x"/>');
+    pinnedFetchResponseMock.mockResolvedValueOnce(
+      new Response(compressed, {
+        status: 200,
+        headers: {
+          'content-encoding': 'gzip',
+          'content-length': String(compressed.byteLength),
+        },
+      }),
+    );
+
+    await expect(sso.startSamlLogin('okta')).rejects.toThrow(/missing entry point/);
+  });
+
+  test('applies the response cap to decompressed metadata bytes', async () => {
+    const compressed = gzipSync(new Uint8Array(2 * 1024 * 1024).fill(65));
+    pinnedFetchResponseMock.mockResolvedValueOnce(
+      new Response(compressed, {
+        status: 200,
+        headers: { 'content-encoding': 'gzip' },
+      }),
+    );
+
     await expect(sso.startSamlLogin('okta')).rejects.toThrow(/exceeded/);
   });
 });
@@ -548,9 +671,7 @@ describe('completeOidcLogin state-before-provider ordering', () => {
 });
 
 describe('OIDC remote endpoint hardening', () => {
-  const realFetch = globalThis.fetch;
   const originalSsoBase = process.env.SSO_CALLBACK_BASE_URL;
-  const fetchMock = mock();
 
   const OIDC_PROVIDER_ENDPOINTS: realSsoProvidersRepo.SsoProvider = {
     ...SAML_PROVIDER,
@@ -568,14 +689,8 @@ describe('OIDC remote endpoint hardening', () => {
 
   beforeEach(() => {
     process.env.SSO_CALLBACK_BASE_URL = 'https://app.example.com';
-    fetchMock.mockReset();
-    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
     findBySlugMock.mockResolvedValue(OIDC_PROVIDER_ENDPOINTS);
     oidcBuildAuthorizationUrlMock.mockReturnValue(new URL('https://accounts.google.com/auth'));
-  });
-
-  afterEach(() => {
-    globalThis.fetch = realFetch;
   });
 
   afterAll(() => {
@@ -605,10 +720,62 @@ describe('OIDC remote endpoint hardening', () => {
     ).rejects.toThrow(/private\/loopback/);
   });
 
+  test('pins OIDC custom fetches to the address returned by their safety lookup', async () => {
+    dnsLookupMock.mockResolvedValue([{ address: '142.251.32.46', family: 4 }]);
+    oidcDiscoveryMock.mockResolvedValue({ serverMetadata: () => ({}) });
+    await sso.startOidcLogin('google');
+    const options = oidcDiscoveryMock.mock.calls[0][4];
+
+    dnsLookupMock.mockReset();
+    dnsLookupMock.mockResolvedValue([{ address: '203.0.113.25', family: 4 }]);
+    httpsRequestMock.mockClear();
+    pinnedFetchResponseMock.mockResolvedValueOnce(new Response('{}', { status: 200 }));
+
+    await options[realOidc.customFetch]('https://idp.example.com/token', {
+      body: 'grant_type=client_credentials',
+      headers: {},
+      method: 'POST',
+      redirect: 'manual',
+    });
+
+    expect(dnsLookupMock).toHaveBeenCalledTimes(1);
+    expect(httpsRequestMock).toHaveBeenCalledTimes(1);
+    expect(httpsRequestMock.mock.calls[0][0]).toMatchObject({
+      agent: false,
+      hostname: '203.0.113.25',
+      servername: 'idp.example.com',
+    });
+    expect(Buffer.from(pinnedFetchResponseMock.mock.calls[0][1]).toString()).toBe(
+      'grant_type=client_credentials',
+    );
+  });
+
+  test('aborts an OIDC response body after headers when the request signal is cancelled', async () => {
+    dnsLookupMock.mockResolvedValue([{ address: '142.251.32.46', family: 4 }]);
+    oidcDiscoveryMock.mockResolvedValue({ serverMetadata: () => ({}) });
+    await sso.startOidcLogin('google');
+    const options = oidcDiscoveryMock.mock.calls[0][4];
+
+    const incoming = new Readable({ read() {} }) as IncomingMessage;
+    incoming.statusCode = 200;
+    incoming.statusMessage = 'OK';
+    incoming.rawHeaders = [];
+    pinnedFetchResponseMock.mockResolvedValueOnce(incoming);
+    const controller = new AbortController();
+    const response = await options[realOidc.customFetch]('https://idp.example.com/userinfo', {
+      body: undefined,
+      headers: {},
+      method: 'GET',
+      redirect: 'manual',
+      signal: controller.signal,
+    });
+
+    controller.abort();
+    await expect(response.text()).rejects.toThrow(/abort/i);
+  });
+
   test('rejects discovered OIDC endpoints that resolve to private addresses before redirecting', async () => {
-    dnsLookupMock
-      .mockResolvedValueOnce([{ address: '142.251.32.46', family: 4 }])
-      .mockResolvedValueOnce([{ address: '10.0.0.5', family: 4 }]);
+    dnsLookupMock.mockResolvedValueOnce([{ address: '10.0.0.5', family: 4 }]);
     oidcDiscoveryMock.mockResolvedValue({
       serverMetadata: () => ({
         token_endpoint: 'https://internal.example.com/token',
@@ -627,7 +794,7 @@ describe('OIDC remote endpoint hardening', () => {
 
     dnsLookupMock.mockReset();
     dnsLookupMock.mockResolvedValue([{ address: '203.0.113.10', family: 4 }]);
-    fetchMock.mockResolvedValueOnce(
+    pinnedFetchResponseMock.mockResolvedValueOnce(
       new Response(null, {
         status: 200,
         headers: { 'content-length': String(2 * 1024 * 1024) },
@@ -660,7 +827,7 @@ describe('OIDC remote endpoint hardening', () => {
         controller.close();
       },
     });
-    fetchMock.mockResolvedValueOnce(new Response(stream, { status: 200 }));
+    pinnedFetchResponseMock.mockResolvedValueOnce(new Response(stream, { status: 200 }));
 
     const response = await options[realOidc.customFetch]('https://idp.example.com/userinfo', {
       body: undefined,
@@ -672,9 +839,6 @@ describe('OIDC remote endpoint hardening', () => {
   });
 
   test('does not validate end_session_endpoint during login when OIDC logout is disabled', async () => {
-    dnsLookupMock
-      .mockResolvedValueOnce([{ address: '142.251.32.46', family: 4 }])
-      .mockResolvedValueOnce([{ address: '10.0.0.5', family: 4 }]);
     oidcDiscoveryMock.mockResolvedValue({
       serverMetadata: () => ({
         end_session_endpoint: 'https://internal.example.com/logout',
@@ -683,15 +847,13 @@ describe('OIDC remote endpoint hardening', () => {
 
     await sso.startOidcLogin('google');
 
-    expect(dnsLookupMock).toHaveBeenCalledTimes(1);
+    expect(dnsLookupMock).not.toHaveBeenCalled();
     expect(oidcBuildAuthorizationUrlMock).toHaveBeenCalledTimes(1);
   });
 
   test('rejects unsafe end_session_endpoint during login when OIDC logout is enabled', async () => {
     findBySlugMock.mockResolvedValue({ ...OIDC_PROVIDER_ENDPOINTS, endSessionEnabled: true });
-    dnsLookupMock
-      .mockResolvedValueOnce([{ address: '142.251.32.46', family: 4 }])
-      .mockResolvedValueOnce([{ address: '10.0.0.5', family: 4 }]);
+    dnsLookupMock.mockResolvedValueOnce([{ address: '10.0.0.5', family: 4 }]);
     oidcDiscoveryMock.mockResolvedValue({
       serverMetadata: () => ({
         end_session_endpoint: 'https://internal.example.com/logout',
@@ -1543,8 +1705,6 @@ describe('OIDC nonce wiring', () => {
   beforeEach(() => {
     process.env.SSO_CALLBACK_BASE_URL = 'https://app.example.com';
     oidcDiscoveryMock.mockResolvedValue({ serverMetadata: () => ({}) });
-    // createOidcConfig SSRF-checks issuerUrl via dns.lookup({ all: true }).
-    dnsLookupMock.mockResolvedValue([{ address: '142.251.32.46', family: 4 }]);
   });
   afterAll(() => {
     if (originalSsoBase === undefined) delete process.env.SSO_CALLBACK_BASE_URL;

--- a/server/test/services/sso.test.ts
+++ b/server/test/services/sso.test.ts
@@ -530,6 +530,18 @@ describe('safeFetchRemoteUrl behavior (exercised via SAML metadata fetch)', () =
     await expect(sso.startSamlLogin('okta')).rejects.toThrow(/Location header/);
   });
 
+  test('closes a malformed redirect stream before throwing for a missing Location header', async () => {
+    const incoming = new Readable({ read() {} }) as IncomingMessage;
+    incoming.statusCode = 302;
+    incoming.statusMessage = 'Found';
+    incoming.rawHeaders = [];
+    pinnedFetchResponseMock.mockResolvedValueOnce(incoming);
+
+    await expect(sso.startSamlLogin('okta')).rejects.toThrow(/Location header/);
+
+    expect(incoming.destroyed).toBe(true);
+  });
+
   test('rejects when a redirect target resolves to a private IP (per-hop revalidation)', async () => {
     pinnedFetchResponseMock.mockResolvedValueOnce(
       new Response(null, {


### PR DESCRIPTION
## Summary
- Prevents DNS rebinding between SSRF validation and outbound SAML/OIDC HTTPS connections.
- Pins each connection to the vetted public IP while preserving the original hostname for the Host header, SNI, and certificate verification.
- Preserves fetch-compatible response handling for redirects, compression, cancellation, timeouts, and bounded metadata bodies.

## Changes
- Replaces check-then-fetch DNS validation with a single-resolution pinned HTTPS transport.
- Revalidates and pins every SAML redirect hop, normalizes IPv6 literals, and applies one total redirect/body timeout.
- Routes OIDC discovery and endpoint requests through the same pinned transport without a redundant issuer preflight lookup.
- Adds regression coverage for SAML and OIDC pinning, TLS hostname preservation, redirects, IPv6, compressed responses, decompression size limits, request bodies, and abort propagation.

## Testing
- `bun test server/test/services/sso.test.ts` — 81 passed
- `bun run test` — 2,273 passed
- `bun run lint` — passed
- `cd server && bun run build` — passed
- `bunx biome check server/services/sso.ts server/test/services/sso.test.ts` — passed
- `bun run test:react-doctor` — 84/100, unchanged; only the pre-existing `DashboardGrid.tsx` finding remains
- Keycloak integration tests were not run because they require `SSO_TEST_KEYCLOAK_URL`

## Risks / Rollout
- Security-sensitive authentication transport change, scoped to remote SAML metadata and OIDC HTTP requests.
- No database migration, configuration change, dependency change, or user-facing documentation update is required.
- Standard application rollout; monitor SAML/OIDC discovery and login errors after deployment.

## Issues
Fixes #900