### PR TITLE
reports(fix): include assigned report filters

### DIFF
--- a/components/reports/TimeReportView.tsx
+++ b/components/reports/TimeReportView.tsx
@@ -250,13 +250,15 @@ const TimeReportView = ({
     updateDefinition({ periodPreset: preset, ...periodRange(preset, startOfWeek) });
   };
 
-  const visibleProjects = useMemo(
-    () =>
-      options?.projects.filter(
-        (project) => definition.clientId === null || project.clientId === definition.clientId,
-      ) ?? [],
-    [definition.clientId, options],
-  );
+  const visibleProjects = useMemo(() => {
+    const seenProjectIds = new Set<string>();
+    return (options?.projects ?? []).filter((project) => {
+      if (definition.clientId !== null && project.clientId !== definition.clientId) return false;
+      if (seenProjectIds.has(project.id)) return false;
+      seenProjectIds.add(project.id);
+      return true;
+    });
+  }, [definition.clientId, options]);
 
   const visibleTasks = useMemo(() => {
     const visibleProjectIds =

--- a/components/reports/TimeReportView.tsx
+++ b/components/reports/TimeReportView.tsx
@@ -274,7 +274,7 @@ const TimeReportView = ({
         .filter((project) => clientId === null || project.clientId === clientId)
         .map((project) => project.id) ?? [],
     );
-    const projectIds = definition.projectIds.filter((id) => allowedProjects.has(id));
+    const projectIds = definition.projectIds.filter((id) => allowedProjects.has(id)).slice(0, 1);
     updateDefinition({
       clientId,
       projectIds,
@@ -284,11 +284,13 @@ const TimeReportView = ({
   };
 
   const handleProjectChange = (value: string | string[]) => {
-    if (!Array.isArray(value)) return;
+    if (Array.isArray(value)) return;
+    const projectIds = value ? [value] : [];
     updateDefinition({
-      projectIds: value,
+      projectIds,
       task:
-        definition.task && (value.length === 0 || value.includes(definition.task.projectId))
+        definition.task &&
+        (projectIds.length === 0 || projectIds.includes(definition.task.projectId))
           ? definition.task
           : null,
     });
@@ -719,15 +721,14 @@ const TimeReportView = ({
               value={definition.clientId ?? ''}
               onChange={handleClientChange}
               label={t('timeReport.filters.client')}
+              searchable
             />
             <SelectControl
-              options={visibleProjects}
-              value={definition.projectIds}
+              options={[{ id: '', name: t('timeReport.filters.allProjects') }, ...visibleProjects]}
+              value={definition.projectIds[0] ?? ''}
               onChange={handleProjectChange}
               label={t('timeReport.filters.projects')}
-              placeholder={t('timeReport.filters.allProjects')}
               searchable
-              isMulti
             />
             <SelectControl
               options={[

--- a/docs-site/src/content/docs/en/time-report.md
+++ b/docs-site/src/content/docs/en/time-report.md
@@ -11,6 +11,8 @@ The **Reporting > Report** page builds tables from Time Tracker entries. The cur
 
 Choose a relative period (today, yesterday, current/previous week, month, or year) or a custom range. You can filter by one client, multiple projects, one task, and text contained in notes. Start and end dates are inclusive.
 
+Client, project, and task filters include both items assigned to users in the visible report scope and values found in their historical entries. You can therefore select an assigned item before its first time entry while retaining access to data for items that are no longer assigned.
+
 Date is always shown. You can add or remove user, client, project, task, duration, note, and cost. Cost is available only with `reports.cost.view` and uses the historical hourly cost stored on each entry.
 
 ## Users and visibility

--- a/docs-site/src/content/docs/en/time-report.md
+++ b/docs-site/src/content/docs/en/time-report.md
@@ -11,7 +11,7 @@ The **Reporting > Report** page builds tables from Time Tracker entries. The cur
 
 Choose a relative period (today, yesterday, current/previous week, month, or year) or a custom range. You can filter by one client, one project, one task, and text contained in notes. Client, project, and task controls are searchable and include an option that leaves the corresponding filter unrestricted. Start and end dates are inclusive.
 
-Client, project, and task filters include both items assigned to users in the visible report scope and values found in their historical entries. You can therefore select an assigned item before its first time entry while retaining access to data for items that are no longer assigned.
+Client, project, and task filters include both items assigned to users in the visible report scope and values found in their historical entries. You can therefore select an assigned item before its first time entry while retaining access to data for items that are no longer assigned. If a project is moved to another client, its historical client-project pair remains available under the original client.
 
 Date is always shown. You can add or remove user, client, project, task, duration, note, and cost. Cost is available only with `reports.cost.view` and uses the historical hourly cost stored on each entry.
 

--- a/docs-site/src/content/docs/en/time-report.md
+++ b/docs-site/src/content/docs/en/time-report.md
@@ -9,7 +9,7 @@ The **Reporting > Report** page builds tables from Time Tracker entries. The cur
 
 ## Filters and fields
 
-Choose a relative period (today, yesterday, current/previous week, month, or year) or a custom range. You can filter by one client, multiple projects, one task, and text contained in notes. Start and end dates are inclusive.
+Choose a relative period (today, yesterday, current/previous week, month, or year) or a custom range. You can filter by one client, one project, one task, and text contained in notes. Client, project, and task controls are searchable and include an option that leaves the corresponding filter unrestricted. Start and end dates are inclusive.
 
 Client, project, and task filters include both items assigned to users in the visible report scope and values found in their historical entries. You can therefore select an assigned item before its first time entry while retaining access to data for items that are no longer assigned.
 

--- a/docs-site/src/content/docs/time-report.md
+++ b/docs-site/src/content/docs/time-report.md
@@ -11,6 +11,8 @@ La pagina **Reporting > Report** genera tabelle a partire dalle registrazioni de
 
 Puoi scegliere un periodo relativo (oggi, ieri, settimana, mese o anno corrente/precedente) oppure un intervallo personalizzato. Sono disponibili filtri per cliente, più progetti, attività e testo contenuto nelle note. Le date iniziale e finale sono incluse.
 
+I filtri cliente, progetto e attività includono sia gli elementi assegnati agli utenti visibili nel report sia i valori presenti nelle loro registrazioni storiche. Puoi quindi selezionare un elemento assegnato anche prima che sia stata registrata la prima ora, senza perdere la possibilità di consultare dati relativi a elementi non più assegnati.
+
 La data è sempre visibile. Puoi aggiungere o rimuovere utente, cliente, progetto, attività, durata, nota e costo. Il costo appare solo con il permesso `reports.cost.view` ed è calcolato usando il costo orario storico salvato sulla registrazione.
 
 ## Utenti e visibilità

--- a/docs-site/src/content/docs/time-report.md
+++ b/docs-site/src/content/docs/time-report.md
@@ -11,7 +11,7 @@ La pagina **Reporting > Report** genera tabelle a partire dalle registrazioni de
 
 Puoi scegliere un periodo relativo (oggi, ieri, settimana, mese o anno corrente/precedente) oppure un intervallo personalizzato. Sono disponibili filtri per cliente, un progetto, attività e testo contenuto nelle note. Cliente, progetto e attività sono ricercabili e includono un'opzione per non applicare quel filtro. Le date iniziale e finale sono incluse.
 
-I filtri cliente, progetto e attività includono sia gli elementi assegnati agli utenti visibili nel report sia i valori presenti nelle loro registrazioni storiche. Puoi quindi selezionare un elemento assegnato anche prima che sia stata registrata la prima ora, senza perdere la possibilità di consultare dati relativi a elementi non più assegnati.
+I filtri cliente, progetto e attività includono sia gli elementi assegnati agli utenti visibili nel report sia i valori presenti nelle loro registrazioni storiche. Puoi quindi selezionare un elemento assegnato anche prima che sia stata registrata la prima ora, senza perdere la possibilità di consultare dati relativi a elementi non più assegnati. Se un progetto viene spostato a un altro cliente, la coppia storica cliente-progetto rimane disponibile sotto il cliente originario.
 
 La data è sempre visibile. Puoi aggiungere o rimuovere utente, cliente, progetto, attività, durata, nota e costo. Il costo appare solo con il permesso `reports.cost.view` ed è calcolato usando il costo orario storico salvato sulla registrazione.
 

--- a/docs-site/src/content/docs/time-report.md
+++ b/docs-site/src/content/docs/time-report.md
@@ -9,7 +9,7 @@ La pagina **Reporting > Report** genera tabelle a partire dalle registrazioni de
 
 ## Filtri e campi
 
-Puoi scegliere un periodo relativo (oggi, ieri, settimana, mese o anno corrente/precedente) oppure un intervallo personalizzato. Sono disponibili filtri per cliente, più progetti, attività e testo contenuto nelle note. Le date iniziale e finale sono incluse.
+Puoi scegliere un periodo relativo (oggi, ieri, settimana, mese o anno corrente/precedente) oppure un intervallo personalizzato. Sono disponibili filtri per cliente, un progetto, attività e testo contenuto nelle note. Cliente, progetto e attività sono ricercabili e includono un'opzione per non applicare quel filtro. Le date iniziale e finale sono incluse.
 
 I filtri cliente, progetto e attività includono sia gli elementi assegnati agli utenti visibili nel report sia i valori presenti nelle loro registrazioni storiche. Puoi quindi selezionare un elemento assegnato anche prima che sia stata registrata la prima ora, senza perdere la possibilità di consultare dati relativi a elementi non più assegnati.
 

--- a/server/repositories/timeReportsRepo.ts
+++ b/server/repositories/timeReportsRepo.ts
@@ -158,36 +158,117 @@ export const listOptions = async (
     ),
     executeRows<{ id: string; name: string }>(
       exec,
-      sql`SELECT DISTINCT ON (te.client_id)
-                  te.client_id AS id, te.client_name AS name
-            FROM time_entries te
-           WHERE te.user_id = ANY(${ids}::text[])
-           ORDER BY te.client_id, te.date DESC, te.created_at DESC NULLS LAST`,
+      sql`SELECT DISTINCT ON (available.id)
+                  available.id, available.name
+            FROM (
+              SELECT c.id,
+                     c.name,
+                     0 AS source_order,
+                     NULL::date AS entry_date,
+                     NULL::timestamp AS entry_created_at
+                FROM (
+                  SELECT uc.client_id AS id
+                    FROM user_clients uc
+                   WHERE uc.user_id = ANY(${ids}::text[])
+                  UNION
+                  SELECT p.client_id AS id
+                    FROM user_projects up
+                    JOIN projects p ON p.id = up.project_id
+                   WHERE up.user_id = ANY(${ids}::text[])
+                  UNION
+                  SELECT p.client_id AS id
+                    FROM user_tasks ut
+                    JOIN tasks t ON t.id = ut.task_id
+                    JOIN projects p ON p.id = t.project_id
+                   WHERE ut.user_id = ANY(${ids}::text[])
+                ) assigned
+                JOIN clients c ON c.id = assigned.id
+              UNION ALL
+              SELECT te.client_id AS id,
+                     te.client_name AS name,
+                     1 AS source_order,
+                     te.date AS entry_date,
+                     te.created_at AS entry_created_at
+                FROM time_entries te
+               WHERE te.user_id = ANY(${ids}::text[])
+            ) available
+           ORDER BY available.id,
+                    available.source_order,
+                    available.entry_date DESC NULLS LAST,
+                    available.entry_created_at DESC NULLS LAST`,
     ),
     executeRows<{ id: string; name: string; clientId: string }>(
       exec,
-      sql`SELECT DISTINCT ON (te.project_id)
-                  te.project_id AS id,
-                  te.project_name AS name,
-                  te.client_id AS "clientId"
-            FROM time_entries te
-           WHERE te.user_id = ANY(${ids}::text[])
-           ORDER BY te.project_id, te.date DESC, te.created_at DESC NULLS LAST`,
+      sql`SELECT DISTINCT ON (available.id)
+                  available.id,
+                  available.name,
+                  available.client_id AS "clientId"
+            FROM (
+              SELECT p.id,
+                     p.name,
+                     p.client_id,
+                     0 AS source_order,
+                     NULL::date AS entry_date,
+                     NULL::timestamp AS entry_created_at
+                FROM (
+                  SELECT up.project_id AS id
+                    FROM user_projects up
+                   WHERE up.user_id = ANY(${ids}::text[])
+                  UNION
+                  SELECT t.project_id AS id
+                    FROM user_tasks ut
+                    JOIN tasks t ON t.id = ut.task_id
+                   WHERE ut.user_id = ANY(${ids}::text[])
+                ) assigned
+                JOIN projects p ON p.id = assigned.id
+              UNION ALL
+              SELECT te.project_id AS id,
+                     te.project_name AS name,
+                     te.client_id,
+                     1 AS source_order,
+                     te.date AS entry_date,
+                     te.created_at AS entry_created_at
+                FROM time_entries te
+               WHERE te.user_id = ANY(${ids}::text[])
+            ) available
+           ORDER BY available.id,
+                    available.source_order,
+                    available.entry_date DESC NULLS LAST,
+                    available.entry_created_at DESC NULLS LAST`,
     ),
     executeRows<{ projectId: string; taskId: string | null; name: string }>(
       exec,
       sql`SELECT DISTINCT ON (
-                  te.project_id,
-                  COALESCE(te.task_id, 'legacy:' || lower(te.task))
-                ) te.project_id AS "projectId",
-                  te.task_id AS "taskId",
-                  te.task AS name
-            FROM time_entries te
-           WHERE te.user_id = ANY(${ids}::text[])
-           ORDER BY te.project_id,
-                    COALESCE(te.task_id, 'legacy:' || lower(te.task)),
-                    te.date DESC,
-                    te.created_at DESC NULLS LAST`,
+                  available.project_id,
+                  COALESCE(available.task_id, 'legacy:' || lower(available.name))
+                ) available.project_id AS "projectId",
+                  available.task_id AS "taskId",
+                  available.name
+            FROM (
+              SELECT t.project_id,
+                     t.id AS task_id,
+                     t.name,
+                     0 AS source_order,
+                     NULL::date AS entry_date,
+                     NULL::timestamp AS entry_created_at
+                FROM user_tasks ut
+                JOIN tasks t ON t.id = ut.task_id
+               WHERE ut.user_id = ANY(${ids}::text[])
+              UNION ALL
+              SELECT te.project_id,
+                     te.task_id,
+                     te.task AS name,
+                     1 AS source_order,
+                     te.date AS entry_date,
+                     te.created_at AS entry_created_at
+                FROM time_entries te
+               WHERE te.user_id = ANY(${ids}::text[])
+            ) available
+           ORDER BY available.project_id,
+                    COALESCE(available.task_id, 'legacy:' || lower(available.name)),
+                    available.source_order,
+                    available.entry_date DESC NULLS LAST,
+                    available.entry_created_at DESC NULLS LAST`,
     ),
   ]);
   return {

--- a/server/repositories/timeReportsRepo.ts
+++ b/server/repositories/timeReportsRepo.ts
@@ -197,12 +197,13 @@ export const listOptions = async (
                     available.entry_date DESC NULLS LAST,
                     available.entry_created_at DESC NULLS LAST`,
     ),
-    executeRows<{ id: string; name: string; clientId: string }>(
+    executeRows<{ id: string; name: string; clientId: string; sourceOrder: number }>(
       exec,
-      sql`SELECT DISTINCT ON (available.id)
+      sql`SELECT DISTINCT ON (available.id, available.client_id)
                   available.id,
                   available.name,
-                  available.client_id AS "clientId"
+                  available.client_id AS "clientId",
+                  available.source_order AS "sourceOrder"
             FROM (
               SELECT p.id,
                      p.name,
@@ -223,15 +224,17 @@ export const listOptions = async (
                 JOIN projects p ON p.id = assigned.id
               UNION ALL
               SELECT te.project_id AS id,
-                     te.project_name AS name,
+                     COALESCE(current_project.name, te.project_name) AS name,
                      te.client_id,
                      1 AS source_order,
                      te.date AS entry_date,
                      te.created_at AS entry_created_at
                 FROM time_entries te
+                LEFT JOIN projects current_project ON current_project.id = te.project_id
                WHERE te.user_id = ANY(${ids}::text[])
             ) available
            ORDER BY available.id,
+                    available.client_id,
                     available.source_order,
                     available.entry_date DESC NULLS LAST,
                     available.entry_created_at DESC NULLS LAST`,
@@ -274,7 +277,9 @@ export const listOptions = async (
   return {
     users,
     clients: clients.sort((a, b) => a.name.localeCompare(b.name)),
-    projects: projects.sort((a, b) => a.name.localeCompare(b.name)),
+    projects: projects
+      .sort((a, b) => a.name.localeCompare(b.name) || a.sourceOrder - b.sourceOrder)
+      .map(({ id, name, clientId }) => ({ id, name, clientId })),
     tasks: tasks.map((task) => ({
       ...task,
       key: task.taskId ?? `legacy:${task.projectId}:${task.name.toLowerCase()}`,

--- a/server/test/repositories/timeReportsRepo.test.ts
+++ b/server/test/repositories/timeReportsRepo.test.ts
@@ -105,7 +105,7 @@ describe('timeReportsRepo', () => {
     expect(totals).toEqual({ count: 6000, duration: 125.5, cost: 333.34 });
   });
 
-  test('deduplicates renamed persisted tasks by stable task identity', async () => {
+  test('combines assigned tracker catalog hierarchies with historical filter values', async () => {
     exec.enqueue({ rows: [] });
     exec.enqueue({ rows: [] });
     exec.enqueue({ rows: [] });
@@ -113,11 +113,34 @@ describe('timeReportsRepo', () => {
 
     await repo.listOptions(['u1'], testDb);
 
+    for (const [callIndex, assignmentTable, scopeCount] of [
+      [1, 'user_clients', 4],
+      [2, 'user_projects', 3],
+      [3, 'user_tasks', 2],
+    ] as const) {
+      const query = exec.calls[callIndex];
+      expect(query.sql).toContain(`FROM ${assignmentTable}`);
+      expect(query.sql).toContain('FROM time_entries');
+      expect(query.sql).toContain('UNION ALL');
+      expect(query.sql).toContain('available.source_order');
+      expect(query.params).toEqual(Array.from({ length: scopeCount }, () => ['u1']));
+    }
+
+    const clientQuery = exec.calls[1];
+    expect(clientQuery.sql).toContain('FROM user_projects');
+    expect(clientQuery.sql).toContain('FROM user_tasks');
+
+    const projectQuery = exec.calls[2];
+    expect(projectQuery.sql).toContain('FROM user_tasks');
+
     const taskQuery = exec.calls[3];
     expect(taskQuery.sql).toContain('SELECT DISTINCT ON');
-    expect(taskQuery.sql).toContain("COALESCE(te.task_id, 'legacy:' || lower(te.task))");
-    expect(taskQuery.sql).toContain('te.date DESC');
-    expect(taskQuery.sql).toContain('te.created_at DESC NULLS LAST');
+    expect(taskQuery.sql).toContain(
+      "COALESCE(available.task_id, 'legacy:' || lower(available.name))",
+    );
+    expect(taskQuery.sql).toContain('available.source_order');
+    expect(taskQuery.sql).toContain('available.entry_date DESC NULLS LAST');
+    expect(taskQuery.sql).toContain('available.entry_created_at DESC NULLS LAST');
   });
 
   test('filters only candidate IDs when excluding administrators', async () => {

--- a/server/test/repositories/timeReportsRepo.test.ts
+++ b/server/test/repositories/timeReportsRepo.test.ts
@@ -132,6 +132,10 @@ describe('timeReportsRepo', () => {
 
     const projectQuery = exec.calls[2];
     expect(projectQuery.sql).toContain('FROM user_tasks');
+    expect(projectQuery.sql).toMatch(
+      /SELECT DISTINCT ON \(\s*available\.id,\s*available\.client_id\s*\)/,
+    );
+    expect(projectQuery.sql).toContain('LEFT JOIN projects current_project');
 
     const taskQuery = exec.calls[3];
     expect(taskQuery.sql).toContain('SELECT DISTINCT ON');

--- a/test/components/reports/TimeReportView.test.tsx
+++ b/test/components/reports/TimeReportView.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, mock } from 'bun:test';
-import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import TimeReportView, {
   type TimeReportViewProps,
@@ -222,12 +222,18 @@ describe('TimeReportView', () => {
         { id: 'c2', name: 'Beta' },
       ],
       projects: [
+        { id: 'p1', name: 'Migration', clientId: 'c1' },
         { id: 'p1', name: 'Migration', clientId: 'c2' },
         { id: 'p2', name: 'Portal', clientId: 'c2' },
       ],
       tasks: [],
     });
     renderView(['reports.time_report.view']);
+
+    await user.click(await screen.findByRole('button', { name: 'timeReport.filters.allProjects' }));
+    const projectDialog = screen.getByRole('dialog');
+    expect(within(projectDialog).getAllByText('Migration')).toHaveLength(1);
+    await user.click(within(projectDialog).getByText('timeReport.filters.allProjects'));
 
     await user.click(await screen.findByRole('button', { name: 'timeReport.filters.allClients' }));
     await user.type(screen.getByPlaceholderText('select.search'), 'beta');

--- a/test/components/reports/TimeReportView.test.tsx
+++ b/test/components/reports/TimeReportView.test.tsx
@@ -212,6 +212,48 @@ describe('TimeReportView', () => {
     expect(screen.getByText('timeReport.filters.users')).toBeTruthy();
     expect(screen.getByText('timeReport.columns.cost')).toBeTruthy();
   });
+  test('searches clients and limits the project filter to all or one project', async () => {
+    const user = userEvent.setup();
+    optionsMock.mockResolvedValue({
+      editableUserIds: ['u1'],
+      users: [{ id: 'u1', name: 'Alice' }],
+      clients: [
+        { id: 'c1', name: 'Acme' },
+        { id: 'c2', name: 'Beta' },
+      ],
+      projects: [
+        { id: 'p1', name: 'Migration', clientId: 'c2' },
+        { id: 'p2', name: 'Portal', clientId: 'c2' },
+      ],
+      tasks: [],
+    });
+    renderView(['reports.time_report.view']);
+
+    await user.click(await screen.findByRole('button', { name: 'timeReport.filters.allClients' }));
+    await user.type(screen.getByPlaceholderText('select.search'), 'beta');
+    expect(screen.queryByText('Acme')).toBeNull();
+    await user.click(screen.getByText('Beta'));
+
+    await user.click(screen.getByRole('button', { name: 'timeReport.filters.allProjects' }));
+    expect(screen.queryByRole('button', { name: 'select.selectAll' })).toBeNull();
+    await user.click(screen.getByText('Migration'));
+    await user.click(screen.getByRole('button', { name: 'Migration' }));
+    await user.click(screen.getByText('Portal'));
+    await user.click(screen.getByText('timeReport.actions.generate'));
+
+    await waitFor(() => expect(generateMock).toHaveBeenCalledTimes(1));
+    expect(generateMock.mock.calls[0]?.[0]).toMatchObject({
+      clientId: 'c2',
+      projectIds: ['p2'],
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Portal' }));
+    await user.click(screen.getByText('timeReport.filters.allProjects'));
+    await user.click(screen.getByText('timeReport.actions.generate'));
+
+    await waitFor(() => expect(generateMock).toHaveBeenCalledTimes(2));
+    expect(generateMock.mock.calls[1]?.[0]).toMatchObject({ projectIds: [] });
+  });
 
   test('shows the edit action in the row actions menu for an owned detail entry', async () => {
     const user = userEvent.setup();

--- a/test/utils/timeReportFavorites.test.ts
+++ b/test/utils/timeReportFavorites.test.ts
@@ -113,4 +113,31 @@ describe('sanitizeTimeReportFavorite', () => {
 
     expect(sanitized.task).toEqual(legacySaved.task);
   });
+
+  test('reduces legacy multi-project favorites to one project and its tasks', () => {
+    const options: TimeReportOptions = {
+      editableUserIds: [],
+      users: [{ id: 'user-1', name: 'Current user' }],
+      clients: [],
+      projects: [
+        { id: 'project-1', name: 'Project 1', clientId: 'client-1' },
+        { id: 'project-2', name: 'Project 2', clientId: 'client-1' },
+      ],
+      tasks: [{ key: 'task-2', projectId: 'project-2', taskId: 'task-2', name: 'Task 2' }],
+    };
+    const legacySaved: TimeReportDefinition = {
+      ...saved,
+      projectIds: ['project-1', 'project-2'],
+      task: { projectId: 'project-2', taskId: 'task-2', name: 'Task 2' },
+    };
+
+    const sanitized = sanitizeTimeReportFavorite(legacySaved, options, {
+      canSelectUsers: false,
+      canViewCost: false,
+      currentUserId: 'user-1',
+    });
+
+    expect(sanitized.projectIds).toEqual(['project-1']);
+    expect(sanitized.task).toBeNull();
+  });
 });

--- a/utils/timeReportFavorites.ts
+++ b/utils/timeReportFavorites.ts
@@ -23,7 +23,7 @@ export const sanitizeTimeReportFavorite = (
       .filter((project) => clientId === null || project.clientId === clientId)
       .map((project) => project.id),
   );
-  const projectIds = saved.projectIds.filter((id) => eligibleProjectIds.has(id));
+  const projectIds = saved.projectIds.filter((id) => eligibleProjectIds.has(id)).slice(0, 1);
   const visibleTasks = new Set(
     options.tasks
       .filter(


### PR DESCRIPTION
## Summary
- Fixes time report filters that omitted assigned clients, projects, and tasks until a time entry existed.
- Makes client, project, and task filters searchable and aligns the project selector with the single-value “All projects” behavior.
- Preserves historical filter values and client-project pairs while preferring current catalog names.

## Changes
- Combines scoped user assignments with historical time-entry values for report options.
- Includes parent projects and clients for task-only assignments, matching the Time Tracker catalog hierarchy.
- Changes the project filter from multi-select to an all-or-one searchable selector while keeping the API payload backward compatible.
- Normalizes legacy multi-project favorites to one visible project and clears incompatible tasks.
- Keeps historical client-project pairs selectable after a project moves to another client, while deduplicating projects under “All clients”.
- Adds regression coverage for assignment sources, hierarchy closure, user scoping, stable task identities, client search, project selection, moved projects, and legacy favorites.
- Documents the filter behavior in Italian and English.

## Testing
- `bun test ./test/repositories/timeReportsRepo.test.ts ./test/routes/time-reports.test.ts` — 18 passed
- `bun run test:server` — 4,237 passed, 28 skipped, 0 failed
- `bun test ./test/components/reports/TimeReportView.test.tsx ./test/utils/timeReportFavorites.test.ts` — 14 passed
- `bun run test:frontend` — 2,393 passed, 0 failed
- `bun run typecheck`
- `bun run i18n:check`
- `bunx biome check components/reports/TimeReportView.tsx server/repositories/timeReportsRepo.ts test/components/reports/TimeReportView.test.tsx server/test/repositories/timeReportsRepo.test.ts`
- `bun run docs:user`
- `bun run test:react-doctor` — 83/100, unchanged; the existing `DashboardGrid.tsx` finding is unrelated
- GitHub CI, CodeQL, migrations, LDAP, SSO, frontend build, and Docker health — passed

## Risks / Rollout
- Low risk and limited to read-only report options plus the time-report filter UI.
- Existing API definitions remain compatible because the selected project is still sent as `projectIds` with zero or one value.
- Legacy favorites with multiple projects are narrowed to the first currently visible project and display the existing sanitization warning.
- Historical client-project pairs remain selectable without changing stored entries.
- No schema migration, data backfill, configuration change, or deployment ordering requirement.

## Issues
Issue: Not linked