### PR TITLE
app(chore): bump version to 0.12.0

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Praetor API",
     "description": "Praetor API documentation",
-    "version": "0.11.1"
+    "version": "0.12.0"
   },
   "components": {
     "securitySchemes": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praetor",
   "private": true,
-  "version": "0.11.1",
+  "version": "0.12.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "praetor-server",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Praetor API Server",
   "main": "index.ts",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bumps the Praetor application minor version from 0.11.1 to 0.12.0.
- Keeps the frontend package, backend package, and generated OpenAPI metadata aligned.

## Changes
- Updates `package.json` to version 0.12.0.
- Updates `server/package.json` to version 0.12.0.
- Regenerates `docs/api/openapi.json` with version 0.12.0.

## Testing
- `bun run docs:api` (passed)
- `bun run lint` (passed)
- `bun run test` (passed; final frontend suite: 2,404 passed, 0 failed)
- `bun run test:react-doctor` before and after: 80/100, unchanged (one pre-existing finding in `components/projects/DashboardGrid.tsx`)

## Risks / Rollout
- Low risk. Metadata-only minor version update with no runtime, database, configuration, or dependency changes.

## Issues
Issue: Not linked