### PR TITLE
ril(fix): defer export URL revocation

### DIFF
--- a/test/utils/rilExport.test.ts
+++ b/test/utils/rilExport.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
 import { Workbook } from 'exceljs';
 import { applyRilDraftToRows, generateRilRows } from '../../utils/ril';
-import { buildRilWorkbook } from '../../utils/rilExport';
+import { buildRilWorkbook, downloadRilWorkbook } from '../../utils/rilExport';
 
 const buildTestRilWorkbook = (input: Parameters<typeof buildRilWorkbook>[0]) =>
   buildRilWorkbook(input, new Workbook());
@@ -224,5 +224,46 @@ describe('RIL Excel export', () => {
     expect(worksheet?.getCell('H39').value).toBe(21);
     expect(worksheet?.getCell('H41').value).toBe('168:00');
     expect(worksheet?.getCell('H42').value).toBe('168,00');
+  });
+});
+
+describe('RIL Excel download', () => {
+  let previousExcelJs: typeof window.ExcelJS;
+
+  beforeEach(() => {
+    previousExcelJs = window.ExcelJS;
+    window.ExcelJS = { Workbook };
+  });
+
+  afterEach(() => {
+    window.ExcelJS = previousExcelJs;
+    mock.restore();
+  });
+
+  test('revokes the object URL only after the browser handles the download click', async () => {
+    const events: string[] = [];
+    spyOn(URL, 'createObjectURL').mockImplementation(() => 'blob:ril-workbook');
+    spyOn(URL, 'revokeObjectURL').mockImplementation(() => {
+      events.push('revoke');
+    });
+    spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {
+      events.push('click');
+    });
+
+    const filename = await downloadRilWorkbook({
+      rows: [],
+      employeeName: 'User Name',
+      companyName: 'ACME',
+      year: 2026,
+      month: 5,
+      lunchBreakMinutes: 60,
+    });
+    events.push('resolved');
+
+    expect(filename).toBe('RIL_2026_05_User_Name.xlsx');
+    expect(events).toEqual(['click', 'resolved']);
+
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    expect(events).toEqual(['click', 'resolved', 'revoke']);
   });
 });

--- a/utils/rilExport.ts
+++ b/utils/rilExport.ts
@@ -1,4 +1,5 @@
 import type { Cell, Workbook } from 'exceljs';
+import { downloadBlob } from './download';
 import type { RilRow } from './ril';
 import {
   calculateRilTotals,
@@ -283,13 +284,6 @@ export const downloadRilWorkbook = async (input: RilWorkbookInput): Promise<stri
   const blob = new Blob([buffer], {
     type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
   });
-  const url = URL.createObjectURL(blob);
-  const anchor = document.createElement('a');
-  anchor.href = url;
-  anchor.download = filename;
-  document.body.appendChild(anchor);
-  anchor.click();
-  anchor.remove();
-  URL.revokeObjectURL(url);
+  downloadBlob(filename, blob);
   return filename;
 };


### PR DESCRIPTION
## Summary
- Prevents RIL `.xlsx` downloads from losing their blob URL before the browser starts consuming it.
- Adds direct regression coverage for the click, promise-resolution, and deferred-revocation order.

## Changes
- Routes RIL workbook downloads through the existing shared `downloadBlob` helper, which removes the temporary anchor immediately and revokes the object URL in a later task.
- Exercises the real RIL workbook serialization path while pinning URL cleanup timing.
- Reviewed the Italian and English RIL user documentation; both already describe the intended successful Excel export, so no documentation change is required.

## Testing
- `bun test test/utils/rilExport.test.ts test/utils/csv.test.ts test/components/timesheet/RilView.test.tsx` — 50 passed
- `bun run test:server` — passed as the first stage of the full `bun run test` verification
- `bun run test:frontend` — 2,296 passed
- `bun run lint` — passed (i18n, backend/frontend typecheck, Biome)
- `bun run build` — passed, including user docs and production login smoke test
- `bun run test:react-doctor` — 84/100 before and after; unchanged existing findings outside this scope
- `git diff --check` — passed

## Risks / Rollout
- Low risk and browser-client only; the change reuses an established download helper already used by other XLSX exports.
- No database, migration, API, permissions, persisted-data, configuration, or production-upgrade impact.
- Standard frontend deployment is sufficient; rollback is the single commit if needed.

## Issues
Fixes #926