### PR TITLE
sso(fix): target external identity conflicts

### DIFF
--- a/server/repositories/externalIdentitiesRepo.ts
+++ b/server/repositories/externalIdentitiesRepo.ts
@@ -39,7 +39,17 @@ export const findByIdentity = async (
 };
 
 export const insert = async (identity: ExternalIdentity, exec: DbExecutor = db): Promise<void> => {
-  await exec.insert(externalIdentities).values(identity).onConflictDoNothing();
+  await exec
+    .insert(externalIdentities)
+    .values(identity)
+    .onConflictDoNothing({
+      target: [
+        externalIdentities.providerId,
+        externalIdentities.protocol,
+        externalIdentities.issuer,
+        externalIdentities.subject,
+      ],
+    });
 };
 
 export const hasOtherSubjectForUserAndProvider = async (

--- a/server/test/repositories/externalIdentitiesRepo.test.ts
+++ b/server/test/repositories/externalIdentitiesRepo.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import type { DbExecutor } from '../../db/drizzle.ts';
+import * as externalIdentitiesRepo from '../../repositories/externalIdentitiesRepo.ts';
+import { type FakeExecutor, setupTestDb } from '../helpers/fakeExecutor.ts';
+
+let exec: FakeExecutor;
+let testDb: DbExecutor;
+
+beforeEach(() => {
+  ({ exec, testDb } = setupTestDb());
+});
+
+describe('insert', () => {
+  test('ignores only conflicts on the external identity business key', async () => {
+    exec.enqueue({ rows: [] });
+
+    await externalIdentitiesRepo.insert(
+      {
+        id: 'eid-1',
+        providerId: 'sso-1',
+        protocol: 'oidc',
+        issuer: 'https://issuer.example',
+        subject: 'subject-1',
+        userId: 'user-1',
+      },
+      testDb,
+    );
+
+    expect(exec.calls[0].sql.toLowerCase()).toContain(
+      'on conflict ("provider_id","protocol","issuer","subject") do nothing',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Restricts external identity insert deduplication to the existing `(provider_id, protocol, issuer, subject)` business key.
- Allows primary-key and any unrelated unique-constraint violations to propagate instead of being silently ignored.

## Changes
- Adds an explicit composite target to `externalIdentitiesRepo.insert`.
- Adds a repository regression test that pins the generated `ON CONFLICT` target.
- Reviewed Italian and English authentication/administration docs; no update is needed because there is no user-facing or configuration change.

## Testing
- `bun test ./test/repositories/externalIdentitiesRepo.test.ts ./test/services/external-auth.resolve.test.ts` — 21 passed.
- `bun run lint` — passed (i18n check, backend/frontend typecheck, Biome).
- `bun run test` — passed once with 2,287 tests.
- Final full-suite rerun reached 2,286 passes but the unrelated existing `SuppliersView` contact-edit test exceeded its fixed 5-second timeout; it also timed out in isolation at 5.27 seconds.
- `bun run test:react-doctor` — 84/100 before and after; the same three pre-existing frontend findings remain.

## Risks / Rollout
- Low risk and scoped to SSO external-identity persistence.
- No schema, migration, seed, backfill, API, configuration, or dependency changes.
- No deployment ordering or compatibility window is required. Existing business-key races remain idempotent; PK collisions now fail the transaction as intended.
- Rollback is the single repository/test commit; no persisted data transformation is involved.

## Issues
Fixes #913