### PR TITLE
app(chore): bump version to 0.11.1

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Praetor API",
     "description": "Praetor API documentation",
-    "version": "0.11.0"
+    "version": "0.11.1"
   },
   "components": {
     "securitySchemes": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praetor",
   "private": true,
-  "version": "0.11.0",
+  "version": "0.11.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "praetor-server",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Praetor API Server",
   "main": "index.ts",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bumps the Praetor application patch version from 0.11.0 to 0.11.1.
- Keeps the frontend package, backend package, and generated OpenAPI metadata aligned.

## Changes
- Updates `package.json` to version 0.11.1.
- Updates `server/package.json` to version 0.11.1.
- Regenerates `docs/api/openapi.json` with version 0.11.1.

## Testing
- `bun run lint` (passed)
- `bun run test` (2,375 passed; production-bundle smoke test was sandbox-blocked from spawning Bun)
- `bun test ./test/build/productionBundle.test.ts` outside the sandbox (passed)
- `bun run test:react-doctor` before and after: 83/100, unchanged (one pre-existing finding in `components/projects/DashboardGrid.tsx`)

## Risks / Rollout
- Low risk. Metadata-only patch version update with no runtime, database, configuration, or dependency changes.

## Issues
Issue: Not linked