### PR TITLE
db(fix): serialize bootstrap admin creation

### DIFF
--- a/server/db/bootstrapAdmin.ts
+++ b/server/db/bootstrapAdmin.ts
@@ -1,9 +1,10 @@
 import bcrypt from 'bcryptjs';
+import { sql } from 'drizzle-orm';
 import * as notificationsRepo from '../repositories/notificationsRepo.ts';
 import * as usersRepo from '../repositories/usersRepo.ts';
 import { createChildLogger } from '../utils/logger.ts';
 import { generatePrefixedId } from '../utils/order-ids.ts';
-import { query } from './index.ts';
+import { withDbTransaction } from './drizzle.ts';
 
 export const ADMIN_USERNAME = 'admin';
 export const DEFAULT_ADMIN_USER_ID = 'u1';
@@ -12,6 +13,11 @@ const INSECURE_BOOTSTRAP_ADMIN_PASSWORDS = [
   DEFAULT_BOOTSTRAP_ADMIN_PASSWORD,
   'change-me-strong-admin-password',
 ] as const;
+
+// Dedicated two-key namespace for the transaction-level startup lock. Every replica uses the
+// same keys, so the existence check and possible creation cannot overlap across processes.
+const BOOTSTRAP_ADMIN_LOCK_CLASS = 0x50524145; // "PRAE"
+const BOOTSTRAP_ADMIN_LOCK_OBJECT = 1;
 
 const logger = createChildLogger({ module: 'db:bootstrap-admin' });
 
@@ -42,40 +48,44 @@ export const syncDefaultAdminPasswordWarning = async (
 };
 
 export const ensureBootstrapAdmin = async () => {
-  const existingAdmin = await query(
-    'SELECT id, password_hash FROM users WHERE username = $1 LIMIT 1',
-    [ADMIN_USERNAME],
+  const { adminId, adminPasswordHash, created } = await withDbTransaction(async (tx) => {
+    await tx.execute(
+      sql`SELECT pg_advisory_xact_lock(${BOOTSTRAP_ADMIN_LOCK_CLASS}, ${BOOTSTRAP_ADMIN_LOCK_OBJECT})`,
+    );
+
+    const existingAdmin = await usersRepo.findLoginUserByExactUsername(ADMIN_USERNAME, tx);
+    let adminId: string;
+    let adminPasswordHash: string | null;
+    let created = false;
+    if (existingAdmin) {
+      adminId = existingAdmin.id;
+      adminPasswordHash = existingAdmin.passwordHash;
+    } else {
+      const defaultIdUser = await usersRepo.findLoginUserById(DEFAULT_ADMIN_USER_ID, tx);
+      adminId = defaultIdUser === null ? DEFAULT_ADMIN_USER_ID : generatePrefixedId('u');
+      adminPasswordHash = await bcrypt.hash(resolveBootstrapAdminPassword(), 12);
+
+      await usersRepo.createUser(
+        {
+          id: adminId,
+          name: 'Admin User',
+          username: ADMIN_USERNAME,
+          passwordHash: adminPasswordHash,
+          role: 'admin',
+          avatarInitials: 'AD',
+        },
+        tx,
+      );
+      created = true;
+    }
+
+    await usersRepo.addUserRole(adminId, 'admin', tx);
+    return { adminId, adminPasswordHash, created };
+  });
+
+  logger.info(
+    created ? 'Bootstrap admin created' : 'Bootstrap admin already exists. Skipping admin creation',
   );
-
-  let adminId: string;
-  let adminPasswordHash: string | null | undefined;
-  if (existingAdmin.rows.length > 0) {
-    adminId = existingAdmin.rows[0].id as string;
-    adminPasswordHash = existingAdmin.rows[0].password_hash as string | null | undefined;
-    logger.info('Bootstrap admin already exists. Skipping admin creation');
-  } else {
-    const defaultIdCheck = await query('SELECT 1 FROM users WHERE id = $1 LIMIT 1', [
-      DEFAULT_ADMIN_USER_ID,
-    ]);
-    adminId = defaultIdCheck.rows.length === 0 ? DEFAULT_ADMIN_USER_ID : generatePrefixedId('u');
-
-    adminPasswordHash = await bcrypt.hash(resolveBootstrapAdminPassword(), 12);
-
-    await usersRepo.createUser({
-      id: adminId,
-      name: 'Admin User',
-      username: ADMIN_USERNAME,
-      passwordHash: adminPasswordHash,
-      role: 'admin',
-      avatarInitials: 'AD',
-    });
-    logger.info('Bootstrap admin created');
-  }
-
-  await query('INSERT INTO user_roles (user_id, role_id) VALUES ($1, $2) ON CONFLICT DO NOTHING', [
-    adminId,
-    'admin',
-  ]);
 
   await syncDefaultAdminPasswordWarning(adminId, adminPasswordHash);
 

--- a/server/repositories/usersRepo.ts
+++ b/server/repositories/usersRepo.ts
@@ -395,6 +395,18 @@ export const revokeTokensForUnenrolledEnforcedUsers = async (
   return rows.length;
 };
 
+export const findLoginUserByExactUsername = async (
+  username: string,
+  exec: DbExecutor = db,
+): Promise<LoginUserWithAuth | null> => {
+  const rows = await exec
+    .select(LOGIN_USER_PROJECTION)
+    .from(users)
+    .where(eq(users.username, username))
+    .limit(1);
+  return rows[0] ? mapLoginUserRow(rows[0]) : null;
+};
+
 export const findLoginUserByNormalizedUsername = async (
   username: string,
   exec: DbExecutor = db,

--- a/server/test/db/bootstrapAdmin.test.ts
+++ b/server/test/db/bootstrapAdmin.test.ts
@@ -1,18 +1,25 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
 import * as realBcrypt from 'bcryptjs';
-import * as realDbIndex from '../../db/index.ts';
+import * as realDrizzle from '../../db/drizzle.ts';
 import * as realNotificationsRepo from '../../repositories/notificationsRepo.ts';
 import * as realUsersRepo from '../../repositories/usersRepo.ts';
 
 type BootstrapAdminModule = typeof import('../../db/bootstrapAdmin.ts');
 
-const dbIndexSnap = { ...realDbIndex };
+const drizzleSnap = { ...realDrizzle };
 const usersRepoSnap = { ...realUsersRepo };
 const notificationsRepoSnap = { ...realNotificationsRepo };
 const bcryptSnap = { ...(realBcrypt as Record<string, unknown>) };
 
-const queryMock = mock();
+const advisoryLockMock = mock();
+const withDbTransactionMock = mock(async (callback: (tx: unknown) => unknown): Promise<unknown> => {
+  const tx = { execute: advisoryLockMock };
+  return callback(tx);
+});
+const findLoginUserByExactUsernameMock = mock();
+const findLoginUserByIdMock = mock();
 const createUserMock = mock();
+const addUserRoleMock = mock();
 const upsertAdminPasswordWarningMock = mock();
 const deleteAdminPasswordWarningMock = mock();
 const bcryptHashMock = mock();
@@ -21,13 +28,16 @@ const bcryptCompareMock = mock();
 let bootstrapAdmin: BootstrapAdminModule;
 
 beforeAll(async () => {
-  mock.module('../../db/index.ts', () => ({
-    ...dbIndexSnap,
-    query: queryMock,
+  mock.module('../../db/drizzle.ts', () => ({
+    ...drizzleSnap,
+    withDbTransaction: withDbTransactionMock,
   }));
   mock.module('../../repositories/usersRepo.ts', () => ({
     ...usersRepoSnap,
+    findLoginUserByExactUsername: findLoginUserByExactUsernameMock,
+    findLoginUserById: findLoginUserByIdMock,
     createUser: createUserMock,
+    addUserRole: addUserRoleMock,
   }));
   mock.module('../../repositories/notificationsRepo.ts', () => ({
     ...notificationsRepoSnap,
@@ -44,15 +54,19 @@ beforeAll(async () => {
 });
 
 afterAll(() => {
-  mock.module('../../db/index.ts', () => dbIndexSnap);
+  mock.module('../../db/drizzle.ts', () => drizzleSnap);
   mock.module('../../repositories/usersRepo.ts', () => usersRepoSnap);
   mock.module('../../repositories/notificationsRepo.ts', () => notificationsRepoSnap);
   mock.module('bcryptjs', () => bcryptSnap);
 });
 
 const allMocks = [
-  queryMock,
+  advisoryLockMock,
+  withDbTransactionMock,
+  findLoginUserByExactUsernameMock,
+  findLoginUserByIdMock,
   createUserMock,
+  addUserRoleMock,
   upsertAdminPasswordWarningMock,
   deleteAdminPasswordWarningMock,
   bcryptHashMock,
@@ -64,7 +78,15 @@ const originalAdminPasswordEnv = process.env[ADMIN_PASSWORD_ENV];
 
 beforeEach(() => {
   for (const mockedFn of allMocks) mockedFn.mockReset();
+  advisoryLockMock.mockResolvedValue({ rows: [] });
+  withDbTransactionMock.mockImplementation(async (callback: (tx: unknown) => unknown) => {
+    const tx = { execute: advisoryLockMock };
+    return callback(tx);
+  });
+  findLoginUserByExactUsernameMock.mockResolvedValue(null);
+  findLoginUserByIdMock.mockResolvedValue(null);
   createUserMock.mockResolvedValue(undefined);
+  addUserRoleMock.mockResolvedValue(undefined);
   upsertAdminPasswordWarningMock.mockResolvedValue(undefined);
   deleteAdminPasswordWarningMock.mockResolvedValue(undefined);
   delete process.env[ADMIN_PASSWORD_ENV];
@@ -79,11 +101,48 @@ afterEach(() => {
 });
 
 describe('ensureBootstrapAdmin', () => {
+  test('concurrent startup creates the bootstrap admin only once', async () => {
+    let admin: { id: string; passwordHash: string } | null = null;
+    let lockTail = Promise.resolve();
+    let lockAcquisitions = 0;
+    withDbTransactionMock.mockImplementation(async (callback: (tx: unknown) => unknown) => {
+      const previousLock = lockTail;
+      let releaseLock: () => void = () => undefined;
+      lockTail = new Promise<void>((resolve) => {
+        releaseLock = resolve;
+      });
+      const tx = {
+        execute: async () => {
+          lockAcquisitions += 1;
+          await previousLock;
+          return { rows: [] };
+        },
+      };
+      try {
+        return await callback(tx);
+      } finally {
+        releaseLock();
+      }
+    });
+    findLoginUserByExactUsernameMock.mockImplementation(async () => admin);
+    createUserMock.mockImplementation(async (user: { id: string; passwordHash: string }) => {
+      admin = { id: user.id, passwordHash: user.passwordHash };
+    });
+    bcryptHashMock.mockResolvedValue('$2a$password-hash');
+    bcryptCompareMock.mockResolvedValue(true);
+
+    const adminIds = await Promise.all([
+      bootstrapAdmin.ensureBootstrapAdmin(),
+      bootstrapAdmin.ensureBootstrapAdmin(),
+    ]);
+
+    expect(adminIds).toEqual(['u1', 'u1']);
+    expect(lockAcquisitions).toBe(2);
+    expect(createUserMock).toHaveBeenCalledTimes(1);
+    expect(addUserRoleMock).toHaveBeenCalledTimes(2);
+  });
+
   test('creates a fresh admin with the literal default password', async () => {
-    queryMock
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [], rowCount: 1 });
     bcryptHashMock.mockResolvedValue('$2a$password-hash');
     bcryptCompareMock.mockResolvedValue(true);
 
@@ -91,21 +150,40 @@ describe('ensureBootstrapAdmin', () => {
 
     expect(adminId).toBe('u1');
     expect(bcryptHashMock).toHaveBeenCalledWith('password', 12);
-    expect(createUserMock).toHaveBeenCalledWith({
-      id: 'u1',
-      name: 'Admin User',
-      username: 'admin',
-      passwordHash: '$2a$password-hash',
-      role: 'admin',
-      avatarInitials: 'AD',
-    });
+    expect(createUserMock).toHaveBeenCalledWith(
+      {
+        id: 'u1',
+        name: 'Admin User',
+        username: 'admin',
+        passwordHash: '$2a$password-hash',
+        role: 'admin',
+        avatarInitials: 'AD',
+      },
+      expect.anything(),
+    );
+    const transaction = createUserMock.mock.calls[0][1];
+    expect(addUserRoleMock).toHaveBeenCalledWith('u1', 'admin', transaction);
+    expect(advisoryLockMock).toHaveBeenCalledTimes(1);
     expect(upsertAdminPasswordWarningMock).toHaveBeenCalledWith('u1');
   });
 
+  test('keeps user creation and role assignment in the same transaction', async () => {
+    addUserRoleMock.mockRejectedValue(new Error('role assignment failed'));
+    bcryptHashMock.mockResolvedValue('$2a$password-hash');
+
+    await expect(bootstrapAdmin.ensureBootstrapAdmin()).rejects.toThrow('role assignment failed');
+
+    expect(createUserMock).toHaveBeenCalledTimes(1);
+    expect(createUserMock.mock.calls[0][1]).toBe(addUserRoleMock.mock.calls[0][2]);
+    expect(upsertAdminPasswordWarningMock).not.toHaveBeenCalled();
+    expect(deleteAdminPasswordWarningMock).not.toHaveBeenCalled();
+  });
+
   test('existing admin with default password gets the warning', async () => {
-    queryMock
-      .mockResolvedValueOnce({ rows: [{ id: 'u1', password_hash: '$2a$existing' }] })
-      .mockResolvedValueOnce({ rows: [], rowCount: 1 });
+    findLoginUserByExactUsernameMock.mockResolvedValue({
+      id: 'u1',
+      passwordHash: '$2a$existing',
+    });
     bcryptCompareMock.mockResolvedValue(true);
 
     const adminId = await bootstrapAdmin.ensureBootstrapAdmin();
@@ -118,9 +196,10 @@ describe('ensureBootstrapAdmin', () => {
   });
 
   test('existing admin with changed password removes the warning', async () => {
-    queryMock
-      .mockResolvedValueOnce({ rows: [{ id: 'u1', password_hash: '$2a$changed' }] })
-      .mockResolvedValueOnce({ rows: [], rowCount: 1 });
+    findLoginUserByExactUsernameMock.mockResolvedValue({
+      id: 'u1',
+      passwordHash: '$2a$changed',
+    });
     bcryptCompareMock.mockResolvedValue(false);
 
     const adminId = await bootstrapAdmin.ensureBootstrapAdmin();
@@ -139,10 +218,6 @@ describe('ensureBootstrapAdmin', () => {
 
   test('fresh admin uses ADMIN_DEFAULT_PASSWORD when set', async () => {
     process.env[ADMIN_PASSWORD_ENV] = 'op-chosen-strong-pw';
-    queryMock
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [], rowCount: 1 });
     bcryptHashMock.mockResolvedValue('$2a$op-hash');
     bcryptCompareMock.mockResolvedValue(false);
 
@@ -152,6 +227,7 @@ describe('ensureBootstrapAdmin', () => {
     expect(bcryptHashMock).not.toHaveBeenCalledWith('password', 12);
     expect(createUserMock).toHaveBeenCalledWith(
       expect.objectContaining({ passwordHash: '$2a$op-hash' }),
+      expect.anything(),
     );
     expect(upsertAdminPasswordWarningMock).not.toHaveBeenCalled();
     expect(deleteAdminPasswordWarningMock).toHaveBeenCalledTimes(1);
@@ -160,10 +236,6 @@ describe('ensureBootstrapAdmin', () => {
 
   test('fresh admin falls back to literal default when env var is whitespace', async () => {
     process.env[ADMIN_PASSWORD_ENV] = '   ';
-    queryMock
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [], rowCount: 1 });
     bcryptHashMock.mockResolvedValue('$2a$password-hash');
     bcryptCompareMock.mockResolvedValue(true);
 
@@ -173,9 +245,10 @@ describe('ensureBootstrapAdmin', () => {
   });
 
   test('existing admin still using the .env.example placeholder gets the warning', async () => {
-    queryMock
-      .mockResolvedValueOnce({ rows: [{ id: 'u1', password_hash: '$2a$placeholder' }] })
-      .mockResolvedValueOnce({ rows: [], rowCount: 1 });
+    findLoginUserByExactUsernameMock.mockResolvedValue({
+      id: 'u1',
+      passwordHash: '$2a$placeholder',
+    });
     bcryptCompareMock.mockImplementation(
       async (candidate: string) => candidate === 'change-me-strong-admin-password',
     );

--- a/server/test/repositories/usersRepo.test.ts
+++ b/server/test/repositories/usersRepo.test.ts
@@ -76,6 +76,16 @@ describe('findAuthUserById', () => {
   });
 });
 
+describe('findLoginUserByExactUsername', () => {
+  test('uses an exact username lookup for bootstrap compatibility', async () => {
+    exec.enqueue({ rows: [] });
+
+    expect(await usersRepo.findLoginUserByExactUsername('admin', testDb)).toBeNull();
+    expect(exec.calls[0].params).toContain('admin');
+    expect(exec.calls[0].sql).not.toContain('LOWER(');
+  });
+});
+
 describe('findLoginUserByNormalizedUsername', () => {
   test('returns the mapped login user when the row exists', async () => {
     // Projection: id, name, username, role, passwordHash, avatarInitials, isDisabled,


### PR DESCRIPTION
## Summary
- Serialize bootstrap-admin initialization across concurrently starting Praetor replicas.
- Make user creation and the required `admin` role assignment atomic.
- Preserve the existing exact, case-sensitive bootstrap username lookup.

## Changes
- Acquire a PostgreSQL transaction-level advisory lock before checking for the bootstrap admin.
- Run the username lookup, fallback-ID check, user insert, and `user_roles` insert through one Drizzle transaction executor.
- Add a transaction-aware exact-username repository lookup.
- Add regression coverage for concurrent startup and role-assignment failure, plus repository query coverage.

## Testing
- `bun test ./test/db/bootstrapAdmin.test.ts ./test/repositories/usersRepo.test.ts` — 73 passed.
- `bun run test` — 2,295 passed.
- `bun run lint` — passed (i18n check, backend/frontend typecheck, Biome).
- `bun run test:react-doctor` — 84/100 before and after; unchanged pre-existing findings in `components/projects/DashboardGrid.tsx` and related frontend warnings.

## Risks / Rollout
- Low risk and startup-only. The advisory lock is held only for the bootstrap lookup/create/role transaction and is released automatically on commit or rollback.
- No schema migration, data backfill, seed/reference-data update, API/config change, or deployment ordering step is required. Existing data and older binaries remain compatible.
- Updated replicas coordinate with each other. During a mixed-version rollout, an old image that cold-starts concurrently does not acquire the new advisory lock; the existing unique constraint still prevents duplicate usernames, but that old process could retain the legacy startup failure until restarted.

## Issues
Fixes #927