### PR TITLE
tabs(fix): align overflow and dividers

### DIFF
--- a/components/administration/LogsView.tsx
+++ b/components/administration/LogsView.tsx
@@ -453,12 +453,15 @@ const LogsView: React.FC<LogsViewProps> = ({
       </div>
 
       <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as 'audit' | 'siem')}>
-        <TabsList variant="line" className="justify-start">
-          <TabsTrigger value="audit">
+        <TabsList
+          variant="line"
+          className="w-full justify-start overflow-x-auto overflow-y-hidden border-b px-0"
+        >
+          <TabsTrigger value="audit" className="flex-none rounded-none pb-3">
             <ShieldCheck />
             {t('logs.tabs.audit')}
           </TabsTrigger>
-          <TabsTrigger value="siem">
+          <TabsTrigger value="siem" className="flex-none rounded-none pb-3">
             <RadioTower />
             {t('logs.tabs.siem')}
           </TabsTrigger>

--- a/components/projects/ProjectsView.tsx
+++ b/components/projects/ProjectsView.tsx
@@ -1612,7 +1612,10 @@ const ProjectsTabs: React.FC<{ controller: ProjectsController }> = ({ controller
     onValueChange={controller.handleTabChange}
     className="space-y-6"
   >
-    <TabsList variant="line" className="w-full justify-start overflow-x-auto border-b px-0">
+    <TabsList
+      variant="line"
+      className="w-full justify-start overflow-x-auto overflow-y-hidden border-b px-0"
+    >
       {controller.canViewCommissions && (
         <TabsTrigger value="commissions" className="flex-none rounded-none pb-3">
           <Folder className="size-4" aria-hidden="true" />

--- a/components/projects/ResalesView.tsx
+++ b/components/projects/ResalesView.tsx
@@ -1114,7 +1114,10 @@ const ResalesLayout: React.FC<{ controller: ResalesController }> = ({ controller
       onValueChange={controller.handleTabChange}
       className="space-y-6"
     >
-      <TabsList variant="line" className="w-full justify-start overflow-x-auto border-b px-0">
+      <TabsList
+        variant="line"
+        className="w-full justify-start overflow-x-auto overflow-y-hidden border-b px-0"
+      >
         <TabsTrigger value="archive" className="flex-none rounded-none pb-3">
           <ShoppingCart className="size-4" aria-hidden="true" />
           {controller.t('resales.tabs.archive')}

--- a/test/components/administration/LogsView.test.tsx
+++ b/test/components/administration/LogsView.test.tsx
@@ -144,6 +144,23 @@ describe('<LogsView />', () => {
     toastError.mockClear();
   });
 
+  test('renders a full-width tab divider without vertical overflow', () => {
+    render(<LogsView />);
+
+    expect(screen.getByRole('tablist')).toHaveClass(
+      'w-full',
+      'justify-start',
+      'overflow-x-auto',
+      'overflow-y-hidden',
+      'border-b',
+      'px-0',
+    );
+
+    for (const name of ['logs.tabs.audit', 'logs.tabs.siem']) {
+      expect(screen.getByRole('tab', { name })).toHaveClass('flex-none', 'rounded-none', 'pb-3');
+    }
+  });
+
   test('ignores stale audit log responses after rapid date range changes', async () => {
     render(<LogsView />);
 

--- a/test/components/projects/ProjectsView.test.ts
+++ b/test/components/projects/ProjectsView.test.ts
@@ -25,6 +25,16 @@ describe('ProjectsView (create-only dialog after detail-page revamp)', () => {
     expect(source).toContain('<TasksView');
   });
 
+  test('keeps the commissions tab bar horizontally scrollable without vertical overflow', async () => {
+    const source = await Bun.file(
+      new URL('../../../components/projects/ProjectsView.tsx', import.meta.url),
+    ).text();
+
+    expect(source).toContain(
+      'className="w-full justify-start overflow-x-auto overflow-y-hidden border-b px-0"',
+    );
+  });
+
   test('loads project progress hours only for the commissions tab', async () => {
     const source = await Bun.file(
       new URL('../../../components/projects/ProjectsView.tsx', import.meta.url),

--- a/test/components/projects/ResalesView.test.ts
+++ b/test/components/projects/ResalesView.test.ts
@@ -118,6 +118,14 @@ describe('ResalesView wiring', () => {
     expect(source).toContain('resales.selectResaleForActivities');
   });
 
+  test('keeps the resales tab bar horizontally scrollable without vertical overflow', async () => {
+    const source = await readSource();
+
+    expect(source).toContain(
+      'className="w-full justify-start overflow-x-auto overflow-y-hidden border-b px-0"',
+    );
+  });
+
   test('opens the activities tab after a resale is created', async () => {
     const source = await readSource();
 


### PR DESCRIPTION
## Summary
- Removes the unintended vertical scrollbar from the Commesse and Rivendite tab bars while preserving horizontal overflow.
- Adds the same full-width divider treatment to the Audit and SIEM tabs in Logs.
- Keeps Audit and SIEM tabs compact instead of stretching across the full row.

## Changes
- Hides vertical overflow on the horizontal project and resale tab lists.
- Aligns the Logs tab list and triggers with the existing project tab presentation.
- Adds regression coverage for overflow, divider, and compact trigger classes.

## Testing
- `bun test test/components/administration/LogsView.test.tsx` — 18 passed.
- `bun run lint` — passed, including i18n checks, backend/frontend typechecking, and Biome.
- `bun run test` — server suite completed; frontend reported 2394 passed and 0 failed. The command timed out after the test summary because a process handle remained open.
- `bun run test:react-doctor` — 83/100, unchanged from baseline; the existing DashboardGrid finding remains.

## Risks / Rollout
- Low risk: frontend-only class changes with no API, database, permissions, configuration, or migration impact.
- No special rollout or rollback steps are required.

## Issues
Issue: Not linked