### PR TITLE
auth(fix): reject empty role guards

### DIFF
--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -423,7 +423,11 @@ const denyForbidden = async (
   return reply.code(403).send({ error: 'Insufficient permissions' });
 };
 
-export const requireRole = (...roles: string[]) => {
+export const requireRole = (...roles: NonEmptyGuardArgs) => {
+  if (roles.length === 0) {
+    throw new Error('requireRole requires at least one role');
+  }
+
   return async (request: FastifyRequest, reply: FastifyReply) => {
     if (!request.user) {
       return reply.code(401).send({ error: 'Authentication required' });

--- a/server/test/middleware/auth.test.ts
+++ b/server/test/middleware/auth.test.ts
@@ -760,6 +760,11 @@ describe('authenticateToken', () => {
 });
 
 describe('requireRole', () => {
+  test('rejects empty role guards before a route can be registered', () => {
+    // @ts-expect-error Regression coverage for runtime JavaScript callers.
+    expect(() => requireRole()).toThrow('requireRole requires at least one role');
+  });
+
   test('401 when request.user is undefined', async () => {
     const reply = buildFakeReply();
     await requireRole('manager')({} as never, reply as never);


### PR DESCRIPTION
## Summary
- Prevents empty requireRole guards from silently denying every authenticated user.
- Adds compile-time and runtime protection for route registration.

## Changes
- Reuses the existing non-empty guard argument tuple for requireRole.
- Throws a clear registration-time error when runtime JavaScript calls requireRole without roles.
- Adds regression coverage for the empty-role case.
- Documentation reviewed; no user-facing or API documentation changes are required.

## Testing
- bun test server/test/middleware/auth.test.ts — 54 passed
- bun run test:server — 4,058 passed, 28 skipped, 0 failed
- bun run typecheck — passed
- bun run lint — passed
- bun run test:react-doctor — unchanged at 84/100; existing unrelated frontend finding remains
- git diff --check — passed

## Risks / Rollout
- Low risk and scoped to auth middleware route registration.
- Existing valid requireRole call sites are unchanged.
- No database migrations, configuration changes, or deployment ordering requirements.

## Issues
Fixes #899