### PR TITLE
auth(fix): preserve state for unknown reducer actions

### DIFF
--- a/components/administration/AuthSettings.tsx
+++ b/components/administration/AuthSettings.tsx
@@ -28,7 +28,6 @@ import { ssoApi } from '../../services/api/sso';
 import type {
   LdapConfig,
   LdapRoleResolution,
-  LdapSyncResponse,
   LdapTestResponse,
   MfaExemptionUser,
   Role,
@@ -58,15 +57,18 @@ import { FieldDescription, FieldError, FieldLabel, Field as UIField } from '../u
 import { Input } from '../ui/input';
 import { Switch } from '../ui/switch';
 import { Textarea } from '../ui/textarea';
+import {
+  type AcsUrlState,
+  type AuthSettingsState,
+  type AuthSettingsTab,
+  authSettingsReducer,
+  type SsoSecretFieldKey,
+  type StateUpdate,
+} from './authSettingsState';
 
 const PEM_BEGIN_MARKER = '-----BEGIN CERTIFICATE-----';
 const PEM_END_MARKER = '-----END CERTIFICATE-----';
 
-type SsoSecretFieldKey = 'clientSecret' | 'privateKey' | 'metadataXml' | 'idpCert';
-type AcsUrlState =
-  | { status: 'loading' }
-  | { status: 'ready'; template: string }
-  | { status: 'error'; message: string };
 type RoleOption = { id: string; name: string };
 
 export interface AuthSettingsProps {
@@ -206,56 +208,6 @@ const LDAP_ROLE_RESOLUTION_HELP_KEYS: Partial<Record<LdapRoleResolution, string>
   rejected: 'admin.ldap.test.rejectedRoleHelp',
 };
 
-type AuthSettingsTab = 'ldap' | 'mfa' | 'session' | SsoProtocol;
-type StateUpdate<T> = T | ((prev: T) => T);
-
-type AuthSettingsState = {
-  activeTab: AuthSettingsTab;
-  ldapForm: LdapConfig;
-  providerDrafts: Record<SsoProtocol, Partial<SsoProvider>>;
-  replacingSecrets: Record<SsoProtocol, Partial<Record<SsoSecretFieldKey, boolean>>>;
-  errors: Record<string, string>;
-  testUsername: string;
-  testPassword: string;
-  testErrors: Record<string, string>;
-  testResult: LdapTestResponse | null;
-  isTestingLdap: boolean;
-  isSaved: boolean;
-  syncResult: LdapSyncResponse | null;
-  syncError: string | null;
-  isSyncingLdap: boolean;
-  isSavingLdap: boolean;
-  savingProvider: SsoProtocol | null;
-  providerSaveErrors: Partial<Record<SsoProtocol, string>>;
-  acsUrlState: AcsUrlState;
-};
-
-type AuthSettingsAction =
-  | { type: 'setActiveTab'; update: StateUpdate<AuthSettingsState['activeTab']> }
-  | { type: 'setLdapForm'; update: StateUpdate<AuthSettingsState['ldapForm']> }
-  | { type: 'setProviderDrafts'; update: StateUpdate<AuthSettingsState['providerDrafts']> }
-  | { type: 'setReplacingSecrets'; update: StateUpdate<AuthSettingsState['replacingSecrets']> }
-  | { type: 'setErrors'; update: StateUpdate<AuthSettingsState['errors']> }
-  | { type: 'setTestUsername'; update: StateUpdate<AuthSettingsState['testUsername']> }
-  | { type: 'setTestPassword'; update: StateUpdate<AuthSettingsState['testPassword']> }
-  | { type: 'setTestErrors'; update: StateUpdate<AuthSettingsState['testErrors']> }
-  | { type: 'setTestResult'; update: StateUpdate<AuthSettingsState['testResult']> }
-  | { type: 'setIsTestingLdap'; update: StateUpdate<AuthSettingsState['isTestingLdap']> }
-  | { type: 'setIsSaved'; update: StateUpdate<AuthSettingsState['isSaved']> }
-  | { type: 'setSyncResult'; update: StateUpdate<AuthSettingsState['syncResult']> }
-  | { type: 'setSyncError'; update: StateUpdate<AuthSettingsState['syncError']> }
-  | { type: 'setIsSyncingLdap'; update: StateUpdate<AuthSettingsState['isSyncingLdap']> }
-  | { type: 'setIsSavingLdap'; update: StateUpdate<AuthSettingsState['isSavingLdap']> }
-  | { type: 'setSavingProvider'; update: StateUpdate<AuthSettingsState['savingProvider']> }
-  | {
-      type: 'setProviderSaveErrors';
-      update: StateUpdate<AuthSettingsState['providerSaveErrors']>;
-    }
-  | { type: 'setAcsUrlState'; update: StateUpdate<AuthSettingsState['acsUrlState']> };
-
-const resolveStateUpdate = <T,>(current: T, update: StateUpdate<T>): T =>
-  typeof update === 'function' ? (update as (prev: T) => T)(current) : update;
-
 const createAuthSettingsState = (): AuthSettingsState => ({
   activeTab: 'ldap',
   ldapForm: DEFAULT_LDAP_CONFIG,
@@ -279,59 +231,6 @@ const createAuthSettingsState = (): AuthSettingsState => ({
   providerSaveErrors: {},
   acsUrlState: { status: 'loading' },
 });
-
-const authSettingsReducer = (
-  state: AuthSettingsState,
-  action: AuthSettingsAction,
-): AuthSettingsState => {
-  switch (action.type) {
-    case 'setActiveTab':
-      return { ...state, activeTab: resolveStateUpdate(state.activeTab, action.update) };
-    case 'setLdapForm':
-      return { ...state, ldapForm: resolveStateUpdate(state.ldapForm, action.update) };
-    case 'setProviderDrafts':
-      return {
-        ...state,
-        providerDrafts: resolveStateUpdate(state.providerDrafts, action.update),
-      };
-    case 'setReplacingSecrets':
-      return {
-        ...state,
-        replacingSecrets: resolveStateUpdate(state.replacingSecrets, action.update),
-      };
-    case 'setErrors':
-      return { ...state, errors: resolveStateUpdate(state.errors, action.update) };
-    case 'setTestUsername':
-      return { ...state, testUsername: resolveStateUpdate(state.testUsername, action.update) };
-    case 'setTestPassword':
-      return { ...state, testPassword: resolveStateUpdate(state.testPassword, action.update) };
-    case 'setTestErrors':
-      return { ...state, testErrors: resolveStateUpdate(state.testErrors, action.update) };
-    case 'setTestResult':
-      return { ...state, testResult: resolveStateUpdate(state.testResult, action.update) };
-    case 'setIsTestingLdap':
-      return { ...state, isTestingLdap: resolveStateUpdate(state.isTestingLdap, action.update) };
-    case 'setIsSaved':
-      return { ...state, isSaved: resolveStateUpdate(state.isSaved, action.update) };
-    case 'setSyncResult':
-      return { ...state, syncResult: resolveStateUpdate(state.syncResult, action.update) };
-    case 'setSyncError':
-      return { ...state, syncError: resolveStateUpdate(state.syncError, action.update) };
-    case 'setIsSyncingLdap':
-      return { ...state, isSyncingLdap: resolveStateUpdate(state.isSyncingLdap, action.update) };
-    case 'setIsSavingLdap':
-      return { ...state, isSavingLdap: resolveStateUpdate(state.isSavingLdap, action.update) };
-    case 'setSavingProvider':
-      return { ...state, savingProvider: resolveStateUpdate(state.savingProvider, action.update) };
-    case 'setProviderSaveErrors':
-      return {
-        ...state,
-        providerSaveErrors: resolveStateUpdate(state.providerSaveErrors, action.update),
-      };
-    case 'setAcsUrlState':
-      return { ...state, acsUrlState: resolveStateUpdate(state.acsUrlState, action.update) };
-  }
-};
 
 const useAuthSettingsController = ({
   config,

--- a/components/administration/authSettingsState.ts
+++ b/components/administration/authSettingsState.ts
@@ -1,0 +1,117 @@
+import type {
+  LdapConfig,
+  LdapSyncResponse,
+  LdapTestResponse,
+  SsoProtocol,
+  SsoProvider,
+} from '../../types';
+
+export type SsoSecretFieldKey = 'clientSecret' | 'privateKey' | 'metadataXml' | 'idpCert';
+export type AcsUrlState =
+  | { status: 'loading' }
+  | { status: 'ready'; template: string }
+  | { status: 'error'; message: string };
+export type AuthSettingsTab = 'ldap' | 'mfa' | 'session' | SsoProtocol;
+export type StateUpdate<T> = T | ((prev: T) => T);
+
+export type AuthSettingsState = {
+  activeTab: AuthSettingsTab;
+  ldapForm: LdapConfig;
+  providerDrafts: Record<SsoProtocol, Partial<SsoProvider>>;
+  replacingSecrets: Record<SsoProtocol, Partial<Record<SsoSecretFieldKey, boolean>>>;
+  errors: Record<string, string>;
+  testUsername: string;
+  testPassword: string;
+  testErrors: Record<string, string>;
+  testResult: LdapTestResponse | null;
+  isTestingLdap: boolean;
+  isSaved: boolean;
+  syncResult: LdapSyncResponse | null;
+  syncError: string | null;
+  isSyncingLdap: boolean;
+  isSavingLdap: boolean;
+  savingProvider: SsoProtocol | null;
+  providerSaveErrors: Partial<Record<SsoProtocol, string>>;
+  acsUrlState: AcsUrlState;
+};
+
+type AuthSettingsAction =
+  | { type: 'setActiveTab'; update: StateUpdate<AuthSettingsState['activeTab']> }
+  | { type: 'setLdapForm'; update: StateUpdate<AuthSettingsState['ldapForm']> }
+  | { type: 'setProviderDrafts'; update: StateUpdate<AuthSettingsState['providerDrafts']> }
+  | { type: 'setReplacingSecrets'; update: StateUpdate<AuthSettingsState['replacingSecrets']> }
+  | { type: 'setErrors'; update: StateUpdate<AuthSettingsState['errors']> }
+  | { type: 'setTestUsername'; update: StateUpdate<AuthSettingsState['testUsername']> }
+  | { type: 'setTestPassword'; update: StateUpdate<AuthSettingsState['testPassword']> }
+  | { type: 'setTestErrors'; update: StateUpdate<AuthSettingsState['testErrors']> }
+  | { type: 'setTestResult'; update: StateUpdate<AuthSettingsState['testResult']> }
+  | { type: 'setIsTestingLdap'; update: StateUpdate<AuthSettingsState['isTestingLdap']> }
+  | { type: 'setIsSaved'; update: StateUpdate<AuthSettingsState['isSaved']> }
+  | { type: 'setSyncResult'; update: StateUpdate<AuthSettingsState['syncResult']> }
+  | { type: 'setSyncError'; update: StateUpdate<AuthSettingsState['syncError']> }
+  | { type: 'setIsSyncingLdap'; update: StateUpdate<AuthSettingsState['isSyncingLdap']> }
+  | { type: 'setIsSavingLdap'; update: StateUpdate<AuthSettingsState['isSavingLdap']> }
+  | { type: 'setSavingProvider'; update: StateUpdate<AuthSettingsState['savingProvider']> }
+  | {
+      type: 'setProviderSaveErrors';
+      update: StateUpdate<AuthSettingsState['providerSaveErrors']>;
+    }
+  | { type: 'setAcsUrlState'; update: StateUpdate<AuthSettingsState['acsUrlState']> };
+
+const resolveStateUpdate = <T>(current: T, update: StateUpdate<T>): T =>
+  typeof update === 'function' ? (update as (prev: T) => T)(current) : update;
+
+export const authSettingsReducer = (
+  state: AuthSettingsState,
+  action: AuthSettingsAction,
+): AuthSettingsState => {
+  switch (action.type) {
+    case 'setActiveTab':
+      return { ...state, activeTab: resolveStateUpdate(state.activeTab, action.update) };
+    case 'setLdapForm':
+      return { ...state, ldapForm: resolveStateUpdate(state.ldapForm, action.update) };
+    case 'setProviderDrafts':
+      return {
+        ...state,
+        providerDrafts: resolveStateUpdate(state.providerDrafts, action.update),
+      };
+    case 'setReplacingSecrets':
+      return {
+        ...state,
+        replacingSecrets: resolveStateUpdate(state.replacingSecrets, action.update),
+      };
+    case 'setErrors':
+      return { ...state, errors: resolveStateUpdate(state.errors, action.update) };
+    case 'setTestUsername':
+      return { ...state, testUsername: resolveStateUpdate(state.testUsername, action.update) };
+    case 'setTestPassword':
+      return { ...state, testPassword: resolveStateUpdate(state.testPassword, action.update) };
+    case 'setTestErrors':
+      return { ...state, testErrors: resolveStateUpdate(state.testErrors, action.update) };
+    case 'setTestResult':
+      return { ...state, testResult: resolveStateUpdate(state.testResult, action.update) };
+    case 'setIsTestingLdap':
+      return { ...state, isTestingLdap: resolveStateUpdate(state.isTestingLdap, action.update) };
+    case 'setIsSaved':
+      return { ...state, isSaved: resolveStateUpdate(state.isSaved, action.update) };
+    case 'setSyncResult':
+      return { ...state, syncResult: resolveStateUpdate(state.syncResult, action.update) };
+    case 'setSyncError':
+      return { ...state, syncError: resolveStateUpdate(state.syncError, action.update) };
+    case 'setIsSyncingLdap':
+      return { ...state, isSyncingLdap: resolveStateUpdate(state.isSyncingLdap, action.update) };
+    case 'setIsSavingLdap':
+      return { ...state, isSavingLdap: resolveStateUpdate(state.isSavingLdap, action.update) };
+    case 'setSavingProvider':
+      return { ...state, savingProvider: resolveStateUpdate(state.savingProvider, action.update) };
+    case 'setProviderSaveErrors':
+      return {
+        ...state,
+        providerSaveErrors: resolveStateUpdate(state.providerSaveErrors, action.update),
+      };
+    case 'setAcsUrlState':
+      return { ...state, acsUrlState: resolveStateUpdate(state.acsUrlState, action.update) };
+    default:
+      return state;
+  }
+};

--- a/test/components/administration/AuthSettings.test.tsx
+++ b/test/components/administration/AuthSettings.test.tsx
@@ -1,6 +1,7 @@
 import { afterAll, beforeEach, describe, expect, mock } from 'bun:test';
 import { act, fireEvent, screen, waitFor, within } from '@testing-library/react';
 import type { ComponentProps } from 'react';
+import { authSettingsReducer } from '../../../components/administration/authSettingsState';
 import type {
   LdapConfig,
   LdapSyncResponse,
@@ -212,6 +213,14 @@ const fillMinimalOidcProvider = () => {
 
   return form;
 };
+
+describe('authSettingsReducer', () => {
+  test('preserves the current state for an unrecognized action', () => {
+    const state = { marker: true } as unknown as Parameters<typeof authSettingsReducer>[0];
+
+    expect(authSettingsReducer(state, { type: 'unknown' } as never)).toBe(state);
+  });
+});
 
 describe('<AuthSettings />', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- Prevents `authSettingsReducer` from returning `undefined` when it receives an unrecognized runtime action.
- Adds direct regression coverage for preserving the existing state object.

## Changes
- Moves AuthSettings reducer state/types into a focused non-component module so the reducer can be tested without violating Fast Refresh export rules.
- Adds a `default` branch that returns the current state while preserving all 18 existing action behaviors.
- Adds a reducer-level regression test that failed with `Received: undefined` before the fix.

## Testing
- `bun test ./test/components/administration/AuthSettings.test.tsx` — 44 passed
- `bun run test` — 2,288 passed across 190 files
- `bun run lint` — passed
- `bun run build` — passed, including production login smoke test
- React Doctor — 84/100 before and after; no findings in changed files
- Three consecutive iterative review/simplify cycles completed cleanly

## Risks / Rollout
- Low risk: client-side reducer fallback only; recognized actions retain identical behavior.
- No database migrations, persisted-data changes, API/permission/config changes, deployment sequencing, or compatibility window required.
- Rollback is a normal application-code revert.

## Documentation
- Reviewed Italian and English user documentation; unchanged because this is an internal crash-prevention fix with no user-facing workflow or API change.

## Issues
Fixes #917