### PR TITLE
projects(fix): allow null descriptions

### DIFF
--- a/server/routes/projects.ts
+++ b/server/routes/projects.ts
@@ -129,7 +129,7 @@ const projectCreateBodySchema = {
   properties: {
     name: { type: 'string' },
     clientId: { type: 'string' },
-    description: { type: 'string' },
+    description: { type: ['string', 'null'] },
     orderId: { type: 'string' },
     offerId: { type: ['string', 'null'] },
     startDate: { type: 'string' },
@@ -148,7 +148,7 @@ const projectUpdateBodySchema = {
   properties: {
     name: { type: 'string' },
     clientId: { type: 'string' },
-    description: { type: 'string' },
+    description: { type: ['string', 'null'] },
     isDisabled: { type: 'boolean' },
     orderId: { type: ['string', 'null'] },
     offerId: { type: ['string', 'null'] },
@@ -346,7 +346,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const { name, clientId, description, orderId } = request.body as {
         name: string;
         clientId: string;
-        description?: string;
+        description?: string | null;
         orderId?: string;
         billingType?: string;
         billingFrequency?: string;
@@ -595,7 +595,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const body = request.body as {
         name?: string;
         clientId?: string;
-        description?: string;
+        description?: string | null;
         isDisabled?: boolean;
         orderId?: string | null;
         offerId?: string | null;
@@ -766,7 +766,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
             {
               name: name || undefined,
               clientId: clientChanged ? requestedClientId : undefined,
-              description: description || undefined,
+              description: description === null ? null : description || undefined,
               isDisabled,
               orderId: orderIdPatch,
               offerId: offerIdPatch.provided ? offerIdPatch.value : undefined,

--- a/server/test/routes/projects.test.ts
+++ b/server/test/routes/projects.test.ts
@@ -623,6 +623,23 @@ describe('POST /api/projects', () => {
     );
   });
 
+  test('201: accepts an explicitly null description', async () => {
+    createMock.mockResolvedValue(SAMPLE_PROJECT);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/projects',
+      headers: authHeader(),
+      payload: { ...VALID_CREATE_PAYLOAD, description: null },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({ description: null }),
+      TX_SENTINEL,
+    );
+  });
+
   test('201: color is no longer part of the project model (create)', async () => {
     createMock.mockResolvedValue(SAMPLE_PROJECT);
 
@@ -1245,6 +1262,42 @@ describe('PUT /api/projects/:id', () => {
     expect(logAuditMock).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'project.updated' }),
     );
+  });
+
+  test('200: clears the description when explicitly set to null', async () => {
+    lockClientIdByIdMock.mockResolvedValue('c-1');
+    updateMock.mockResolvedValue(SAMPLE_PROJECT);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/projects/p-1',
+      headers: authHeader(),
+      payload: { description: null },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(updateMock).toHaveBeenCalledWith(
+      'p-1',
+      expect.objectContaining({ description: null }),
+      TX_SENTINEL,
+    );
+  });
+
+  test('200: leaves the description unchanged when set to an empty string', async () => {
+    lockClientIdByIdMock.mockResolvedValue('c-1');
+    updateMock.mockResolvedValue(SAMPLE_PROJECT);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/projects/p-1',
+      headers: authHeader(),
+      payload: { description: '' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(updateMock).toHaveBeenCalled();
+    const updateArgs = updateMock.mock.calls.at(-1)?.[1] as Record<string, unknown> | undefined;
+    expect(updateArgs?.description).toBeUndefined();
   });
 
   test('200: color is no longer part of the project model (update)', async () => {

--- a/services/api/projects.ts
+++ b/services/api/projects.ts
@@ -46,7 +46,7 @@ export const projectsApi = {
   create: (data: {
     name: string;
     clientId: string;
-    description?: string;
+    description?: string | null;
     orderId: string;
     offerId?: string | null;
     startDate?: string | null;

--- a/types.ts
+++ b/types.ts
@@ -368,7 +368,7 @@ export interface Project {
   id: string;
   name: string;
   clientId: string;
-  description?: string;
+  description?: string | null;
   isDisabled?: boolean;
   createdAt?: number;
   orderId?: string | null;


### PR DESCRIPTION
## Summary
- Allow project descriptions to be explicitly cleared with `description: null`.
- Align the create/update schemas and TypeScript API contract with the existing nullable response/database model.
- Preserve the established behavior where an empty string skips the description update.

## Changes
- Admit `string | null` for project descriptions in create and update request schemas.
- Forward explicit `null` to the repository while continuing to treat omitted/empty values as no update.
- Widen the shared project/API types to represent nullable descriptions.
- Add route regressions for nullable create input, explicit-null clearing, and empty-string compatibility.

## Testing
- `bun test test/routes/projects.test.ts` — 100 passed after rebasing onto current `main`.
- `bun run lint` — i18n, backend/frontend typecheck, and Biome passed after rebase.
- `bun run test` — 2,295 passed, 0 failed across 193 files.
- `bun run build` — user docs, production frontend, and login smoke test passed.
- `bun run test:react-doctor` — 84/100 before and after; no score regression.
- Three consecutive iterative review/simplify cycles completed cleanly.

## Risks / Rollout
- Low risk and backward compatible: this expands accepted JSON input and uses the existing nullable database column/repository path.
- No database migration, backfill, configuration change, deployment ordering, or compatibility window is required.
- Existing clients that omit `description` or send an empty string retain their current behavior.
- Italian and English user guides were reviewed; no copy change is needed for this transport-level fix. The generated OpenAPI contract is updated from the route schema.

## Issues
Fixes #925