### PR TITLE
notifications(fix): make admin warning upsert atomic

### DIFF
--- a/server/repositories/notificationsRepo.ts
+++ b/server/repositories/notificationsRepo.ts
@@ -1,5 +1,5 @@
 import { and, count, desc, eq, inArray, sql } from 'drizzle-orm';
-import { type DbExecutor, db } from '../db/drizzle.ts';
+import { type DbExecutor, db, runAtomically } from '../db/drizzle.ts';
 import { notifications } from '../db/schema/notifications.ts';
 import { generatePrefixedId } from '../utils/order-ids.ts';
 
@@ -167,34 +167,35 @@ export const createRilPreferencesTip = async (
 export const upsertAdminPasswordWarning = async (
   userId: string,
   exec: DbExecutor = db,
-): Promise<void> => {
-  const warning = {
-    userId,
-    type: ADMIN_PASSWORD_WARNING_TYPE,
-    title: ADMIN_PASSWORD_WARNING_TITLE,
-    message: ADMIN_PASSWORD_WARNING_MESSAGE,
-    data: adminPasswordWarningData,
-    isRead: false,
-  };
+): Promise<void> =>
+  runAtomically(exec, async (tx) => {
+    const warning = {
+      userId,
+      type: ADMIN_PASSWORD_WARNING_TYPE,
+      title: ADMIN_PASSWORD_WARNING_TITLE,
+      message: ADMIN_PASSWORD_WARNING_MESSAGE,
+      data: adminPasswordWarningData,
+      isRead: false,
+    };
 
-  await exec
-    .delete(notifications)
-    .where(eq(notifications.id, LEGACY_ADMIN_PASSWORD_WARNING_NOTIFICATION_ID));
+    await tx
+      .delete(notifications)
+      .where(eq(notifications.id, LEGACY_ADMIN_PASSWORD_WARNING_NOTIFICATION_ID));
 
-  await exec
-    .insert(notifications)
-    .values({
-      id: adminPasswordWarningNotificationId(userId),
-      ...warning,
-    })
-    .onConflictDoUpdate({
-      target: notifications.id,
-      set: {
+    await tx
+      .insert(notifications)
+      .values({
+        id: adminPasswordWarningNotificationId(userId),
         ...warning,
-        createdAt: sql`CURRENT_TIMESTAMP`,
-      },
-    });
-};
+      })
+      .onConflictDoUpdate({
+        target: notifications.id,
+        set: {
+          ...warning,
+          createdAt: sql`CURRENT_TIMESTAMP`,
+        },
+      });
+  });
 
 export const deleteAdminPasswordWarning = async (
   userId: string,

--- a/server/test/repositories/notificationsRepoTransactional.test.ts
+++ b/server/test/repositories/notificationsRepoTransactional.test.ts
@@ -1,0 +1,100 @@
+// Verifies the legacy warning cleanup and replacement upsert share one transaction when
+// the repo uses its default executor. If the INSERT fails, the legacy warning must survive.
+
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as realDrizzle from '../../db/drizzle.ts';
+
+const LEGACY_WARNING_ID = 'admin-default-password-warning';
+
+let table = new Set<string>();
+let pending: Set<string> | null = null;
+let failNextInsert = false;
+let transactionCount = 0;
+
+const live = (): Set<string> => pending ?? table;
+
+const fakeDb = {
+  delete() {
+    return {
+      where: async () => {
+        live().delete(LEGACY_WARNING_ID);
+        return { rowCount: 1 };
+      },
+    };
+  },
+  insert() {
+    return {
+      values: (row: { id: string }) => ({
+        onConflictDoUpdate: async () => {
+          if (failNextInsert) {
+            failNextInsert = false;
+            throw new Error('forced admin warning INSERT failure');
+          }
+          live().add(row.id);
+          return { rowCount: 1 };
+        },
+      }),
+    };
+  },
+};
+
+const fakeWithDbTransaction = async <T>(cb: (tx: unknown) => Promise<T>): Promise<T> => {
+  transactionCount += 1;
+  pending = new Set(table);
+  try {
+    const result = await cb(fakeDb);
+    table = pending;
+    return result;
+  } finally {
+    pending = null;
+  }
+};
+
+const fakeRunAtomically = <T>(exec: unknown, cb: (tx: unknown) => Promise<T>): Promise<T> =>
+  exec === fakeDb ? fakeWithDbTransaction(cb) : cb(exec);
+
+const drizzleSnap = { ...realDrizzle };
+
+mock.module('../../db/drizzle.ts', () => ({
+  ...drizzleSnap,
+  db: fakeDb,
+  withDbTransaction: fakeWithDbTransaction,
+  runAtomically: fakeRunAtomically,
+}));
+
+let notificationsRepo: typeof import('../../repositories/notificationsRepo.ts');
+
+beforeAll(async () => {
+  notificationsRepo = await import('../../repositories/notificationsRepo.ts');
+});
+
+afterAll(() => {
+  mock.module('../../db/drizzle.ts', () => drizzleSnap);
+});
+
+beforeEach(() => {
+  table = new Set([LEGACY_WARNING_ID]);
+  pending = null;
+  failNextInsert = false;
+  transactionCount = 0;
+});
+
+describe('upsertAdminPasswordWarning atomicity', () => {
+  test('failed upsert rolls back the legacy warning delete', async () => {
+    failNextInsert = true;
+
+    await expect(notificationsRepo.upsertAdminPasswordWarning('admin-1')).rejects.toThrow(
+      'forced admin warning INSERT failure',
+    );
+
+    expect(transactionCount).toBe(1);
+    expect([...table]).toEqual([LEGACY_WARNING_ID]);
+  });
+
+  test('successful upsert commits the replacement warning', async () => {
+    await notificationsRepo.upsertAdminPasswordWarning('admin-1');
+
+    expect(transactionCount).toBe(1);
+    expect([...table]).toEqual([notificationsRepo.adminPasswordWarningNotificationId('admin-1')]);
+  });
+});


### PR DESCRIPTION
## Summary
- Make the admin default-password warning's legacy cleanup and replacement upsert atomic.
- Prevent a failed replacement insert from permanently deleting the security warning.

## Changes
- Route the DELETE + INSERT/ON CONFLICT sequence through the existing executor-aware `runAtomically` helper.
- Add regression coverage proving failed upserts roll back the legacy delete and successful upserts commit the replacement.

## Testing
- `bun test server/test/repositories/notificationsRepo.test.ts server/test/repositories/notificationsRepoTransactional.test.ts` — 27 passed
- `bun test server/test/db/bootstrapAdmin.test.ts server/test/routes/settings.test.ts server/test/repositories/notificationsRepo.test.ts server/test/repositories/notificationsRepoTransactional.test.ts` — 72 passed
- `bun test server/test/repositories` — 1,122 passed
- `bun run test` — 2,287 passed
- `bun run lint` — passed
- `bun run build` — passed (existing Vite large-chunk advisory only)
- `bun run test:react-doctor` — 84/100, matching the pre-change baseline (existing frontend findings only)

## Risks / Rollout
- Low risk: transaction scope is limited to the existing legacy-row DELETE and warning upsert.
- No schema, migration, backfill, API, configuration, seed, or user-documentation changes.
- Production upgrade is backward-compatible and needs no special deployment order; rollback is a normal code revert.

## Issues
Fixes #910