### PR TITLE
roles(fix): preserve state for unknown reducer actions

### DIFF
--- a/components/administration/RolesView.tsx
+++ b/components/administration/RolesView.tsx
@@ -77,6 +77,7 @@ import {
   ModalHeader,
   ModalTitle,
 } from '../shared/ModalLayout';
+import { initialRolesViewState, rolesViewReducer } from './rolesViewState';
 
 export interface RolesViewProps {
   roles: Role[];
@@ -308,116 +309,6 @@ const getModuleActions = (definitions: readonly PermissionDefinition[]): Permiss
   });
   const canonicalOrder: PermissionAction[] = ['view', 'create', 'update', 'delete'];
   return canonicalOrder.filter((action) => actionsSet.has(action));
-};
-
-type RolesViewState = {
-  isCreateOpen: boolean;
-  isRenameOpen: boolean;
-  isPermissionsOpen: boolean;
-  isDeleteConfirmOpen: boolean;
-  isDeleting: boolean;
-  activeRole: Role | null;
-  roleName: string;
-  selectedPermissions: string[];
-  formErrors: Record<string, string>;
-  activeModuleTab: string;
-};
-
-type RolesViewAction =
-  | { type: 'openCreate'; firstModule: string }
-  | { type: 'openRename'; role: Role }
-  | { type: 'openPermissions'; role: Role; permissions: string[]; firstModule: string }
-  | { type: 'openDelete'; role: Role }
-  | { type: 'setCreateOpen'; isOpen: boolean }
-  | { type: 'setRenameOpen'; isOpen: boolean }
-  | { type: 'setPermissionsOpen'; isOpen: boolean }
-  | { type: 'setDeleteConfirmOpen'; isOpen: boolean }
-  | { type: 'setDeleting'; isDeleting: boolean }
-  | { type: 'setRoleName'; roleName: string }
-  | { type: 'setSelectedPermissions'; permissions: string[] }
-  | { type: 'setFormErrors'; errors: Record<string, string> }
-  | { type: 'setActiveModuleTab'; tab: string }
-  | { type: 'createSuccess' }
-  | { type: 'renameSuccess' }
-  | { type: 'permissionsSuccess' }
-  | { type: 'deleteSuccess' };
-
-const initialRolesViewState: RolesViewState = {
-  isCreateOpen: false,
-  isRenameOpen: false,
-  isPermissionsOpen: false,
-  isDeleteConfirmOpen: false,
-  isDeleting: false,
-  activeRole: null,
-  roleName: '',
-  selectedPermissions: [],
-  formErrors: {},
-  activeModuleTab: '',
-};
-
-const rolesViewReducer = (state: RolesViewState, action: RolesViewAction): RolesViewState => {
-  switch (action.type) {
-    case 'openCreate':
-      return {
-        ...state,
-        activeRole: null,
-        roleName: '',
-        selectedPermissions: [],
-        formErrors: {},
-        activeModuleTab: action.firstModule,
-        isCreateOpen: true,
-      };
-    case 'openRename':
-      return {
-        ...state,
-        activeRole: action.role,
-        roleName: action.role.name,
-        formErrors: {},
-        isRenameOpen: true,
-      };
-    case 'openPermissions':
-      return {
-        ...state,
-        activeRole: action.role,
-        selectedPermissions: action.permissions,
-        formErrors: {},
-        activeModuleTab: action.firstModule,
-        isPermissionsOpen: true,
-      };
-    case 'openDelete':
-      return {
-        ...state,
-        activeRole: action.role,
-        formErrors: {},
-        isDeleteConfirmOpen: true,
-      };
-    case 'setCreateOpen':
-      return { ...state, isCreateOpen: action.isOpen };
-    case 'setRenameOpen':
-      return { ...state, isRenameOpen: action.isOpen };
-    case 'setPermissionsOpen':
-      return { ...state, isPermissionsOpen: action.isOpen };
-    case 'setDeleteConfirmOpen':
-      return { ...state, isDeleteConfirmOpen: action.isOpen };
-    case 'setDeleting':
-      return { ...state, isDeleting: action.isDeleting };
-    case 'setRoleName':
-      return { ...state, roleName: action.roleName };
-    case 'setSelectedPermissions':
-      return { ...state, selectedPermissions: action.permissions };
-    case 'setFormErrors':
-      return { ...state, formErrors: action.errors };
-    case 'setActiveModuleTab':
-      return { ...state, activeModuleTab: action.tab };
-    case 'createSuccess':
-      return { ...state, isCreateOpen: false };
-    case 'renameSuccess':
-      return { ...state, isRenameOpen: false, activeRole: null };
-    case 'permissionsSuccess':
-      return { ...state, isPermissionsOpen: false, activeRole: null };
-    case 'deleteSuccess':
-      return { ...state, isDeleteConfirmOpen: false, activeRole: null };
-  }
 };
 
 const RolesGrid: React.FC<{

--- a/components/administration/rolesViewState.ts
+++ b/components/administration/rolesViewState.ts
@@ -1,0 +1,116 @@
+import type { Role } from '../../types';
+
+type RolesViewState = {
+  isCreateOpen: boolean;
+  isRenameOpen: boolean;
+  isPermissionsOpen: boolean;
+  isDeleteConfirmOpen: boolean;
+  isDeleting: boolean;
+  activeRole: Role | null;
+  roleName: string;
+  selectedPermissions: string[];
+  formErrors: Record<string, string>;
+  activeModuleTab: string;
+};
+
+type RolesViewAction =
+  | { type: 'openCreate'; firstModule: string }
+  | { type: 'openRename'; role: Role }
+  | { type: 'openPermissions'; role: Role; permissions: string[]; firstModule: string }
+  | { type: 'openDelete'; role: Role }
+  | { type: 'setCreateOpen'; isOpen: boolean }
+  | { type: 'setRenameOpen'; isOpen: boolean }
+  | { type: 'setPermissionsOpen'; isOpen: boolean }
+  | { type: 'setDeleteConfirmOpen'; isOpen: boolean }
+  | { type: 'setDeleting'; isDeleting: boolean }
+  | { type: 'setRoleName'; roleName: string }
+  | { type: 'setSelectedPermissions'; permissions: string[] }
+  | { type: 'setFormErrors'; errors: Record<string, string> }
+  | { type: 'setActiveModuleTab'; tab: string }
+  | { type: 'createSuccess' }
+  | { type: 'renameSuccess' }
+  | { type: 'permissionsSuccess' }
+  | { type: 'deleteSuccess' };
+
+export const initialRolesViewState: RolesViewState = {
+  isCreateOpen: false,
+  isRenameOpen: false,
+  isPermissionsOpen: false,
+  isDeleteConfirmOpen: false,
+  isDeleting: false,
+  activeRole: null,
+  roleName: '',
+  selectedPermissions: [],
+  formErrors: {},
+  activeModuleTab: '',
+};
+
+export const rolesViewReducer = (
+  state: RolesViewState,
+  action: RolesViewAction,
+): RolesViewState => {
+  switch (action.type) {
+    case 'openCreate':
+      return {
+        ...state,
+        activeRole: null,
+        roleName: '',
+        selectedPermissions: [],
+        formErrors: {},
+        activeModuleTab: action.firstModule,
+        isCreateOpen: true,
+      };
+    case 'openRename':
+      return {
+        ...state,
+        activeRole: action.role,
+        roleName: action.role.name,
+        formErrors: {},
+        isRenameOpen: true,
+      };
+    case 'openPermissions':
+      return {
+        ...state,
+        activeRole: action.role,
+        selectedPermissions: action.permissions,
+        formErrors: {},
+        activeModuleTab: action.firstModule,
+        isPermissionsOpen: true,
+      };
+    case 'openDelete':
+      return {
+        ...state,
+        activeRole: action.role,
+        formErrors: {},
+        isDeleteConfirmOpen: true,
+      };
+    case 'setCreateOpen':
+      return { ...state, isCreateOpen: action.isOpen };
+    case 'setRenameOpen':
+      return { ...state, isRenameOpen: action.isOpen };
+    case 'setPermissionsOpen':
+      return { ...state, isPermissionsOpen: action.isOpen };
+    case 'setDeleteConfirmOpen':
+      return { ...state, isDeleteConfirmOpen: action.isOpen };
+    case 'setDeleting':
+      return { ...state, isDeleting: action.isDeleting };
+    case 'setRoleName':
+      return { ...state, roleName: action.roleName };
+    case 'setSelectedPermissions':
+      return { ...state, selectedPermissions: action.permissions };
+    case 'setFormErrors':
+      return { ...state, formErrors: action.errors };
+    case 'setActiveModuleTab':
+      return { ...state, activeModuleTab: action.tab };
+    case 'createSuccess':
+      return { ...state, isCreateOpen: false };
+    case 'renameSuccess':
+      return { ...state, isRenameOpen: false, activeRole: null };
+    case 'permissionsSuccess':
+      return { ...state, isPermissionsOpen: false, activeRole: null };
+    case 'deleteSuccess':
+      return { ...state, isDeleteConfirmOpen: false, activeRole: null };
+    default:
+      return state;
+  }
+};

--- a/test/components/administration/RolesView.test.tsx
+++ b/test/components/administration/RolesView.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, mock, test } from 'bun:test';
 import { fireEvent, screen, within } from '@testing-library/react';
 import RolesView from '../../../components/administration/RolesView';
+import { rolesViewReducer } from '../../../components/administration/rolesViewState';
 import type { Role } from '../../../types';
 import { installI18nMock } from '../../helpers/i18n';
 import { render } from '../../helpers/render';
@@ -48,6 +49,28 @@ const findHrInternalRow = () => {
   if (!row) throw new Error('hr.internal row not found');
   return row as HTMLElement;
 };
+
+describe('rolesViewReducer', () => {
+  test('preserves state for unrecognized reducer actions', () => {
+    const state = {
+      isCreateOpen: false,
+      isRenameOpen: false,
+      isPermissionsOpen: false,
+      isDeleteConfirmOpen: false,
+      isDeleting: false,
+      activeRole: null,
+      roleName: '',
+      selectedPermissions: [],
+      formErrors: {},
+      activeModuleTab: '',
+    } satisfies Parameters<typeof rolesViewReducer>[0];
+    const unrecognizedAction = { type: 'unrecognized' } as unknown as Parameters<
+      typeof rolesViewReducer
+    >[1];
+
+    expect(rolesViewReducer(state, unrecognizedAction)).toBe(state);
+  });
+});
 
 describe('<RolesView />', () => {
   test('renders create/update/delete checkboxes for all-scope permission rows', () => {


### PR DESCRIPTION
## Summary
- Prevents `rolesViewReducer` from returning `undefined` when it receives an unrecognized runtime action.
- Adds regression coverage that verifies the reducer preserves the existing state object.

## Changes
- Moves the RolesView reducer state/action definitions into a focused `rolesViewState.ts` module so the reducer can be unit-tested without violating the component-only Fast Refresh export rule.
- Adds a `default` branch that returns the current state reference.
- Adds a direct reducer regression test; the test failed before the fix with `Received: undefined`.

## Testing
- `bun test test/components/administration/RolesView.test.tsx` — 5 passed
- `bun run test` — 2,288 passed, 0 failed (run twice, including after rebasing onto current `main`)
- `bun run lint` — passed
- `bun run build` — passed, including production login smoke test
- `bun run test:react-doctor` — 84/100, matching the pristine `main` baseline; remaining findings are pre-existing and outside this change
- Three consecutive iterative review/simplify cycles completed with no remaining findings

## Risks / Rollout
- Low risk and frontend-internal. Recognized reducer actions retain their existing behavior; unknown actions now preserve state instead of returning `undefined`.
- No API, database schema, data migration, permissions, configuration, deployment-order, or production-upgrade impact.
- Italian and English administration docs were reviewed; no update is needed because this does not change documented user-facing behavior.

## Issues
Fixes #919