### PR TITLE
auth(fix): settle cancelled retry sleep

### DIFF
--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -57,14 +57,19 @@ export function useAuth(opts: UseAuthOptions = {}) {
 
   useEffect(() => {
     let cancelled = false;
-    let pendingRetryTimer: ReturnType<typeof setTimeout> | null = null;
+    let cancelPendingRetry: (() => void) | null = null;
     const delays = retryDelaysRef.current;
     const sleep = (ms: number) =>
       new Promise<void>((resolve) => {
-        pendingRetryTimer = setTimeout(() => {
-          pendingRetryTimer = null;
+        const finish = () => {
+          cancelPendingRetry = null;
           resolve();
-        }, ms);
+        };
+        const timer = setTimeout(finish, ms);
+        cancelPendingRetry = () => {
+          clearTimeout(timer);
+          finish();
+        };
       });
     const checkAuth = async () => {
       const token = getAuthToken();
@@ -106,10 +111,7 @@ export function useAuth(opts: UseAuthOptions = {}) {
     checkAuth();
     return () => {
       cancelled = true;
-      if (pendingRetryTimer !== null) {
-        clearTimeout(pendingRetryTimer);
-        pendingRetryTimer = null;
-      }
+      cancelPendingRetry?.();
     };
   }, [loadUserSettings]);
 

--- a/test/hooks/useAuth.test.ts
+++ b/test/hooks/useAuth.test.ts
@@ -573,7 +573,7 @@ describe('useAuth', () => {
     expect(onLoginB).toHaveBeenLastCalledWith({ id: 'check-b' });
   });
 
-  test('pending retry-sleep timer is cleared on unmount (no leaked setTimeout)', async () => {
+  test('pending retry sleep is cleared and settled on unmount', async () => {
     tokenStore.token = 'good-token';
     apiMocks.authMe.mockImplementation(() => Promise.reject(new ApiErrorStub('offline', 0, true)));
 
@@ -582,8 +582,31 @@ describe('useAuth', () => {
     const SLEEP_MS = 5000;
     const sleepTimerIds = new Set<unknown>();
     const clearedIds: unknown[] = [];
+    let retrySleepScheduled = false;
+    let retrySleepSettled = false;
     const realSetTimeout = globalThis.setTimeout;
     const realClearTimeout = globalThis.clearTimeout;
+    const RealPromise = globalThis.Promise;
+    // Track the explicit Promise created by sleep() without exposing test-only
+    // state from the hook; the distinctive timer delay identifies that Promise.
+    const TrackedPromise = function <T>(
+      executor: (
+        resolve: (value: T | PromiseLike<T>) => void,
+        reject: (reason?: unknown) => void,
+      ) => void,
+    ) {
+      let isRetrySleep = false;
+      return new RealPromise<T>((resolve, reject) => {
+        executor((value) => {
+          if (isRetrySleep) retrySleepSettled = true;
+          resolve(value);
+        }, reject);
+        isRetrySleep = retrySleepScheduled;
+        retrySleepScheduled = false;
+      });
+    };
+    Object.setPrototypeOf(TrackedPromise, RealPromise);
+    TrackedPromise.prototype = RealPromise.prototype;
     // Use plain assignment instead of spyOn so @testing-library doesn't treat
     // setTimeout as a jest-fake-timer mock (which makes waitFor explode).
     globalThis.setTimeout = ((
@@ -592,13 +615,17 @@ describe('useAuth', () => {
       ...rest: unknown[]
     ) => {
       const id = (realSetTimeout as unknown as (...a: unknown[]) => unknown)(cb, ms, ...rest);
-      if (ms === SLEEP_MS) sleepTimerIds.add(id);
+      if (ms === SLEEP_MS) {
+        sleepTimerIds.add(id);
+        retrySleepScheduled = true;
+      }
       return id;
     }) as unknown as typeof setTimeout;
     globalThis.clearTimeout = ((id: unknown) => {
       clearedIds.push(id);
       return (realClearTimeout as unknown as (i: unknown) => void)(id);
     }) as unknown as typeof clearTimeout;
+    globalThis.Promise = TrackedPromise as unknown as PromiseConstructor;
 
     try {
       const { unmount } = renderHook(() => useAuth({ retryDelaysMs: [SLEEP_MS] }));
@@ -611,9 +638,11 @@ describe('useAuth', () => {
 
       const cleared = clearedIds.some((id) => sleepTimerIds.has(id));
       expect(cleared).toBe(true);
+      expect(retrySleepSettled).toBe(true);
     } finally {
       globalThis.setTimeout = realSetTimeout;
       globalThis.clearTimeout = realClearTimeout;
+      globalThis.Promise = RealPromise;
     }
   });
 


### PR DESCRIPTION
## Summary
- Release the pending initial-auth retry sleep when `useAuth` is cleaned up.
- Preserve timer cancellation while allowing the cancelled async retry loop to terminate.

## Changes
- Replace the timer-only cleanup handle with an atomic cancellation callback that clears the timeout and resolves the pending sleep.
- Extend the unmount regression test to verify both timeout cleanup and Promise settlement.

## Testing
- `bun test test/hooks/useAuth.test.ts` — 26 passed
- `bun run test` — 2,295 passed
- `bun run lint` — passed (i18n, backend/frontend typecheck, Biome)
- `bun run build` — passed, including user docs and production login smoke test
- `bun run test:react-doctor` — 84/100 before and after (no regression)
- Three consecutive iterative review/simplify cycles completed with no remaining findings

## Risks / Rollout
- Low risk and narrowly scoped to initial-auth retry cleanup during component teardown.
- No database migration, persisted-data change, API/configuration change, dependency upgrade, or deployment-order requirement.
- Rollback is a normal application-code revert; no production upgrade compatibility impact.
- The existing production bundle large-chunk warning remains unchanged.

## Issues
Fixes #922