### PR TITLE
app(chore): bump version to 0.11.0

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Praetor API",
     "description": "Praetor API documentation",
-    "version": "0.10.0"
+    "version": "0.11.0"
   },
   "components": {
     "securitySchemes": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praetor",
   "private": true,
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "praetor-server",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Praetor API Server",
   "main": "index.ts",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bumps Praetor to the next minor version, from 0.10.0 to 0.11.0.
- Keeps frontend, backend, and published OpenAPI version metadata synchronized.

## Changes
- Updates the root application package version.
- Updates the server package version used by API and MCP metadata.
- Updates the generated OpenAPI document version.

## Testing
- bun run typecheck
- bun test ./server/test/routes/mcp.test.ts (17 passed)
- Version consistency assertion across both package manifests and OpenAPI metadata
- bun run test:react-doctor (84/100 before and after; unchanged pre-existing finding in DashboardGrid.tsx)

## Risks / Rollout
- Low risk. This is a metadata-only version bump with no database, configuration, dependency, or runtime behavior changes.

## Issues
Issue: Not linked