### PR TITLE
email-settings(fix): preserve state for unknown reducer actions

### DIFF
--- a/components/administration/EmailSettings.tsx
+++ b/components/administration/EmailSettings.tsx
@@ -26,6 +26,11 @@ import { cn } from '@/lib/utils';
 import { useSecretReplaceState } from '../../hooks/useSecretReplaceState';
 import type { EmailConfig, SmtpEncryption } from '../../types';
 import SecretField from '../shared/SecretField';
+import {
+  type EmailTestResult,
+  emailSettingsReducer,
+  type StateUpdate,
+} from './emailSettingsReducer';
 
 export interface EmailSettingsProps {
   config: EmailConfig;
@@ -51,69 +56,6 @@ const DEFAULT_CONFIG: EmailConfig = {
   smtpPassword: '',
   fromEmail: '',
   fromName: 'Praetor',
-};
-
-type EmailTestResult = {
-  success: boolean;
-  code: string;
-  params?: Record<string, string>;
-};
-
-type EmailSettingsState = {
-  formData: EmailConfig;
-  originalConfig: EmailConfig;
-  testEmail: string;
-  testResult: EmailTestResult | null;
-  isTestLoading: boolean;
-  isSaving: boolean;
-  isSaved: boolean;
-  errors: Record<string, string>;
-  testErrors: Record<string, string>;
-};
-
-type StateUpdate<T> = T | ((prev: T) => T);
-
-type EmailSettingsAction =
-  | { type: 'loadConfig'; config: EmailConfig }
-  | { type: 'setFormData'; update: StateUpdate<EmailConfig> }
-  | { type: 'setOriginalConfig'; config: EmailConfig }
-  | { type: 'setTestEmail'; value: string }
-  | { type: 'setTestResult'; value: EmailTestResult | null }
-  | { type: 'setIsTestLoading'; value: boolean }
-  | { type: 'setIsSaving'; value: boolean }
-  | { type: 'setIsSaved'; value: boolean }
-  | { type: 'setErrors'; update: StateUpdate<Record<string, string>> }
-  | { type: 'setTestErrors'; update: StateUpdate<Record<string, string>> };
-
-const resolveStateUpdate = <T,>(current: T, update: StateUpdate<T>): T =>
-  typeof update === 'function' ? (update as (prev: T) => T)(current) : update;
-
-const emailSettingsReducer = (
-  state: EmailSettingsState,
-  action: EmailSettingsAction,
-): EmailSettingsState => {
-  switch (action.type) {
-    case 'loadConfig':
-      return { ...state, formData: action.config, originalConfig: action.config };
-    case 'setFormData':
-      return { ...state, formData: resolveStateUpdate(state.formData, action.update) };
-    case 'setOriginalConfig':
-      return { ...state, originalConfig: action.config };
-    case 'setTestEmail':
-      return { ...state, testEmail: action.value };
-    case 'setTestResult':
-      return { ...state, testResult: action.value };
-    case 'setIsTestLoading':
-      return { ...state, isTestLoading: action.value };
-    case 'setIsSaving':
-      return { ...state, isSaving: action.value };
-    case 'setIsSaved':
-      return { ...state, isSaved: action.value };
-    case 'setErrors':
-      return { ...state, errors: resolveStateUpdate(state.errors, action.update) };
-    case 'setTestErrors':
-      return { ...state, testErrors: resolveStateUpdate(state.testErrors, action.update) };
-  }
 };
 
 type EmailSettingsUpdater = (update: StateUpdate<EmailConfig>) => void;

--- a/components/administration/emailSettingsReducer.ts
+++ b/components/administration/emailSettingsReducer.ts
@@ -1,0 +1,66 @@
+import type { EmailConfig } from '../../types';
+
+export type EmailTestResult = {
+  success: boolean;
+  code: string;
+  params?: Record<string, string>;
+};
+
+type EmailSettingsState = {
+  formData: EmailConfig;
+  originalConfig: EmailConfig;
+  testEmail: string;
+  testResult: EmailTestResult | null;
+  isTestLoading: boolean;
+  isSaving: boolean;
+  isSaved: boolean;
+  errors: Record<string, string>;
+  testErrors: Record<string, string>;
+};
+
+export type StateUpdate<T> = T | ((prev: T) => T);
+
+type EmailSettingsAction =
+  | { type: 'loadConfig'; config: EmailConfig }
+  | { type: 'setFormData'; update: StateUpdate<EmailConfig> }
+  | { type: 'setOriginalConfig'; config: EmailConfig }
+  | { type: 'setTestEmail'; value: string }
+  | { type: 'setTestResult'; value: EmailTestResult | null }
+  | { type: 'setIsTestLoading'; value: boolean }
+  | { type: 'setIsSaving'; value: boolean }
+  | { type: 'setIsSaved'; value: boolean }
+  | { type: 'setErrors'; update: StateUpdate<Record<string, string>> }
+  | { type: 'setTestErrors'; update: StateUpdate<Record<string, string>> };
+
+const resolveStateUpdate = <T>(current: T, update: StateUpdate<T>): T =>
+  typeof update === 'function' ? (update as (prev: T) => T)(current) : update;
+
+export const emailSettingsReducer = (
+  state: EmailSettingsState,
+  action: EmailSettingsAction,
+): EmailSettingsState => {
+  switch (action.type) {
+    case 'loadConfig':
+      return { ...state, formData: action.config, originalConfig: action.config };
+    case 'setFormData':
+      return { ...state, formData: resolveStateUpdate(state.formData, action.update) };
+    case 'setOriginalConfig':
+      return { ...state, originalConfig: action.config };
+    case 'setTestEmail':
+      return { ...state, testEmail: action.value };
+    case 'setTestResult':
+      return { ...state, testResult: action.value };
+    case 'setIsTestLoading':
+      return { ...state, isTestLoading: action.value };
+    case 'setIsSaving':
+      return { ...state, isSaving: action.value };
+    case 'setIsSaved':
+      return { ...state, isSaved: action.value };
+    case 'setErrors':
+      return { ...state, errors: resolveStateUpdate(state.errors, action.update) };
+    case 'setTestErrors':
+      return { ...state, testErrors: resolveStateUpdate(state.testErrors, action.update) };
+    default:
+      return state;
+  }
+};

--- a/test/components/administration/EmailSettings.test.tsx
+++ b/test/components/administration/EmailSettings.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, mock, test } from 'bun:test';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import type { ComponentProps } from 'react';
+import { emailSettingsReducer } from '../../../components/administration/emailSettingsReducer';
 import type { EmailConfig } from '../../../types';
 import { installI18nMock } from '../../helpers/i18n';
 import { clearSpyStateAfterAll } from '../../helpers/mockCleanup.ts';
@@ -25,6 +26,27 @@ const baseConfig: EmailConfig = {
   fromEmail: 'noreply@example.com',
   fromName: 'Praetor',
 };
+
+describe('emailSettingsReducer', () => {
+  test('preserves state for an unknown action', () => {
+    const state: Parameters<typeof emailSettingsReducer>[0] = {
+      formData: baseConfig,
+      originalConfig: baseConfig,
+      testEmail: '',
+      testResult: null,
+      isTestLoading: false,
+      isSaving: false,
+      isSaved: false,
+      errors: {},
+      testErrors: {},
+    };
+    const unknownAction = { type: 'unknown' } as unknown as Parameters<
+      typeof emailSettingsReducer
+    >[1];
+
+    expect(emailSettingsReducer(state, unknownAction)).toBe(state);
+  });
+});
 
 const renderEmailSettings = (overrides: Partial<ComponentProps<typeof EmailSettings>> = {}) => {
   const onSave = mock(async (_config: EmailConfig) => {});


### PR DESCRIPTION
## Summary
- Preserve the current Email Settings state when the reducer receives an unrecognized action.
- Add direct regression coverage for the unknown-action fallback.

## Changes
- Move the Email Settings reducer into an adjacent component-domain module so it can be tested without violating the component-only Fast Refresh rule.
- Add a `default` branch that returns the existing state object.
- Verify the fallback returns the exact same state reference.

## Testing
- `bun test test/components/administration/EmailSettings.test.tsx` — 7 passed, including after rebasing onto the latest `main`
- `bun run test` — 2,288 passed
- `bun run lint` — passed after rebase (i18n check, backend/frontend typecheck, Biome)
- `bun run build` — passed after rebase, including production login smoke test
- `bun run test:react-doctor` — 84/100 on the reconstructed baseline and exact pushed PR head; the command exits non-zero for findings outside this change

## Risks / Rollout
- Low risk and frontend-only. Existing recognized reducer actions are unchanged.
- No database migration, backfill, API or schema contract change, configuration change, permission change, or deployment ordering requirement.
- Italian and English administration docs were reviewed; no update is needed because the user-facing workflow is unchanged.
- Rollback is a normal code revert.

## Issues
Fixes #918