### PR TITLE
email(fix): align SMTP connection response contract

### DIFF
--- a/services/api/email.ts
+++ b/services/api/email.ts
@@ -23,6 +23,9 @@ export const emailApi = {
       body: JSON.stringify({ recipientEmail }),
     }),
 
-  testConnection: (): Promise<{ success: boolean; message: string }> =>
-    fetchApi('/email/test-connection', { method: 'POST' }),
+  testConnection: (): Promise<{
+    success: boolean;
+    code: string;
+    params?: Record<string, string> | null;
+  }> => fetchApi('/email/test-connection', { method: 'POST' }),
 };

--- a/test/services/email.test.ts
+++ b/test/services/email.test.ts
@@ -1,0 +1,44 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { buildResponse } from '../helpers/fetchMock';
+
+const respondWith = (body: unknown, status = 200) => buildResponse({ status, json: () => body });
+
+const originalFetch = globalThis.fetch;
+const fetchMock = mock(
+  async (_input: unknown, _init?: unknown): Promise<unknown> => respondWith({}),
+);
+globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+const { emailApi } = await import('../../services/api/email');
+const { setAuthToken } = await import('../../services/api/client');
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  fetchMock.mockImplementation(async () => respondWith({}));
+  setAuthToken(null);
+});
+
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('emailApi.testConnection', () => {
+  test('POSTs the SMTP connection test and returns its structured result', async () => {
+    fetchMock.mockImplementation(async () =>
+      respondWith({
+        success: true,
+        code: 'CONNECTION_SUCCESS',
+        params: null,
+      }),
+    );
+
+    const result = await emailApi.testConnection();
+
+    const [url, init] = fetchMock.mock.calls[0] as [unknown, RequestInit];
+    expect(String(url)).toContain('/email/test-connection');
+    expect(init.method).toBe('POST');
+    expect(result.success).toBe(true);
+    expect(result.code).toBe('CONNECTION_SUCCESS');
+    expect(result.params).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Aligns the frontend SMTP connection-test return type with the server's structured `{ success, code, params }` contract.
- Preserves the server/OpenAPI behavior where `success` and `code` are required and `params` is optional and nullable.

## Changes
- Replaces the stale frontend `message` response field with `code` and optional nullable `params`.
- Adds a frontend API regression test that exercises the real fetch wrapper, POST endpoint, and structured response fields.

## Testing
- `bun test ./test/services/email.test.ts` — passed (1 test).
- `bun x tsc -p tsconfig.json` — passed.
- `bun run lint` — passed, including i18n, backend/frontend typecheck, and repository-wide Biome checks.
- `bun run build` — passed, including the production login smoke check; existing large-chunk warning remains.
- `bun run test` — backend suite passed; frontend reached 2,295 passes with only the production-bundle test failing before the bundle was built.
- `bun test ./test/build/productionBundle.test.ts ./test/components/StandardTableSharing.test.tsx` — passed (16 tests) after building and rerunning the sandbox-spawn/unrelated timeout residuals without full-suite contention.
- `bun run test:react-doctor` — 84/100 before and after; the existing 1 error and 3 warnings are unchanged and outside this change.

## Risks / Rollout
- Low risk: this is a frontend TypeScript contract correction plus regression coverage; the server payload and runtime request behavior are unchanged.
- No database migration, data backfill, configuration change, deployment ordering, or production compatibility window is required.
- Existing clients that already consume the server's `code`/`params` payload remain compatible.

## Issues
Fixes #923