### PR TITLE
users(fix): retain top managers in scoped user lists

### DIFF
--- a/server/repositories/usersRepo.ts
+++ b/server/repositories/usersRepo.ts
@@ -859,7 +859,7 @@ export const listScopedForManager = async (
        LEFT JOIN user_work_units uw ON u.id = uw.user_id
        LEFT JOIN work_unit_managers wum ON uw.work_unit_id = wum.work_unit_id
        WHERE (${whereClause})
-         AND ${topManagerFilter}
+         AND (u.id = ${viewerId} OR ${topManagerFilter})
        ORDER BY u.name`,
   );
   return rows.map(mapUserListRow);

--- a/server/test/repositories/usersRepo.test.ts
+++ b/server/test/repositories/usersRepo.test.ts
@@ -441,7 +441,7 @@ describe('listScopedForManager', () => {
     expect(exec.calls[0].params).toContain('viewer-1');
   });
 
-  test('hides top managers from results via NOT EXISTS', async () => {
+  test('keeps the viewer visible while hiding other top managers', async () => {
     exec.enqueue({ rows: [] });
     await usersRepo.listScopedForManager(
       'viewer-1',
@@ -449,14 +449,14 @@ describe('listScopedForManager', () => {
       testDb,
     );
     const sql = exec.calls[0].sql.replace(/\s+/g, ' ');
-    expect(sql).toContain('NOT EXISTS');
+    expect(sql).toMatch(/AND \(u\.id = \$\d+ OR NOT EXISTS \(/);
     expect(exec.calls[0].params).toContain('top_manager');
     // Without canViewManagedUsers, the shared-work-unit relaxation must not apply, or callers
     // with only hr.internal/hr.external view could see top managers via incidental wum rows.
     expect(sql).not.toMatch(/NOT EXISTS[\s\S]+OR wum\.user_id =/);
   });
 
-  test('still includes top managers reachable via the viewer’s managed work units', async () => {
+  test('keeps the viewer visible and includes top managers from managed work units', async () => {
     exec.enqueue({ rows: [] });
     await usersRepo.listScopedForManager(
       'viewer-1',
@@ -464,6 +464,7 @@ describe('listScopedForManager', () => {
       testDb,
     );
     const sql = exec.calls[0].sql.replace(/\s+/g, ' ');
+    expect(sql).toMatch(/AND \(u\.id = \$\d+ OR \( NOT EXISTS \(/);
     expect(sql).toMatch(/NOT EXISTS[\s\S]+OR wum\.user_id =/);
   });
 });


### PR DESCRIPTION
## Summary
- Restores a top manager's own row in manager-scoped user lists.
- Preserves the existing exclusion of unrelated top managers and the managed-work-unit permission boundary.

## Changes
- Lets the viewer's explicit self row bypass the separate top-manager visibility gate.
- Adds regression coverage for both `canViewManagedUsers=false` and `canViewManagedUsers=true`, including the existing managed-work-unit exception.

## Testing
- `bun test server/test/repositories/usersRepo.test.ts` — 64 passed
- `bun test server/test/routes/users.test.ts server/test/routes/mcp.test.ts` — 163 passed
- `bun run test` — 2,280 passed
- `bun run lint` — i18n, backend/frontend typecheck, and Biome passed
- `bun run test:react-doctor -- -y --score --blocking none` — 84 before and after
- Three consecutive iterative review/simplify cycles completed cleanly

## Risks / Rollout
- Low risk and code-only. The self exception applies only to the row already admitted by `u.id = viewerId`; all other rows retain the existing top-manager filter.
- No database migration, backfill, API/schema, seed, configuration, or deployment-order change is required.
- Backward-compatible normal application deployment; rollback is a code revert with no data restoration needed.

## Documentation
- Reviewed the Italian and English administration and AI reporting documentation. No update is needed because permissions, routes, response contracts, and documented behavior are unchanged.

## Issues
Fixes #907