### PR TITLE
login(fix): preserve state for unknown reducer actions

### DIFF
--- a/components/Login.tsx
+++ b/components/Login.tsx
@@ -22,6 +22,7 @@ import {
   SSO_LOGIN_ERROR_CODES,
   type User,
 } from '../types';
+import { initialLoginUiState, loginUiReducer } from './loginUiReducer';
 import TotpSetupWizard, { type TotpSetupResult } from './TotpSetupWizard';
 
 export interface LoginProps {
@@ -38,9 +39,6 @@ interface LoginFormValues {
   username: string;
   password: string;
 }
-
-// Multi-step login: credentials → (optional) TOTP challenge or forced enrollment.
-type LoginPhase = 'credentials' | 'totp' | 'enroll';
 
 // Captures the { token, user } that /auth/2fa/confirm issues during the forced
 // enrollment flow, so onFinished can complete login after the user views their
@@ -77,97 +75,6 @@ const gridOverlayStyle: React.CSSProperties = {
   `,
   maskComposite: 'intersect',
   WebkitMaskComposite: 'source-in',
-};
-
-interface LoginUiState {
-  showPassword: boolean;
-  error: string;
-  isLoading: boolean;
-  ssoProviders: PublicSsoProvider[];
-  failedLogoUrl: string | null;
-  phase: LoginPhase;
-  totpCode: string;
-  useBackupCode: boolean;
-  totpError: string;
-  verifyingTotp: boolean;
-}
-
-type LoginUiAction =
-  | { type: 'togglePassword' }
-  | { type: 'setError'; error: string }
-  | { type: 'setLoading'; isLoading: boolean }
-  | { type: 'setSsoProviders'; providers: PublicSsoProvider[] }
-  | { type: 'logoFailed'; url: string }
-  | { type: 'beginTotpChallenge' }
-  | { type: 'beginEnrollment' }
-  | { type: 'resetCredentials'; error?: string }
-  | { type: 'setTotpCode'; code: string; clearError?: boolean }
-  | { type: 'toggleBackupCode' }
-  | { type: 'setTotpError'; error: string }
-  | { type: 'setVerifyingTotp'; verifying: boolean };
-
-const initialLoginUiState: LoginUiState = {
-  showPassword: false,
-  error: '',
-  isLoading: false,
-  ssoProviders: [],
-  failedLogoUrl: null,
-  phase: 'credentials',
-  totpCode: '',
-  useBackupCode: false,
-  totpError: '',
-  verifyingTotp: false,
-};
-
-const loginUiReducer = (state: LoginUiState, action: LoginUiAction): LoginUiState => {
-  switch (action.type) {
-    case 'togglePassword':
-      return { ...state, showPassword: !state.showPassword };
-    case 'setError':
-      return { ...state, error: action.error };
-    case 'setLoading':
-      return { ...state, isLoading: action.isLoading };
-    case 'setSsoProviders':
-      return { ...state, ssoProviders: action.providers };
-    case 'logoFailed':
-      return { ...state, failedLogoUrl: action.url };
-    case 'beginTotpChallenge':
-      return {
-        ...state,
-        phase: 'totp',
-        totpCode: '',
-        useBackupCode: false,
-        totpError: '',
-      };
-    case 'beginEnrollment':
-      return { ...state, phase: 'enroll' };
-    case 'resetCredentials':
-      return {
-        ...state,
-        phase: 'credentials',
-        totpCode: '',
-        useBackupCode: false,
-        totpError: '',
-        error: action.error ?? '',
-      };
-    case 'setTotpCode':
-      return {
-        ...state,
-        totpCode: action.code,
-        totpError: action.clearError ? '' : state.totpError,
-      };
-    case 'toggleBackupCode':
-      return {
-        ...state,
-        useBackupCode: !state.useBackupCode,
-        totpCode: '',
-        totpError: '',
-      };
-    case 'setTotpError':
-      return { ...state, totpError: action.error };
-    case 'setVerifyingTotp':
-      return { ...state, verifyingTotp: action.verifying };
-  }
 };
 
 const Login: React.FC<LoginProps> = ({

--- a/components/loginUiReducer.ts
+++ b/components/loginUiReducer.ts
@@ -1,0 +1,97 @@
+import type { PublicSsoProvider } from '../types';
+
+// Multi-step login: credentials → (optional) TOTP challenge or forced enrollment.
+type LoginPhase = 'credentials' | 'totp' | 'enroll';
+
+interface LoginUiState {
+  showPassword: boolean;
+  error: string;
+  isLoading: boolean;
+  ssoProviders: PublicSsoProvider[];
+  failedLogoUrl: string | null;
+  phase: LoginPhase;
+  totpCode: string;
+  useBackupCode: boolean;
+  totpError: string;
+  verifyingTotp: boolean;
+}
+
+type LoginUiAction =
+  | { type: 'togglePassword' }
+  | { type: 'setError'; error: string }
+  | { type: 'setLoading'; isLoading: boolean }
+  | { type: 'setSsoProviders'; providers: PublicSsoProvider[] }
+  | { type: 'logoFailed'; url: string }
+  | { type: 'beginTotpChallenge' }
+  | { type: 'beginEnrollment' }
+  | { type: 'resetCredentials'; error?: string }
+  | { type: 'setTotpCode'; code: string; clearError?: boolean }
+  | { type: 'toggleBackupCode' }
+  | { type: 'setTotpError'; error: string }
+  | { type: 'setVerifyingTotp'; verifying: boolean };
+
+export const initialLoginUiState: LoginUiState = {
+  showPassword: false,
+  error: '',
+  isLoading: false,
+  ssoProviders: [],
+  failedLogoUrl: null,
+  phase: 'credentials',
+  totpCode: '',
+  useBackupCode: false,
+  totpError: '',
+  verifyingTotp: false,
+};
+
+export const loginUiReducer = (state: LoginUiState, action: LoginUiAction): LoginUiState => {
+  switch (action.type) {
+    case 'togglePassword':
+      return { ...state, showPassword: !state.showPassword };
+    case 'setError':
+      return { ...state, error: action.error };
+    case 'setLoading':
+      return { ...state, isLoading: action.isLoading };
+    case 'setSsoProviders':
+      return { ...state, ssoProviders: action.providers };
+    case 'logoFailed':
+      return { ...state, failedLogoUrl: action.url };
+    case 'beginTotpChallenge':
+      return {
+        ...state,
+        phase: 'totp',
+        totpCode: '',
+        useBackupCode: false,
+        totpError: '',
+      };
+    case 'beginEnrollment':
+      return { ...state, phase: 'enroll' };
+    case 'resetCredentials':
+      return {
+        ...state,
+        phase: 'credentials',
+        totpCode: '',
+        useBackupCode: false,
+        totpError: '',
+        error: action.error ?? '',
+      };
+    case 'setTotpCode':
+      return {
+        ...state,
+        totpCode: action.code,
+        totpError: action.clearError ? '' : state.totpError,
+      };
+    case 'toggleBackupCode':
+      return {
+        ...state,
+        useBackupCode: !state.useBackupCode,
+        totpCode: '',
+        totpError: '',
+      };
+    case 'setTotpError':
+      return { ...state, totpError: action.error };
+    case 'setVerifyingTotp':
+      return { ...state, verifyingTotp: action.verifying };
+    default:
+      return state;
+  }
+};

--- a/test/components/Login.test.tsx
+++ b/test/components/Login.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { loginUiReducer } from '../../components/loginUiReducer';
 import { THEME_STORAGE_KEY } from '../../utils/theme';
 import { ApiErrorStub } from '../helpers/apiErrorStub';
 import { installI18nMock } from '../helpers/i18n';
@@ -117,6 +118,26 @@ mock.module('../../services/api', () => ({
 clearSpyStateAfterAll();
 
 const Login = (await import('../../components/Login')).default;
+
+describe('loginUiReducer', () => {
+  test('preserves state for an unknown runtime action', () => {
+    const state: Parameters<typeof loginUiReducer>[0] = {
+      showPassword: false,
+      error: 'Existing error',
+      isLoading: false,
+      ssoProviders: [],
+      failedLogoUrl: null,
+      phase: 'credentials',
+      totpCode: '',
+      useBackupCode: false,
+      totpError: '',
+      verifyingTotp: false,
+    };
+    const unknownAction = { type: 'unexpected' } as unknown as Parameters<typeof loginUiReducer>[1];
+
+    expect(loginUiReducer(state, unknownAction)).toBe(state);
+  });
+});
 
 describe('<Login />', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- Prevents the Login UI reducer from returning `undefined` for an unrecognized runtime action.
- Adds direct regression coverage that verifies the existing state object is preserved.

## Changes
- Moves the Login UI state and reducer into a focused non-component module so it can be tested without weakening Fast Refresh.
- Adds a `default` reducer branch that returns the current state while preserving all 12 recognized action behaviors.
- Adds a reducer-level regression test for an unexpected action type.

## Testing
- `bun test test/components/Login.test.tsx` — 37 passed
- `bun run test` — 2,293 passed across 192 files
- `bun run lint` — passed, including i18n checks and frontend/backend typecheck
- `bun run build` — passed, including Italian/English docs generation and production login smoke test
- `bun run test:react-doctor` — 84/100 before and after; no findings in changed files
- Three consecutive iterative review/simplify cycles completed cleanly after the final implementation change

## Risks / Rollout
- Low risk: client-side reducer fallback only; recognized actions retain identical behavior.
- No database migrations, persisted-data changes, API/permission/config changes, deployment sequencing, or compatibility window required.
- Rollback is a normal application-code revert.

## Documentation
- Reviewed Italian and English sign-in documentation; unchanged because this is internal crash prevention with no user-facing workflow or API change.

## Issues
Fixes #920