### PR TITLE
projects(fix): show full descriptions in resized columns

### DIFF
--- a/components/projects/ProjectsView.tsx
+++ b/components/projects/ProjectsView.tsx
@@ -949,11 +949,7 @@ const useProjectsController = ({
       header: t('projects:projects.tableHeaders.description'),
       accessorKey: 'description',
       cell: ({ row }) => (
-        <p
-          className={`text-xs max-w-md italic line-clamp-1 ${
-            row.isDisabled ? 'text-zinc-400' : 'text-zinc-500'
-          }`}
-        >
+        <p className={`text-xs italic ${row.isDisabled ? 'text-zinc-400' : 'text-zinc-500'}`}>
           {row.description || t('projects:projects.noDescriptionProvided')}
         </p>
       ),

--- a/test/components/projects/ProjectsView.test.ts
+++ b/test/components/projects/ProjectsView.test.ts
@@ -140,6 +140,19 @@ describe('ProjectsView create-form validation', () => {
     expect(source).toContain('formatDateOnlyForLocale(String(value), i18n.language)');
   });
 
+  test('lets the description use the full width of a resized column', async () => {
+    const source = await Bun.file(
+      new URL('../../../components/projects/ProjectsView.tsx', import.meta.url),
+    ).text();
+    const descriptionColumn = source.match(
+      /header: t\('projects:projects\.tableHeaders\.description'\)[\s\S]*?header: t\('projects:projects\.tipo'\)/,
+    )?.[0];
+
+    expect(descriptionColumn).toBeDefined();
+    expect(descriptionColumn).not.toContain('max-w-md');
+    expect(descriptionColumn).not.toContain('line-clamp-1');
+  });
+
   test('requires and forwards the project status with tooltip and table column', async () => {
     const source = await Bun.file(
       new URL('../../../components/projects/ProjectsView.tsx', import.meta.url),


### PR DESCRIPTION
## Summary
- Fixes commission descriptions that remained clipped after users resized the Description column.
- Keeps the existing single-row table layout while allowing the complete stored description to become visible.

## Changes
- Removes the fixed maximum width and single-line clamp from project description cells.
- Adds regression coverage that prevents those truncation utilities from returning.

## Testing
- `bun test test/components/projects/ProjectsView.test.ts` — 21 passed
- `bun run test:server` — 4237 passed, 28 optional integration tests skipped, 0 failed
- `bun run test:frontend` — 2392 passed, 0 failed
- `bun run lint`
- `bun run build` — production build and login smoke test passed
- `bun run test:react-doctor` — 83/100 before and after; existing DashboardGrid finding remains

## Risks / Rollout
- Low risk and presentation-only; no database, API, permission, configuration, or dependency changes.
- Existing build warning for chunks over 500 kB is unchanged.
- Roll back by reverting commit `3df1d6907`.

## Issues
Issue: Not linked