### PR TITLE
projects(fix): standardize forbidden error responses

### DIFF
--- a/server/routes/projects.ts
+++ b/server/routes/projects.ts
@@ -35,6 +35,7 @@ import { replyError } from '../utils/replyError.ts';
 import {
   badRequest,
   ensureArrayOfStrings,
+  forbidden,
   optionalDateString,
   optionalEnum,
   optionalNonEmptyString,
@@ -234,7 +235,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const targetUserId = targetUserIdResult.value;
       if (targetUserId) {
         if (!(await canListProjectsForTargetUser(request, targetUserId))) {
-          return reply.code(403).send({ message: 'Insufficient permissions' });
+          return forbidden(reply, 'Insufficient permissions');
         }
         return projectsRepo.listForUser(targetUserId);
       }
@@ -275,7 +276,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       if (!targetUserId) return badRequest(reply, 'userId is required');
 
       if (!(await canListProjectsForTargetUser(request, targetUserId))) {
-        return reply.code(403).send({ message: 'Insufficient permissions' });
+        return forbidden(reply, 'Insufficient permissions');
       }
 
       return projectsRepo.listRilCatalogForUser(targetUserId);

--- a/server/test/routes/projects.test.ts
+++ b/server/test/routes/projects.test.ts
@@ -380,6 +380,7 @@ describe('GET /api/projects', () => {
     });
 
     expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Insufficient permissions' });
     expect(listForUserMock).not.toHaveBeenCalled();
     expect(listAllMock).not.toHaveBeenCalled();
   });
@@ -447,6 +448,7 @@ describe('GET /api/projects/ril-catalog', () => {
     });
 
     expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Insufficient permissions' });
     expect(listRilCatalogForUserMock).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary
- Standardizes the two project-list authorization failures on the shared `{ error }` response contract.
- Preserves the intended `Insufficient permissions` message instead of allowing schema serialization to fall back to `Forbidden`.
- Adds exact response-body regression coverage for both affected endpoints.

## Changes
- Reuses the existing `forbidden(reply, message)` helper in `GET /api/projects?userId=...` and `GET /api/projects/ril-catalog?userId=...`.
- Extends the existing route tests to assert `{ error: 'Insufficient permissions' }` for unmanaged users.
- No database, migration, configuration, permission, or generated OpenAPI changes are required; the OpenAPI contract already specifies the standard error schema.
- Reviewed Italian and English user documentation; no update is needed because these pages do not document raw error payload fields.

## Testing
- `bun test server/test/routes/projects.test.ts` — 97 passed
- `bun run lint` — passed (i18n check, backend/frontend typecheck, Biome across 1,092 files)
- `bun test test/build/productionBundle.test.ts test/components/StandardTableSharing.test.tsx` — all 15 `StandardTableSharing` tests passed; the bundle test hit the sandbox child-spawn restriction
- `bun test test/build/productionBundle.test.ts` outside the sandbox — 1 passed
- `bun run test:react-doctor` — 84/100 before and after; unchanged pre-existing findings
- `bun run test` — reached 2,293 passed; one unrelated `StandardTable` test timed out under full-suite load but passed in the isolated two-file run, and the production-bundle test could not spawn Bun inside the sandbox but passed outside it
- Completed three consecutive clean iterative review/simplify cycles after the final edit

## Risks / Rollout
- Low risk and backward-compatible with the documented API schema and current client, which accepts both `message` and `error` during transition.
- No production data, schema, deployment-order, or rollback considerations. Standard application rollback is sufficient.

## Issues
Fixes #924