### PR TITLE
app(fix): preserve navigation state for unknown actions

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -427,6 +427,8 @@ const appNavigationReducer = (
         ? state
         : { ...state, [action.key]: nextValue };
     }
+    default:
+      return state;
   }
 };
 

--- a/test/App.navigationReducer.test.ts
+++ b/test/App.navigationReducer.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'bun:test';
+
+const source = await Bun.file(new URL('../App.tsx', import.meta.url)).text();
+
+describe('App navigation state reducer', () => {
+  test('preserves state for unknown runtime actions (issue #915)', () => {
+    const reducerStart = source.indexOf('const appNavigationReducer = (');
+    expect(reducerStart).toBeGreaterThan(-1);
+
+    const reducerEnd = source.indexOf('\n};', reducerStart);
+    expect(reducerEnd).toBeGreaterThan(reducerStart);
+
+    const reducerSource = source.slice(reducerStart, reducerEnd);
+    expect(reducerSource).toMatch(/default:\s+return state;/);
+  });
+});


### PR DESCRIPTION
## Summary
- Preserve the current app navigation state when the reducer receives an unknown runtime action instead of returning `undefined`.
- Add focused regression coverage following the existing App reducer test convention.

## Changes
- Add a `default` branch to `appNavigationReducer` that returns the existing state reference.
- Pin the fallback contract in `test/App.navigationReducer.test.ts`.

## Testing
- `bun run test` — passed (backend suite and 2,288 frontend tests).
- App-focused Bun suite — passed on the final rebase (64 tests).
- `bun run lint` — passed (i18n check, backend/frontend typecheck, and Biome).
- `bun run test:react-doctor` — 84/100 before and after; the command remains nonzero for unrelated diagnostics in untouched files.

## Risks / Rollout
- Low risk. The change only handles unsupported runtime action types and preserves the existing state reference.
- No database migration, backfill, API/configuration change, deployment ordering, compatibility window, or user-documentation update is required.
- Rollback is a normal code revert; no production data is affected.

## Issues
Fixes #915